### PR TITLE
CDAP-383 Fix configuration of readless increments and add test coverage

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseOrderedTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseOrderedTable.java
@@ -65,7 +65,7 @@ public class HBaseOrderedTable extends BufferingOrderedTable {
 
   public HBaseOrderedTable(String name, ConflictDetection level, Configuration hConf, boolean enableReadlessIncrements)
     throws IOException {
-    super(name, level);
+    super(name, level, enableReadlessIncrements);
 
     hTableName = HBaseTableUtil.getHBaseTableName(name);
     HTable hTable = new HTable(hConf, hTableName);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/ordered/Updates.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/ordered/Updates.java
@@ -90,11 +90,11 @@ public final class Updates {
       if (base instanceof PutValue) {
         PutValue put = (PutValue) base;
         byte[] putBytes = put.getBytes();
-        if (putBytes.length != Bytes.SIZEOF_LONG) {
+        if (putBytes != null && putBytes.length != Bytes.SIZEOF_LONG) {
           throw new NumberFormatException("Attempted to increment a value that is not convertible to long");
         }
 
-        long newValue = Bytes.toLong(putBytes) + increment.getValue();
+        long newValue = (putBytes == null ? 0L : Bytes.toLong(putBytes)) + increment.getValue();
         return new PutValue(Bytes.toBytes(newValue));
       } else if (base instanceof IncrementValue) {
         IncrementValue baseIncrement = (IncrementValue) base;

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/ordered/OrderedTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/ordered/OrderedTableTest.java
@@ -102,6 +102,7 @@ public abstract class OrderedTableTest<T extends OrderedTable> {
     Assert.assertTrue(admin.exists());
     // creation of non-existing table should do nothing
     admin.create();
+    admin.drop();
   }
 
   @Test
@@ -486,6 +487,7 @@ public abstract class OrderedTableTest<T extends OrderedTable> {
     verify(Bytes.toBytes(-6L), myTable.get(R1, C1));
 
     commitAndAssertSuccess(tx, (TransactionAware) myTable);
+    admin.drop();
   }
 
   private void commitAndAssertSuccess(Transaction tx, TransactionAware txAware) throws Exception {


### PR DESCRIPTION
Fixes setting of enableReadlessIncrements flag in BufferingOrderedTable and add test coverage for how increment data is written.  Also adds some test fixes (passage was ordering dependent).
