### PR TITLE
Loading screen in data explore screen

### DIFF
--- a/web-app/client/assets/css/new/main.css
+++ b/web-app/client/assets/css/new/main.css
@@ -4263,6 +4263,8 @@ div.tooltip-inner {
 
 .object-list-empty.dataexplore-nodataset {
   position: relative;
+  height:500px;
+  padding-top:20px;
 }
 
 #goto-btn {

--- a/web-app/client/index.html
+++ b/web-app/client/index.html
@@ -588,7 +588,7 @@
       </div>
 
   {{ else }}
-    <div class="object-list-empty dataexplore-nodataset" style="height:500px;padding-top:20px;">
+    <div class="object-list-empty dataexplore-nodataset">
       {{#if C.showLoadingIcon}}
       <div class="loading-icon">
           <div class="overlay-background">


### PR DESCRIPTION
The loading icon in data explore screen now occupies only the section that is being loaded and not the entire screen.

http://ajai-hivetablestest9421-1000.dev.continuuity.net:9999/#/dataexplore/query

The changes in the cluster have UI updates but I think there are some backend fixes that needs to be checked in. The cluster shows visually how the loading animation will look.
