### PR TITLE
CDAP-460: Updated docs to use new configurer style API for MapReduce

### DIFF
--- a/cdap-docs/developers-manual/source/building-blocks/mapreduce-jobs.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/mapreduce-jobs.rst
@@ -141,11 +141,10 @@ declaration and (2) an injection:
 
      public class MyMapReduceJob implements MapReduce {
        @Override
-       public MapReduceSpecification configure() {
-         return MapReduceSpecification.Builder.with()
-           ...
-           .useDataSet("catalog")
-           ...
+       public void configure(MapReduceConfigurer configurer) {
+         ...
+         useDatasets(Arrays.asList("catalog"))
+         ...
 
 #. Inject the Dataset into the mapper or reducer that uses it::
 


### PR DESCRIPTION
No mentions of ResourceSpecification or ServiceSpecification.Builder in the docs, so I only have MapReduceSpecification.Builder changes in this PR:

```
$ find . -name *.rst | xargs grep "ResourceSpecification"
$ find . -name *.rst | xargs grep "ServiceSpecification"
$ find . -name *.rst | xargs grep "MapReduceSpecification"
./cdap-docs/developers-manual/source/building-blocks/mapreduce-jobs.rst:       public MapReduceSpecification configure() {
./cdap-docs/developers-manual/source/building-blocks/mapreduce-jobs.rst:         return MapReduceSpecification.Builder.with()
```
