### PR TITLE
[2.4] Fix Http Service Configure

### DIFF
--- a/api/src/main/java/co/cask/cdap/api/service/http/HttpServiceContext.java
+++ b/api/src/main/java/co/cask/cdap/api/service/http/HttpServiceContext.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.api.service.http;
 
+import java.util.Map;
+
 /**
  * TODO: Extend runtime context later for transactions and dataset
  */
@@ -24,4 +26,9 @@ public interface HttpServiceContext {
    * @return The HttpServiceSpecification for this HttpServiceContext
    */
   HttpServiceSpecification getSpecification();
+
+  /**
+   * @return the user runtime arguments for the Twill Application that implements the HTTP Service
+   */
+  Map<String, String> getRuntimeArguments();
 }

--- a/api/src/main/java/co/cask/cdap/internal/service/http/DefaultHttpServiceContext.java
+++ b/api/src/main/java/co/cask/cdap/internal/service/http/DefaultHttpServiceContext.java
@@ -16,22 +16,50 @@
 
 package co.cask.cdap.internal.service.http;
 
+import co.cask.cdap.api.common.RuntimeArguments;
 import co.cask.cdap.api.service.http.HttpServiceContext;
 import co.cask.cdap.api.service.http.HttpServiceSpecification;
 
+import java.util.Map;
+
 /**
- *
+ * Default implementation of HttpServiceContext which simply stores and retrieves the
+ * spec provided when this class is instantiated
  */
 public class DefaultHttpServiceContext implements HttpServiceContext {
 
-  HttpServiceSpecification spec;
+  private final HttpServiceSpecification spec;
+  private final Map<String, String> runtimeArgs;
 
-  public DefaultHttpServiceContext(HttpServiceSpecification spec) {
+  /**
+   * Instantiates the context with a spec and a map for the runtime arguments
+   *
+   * @param spec the {@link HttpServiceSpecification} for this context
+   * @param runtimeArgs the runtime arguments as a map of string to string
+   */
+  public DefaultHttpServiceContext(HttpServiceSpecification spec, Map<String, String> runtimeArgs) {
     this.spec = spec;
+    this.runtimeArgs = runtimeArgs;
   }
 
+  /**
+   * @param spec the {@link HttpServiceSpecification} for this context
+   */
+  public DefaultHttpServiceContext(HttpServiceSpecification spec, String[] runtimeArgs) {
+    this.spec = spec;
+    this.runtimeArgs = RuntimeArguments.fromPosixArray(runtimeArgs);
+  }
+
+  /**
+   * @return the {@link HttpServiceSpecification} for this context
+   */
   @Override
   public HttpServiceSpecification getSpecification() {
     return spec;
+  }
+
+  @Override
+  public Map<String, String> getRuntimeArguments() {
+    return runtimeArgs;
   }
 }

--- a/app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
+++ b/app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import java.net.InetSocketAddress;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.Map;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -73,6 +74,11 @@ public class HttpHandlerGeneratorTest {
     HttpHandler httpHandler = factory.createHttpHandler(new MyHttpHandler(), new HttpServiceContext() {
       @Override
       public HttpServiceSpecification getSpecification() {
+        return null;
+      }
+
+      @Override
+      public Map<String, String> getRuntimeArguments() {
         return null;
       }
     });


### PR DESCRIPTION
Fixed http service configure so that it actually calls the user's configure method and the user's initialize and destroy methods. The context also does not return runtimeArguments anymore because the spec that it returns already has the runtime arguments.
