### PR TITLE
(CDAP-24) Update CDAP to release version of Twill (0.4.0-incubating)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,10 +58,6 @@
 
   <repositories>
     <repository>
-      <id>apache.snapshots</id>
-      <url>https://repository.apache.org/content/repositories/snapshots</url>
-    </repository>
-    <repository>
       <id>sonatype</id>
       <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
     </repository>
@@ -129,7 +125,7 @@
     <slf4j.version>1.7.5</slf4j.version>
     <tephra.version>0.3.0</tephra.version>
     <thrift.version>0.9.0</thrift.version>
-    <twill.version>[0.4.0-incubating-SNAPSHOT,0.5.0-incubating-SNAPSHOT)</twill.version>
+    <twill.version>0.4.0-incubating</twill.version>
     <unboundid.version>2.3.6</unboundid.version>
     <zookeeper.version>3.4.5</zookeeper.version>
     <spark.version>1.1.0</spark.version>


### PR DESCRIPTION
- Also remove the need of apache snapshot repo.
