### PR TITLE
Runs endpoint, ignore endTime if status is Running for program

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
@@ -81,7 +81,6 @@ import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.ProgramTypes;
-import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.StreamRecord;
 import co.cask.http.BodyConsumer;
 import co.cask.http.ChunkResponder;
@@ -108,10 +107,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
@@ -145,7 +141,6 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
-import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -751,15 +746,6 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
     }
   }
 
-  private String getQueryParameter(Map<String, List<String>> parameters, String parameterName) {
-    if (parameters == null || parameters.isEmpty()) {
-      return null;
-    } else {
-      List<String> matchedParams = parameters.get(parameterName);
-      return matchedParams == null || matchedParams.isEmpty() ? null : matchedParams.get(0);
-    }
-  }
-
   private void getRuns(HttpRequest request, HttpResponder responder, String appId,
                        String runnableId, String status, long start, long end, int limit) {
     try {
@@ -768,9 +754,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
       try {
         ProgramRunStatus runStatus = (status == null) ? ProgramRunStatus.ALL :
           ProgramRunStatus.valueOf(status.toUpperCase());
-        Gson gson = new GsonBuilder().registerTypeAdapter(RunRecord.class, new RunRecordAdapter()).create();
-        responder.sendJson(HttpResponseStatus.OK, store.getRuns(programId, runStatus, start, end, limit),
-                           new TypeToken<List<RunRecord>>() { }.getType(), gson);
+        responder.sendJson(HttpResponseStatus.OK, store.getRuns(programId, runStatus, start, end, limit));
       } catch (IllegalArgumentException e) {
         responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,
                              "Supported options for status of runs are running/completed/failed");
@@ -784,24 +768,6 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
     } catch (Throwable e) {
       LOG.error("Got exception:", e);
       responder.sendStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
-    }
-  }
-
-
-  /**
-   *  Adapter class for {@link co.cask.cdap.proto.RunRecord}
-   */
-  private static final class RunRecordAdapter implements JsonSerializer<RunRecord> {
-    @Override
-    public JsonElement serialize(RunRecord src, Type typeOfSrc, JsonSerializationContext context) {
-      JsonObject json = new JsonObject();
-      json.addProperty("runid", src.getPid());
-      json.addProperty("start", src.getStartTs());
-      if (src.getStatus() != ProgramRunStatus.RUNNING) {
-        json.addProperty("end", src.getStopTs());
-      }
-      json.addProperty("status", src.getStatus().toString());
-      return json;
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
@@ -123,7 +123,7 @@ public class AppMetadataStore extends MetadataStoreDataset {
 
   public void recordProgramStart(String accountId, String appId, String programId, String pid, long startTs) {
       write(new Key.Builder().add(TYPE_RUN_RECORD_STARTED, accountId, appId, programId, pid).build(),
-            new RunRecord(pid, startTs, -1, ProgramRunStatus.RUNNING));
+            new RunRecord(pid, startTs, null, ProgramRunStatus.RUNNING));
   }
 
   public void recordProgramStop(String accountId, String appId, String programId,

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppFabricHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppFabricHttpHandlerTest.java
@@ -209,8 +209,8 @@ public class AppFabricHttpHandlerTest extends AppFabricTestBase {
       if (result.size() >= size) {
         // For each one, we have 4 fields.
         for (Map<String, String> m : result) {
-          int expextedFieldSize = m.get("status").equals("RUNNING") ? 3 : 4;
-          Assert.assertEquals(expextedFieldSize, m.size());
+          int expectedFieldSize = m.get("status").equals("RUNNING") ? 3 : 4;
+          Assert.assertEquals(expectedFieldSize, m.size());
         }
         break;
       }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/RunRecord.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/RunRecord.java
@@ -31,16 +31,12 @@ public final class RunRecord {
   private final long startTs;
 
   @SerializedName("end")
-  private final long stopTs;
+  private final Long stopTs;
 
   @SerializedName("status")
   private final ProgramRunStatus status;
 
-  public RunRecord(String pid, long startTs) {
-    this(pid, startTs, -1, null);
-  }
-
-  public RunRecord(String pid, long startTs, long stopTs, ProgramRunStatus status) {
+  public RunRecord(String pid, long startTs, Long stopTs, ProgramRunStatus status) {
     this.pid = pid;
     this.startTs = startTs;
     this.stopTs = stopTs;


### PR DESCRIPTION
Currently, /runs endpoint returns run records of program. for a "Running" program we would return endTime as -1, its better to not have endTime for a "Running" program. so this PR is to skip sending endTime for Running programs. 
