### PR TITLE
REACTOR-771 DefaultTransactionStateCacheSupplier can cause lockup of region assignment

### DIFF
--- a/data-fabric/src/main/java/co/cask/cdap/data2/transaction/coprocessor/DefaultTransactionStateCache.java
+++ b/data-fabric/src/main/java/co/cask/cdap/data2/transaction/coprocessor/DefaultTransactionStateCache.java
@@ -51,6 +51,7 @@ public class DefaultTransactionStateCache extends TransactionStateCache {
     this.configTable = new ConfigurationTable(conf);
   }
 
+  @Override
   protected Configuration getSnapshotConfiguration() throws IOException {
     CConfiguration cConf = configTable.read(ConfigurationTable.Type.DEFAULT, tableNamespace);
     Configuration txConf = HBaseConfiguration.create();

--- a/data-fabric/src/main/java/co/cask/cdap/data2/transaction/coprocessor/DefaultTransactionStateCacheSupplier.java
+++ b/data-fabric/src/main/java/co/cask/cdap/data2/transaction/coprocessor/DefaultTransactionStateCacheSupplier.java
@@ -44,7 +44,7 @@ public class DefaultTransactionStateCacheSupplier extends TransactionStateCacheS
         if (instance == null) {
           instance = new DefaultTransactionStateCache(namespace);
           instance.setConf(conf);
-          instance.startAndWait();
+          instance.start();
         }
       }
     }


### PR DESCRIPTION
Use async startup instead of blocking.

Without this change, initial region assignment hangs on a full HBase cluster restart.  With this change, region assignment quickly completes without a problem.
