### PR TITLE
Fix cdap-cli help message

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
@@ -20,17 +20,17 @@ package co.cask.cdap.cli;
  * Argument names.
  */
 public enum ArgumentName {
-  PROGRAM("program-id"),
+  PROGRAM("app-id.program-id"),
   STREAM("stream-id"),
-  PROCEDURE("procedure-id"),
-  METHOD("method-id"),
-  FLOW("flow-id"),
-  FLOWLET("flowlet-id"),
-  WORKFLOW("workflow-id"),
-  SERVICE("service-id"),
-  RUNNABLE("runnable-id"),
-  MAPREDUCE("mapreduce-id"),
-  SPARK("spark-id"),
+  PROCEDURE("app-id.procedure-id"),
+  METHOD("app-id.method-id"),
+  FLOW("app-id.flow-id"),
+  FLOWLET("app-id.flow-id.flowlet-id"),
+  WORKFLOW("app-id.workflow-id"),
+  SERVICE("app-id.service-id"),
+  RUNNABLE("app-id.runnable-id"),
+  MAPREDUCE("app-id.mapreduce-id"),
+  SPARK("app-id.spark-id"),
 
   HOSTNAME("hostname"),
   DATASET_TYPE("dataset-type"),

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/docs/GenerateCLIDocsTable.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/docs/GenerateCLIDocsTable.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2012-2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.cli.docs;
+
+import co.cask.cdap.cli.CLIConfig;
+import co.cask.cdap.cli.Constants;
+import co.cask.cdap.cli.DefaultCommands;
+import co.cask.cdap.cli.command.HelpCommand;
+import co.cask.cdap.client.config.ClientConfig;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.common.cli.Arguments;
+import co.cask.common.cli.Command;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Generates data for the table in cdap-docs/reference-manual/source/cli-api.rst.
+ */
+public class GenerateCLIDocsTable {
+
+  private final Command printDocsCommand;
+
+  private final Iterable<Command> commands;
+
+  public GenerateCLIDocsTable(final CLIConfig cliConfig) throws URISyntaxException, IOException {
+    this.printDocsCommand = new Command() {
+
+      @Override
+      public void execute(Arguments arguments, PrintStream output) throws Exception {
+        List<Command> commandList = com.googlecode.concurrenttrees.common.Iterables.toList(commands);
+        Collections.sort(commandList, new Comparator<Command>() {
+          @Override
+          public int compare(Command command, Command command2) {
+            return command.getPattern().compareTo(command2.getPattern());
+          }
+        });
+        for (Command command : commandList) {
+          output.printf("   ``%s``,%s\n", command.getPattern(), command.getDescription());
+        }
+      }
+
+      @Override
+      public String getPattern() {
+        return "null";
+      }
+
+      @Override
+      public String getDescription() {
+        return "null";
+      }
+    };
+
+    Injector injector = Guice.createInjector(
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(CLIConfig.class).toInstance(cliConfig);
+          bind(ClientConfig.class).toInstance(cliConfig.getClientConfig());
+          bind(CConfiguration.class).toInstance(CConfiguration.create());
+        }
+      }
+    );
+
+    this.commands = Iterables.concat(new DefaultCommands(injector).get(),
+                                     ImmutableList.<Command>of(new HelpCommand(null, null)));
+  }
+
+  public static void main(String[] args) throws Exception {
+    String hostname = Objects.firstNonNull(System.getenv(Constants.EV_HOSTNAME), "localhost");
+    PrintStream output = System.out;
+
+    CLIConfig config = new CLIConfig(hostname);
+    GenerateCLIDocsTable generateCLIDocsTable = new GenerateCLIDocsTable(config);
+    generateCLIDocsTable.printDocsCommand.execute(null, output);
+  }
+}


### PR DESCRIPTION
Changes
- Change `program-id` argument names to be `app-id.program-id`.

New cdap-cli help output:

```
cdap (http://localhost:10000)> help
CLI version 2.6.0-SNAPSHOT
CDAP_HOST=localhost
Available commands:
call procedure <app-id.procedure-id> <app-id.method-id> [<parameter-map>]: Calls a Procedure
call service <app-id.service-id> <http-method> <endpoint> [headers <headers>] [body <body>]: Calls a Serviceendpoint.The header is formatted as "{'key' : 'value', ...}" and the body is a String.
connect <cdap-instance-uri>: Connects to a CDAP instance. <credential(s)> parameter(s) could be used if authentication is enabled in the gateway server.
create dataset instance <dataset-type> <new-dataset-name>: Creates a Dataset
create stream <new-stream-id>: Creates a Stream
delete app <app-id>: Deletes an application
delete dataset instance <dataset-name>: Deletes a Dataset
delete dataset module <dataset-module>: Deletes a Dataset module
deploy app <app-jar-file>: Deploys an application
deploy dataset module <new-dataset-module> <module-jar-file> <module-jar-classname>: Deploys a Dataset module
describe app <app-id>: Shows detailed information about an application
describe dataset module <dataset-module>: Shows information about a Dataset module
describe dataset type <dataset-type>: Shows information about a Dataset type
describe stream <stream-id>: Shows detailed information about a Stream
execute <query>: Executes a Dataset query
exit: Exits the CLI
get endpoints service <app-id.service-id>: List the endpoints that a Service exposes
get flow live <app-id.flow-id>: Gets the live info of a Flow
get flow logs <app-id.flow-id> [<start-time>] [<end-time>]: Gets the logs of a Flow
get flow runs <app-id.flow-id> [<status>] [<start-time>] [<end-time>] [<limit>]: Gets the run history of a Flow
get flow status <app-id.flow-id>: Gets the status of a Flow
get flowlet instances <app-id.flow-id.flowlet-id>: Gets the instances of a Flowlet
get mapreduce logs <app-id.mapreduce-id> [<start-time>] [<end-time>]: Gets the logs of a MapReduce job
get mapreduce runs <app-id.mapreduce-id> [<status>] [<start-time>] [<end-time>] [<limit>]: Gets the run history of a MapReduce job
get mapreduce status <app-id.mapreduce-id>: Gets the status of a MapReduce job
get procedure instances <app-id.procedure-id>: Gets the instances of a Procedure
get procedure live <app-id.procedure-id>: Gets the live info of a Procedure
get procedure logs <app-id.procedure-id> [<start-time>] [<end-time>]: Gets the logs of a Procedure
get procedure runs <app-id.procedure-id> [<status>] [<start-time>] [<end-time>] [<limit>]: Gets the run history of a Procedure
get procedure status <app-id.procedure-id>: Gets the status of a Procedure
get runnable instances <app-id.runnable-id>: Gets the instances of a Runnable
get runnable logs <app-id.runnable-id> [<start-time>] [<end-time>]: Gets the logs of a Runnable
get runnable runs <app-id.runnable-id> [<status>] [<start-time>] [<end-time>] [<limit>]: Gets the run history of a Runnable
get service status <app-id.service-id>: Gets the status of a Service
get spark logs <app-id.spark-id> [<start-time>] [<end-time>]: Gets the logs of a Spark job
get spark runs <app-id.spark-id> [<status>] [<start-time>] [<end-time>] [<limit>]: Gets the run history of a Spark job
get spark status <app-id.spark-id>: Gets the status of a Spark job
get stream <stream-id> [<start-time>] [<end-time>] [<limit>]: Gets events from a Stream. The time format for <start-time> and <end-time> could be timestamp in milliseconds or relative time in the form of [+\-][0-9]+[hms]. For <start-time>, it is relative to current time, while for <end-time>, it's relative to start time. Special constants "min" and "max" can also be used to represent 0 and max timestamp respectively.
get workflow runs <app-id.workflow-id> [<status>] [<start-time>] [<end-time>] [<limit>]: Gets the run history of a Workflow
get workflow status <app-id.workflow-id>: Gets the status of a Workflow
help: Prints this helper text
list apps: Lists all applications
list dataset instances: Lists all Datasets
list dataset modules: Lists Dataset modules
list dataset types: Lists Dataset types
list flows: Lists Flows
list mapreduce: Lists MapReduce jobs
list procedures: Lists Procedures
list programs: Lists all programs
list services: Lists Services
list spark: Lists Spark jobs
list streams: Lists Streams
list workflows: Lists Workflows
send stream <stream-id> <stream-event>: Sends an event to a Stream
set flowlet instances <app-id.flow-id.flowlet-id> <num-instances>: Sets the instances of a Flowlet
set procedure instances <app-id.procedure-id> <num-instances>: Sets the instances of a Procedure
set runnable instances <app-id.runnable-id> <num-instances>: Sets the instances of a Runnable
set stream ttl <stream-id> <ttl-in-seconds>: Sets the Time-to-Live (TTL) of a Stream
start flow <app-id.flow-id>: Starts a Flow
start mapreduce <app-id.mapreduce-id>: Starts a MapReduce job
start procedure <app-id.procedure-id>: Starts a Procedure
start service <app-id.service-id>: Starts a Service
start spark <app-id.spark-id>: Starts a Spark job
start workflow <app-id.workflow-id>: Starts a Workflow
stop flow <app-id.flow-id>: Stops a Flow
stop mapreduce <app-id.mapreduce-id>: Stops a MapReduce job
stop procedure <app-id.procedure-id>: Stops a Procedure
stop service <app-id.service-id>: Stops a Service
stop spark <app-id.spark-id>: Stops a Spark job
stop workflow <app-id.workflow-id>: Stops a Workflow
truncate dataset instance <dataset-name>: Truncates a Dataset
truncate stream <stream-id>: Truncates a Stream
```

cli-api.rst changes:

```
   ``call procedure <app-id.procedure-id> <app-id.method-id> [<parameter-map>]``,Calls a Procedure
   ``call service <app-id.service-id> <http-method> <endpoint> [headers <headers>] [body <body>]``,Calls a Serviceendpoint.The header is formatted as "{'key' : 'value', ...}" and the body is a String.
   ``connect <cdap-instance-uri>``,Connects to a CDAP instance. <credential(s)> parameter(s) could be used if authentication is enabled in the gateway server.
   ``create dataset instance <dataset-type> <new-dataset-name>``,Creates a Dataset
   ``create stream <new-stream-id>``,Creates a Stream
   ``delete app <app-id>``,Deletes an application
   ``delete dataset instance <dataset-name>``,Deletes a Dataset
   ``delete dataset module <dataset-module>``,Deletes a Dataset module
   ``deploy app <app-jar-file>``,Deploys an application
   ``deploy dataset module <new-dataset-module> <module-jar-file> <module-jar-classname>``,Deploys a Dataset module
   ``describe app <app-id>``,Shows detailed information about an application
   ``describe dataset module <dataset-module>``,Shows information about a Dataset module
   ``describe dataset type <dataset-type>``,Shows information about a Dataset type
   ``describe stream <stream-id>``,Shows detailed information about a Stream
   ``execute <query>``,Executes a Dataset query
   ``exit``,Exits the CLI
   ``get endpoints service <app-id.service-id>``,List the endpoints that a Service exposes
   ``get flow live <app-id.flow-id>``,Gets the live info of a Flow
   ``get flow logs <app-id.flow-id> [<start-time>] [<end-time>]``,Gets the logs of a Flow
   ``get flow runs <app-id.flow-id> [<status>] [<start-time>] [<end-time>] [<limit>]``,Gets the run history of a Flow
   ``get flow status <app-id.flow-id>``,Gets the status of a Flow
   ``get flowlet instances <app-id.flow-id.flowlet-id>``,Gets the instances of a Flowlet
   ``get mapreduce logs <app-id.mapreduce-id> [<start-time>] [<end-time>]``,Gets the logs of a MapReduce job
   ``get mapreduce runs <app-id.mapreduce-id> [<status>] [<start-time>] [<end-time>] [<limit>]``,Gets the run history of a MapReduce job
   ``get mapreduce status <app-id.mapreduce-id>``,Gets the status of a MapReduce job
   ``get procedure instances <app-id.procedure-id>``,Gets the instances of a Procedure
   ``get procedure live <app-id.procedure-id>``,Gets the live info of a Procedure
   ``get procedure logs <app-id.procedure-id> [<start-time>] [<end-time>]``,Gets the logs of a Procedure
   ``get procedure runs <app-id.procedure-id> [<status>] [<start-time>] [<end-time>] [<limit>]``,Gets the run history of a Procedure
   ``get procedure status <app-id.procedure-id>``,Gets the status of a Procedure
   ``get runnable instances <app-id.runnable-id>``,Gets the instances of a Runnable
   ``get runnable logs <app-id.runnable-id> [<start-time>] [<end-time>]``,Gets the logs of a Runnable
   ``get runnable runs <app-id.runnable-id> [<status>] [<start-time>] [<end-time>] [<limit>]``,Gets the run history of a Runnable
   ``get service status <app-id.service-id>``,Gets the status of a Service
   ``get spark logs <app-id.spark-id> [<start-time>] [<end-time>]``,Gets the logs of a Spark job
   ``get spark runs <app-id.spark-id> [<status>] [<start-time>] [<end-time>] [<limit>]``,Gets the run history of a Spark job
   ``get spark status <app-id.spark-id>``,Gets the status of a Spark job
   ``get stream <stream-id> [<start-time>] [<end-time>] [<limit>]``,Gets events from a Stream. The time format for <start-time> and <end-time> could be timestamp in milliseconds or relative time in the form of [+\-][0-9]+[hms]. For <start-time>, it is relative to current time, while for <end-time>, it's relative to start time. Special constants "min" and "max" can also be used to represent 0 and max timestamp respectively.
   ``get workflow runs <app-id.workflow-id> [<status>] [<start-time>] [<end-time>] [<limit>]``,Gets the run history of a Workflow
   ``get workflow status <app-id.workflow-id>``,Gets the status of a Workflow
   ``help``,Prints this helper text
   ``list apps``,Lists all applications
   ``list dataset instances``,Lists all Datasets
   ``list dataset modules``,Lists Dataset modules
   ``list dataset types``,Lists Dataset types
   ``list flows``,Lists Flows
   ``list mapreduce``,Lists MapReduce jobs
   ``list procedures``,Lists Procedures
   ``list programs``,Lists all programs
   ``list services``,Lists Services
   ``list spark``,Lists Spark jobs
   ``list streams``,Lists Streams
   ``list workflows``,Lists Workflows
   ``send stream <stream-id> <stream-event>``,Sends an event to a Stream
   ``set flowlet instances <app-id.flow-id.flowlet-id> <num-instances>``,Sets the instances of a Flowlet
   ``set procedure instances <app-id.procedure-id> <num-instances>``,Sets the instances of a Procedure
   ``set runnable instances <app-id.runnable-id> <num-instances>``,Sets the instances of a Runnable
   ``set stream ttl <stream-id> <ttl-in-seconds>``,Sets the Time-to-Live (TTL) of a Stream
   ``start flow <app-id.flow-id>``,Starts a Flow
   ``start mapreduce <app-id.mapreduce-id>``,Starts a MapReduce job
   ``start procedure <app-id.procedure-id>``,Starts a Procedure
   ``start service <app-id.service-id>``,Starts a Service
   ``start spark <app-id.spark-id>``,Starts a Spark job
   ``start workflow <app-id.workflow-id>``,Starts a Workflow
   ``stop flow <app-id.flow-id>``,Stops a Flow
   ``stop mapreduce <app-id.mapreduce-id>``,Stops a MapReduce job
   ``stop procedure <app-id.procedure-id>``,Stops a Procedure
   ``stop service <app-id.service-id>``,Stops a Service
   ``stop spark <app-id.spark-id>``,Stops a Spark job
   ``stop workflow <app-id.workflow-id>``,Stops a Workflow
   ``truncate dataset instance <dataset-name>``,Truncates a Dataset
   ``truncate stream <stream-id>``,Truncates a Stream
```
