### PR TITLE
CDAP-608 Better error message when flowlet has no input

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
@@ -366,7 +366,10 @@ public final class FlowletProgramRunner implements ProgramRunner {
         }
       }
     }
-    Preconditions.checkArgument(!result.isEmpty(), "No process or tick method found for " + flowletType);
+    Preconditions.checkArgument(!result.isEmpty(),
+                                "No inputs found for flowlet '%s' of flow '%s' of application '%s' (%s)",
+                                flowletContext.getFlowletId(), flowletContext.getFlowId(),
+                                flowletContext.getApplicationId(), flowletType);
     return result;
   }
 


### PR DESCRIPTION
New error message:

```
2014-11-24 17:23:42,513 - ERROR [executor-11:c.c.c.g.h.AppFabricHttpHandler@881] - No inputs found for flowlet 'saver' of flow 'WhoFlow' of application 'HelloWorld' (co.cask.cdap.examples.helloworld.HelloWorld$NameSaver)
java.lang.IllegalArgumentException: No inputs found for flowlet 'saver' of flow 'WhoFlow' of application 'HelloWorld' (co.cask.cdap.examples.helloworld.HelloWorld$NameSaver)
    at com.google.common.base.Preconditions.checkArgument(Preconditions.java:92) ~[guava-13.0.1.jar:na]
    at co.cask.cdap.internal.app.runtime.flow.FlowletProgramRunner.createProcessSpecification(FlowletProgramRunner.java:369) ~[classes/:na]
    at co.cask.cdap.internal.app.runtime.flow.FlowletProgramRunner.run(FlowletProgramRunner.java:240) ~[classes/:na]
    at co.cask.cdap.internal.app.runtime.flow.FlowProgramRunner.startFlowlet(FlowProgramRunner.java:142) ~[classes/:na]
    at co.cask.cdap.internal.app.runtime.flow.FlowProgramRunner.createFlowlets(FlowProgramRunner.java:119) ~[classes/:na]
    at co.cask.cdap.internal.app.runtime.flow.FlowProgramRunner.run(FlowProgramRunner.java:97) ~[classes/:na]
    at co.cask.cdap.app.runtime.AbstractProgramRuntimeService.run(AbstractProgramRuntimeService.java:55) ~[classes/:na]
    at co.cask.cdap.internal.app.runtime.service.InMemoryProgramRuntimeService.run(InMemoryProgramRuntimeService.java:79) ~[classes/:na]
    at co.cask.cdap.gateway.handlers.AppFabricHttpHandler.start(AppFabricHttpHandler.java:852) [classes/:na]
    at co.cask.cdap.gateway.handlers.AppFabricHttpHandler.runnableStartStop(AppFabricHttpHandler.java:802) [classes/:na]
    at co.cask.cdap.gateway.handlers.AppFabricHttpHandler.startStopProgram(AppFabricHttpHandler.java:790) [classes/:na]
    at co.cask.cdap.gateway.handlers.AppFabricHttpHandler.startProgram(AppFabricHttpHandler.java:629) [classes/:na]
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.7.0_51]
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57) ~[na:1.7.0_51]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.7.0_51]
    at java.lang.reflect.Method.invoke(Method.java:606) ~[na:1.7.0_51]
    at co.cask.http.HttpMethodInfo.invoke(HttpMethodInfo.java:83) [netty-http-0.6.0.jar:na]
    at co.cask.http.HttpDispatcher.messageReceived(HttpDispatcher.java:41) [netty-http-0.6.0.jar:na]
    at org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:70) [netty-3.6.6.Final.jar:na]
    at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:564) [netty-3.6.6.Final.jar:na]
    at org.jboss.netty.channel.DefaultChannelPipeline$DefaultChannelHandlerContext.sendUpstream(DefaultChannelPipeline.java:791) [netty-3.6.6.Final.jar:na]
    at org.jboss.netty.handler.execution.ChannelUpstreamEventRunnable.doRun(ChannelUpstreamEventRunnable.java:43) [netty-3.6.6.Final.jar:na]
    at org.jboss.netty.handler.execution.ChannelEventRunnable.run(ChannelEventRunnable.java:67) [netty-3.6.6.Final.jar:na]
    at org.jboss.netty.handler.execution.OrderedMemoryAwareThreadPoolExecutor$ChildExecutor.run(OrderedMemoryAwareThreadPoolExecutor.java:314) [netty-3.6.6.Final.jar:na]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_51]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_51]
    at java.lang.Thread.run(Thread.java:744) [na:1.7.0_51]
```
