### PR TITLE
remove creation of dataset at runtime of program

### DIFF
--- a/app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractDataFabricFacade.java
+++ b/app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractDataFabricFacade.java
@@ -62,8 +62,7 @@ public abstract class AbstractDataFabricFacade implements DataFabricFacade {
     this.queueClientFactory = queueClientFactory;
     this.streamConsumerFactory = streamConsumerFactory;
     this.txExecutorFactory = txExecutorFactory;
-    this.dataSetContext = createDataSetContext(program, locationFactory,
-                                               datasetFramework, configuration);
+    this.dataSetContext = createDataSetContext(program, datasetFramework, configuration);
     this.programId = program.getId();
   }
 
@@ -123,14 +122,11 @@ public abstract class AbstractDataFabricFacade implements DataFabricFacade {
   }
 
   private DataSetInstantiator createDataSetContext(Program program,
-                                                   LocationFactory locationFactory,
                                                    DatasetFramework datasetFramework,
                                                    CConfiguration configuration) {
     try {
-      DataSetInstantiator dataSetInstantiator = new DataSetInstantiator(datasetFramework, configuration,
+      return new DataSetInstantiator(datasetFramework, configuration,
                                                                         program.getClassLoader());
-      dataSetInstantiator.setDataSets(program.getSpecification().getDatasets().values());
-      return dataSetInstantiator;
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }

--- a/app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/AbstractMapReduceContextBuilder.java
+++ b/app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/AbstractMapReduceContextBuilder.java
@@ -107,7 +107,6 @@ public abstract class AbstractMapReduceContextBuilder {
 
     DataSetInstantiator dataSetContext = new DataSetInstantiator(datasetFramework, configuration, classLoader);
     ApplicationSpecification programSpec = program.getSpecification();
-    dataSetContext.setDataSets(programSpec.getDatasets().values());
 
     // if this is not for a mapper or a reducer, we don't need the metrics collection service
     MetricsCollectionService metricsCollectionService =

--- a/app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -172,8 +172,6 @@ public class MapReduceProgramRunner implements ProgramRunner {
     DataSetInstantiator dataSetInstantiator = new DataSetInstantiator(datasetFramework,
                                                                       cConf, program.getClassLoader());
     Map<String, DatasetCreationSpec> datasetSpecs = program.getSpecification().getDatasets();
-    dataSetInstantiator.setDataSets(datasetSpecs.values());
-
     Map<String, Closeable> dataSets = DataSets.createDataSets(dataSetInstantiator, datasetSpecs.keySet());
 
     final BasicMapReduceContext context =

--- a/app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
+++ b/app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
@@ -23,7 +23,6 @@ import co.cask.cdap.api.dataset.lib.ObjectStore;
 import co.cask.cdap.api.dataset.lib.TimeseriesTable;
 import co.cask.cdap.api.dataset.table.Get;
 import co.cask.cdap.api.dataset.table.Table;
-import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramRunner;
@@ -33,7 +32,6 @@ import co.cask.cdap.data.dataset.DataSetInstantiator;
 import co.cask.cdap.data2.datafabric.DefaultDatasetNamespace;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.NamespacedDatasetFramework;
-import co.cask.cdap.internal.app.Specifications;
 import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
 import co.cask.cdap.internal.app.runtime.BasicArguments;
 import co.cask.cdap.internal.app.runtime.ProgramRunnerFactory;
@@ -134,8 +132,6 @@ public class MapReduceProgramRunnerTest {
     final ApplicationWithPrograms app =
       AppFabricTestHelper.deployApplicationWithManager(AppWithMapReduceUsingObjectStore.class, TEMP_FOLDER_SUPPLIER);
 
-    ApplicationSpecification spec = Specifications.from(new AppWithMapReduceUsingObjectStore());
-    dataSetInstantiator.setDataSets(spec.getDatasets().values());
     final ObjectStore<String> input = dataSetInstantiator.getDataSet("keys");
 
     //Populate some input
@@ -176,8 +172,6 @@ public class MapReduceProgramRunnerTest {
     final String inputPath = createInput();
     final File outputDir = new File(tmpFolder.newFolder(), "output");
 
-    ApplicationSpecification spec = Specifications.from(new AppWithMapReduce());
-    dataSetInstantiator.setDataSets(spec.getDatasets().values());
     final KeyValueTable jobConfigTable = dataSetInstantiator.getDataSet("jobConfig");
 
     // write config into dataset
@@ -229,8 +223,6 @@ public class MapReduceProgramRunnerTest {
   private void testSuccess(boolean frequentFlushing) throws Exception {
     final ApplicationWithPrograms app = AppFabricTestHelper.deployApplicationWithManager(AppWithMapReduce.class,
                                                                                          TEMP_FOLDER_SUPPLIER);
-    ApplicationSpecification spec = Specifications.from(new AppWithMapReduce());
-    dataSetInstantiator.setDataSets(spec.getDatasets().values());
 
     // we need to do a "get" on all datasets we use so that they are in dataSetInstantiator.getTransactionAware()
     final TimeseriesTable table = (TimeseriesTable) dataSetInstantiator.getDataSet("timeSeries");
@@ -300,8 +292,6 @@ public class MapReduceProgramRunnerTest {
 
     final ApplicationWithPrograms app = AppFabricTestHelper.deployApplicationWithManager(AppWithMapReduce.class,
                                                                                          TEMP_FOLDER_SUPPLIER);
-    ApplicationSpecification spec = Specifications.from(new AppWithMapReduce());
-    dataSetInstantiator.setDataSets(spec.getDatasets().values());
 
     // we need to do a "get" on all datasets we use so that they are in dataSetInstantiator.getTransactionAware()
     final TimeseriesTable table = (TimeseriesTable) dataSetInstantiator.getDataSet("timeSeries");

--- a/app-fabric/src/test/java/co/cask/cdap/runtime/MultiConsumerTest.java
+++ b/app-fabric/src/test/java/co/cask/cdap/runtime/MultiConsumerTest.java
@@ -17,14 +17,12 @@
 package co.cask.cdap.runtime;
 
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
-import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data.dataset.DataSetInstantiator;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
-import co.cask.cdap.internal.app.Specifications;
 import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
 import co.cask.cdap.internal.app.runtime.ProgramRunnerFactory;
 import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
@@ -37,7 +35,6 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Longs;
-import org.apache.twill.filesystem.LocationFactory;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -81,14 +78,11 @@ public class MultiConsumerTest {
       controllers.add(runner.run(program, new SimpleProgramOptions(program)));
     }
 
-    LocationFactory locationFactory = AppFabricTestHelper.getInjector().getInstance(LocationFactory.class);
     DatasetFramework datasetFramework = AppFabricTestHelper.getInjector().getInstance(DatasetFramework.class);
 
     DataSetInstantiator dataSetInstantiator =
       new DataSetInstantiator(datasetFramework, CConfiguration.create(),
                               getClass().getClassLoader());
-    ApplicationSpecification spec = Specifications.from(new MultiApp());
-    dataSetInstantiator.setDataSets(spec.getDatasets().values());
 
     final KeyValueTable accumulated = dataSetInstantiator.getDataSet("accumulated");
     TransactionExecutorFactory txExecutorFactory =

--- a/data-fabric/src/main/java/co/cask/cdap/data/dataset/DataSetInstantiator.java
+++ b/data-fabric/src/main/java/co/cask/cdap/data/dataset/DataSetInstantiator.java
@@ -60,8 +60,6 @@ public class DataSetInstantiator implements DataSetContext {
   private final DatasetFramework datasetFramework;
   // the class loader to use for data set classes
   private final ClassLoader classLoader;
-  // the known data set specifications
-  private final Map<String, DatasetCreationSpec> datasetsV2 = Maps.newHashMap();
   private final Set<TransactionAware> txAware = Sets.newIdentityHashSet();
   // in this collection we have only datasets initialized with getDataSet() which is OK for now...
   private final Map<TransactionAware, String> txAwareToMetricNames = Maps.newIdentityHashMap();
@@ -89,14 +87,6 @@ public class DataSetInstantiator implements DataSetContext {
   public <T extends Closeable> T getDataSet(String name, Map<String, String> arguments)
     throws DataSetInstantiationException {
     return (T) getDataSet(name, arguments, this.datasetFramework);
-  }
-
-  public void setDataSets(Iterable<DatasetCreationSpec> creationSpec) {
-    for (DatasetCreationSpec spec : creationSpec) {
-      if (spec != null) {
-        this.datasetsV2.put(spec.getInstanceName(), spec);
-      }
-    }
   }
 
   /**

--- a/data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtil.java
+++ b/data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtil.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.data2.datafabric.dataset;
 
 import co.cask.cdap.api.dataset.Dataset;
-import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DatasetManagementException;
@@ -73,14 +72,5 @@ public final class DatasetsUtil {
         throw Throwables.propagate(e);
       }
     }
-  }
-
-  /**
-   * Performs an upgrade of a dataset instance.
-   */
-  public static void upgradeDataset(DatasetFramework datasetFramework, String instanceName, ClassLoader cl)
-    throws Exception {
-    DatasetAdmin admin = datasetFramework.getAdmin(instanceName, cl);
-    admin.upgrade();
   }
 }

--- a/unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
+++ b/unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.test.internal;
 
-import co.cask.cdap.app.ApplicationSpecification;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.lang.ApiResourceListHolder;
 import co.cask.cdap.common.lang.ClassLoaders;
@@ -89,8 +88,7 @@ public class DefaultApplicationManager implements ApplicationManager {
                                    TemporaryFolder tempFolder,
                                    @Assisted("accountId") String accountId,
                                    @Assisted("applicationId") String applicationId,
-                                   @Assisted Location deployedJar,
-                                   @Assisted ApplicationSpecification appSpec) {
+                                   @Assisted Location deployedJar) {
     this.accountId = accountId;
     this.applicationId = applicationId;
     this.streamWriterFactory = streamWriterFactory;
@@ -108,7 +106,6 @@ public class DefaultApplicationManager implements ApplicationManager {
     } catch (IOException e) {
       throw Throwables.propagate(e);
     }
-    this.dataSetInstantiator.setDataSets(appSpec.getDatasets().values());
   }
 
   @Override


### PR DESCRIPTION
was looking at were the dataset metrics context should be properly passed - found some old piece that can be mis-used: we never want to create datasets at runtime of the program - not at this point
