### PR TITLE
[2.4] Application delete function should not error out if program jar is missing

### DIFF
--- a/app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
+++ b/app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
@@ -2297,8 +2297,8 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
       try {
         Location location = Programs.programLocation(locationFactory, appFabricDir, programId, type);
         location.delete();
-      } catch (FileNotFoundException e){
-        LOG.warn("Program jar for program {} not found", programId.toString());
+      } catch (FileNotFoundException e) {
+        LOG.warn("Program jar for program {} not found.", programId.toString(), e);
       }
     }
 


### PR DESCRIPTION
- Current application delete logic will error out if it tries to delete a program jar that is missing.
- The fix will log a warning if program jar is missing and continue with deletion process
  Will add an audi test case for this
