### PR TITLE
(REACTOR-827) Provide way to specify start/end time of stream events to be used in MapReduce job.

### DIFF
--- a/api/src/main/java/co/cask/cdap/api/data/stream/StreamBatchReadable.java
+++ b/api/src/main/java/co/cask/cdap/api/data/stream/StreamBatchReadable.java
@@ -18,8 +18,13 @@ package co.cask.cdap.api.data.stream;
 import co.cask.cdap.api.data.batch.BatchReadable;
 import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.data.batch.SplitReader;
+import co.cask.cdap.api.mapreduce.MapReduceContext;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
 
+import java.net.URI;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This class is for using a Stream as input for a MapReduce job. An instance of this class should be set in the
@@ -39,9 +44,60 @@ import java.util.List;
  */
 public class StreamBatchReadable implements BatchReadable<Long, String> {
 
+  private static final String START_TIME_KEY = "start";
+  private static final String END_TIME_KEY = "end";
+
   private final String streamName;
   private final long startTime;
   private final long endTime;
+
+  /**
+   * Specifies to use the given stream as input of a MapReduce job. Same as calling
+   * {@link #useStreamInput(co.cask.cdap.api.mapreduce.MapReduceContext, String, long, long)
+   * useStreamInput(context, streamName, 0L, Long.MAX_VALUE)}
+   */
+  public static void useStreamInput(MapReduceContext context, String streamName) {
+    useStreamInput(context, streamName, 0L, Long.MAX_VALUE);
+  }
+
+  /**
+   * Specifies to use the given stream as input of a MapReduce job.
+   *
+   * @param context The context of the MapReduce job
+   * @param streamName Name of the stream
+   * @param startTime Start timestamp in milliseconds (inclusive) of stream events provided to the job
+   * @param endTime End timestamp in milliseconds (exclusive) of stream events provided to the job
+   */
+  public static void useStreamInput(MapReduceContext context, String streamName, long startTime, long endTime) {
+    context.setInput(URI.create(String.format("stream://%s?%s=%d&%s=%d",
+                                              streamName, START_TIME_KEY, startTime, END_TIME_KEY, endTime)).toString(),
+                     null);
+  }
+
+  /**
+   * Creates a StreamBatchReadable with the given URI. The URI should be in the form
+   *
+   * <pre>
+   * {@code
+   * stream://<stream_name>[?start=<start_time>[&end=<end_time>]]
+   * }
+   * </pre>
+   */
+  public StreamBatchReadable(URI uri) {
+    Preconditions.checkArgument("stream".equals(uri.getScheme()));
+    streamName = uri.getHost();
+
+    String query = uri.getQuery();
+    if (query != null && !query.isEmpty()) {
+      Map<String, String> parameters = Splitter.on('&').withKeyValueSeparator("=").split(query);
+
+      startTime = parameters.containsKey(START_TIME_KEY) ? Long.parseLong(parameters.get(START_TIME_KEY)) : 0L;
+      endTime = parameters.containsKey(END_TIME_KEY) ? Long.parseLong(parameters.get(END_TIME_KEY)) : Long.MAX_VALUE;
+    } else {
+      startTime = 0L;
+      endTime = Long.MAX_VALUE;
+    }
+  }
 
   /**
    * Constructs an instance with the given stream name with all time range.
@@ -60,9 +116,8 @@ public class StreamBatchReadable implements BatchReadable<Long, String> {
    * @param endTime End timestamp in milliseconds.
    */
   public StreamBatchReadable(String streamName, long startTime, long endTime) {
-    this.streamName = streamName;
-    this.startTime = startTime;
-    this.endTime = endTime;
+    this(URI.create(String.format("stream://%s?%s=%d&%s=%d",
+                                  streamName, START_TIME_KEY, startTime, END_TIME_KEY, endTime)));
   }
 
   public String getStreamName() {

--- a/app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -90,6 +90,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -517,7 +518,7 @@ public class MapReduceProgramRunner implements ProgramRunner {
     if (inputDataSetName != null) {
       // TODO: It's a hack for stream
       if (inputDataSetName.startsWith("stream://")) {
-        StreamBatchReadable stream = new StreamBatchReadable(inputDataSetName.substring("stream://".length()));
+        StreamBatchReadable stream = new StreamBatchReadable(URI.create(inputDataSetName));
         StreamConfig streamConfig = streamAdmin.getConfig(stream.getStreamName());
         Location streamPath = StreamUtils.createGenerationLocation(streamConfig.getLocation(),
                                                                    StreamUtils.getGeneration(streamConfig));

--- a/unit-test/src/test/java/co/cask/cdap/batch/stream/TestBatchStreamIntegrationApp.java
+++ b/unit-test/src/test/java/co/cask/cdap/batch/stream/TestBatchStreamIntegrationApp.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.annotation.ProcessInput;
 import co.cask.cdap.api.app.AbstractApplication;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.stream.Stream;
+import co.cask.cdap.api.data.stream.StreamBatchReadable;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.flow.Flow;
 import co.cask.cdap.api.flow.FlowSpecification;
@@ -67,7 +68,6 @@ public class TestBatchStreamIntegrationApp extends AbstractApplication {
       return MapReduceSpecification.Builder.with()
         .setName("StreamTestBatch")
         .setDescription("Batch job for testing batch stream read")
-        .useInputDataSet("stream://s1")
         .useOutputDataSet("results")
         .build();
     }
@@ -79,6 +79,8 @@ public class TestBatchStreamIntegrationApp extends AbstractApplication {
       job.setMapOutputKeyClass(Text.class);
       job.setMapOutputValueClass(Text.class);
       job.setReducerClass(StreamTestBatchReducer.class);
+
+      StreamBatchReadable.useStreamInput(context, "s1");
     }
   }
 


### PR DESCRIPTION
The ability to do so was removed by removing a deprecated API, without providing a new one.
