### PR TITLE
REACTOR-701 Fix IncrementHandler region scanner wrapping on flush and compaction

### DIFF
--- a/hbase-compat-0.94/src/main/java/co/cask/cdap/data2/increment/hbase94/IncrementSummingScanner.java
+++ b/hbase-compat-0.94/src/main/java/co/cask/cdap/data2/increment/hbase94/IncrementSummingScanner.java
@@ -87,7 +87,7 @@ class IncrementSummingScanner implements RegionScanner {
     }
     throw new IllegalStateException(
       "RegionScanner.isFilterDone() called when the wrapped scanner is not a RegionScanner");
-}
+  }
 
   @Override
   public boolean nextRaw(List<KeyValue> cells, String metric) throws IOException {


### PR DESCRIPTION
This fixes a ClassCastException in HBase 0.96+ that occurs on flush and compaction.  We only attempt to handle the underlying scanner as a RegionScanner when RegionScanner methods are being called.  This keeps us safe for the flush and compaction context, where a StoreScanner is used.
