### PR TITLE
Feature/script use cdap site

### DIFF
--- a/data-fabric/bin/dfbench
+++ b/data-fabric/bin/dfbench
@@ -31,10 +31,4 @@ SAVED="`pwd`"
 cd "`dirname \"$PRG\"`/.."
 APP_HOME="`pwd -P`"
 
-# Add conf directory
-CDAP_CONF=${CDAP_CONF:-/etc/cdap/conf}
-if [ -d "$CDAP_CONF" ]; then
-  CLASSPATH=$CLASSPATH:"$CDAP_CONF"
-fi
-
 java -cp @classpath@ co.cask.cdap.performance.benchmark.BenchmarkRunner "$@"

--- a/data-fabric/bin/tx-debugger
+++ b/data-fabric/bin/tx-debugger
@@ -49,11 +49,10 @@ else
 fi
 
 # Load the configuration too.
-if [ -d "$conf" ]; then
-  CLASSPATH=$CLASSPATH:"$conf"/
-fi
 if [ -d "$CDAP_CONF" ]; then
   CLASSPATH=$CLASSPATH:"$CDAP_CONF"
+elif [ -d "$conf" ]; then
+  CLASSPATH=$CLASSPATH:"$conf"/
 fi
 
 auth_file="$HOME/.cdap.accesstoken"

--- a/data-fabric/bin/tx-test-main.sh
+++ b/data-fabric/bin/tx-test-main.sh
@@ -67,11 +67,10 @@ else
 fi
 
 # Load the configuration too.
-if [ -d "$conf" ]; then
-  CLASSPATH=$CLASSPATH:"$conf"/
-fi
 if [ -d "$CDAP_CONF" ]; then
   CLASSPATH=$CLASSPATH:"$CDAP_CONF"
+elif [ -d "$conf" ]; then
+  CLASSPATH=$CLASSPATH:"$conf"/
 fi
 
 # Set Log location

--- a/gateway/bin/accesstoken-client
+++ b/gateway/bin/accesstoken-client
@@ -51,11 +51,10 @@ else
 fi
 
 # Load the configuration too.
-if [ -d "$conf" ]; then
-  CLASSPATH=$CLASSPATH:"$conf"/
-fi
 if [ -d "$CDAP_CONF" ]; then
   CLASSPATH=$CLASSPATH:"$CDAP_CONF"
+elif [ -d "$conf" ]; then
+  CLASSPATH=$CLASSPATH:"$conf"/
 fi
 
 auth_file="$HOME/.cdap.accesstoken"

--- a/gateway/bin/flume-client
+++ b/gateway/bin/flume-client
@@ -50,11 +50,10 @@ else
 fi
 
 # Load the configuration too.
-if [ -d "$conf" ]; then
-  CLASSPATH=$CLASSPATH:"$conf"/
-fi
 if [ -d "$CDAP_CONF" ]; then
   CLASSPATH=$CLASSPATH:"$CDAP_CONF"
+elif [ -d "$conf" ]; then
+  CLASSPATH=$CLASSPATH:"$conf"/
 fi
 
 java -cp ${CLASSPATH} -Dscript=$script co.cask.cdap.gateway.tools.FlumeClient "$@"

--- a/gateway/bin/meta-client
+++ b/gateway/bin/meta-client
@@ -50,11 +50,10 @@ else
 fi
 
 # Load the configuration too.
-if [ -d "$conf" ]; then
-  CLASSPATH=$CLASSPATH:"$conf"/
-fi
 if [ -d "$CDAP_CONF" ]; then
   CLASSPATH=$CLASSPATH:"$CDAP_CONF"
+elif [ -d "$conf" ]; then
+  CLASSPATH=$CLASSPATH:"$conf"/
 fi
 
 auth_file="$HOME/.cdap.accesstoken"

--- a/web-app/bin/config-tool
+++ b/web-app/bin/config-tool
@@ -50,11 +50,10 @@ else
 fi
 
 # Load the configuration too.
-if [ -d "$conf" ]; then
-  CLASSPATH=$CLASSPATH:"$conf"/:/etc/cdap/conf
-fi
 if [ -d "$CDAP_CONF" ]; then
   CLASSPATH=$CLASSPATH:"$CDAP_CONF"
+elif [ -d "$conf" ]; then
+  CLASSPATH=$CLASSPATH:"$conf"/
 fi
 
 auth_file="$HOME/.cdap.accesstoken"


### PR DESCRIPTION
Changed shell scripts to check for an env variable for the cdap-site.xml file location and add that to the classpath. If not env variable is found, then it defaults to "/etc/cdap/conf"
