### PR TITLE
Fix MR memory limits.

### DIFF
--- a/api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceSpecification.java
+++ b/api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceSpecification.java
@@ -84,8 +84,10 @@ public interface MapReduceSpecification extends ProgramSpecification, PropertyPr
     private String outputDataSet;
     private Map<String, String> arguments;
     private final ImmutableSet.Builder<String> dataSets = ImmutableSet.builder();
-    private int mapperMemoryMB = 1024;
-    private int reducerMemoryMB = 1024;
+
+    // Default memory size to use the one from the cluster configuration (mapred-site.xml)
+    private int mapperMemoryMB = -1;
+    private int reducerMemoryMB = -1;
 
     /**
      * Start defining {@link MapReduceSpecification}.

--- a/app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceMetricsWriter.java
+++ b/app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceMetricsWriter.java
@@ -77,8 +77,8 @@ public class MapReduceMetricsWriter {
     for (TaskReport tr : jobConf.getTaskReports(TaskType.REDUCE)) {
       runningReducers += tr.getRunningTaskAttemptIds().size();
     }
-    int memoryPerMapper = context.getSpecification().getMapperMemoryMB();
-    int memoryPerReducer = context.getSpecification().getReducerMemoryMB();
+    int memoryPerMapper = jobConf.getConfiguration().getInt(Job.MAP_MEMORY_MB, Job.DEFAULT_MAP_MEMORY_MB);
+    int memoryPerReducer = jobConf.getConfiguration().getInt(Job.REDUCE_MEMORY_MB, Job.DEFAULT_REDUCE_MEMORY_MB);
 
     // mapred counters are running counters whereas our metrics timeseries and aggregates make more
     // sense as incremental numbers.  So we want to subtract the current counter value from the previous before

--- a/app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -226,7 +226,8 @@ public class MapReduceProgramRunner implements ProgramRunner {
   private void submit(final MapReduce job, MapReduceSpecification mapredSpec, Location jobJarLocation,
                       final BasicMapReduceContext context,
                       final DataSetInstantiator dataSetInstantiator) throws Exception {
-    Configuration mapredConf = new Configuration(hConf);
+    jobConf = Job.getInstance(new Configuration(hConf));
+    Configuration mapredConf = jobConf.getConfiguration();
 
     if (UserGroupInformation.isSecurityEnabled()) {
       // If runs in secure cluster, this program runner is running in a yarn container, hence not able
@@ -238,17 +239,21 @@ public class MapReduceProgramRunner implements ProgramRunner {
     int mapperMemory = mapredSpec.getMapperMemoryMB();
     int reducerMemory = mapredSpec.getReducerMemoryMB();
     // this will determine how much memory the yarn container will run with
-    mapredConf.setInt("mapreduce.map.memory.mb", mapperMemory);
-    mapredConf.setInt("mapreduce.reduce.memory.mb", reducerMemory);
-    // java heap size doesn't automatically get set to the yarn container memory...
-    mapredConf.set("mapreduce.map.java.opts", "-Xmx" + mapperMemory + "m");
-    mapredConf.set("mapreduce.reduce.java.opts", "-Xmx" + reducerMemory + "m");
-    jobConf = Job.getInstance(mapredConf);
+    if (mapperMemory > 0) {
+      mapredConf.setInt(Job.MAP_MEMORY_MB, mapperMemory);
+      // Also set the Xmx to be smaller than the container memory.
+      mapredConf.set(Job.MAP_JAVA_OPTS, "-Xmx" + mapperMemory * 0.8 + "m");
+    }
+    if (reducerMemory > 0) {
+      mapredConf.setInt(Job.REDUCE_MEMORY_MB, reducerMemory);
+      // Also set the Xmx to be smaller than the container memory.
+      mapredConf.set(Job.REDUCE_JAVA_OPTS, "-Xmx" + reducerMemory * 0.8 + "m");
+    }
 
     // Prefer our job jar in the classpath
     // Set both old and new keys
-    jobConf.getConfiguration().setBoolean("mapreduce.user.classpath.first", true);
-    jobConf.getConfiguration().setBoolean(Job.MAPREDUCE_JOB_USER_CLASSPATH_FIRST, true);
+    mapredConf.setBoolean("mapreduce.user.classpath.first", true);
+    mapredConf.setBoolean(Job.MAPREDUCE_JOB_USER_CLASSPATH_FIRST, true);
 
     if (UserGroupInformation.isSecurityEnabled()) {
       Credentials credentials = UserGroupInformation.getCurrentUser().getCredentials();


### PR DESCRIPTION
- Use cluster default mapper/reducer memory size when not set.
- If set explicitly, reduce the -Xmx by 80% to avoid NM killing container.
