### PR TITLE
Spark Integration: Inc spark program timeout in test

### DIFF
--- a/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/TestBatchStreamIntegration.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/TestBatchStreamIntegration.java
@@ -47,7 +47,7 @@ public class TestBatchStreamIntegration extends TestBase {
       }
 
       MapReduceManager mapReduceManager = applicationManager.startMapReduce("StreamTestBatch");
-      mapReduceManager.waitForFinish(2, TimeUnit.MINUTES);
+      mapReduceManager.waitForFinish(5, TimeUnit.MINUTES);
 
       // The MR job simply turns every stream event body into key/value pairs, with key==value.
       DataSetManager<KeyValueTable> datasetManager = applicationManager.getDataSet("results");


### PR DESCRIPTION
To fix failing unit test on develop where spark takes more than 2 minutes. 
