### PR TITLE
Spark Integration: Ranaming JavaSparkJob and ScalaSparkJob

### DIFF
--- a/api/src/main/java/co/cask/cdap/api/spark/JavaSparkProgram.java
+++ b/api/src/main/java/co/cask/cdap/api/spark/JavaSparkProgram.java
@@ -19,13 +19,13 @@ package co.cask.cdap.api.spark;
 import java.io.Serializable;
 
 /**
- * Defines an interface for User's Spark job written in Scala
+ * Defines an interface for User's Spark job written in Java
  * This interface extends serializable because the closures are anonymous class in Java and Spark Serializes the
  * closures before sending it to worker nodes. This serialization of inner anonymous class expects the outer
  * containing class to be serializable else java.io.NotSerializableException is thrown. We do not expect user job
  * class to be serializable so we serialize this interface which user job class implements to have a neater API.
  */
-public interface ScalaSparkJob extends Serializable {
+public interface JavaSparkProgram extends Serializable {
   /**
    * User Spark job which will be executed
    *

--- a/api/src/main/java/co/cask/cdap/api/spark/ScalaSparkProgram.java
+++ b/api/src/main/java/co/cask/cdap/api/spark/ScalaSparkProgram.java
@@ -19,13 +19,13 @@ package co.cask.cdap.api.spark;
 import java.io.Serializable;
 
 /**
- * Defines an interface for User's Spark job written in Java
+ * Defines an interface for User's Spark job written in Scala
  * This interface extends serializable because the closures are anonymous class in Java and Spark Serializes the
  * closures before sending it to worker nodes. This serialization of inner anonymous class expects the outer
  * containing class to be serializable else java.io.NotSerializableException is thrown. We do not expect user job
  * class to be serializable so we serialize this interface which user job class implements to have a neater API.
  */
-public interface JavaSparkJob extends Serializable {
+public interface ScalaSparkProgram extends Serializable {
   /**
    * User Spark job which will be executed
    *

--- a/app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramWrapper.java
+++ b/app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkProgramWrapper.java
@@ -16,8 +16,8 @@
 
 package co.cask.cdap.internal.app.runtime.spark;
 
-import co.cask.cdap.api.spark.JavaSparkJob;
-import co.cask.cdap.api.spark.ScalaSparkJob;
+import co.cask.cdap.api.spark.JavaSparkProgram;
+import co.cask.cdap.api.spark.ScalaSparkProgram;
 import co.cask.cdap.api.spark.SparkContext;
 import com.google.common.base.Throwables;
 import org.slf4j.Logger;
@@ -40,7 +40,7 @@ import java.lang.reflect.Method;
  * </li>
  * <li>
  * Sets {@link SparkContext} to concrete implementation of {@link JavaSparkContext} if user job implements {@link
- * JavaSparkJob} or to {@link ScalaSparkContext} if user's job implements {@link ScalaSparkJob}
+ * JavaSparkProgram} or to {@link ScalaSparkContext} if user's job implements {@link ScalaSparkProgram}
  * </li>
  * <li>
  * Run user's job with extracted arguments from the argument list
@@ -135,16 +135,16 @@ public class SparkProgramWrapper {
 
   /**
    * Sets the {@link SparkContext} to {@link JavaSparkContext} or to {@link ScalaSparkContext} depending on whether
-   * the user class implements {@link JavaSparkJob} or {@link ScalaSparkJob}
+   * the user class implements {@link JavaSparkProgram} or {@link ScalaSparkProgram}
    */
   public void setSparkContext() {
-    if (JavaSparkJob.class.isAssignableFrom(userJobClass)) {
+    if (JavaSparkProgram.class.isAssignableFrom(userJobClass)) {
       sparkContext = new JavaSparkContext();
-    } else if (ScalaSparkJob.class.isAssignableFrom(userJobClass)) {
+    } else if (ScalaSparkProgram.class.isAssignableFrom(userJobClass)) {
       sparkContext = new ScalaSparkContext();
       scalaJobFlag = true;
     } else {
-      throw new IllegalArgumentException("User's Spark Job must implement either JavaSparkJob or ScalaSparkJob");
+      throw new IllegalArgumentException("User's Spark Job must implement either JavaSparkProgram or ScalaSparkProgram");
     }
   }
 


### PR DESCRIPTION
@poornachandra : Reason for the change: Spark uses the term "job" for operation/transformations which are sent to workers. So a Spark program can have n number of jobs. We want to be clear about this in our class naming.

@anew: I want to get this in as soon as possible because these APIs are being used in the example and other places a lot.

I will do the other internal renaming in a different PR and send it through.
