### PR TITLE
Changes the phrase rendered on a page in the UI, accesible from the left...

### DIFF
--- a/cdap-web-app/client/core/controllers/list.js
+++ b/cdap-web-app/client/core/controllers/list.js
@@ -16,7 +16,7 @@ define([], function () {
             'Stream': 'Collect',
             'Procedure': 'Query',
             'Dataset': 'Store',
-            'Spark': 'Spark'
+            'Spark': 'Process'
         },
 
         __plurals: {


### PR DESCRIPTION
I recently noticed an incorrect phrasing in the UI. It appears to be an artifact of when Spark was pulled into the UI.
This PR changes the phrase rendered on a page in the UI, accesible from the left NavBar - the list of Process elements.

The UI currently shows "Data Spark" instead of "Data Process" in the page displaying the list of Process elements. The other pages show phrases such as "Data Query," "Data Store," and "Data Collect."

Attached are the before and after images (in that order):
![image](https://s3.amazonaws.com/uploads.hipchat.com/26476/1011205/WHJrlXbHkQC1QYh/Screen%20Shot%202014-11-13%20at%201.36.49%20AM.png)
![image](https://cloud.githubusercontent.com/assets/2440977/5026175/0590109c-6ad6-11e4-884a-51cfd7468753.png)
