### PR TITLE
[2.4] Update the instances only when service is running

### DIFF
--- a/app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ServiceHttpHandler.java
+++ b/app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ServiceHttpHandler.java
@@ -216,13 +216,13 @@ public class ServiceHttpHandler extends AbstractAppFabricHttpHandler {
       }
 
       int oldInstances = store.getServiceRunnableInstances(programId, runnableName);
-      store.setServiceRunnableInstances(programId, runnableName, instances);
 
       ProgramRuntimeService.RuntimeInfo runtimeInfo = findRuntimeInfo(programId.getAccountId(),
                                                                       programId.getApplicationId(),
                                                                       programId.getId(),
                                                                       ProgramType.SERVICE);
       if (runtimeInfo != null) {
+        store.setServiceRunnableInstances(programId, runnableName, instances);
         runtimeInfo.getController().command(ProgramOptionConstants.RUNNABLE_INSTANCES,
                                             ImmutableMap.of("runnable", runnableName,
                                                             "newInstances", String.valueOf(instances),


### PR DESCRIPTION
Fixes: https://jira.continuuity.com/browse/REACTOR-651

Update instances for a runnable only when the service is running i.e. when `runtimeInfo` is not null. 
