### PR TITLE
fix upgrade queue tables

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
@@ -277,10 +277,8 @@ public class HBaseQueueAdmin implements QueueAdmin {
   }
 
   @Override
-  public void upgrade(String name, Properties properties) throws Exception {
-    QueueName queueName = QueueName.from(URI.create(name));
-    String hBaseTableName = getActualTableName(queueName);
-    AbstractHBaseDataSetAdmin dsAdmin = new DatasetAdmin(hBaseTableName, hConf, tableUtil);
+  public void upgrade(String tableName, Properties properties) throws Exception {
+    AbstractHBaseDataSetAdmin dsAdmin = new DatasetAdmin(tableName, hConf, tableUtil);
     try {
       dsAdmin.upgrade();
     } finally {


### PR DESCRIPTION
The passed parameter is always table name. The logic was wrong. https://issues.cask.co/browse/CDAP-894
