### PR TITLE
Remove 5 seconds waiting in Explore service start

### DIFF
--- a/explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -155,8 +155,6 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     LOG.info("Starting {}...", Hive13ExploreService.class.getSimpleName());
     cliService.init(getHiveConf());
     cliService.start();
-    // TODO: Figure out a way to determine when cliService has started successfully - REACTOR-254
-    TimeUnit.SECONDS.sleep(5);
 
     // Schedule the cache cleanup
     scheduledExecutorService.scheduleWithFixedDelay(new Runnable() {


### PR DESCRIPTION
After reviewing Hive code again, it appears that the `start` call in the `HiveCliService` is synchronous, and so waiting for 5 seconds is useless. 
After talking with Poorna, we can't remember why we thought `start` was asynchronous in the first place. 
Bamboo build is green - https://bamboo-prod.continuuity.com/browse/CDAP-DUT31-1/test.
