### PR TITLE
CDAP-462 - fixed deleting metrics upon redeployment of changed application

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
@@ -128,7 +128,7 @@ public class DeletedProgramHandlerStage extends AbstractStage<ApplicationDeploya
   }
 
   private void deleteMetrics(String account, String application, Iterable<String> flows) throws IOException {
-    Iterable<Discoverable> discoverables = this.discoveryServiceClient.discover(Constants.Service.GATEWAY);
+    Iterable<Discoverable> discoverables = this.discoveryServiceClient.discover(Constants.Service.METRICS);
     Discoverable discoverable = new TimeLimitEndpointStrategy(new RandomEndpointStrategy(discoverables),
                                                               DISCOVERY_TIMEOUT_SECONDS, TimeUnit.SECONDS).pick();
 


### PR DESCRIPTION
Metrics were not being deleted upon redeployment of changed application. Fixed.
