### PR TITLE
(CDAP-600) Make Spark test runs faster

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/test/internal/AppFabricClient.java
@@ -250,7 +250,8 @@ public class AppFabricClient {
     ApplicationBundler bundler = new ApplicationBundler(ImmutableList.of("co.cask.cdap.api",
                                                                          "org.apache.hadoop",
                                                                          "org.apache.hbase",
-                                                                         "org.apache.hive"));
+                                                                         "org.apache.hive",
+                                                                         "org.apache.spark"));
     Location jarLocation = locationFactory.create(clz.getName()).getTempFile(".jar");
     bundler.createBundle(jarLocation, clz);
 

--- a/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/TestBatchStreamIntegration.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/TestBatchStreamIntegration.java
@@ -47,7 +47,7 @@ public class TestBatchStreamIntegration extends TestBase {
       }
 
       MapReduceManager mapReduceManager = applicationManager.startMapReduce("StreamTestBatch");
-      mapReduceManager.waitForFinish(5, TimeUnit.MINUTES);
+      mapReduceManager.waitForFinish(300, TimeUnit.SECONDS);
 
       // The MR job simply turns every stream event body into key/value pairs, with key==value.
       DataSetManager<KeyValueTable> datasetManager = applicationManager.getDataSet("results");
@@ -76,7 +76,7 @@ public class TestBatchStreamIntegration extends TestBase {
       }
 
       MapReduceManager mapReduceManager = applicationManager.startMapReduce("NoMapperMapReduce");
-      mapReduceManager.waitForFinish(2, TimeUnit.MINUTES);
+      mapReduceManager.waitForFinish(120, TimeUnit.SECONDS);
 
       // The Reducer in the MR simply turns every stream event body into key/value pairs, with key==value.
       DataSetManager<KeyValueTable> datasetManager = applicationManager.getDataSet("results");

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/service/TestSparkServiceIntegration.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/service/TestSparkServiceIntegration.java
@@ -51,7 +51,7 @@ public class TestSparkServiceIntegration extends TestBase {
 
       SparkManager sparkManager = applicationManager.startSpark(
         TestSparkServiceIntegrationApp.SparkServiceProgram.class.getSimpleName());
-      sparkManager.waitForFinish(5, TimeUnit.MINUTES);
+      sparkManager.waitForFinish(120, TimeUnit.SECONDS);
 
       DataSetManager<KeyValueTable> datasetManager = applicationManager.getDataSet("result");
       KeyValueTable results = datasetManager.get();

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/stream/TestSparkStreamIntegration.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/stream/TestSparkStreamIntegration.java
@@ -46,7 +46,7 @@ public class TestSparkStreamIntegration extends TestBase {
       }
 
       SparkManager sparkManager = applicationManager.startSpark("SparkStreamProgram");
-      sparkManager.waitForFinish(2, TimeUnit.MINUTES);
+      sparkManager.waitForFinish(120, TimeUnit.SECONDS);
 
       // The Spark job simply turns every stream event body into key/value pairs, with key==value.
       DataSetManager<KeyValueTable> datasetManager = applicationManager.getDataSet("result");


### PR DESCRIPTION
- Bundle jar created by TestBase shouldn’t include spark library jar
- The side effect of having sleep unit minute will cause the problem sleep for at least a minute. Changed to use second.
