### PR TITLE
[Docker] Feature/remove missing dirs dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,5 +85,6 @@ RUN apt-get purge -y maven unzip && \
     apt-get autoclean && \
     apt-get -y autoremove 
 
-# start CDAP in the background and ssh in the foreground
-CMD /Software/cdap-sdk-[0-9]*.[0-9]*.[0-9]*/bin/cdap.sh start && /usr/bin/tail -F /var/log/cdap/*.log
+# start CDAP in the background and tail in the foreground
+ENTRYPOINT /Software/cdap-sdk-[0-9]*.[0-9]*.[0-9]*/bin/cdap.sh start && \
+    /usr/bin/tail -F /Software/cdap-sdk-[0-9]*.[0-9]*.[0-9]*/logs/*.log


### PR DESCRIPTION
This fixes the docker build on 2.5, removes SSH, as we were insecurely setting a bad root password (my bad) and exposing it, and clean up some files that we don't need on the system.
