### PR TITLE
use JKS as default keystore type

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1071,11 +1071,6 @@
     <value>10010</value>
   </property>
 
-  <property>
-    <name>security.auth.server.ssl.keystore.type</name>
-    <value>JKS</value>
-  </property>
-
   <!-- Router configuration-->
 
   <property>

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/NettyRouter.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/NettyRouter.java
@@ -152,7 +152,7 @@ public class NettyRouter extends AbstractIdleService {
                                      + sConf.get(Constants.Security.Router.SSL_KEYSTORE_PATH));
       }
       this.sslHandlerFactory = new SSLHandlerFactory(
-        keystore, sConf.get(Constants.Security.Router.SSL_KEYSTORE_TYPE),
+        keystore, sConf.get(Constants.Security.Router.SSL_KEYSTORE_TYPE, "JKS"),
         sConf.get(Constants.Security.Router.SSL_KEYSTORE_PASSWORD),
         sConf.get(Constants.Security.Router.SSL_KEYPASSWORD));
     } else {

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/ExternalAuthenticationServer.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/ExternalAuthenticationServer.java
@@ -157,7 +157,7 @@ public class ExternalAuthenticationServer extends AbstractExecutionThreadService
         SslContextFactory sslContextFactory = new SslContextFactory();
         String keyStorePath = sConfiguration.get(Constants.Security.AuthenticationServer.SSL_KEYSTORE_PATH);
         String keyStorePassword = sConfiguration.get(Constants.Security.AuthenticationServer.SSL_KEYSTORE_PASSWORD);
-        String keyStoreType = sConfiguration.get(Constants.Security.AuthenticationServer.SSL_KEYSTORE_TYPE);
+        String keyStoreType = sConfiguration.get(Constants.Security.AuthenticationServer.SSL_KEYSTORE_TYPE, "JKS");
         String keyPassword = sConfiguration.get(Constants.Security.AuthenticationServer.SSL_KEYPASSWORD);
 
         Preconditions.checkArgument(keyStorePath != null, "Key Store Path Not Configured");


### PR DESCRIPTION
Use JKS as default keystore type, remove the unwanted JKS type property in the cdap-default.xml as the type is read from security config always.
