### PR TITLE
[CDAP-857] Temporary refactoring in router to lookup /v3 paths

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/services/AbstractServiceDiscoverer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/services/AbstractServiceDiscoverer.java
@@ -107,7 +107,7 @@ public abstract class AbstractServiceDiscoverer implements ServiceDiscoverer {
     String hostName = discoverable.getSocketAddress().getHostName();
     int port = discoverable.getSocketAddress().getPort();
     String path = String.format("http://%s:%d%s/apps/%s/services/%s/methods/", hostName, port,
-                                Constants.Gateway.GATEWAY_VERSION, applicationId, serviceId);
+                                Constants.Gateway.API_VERSION_2, applicationId, serviceId);
     try {
       return new URL(path);
     } catch (MalformedURLException e) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppFabricHttpHandler.java
@@ -165,7 +165,7 @@ import javax.ws.rs.QueryParam;
 /**
  *  HttpHandler class for app-fabric requests.
  */
-@Path(Constants.Gateway.GATEWAY_VERSION) //this will be removed/changed when gateway goes.
+@Path(Constants.Gateway.API_VERSION_2) //this will be removed/changed when gateway goes.
 public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
   private static final Logger LOG = LoggerFactory.getLogger(AppFabricHttpHandler.class);
 
@@ -2301,7 +2301,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
         String url = String.format("http://%s:%d%s/metrics/%s/apps/%s",
                                    discoverable.getSocketAddress().getHostName(),
                                    discoverable.getSocketAddress().getPort(),
-                                   Constants.Gateway.GATEWAY_VERSION,
+                                   Constants.Gateway.API_VERSION_2,
                                    scope.name().toLowerCase(),
                                    application.getName());
         sendMetricsDelete(url);
@@ -2310,7 +2310,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
 
     if (applicationId == null) {
       String url = String.format("http://%s:%d%s/metrics", discoverable.getSocketAddress().getHostName(),
-                                 discoverable.getSocketAddress().getPort(), Constants.Gateway.GATEWAY_VERSION);
+                                 discoverable.getSocketAddress().getPort(), Constants.Gateway.API_VERSION_2);
       sendMetricsDelete(url);
     }
   }
@@ -2330,7 +2330,7 @@ public class AppFabricHttpHandler extends AbstractAppFabricHttpHandler {
     String url = String.format("http://%s:%d%s/metrics/system/apps/%s/flows/%s?prefixEntity=process",
                                discoverable.getSocketAddress().getHostName(),
                                discoverable.getSocketAddress().getPort(),
-                               Constants.Gateway.GATEWAY_VERSION,
+                               Constants.Gateway.API_VERSION_2,
                                application, flow);
 
     long timeout = TimeUnit.MILLISECONDS.convert(1, TimeUnit.MINUTES);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/MonitorHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/MonitorHandler.java
@@ -44,7 +44,7 @@ import javax.ws.rs.PathParam;
 /**
  * Monitor Handler returns the status of different discoverable services
  */
-@Path(Constants.Gateway.GATEWAY_VERSION)
+@Path(Constants.Gateway.API_VERSION_2)
 public class MonitorHandler extends AbstractAppFabricHttpHandler {
   private final Map<String, MasterServiceManager> serviceManagementMap;
   private static final String STATUSOK = Constants.Monitor.STATUS_OK;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
@@ -43,7 +43,7 @@ import javax.ws.rs.PathParam;
 /**
  * The {@link HttpHandler} for handling REST calls to namespace endpoints.
  */
-@Path(Constants.Gateway.API_VERSION)
+@Path(Constants.Gateway.API_VERSION_3)
 public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
   private static final Logger LOG = LoggerFactory.getLogger(NamespaceHttpHandler.class);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ServiceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ServiceHttpHandler.java
@@ -36,8 +36,6 @@ import co.cask.cdap.proto.ServiceInstances;
 import co.cask.http.HttpHandler;
 import co.cask.http.HttpResponder;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
@@ -55,7 +53,7 @@ import javax.ws.rs.PathParam;
 /**
  *  {@link HttpHandler} for User Services.
  */
-@Path(Constants.Gateway.GATEWAY_VERSION)
+@Path(Constants.Gateway.API_VERSION_2)
 public class ServiceHttpHandler extends AbstractAppFabricHttpHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(ServiceHttpHandler.class);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
@@ -143,7 +143,7 @@ public class DeletedProgramHandlerStage extends AbstractStage<ApplicationDeploya
         String url = String.format("http://%s:%d%s/metrics/%s/apps/%s/flows/%s",
                                    discoverable.getSocketAddress().getHostName(),
                                    discoverable.getSocketAddress().getPort(),
-                                   Constants.Gateway.GATEWAY_VERSION,
+                                   Constants.Gateway.API_VERSION_2,
                                    scope.name().toLowerCase(),
                                    application, flow);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/ServePathGenerator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/ServePathGenerator.java
@@ -29,7 +29,7 @@ import java.net.URI;
 public class ServePathGenerator {
   public static final String SRC_PATH = "/src/";
   public static final String DEFAULT_DIR_NAME = "default";
-  private static final String GATEWAY_PATH = Constants.Gateway.GATEWAY_VERSION.substring(1) + "/";
+  private static final String GATEWAY_PATH = Constants.Gateway.API_VERSION_2.substring(1) + "/";
 
   private static final String DEFAULT_PORT_STR = ":80";
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceHttpServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceHttpServer.java
@@ -125,7 +125,7 @@ public class ServiceHttpServer extends AbstractIdleService {
 
     // The service URI is always prefixed for routing purpose
     String pathPrefix = String.format("%s/apps/%s/services/%s/methods",
-                                      Constants.Gateway.GATEWAY_VERSION,
+                                      Constants.Gateway.API_VERSION_2,
                                       programId.getApplicationId(),
                                       programId.getId());
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
@@ -63,20 +63,20 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
   }
 
   private HttpResponse createNamespace(String metadata) throws Exception {
-    return doPut(String.format("%s/namespaces", Constants.Gateway.API_VERSION), metadata);
+    return doPut(String.format("%s/namespaces", Constants.Gateway.API_VERSION_3), metadata);
   }
 
   private HttpResponse listAllNamespaces() throws Exception {
-    return doGet(String.format("%s/namespaces", Constants.Gateway.API_VERSION));
+    return doGet(String.format("%s/namespaces", Constants.Gateway.API_VERSION_3));
   }
 
   private HttpResponse getNamespace(String name) throws Exception {
     Preconditions.checkArgument(name != null, "namespace name cannot be null");
-    return doGet(String.format("%s/namespaces/%s", Constants.Gateway.API_VERSION, name));
+    return doGet(String.format("%s/namespaces/%s", Constants.Gateway.API_VERSION_3, name));
   }
 
   private HttpResponse deleteNamespace(String name) throws Exception {
-    return doDelete(String.format("%s/namespaces/%s", Constants.Gateway.API_VERSION, name));
+    return doDelete(String.format("%s/namespaces/%s", Constants.Gateway.API_VERSION_3, name));
   }
 
   private void assertResponseCode(int expected, HttpResponse response) {

--- a/cdap-client/src/main/java/co/cask/cdap/client/config/ClientConfig.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/config/ClientConfig.java
@@ -44,7 +44,7 @@ public class ClientConfig {
   private static final int DEFAULT_CONNECT_TIMEOUT = 15000;
   private static final boolean DEFAULT_VERIFY_SSL_CERTIFICATE = true;
 
-  private static final String DEFAULT_VERSION = Constants.Gateway.GATEWAY_VERSION_TOKEN;
+  private static final String DEFAULT_VERSION = Constants.Gateway.API_VERSION_2_TOKEN;
   private static final int DEFAULT_PORT = CONF.getInt(Constants.Router.ROUTER_PORT);
   private static final int DEFAULT_SSL_PORT = CONF.getInt(Constants.Router.ROUTER_SSL_PORT);
   private static final boolean DEFAULT_SSL_ENABLED = CONF.getBoolean(Constants.Security.SSL_ENABLED);

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -267,13 +267,13 @@ public final class Constants {
    * Gateway Configurations.
    */
   public static final class Gateway {
-    public static final String GATEWAY_VERSION_TOKEN = "v2";
-    public static final String GATEWAY_VERSION = "/" + GATEWAY_VERSION_TOKEN;
+    public static final String API_VERSION_2_TOKEN = "v2";
+    public static final String API_VERSION_2 = "/" + API_VERSION_2_TOKEN;
     /**
      * v3 API.
      */
-    public static final String API_VERSION_TOKEN = "v3";
-    public static final String API_VERSION = "/" + API_VERSION_TOKEN;
+    public static final String API_VERSION_3_TOKEN = "v3";
+    public static final String API_VERSION_3 = "/" + API_VERSION_3_TOKEN;
     public static final String STREAM_HANDLER_NAME = "stream.rest";
     public static final String METRICS_CONTEXT = "gateway." + Gateway.STREAM_HANDLER_NAME;
     public static final String API_KEY = "X-ApiKey";

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFetchHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFetchHandler.java
@@ -63,7 +63,7 @@ import javax.ws.rs.PathParam;
 /**
  * A HTTP handler for handling getting stream events.
  */
-@Path(Constants.Gateway.GATEWAY_VERSION + "/streams")
+@Path(Constants.Gateway.API_VERSION_2 + "/streams")
 public final class StreamFetchHandler extends AuthenticatedHttpHandler {
 
   private static final Gson GSON = StreamEventTypeAdapter.register(new GsonBuilder()).create();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
@@ -66,7 +66,7 @@ import javax.ws.rs.PathParam;
  *
  * TODO: Currently stream "dataset" is implementing old dataset API, hence not supporting multi-tenancy.
  */
-@Path(Constants.Gateway.GATEWAY_VERSION + "/streams")
+@Path(Constants.Gateway.API_VERSION_2 + "/streams")
 public final class StreamHandler extends AuthenticatedHttpHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(StreamHandler.class);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -297,6 +297,6 @@ class DatasetServiceClient {
     }
     InetSocketAddress addr = discoverable.getSocketAddress();
     return String.format("http://%s:%s%s/data/%s", addr.getHostName(), addr.getPort(),
-                         Constants.Gateway.GATEWAY_VERSION, resource);
+                         Constants.Gateway.API_VERSION_2, resource);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
@@ -64,7 +64,7 @@ import javax.ws.rs.PathParam;
  * Handles dataset instance management calls.
  */
 // todo: do we want to make it authenticated? or do we treat it always as "internal" piece?
-@Path(Constants.Gateway.GATEWAY_VERSION)
+@Path(Constants.Gateway.API_VERSION_2)
 public class DatasetInstanceHandler extends AbstractHttpHandler {
   private static final Logger LOG = LoggerFactory.getLogger(DatasetInstanceHandler.class);
   private static final Gson GSON = new GsonBuilder()

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeHandler.java
@@ -54,7 +54,7 @@ import javax.ws.rs.PathParam;
  * Handles dataset type management calls.
  */
 // todo: do we want to make it authenticated? or do we treat it always as "internal" piece?
-@Path(Constants.Gateway.GATEWAY_VERSION)
+@Path(Constants.Gateway.API_VERSION_2)
 public class DatasetTypeHandler extends AbstractHttpHandler {
   public static final String HEADER_CLASS_NAME = "X-Class-Name";
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetAdminOpHTTPHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetAdminOpHTTPHandler.java
@@ -46,7 +46,7 @@ import javax.ws.rs.PathParam;
 /**
  * Provides REST endpoints for {@link DatasetAdmin} operations.
  */
-@Path(Constants.Gateway.GATEWAY_VERSION)
+@Path(Constants.Gateway.API_VERSION_2)
 public class DatasetAdminOpHTTPHandler extends AuthenticatedHttpHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(DatasetAdminOpHTTPHandler.class);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/RemoteDatasetOpExecutor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/RemoteDatasetOpExecutor.java
@@ -122,7 +122,7 @@ public abstract class RemoteDatasetOpExecutor extends AbstractIdleService implem
     InetSocketAddress addr = endpoint.getSocketAddress();
     return new URL(String.format("http://%s:%s%s/data/%s",
                          addr.getHostName(), addr.getPort(),
-                         Constants.Gateway.GATEWAY_VERSION,
+                         Constants.Gateway.API_VERSION_2,
                          path));
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -178,7 +178,7 @@ public abstract class DatasetServiceTestBase {
   }
 
   protected URL getUrl(String resource) throws MalformedURLException {
-    return new URL("http://" + "localhost" + ":" + getPort() + Constants.Gateway.GATEWAY_VERSION + resource);
+    return new URL("http://" + "localhost" + ":" + getPort() + Constants.Gateway.API_VERSION_2 + resource);
   }
 
   protected int deployModule(String moduleName, Class moduleClass) throws Exception {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorServiceTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorServiceTest.java
@@ -218,7 +218,7 @@ public class DatasetOpExecutorServiceTest {
   private URL resolve(String path) throws URISyntaxException, MalformedURLException {
     InetSocketAddress socketAddress = endpointStrategy.pick().getSocketAddress();
     return new URL(String.format("http://%s:%d%s%s", socketAddress.getHostName(),
-                                 socketAddress.getPort(), Constants.Gateway.GATEWAY_VERSION, path));
+                                 socketAddress.getPort(), Constants.Gateway.API_VERSION_2, path));
   }
 
   private DatasetAdminOpResponse getResponse(byte[] body) {

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreHttpClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreHttpClient.java
@@ -361,7 +361,7 @@ abstract class ExploreHttpClient implements Explore {
   private String resolve(String resource) {
     InetSocketAddress addr = getExploreServiceAddress();
     String url = String.format("http://%s:%s%s/%s", addr.getHostName(), addr.getPort(),
-                               Constants.Gateway.GATEWAY_VERSION, resource);
+                               Constants.Gateway.API_VERSION_2, resource);
     LOG.trace("Explore URL = {}", url);
     return url;
   }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorHttpHandler.java
@@ -47,7 +47,7 @@ import javax.ws.rs.PathParam;
 /**
  * Handler that implements internal explore APIs.
  */
-@Path(Constants.Gateway.GATEWAY_VERSION)
+@Path(Constants.Gateway.API_VERSION_2)
 public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
   private static final Logger LOG = LoggerFactory.getLogger(QueryExecutorHttpHandler.class);
 

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreMetadataHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreMetadataHttpHandler.java
@@ -55,7 +55,7 @@ import javax.ws.rs.PathParam;
 /**
  * Handler that implements explore metadata APIs.
  */
-@Path(Constants.Gateway.GATEWAY_VERSION)
+@Path(Constants.Gateway.API_VERSION_2)
 public class ExploreMetadataHttpHandler extends AbstractHttpHandler {
   private static final Logger LOG = LoggerFactory.getLogger(ExploreMetadataHttpHandler.class);
   private static final Gson GSON = new Gson();

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExplorePingHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExplorePingHandler.java
@@ -30,7 +30,7 @@ import javax.ws.rs.Path;
 /**
  * Explore ping handler - reachable outside of CDAP.
  */
-@Path(Constants.Gateway.GATEWAY_VERSION)
+@Path(Constants.Gateway.API_VERSION_2)
 public class ExplorePingHandler extends AbstractHttpHandler {
 
   @Path("/explore/status")

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/QueryExecutorHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/QueryExecutorHttpHandler.java
@@ -66,7 +66,7 @@ import javax.ws.rs.PathParam;
 /**
  * Provides REST endpoints for {@link co.cask.cdap.explore.service.ExploreService} operations.
  */
-@Path(Constants.Gateway.GATEWAY_VERSION)
+@Path(Constants.Gateway.API_VERSION_2)
 public class QueryExecutorHttpHandler extends AbstractHttpHandler {
   private static final Logger LOG = LoggerFactory.getLogger(QueryExecutorHttpHandler.class);
   private static final Gson GSON = new Gson();

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathTest.java
@@ -286,4 +286,12 @@ public class RouterPathTest {
     Assert.assertEquals(Constants.Service.METRICS, result);
   }
 
+  @Test
+  public void testRouterV3PathLookup() {
+    final String namespacePath = "/v3////namespace/////";
+    HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), namespacePath);
+    String result = pathLookup.getRoutingService(FALLBACKSERVICE, namespacePath, httpRequest);
+    Assert.assertEquals(Constants.Service.APP_FABRIC_HTTP, result);
+  }
+
 }

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RoutingToDataSetsTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RoutingToDataSetsTest.java
@@ -116,7 +116,7 @@ public class RoutingToDataSetsTest {
     Assert.assertEquals("get:cdap.user.myInstance", doRequest("/data/datasets/myInstance", "GET"));
   }
 
-  @Path(Constants.Gateway.GATEWAY_VERSION)
+  @Path(Constants.Gateway.API_VERSION_2)
   public static final class MockDatasetTypeHandler extends AbstractHttpHandler {
     @GET
     @Path("/data/modules")
@@ -157,7 +157,7 @@ public class RoutingToDataSetsTest {
     }
   }
 
-  @Path(Constants.Gateway.GATEWAY_VERSION)
+  @Path(Constants.Gateway.API_VERSION_2)
   public static final class DatasetInstanceHandler extends AbstractHttpHandler {
     @GET
     @Path("/data/datasets/")
@@ -188,7 +188,7 @@ public class RoutingToDataSetsTest {
   }
 
   private String doRequest(String resource, String requestMethod) throws Exception {
-    resource = String.format("http://localhost:%d%s" + resource, port, Constants.Gateway.GATEWAY_VERSION);
+    resource = String.format("http://localhost:%d%s" + resource, port, Constants.Gateway.API_VERSION_2);
     URL url = new URL(resource);
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
     conn.setRequestMethod(requestMethod);

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RoutingToExploreTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RoutingToExploreTest.java
@@ -131,7 +131,7 @@ public class RoutingToExploreTest {
     Assert.assertEquals("info:some_type", doRequest("/data/explore/jdbc/info/some_type", "GET"));
   }
 
-  @Path(Constants.Gateway.GATEWAY_VERSION)
+  @Path(Constants.Gateway.API_VERSION_2)
   public static final class MockExplorePingHandler extends AbstractHttpHandler {
     @GET
     @Path("/explore/status")
@@ -140,7 +140,7 @@ public class RoutingToExploreTest {
     }
   }
 
-  @Path(Constants.Gateway.GATEWAY_VERSION)
+  @Path(Constants.Gateway.API_VERSION_2)
   public static final class MockQueryExecutorHandler extends AbstractHttpHandler {
 
     @POST
@@ -189,7 +189,7 @@ public class RoutingToExploreTest {
     }
   }
 
-  @Path(Constants.Gateway.GATEWAY_VERSION)
+  @Path(Constants.Gateway.API_VERSION_2)
   public static final class MockExploreMetadataHandler extends AbstractHttpHandler {
     @POST
     @Path("/data/explore/jdbc/tables")
@@ -240,7 +240,7 @@ public class RoutingToExploreTest {
     }
   }
 
-  @Path(Constants.Gateway.GATEWAY_VERSION)
+  @Path(Constants.Gateway.API_VERSION_2)
   public static class MockExploreExecutorHandler extends AbstractHttpHandler {
     @GET
     @Path("/data/explore/datasets/{dataset}/schema")
@@ -251,7 +251,7 @@ public class RoutingToExploreTest {
   }
 
   private String doRequest(String resource, String requestMethod) throws Exception {
-    resource = String.format("http://localhost:%d%s" + resource, port, Constants.Gateway.GATEWAY_VERSION);
+    resource = String.format("http://localhost:%d%s" + resource, port, Constants.Gateway.API_VERSION_2);
     URL url = new URL(resource);
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
     conn.setRequestMethod(requestMethod);

--- a/cdap-security-service/src/main/java/co/cask/cdap/security/authorization/ACLHandler.java
+++ b/cdap-security-service/src/main/java/co/cask/cdap/security/authorization/ACLHandler.java
@@ -44,7 +44,7 @@ import javax.ws.rs.PathParam;
 /**
  * Exposes the system {@link ACLTable} via REST endpoints.
  */
-@Path(Constants.Gateway.GATEWAY_VERSION)
+@Path(Constants.Gateway.API_VERSION_2)
 public final class ACLHandler extends AbstractHttpHandler {
 
   private static final Gson GSON = new Gson();

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultServiceManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultServiceManager.java
@@ -145,7 +145,7 @@ public class DefaultServiceManager implements ServiceManager {
     String hostName = discoverable.getSocketAddress().getHostName();
     int port = discoverable.getSocketAddress().getPort();
     String path = String.format("http://%s:%d%s/apps/%s/services/%s/methods/", hostName, port,
-                                Constants.Gateway.GATEWAY_VERSION, applicationId, serviceName);
+                                Constants.Gateway.API_VERSION_2, applicationId, serviceName);
     try {
       return new URL(path);
     } catch (MalformedURLException e) {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandler.java
@@ -44,7 +44,7 @@ import javax.ws.rs.PathParam;
 /**
  * Handler to serve log requests.
  */
-@Path(Constants.Gateway.GATEWAY_VERSION)
+@Path(Constants.Gateway.API_VERSION_2)
 public class LogHandler extends AuthenticatedHttpHandler {
   private static final Logger LOG = LoggerFactory.getLogger(LogHandler.class);
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/BatchMetricsHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/BatchMetricsHandler.java
@@ -47,7 +47,7 @@ import javax.ws.rs.Path;
 /**
  * Class for handling batch requests for metrics data.
  */
-@Path(Constants.Gateway.GATEWAY_VERSION + "/metrics")
+@Path(Constants.Gateway.API_VERSION_2 + "/metrics")
 public final class BatchMetricsHandler extends BaseMetricsHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(BatchMetricsHandler.class);

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/DeleteMetricsHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/DeleteMetricsHandler.java
@@ -55,7 +55,7 @@ import javax.ws.rs.PathParam;
 /**
  * Handlers for clearing metrics.
  */
-@Path(Constants.Gateway.GATEWAY_VERSION + "/metrics")
+@Path(Constants.Gateway.API_VERSION_2 + "/metrics")
 public class DeleteMetricsHandler extends BaseMetricsHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(DeleteMetricsHandler.class);

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsDiscoveryHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsDiscoveryHandler.java
@@ -51,7 +51,7 @@ import javax.ws.rs.Path;
  * Class for handling requests for aggregate application metrics of the
  * {@link co.cask.cdap.common.metrics.MetricsScope#USER} scope.
  */
-@Path(Constants.Gateway.GATEWAY_VERSION + "/metrics/available")
+@Path(Constants.Gateway.API_VERSION_2 + "/metrics/available")
 public final class MetricsDiscoveryHandler extends BaseMetricsHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(MetricsDiscoveryHandler.class);
@@ -199,7 +199,7 @@ public final class MetricsDiscoveryHandler extends BaseMetricsHandler {
     String contextPrefix = null;
     try {
       String path = request.getUri();
-      String base = Constants.Gateway.GATEWAY_VERSION + "/metrics/available/apps";
+      String base = Constants.Gateway.API_VERSION_2 + "/metrics/available/apps";
       if (path.startsWith(base)) {
         Iterator<String> pathParts = Splitter.on('/').split(path.substring(base.length() + 1)).iterator();
         MetricsRequestContext.Builder builder = new MetricsRequestContext.Builder();

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsQueryHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsQueryHandler.java
@@ -33,7 +33,7 @@ import javax.ws.rs.Path;
 /**
  * Class for handling requests for a single metric in a context.
  */
-@Path(Constants.Gateway.GATEWAY_VERSION + "/metrics")
+@Path(Constants.Gateway.API_VERSION_2 + "/metrics")
 public class MetricsQueryHandler extends BaseMetricsHandler {
 
   private final MetricsRequestExecutor requestExecutor;

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsRequestParser.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsRequestParser.java
@@ -111,7 +111,7 @@ final class MetricsRequestParser {
    */
   static String stripVersionAndMetricsFromPath(String path) {
     // +8 for "/metrics"
-    int startPos = Constants.Gateway.GATEWAY_VERSION.length() + 8;
+    int startPos = Constants.Gateway.API_VERSION_2.length() + 8;
     return path.substring(startPos, path.length());
   }
 

--- a/cdap-watchdog/src/test/java/co/cask/cdap/metrics/query/MetricsRequestParserTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/metrics/query/MetricsRequestParserTest.java
@@ -33,7 +33,7 @@ public class MetricsRequestParserTest {
   @Test
   public void testPathStrip() {
     String expected = "/system/apps/app1/flows/flow1/metric?aggregate=true";
-    String path = Constants.Gateway.GATEWAY_VERSION + "/metrics" + expected;
+    String path = Constants.Gateway.API_VERSION_2 + "/metrics" + expected;
     Assert.assertEquals(expected, MetricsRequestParser.stripVersionAndMetricsFromPath(path));
   }
 


### PR DESCRIPTION
This is temporary refactoring of `RouterPathLookup` to support `v3` APIs. Temporary because `v3` affect and change a large portion (though not all) of the APIs, to reflect namespace, and I currently do not have a complete list of exactly how each API will be changed to "namespace" it. During the course of the next few weeks, I will update the `RouterPathLookup.getV3RoutingService()` method to capture all required changes during namespace implementation. Once done, we could do a complete refactor of this class in a much cleaner way.

Also, this PR has a lot of files primarily because I changed the name of `Constants.Gateway.GATEWAY_VERSION` to `Constants.Gateway.API_VERSION_2` for consistency.

Testing done:
- [x] All tests in `RoutePathTest` pass.
- [x] Tested some APIs in standalone mode
- [x] Played around with the `SparkPageRank` app on the UI with these changes and it seemed to work fine.
- [ ] Cluster testing
