### PR TITLE
[CDAP-331] Allows more flexibility on the data type for consuming from stream for MapReduce

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/data/stream/StreamBatchReadable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/stream/StreamBatchReadable.java
@@ -18,11 +18,21 @@ package co.cask.cdap.api.data.stream;
 import co.cask.cdap.api.data.batch.BatchReadable;
 import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.data.batch.SplitReader;
+import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
+import co.cask.cdap.api.stream.StreamEventDecoder;
+import com.google.common.base.Charsets;
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.util.List;
 import java.util.Map;
 
@@ -46,10 +56,12 @@ public class StreamBatchReadable implements BatchReadable<Long, String> {
 
   private static final String START_TIME_KEY = "start";
   private static final String END_TIME_KEY = "end";
+  private static final String DECODER_KEY = "decoder";
 
   private final String streamName;
   private final long startTime;
   private final long endTime;
+  private final String decoderType;
 
   /**
    * Specifies to use the given stream as input of a MapReduce job. Same as calling
@@ -62,6 +74,13 @@ public class StreamBatchReadable implements BatchReadable<Long, String> {
 
   /**
    * Specifies to use the given stream as input of a MapReduce job.
+   * <p/>
+   * The {@code Mapper} or {@code Reducer} class
+   * that reads from the Stream needs to have the {@code KEYIN} type as {@code LongWritable}, which
+   * will carry timestamp of the {@link StreamEvent}.
+   * <p/>
+   * The {@code VALUEIN} type can be {@code BytesWritable} or {@code Text}. For {@code Text} value type,
+   * the {@link StreamEvent} body will be decoded as UTF-8 String.
    *
    * @param context The context of the MapReduce job
    * @param streamName Name of the stream
@@ -69,9 +88,53 @@ public class StreamBatchReadable implements BatchReadable<Long, String> {
    * @param endTime End timestamp in milliseconds (exclusive) of stream events provided to the job
    */
   public static void useStreamInput(MapReduceContext context, String streamName, long startTime, long endTime) {
-    context.setInput(URI.create(String.format("stream://%s?%s=%d&%s=%d",
-                                              streamName, START_TIME_KEY, startTime, END_TIME_KEY, endTime)).toString(),
-                     null);
+    URI uri = createStreamURI(streamName, ImmutableMap.<String, Object>of(START_TIME_KEY, startTime,
+                                                                          END_TIME_KEY, endTime));
+    context.setInput(uri.toString(), null);
+  }
+
+  /**
+   * Specifies to use the given stream as input of a MapReduce job, with a custom {@link StreamEventDecoder} to
+   * decode {@link StreamEvent} into key/value pairs.
+   *
+   * @param context The context of the MapReduce job
+   * @param streamName Name of the stream
+   * @param startTime Start timestamp in milliseconds (inclusive) of stream events provided to the job
+   * @param endTime End timestamp in milliseconds (exclusive) of stream events provided to the job
+   * @param decoderType The {@link StreamEventDecoder} class for decoding {@link StreamEvent}
+   */
+  public static void useStreamInput(MapReduceContext context, String streamName,
+                                    long startTime, long endTime, Class<? extends StreamEventDecoder> decoderType) {
+    URI uri = createStreamURI(streamName, ImmutableMap.<String, Object>of(START_TIME_KEY, startTime,
+                                                                          END_TIME_KEY, endTime,
+                                                                          DECODER_KEY, decoderType.getName()));
+    context.setInput(uri.toString(), null);
+  }
+
+  /**
+   * Constructs an {@link URI} that represents the stream input.
+   *
+   * @param streamName Name of the stream
+   * @param arguments A map containing the arguments of the URI.
+   */
+  private static URI createStreamURI(String streamName, Map<String, Object> arguments) {
+    // It forms the query string for all key/value pairs in the arguments map
+    // It encodes both key and value using the URLEncoder
+    String queryString = Joiner.on('&').join(
+      Iterables.transform(arguments.entrySet(), new Function<Map.Entry<String, Object>, String>() {
+        @Override
+        public String apply(Map.Entry<String, Object> entry) {
+          try {
+            return String.format("%s=%s",
+                                 URLEncoder.encode(entry.getKey(), Charsets.UTF_8.name()),
+                                 URLEncoder.encode(entry.getValue().toString(), Charsets.UTF_8.name()));
+          } catch (UnsupportedEncodingException e) {
+            // Shouldn't happen as UTF-8 should always supported.
+            throw Throwables.propagate(e);
+          }
+        }
+      }));
+    return URI.create(String.format("stream://%s?%s", streamName, queryString));
   }
 
   /**
@@ -79,7 +142,7 @@ public class StreamBatchReadable implements BatchReadable<Long, String> {
    *
    * <pre>
    * {@code
-   * stream://<stream_name>[?start=<start_time>[&end=<end_time>]]
+   * stream://<stream_name>[?start=<start_time>[&end=<end_time>[&decoder=<decoderClass>]]]
    * }
    * </pre>
    */
@@ -93,9 +156,11 @@ public class StreamBatchReadable implements BatchReadable<Long, String> {
 
       startTime = parameters.containsKey(START_TIME_KEY) ? Long.parseLong(parameters.get(START_TIME_KEY)) : 0L;
       endTime = parameters.containsKey(END_TIME_KEY) ? Long.parseLong(parameters.get(END_TIME_KEY)) : Long.MAX_VALUE;
+      decoderType = parameters.get(DECODER_KEY);
     } else {
       startTime = 0L;
       endTime = Long.MAX_VALUE;
+      decoderType = null;
     }
   }
 
@@ -130,6 +195,10 @@ public class StreamBatchReadable implements BatchReadable<Long, String> {
 
   public long getEndTime() {
     return endTime;
+  }
+
+  public String getDecoderType() {
+    return decoderType;
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapperWrapper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapperWrapper.java
@@ -26,6 +26,9 @@ import co.cask.cdap.internal.app.runtime.MetricsFieldSetter;
 import co.cask.cdap.internal.lang.Reflections;
 import com.google.common.base.Throwables;
 import com.google.common.reflect.TypeToken;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.lib.map.WrappedMapper;
 import org.slf4j.Logger;
@@ -39,9 +42,23 @@ import java.util.concurrent.TimeUnit;
  */
 public class MapperWrapper extends Mapper {
 
-  public static final String ATTR_MAPPER_CLASS = "c.mapper.class";
+  private static final String ATTR_MAPPER_CLASS = "c.mapper.class";
 
   private static final Logger LOG = LoggerFactory.getLogger(MapperWrapper.class);
+
+  /**
+   * Wraps the mapper defined in the job with this {@link MapperWrapper} if it is defined.
+   * @param job
+   */
+  public static void wrap(Job job) {
+    // NOTE: we don't use job.getMapperClass() as we don't need to load user class here
+    Configuration conf = job.getConfiguration();
+    String mapClass = conf.get(MRJobConfig.MAP_CLASS_ATTR);
+    if (mapClass != null) {
+      conf.set(MapperWrapper.ATTR_MAPPER_CLASS, mapClass);
+      job.setMapperClass(MapperWrapper.class);
+    }
+  }
 
   @SuppressWarnings("unchecked")
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/ReducerWrapper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/ReducerWrapper.java
@@ -26,6 +26,9 @@ import co.cask.cdap.internal.app.runtime.MetricsFieldSetter;
 import co.cask.cdap.internal.lang.Reflections;
 import com.google.common.base.Throwables;
 import com.google.common.reflect.TypeToken;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.Reducer;
 import org.apache.hadoop.mapreduce.lib.reduce.WrappedReducer;
 import org.slf4j.Logger;
@@ -39,9 +42,24 @@ import java.util.concurrent.TimeUnit;
  */
 public class ReducerWrapper extends Reducer {
 
-  public static final String ATTR_REDUCER_CLASS = "c.reducer.class";
+  private static final String ATTR_REDUCER_CLASS = "c.reducer.class";
 
   private static final Logger LOG = LoggerFactory.getLogger(MapperWrapper.class);
+
+  /**
+   * Wraps the mapper defined in the job with this {@link MapperWrapper} if it is defined.
+   * @param job
+   */
+  public static void wrap(Job job) {
+    // NOTE: we don't use job.getReducerClass() as we don't need to load user class here
+    Configuration conf = job.getConfiguration();
+    String reducerClass = conf.get(MRJobConfig.REDUCE_CLASS_ATTR);
+    if (reducerClass != null) {
+      conf.set(ReducerWrapper.ATTR_REDUCER_CLASS, reducerClass);
+      job.setReducerClass(ReducerWrapper.class);
+    }
+  }
+
 
   @SuppressWarnings("unchecked")
   @Override

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamInputFormatTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamInputFormatTest.java
@@ -15,6 +15,7 @@
  */
 package co.cask.cdap.data.stream;
 
+import co.cask.cdap.api.stream.StreamEventDecoder;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
@@ -285,7 +286,13 @@ public class StreamInputFormatTest {
   /**
    * StreamInputFormat for testing.
    */
-  private static final class TestStreamInputFormat extends TextStreamInputFormat {
+  private static final class TestStreamInputFormat extends StreamInputFormat<LongWritable, Text> {
+
+    @Override
+    protected StreamEventDecoder<LongWritable, Text> createStreamEventDecoder(Configuration conf) {
+      return new TextStreamEventDecoder();
+    }
+
     @Override
     protected long getCurrentTime() {
       return CURRENT_TIME;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/BytesStreamEventDecoder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/BytesStreamEventDecoder.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.stream;
+
+import co.cask.cdap.api.flow.flowlet.StreamEvent;
+import co.cask.cdap.api.stream.StreamEventDecoder;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.LongWritable;
+
+import java.nio.ByteBuffer;
+
+/**
+ * A {@link StreamEventDecoder} that decodes {@link StreamEvent} into {@link LongWritable} as key
+ * and {@link BytesWritable} as value for Mapper input. The key carries the event timestamp, while
+ * the value is the stream event body.
+ */
+public final class BytesStreamEventDecoder implements StreamEventDecoder<LongWritable, BytesWritable> {
+
+  private final LongWritable key = new LongWritable();
+  private BytesWritable value = new BytesWritable();
+
+  @Override
+  public DecodeResult<LongWritable, BytesWritable> decode(StreamEvent event,
+                                                          DecodeResult<LongWritable, BytesWritable> result) {
+    key.set(event.getTimestamp());
+    value = getEventBody(event, value);
+    return result.setKey(key).setValue(value);
+  }
+
+  private BytesWritable getEventBody(StreamEvent event, BytesWritable result) {
+    ByteBuffer body = event.getBody();
+    if (body.hasArray()) {
+      // If the ByteBuffer is backed by an array, which is exactly the same as exposed by the ByteBuffer
+      // simply use the back array. No copying is needed (because read from stream->mapper is synchronous).
+      // Creating a new BytesWritable is more efficient as it doesn't need to do array copy,
+      // which BytesWritable.set() does.
+      if (body.array().length == body.remaining()) {
+        return new BytesWritable(body.array());
+      }
+      // Otherwise, need to copy the byte[], done by the BytesWritable.set() method
+      result.set(body.array(), body.arrayOffset() + body.position(), body.remaining());
+      return result;
+    }
+
+    // Otherwise, need to copy to a new array
+    byte[] copy = new byte[body.remaining()];
+    body.mark();
+    body.get(copy);
+    body.reset();
+    return new BytesWritable(copy);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/TextStreamEventDecoder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/TextStreamEventDecoder.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.data.stream;
 
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
@@ -22,22 +23,19 @@ import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 
 /**
- * An {@link StreamInputFormat} that decode {@link StreamEvent} into timestamp and body text.
+ * A {@link StreamEventDecoder} that decodes {@link StreamEvent} into {@link LongWritable} as key and {@link Text} as
+ * value for Mapper input. The key carries the event timestamp, while the text value is a UTF-8 decode of the
+ * event body.
  */
-public class TextStreamInputFormat extends StreamInputFormat<LongWritable, Text> {
+public final class TextStreamEventDecoder implements StreamEventDecoder<LongWritable, Text> {
+
+  private final LongWritable key = new LongWritable();
+  private final Text value = new Text();
 
   @Override
-  protected StreamEventDecoder<LongWritable, Text> createStreamEventDecoder() {
-    return new StreamEventDecoder<LongWritable, Text>() {
-      private final LongWritable key = new LongWritable();
-      private final Text value = new Text();
-
-      @Override
-      public DecodeResult<LongWritable, Text> decode(StreamEvent event, DecodeResult<LongWritable, Text> result) {
-        key.set(event.getTimestamp());
-        value.set(Charsets.UTF_8.decode(event.getBody()).toString());
-        return result.setKey(key).setValue(value);
-      }
-    };
+  public DecodeResult<LongWritable, Text> decode(StreamEvent event, DecodeResult<LongWritable, Text> result) {
+    key.set(event.getTimestamp());
+    value.set(Charsets.UTF_8.decode(event.getBody()).toString());
+    return result.setKey(key).setValue(value);
   }
 }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/NoMapperApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/NoMapperApp.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.batch.stream;
+
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.data.stream.Stream;
+import co.cask.cdap.api.data.stream.StreamBatchReadable;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.mapreduce.AbstractMapReduce;
+import co.cask.cdap.api.mapreduce.MapReduceContext;
+import co.cask.cdap.api.mapreduce.MapReduceSpecification;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Reducer;
+
+import java.io.IOException;
+
+/**
+ * A Test application that has one MapReduce which doesn't have Mapper.
+ */
+public class NoMapperApp extends AbstractApplication {
+
+  @Override
+  public void configure() {
+    addStream(new Stream("nomapper"));
+    createDataset("results", KeyValueTable.class);
+    addMapReduce(new NoMapperMapReduce());
+  }
+
+  /**
+   * A MapReduce without a Mapper.
+   */
+  public static final class NoMapperMapReduce extends AbstractMapReduce {
+
+    @Override
+    public MapReduceSpecification configure() {
+      return MapReduceSpecification.Builder.with()
+        .setName("NoMapperMapReduce")
+        .setDescription("No Mapper MapReduce Job")
+        .useOutputDataSet("results")
+        .build();
+    }
+
+    @Override
+    public void beforeSubmit(MapReduceContext context) throws Exception {
+      Job job = context.getHadoopJob();
+      job.setReducerClass(NoMapperReducer.class);
+      StreamBatchReadable.useStreamInput(context, "nomapper");
+    }
+  }
+
+  /**
+   * Reducer to read from stream and write to the output KeyValueTable with stream body as both key and value.
+   */
+  public static final class NoMapperReducer extends Reducer<LongWritable, Text, byte[], byte[]> {
+    @Override
+    protected void reduce(LongWritable key, Iterable<Text> values,
+                          Context context) throws IOException, InterruptedException {
+      for (Text value : values) {
+        byte[] bytes = value.copyBytes();
+        context.write(bytes, bytes);
+      }
+    }
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/TestBatchStreamIntegration.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/TestBatchStreamIntegration.java
@@ -16,11 +16,17 @@
 
 package co.cask.cdap.batch.stream;
 
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.MapReduceManager;
 import co.cask.cdap.test.StreamWriter;
 import co.cask.cdap.test.TestBase;
 import co.cask.cdap.test.XSlowTests;
+import com.google.common.base.Charsets;
+import com.google.common.reflect.TypeToken;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -43,7 +49,43 @@ public class TestBatchStreamIntegration extends TestBase {
       MapReduceManager mapReduceManager = applicationManager.startMapReduce("StreamTestBatch");
       mapReduceManager.waitForFinish(2, TimeUnit.MINUTES);
 
-      // TODO: verify results
+      // The MR job simply turns every stream event body into key/value pairs, with key==value.
+      DataSetManager<KeyValueTable> datasetManager = applicationManager.getDataSet("results");
+      KeyValueTable results = datasetManager.get();
+      for (int i = 0; i < 50; i++) {
+        byte[] key = String.valueOf(i).getBytes(Charsets.UTF_8);
+        Assert.assertArrayEquals(key, results.read(key));
+      }
+    } finally {
+      applicationManager.stopAll();
+      TimeUnit.SECONDS.sleep(1);
+      clear();
+    }
+  }
+
+  /**
+   * Tests MapReduce that consumes from stream without mapper.
+   */
+  @Test
+  public void testNoMapperStreamInput() throws Exception {
+    ApplicationManager applicationManager = deployApplication(NoMapperApp.class);
+    try {
+      StreamWriter writer = applicationManager.getStreamWriter("nomapper");
+      for (int i = 0; i < 50; i++) {
+        writer.send(String.valueOf(i));
+      }
+
+      MapReduceManager mapReduceManager = applicationManager.startMapReduce("NoMapperMapReduce");
+      mapReduceManager.waitForFinish(2, TimeUnit.MINUTES);
+
+      // The Reducer in the MR simply turns every stream event body into key/value pairs, with key==value.
+      DataSetManager<KeyValueTable> datasetManager = applicationManager.getDataSet("results");
+      KeyValueTable results = datasetManager.get();
+      for (int i = 0; i < 50; i++) {
+        byte[] key = String.valueOf(i).getBytes(Charsets.UTF_8);
+        Assert.assertArrayEquals(key, results.read(key));
+      }
+
     } finally {
       applicationManager.stopAll();
       TimeUnit.SECONDS.sleep(1);


### PR DESCRIPTION
- Added auto-detection based on Mapper/Reducer input type to support Text or BytesWritable to carry stream event body
- Added support for user to provide a custom StreamEventDecoder to transform StreamEvent into Key/Value pair for MR input.
