### PR TITLE
Wait longer for MR job to finish.

### DIFF
--- a/cdap-examples/Purchase/src/test/java/co/cask/cdap/examples/purchase/PurchaseAppTest.java
+++ b/cdap-examples/Purchase/src/test/java/co/cask/cdap/examples/purchase/PurchaseAppTest.java
@@ -67,7 +67,7 @@ public class PurchaseAppTest extends TestBase {
     // Run PurchaseHistoryWorkflow which will process the data
     MapReduceManager mapReduceManager = appManager.startMapReduce("PurchaseHistoryWorkflow_PurchaseHistoryBuilder",
                                                                   ImmutableMap.<String, String>of());
-    mapReduceManager.waitForFinish(60, TimeUnit.SECONDS);
+    mapReduceManager.waitForFinish(3, TimeUnit.MINUTES);
 
     // Start PurchaseProcedure and query
     ProcedureManager procedureManager = appManager.startProcedure("PurchaseProcedure");


### PR DESCRIPTION
Because of changes in MR that the "start" call would returns much faster than it used to be, the wait for finish time need to accompany for the time to submit the MR job.
