### PR TITLE
[2.4] Fix CLI packaging

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -88,6 +88,55 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>2.6</version>
+        <executions>
+          <execution>
+            <id>copy-opt</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration combine.self="override">
+              <outputDirectory>${project.build.directory}</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/bin</directory>
+                  <includes>
+                    <include>cdap-cli.sh</include>
+                    <include>cdap-cli.bat</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.7</version>
+        <executions>
+          <!-- Rename CLI jar and make CLI scripts executable -->
+          <execution>
+            <id>copy-cli-bash</id>
+            <phase>package</phase>
+            <configuration>
+              <target>
+                <copy file="${project.build.directory}/cli-${project.version}.jar" tofile="${project.build.directory}/cdap-cli.jar" />
+                <chmod file="${project.build.directory}/cdap-cli.sh" perm="755"/>
+                <chmod file="${project.build.directory}/cdap-cli.bat" perm="755"/>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Removing the "really executable jar" plugin also changed packaging to not build the executable at `cli/target/cdap-cli`. This PR fixes that.
