### PR TITLE
Use JAVACMD rather than path-default java to check Java version

### DIFF
--- a/cdap-standalone/bin/cdap.sh
+++ b/cdap-standalone/bin/cdap.sh
@@ -99,7 +99,7 @@ location of your Java installation."
 fi
 
 # java version check
-JAVA_VERSION=`java -version 2>&1 | grep "java version" | awk '{print $3}' | awk -F '.' '{print $2}'`
+JAVA_VERSION=`$JAVACMD -version 2>&1 | grep "java version" | awk '{print $3}' | awk -F '.' '{print $2}'`
 if [ $JAVA_VERSION -ne 6 ] && [ $JAVA_VERSION -ne 7 ]; then
   die "ERROR: Java version not supported
 Please install Java 6 or 7 - other versions of Java are not yet supported."


### PR DESCRIPTION
The cdap-standalone *nix startup script (`cdap.sh`) determines the `java` command to use based on `JAVA_HOME`, but uses the default `java` command on the path to check that an appropriate Java version is in use.  If the default `java` on the path is Java 8+, then the script fails with a message that the Java version is not 6 or 7, even if `JAVA_HOME` points to a 6/7 installation.
