### PR TITLE
Feature/open close dataset unit test small fix

### DIFF
--- a/app-fabric/src/test/java/co/cask/cdap/runtime/OpenCloseDataSetTest.java
+++ b/app-fabric/src/test/java/co/cask/cdap/runtime/OpenCloseDataSetTest.java
@@ -88,6 +88,7 @@ public class OpenCloseDataSetTest {
 
   @Test(timeout = 120000)
   public void testDataSetsAreClosed() throws Exception {
+    final String tableName = "cdap.user.foo";
     TrackingTable.resetTracker();
     ApplicationWithPrograms app = AppFabricTestHelper.deployApplicationWithManager(DummyAppWithTrackingTable.class,
                                                                                    TEMP_FOLDER_SUPPLIER);
@@ -127,14 +128,14 @@ public class OpenCloseDataSetTest {
     ((TransactionAware) producer).commitTx();
     txSystemClient.commit(tx);
 
-    while (TrackingTable.getTracker("cdap.user.foo", "write") < 4) {
+    while (TrackingTable.getTracker(tableName, "write") < 4) {
       TimeUnit.MILLISECONDS.sleep(50);
     }
 
     // get the number of writes to the foo table
-    Assert.assertEquals(4, TrackingTable.getTracker("cdap.user.foo", "write"));
+    Assert.assertEquals(4, TrackingTable.getTracker(tableName, "write"));
     // only the flow has started with s single flowlet (procedure is loaded lazily on 1sy request
-    Assert.assertEquals(1, TrackingTable.getTracker("cdap.user.foo", "open"));
+    Assert.assertEquals(1, TrackingTable.getTracker(tableName, "open"));
 
     // now send a request to the procedure
     Gson gson = new Gson();
@@ -158,15 +159,15 @@ public class OpenCloseDataSetTest {
     Assert.assertEquals("x1", responseContent);
 
     // now the dataset must have a read and another open operation
-    Assert.assertEquals(1, TrackingTable.getTracker("cdap.user.foo", "read"));
-    Assert.assertEquals(2, TrackingTable.getTracker("cdap.user.foo", "open"));
-    Assert.assertEquals(0, TrackingTable.getTracker("cdap.user.foo", "close"));
+    Assert.assertEquals(1, TrackingTable.getTracker(tableName, "read"));
+    Assert.assertEquals(2, TrackingTable.getTracker(tableName, "open"));
+    Assert.assertEquals(0, TrackingTable.getTracker(tableName, "close"));
 
     // stop flow and procedure, they shuld both close the data set foo
     for (ProgramController controller : controllers) {
       controller.stop().get();
     }
-    Assert.assertEquals(2, TrackingTable.getTracker("cdap.user.foo", "close"));
+    Assert.assertEquals(2, TrackingTable.getTracker(tableName, "close"));
 
     // now start the m/r job
     // start the flow and procedure
@@ -187,9 +188,9 @@ public class OpenCloseDataSetTest {
     // M/r job is done, one mapper and the m/r client should have opened and closed the data set foo
     // we don't know the exact number of times opened, but it is at least once, and it must be closed the same number
     // of times.
-    Assert.assertTrue(2 < TrackingTable.getTracker("cdap.user.foo", "open"));
-    Assert.assertEquals(TrackingTable.getTracker("cdap.user.foo", "open"),
-                        TrackingTable.getTracker("cdap.user.foo", "close"));
+    Assert.assertTrue(2 < TrackingTable.getTracker(tableName, "open"));
+    Assert.assertEquals(TrackingTable.getTracker(tableName, "open"),
+                        TrackingTable.getTracker(tableName, "close"));
     Assert.assertTrue(0 < TrackingTable.getTracker("cdap.user.bar", "open"));
     Assert.assertEquals(TrackingTable.getTracker("cdap.user.bar", "open"),
                         TrackingTable.getTracker("cdap.user.bar", "close"));


### PR DESCRIPTION
Fix OpenCloseDatasetTest which was ignored before. The table name was not complete before, causing the failure.
https://jira.continuuity.com/browse/REACTOR-690
