### PR TITLE
CDAP-641: Replaced slf4j-nop by the logback.

### DIFF
--- a/cdap-cli/pom.xml
+++ b/cdap-cli/pom.xml
@@ -44,8 +44,12 @@
       <artifactId>common-cli</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-nop</artifactId>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -61,12 +61,6 @@
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-cli</artifactId>
       <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-nop</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -180,11 +180,6 @@
         <version>${slf4j.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-nop</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-      <dependency>
         <groupId>co.cask.common</groupId>
         <artifactId>common-cli</artifactId>
         <version>${cask.common.cli.version}</version>


### PR DESCRIPTION
To resolve multiple SLF4J bindings, slf4j-nop has been replaced by the logback.
