### PR TITLE
CYB #9: Removed SNAPSHOT from doc

### DIFF
--- a/archetypes/cdap-spark-java-archetype/README.md
+++ b/archetypes/cdap-spark-java-archetype/README.md
@@ -16,7 +16,7 @@ To create a project from the archetype, use this script as an example:
  mvn archetype:generate 					
   -DarchetypeGroupId=co.cask.cdap 			
   -DarchetypeArtifactId=cdap-spark-java-archetype 	
-  -DarchetypeVersion=2.5.0-SNAPSHOT
+  -DarchetypeVersion=2.5.0
   -DgroupId=com.example
   -DartifactId=SparkPageRankExample
   -Dversion=1.0						


### PR DESCRIPTION
This is the change to the merge I did from CYB: https://github.com/caskco/cdap/pull/304

The SNAPSHOT here is in README file and our script will not update it during release when we get rid of SNAPSHOT from everywhere so fixing it now.
