### PR TITLE
[2.5] [DOCS] Fix the doc build.

### DIFF
--- a/docs/developer-guide/source/conf.py
+++ b/docs/developer-guide/source/conf.py
@@ -17,7 +17,7 @@ import subprocess
 
 def get_sdk_version():
     # Sets the CDAP Build Version via maven
-    mvn_version_cmd = "mvn help:evaluate -o -Dexpression=project.version -f ../../../ | grep -v '^\['"
+    mvn_version_cmd = "mvn help:evaluate -o -Dexpression=project.version -f ../../../pom.xml | grep -v '^\['"
     version = None
     try:
         version = subprocess.check_output(mvn_version_cmd, shell=True).strip().replace("-SNAPSHOT", "")


### PR DESCRIPTION
Somehow this (pom.xml) was missing from earlier versions of this file. And, for some strange reason, the docs built correctly. Until T-rex tried it. But now it's fixed.
