### PR TITLE
Spark Integration: MapReduceContext extends ServiceDiscoverer

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.api.mapreduce;
 
 import co.cask.cdap.api.RuntimeContext;
+import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.data.DataSetContext;
 import co.cask.cdap.api.data.batch.Split;
 
@@ -25,7 +26,7 @@ import java.util.List;
 /**
  * MapReduce job execution context.
  */
-public interface MapReduceContext extends RuntimeContext, DataSetContext {
+public interface MapReduceContext extends RuntimeContext, DataSetContext, ServiceDiscoverer {
   /**
    * @return The specification used to configure this {@link MapReduce} job instance.
    */


### PR DESCRIPTION
MapReduceConext should extend ServiceDiscoverer like ProcedureContext and FlowletContext to support ServiceDiscovery in beforeSubmit() of MapReduce which has MapReduceContext else the user cannot do ServiceDiscovery in MapReduce at all.

This passed through initially as there is no app, unit test or usage of service discover in MapReduce. Have opened a Jira issue for it here: https://issues.cask.co/browse/CDAP-654

Build running here: https://builds.cask.co/browse/CDAP-DUT109-10
