### PR TITLE
[2.5] Spark Integration: SparkJobWrapper loads user class with custom classloader

### DIFF
--- a/app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkJobWrapper.java
+++ b/app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkJobWrapper.java
@@ -69,7 +69,9 @@ public class SparkJobWrapper {
   public SparkJobWrapper(String[] args) {
     arguments = validateArgs(args);
     try {
-      userJobClass = Class.forName(arguments[0]);
+      // get the Spark job main class with the custom classloader created by spark which has the program and
+      // dependency jar.
+      userJobClass = Class.forName(arguments[0], true, Thread.currentThread().getContextClassLoader());
     } catch (ClassNotFoundException cnfe) {
       LOG.warn("Unable to find the user job class: {}", arguments[0], cnfe);
       throw Throwables.propagate(cnfe);


### PR DESCRIPTION
We need to specify a custom class loader which includes Spark Program and CDAP dependencies when we load Spark job main class else we get ClassNotFoundException.
