### PR TITLE
Make sure new ChannelBuffer is created on every channel event 

### DIFF
--- a/data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
+++ b/data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
@@ -188,9 +188,8 @@ public final class StreamHandler extends AuthenticatedHttpHandler {
   public void asyncEnqueue(HttpRequest request, HttpResponder responder,
                            @PathParam("stream") final String stream) throws Exception {
     String accountId = getAuthenticatedAccountId(request);
-    // No need to copy the content buffer as the netty-http library always uses a ChannelBufferFactory
-    // that won't reuse buffer. Until that is changed, it is safe to do it without copying the bytes.
-    // TODO: See ENG-4171 for fix in netty-http library
+    // No need to copy the content buffer as we always uses a ChannelBufferFactory that won't reuse buffer.
+    // See StreamHttpService
     streamWriter.asyncEnqueue(accountId, stream,
                               getHeaders(request, stream), request.getContent().toByteBuffer(), asyncExecutor);
     responder.sendStatus(HttpResponseStatus.ACCEPTED);

--- a/data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHttpService.java
+++ b/data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHttpService.java
@@ -32,6 +32,7 @@ import com.google.inject.name.Named;
 import org.apache.twill.common.Cancellable;
 import org.apache.twill.discovery.Discoverable;
 import org.apache.twill.discovery.DiscoveryService;
+import org.jboss.netty.buffer.HeapChannelBufferFactory;
 
 import java.net.InetSocketAddress;
 import java.util.Set;
@@ -65,8 +66,10 @@ public final class StreamHttpService extends AbstractIdleService {
                                                                 Constants.Stream.STREAM_HANDLER)))
       .setHost(cConf.get(Constants.Stream.ADDRESS))
       .setWorkerThreadPoolSize(workerThreads)
-      .setExecThreadPoolSize(0)
+      .setExecThreadPoolSize(0)         // Execution happens in the io worker thread directly
       .setConnectionBacklog(20000)
+      .setChannelConfig("child.bufferFactory",
+                        HeapChannelBufferFactory.getInstance()) // ChannelBufferFactory that always creates new Buffer
       .build();
   }
 


### PR DESCRIPTION
so that buffer content doesn't needs to be copied for async operation.
