### PR TITLE
[2.4] Make the MR use the user job jar in the class path first to avoid ASM conflict.

### DIFF
--- a/app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -245,6 +245,11 @@ public class MapReduceProgramRunner implements ProgramRunner {
     mapredConf.set("mapreduce.reduce.java.opts", "-Xmx" + reducerMemory + "m");
     jobConf = Job.getInstance(mapredConf);
 
+    // Prefer our job jar in the classpath
+    // Set both old and new keys
+    jobConf.getConfiguration().setBoolean("mapreduce.user.classpath.first", true);
+    jobConf.getConfiguration().setBoolean(Job.MAPREDUCE_JOB_USER_CLASSPATH_FIRST, true);
+
     if (UserGroupInformation.isSecurityEnabled()) {
       Credentials credentials = UserGroupInformation.getCurrentUser().getCredentials();
       LOG.info("Running in secure mode; adding all user credentials: {}", credentials.getAllTokens());


### PR DESCRIPTION
Haven't been able to test on the cluster yet, due to dateset service start up issue.
