### PR TITLE
Marking ServiceWorker APIs with @beta. Removing relevant docs.

### DIFF
--- a/api/src/main/java/co/cask/cdap/api/service/AbstractService.java
+++ b/api/src/main/java/co/cask/cdap/api/service/AbstractService.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.api.service;
 
+import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.service.http.HttpServiceHandler;
 
 /**
@@ -68,6 +69,7 @@ public abstract class AbstractService implements Service {
    * Add a worker to the Service.
    * @param worker for the service.
    */
+  @Beta
   protected void addWorker(ServiceWorker worker) {
     configurer.addWorker(worker);
   }
@@ -76,6 +78,7 @@ public abstract class AbstractService implements Service {
    * Add a list of workers to the Service.
    * @param workers for the service.
    */
+  @Beta
   protected void addWorkers(Iterable<? extends ServiceWorker> workers) {
     configurer.addWorkers(workers);
   }

--- a/api/src/main/java/co/cask/cdap/api/service/AbstractServiceWorker.java
+++ b/api/src/main/java/co/cask/cdap/api/service/AbstractServiceWorker.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.api.service;
 
+import co.cask.cdap.api.annotation.Beta;
 import com.google.common.collect.ImmutableMap;
 import org.apache.twill.api.ResourceSpecification;
 
@@ -24,6 +25,7 @@ import java.util.Map;
 /**
  * Extend this class to add workers to a custom Service.
  */
+@Beta
 public abstract class AbstractServiceWorker implements ServiceWorker {
   private ServiceWorkerContext context;
 

--- a/api/src/main/java/co/cask/cdap/api/service/ServiceWorker.java
+++ b/api/src/main/java/co/cask/cdap/api/service/ServiceWorker.java
@@ -17,10 +17,12 @@
 package co.cask.cdap.api.service;
 
 import co.cask.cdap.api.ProgramLifecycle;
+import co.cask.cdap.api.annotation.Beta;
 
 /**
  * Workers for user services must implement this interface.
  */
+@Beta
 public interface ServiceWorker extends Runnable, ProgramLifecycle<ServiceWorkerContext> {
 
   /**

--- a/docs/developer-guide/source/advanced.rst
+++ b/docs/developer-guide/source/advanced.rst
@@ -15,10 +15,9 @@ Cask Data Application Platform (CDAP) Application. Developers can implement Cust
 to interface with a legacy system and perform additional processing beyond the CDAP processing
 paradigms. Examples could include running an IP-to-Geo lookup and serving user-profiles.
 
-Services are implemented by extending ``AbstractService``. They consist of ``HttpServiceHandler`` \s to serve requests
-and ``ServiceWorker`` \s to passively execute tasks on behalf of the Service.
+Services are implemented by extending ``AbstractService``, which consists of ``HttpServiceHandler`` \s to serve requests.
 
-You can add services to your application by calling the ``addService`` method in the
+You can add Services to your application by calling the ``addService`` method in the
 Application's ``configure`` method::
 
   public class AnalyticsApp extends AbstractApplication {
@@ -45,7 +44,6 @@ Application's ``configure`` method::
       setDescription("Service to lookup locations of IP addresses.");
       useDataset("IPGeoTable");
       addHandler(new IPGeoLookupHandler());
-      addWorker(new LogCleanupWorker();
     }
   }
 
@@ -74,53 +72,6 @@ method with ``@Transactional``. Each request to that method is then committed as
       responder.sendString(200, location, Charsets.UTF_8);
     }
   }
-
-Service Workers
-----------------
-``ServiceWorker`` \s are used to execute tasks and act passively on behalf of the ``Service``.
-Each worker runs in its own YARN container and their instances may be updated via the CDAP Console or the REST APIs.
-
-You add workers to your Service by calling the ``addWorker`` method in the Service's ``configure`` method.
-
-::
-
-  public class LogCleanupWorker extends AbstractServiceWorker {
-
-    @Override
-    public void stop() {
-      ...
-    }
-
-    @Override
-    public void destroy() {
-      ...
-    }
-
-    @Override
-    public void run() {
-      // Cleanup and rotate logs.
-      ...
-    }
-  }
-
-Workers can access and use ``Dataset`` \s via a ``DataSetContext`` inside their ``run`` method.
-
-::
-
-    @Override
-    public void run() {
-      getContext().execute(new TxRunnable(){
-        @Override
-        public void run(DataSetContext context) {
-          Dataset dataset = context.getDataSet("table");
-          ...
-        }
-      });
-    }
-
-Operations executed on ``Dataset`` \s within a  ``run`` are committed as part of a single transaction.
-The transaction is started before ``run`` is invoked and is committed upon successful execution. Exceptions thrown
-while committing the transaction or thrown by user-code result in a rollback of the transaction.
 
 Service Discovery
 -----------------


### PR DESCRIPTION
Since ServiceWorker's aren't a fully built feature yet, we're marking all exposed APIs as `@Beta` and removing the relevant documentation. 

The docs will be reintroduced as public when we complete the feature.
