### PR TITLE
Add a link to the Kafka-Flow-pack to the documentation

### DIFF
--- a/cdap-docs/examples-manual/source/apps-packs.rst
+++ b/cdap-docs/examples-manual/source/apps-packs.rst
@@ -81,7 +81,7 @@ useful when building big data applications:
 
 
 .. |kafka-flow-pack| replace:: **Kafka-Flow-pack** *for Kafka Flow Integration:*
-.. _kafka-flow-pack: https://github.com/caskdata/cdap-packs/blob/develop/cdap-twitter-pack
+.. _kafka-flow-pack: https://github.com/caskdata/cdap-packs/tree/develop/cdap-kafka-pack/cdap-kafka-flow
 
 - |kafka-flow-pack|_ The Kafka-Flow-pack library is designed to ease the CDAP Flow
   development tasks that require integration with Kafka, such as consuming Kafka messages.


### PR DESCRIPTION
...and change copy to use "library" when describing a "pack".
