### PR TITLE
Dataset: Support delete() in ObjectStore

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/ObjectStore.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/ObjectStore.java
@@ -69,4 +69,10 @@ public interface ObjectStore<T> extends Dataset, BatchReadable<byte[], T>, Batch
    * @return the object if found, or null if not found
    */
   T read(byte[] key);
+
+  /**
+   * Delete the object for the specified key.
+   * @param key key of the object to be deleted
+   */
+  void delete(byte[] key);
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/ObjectStoreDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/ObjectStoreDataset.java
@@ -93,6 +93,11 @@ public class ObjectStoreDataset<T> extends AbstractDataset implements ObjectStor
     return decode(read);
   }
 
+  @Override
+  public void delete(byte[] key) {
+    kvTable.delete(key);
+  }
+
   // this function only exists to reduce the scope of the SuppressWarnings annotation to a single cast.
   @SuppressWarnings("unchecked")
   private TypeToken<T> getTypeToken() {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/IntegerStore.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/IntegerStore.java
@@ -40,4 +40,7 @@ public class IntegerStore extends ObjectStoreDataset<Integer> {
     return super.read(Bytes.toBytes(key));
   }
 
+  public void delete(int key) {
+    super.delete(Bytes.toBytes(key));
+  }
 }


### PR DESCRIPTION
Jira: REACTOR-1021
- Added delete() support in ObjectStore
- Updated ObjectStoreDatasetTest to test delete

Bamboo build: https://bamboo-prod.continuuity.com/browse/CDAP-RUT20-9
