### PR TITLE
(CDAP-355) Insecurely pass user id from router to downstream services

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/WebappProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/WebappProgramRunner.java
@@ -20,7 +20,9 @@ import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.http.CommonNettyHttpServiceBuilder;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.proto.ProgramType;
@@ -63,15 +65,18 @@ public class WebappProgramRunner implements ProgramRunner {
   private final DiscoveryService discoveryService;
   private final InetAddress hostname;
   private final WebappHttpHandlerFactory webappHttpHandlerFactory;
+  private final CConfiguration cConf;
 
   @Inject
   public WebappProgramRunner(ServiceAnnouncer serviceAnnouncer, DiscoveryService discoveryService,
                              @Named(Constants.AppFabric.SERVER_ADDRESS) InetAddress hostname,
-                             WebappHttpHandlerFactory webappHttpHandlerFactory) {
+                             WebappHttpHandlerFactory webappHttpHandlerFactory,
+                             CConfiguration cConf) {
     this.serviceAnnouncer = serviceAnnouncer;
     this.discoveryService = discoveryService;
     this.hostname = hostname;
     this.webappHttpHandlerFactory = webappHttpHandlerFactory;
+    this.cConf = cConf;
   }
 
   @Override
@@ -92,7 +97,7 @@ public class WebappProgramRunner implements ProgramRunner {
       // Start netty server
       // TODO: add metrics reporting
       JarHttpHandler jarHttpHandler = webappHttpHandlerFactory.createHandler(program.getJarLocation());
-      NettyHttpService.Builder builder = NettyHttpService.builder();
+      NettyHttpService.Builder builder = new CommonNettyHttpServiceBuilder(cConf);
       builder.addHttpHandlers(ImmutableSet.of(jarHttpHandler));
       builder.setUrlRewriter(new WebappURLRewriter(jarHttpHandler));
       builder.setHost(hostname.getCanonicalHostName());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
@@ -20,6 +20,7 @@ import co.cask.cdap.app.runtime.ProgramRuntimeService;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.hooks.MetricsReporterHook;
+import co.cask.cdap.common.http.CommonNettyHttpServiceBuilder;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.common.logging.ServiceLoggingContext;
 import co.cask.cdap.common.metrics.MetricsCollectionService;
@@ -98,7 +99,7 @@ public final class AppFabricServer extends AbstractIdleService {
     programRuntimeService.start();
 
     // Run http service on random port
-    httpService = NettyHttpService.builder()
+    httpService = new CommonNettyHttpServiceBuilder(configuration)
       .setHost(hostname.getCanonicalHostName())
       .setHandlerHooks(ImmutableList.of(new MetricsReporterHook(metricsCollectionService,
                                                                 Constants.Service.APP_FABRIC_HTTP)))

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -391,7 +391,11 @@ public final class Constants {
    * Security configuration.
    */
   public static final class Security {
-    /** Enables Kerberos authentication */
+    /** Enables security. */
+    public static final String ENABLED = "security.enabled";
+    /** Enables authorization. */
+    public static final String AUTHORIZATION_ENABLED = "security.authorization.enabled";
+    /** Enables Kerberos authentication. */
     public static final String KERBEROS_ENABLED = "kerberos.auth.enabled";
     /** Algorithm used to generate the digest for access tokens. */
     public static final String TOKEN_DIGEST_ALGO = "security.token.digest.algorithm";
@@ -412,8 +416,6 @@ public final class Constants {
     /** Long lasting Access token expiration time in milliseconds. */
     public static final String EXTENDED_TOKEN_EXPIRATION = "security.server.extended.token.expiration.ms";
     public static final String CFG_FILE_BASED_KEYFILE_PATH = "security.data.keyfile.path";
-    /** Configuration for enabling the security. */
-    public static final String CFG_SECURITY_ENABLED = "security.enabled";
     /** Configuration for security realm. */
     public static final String CFG_REALM = "security.realm";
     /** Authentication Handler class name */
@@ -426,6 +428,14 @@ public final class Constants {
     public static final String BASIC_REALM_FILE = "security.authentication.basic.realmfile";
     /** Enables SSL */
     public static final String SSL_ENABLED = "ssl.enabled";
+
+    /**
+     * Headers for security.
+     */
+    public static final class Headers {
+      /** Internal user ID header passed from Router to downstream services */
+      public static final String USER_ID = "CDAP-UserId";
+    }
 
     /**
      * Security configuration for Router.

--- a/cdap-common/src/main/java/co/cask/cdap/common/http/AuthenticationChannelHandler.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/http/AuthenticationChannelHandler.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.common.http;
+
+import co.cask.cdap.common.conf.Constants;
+import org.jboss.netty.channel.ChannelFuture;
+import org.jboss.netty.channel.ChannelFutureListener;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.Channels;
+import org.jboss.netty.channel.ExceptionEvent;
+import org.jboss.netty.channel.MessageEvent;
+import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
+import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
+import org.jboss.netty.handler.codec.http.HttpChunk;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponse;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.jboss.netty.handler.codec.http.HttpVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.security.auth.login.CredentialNotFoundException;
+
+/**
+ * An UpstreamHandler that verifies the userId in a request header and updates the {@code SecurityRequestContext}.
+ */
+public class AuthenticationChannelHandler extends SimpleChannelUpstreamHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(AuthenticationChannelHandler.class);
+
+  private String currentUserId;
+
+  /**
+   * Decode the AccessTokenIdentifier passed as a header and set it in a ThreadLocal.
+   * Returns a 401 if the identifier is malformed. 
+   */
+  @Override
+  public void messageReceived(ChannelHandlerContext ctx, MessageEvent e) throws Exception {
+    Object message = e.getMessage();
+    if (message instanceof HttpRequest) {
+      // TODO: authenticate the user using user id - CDAP-688
+      HttpRequest request = (HttpRequest) message;
+      String userIdHeader = request.getHeader(Constants.Security.Headers.USER_ID);
+      if (userIdHeader == null) {
+        throw new CredentialNotFoundException("No userId was found in request.");
+      }
+
+      currentUserId = userIdHeader;
+      SecurityRequestContext.setUserId(userIdHeader);
+    } else if (message instanceof HttpChunk) {
+      if (currentUserId == null) {
+        throw new CredentialNotFoundException("No userId was found in request.");
+      }
+      SecurityRequestContext.setUserId(currentUserId);
+    }
+
+    super.messageReceived(ctx, e);
+  }
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent e) {
+    LOG.error("Got exception: ", e);
+    ChannelFuture future = Channels.future(ctx.getChannel());
+    future.addListener(ChannelFutureListener.CLOSE);
+    // TODO: add WWW-Authenticate header for 401 response -  REACTOR-900
+    HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.UNAUTHORIZED);
+    Channels.write(ctx, future, response);
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/http/CommonNettyHttpServiceBuilder.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/http/CommonNettyHttpServiceBuilder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.common.http;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.http.NettyHttpService;
+import com.google.common.base.Function;
+import com.google.inject.Inject;
+import org.jboss.netty.channel.ChannelPipeline;
+
+/**
+ * Provides a {@link NettyHttpService.Builder} that has common settings built-in.
+ */
+public class CommonNettyHttpServiceBuilder extends NettyHttpService.Builder {
+  public CommonNettyHttpServiceBuilder(CConfiguration configuration) {
+    super();
+    if (configuration.getBoolean(Constants.Security.AUTHORIZATION_ENABLED)) {
+      this.modifyChannelPipeline(new Function<ChannelPipeline, ChannelPipeline>() {
+        @Override
+        public ChannelPipeline apply(ChannelPipeline input) {
+          input.addAfter("decoder", "authenticator", new AuthenticationChannelHandler());
+          return input;
+        }
+      });
+    }
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/http/SecurityRequestContext.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/http/SecurityRequestContext.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.common.http;
+
+/**
+ * RequestContext that maintains a ThreadLocal with references to {@code AccessTokenIdentifier}.
+ */
+public final class SecurityRequestContext {
+  private static final ThreadLocal<String> userId = new InheritableThreadLocal<String>();
+
+  private SecurityRequestContext() {
+  }
+
+  /**
+   * @return the userId set on the current thread
+   */
+  public static String getUserId() {
+    return userId.get();
+  }
+
+  /**
+   * Set the userId on the current thread.
+   * @param userIdParam userId to be set
+   */
+  public static void setUserId(String userIdParam) {
+    userId.set(userIdParam);
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/kerberos/SecurityUtil.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/kerberos/SecurityUtil.java
@@ -134,6 +134,6 @@ public final class SecurityUtil {
    */
   public static boolean isKerberosEnabled(CConfiguration cConf) {
     return cConf.getBoolean(Constants.Security.KERBEROS_ENABLED,
-                            cConf.getBoolean(Constants.Security.CFG_SECURITY_ENABLED));
+                            cConf.getBoolean(Constants.Security.ENABLED));
   }
 }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1008,6 +1008,12 @@
   </property>
 
   <property>
+      <name>security.authorization.enabled</name>
+      <value>false</value>
+      <description>If this is set to true, authorization checks will be made</description>
+  </property>
+
+  <property>
     <name>kerberos.auth.enabled</name>
     <value>${security.enabled}</value>
     <description>If true, Kerberos authentication will be enabled</description>

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHttpService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHttpService.java
@@ -18,6 +18,7 @@ package co.cask.cdap.data.stream.service;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.hooks.MetricsReporterHook;
+import co.cask.cdap.common.http.CommonNettyHttpServiceBuilder;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.common.logging.ServiceLoggingContext;
 import co.cask.cdap.common.metrics.MetricsCollectionService;
@@ -60,7 +61,7 @@ public final class StreamHttpService extends AbstractIdleService {
     this.janitorService = janitorService;
 
     int workerThreads = cConf.getInt(Constants.Stream.WORKER_THREADS, 10);
-    this.httpService = NettyHttpService.builder()
+    this.httpService = new CommonNettyHttpServiceBuilder(cConf)
       .addHttpHandlers(handlers)
       .setHandlerHooks(ImmutableList.of(new MetricsReporterHook(metricsCollectionService,
                                                                 Constants.Stream.STREAM_HANDLER)))

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetService.java
@@ -19,6 +19,7 @@ package co.cask.cdap.data2.datafabric.dataset.service;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.hooks.MetricsReporterHook;
+import co.cask.cdap.common.http.CommonNettyHttpServiceBuilder;
 import co.cask.cdap.common.metrics.MetricsCollectionService;
 import co.cask.cdap.data2.datafabric.dataset.instance.DatasetInstanceManager;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
@@ -82,10 +83,9 @@ public class DatasetService extends AbstractExecutionThreadService {
                         DatasetExploreFacade datasetExploreFacade,
                         Set<DatasetMetricsReporter> metricReporters) throws Exception {
 
-    NettyHttpService.Builder builder = NettyHttpService.builder();
-
     this.typeManager = typeManager;
 
+    NettyHttpService.Builder builder = new CommonNettyHttpServiceBuilder(cConf);
     builder.addHttpHandlers(ImmutableList.of(new DatasetTypeHandler(typeManager, locationFactory, cConf),
                                              new DatasetInstanceHandler(typeManager, instanceManager, opExecutorClient,
                                                                         datasetExploreFacade, cConf)));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorService.java
@@ -19,6 +19,7 @@ package co.cask.cdap.data2.datafabric.dataset.service.executor;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.hooks.MetricsReporterHook;
+import co.cask.cdap.common.http.CommonNettyHttpServiceBuilder;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.common.logging.ServiceLoggingContext;
 import co.cask.cdap.common.metrics.MetricsCollectionService;
@@ -59,7 +60,7 @@ public class DatasetOpExecutorService extends AbstractIdleService {
     int workerThreads = cConf.getInt(Constants.Dataset.Executor.WORKER_THREADS, 10);
     int execThreads = cConf.getInt(Constants.Dataset.Executor.EXEC_THREADS, 10);
 
-    this.httpService = NettyHttpService.builder()
+    this.httpService = new CommonNettyHttpServiceBuilder(cConf)
       .addHttpHandlers(handlers)
       .setHost(cConf.get(Constants.Dataset.Executor.ADDRESS))
       .setHandlerHooks(ImmutableList.of(

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorService.java
@@ -19,6 +19,7 @@ package co.cask.cdap.explore.executor;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.hooks.MetricsReporterHook;
+import co.cask.cdap.common.http.CommonNettyHttpServiceBuilder;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.common.logging.ServiceLoggingContext;
 import co.cask.cdap.common.metrics.MetricsCollectionService;
@@ -65,7 +66,7 @@ public class ExploreExecutorService extends AbstractIdleService {
     int workerThreads = cConf.getInt(Constants.Explore.WORKER_THREADS, 10);
     int execThreads = cConf.getInt(Constants.Explore.EXEC_THREADS, 10);
 
-    this.httpService = NettyHttpService.builder()
+    this.httpService = new CommonNettyHttpServiceBuilder(cConf)
         .addHttpHandlers(handlers)
         .setHost(cConf.get(Constants.Explore.SERVER_ADDRESS))
         .setHandlerHooks(ImmutableList.of(

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/NettyRouter.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/NettyRouter.java
@@ -124,7 +124,7 @@ public class NettyRouter extends AbstractIdleService {
     this.serviceToPortMap = Maps.newHashMap();
 
     this.serviceLookup = serviceLookup;
-    this.securityEnabled = cConf.getBoolean(Constants.Security.CFG_SECURITY_ENABLED, false);
+    this.securityEnabled = cConf.getBoolean(Constants.Security.ENABLED, false);
     this.realm = cConf.get(Constants.Security.CFG_REALM);
     this.tokenValidator = tokenValidator;
     this.accessTokenTransformer = accessTokenTransformer;

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterMain.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterMain.java
@@ -62,7 +62,7 @@ public class RouterMain extends DaemonMain {
       // Load configuration
       CConfiguration cConf = CConfiguration.create();
 
-      if (cConf.getBoolean(Constants.Security.CFG_SECURITY_ENABLED)) {
+      if (cConf.getBoolean(Constants.Security.ENABLED)) {
         // Enable Kerberos login
         SecurityUtil.enableKerberosLogin(cConf);
       }

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/SecurityAuthenticationHttpHandler.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/SecurityAuthenticationHttpHandler.java
@@ -153,6 +153,8 @@ public class SecurityAuthenticationHttpHandler extends SimpleChannelHandler {
       logEntry.setUserName(accessTokenIdentifierPair.getAccessTokenIdentifierObj().getUsername());
       msg.setHeader(HttpHeaders.Names.AUTHORIZATION,
                     "CDAP-verified " + accessTokenIdentifierPair.getAccessTokenIdentifierStr());
+      msg.setHeader(Constants.Security.Headers.USER_ID,
+                    accessTokenIdentifierPair.getAccessTokenIdentifierObj().getUsername());
       return true;
     }
   }

--- a/cdap-security/src/main/java/co/cask/cdap/security/runtime/AuthenticationServerMain.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/runtime/AuthenticationServerMain.java
@@ -54,7 +54,7 @@ public class AuthenticationServerMain extends DaemonMain {
                                              new ZKClientModule());
     configuration = injector.getInstance(CConfiguration.class);
 
-    if (configuration.getBoolean(Constants.Security.CFG_SECURITY_ENABLED)) {
+    if (configuration.getBoolean(Constants.Security.ENABLED)) {
       this.zkClientService = injector.getInstance(ZKClientService.class);
       this.authServer = injector.getInstance(ExternalAuthenticationServer.class);
     }

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -112,7 +112,7 @@ public class StandaloneMain {
     streamHttpService = injector.getInstance(StreamHttpService.class);
 
     sslEnabled = configuration.getBoolean(Constants.Security.SSL_ENABLED);
-    securityEnabled = configuration.getBoolean(Constants.Security.CFG_SECURITY_ENABLED);
+    securityEnabled = configuration.getBoolean(Constants.Security.ENABLED);
     if (securityEnabled) {
       externalAuthenticationServer = injector.getInstance(ExternalAuthenticationServer.class);
     }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MetricsProcessorStatusService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MetricsProcessorStatusService.java
@@ -19,6 +19,7 @@ package co.cask.cdap.metrics.process;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.hooks.MetricsReporterHook;
+import co.cask.cdap.common.http.CommonNettyHttpServiceBuilder;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.common.logging.ServiceLoggingContext;
 import co.cask.cdap.common.metrics.MetricsCollectionService;
@@ -53,7 +54,7 @@ public class MetricsProcessorStatusService extends AbstractIdleService {
                                         Set<HttpHandler> handlers,
                                         MetricsCollectionService metricsCollectionService) {
     this.discoveryService = discoveryService;
-    this.httpService = NettyHttpService.builder()
+    this.httpService = new CommonNettyHttpServiceBuilder(cConf)
       .addHttpHandlers(handlers)
       .setHandlerHooks(ImmutableList.of(new MetricsReporterHook(metricsCollectionService,
                         Constants.MetricsProcessor.METRICS_PROCESSOR_STATUS_HANDLER)))

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsQueryService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsQueryService.java
@@ -19,6 +19,7 @@ package co.cask.cdap.metrics.query;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.hooks.MetricsReporterHook;
+import co.cask.cdap.common.http.CommonNettyHttpServiceBuilder;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.common.logging.ServiceLoggingContext;
 import co.cask.cdap.common.metrics.MetricsCollectionService;
@@ -59,7 +60,7 @@ public class MetricsQueryService extends AbstractIdleService {
     int bossthreads = cConf.getInt(Constants.Metrics.BOSS_THREADS, 1);
     int workerthreads = cConf.getInt(Constants.Metrics.WORKER_THREADS, 10);
 
-    NettyHttpService.Builder builder = NettyHttpService.builder();
+    NettyHttpService.Builder builder = new CommonNettyHttpServiceBuilder(cConf);
     builder.addHttpHandlers(handlers);
     builder.setHandlerHooks(ImmutableList.of(new MetricsReporterHook(metricsCollectionService,
                                                                      Constants.Service.METRICS)));


### PR DESCRIPTION
This insecurely sets the user id received in the headers as a `ThreadLocal` in `SecurityRequestContext`.

`AuthenticationChannelHandler` is added as a channel pipeline modifier in `BaseNettyHttpServiceTemplate.get()` which all of our services have been changed to use instead of `NettyHttpService.builder()`.
