### PR TITLE
CDAP-475 AvroFileLogReader can miss entries with same timestamp

### DIFF
--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/LoggingTester.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/LoggingTester.java
@@ -22,9 +22,10 @@ import co.cask.cdap.logging.filter.Filter;
 import co.cask.cdap.logging.read.Callback;
 import co.cask.cdap.logging.read.LogEvent;
 import co.cask.cdap.logging.read.LogReader;
-import com.google.common.collect.Lists;
 import org.junit.Assert;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
@@ -32,7 +33,6 @@ import java.util.concurrent.CountDownLatch;
  *
  */
 public class LoggingTester {
-
   public void testGetNext(LogReader logReader, LoggingContext loggingContext) throws Exception {
     LogCallback logCallback1 = new LogCallback();
     logReader.getLogNext(loggingContext, -1, 10, Filter.EMPTY_FILTER, logCallback1);
@@ -175,7 +175,7 @@ public class LoggingTester {
     public void init() {
       firstOffset = -1;
       lastOffset = -1;
-      events = Lists.newArrayList();
+      events = Collections.synchronizedList(new ArrayList<LogEvent>());
     }
 
     @Override


### PR DESCRIPTION
Previously, when reading backwards, AvroFileLogReader could skip log entries that had the same timestamp as the first entry in the previous segment that was read.
