### PR TITLE
[DOCS] Update docs to reflect forced transactions for handlers

### DIFF
--- a/docs/developer-guide/source/advanced.rst
+++ b/docs/developer-guide/source/advanced.rst
@@ -56,7 +56,7 @@ Service Handlers
 You add handlers to your Service by calling the ``addHandler`` method in the Service's ``configure`` method.
 
 To use a Dataset within a handler, specify the Dataset by calling the ``useDataset`` method in the Service's
-``configure`` method and add the ``@UseDataSet`` annotation to obtain an instance of the Dataset.
+``configure`` method and include the ``@UseDataSet`` annotation in the handler to obtain an instance of the Dataset.
 Each request to a method is committed as a single transaction.
 
 ::


### PR DESCRIPTION
Update to docs to reflect an API change: Handler methods are now forced to be transactional. 

Also fixed a line that was a bit ambiguous. "...and add the `@UseDataSet` annotation to the handler to obtain an instance of..." implies that the annotation is added to the handler, which isn't the case. 
