### PR TITLE
Correct cdap.sh messages

### DIFF
--- a/cdap-standalone/bin/cdap.sh
+++ b/cdap-standalone/bin/cdap.sh
@@ -268,7 +268,7 @@ start() {
     echo $! > $pid
 
     check_for_updates
-    echo -n "Starting CDAP ..."
+    echo -n "Starting Standalone CDAP ..."
 
     background_process=$!
     while kill -0 $background_process >/dev/null 2>/dev/null ; do
@@ -306,7 +306,7 @@ start() {
 }
 
 stop() {
-    echo -n "Stopping CDAP ..."
+    echo -n "Stopping Standalone CDAP ..."
     if [ -f $pid ]; then
       pidToKill=`cat $pid`
       # kill -0 == see if the PID exists
@@ -323,7 +323,7 @@ stop() {
       fi
       rm -f $pid
       echo ""
-      echo "CDAP stopped successfully"
+      echo "Standalone CDAP stopped successfully."
     fi
     echo
 }

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -189,15 +189,15 @@ public class StandaloneMain {
     int dashboardPort = sslEnabled ?
       configuration.getInt(Constants.Dashboard.SSL_BIND_PORT) :
       configuration.getInt(Constants.Dashboard.BIND_PORT);
-    System.out.println("Application Server started successfully");
-    System.out.printf("Connect to dashboard at %s://%s:%d\n", protocol, hostname, dashboardPort);
+    System.out.println("Standalone CDAP started successfully.");
+    System.out.printf("Connect to the Console at %s://%s:%d\n", protocol, hostname, dashboardPort);
   }
 
   /**
    * Shutdown the service.
    */
   public void shutDown() {
-    LOG.info("Shutting down the Application Server");
+    LOG.info("Shutting down Standalone CDAP");
 
     try {
       // order matters: first shut down web app 'cause it will stop working after router is down
@@ -289,8 +289,8 @@ public class StandaloneMain {
       main = create(webAppPath);
       main.startUp();
     } catch (Throwable e) {
-      System.err.println("Failed to start server. " + e.getMessage());
-      LOG.error("Failed to start server", e);
+      System.err.println("Failed to start Standalone CDAP. " + e.getMessage());
+      LOG.error("Failed to start Standalone CDAP", e);
       if (main != null) {
         main.shutDown();
       }


### PR DESCRIPTION
Fixes messages in cdap.sh when starting and stopping.
The change is only in cdap.sh, because cdap.bat was already correct.
