### PR TITLE
Adding cdap-common to cdap-client-tests pom to fix flume dependency.

### DIFF
--- a/cdap-client-tests/pom.xml
+++ b/cdap-client-tests/pom.xml
@@ -31,6 +31,12 @@ the License.
   <dependencies>
     <dependency>
       <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-common</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-client</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>


### PR DESCRIPTION
The test failures were reproducible locally. After the pom change, I verified that the tests now pass on my IDE
