### PR TITLE
Spark Integration: Trying to fix spark unit tests

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/spark/SparkAppUsingObjectStore.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/spark/SparkAppUsingObjectStore.java
@@ -26,6 +26,7 @@ import co.cask.cdap.api.spark.SparkContext;
 import co.cask.cdap.api.spark.SparkSpecification;
 import com.google.common.base.Throwables;
 import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.PairFunction;
 import scala.Tuple2;
 
@@ -74,6 +75,7 @@ public class SparkAppUsingObjectStore extends AbstractApplication {
 
       // write the character count to dataset
       context.writeToDataset(stringLengths, "count", byte[].class, byte[].class);
+      ((JavaSparkContext) context.getOriginalSparkContext()).stop();
     }
   }
 }

--- a/cdap-app-fabric/src/test/scala/co/cask/cdap/internal/app/runtime/spark/ScalaCharCountProgram.scala
+++ b/cdap-app-fabric/src/test/scala/co/cask/cdap/internal/app/runtime/spark/ScalaCharCountProgram.scala
@@ -34,5 +34,6 @@ class ScalaCharCountProgram extends ScalaSparkProgram {
 
     // write to dataset
     sc.writeToDataset(stringLengths, "count", classOf[Array[Byte]], classOf[Array[Byte]])
+    sc.getOriginalSparkContext.asInstanceOf[org.apache.spark.SparkContext].stop()
   }
 }


### PR DESCRIPTION
Trying to fix spark unit tests by:
- Giving a new data folder according to @poornachandra suggestion.
- Stopping SparkContext in both the jobs in end.

Since they fail on release its hard to replicate and test on other branches. Lets see how it goes :alien: 

Running on bamboo here: https://bamboo-prod.continuuity.com/browse/CDAP-RUT31-10
