### PR TITLE
CDAP-798 use increment and gauge in mr metrics

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceMetricsWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceMetricsWriter.java
@@ -19,6 +19,10 @@ package co.cask.cdap.internal.app.runtime.batch;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.metrics.MetricsCollector;
 import co.cask.cdap.common.metrics.MetricsScope;
+import co.cask.cdap.metrics.transport.MetricType;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Table;
 import org.apache.hadoop.mapreduce.Counter;
 import org.apache.hadoop.mapreduce.Counters;
 import org.apache.hadoop.mapreduce.Job;
@@ -29,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * Gathers statistics from a running mapreduce job through its counters and writes the data to the metrics system.
@@ -44,10 +49,16 @@ public class MapReduceMetricsWriter {
 
   private final Job jobConf;
   private final BasicMapReduceContext context;
+  private final Table<MetricsScope, String, Integer> previousMapStats;
+  private final Table<MetricsScope, String, Integer> previousReduceStats;
+  private final Table<MetricsScope, String, Integer> previousDatasetStats;
 
   public MapReduceMetricsWriter(Job jobConf, BasicMapReduceContext context) {
     this.jobConf = jobConf;
     this.context = context;
+    this.previousMapStats = HashBasedTable.create();
+    this.previousReduceStats = HashBasedTable.create();
+    this.previousDatasetStats = HashBasedTable.create();
   }
 
   public void reportStats() throws IOException, InterruptedException {
@@ -70,14 +81,17 @@ public class MapReduceMetricsWriter {
     int memoryPerMapper = jobConf.getConfiguration().getInt(Job.MAP_MEMORY_MB, Job.DEFAULT_MAP_MEMORY_MB);
     int memoryPerReducer = jobConf.getConfiguration().getInt(Job.REDUCE_MEMORY_MB, Job.DEFAULT_REDUCE_MEMORY_MB);
 
-    long mapInputRecords = getTaskCounter(TaskCounter.MAP_INPUT_RECORDS);
-    long mapOutputRecords = getTaskCounter(TaskCounter.MAP_OUTPUT_RECORDS);
-    long mapOutputBytes = getTaskCounter(TaskCounter.MAP_OUTPUT_BYTES);
+    // mapred counters are running counters whereas our metrics timeseries and aggregates make more
+    // sense as incremental numbers.  So we want to subtract the current counter value from the previous before
+    // emitting to the metrics system.
+    int mapInputRecords = calcDiffAndSetMapStat(METRIC_INPUT_RECORDS, getTaskCounter(TaskCounter.MAP_INPUT_RECORDS));
+    int mapOutputRecords = calcDiffAndSetMapStat(METRIC_OUTPUT_RECORDS, getTaskCounter(TaskCounter.MAP_OUTPUT_RECORDS));
+    int mapOutputBytes = calcDiffAndSetMapStat(METRIC_BYTES, getTaskCounter(TaskCounter.MAP_OUTPUT_BYTES));
 
     context.getSystemMapperMetrics().gauge(METRIC_COMPLETION, (long) (mapProgress * 100));
-    context.getSystemMapperMetrics().gauge(METRIC_INPUT_RECORDS, mapInputRecords);
-    context.getSystemMapperMetrics().gauge(METRIC_OUTPUT_RECORDS, mapOutputRecords);
-    context.getSystemMapperMetrics().gauge(METRIC_BYTES, mapOutputBytes);
+    context.getSystemMapperMetrics().increment(METRIC_INPUT_RECORDS, mapInputRecords);
+    context.getSystemMapperMetrics().increment(METRIC_OUTPUT_RECORDS, mapOutputRecords);
+    context.getSystemMapperMetrics().increment(METRIC_BYTES, mapOutputBytes);
     context.getSystemMapperMetrics().gauge(METRIC_USED_CONTAINERS, runningMappers);
     context.getSystemMapperMetrics().gauge(METRIC_USED_MEMORY, runningMappers * memoryPerMapper);
 
@@ -87,12 +101,14 @@ public class MapReduceMetricsWriter {
 
     // reduce stats
     float reduceProgress = jobConf.getStatus().getReduceProgress();
-    long reduceInputRecords = getTaskCounter(TaskCounter.REDUCE_INPUT_RECORDS);
-    long reduceOutputRecords = getTaskCounter(TaskCounter.REDUCE_OUTPUT_RECORDS);
+    int reduceInputRecords =
+      calcDiffAndSetReduceStat(METRIC_INPUT_RECORDS, getTaskCounter(TaskCounter.REDUCE_INPUT_RECORDS));
+    int reduceOutputRecords =
+      calcDiffAndSetReduceStat(METRIC_OUTPUT_RECORDS, getTaskCounter(TaskCounter.REDUCE_OUTPUT_RECORDS));
 
     context.getSystemReducerMetrics().gauge(METRIC_COMPLETION, (long) (reduceProgress * 100));
-    context.getSystemReducerMetrics().gauge(METRIC_INPUT_RECORDS, reduceInputRecords);
-    context.getSystemReducerMetrics().gauge(METRIC_OUTPUT_RECORDS, reduceOutputRecords);
+    context.getSystemReducerMetrics().increment(METRIC_INPUT_RECORDS, reduceInputRecords);
+    context.getSystemReducerMetrics().increment(METRIC_OUTPUT_RECORDS, reduceOutputRecords);
     context.getSystemReducerMetrics().gauge(METRIC_USED_CONTAINERS, runningReducers);
     context.getSystemReducerMetrics().gauge(METRIC_USED_MEMORY, runningReducers * memoryPerReducer);
 
@@ -107,6 +123,7 @@ public class MapReduceMetricsWriter {
     for (String group : counters.getGroupNames()) {
       if (group.startsWith("cdap.")) {
         String[] parts = group.split("\\.");
+        MetricType metricType = MetricType.valueOf(parts[parts.length - 2]);
         String scopePart = parts[parts.length - 1];
         // last one should be scope
         MetricsScope scope;
@@ -120,19 +137,90 @@ public class MapReduceMetricsWriter {
         //TODO: Refactor to support any context
         String programPart = parts[1];
         if (programPart.equals("mapper")) {
-          reportSystemStats(counters.getGroup(group), context.getSystemMapperMetrics(scope));
+          reportSystemStats(counters.getGroup(group), context.getSystemMapperMetrics(scope), scope,
+                            previousMapStats, metricType);
         } else if (programPart.equals("reducer")) {
-          reportSystemStats(counters.getGroup(group), context.getSystemReducerMetrics(scope));
+          reportSystemStats(counters.getGroup(group), context.getSystemReducerMetrics(scope), scope,
+                            previousReduceStats, metricType);
         } else if (programPart.equals("dataset")) {
           reportSystemStats(counters.getGroup(group), context.getMetricsCollectionService().getCollector(
-            scope, Constants.Metrics.DATASET_CONTEXT, context.getRunId().getId()));
+                              scope, Constants.Metrics.DATASET_CONTEXT, context.getRunId().getId()),
+                            scope, previousDatasetStats, metricType);
         }
       }
     }
   }
 
-  private void reportSystemStats(Iterable<Counter> counters, MetricsCollector collector) {
+  private int calcDiffAndSetMapStat(String key, long value) {
+    return calcDiffAndSetTableValue(previousMapStats, MetricsScope.SYSTEM, key, value);
+  }
 
+  private int calcDiffAndSetReduceStat(String key, long value) {
+    return calcDiffAndSetTableValue(previousReduceStats, MetricsScope.SYSTEM, key, value);
+  }
+
+  // convenience function to set the table value to the given value and return the difference between the given value
+  // and the previous table value, where the previous value is 0 if there was no entry in the table to begin with.
+  private int calcDiffAndSetTableValue(Table<MetricsScope, String, Integer> table,
+                                       MetricsScope scope, String key, long value) {
+    Integer previous = table.get(scope, key);
+    previous = (previous == null) ? 0 : previous;
+    table.put(scope, key, (int) value);
+    return (int) value - previous;
+  }
+
+  private void reportSystemStats(Iterable<Counter> counters, MetricsCollector collector, MetricsScope scope,
+                                 Table<MetricsScope, String, Integer> previousStats,  MetricType type) {
+    if (type == MetricType.GAUGE) {
+      reportGaugeSystemStats(counters, collector);
+    } else {
+      reportIncrementSystemStats(counters, collector, scope, previousStats);
+    }
+  }
+
+
+  private void reportIncrementSystemStats(Iterable<Counter> counters, MetricsCollector collector, MetricsScope scope,
+                                          Table<MetricsScope, String, Integer> previousStats) {
+
+    // we don't want to overcount the untagged version of the metric.  For example.  If "metric":"store.bytes"
+    // comes in with "tag":"dataset1" and value 10, we will also have another counter for just the metric without the
+    // tag, also with value 10.  If we increment both of them with their values, the final count sent off to the metrics
+    // system for the untagged metric will be 20 instead of 10.  So we need to keep track of the sum of the tagged
+    // values so that we can adjust accordingly.
+    Map<String, Integer> metricTagValues = Maps.newHashMap();
+    Map<String, Integer> metricUntaggedValues = Maps.newHashMap();
+
+    for (Counter counter : counters) {
+
+      // mapred counters are running counters whereas our metrics timeseries and aggregates make more
+      // sense as incremental numbers.  So we want to subtract the current counter value from the previous before
+      // emitting to the metrics system.
+      int emitValue = calcDiffAndSetTableValue(previousStats, scope, counter.getName(), counter.getValue());
+
+      // "<metric>" or "<metric>,<tag>" if tag is present
+      String[] parts = counter.getName().split(",", 2);
+      String metric = parts[0];
+      if (parts.length == 2) {
+        // has tag
+        String tag = parts[1];
+        collector.increment(metric, emitValue, tag);
+        int tagCountSoFar = (metricTagValues.containsKey(metric)) ? metricTagValues.get(metric) : 0;
+        metricTagValues.put(metric, tagCountSoFar + emitValue);
+      } else {
+        metricUntaggedValues.put(metric, emitValue);
+      }
+    }
+
+    // emit adjusted counts for the untagged metrics.
+    for (Map.Entry<String, Integer> untaggedEntry : metricUntaggedValues.entrySet()) {
+      String metric = untaggedEntry.getKey();
+      int tagValueSum = (metricTagValues.containsKey(metric)) ? metricTagValues.get(metric) : 0;
+      int adjustedValue = untaggedEntry.getValue() - tagValueSum;
+      collector.increment(metric, adjustedValue);
+    }
+  }
+
+  private void reportGaugeSystemStats(Iterable<Counter> counters, MetricsCollector collector) {
     for (Counter counter : counters) {
       // "<metric>" or "<metric>,<tag>" if tag is present
       String[] parts = counter.getName().split(",", 2);

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsQueryTestRun.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsQueryTestRun.java
@@ -245,6 +245,21 @@ public class MetricsQueryTestRun extends MetricsSuiteTestBase {
     testSingleMetric(serviceRequest, 10);
   }
 
+  @Test
+  public void testingUserServiceGaugeMetricsTags() throws Exception {
+    MetricsCollector collector = collectionService.getCollector(MetricsScope.USER,
+                                                                "WordCount.u.CounterService", "0");
+    collector.gauge("gtmetric", 10, "tag1");
+    collector.gauge("gtmetric", 20, "tag2");
+
+    // Wait for collection to happen
+    TimeUnit.SECONDS.sleep(2);
+
+    String serviceRequest =
+      "/user/apps/WordCount/services/CounterService/gtmetric?aggregate=true";
+    testSingleMetric(serviceRequest, 20);
+  }
+
 
   @Test
   public void testingInvalidUserServiceMetrics() throws Exception {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/MapReduceCounterCollectionService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/MapReduceCounterCollectionService.java
@@ -72,6 +72,7 @@ public final class MapReduceCounterCollectionService extends AggregatedMetricsCo
         continue;
       }
 
+      counterGroup += "." + record.getType().toString();
       counterGroup += "." + scope.name();
 
       if (record.getType() == MetricType.COUNTER) {


### PR DESCRIPTION
Reintroducing Metrics increment in mapreduce metrics writer. and using metrics increment for entries processed , while using gauge for process completion and other metrics. 

Also added type of the metric(counter/gauge) to the MR counter group and using that information to call increment/gauge.

This PR is to fix the issue at : https://issues.cask.co/browse/CDAP-798
