### PR TITLE
[2.5] Enable HTTPS in dashboard UI

### DIFF
--- a/web-app/server/common/server.js
+++ b/web-app/server/common/server.js
@@ -28,11 +28,11 @@ var Env = require('./env');
  * @param {string} logLevel log level {TRACE|INFO|ERROR}
  * @param {boolean} https whether to use https for requests.
  */
-var WebAppServer = function(dirPath, logLevel, https) {
+var WebAppServer = function(dirPath, logLevel, httpsEnabled) {
   this.dirPath = dirPath;
   this.LOG_LEVEL = logLevel;
   this.lib = http;
-  if (https) {
+  if (httpsEnabled) {
     this.lib = https;
   }
 };
@@ -210,6 +210,22 @@ WebAppServer.prototype.setCookieSession = function(cookieName, secret) {
  */
 WebAppServer.prototype.getServerInstance = function(app) {
   return this.lib.createServer(app);
+};
+
+/**
+ * Creates https server based on app framework.
+ * Currently works only with express.
+ * @param {Object} app framework.
+ * @param {string} key path to SSL key
+ * @param {string} cert path to SSL cert
+ * @return {Object} instance of the http server.
+ */
+WebAppServer.prototype.getHttpsServerInstance = function(app, key, cert) {
+  var options = {
+    key: fs.readFileSync(key),
+    cert: fs.readFileSync(cert)
+  };
+  return this.lib.createServer(options, app);
 };
 
 WebAppServer.prototype.checkAuth = function(req, res, next) {

--- a/web-app/server/enterprise/main.js
+++ b/web-app/server/enterprise/main.js
@@ -28,14 +28,20 @@ process.env.NODE_ENV = 'production';
 var logLevel = 'INFO';
 
 var EntServer = function() {
-  EntServer.super_.call(this, __dirname, logLevel);
+  var self = this;
+  this.getConfig(function(version) {
+    if (self.config['dashboard.https.enabled'] === "true") {
+      EntServer.super_.call(self, __dirname, logLevel, true);
+    } else {
+      EntServer.super_.call(self, __dirname, logLevel, false);
+    }
 
-  this.cookieName = 'continuuity-enterprise-edition';
-  this.secret = 'enterprise-edition-secret';
-  this.logger = this.getLogger('console', 'Enterprise UI');
-  this.setCookieSession(this.cookieName, this.secret);
-  this.configureExpress();
-
+    self.cookieName = 'continuuity-enterprise-edition';
+    self.secret = 'enterprise-edition-secret';
+    self.logger = self.getLogger('console', 'Enterprise UI');
+    self.setCookieSession(self.cookieName, self.secret);
+    self.configureExpress();
+  }
 };
 util.inherits(EntServer, WebAppServer);
 
@@ -81,8 +87,12 @@ EntServer.prototype.start = function() {
   var self = this;
 
   self.getConfig(function(version) {
-
-    self.server = self.getServerInstance(self.app);
+    if (this.config['dashboard.https.enabled'] === "true") {
+      self.server = self.getHttpsServerInstance(self.app, self.config['dashboard.ssl.key'],
+                                                self.config['dashboard.ssl.cert']);
+    } else {
+      self.server = self.getServerInstance(self.app);
+    }
 
     if (!('dashboard.bind.port' in self.config)) {
       self.config['dashboard.bind.port'] = DEFAULT_BIND_PORT;

--- a/web-app/server/local/continuuity-local.xml
+++ b/web-app/server/local/continuuity-local.xml
@@ -7,6 +7,19 @@
 		<name>dashboard.bind.port</name>
 		<value>9999</value>
 	</property>
+  <property>
+    <name>dashboard.https.enabled</name>
+    <value>true</value>
+  </property>
+  <!--TODO: fix these defaults when possible-->
+  <property>
+    <name>dashboard.ssl.key</name>
+    <value>/Users/alvin/Work/workspace/caskco/ssl/server.key</value>
+  </property>
+  <property>
+    <name>dashboard.ssl.cert</name>
+    <value>/Users/alvin/Work/workspace/caskco/ssl/server.crt</value>
+  </property>
 
 	<property>
 		<name>accounts.server.address</name>

--- a/web-app/server/local/main.js
+++ b/web-app/server/local/main.js
@@ -25,14 +25,20 @@ process.env.NODE_ENV = 'development';
 var logLevel = 'INFO';
 
 var DevServer = function() {
-  DevServer.super_.call(this, __dirname, logLevel);
+  var self = this;
+  this.getConfig(function(version) {
+    if (self.config['dashboard.https.enabled'] === "true") {
+      DevServer.super_.call(self, __dirname, logLevel, true);
+    } else {
+      DevServer.super_.call(self, __dirname, logLevel, false);
+    }
 
-  this.cookieName = 'continuuity-local-edition';
-  this.secret = 'local-edition-secret';
-  this.logger = this.getLogger();
-  this.setCookieSession(this.cookieName, this.secret);
-  this.configureExpress();
-
+    self.cookieName = 'continuuity-local-edition';
+    self.secret = 'local-edition-secret';
+    self.logger = self.getLogger();
+    self.setCookieSession(self.cookieName, self.secret);
+    self.configureExpress();
+  });
 };
 util.inherits(DevServer, WebAppServer);
 
@@ -73,8 +79,12 @@ DevServer.prototype.getConfig = function(opt_callback) {
 DevServer.prototype.start = function() {
 
   this.getConfig(function(version) {
-
-    this.server = this.getServerInstance(this.app);
+    if (this.config['dashboard.https.enabled'] === "true") {
+      this.server = this.getHttpsServerInstance(this.app, this.config['dashboard.ssl.key'],
+                                                this.config['dashboard.ssl.cert']);
+    } else {
+      this.server = this.getServerInstance(this.app);
+    }
 
     this.setEnvironment('local', 'Development Kit', version, function () {
 


### PR DESCRIPTION
TODO (will need to talk to @nistala)
- Fix continuuity-local.xml defaults for `dashboard.ssl.key` and `dashboard.ssl.cert`
- Connect to dashboard at https://Alvins-MacBook-Pro-2.local:9999 rather than "...at http://..."
- Redirect from http to https
