### PR TITLE
Fixes CDAP-401 - ui bug (metrics page)

### DIFF
--- a/cdap-web-app/client/core/controllers/analyze.js
+++ b/cdap-web-app/client/core/controllers/analyze.js
@@ -106,9 +106,8 @@ define(['../../helpers/chart-helper'], function (chartHelper) {
                       children.push({id: this.id, text: this.text });
                   }
                 });
-                this.children = children;
                 if (children.length) {
-                  data.push(this);
+                  data.push({text: this.text, children: children});
                 }
               });
               query.callback({results: data});


### PR DESCRIPTION
Existing implementation was overwriting the set of all elements with the set of filtered elements, which made future filters not filter from the entire set of elements, but only from the set that remained after the most recent filter.
(Referring to the 'Select Element' functionality on Explore Metrics page of UI).
[Link to issue](https://issues.cask.co/browse/CDAP-401)
