### PR TITLE
(CDAP-733) Get worker instance id and count from context

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/service/ServiceWorkerContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/ServiceWorkerContext.java
@@ -28,4 +28,14 @@ public interface ServiceWorkerContext extends RuntimeContext {
    * @param runnable
    */
   void execute(TxRunnable runnable);
+
+  /**
+   * @return Number of instances of this worker.
+   */
+  int getInstanceCount();
+
+  /**
+   * @return The instance id of this worker.
+   */
+  int getInstanceId();
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/BasicServiceWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/BasicServiceWorkerContext.java
@@ -64,6 +64,8 @@ public class BasicServiceWorkerContext extends AbstractContext implements Servic
   private final DatasetFramework datasetFramework;
   private final ClassLoader programClassLoader;
   private final ServiceRunnableMetrics serviceRunnableMetrics;
+  private final int instanceId;
+  private final int instanceCount;
 
   /**
    * Create a ServiceWorkerContext with runtime arguments and access to Datasets.
@@ -73,9 +75,8 @@ public class BasicServiceWorkerContext extends AbstractContext implements Servic
    * @param datasetFramework used to get datasets.
    * @param transactionSystemClient used to transactionalize operations.
    */
-  public BasicServiceWorkerContext(Program program, RunId runId, int instanceId, String runnableName,
-                                   ClassLoader programClassLoader,
-                                   CConfiguration cConfiguration,
+  public BasicServiceWorkerContext(Program program, RunId runId, int instanceId, int instanceCount,
+                                   String runnableName, ClassLoader programClassLoader, CConfiguration cConfiguration,
                                    Map<String, String> runtimeArgs, Set<String> datasets,
                                    MetricsCollectionService metricsCollectionService,
                                    DatasetFramework datasetFramework,
@@ -83,6 +84,8 @@ public class BasicServiceWorkerContext extends AbstractContext implements Servic
                                    DiscoveryServiceClient discoveryServiceClient) {
     super(program, runId, datasets, getMetricContext(program, runnableName, instanceId), metricsCollectionService,
           datasetFramework, cConfiguration, discoveryServiceClient);
+    this.instanceId = instanceId;
+    this.instanceCount = instanceCount;
     this.programClassLoader = programClassLoader;
     this.runtimeArgs = ImmutableMap.copyOf(runtimeArgs);
     this.datasets = ImmutableSet.copyOf(datasets);
@@ -121,6 +124,16 @@ public class BasicServiceWorkerContext extends AbstractContext implements Servic
     } catch (Exception e) {
       abortTransaction(e, "Exception occurred running user code. Aborting transaction.", context);
     }
+  }
+
+  @Override
+  public int getInstanceCount() {
+    return instanceCount;
+  }
+
+  @Override
+  public int getInstanceId() {
+    return instanceId;
   }
 
   private void abortTransaction(Exception e, String message, TransactionContext context) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceWorkerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceWorkerTwillRunnable.java
@@ -131,8 +131,10 @@ public class ServiceWorkerTwillRunnable implements TwillRunnable {
         ((GuavaServiceWorker) worker).setDelegate((Service) factory.get(type).create());
       }
       int instanceId = context.getInstanceId();
-      worker.initialize(new BasicServiceWorkerContext(program, runId, instanceId, runnableName, programClassLoader,
-                                                      cConfiguration, context.getSpecification().getConfigs(), datasets,
+      int instanceCount = context.getInstanceCount();
+      worker.initialize(new BasicServiceWorkerContext(program, runId, instanceId, instanceCount,
+                                                      runnableName, programClassLoader, cConfiguration,
+                                                      context.getSpecification().getConfigs(), datasets,
                                                       metricsCollectionService, datasetFramework,
                                                       transactionSystemClient,
                                                       discoveryServiceClient));

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppUsingGetServiceURL.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppUsingGetServiceURL.java
@@ -28,12 +28,14 @@ import co.cask.cdap.api.procedure.ProcedureResponder;
 import co.cask.cdap.api.procedure.ProcedureResponse;
 import co.cask.cdap.api.service.AbstractService;
 import co.cask.cdap.api.service.AbstractServiceWorker;
+import co.cask.cdap.api.service.ServiceWorkerContext;
 import co.cask.cdap.api.service.TxRunnable;
 import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
 import co.cask.cdap.api.service.http.HttpServiceRequest;
 import co.cask.cdap.api.service.http.HttpServiceResponder;
 import com.google.common.base.Charsets;
 import com.google.common.io.ByteStreams;
+import org.apache.twill.api.ResourceSpecification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,14 +59,16 @@ public class AppUsingGetServiceURL extends AbstractApplication {
   public static final String DATASET_NAME = "SharedDataSet";
   public static final String DATASET_WHICH_KEY = "WhichKey";
   public static final String DATASET_KEY = "Key";
+  public static final String WORKER_INSTANCES_DATASET = "WorkerInstancesDataset";
 
   @Override
   public void configure() {
-      setName(APP_NAME);
-      addProcedure(new ForwardingProcedure());
-      addService(new CentralService());
-      addService(new ServiceWithWorker());
-      createDataset(DATASET_NAME, KeyValueTable.class);
+    setName(APP_NAME);
+    addProcedure(new ForwardingProcedure());
+    addService(new CentralService());
+    addService(new ServiceWithWorker());
+    createDataset(DATASET_NAME, KeyValueTable.class);
+    createDataset(WORKER_INSTANCES_DATASET, KeyValueTable.class);
   }
 
 
@@ -119,6 +123,7 @@ public class AppUsingGetServiceURL extends AbstractApplication {
       addHandler(new NoOpHandler());
       addWorker(new PingingWorker());
       useDataset(DATASET_NAME);
+      useDataset(WORKER_INSTANCES_DATASET);
     }
     public static final class NoOpHandler extends AbstractHttpServiceHandler {
       // handles nothing.
@@ -126,6 +131,29 @@ public class AppUsingGetServiceURL extends AbstractApplication {
 
     private static final class PingingWorker extends AbstractServiceWorker {
       private static final Logger LOG = LoggerFactory.getLogger(PingingWorker.class);
+
+      @Override
+      public void initialize(ServiceWorkerContext context) throws Exception {
+        super.initialize(context);
+
+        getContext().execute(new TxRunnable() {
+          @Override
+          public void run(DataSetContext context) throws Exception {
+            KeyValueTable table = context.getDataSet(WORKER_INSTANCES_DATASET);
+            String key = String.format("%d.%d", getContext().getInstanceId(), System.nanoTime());
+            table.write(key, Bytes.toBytes(getContext().getInstanceCount()));
+          }
+        });
+      }
+
+      @Override
+      protected ResourceSpecification getResourceSpecification() {
+        return ResourceSpecification.Builder.with()
+          .setVirtualCores(1)
+          .setMemory(512, ResourceSpecification.SizeUnit.MEGA)
+          .setInstances(5)
+          .build();
+      }
 
       private void writeToDataSet(final String key, final String val) {
         getContext().execute(new TxRunnable() {
@@ -144,8 +172,8 @@ public class AppUsingGetServiceURL extends AbstractApplication {
           return;
         }
 
-        URL url = null;
-        String response = null;
+        URL url;
+        String response;
         try {
           url = new URL(baseURL, "ping");
         } catch (MalformedURLException e) {
@@ -165,12 +193,10 @@ public class AppUsingGetServiceURL extends AbstractApplication {
           }
         } catch (IOException e) {
           LOG.error("Got exception {}", e);
-          return;
         }
       }
     }
   }
-
 
   /**
    * The central service which other programs will ping via their context's getServiceURL method.

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTest.java
@@ -17,7 +17,11 @@
 package co.cask.cdap.test.app;
 
 import co.cask.cdap.api.app.Application;
+import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.dataset.table.Get;
 import co.cask.cdap.api.dataset.table.Put;
 import co.cask.cdap.api.dataset.table.Table;
@@ -41,6 +45,7 @@ import co.cask.cdap.test.WorkflowManager;
 import co.cask.cdap.test.XSlowTests;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
@@ -315,6 +320,20 @@ public class TestFrameworkTest extends TestBase {
       // Test requesting same number of instances.
       serviceManager.setRunnableInstances(runnableName, 2);
       runnableInstancesCheck(serviceManager, runnableName, 2, retries);
+
+      // Test that the worker starts with 5 instances
+      DataSetManager<KeyValueTable> datasetManager = applicationManager
+                                                      .getDataSet(AppUsingGetServiceURL.WORKER_INSTANCES_DATASET);
+      KeyValueTable instancesTable = datasetManager.get();
+      CloseableIterator<KeyValue<byte[], byte[]>> instancesIterator = instancesTable.scan(null, null);
+      List<KeyValue<byte[], byte[]>> workerInstances = Lists.newArrayList(instancesIterator);
+      instancesIterator.close();
+
+      Assert.assertEquals(5, workerInstances.size());
+      // Assert that each instance of the worker knows the total number of instances
+      for (KeyValue<byte[], byte[]> keyValue : workerInstances) {
+        Assert.assertEquals(5, Bytes.toInt(keyValue.getValue()));
+      }
 
       serviceManager.stop();
       serviceStatusCheck(serviceManager, false);


### PR DESCRIPTION
Expose the `instanceCount` and `instanceId` for `ServiceWorker`s. These properties already existed, but were not exposed to the user.
