### PR TITLE
[2.4] Fix too big wait in the /queries endpoints when queries are running

### DIFF
--- a/explore/src/main/java/co/cask/cdap/explore/service/hive/Hive13ExploreService.java
+++ b/explore/src/main/java/co/cask/cdap/explore/service/hive/Hive13ExploreService.java
@@ -52,6 +52,9 @@ public class Hive13ExploreService extends BaseHiveExploreService {
                               CConfiguration cConf, Configuration hConf, HiveConf hiveConf,
                               @Named(Constants.Explore.PREVIEWS_DIR_NAME) File previewsDir) {
     super(txClient, datasetFramework, cConf, hConf, hiveConf, previewsDir);
+    // This config sets the time Hive CLI getOperationStatus method will wait for the status of
+    // a running query.
+    System.setProperty(HiveConf.ConfVars.HIVE_SERVER2_LONG_POLLING_TIMEOUT.toString(), "50");
   }
 
   @Override


### PR DESCRIPTION
This is resolving JIRA https://jira.continuuity.com/browse/REACTOR-730#comment-15578
