### PR TITLE
CDAP-40 Fix IncrementHandlerTest shutdown

### DIFF
--- a/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data2/increment/hbase94/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-0.94/src/test/java/co/cask/cdap/data2/increment/hbase94/IncrementHandlerTest.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -59,6 +60,7 @@ public class IncrementHandlerTest {
     conf = testUtil.getConfiguration();
   }
 
+  @AfterClass
   public static void tearDown() throws Exception {
     testUtil.shutdownMiniCluster();
   }

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementHandlerTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementHandlerTest.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -60,6 +61,7 @@ public class IncrementHandlerTest {
     conf = testUtil.getConfiguration();
   }
 
+  @AfterClass
   public static void tearDown() throws Exception {
     testUtil.shutdownMiniCluster();
   }


### PR DESCRIPTION
IncrementHandlerTest was lacking proper shutdown.

This gets the full test suite of cdap-hbase-compat-0.94 and cdap-hbase-compat-0.96 passing for me locally.  Full bamboo build of the branch: https://builds.cask.co/browse/CDAP-DUT40-2
