### PR TITLE
[2.4] class name typo fix and using SortedMap for properties type

### DIFF
--- a/data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
+++ b/data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
@@ -73,7 +73,7 @@ import javax.ws.rs.PathParam;
 public class DatasetInstanceHandler extends AbstractHttpHandler {
   private static final Logger LOG = LoggerFactory.getLogger(DatasetInstanceHandler.class);
   private static final Gson GSON = new GsonBuilder()
-    .registerTypeAdapter(DatasetSpecification.class, new DatsetSpecificationAdapter())
+    .registerTypeAdapter(DatasetSpecification.class, new DatasetSpecificationAdapter())
     .create();
 
   private final DatasetTypeManager implManager;
@@ -425,9 +425,9 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
   /**
    * Adapter for {@link co.cask.cdap.api.dataset.DatasetSpecification}
    */
-  private static final class DatsetSpecificationAdapter implements JsonSerializer<DatasetSpecification> {
+  private static final class DatasetSpecificationAdapter implements JsonSerializer<DatasetSpecification> {
 
-    private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
+    private static final Type MAP_STRING_STRING_TYPE = new TypeToken<SortedMap<String, String>>() { }.getType();
     private static final Maps.EntryTransformer<String, String, String> TRANSFORM_DATASET_PROPERTIES =
       new Maps.EntryTransformer<String, String, String>() {
         @Override


### PR DESCRIPTION
fixing Typo in class name and using SortedMap as Type for Dataset properties as well.
