### PR TITLE
CDAP-821 Improve CLI error messages

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
@@ -28,7 +28,7 @@ public enum ArgumentName {
   FLOWLET("app-id.flow-id.flowlet-id"),
   WORKFLOW("app-id.workflow-id"),
   SERVICE("app-id.service-id"),
-  RUNNABLE("app-id.runnable-id"),
+  RUNNABLE("app-id.service-id.runnable-id"),
   MAPREDUCE("app-id.mapreduce-id"),
   SPARK("app-id.spark-id"),
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CallProcedureCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CallProcedureCommand.java
@@ -18,6 +18,7 @@ package co.cask.cdap.cli.command;
 
 import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.exception.CommandInputError;
 import co.cask.cdap.client.ProcedureClient;
 import co.cask.common.cli.Arguments;
 import co.cask.common.cli.Command;
@@ -42,6 +43,10 @@ public class CallProcedureCommand implements Command {
   @Override
   public void execute(Arguments arguments, PrintStream output) throws Exception {
     String[] appIdAndProcedureId = arguments.get(ArgumentName.PROCEDURE.toString()).split("\\.");
+    if (appIdAndProcedureId.length < 2) {
+      throw new CommandInputError(this);
+    }
+
     String appId = appIdAndProcedureId[0];
     String procedureId = appIdAndProcedureId[1];
     String methodId = arguments.get(ArgumentName.METHOD.toString());

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CallServiceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CallServiceCommand.java
@@ -19,6 +19,7 @@ package co.cask.cdap.cli.command;
 import co.cask.cdap.api.service.Service;
 import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.exception.CommandInputError;
 import co.cask.cdap.cli.util.AbstractCommand;
 import co.cask.cdap.cli.util.AsciiTable;
 import co.cask.cdap.cli.util.RowMaker;
@@ -64,6 +65,10 @@ public class CallServiceCommand extends AbstractCommand {
   @Override
   public void execute(Arguments arguments, PrintStream output) throws Exception {
     String[] appAndServiceId = arguments.get(ArgumentName.SERVICE.toString()).split("\\.");
+    if (appAndServiceId.length < 2) {
+      throw new CommandInputError(this);
+    }
+
     String appId = appAndServiceId[0];
     String serviceId = appAndServiceId[1];
     String method = arguments.get(ArgumentName.HTTP_METHOD.toString());

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramInstancesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramInstancesCommand.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.cli.command;
 
 import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.exception.CommandInputError;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.common.cli.Arguments;
 import co.cask.common.cli.Command;
@@ -44,15 +45,24 @@ public class GetProgramInstancesCommand implements Command {
     int instances;
     switch (elementType) {
       case FLOWLET:
+        if (programIdParts.length < 3) {
+          throw new CommandInputError(this);
+        }
         String flowId = programIdParts[1];
         String flowletId = programIdParts[2];
         instances = programClient.getFlowletInstances(appId, flowId, flowletId);
         break;
       case PROCEDURE:
+        if (programIdParts.length < 2) {
+          throw new CommandInputError(this);
+        }
         String procedureId = programIdParts[1];
         instances = programClient.getProcedureInstances(appId, procedureId);
         break;
       case RUNNABLE:
+        if (programIdParts.length < 3) {
+          throw new CommandInputError(this);
+        }
         String serviceId = programIdParts[1];
         String runnableId = programIdParts[2];
         instances = programClient.getServiceRunnableInstances(appId, serviceId, runnableId);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLiveInfoCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLiveInfoCommand.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.cli.command;
 
 import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.exception.CommandInputError;
 import co.cask.cdap.cli.util.AsciiTable;
 import co.cask.cdap.cli.util.RowMaker;
 import co.cask.cdap.client.ProgramClient;
@@ -44,6 +45,9 @@ public class GetProgramLiveInfoCommand implements Command {
   @Override
   public void execute(Arguments arguments, PrintStream output) throws Exception {
     String[] programIdParts = arguments.get(elementType.getArgumentName().toString()).split("\\.");
+    if (programIdParts.length < 2) {
+      throw new CommandInputError(this);
+    }
     String appId = programIdParts[0];
     String programId = programIdParts[1];
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLogsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLogsCommand.java
@@ -18,6 +18,7 @@ package co.cask.cdap.cli.command;
 
 import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.exception.CommandInputError;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.common.cli.Arguments;
 import co.cask.common.cli.Command;
@@ -46,10 +47,16 @@ public class GetProgramLogsCommand implements Command {
 
     String logs;
     if (elementType == ElementType.RUNNABLE) {
+      if (programIdParts.length < 3) {
+        throw new CommandInputError(this);
+      }
       String serviceId = programIdParts[1];
       String runnableId = programIdParts[2];
       logs = programClient.getServiceRunnableLogs(appId, serviceId, runnableId, start, stop);
     } else if (elementType.getProgramType() != null) {
+      if (programIdParts.length < 2) {
+        throw new CommandInputError(this);
+      }
       String programId = programIdParts[1];
       logs = programClient.getProgramLogs(appId, elementType.getProgramType(), programId, start, stop);
     } else {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRunsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRunsCommand.java
@@ -18,6 +18,7 @@ package co.cask.cdap.cli.command;
 
 import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.exception.CommandInputError;
 import co.cask.cdap.cli.util.AbstractCommand;
 import co.cask.cdap.cli.util.AsciiTable;
 import co.cask.cdap.cli.util.RowMaker;
@@ -53,6 +54,9 @@ public class GetProgramRunsCommand extends AbstractCommand {
 
     List<RunRecord> records;
     if (elementType.getProgramType() != null) {
+      if (programIdParts.length < 2) {
+        throw new CommandInputError(this);
+      }
       String programId = programIdParts[1];
       if (arguments.hasArgument(ArgumentName.RUN_STATUS.toString())) {
         records = programClient.getProgramRuns(appId, elementType.getProgramType(), programId,

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramStatusCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramStatusCommand.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.cli.command;
 
 import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.exception.CommandInputError;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.common.cli.Arguments;
 import co.cask.common.cli.Command;
@@ -39,6 +40,10 @@ public class GetProgramStatusCommand implements Command {
   @Override
   public void execute(Arguments arguments, PrintStream output) throws Exception {
     String[] programIdParts = arguments.get(elementType.getArgumentName().toString()).split("\\.");
+    if (programIdParts.length < 2) {
+      throw new CommandInputError(this);
+    }
+
     String appId = programIdParts[0];
     String programId = programIdParts[1];
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetServiceEndpointsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetServiceEndpointsCommand.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.service.Service;
 import co.cask.cdap.api.service.http.ServiceHttpEndpoint;
 import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.exception.CommandInputError;
 import co.cask.cdap.cli.util.AsciiTable;
 import co.cask.cdap.cli.util.RowMaker;
 import co.cask.cdap.client.ServiceClient;
@@ -45,6 +46,10 @@ public class GetServiceEndpointsCommand implements Command {
   @Override
   public void execute(Arguments arguments, PrintStream output) throws Exception {
     String[] appAndServiceId = arguments.get(ArgumentName.SERVICE.toString()).split("\\.");
+    if (appAndServiceId.length < 2) {
+      throw new CommandInputError(this);
+    }
+
     String appId = appAndServiceId[0];
     String serviceId = appAndServiceId[1];
     List<ServiceHttpEndpoint> endpoints = serviceClient.getEndpoints(appId, serviceId);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetProgramInstancesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetProgramInstancesCommand.java
@@ -18,6 +18,7 @@ package co.cask.cdap.cli.command;
 
 import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.exception.CommandInputError;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.common.cli.Arguments;
 import co.cask.common.cli.Command;
@@ -45,6 +46,9 @@ public class SetProgramInstancesCommand implements Command {
 
     switch (elementType) {
       case FLOWLET:
+        if (programIdParts.length < 3) {
+          throw new CommandInputError(this);
+        }
         String flowId = programIdParts[1];
         String flowletId = programIdParts[2];
         programClient.setFlowletInstances(appId, flowId, flowletId, numInstances);
@@ -52,12 +56,18 @@ public class SetProgramInstancesCommand implements Command {
                       flowId, flowletId, appId, numInstances);
         break;
       case PROCEDURE:
+        if (programIdParts.length < 2) {
+          throw new CommandInputError(this);
+        }
         String procedureId = programIdParts[1];
         programClient.setProcedureInstances(appId, procedureId, numInstances);
         output.printf("Successfully set procedure '%s' of app '%s' to %d instances\n",
                       procedureId, appId, numInstances);
         break;
       case RUNNABLE:
+        if (programIdParts.length < 3) {
+          throw new CommandInputError(this);
+        }
         String serviceId = programIdParts[1];
         String runnableId = programIdParts[2];
         programClient.setServiceRunnableInstances(appId, serviceId, runnableId, numInstances);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/StartProgramCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/StartProgramCommand.java
@@ -16,8 +16,8 @@
 
 package co.cask.cdap.cli.command;
 
-import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.exception.CommandInputError;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.common.cli.Arguments;
 import co.cask.common.cli.Command;
@@ -40,6 +40,10 @@ public class StartProgramCommand implements Command {
   @Override
   public void execute(Arguments arguments, PrintStream output) throws Exception {
     String[] programIdParts = arguments.get(elementType.getArgumentName().toString()).split("\\.");
+    if (programIdParts.length < 2) {
+      throw new CommandInputError(this);
+    }
+
     String appId = programIdParts[0];
     String programId = programIdParts[1];
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/StopProgramCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/StopProgramCommand.java
@@ -16,8 +16,8 @@
 
 package co.cask.cdap.cli.command;
 
-import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.exception.CommandInputError;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.common.cli.Arguments;
 import co.cask.common.cli.Command;
@@ -40,6 +40,10 @@ public class StopProgramCommand implements Command {
   @Override
   public void execute(Arguments arguments, PrintStream output) throws Exception {
     String[] programIdParts = arguments.get(elementType.getArgumentName().toString()).split("\\.");
+    if (programIdParts.length < 2) {
+      throw new CommandInputError(this);
+    }
+
     String appId = programIdParts[0];
     String programId = programIdParts[1];
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/exception/CommandInputError.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/exception/CommandInputError.java
@@ -16,12 +16,18 @@
 
 package co.cask.cdap.cli.exception;
 
+import co.cask.common.cli.Command;
+
 /**
  * Thrown when there was an error in the command input.
  */
 public class CommandInputError extends RuntimeException {
 
-  public CommandInputError(String message) {
-    super(message);
+  public CommandInputError(Command command) {
+    super("Invalid input. Expected format: " + command.getPattern());
+  }
+
+  public CommandInputError(Command command, String message) {
+    super("Invalid input: " + message + "\nExpected format: " + command.getPattern());
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/util/AbstractCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/util/AbstractCommand.java
@@ -100,7 +100,7 @@ public abstract class AbstractCommand implements Command {
           case 'd':
             return base + dir * TimeUnit.DAYS.toMillis(offset);
           default:
-            throw new CommandInputError("Unsupported relative time format: " + type);
+            throw new CommandInputError(this, "Unsupported relative time format: " + type);
         }
       }
       if (arg.equalsIgnoreCase("min")) {
@@ -112,7 +112,7 @@ public abstract class AbstractCommand implements Command {
 
       return Long.parseLong(arg);
     } catch (NumberFormatException e) {
-      throw new CommandInputError("Invalid number value: " + arg + ". Reason: " + e.getMessage());
+      throw new CommandInputError(this, "Invalid number value: " + arg + ". Reason: " + e.getMessage());
     }
   }
 }


### PR DESCRIPTION
New error messages

```
cdap (http://localhost:10000)> get runnable instances Wise.WiseService
get runnable instances Wise.WiseService
Error: Invalid input. Expected format: get runnable instances <app-id.service-id.runnable-id>
```
