### PR TITLE
Refactor the LDAP classes to have consistent naming

### DIFF
--- a/cdap-docs/admin-manual/source/installation/security.rst
+++ b/cdap-docs/admin-manual/source/installation/security.rst
@@ -245,7 +245,7 @@ properties to ``cdap-site.xml``:
    Property                                             Value
 ====================================================== =========================================================
 security.authentication.handlerClassName                co.cask.cdap.security.server.LDAPAuthenticationHandler
-security.authentication.loginmodule.className           co.cask.cdap.security.server.LdapLoginModule
+security.authentication.loginmodule.className           co.cask.cdap.security.server.LDAPLoginModule
 security.authentication.handler.debug                   true/false
 security.authentication.handler.hostname                <hostname>
 security.authentication.handler.port                    <port>

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/LDAPLoginModule.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/LDAPLoginModule.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.security.server;
 
 import com.google.common.base.Throwables;
+import org.eclipse.jetty.plus.jaas.spi.LdapLoginModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,8 +39,8 @@ import javax.security.auth.spi.LoginModule;
  * A custom {@link LoginModule} that does LDAP authentication. It allows the disabling of SSL
  * certificate verification for connections between the {@link ExternalAuthenticationServer} and an LDAP instance.
  */
-public class LdapLoginModule extends org.eclipse.jetty.plus.jaas.spi.LdapLoginModule {
-  private static final Logger LOG = LoggerFactory.getLogger(LdapLoginModule.class);
+public class LDAPLoginModule extends LdapLoginModule {
+  private static final Logger LOG = LoggerFactory.getLogger(LDAPLoginModule.class);
 
   /**
    * A {@link SocketFactory} that trusts all SSL certificates.

--- a/cdap-security/src/test/java/co/cask/cdap/security/server/ExternalAuthenticationServerTestBase.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/server/ExternalAuthenticationServerTestBase.java
@@ -141,8 +141,8 @@ public abstract class ExternalAuthenticationServerTestBase {
     cConf.setInt(Constants.Security.AUTH_SERVER_PORT, Networks.getRandomPort());
     cConf.setInt(Constants.Security.AuthenticationServer.SSL_PORT, Networks.getRandomPort());
 
-    cConf.set(Constants.Security.AUTH_HANDLER_CLASS, "co.cask.cdap.security.server.LDAPAuthenticationHandler");
-    cConf.set(Constants.Security.LOGIN_MODULE_CLASS_NAME, "co.cask.cdap.security.server.LdapLoginModule");
+    cConf.set(Constants.Security.AUTH_HANDLER_CLASS, LDAPAuthenticationHandler.class.getName());
+    cConf.set(Constants.Security.LOGIN_MODULE_CLASS_NAME, LDAPLoginModule.class.getName());
     cConf.set(configBase.concat("debug"), "true");
     cConf.set(configBase.concat("hostname"), "localhost");
     cConf.set(configBase.concat("port"), Integer.toString(ldapPort));


### PR DESCRIPTION
The documentation was a bit awkward cause our internal classes used both `LDAP` and `Ldap`. This makes it consistent to the former. 
