### PR TITLE
(REACTOR-707) Fix broken java client test

### DIFF
--- a/client/src/main/java/co/cask/cdap/client/DatasetClient.java
+++ b/client/src/main/java/co/cask/cdap/client/DatasetClient.java
@@ -57,7 +57,7 @@ public class DatasetClient {
   /**
    * Lists all datasets.
    *
-   * @return list of {@link DatasetMeta}s.
+   * @return list of {@link DatasetSpecification}.
    * @throws IOException if a network error occurred
    */
   public List<DatasetSpecification> list() throws IOException {
@@ -117,16 +117,6 @@ public class DatasetClient {
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       throw new DatasetNotFoundException(datasetName);
     }
-  }
-
-  /**
-   * Deletes all datasets. WARNING: This is an unrecoverable operation.
-   *
-   * @throws IOException if a network error occurred
-   */
-  public void deleteAll() throws IOException {
-    URL url = config.resolveURL("data/unrecoverable/datasets");
-    restClient.execute(HttpMethod.DELETE, url);
   }
 
   /**

--- a/client/src/main/java/co/cask/cdap/client/MonitorClient.java
+++ b/client/src/main/java/co/cask/cdap/client/MonitorClient.java
@@ -29,6 +29,7 @@ import co.cask.cdap.proto.Instances;
 import co.cask.cdap.proto.SystemServiceMeta;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -84,7 +85,8 @@ public class MonitorClient {
     } else if (response.getResponseCode() == HttpURLConnection.HTTP_BAD_REQUEST) {
       throw new BadRequestException(responseBody);
     }
-    return responseBody;
+    Map<String, String> status = GSON.fromJson(responseBody, new TypeToken<Map<String, String>>() { }.getType());
+    return status.get("status");
   }
 
   /**

--- a/client/src/test/java/co/cask/cdap/reactor/client/DatasetClientTest.java
+++ b/client/src/test/java/co/cask/cdap/reactor/client/DatasetClientTest.java
@@ -58,7 +58,6 @@ public class DatasetClientTest extends ClientTestBase {
   public void testAll() throws Exception {
     int numBaseModules = moduleClient.list().size();
     int numBaseTypes = typeClient.list().size();
-    Assert.assertEquals(0, datasetClient.list().size());
 
     LOG.info("Adding Dataset module");
     File moduleJarFile = createAppJarFile(FakeDatasetModule.class);
@@ -81,20 +80,24 @@ public class DatasetClientTest extends ClientTestBase {
     Assert.assertEquals(FakeDataset.class.getName(), datasetTypeMeta.getName());
 
     LOG.info("Creating, truncating, and deleting dataset of new Dataset type");
-    Assert.assertEquals(0, datasetClient.list().size());
+    // Before creating dataset, there are some system datasets already exist
+    int numBaseDataset = datasetClient.list().size();
+
     datasetClient.create("testDataset", FakeDataset.TYPE_NAME);
-    Assert.assertEquals(1, datasetClient.list().size());
+    Assert.assertEquals(numBaseDataset + 1, datasetClient.list().size());
     datasetClient.truncate("testDataset");
     datasetClient.delete("testDataset");
-    Assert.assertEquals(0, datasetClient.list().size());
+    Assert.assertEquals(numBaseDataset, datasetClient.list().size());
 
     LOG.info("Creating and deleting multiple Datasets");
-    datasetClient.create("testDataset1", FakeDataset.TYPE_NAME);
-    datasetClient.create("testDataset2", FakeDataset.TYPE_NAME);
-    datasetClient.create("testDataset3", FakeDataset.TYPE_NAME);
-    Assert.assertEquals(3, datasetClient.list().size());
-    datasetClient.deleteAll();
-    Assert.assertEquals(0, datasetClient.list().size());
+    for (int i = 1; i <= 3; i++) {
+      datasetClient.create("testDataset" + i, FakeDataset.TYPE_NAME);
+    }
+    Assert.assertEquals(numBaseDataset + 3, datasetClient.list().size());
+    for (int i = 1; i <= 3; i++) {
+      datasetClient.delete("testDataset" + i);
+    }
+    Assert.assertEquals(numBaseDataset, datasetClient.list().size());
 
     LOG.info("Deleting Dataset module");
     moduleClient.delete(FakeDatasetModule.NAME);

--- a/client/src/test/java/co/cask/cdap/reactor/client/app/FakeDataset.java
+++ b/client/src/test/java/co/cask/cdap/reactor/client/app/FakeDataset.java
@@ -40,6 +40,7 @@ public class FakeDataset extends AbstractDataset
 
   public FakeDataset(String instanceName, KeyValueTable table) {
     super(instanceName, table);
+    this.table = table;
   }
 
   public byte[] get(byte[] key) {

--- a/client/src/test/java/co/cask/cdap/reactor/client/common/SingleNodeTestBase.java
+++ b/client/src/test/java/co/cask/cdap/reactor/client/common/SingleNodeTestBase.java
@@ -17,9 +17,14 @@
 package co.cask.cdap.reactor.client.common;
 
 import co.cask.cdap.SingleNodeMain;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.test.internal.AppFabricTestHelper;
+import org.apache.hadoop.conf.Configuration;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,15 +37,21 @@ public class SingleNodeTestBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(SingleNodeTestBase.class);
 
+  @ClassRule
+  public static TemporaryFolder tmpFolder = new TemporaryFolder();
+
   private SingleNodeMain singleNodeMain;
 
   @Before
   public void setUp() throws Throwable {
     try {
-      singleNodeMain = SingleNodeMain.createSingleNodeMain(true);
+      CConfiguration cConf = CConfiguration.create();
+      cConf.set(Constants.CFG_LOCAL_DATA_DIR, tmpFolder.newFolder().getAbsolutePath());
+
+      // Start singlenode without UI
+      singleNodeMain = SingleNodeMain.createSingleNodeMain(true, null, cConf, new Configuration());
       singleNodeMain.startUp();
     } catch (Throwable e) {
-      System.err.println("Failed to start singlenode. " + e.getMessage());
       LOG.error("Failed to start singlenode", e);
       if (singleNodeMain != null) {
         singleNodeMain.shutDown();

--- a/singlenode/src/main/java/co/cask/cdap/WebCloudAppService.java
+++ b/singlenode/src/main/java/co/cask/cdap/WebCloudAppService.java
@@ -31,9 +31,11 @@ import java.util.concurrent.Executor;
  * All output is sent to our Logging service.
  */
 public class WebCloudAppService extends AbstractExecutionThreadService {
+  static final String WEB_APP = "web-app/server/local/main.js"; // Right path passed on command line.
+
   private static final Logger LOG = LoggerFactory.getLogger(WebCloudAppService.class);
   private static final String NODE_JS_EXECUTABLE = "node";
-  public static final String WEB_APP = "web-app/server/local/main.js"; // Right path passed on command line.
+
   private final String webAppPath;
   private Process process;
   private BufferedReader bufferedReader;


### PR DESCRIPTION
- Remove the DatasetClient.deleteAll(), as it’ll delete all system dataset as well
- Fix the DatasetClientTest to expect for existence of system dataset
- Fix the MonitorStatusClient to parse the status response correctly
