### PR TITLE
(CDAP-864) Fix classloading in unit-test mode

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGenerator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGenerator.java
@@ -27,6 +27,8 @@ import co.cask.cdap.internal.asm.Signatures;
 import co.cask.http.HttpResponder;
 import co.cask.tephra.TransactionContext;
 import co.cask.tephra.TransactionFailureException;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
@@ -56,6 +58,7 @@ import java.io.InputStream;
 import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.HEAD;
@@ -91,8 +94,18 @@ import javax.ws.rs.Path;
  */
 final class HttpHandlerGenerator {
 
+  private static final Set<Type> HTTP_ANNOTATION_TYPES = ImmutableSet.of(
+    Type.getType(GET.class),
+    Type.getType(POST.class),
+    Type.getType(PUT.class),
+    Type.getType(DELETE.class),
+    Type.getType(HEAD.class)
+  );
+
   ClassDefinition generate(TypeToken<? extends HttpServiceHandler> delegateType, String pathPrefix) throws IOException {
     Class<?> rawType = delegateType.getRawType();
+    List<Class<?>> preservedClasses = Lists.newArrayList();
+    preservedClasses.add(rawType);
 
     ClassWriter classWriter = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
 
@@ -108,14 +121,14 @@ final class HttpHandlerGenerator {
     // Inspect the delegate class hierarchy to generate public handler methods.
     for (TypeToken<?> type : delegateType.getTypes().classes()) {
       if (!Object.class.equals(type.getRawType())) {
-        inspectHandler(delegateType, type, pathPrefix, classType, classWriter);
+        inspectHandler(delegateType, type, pathPrefix, classType, classWriter, preservedClasses);
       }
     }
 
     generateConstructor(delegateType, classWriter);
     generateLogger(classType, classWriter);
 
-    ClassDefinition classDefinition = new ClassDefinition(classWriter.toByteArray(), className);
+    ClassDefinition classDefinition = new ClassDefinition(classWriter.toByteArray(), className, preservedClasses);
     // DEBUG block. Uncomment for debug
 //    co.cask.cdap.internal.asm.Debugs.debugByteCode(classDefinition, new java.io.PrintWriter(System.out));
     // End DEBUG block
@@ -129,7 +142,8 @@ final class HttpHandlerGenerator {
    * @param inspectType The type that needs to be inspected. It's either the delegateType or one of its parents
    */
   private void inspectHandler(final TypeToken<?> delegateType, final TypeToken<?> inspectType, final String pathPrefix,
-                              final Type classType, final ClassWriter classWriter) throws IOException {
+                              final Type classType, final ClassWriter classWriter,
+                              final List<Class<?>> preservedClasses) throws IOException {
     Class<?> rawType = inspectType.getRawType();
 
     // Visit the delegate class, copy and rewrite handler method, with method body just do delegation
@@ -189,8 +203,8 @@ final class HttpHandlerGenerator {
           if (!Modifier.isPublic(access)) {
             return mv;
           }
-          return new HandlerMethodVisitor(delegateType, mv, desc, signature,
-                                          access, name, exceptions, classType, classWriter);
+          return new HandlerMethodVisitor(delegateType, mv, desc, signature, access, name,
+                                          exceptions, classType, classWriter, preservedClasses);
         }
       }, ClassReader.SKIP_DEBUG);
     } finally {
@@ -238,22 +252,7 @@ final class HttpHandlerGenerator {
    * Returns true if the annotation is of type {@link javax.ws.rs.HttpMethod} annotations.
    */
   private boolean isHandlerMethod(Type annotationType) {
-    if (annotationType.equals(Type.getType(GET.class))) {
-      return true;
-    }
-    if (annotationType.equals(Type.getType(POST.class))) {
-      return true;
-    }
-    if (annotationType.equals(Type.getType(PUT.class))) {
-      return true;
-    }
-    if (annotationType.equals(Type.getType(DELETE.class))) {
-      return true;
-    }
-    if (annotationType.equals(Type.getType(HEAD.class))) {
-      return true;
-    }
-    return false;
+    return HTTP_ANNOTATION_TYPES.contains(annotationType);
   }
 
   /**
@@ -301,6 +300,7 @@ final class HttpHandlerGenerator {
     private final String[] exceptions;
     private final Type classType;
     private final ClassWriter classWriter;
+    private final List<Class<?>> preservedClasses;
 
     /**
      * Constructs a {@link HandlerMethodVisitor}.
@@ -314,9 +314,12 @@ final class HttpHandlerGenerator {
      * @param exceptions Method exceptions list
      * @param classType Type of the generated class
      * @param classWriter Writer for generating bytecode
+     * @param preservedClasses List for storing classes that needs to be preserved for correct class loading.
+     *                         See {@link ClassDefinition} for details.
      */
-    HandlerMethodVisitor(TypeToken<?> delegateType, MethodVisitor mv, String desc, String signature,
-                         int access, String name, String[] exceptions, Type classType, ClassWriter classWriter) {
+    HandlerMethodVisitor(TypeToken<?> delegateType, MethodVisitor mv, String desc,
+                         String signature, int access, String name, String[] exceptions,
+                         Type classType, ClassWriter classWriter, List<Class<?>> preservedClasses) {
       super(Opcodes.ASM4, mv);
       this.delegateType = delegateType;
       this.desc = desc;
@@ -328,6 +331,7 @@ final class HttpHandlerGenerator {
       this.paramAnnotations = LinkedListMultimap.create();
       this.classType = classType;
       this.classWriter = classWriter;
+      this.preservedClasses = preservedClasses;
     }
 
     @Override
@@ -384,6 +388,8 @@ final class HttpHandlerGenerator {
       argTypes[0] = Type.getType(HttpRequest.class);
       argTypes[1] = Type.getType(HttpResponder.class);
 
+      preserveParameterClasses(argTypes);
+
       // Copy the method signature with the first two parameter types changed
       String methodDesc = Type.getMethodDescriptor(returnType, argTypes);
       MethodVisitor methodVisitor = classWriter.visitMethod(access, name, methodDesc,
@@ -404,6 +410,36 @@ final class HttpHandlerGenerator {
       generateTransactionalDelegateBody(mg, new Method(name, desc));
 
       super.visitEnd();
+    }
+
+    /**
+     * Preserves method parameter classes for class loading. The first two parameters are always
+     * {@link HttpServiceRequest} and {@link HttpServiceResponder}, which don't need to be preserved since
+     * they are always loaded by the CDAP system ClassLoader. The third and onward method parameter classes
+     * need to be preserved since they can be defined by user, hence in the user ClassLoader.
+     *
+     * @see ClassDefinition
+     */
+    private void preserveParameterClasses(Type[] argTypes) {
+      if (argTypes.length <= 2) {
+        return;
+      }
+      try {
+        for (int i = 2; i < argTypes.length; i++) {
+          // Only add object type parameter which is not Java class
+          if (argTypes[i].getSort() == Type.OBJECT) {
+            Class<?> cls = delegateType.getRawType().getClassLoader().loadClass(argTypes[i].getClassName());
+
+            // Classes loaded by bootstrap classloader are having null ClassLoader. They don't need to be preserved.
+            if (cls.getClassLoader() != null) {
+              preservedClasses.add(cls);
+            }
+          }
+        }
+      } catch (ClassNotFoundException e) {
+        // Shouldn't happen, as the parameter class should be loading from the user handler ClassLoader
+        throw Throwables.propagate(e);
+      }
     }
 
     /**

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/ClassLoaders.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/ClassLoaders.java
@@ -17,14 +17,7 @@
 package co.cask.cdap.common.lang;
 
 import com.google.common.base.Objects;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-import com.google.common.reflect.TypeToken;
 
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.Queue;
-import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -33,44 +26,6 @@ import javax.annotation.Nullable;
 public final class ClassLoaders {
 
   private ClassLoaders() { }
-
-  /**
-   * Returns the ClassLoader of the given type. If the given type is a {@link ParameterizedType}, it returns
-   * a {@link CombineClassLoader} of all types. The context ClassLoader or System ClassLoader would be used as
-   * the parent of the CombineClassLoader.
-   *
-   * @return A new CombineClassLoader. If no ClassLoader is found from the type,
-   *         it returns the current thread context ClassLoader if it's not null, otherwise, return system ClassLoader.
-   */
-  public static ClassLoader getClassLoader(TypeToken<?> type) {
-    Set<ClassLoader> classLoaders = Sets.newIdentityHashSet();
-
-    // Breath first traversal into the Type.
-    Queue<TypeToken<?>> queue = Lists.newLinkedList();
-    queue.add(type);
-    while (!queue.isEmpty()) {
-      type = queue.remove();
-      ClassLoader classLoader = type.getRawType().getClassLoader();
-      if (classLoader != null) {
-        classLoaders.add(classLoader);
-      }
-
-      if (type.getType() instanceof ParameterizedType) {
-        for (Type typeArg : ((ParameterizedType) type.getType()).getActualTypeArguments()) {
-          queue.add(TypeToken.of(typeArg));
-        }
-      }
-    }
-
-    // Determine the parent classloader
-    ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-    ClassLoader parent = (contextClassLoader == null) ? ClassLoader.getSystemClassLoader() : contextClassLoader;
-
-    if (classLoaders.isEmpty()) {
-      return parent;
-    }
-    return new CombineClassLoader(parent, classLoaders);
-  }
 
   /**
    * Loads the class with the given class name with the given classloader. If it is {@code null},

--- a/cdap-common/src/main/java/co/cask/cdap/internal/asm/ByteCodeClassLoader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/asm/ByteCodeClassLoader.java
@@ -19,7 +19,6 @@ package co.cask.cdap.internal.asm;
 import com.google.common.collect.Maps;
 
 import java.util.Map;
-import javax.annotation.Nullable;
 
 /**
  * A {@link ClassLoader} for loading known bytecode.
@@ -43,15 +42,11 @@ public class ByteCodeClassLoader extends ClassLoader {
    * loaded for the first time, the byte code inside the definition will be used to load the class.
    *
    * @param classDef The class definition
-   * @param typeClass An optional class that the given class definition is generated from. This is to make sure
-   *                  the type class is always loaded by the original ClassLoader when resolving the generated class
-   *                  as given by the class definition.
    */
-  public final synchronized ByteCodeClassLoader addClass(ClassDefinition classDef,
-                                                         @Nullable Class<?> typeClass) {
+  public final synchronized ByteCodeClassLoader addClass(ClassDefinition classDef) {
     bytecodes.put(classDef.getClassName(), classDef.getBytecode());
-    if (typeClass != null) {
-      typeClasses.put(typeClass.getName(), typeClass);
+    for (Class<?> cls : classDef.getPreservedClasses()) {
+      typeClasses.put(cls.getName(), cls);
     }
     return this;
   }

--- a/cdap-common/src/main/java/co/cask/cdap/internal/asm/ClassDefinition.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/asm/ClassDefinition.java
@@ -16,7 +16,10 @@
 
 package co.cask.cdap.internal.asm;
 
+import com.google.common.collect.ImmutableList;
 import org.objectweb.asm.Type;
+
+import java.util.List;
 
 /**
  * Class for carrying information of the generated class.
@@ -24,10 +27,16 @@ import org.objectweb.asm.Type;
 public final class ClassDefinition {
   private final byte[] bytecode;
   private final String internalName;
+  private final List<Class<?>> preservedClasses;
 
   public ClassDefinition(byte[] bytecode, String internalName) {
+    this(bytecode, internalName, ImmutableList.<Class<?>>of());
+  }
+
+  public ClassDefinition(byte[] bytecode, String internalName, Iterable<? extends Class<?>> preservedClasses) {
     this.bytecode = bytecode;
     this.internalName = internalName;
+    this.preservedClasses = ImmutableList.copyOf(preservedClasses);
   }
 
   public byte[] getBytecode() {
@@ -40,5 +49,13 @@ public final class ClassDefinition {
 
   public String getClassName() {
     return Type.getObjectType(internalName).getClassName();
+  }
+
+  /**
+   * Returns list of Classes that are used by the generated class which should be used as is,
+   * instead of loaded again by the {@link ByteCodeClassLoader}.
+   */
+  public List<Class<?>> getPreservedClasses() {
+    return preservedClasses;
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/DatumWriterGenerator.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/DatumWriterGenerator.java
@@ -24,6 +24,7 @@ import co.cask.cdap.internal.lang.Fields;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
@@ -132,7 +133,7 @@ final class DatumWriterGenerator {
   private final Multimap<TypeToken<?>, String> fieldAccessorRequests = HashMultimap.create();
   private ClassWriter classWriter;
   private Type classType;
-//  private String className;
+  private List<Class<?>> preservedClasses;
 
   /**
    * Generates a {@link DatumWriter} class for encoding data of the given output type with the given schema.
@@ -142,6 +143,7 @@ final class DatumWriterGenerator {
    */
   ClassDefinition generate(TypeToken<?> outputType, Schema schema) {
     classWriter = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+    preservedClasses = Lists.newArrayList();
 
     TypeToken<?> interfaceType = getInterfaceType(outputType);
 
@@ -167,7 +169,7 @@ final class DatumWriterGenerator {
     // Constructor
     generateConstructor();
 
-    ClassDefinition classDefinition = new ClassDefinition(classWriter.toByteArray(), className);
+    ClassDefinition classDefinition = new ClassDefinition(classWriter.toByteArray(), className, preservedClasses);
     // DEBUG block. Uncomment for debug
 //    co.cask.cdap.internal.asm.Debugs.debugByteCode(classDefinition, new java.io.PrintWriter(System.out));
     // End DEBUG block
@@ -453,6 +455,8 @@ final class DatumWriterGenerator {
   private void encodeEnum(GeneratorAdapter mg, TypeToken<?> outputType,
                           int value, int encoder, int schemaLocal) {
 
+    // Enum type might be defined by the user, hence need to preserve class loading of it
+    preservedClasses.add(outputType.getRawType());
     // encoder.writeInt(this.schema.getEnumIndex(value.name()));
     mg.loadArg(encoder);
     mg.loadArg(schemaLocal);
@@ -728,6 +732,9 @@ final class DatumWriterGenerator {
 
     try {
       Class<?> rawType = outputType.getRawType();
+
+      // Record type might be defined by the user, hence need to preserve class loading of it
+      preservedClasses.add(rawType);
       boolean isInterface = rawType.isInterface();
 
       /*

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/ClassLoaderTestApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/ClassLoaderTestApp.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.app;
+
+import co.cask.cdap.api.annotation.ProcessInput;
+import co.cask.cdap.api.annotation.Tick;
+import co.cask.cdap.api.annotation.UseDataSet;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.flow.Flow;
+import co.cask.cdap.api.flow.FlowSpecification;
+import co.cask.cdap.api.flow.flowlet.AbstractFlowlet;
+import co.cask.cdap.api.flow.flowlet.OutputEmitter;
+import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
+import co.cask.cdap.api.service.http.HttpServiceRequest;
+import co.cask.cdap.api.service.http.HttpServiceResponder;
+import com.clearspring.analytics.util.Lists;
+import com.google.common.base.Charsets;
+
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+
+/**
+ * An application for testing bytecode generated classes ClassLoading behavior.
+ * In specific, it tests DatumWriter in Flow and HttpHandler in Service.
+ */
+public class ClassLoaderTestApp extends AbstractApplication {
+
+  @Override
+  public void configure() {
+    createDataset("records", KeyValueTable.class);
+    addFlow(new BasicFlow());
+    addService("RecordQuery", new RecordQueryHandler());
+  }
+
+  /**
+   * A dummy record class for verification of DatumWriter generation.
+   */
+  public static final class Record {
+    public enum Type {
+      PUBLIC, PRIVATE
+    }
+
+    private Type type;
+
+    public Record(Type type) {
+      this.type = type;
+    }
+
+    public Record(String type) {
+      this.type = Type.valueOf(type.toUpperCase());
+    }
+
+    public Type getType() {
+      return type;
+    }
+  }
+
+  public static final class BasicFlow implements Flow {
+
+    @Override
+    public FlowSpecification configure() {
+      return FlowSpecification.Builder.with()
+        .setName("BasicFlow")
+        .setDescription("BasicFlow")
+        .withFlowlets()
+          .add(new Source())
+          .add(new Sink())
+        .connect()
+          .from(new Source()).to(new Sink())
+        .build();
+    }
+  }
+
+  public static final class Source extends AbstractFlowlet {
+    private OutputEmitter<List<Record>> output;
+    private Random random = new Random();
+
+    @Tick(delay = 1L, unit = TimeUnit.MILLISECONDS)
+    public void generate() {
+      // Emit PUBLIC or PRIVATE type randomly
+      List<Record> records = Lists.newArrayList();
+      for (int i = 0; i < 10; i++) {
+        records.add(new Record(Record.Type.values()[random.nextInt(Record.Type.values().length)]));
+      }
+      output.emit(records);
+    }
+  }
+
+  public static final class Sink extends AbstractFlowlet {
+
+    @UseDataSet("records")
+    private KeyValueTable records;
+
+    @ProcessInput
+    public void process(List<Record> inputs) {
+      for (Record record : inputs) {
+        records.increment(Bytes.toBytes(record.getType().name()), 1L);
+      }
+    }
+  }
+
+  public static final class RecordQueryHandler extends AbstractHttpServiceHandler {
+
+    @UseDataSet("records")
+    private KeyValueTable records;
+
+    @GET
+    @Path("/query")
+    public void query(HttpServiceRequest request,
+                      HttpServiceResponder responder, @QueryParam("type") Record record) {
+
+      long count = Bytes.toLong(records.read(Bytes.toBytes(record.getType().name())));
+      responder.sendString(200, Long.toString(count), Charsets.UTF_8);
+    }
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTest.java
@@ -788,4 +788,37 @@ public class TestFrameworkTest extends TestBase {
     }
   }
 
+
+  @Category(XSlowTests.class)
+  @Test
+  public void testByteCodeClassLoader() throws Exception {
+    // This test verify bytecode generated classes ClassLoading
+
+    ApplicationManager appManager = deployApplication(ClassLoaderTestApp.class);
+    try {
+      FlowManager flowManager = appManager.startFlow("BasicFlow");
+
+      // Wait for at least 10 records being generated
+      RuntimeMetrics flowMetrics = RuntimeStats.getFlowletMetrics("ClassLoaderTestApp", "BasicFlow", "Sink");
+      flowMetrics.waitForProcessed(10, 1000, TimeUnit.MILLISECONDS);
+      flowManager.stop();
+
+      // Query record
+      ServiceManager serviceManager = appManager.startService("RecordQuery");
+      URL url = new URL(serviceManager.getServiceURL(2000, TimeUnit.MILLISECONDS), "query?type=public");
+      HttpRequest request = HttpRequest.get(url).build();
+      HttpResponse response = HttpRequests.execute(request);
+      Assert.assertEquals(200, response.getResponseCode());
+
+      long count = Long.parseLong(response.getResponseBodyAsString());
+      serviceManager.stop();
+
+      // Verify the record count with dataset
+      KeyValueTable records = appManager.<KeyValueTable>getDataSet("records").get();
+      Assert.assertTrue(count == Bytes.toLong(records.read("PUBLIC")));
+
+    } finally {
+      appManager.stopAll();
+    }
+  }
 }


### PR DESCRIPTION
Make class loading of byte code generated classes aware of classes that needs to be preserved with the original ClassLoader so that even user classes presented in both system classpath and program classloader, it can be loaded correctly.
