### PR TITLE
Feature/detect hive environment

### DIFF
--- a/cdap-common/bin/common.sh
+++ b/cdap-common/bin/common.sh
@@ -154,15 +154,15 @@ set_hive_classpath() {
       HIVE_VAR_OUT=`hive -e 'set -v' 2>/dev/null`
 
       if [ "x$HIVE_HOME" = "x" ]; then
-        HIVE_HOME=`echo $HIVE_VAR_OUT | tr ' ' '\n' | grep 'env:HIVE_HOME=' | cut -f 2 -d '='`
+        HIVE_HOME=`echo $HIVE_VAR_OUT | tr ' ' '\n' | grep '^env:HIVE_HOME=' | cut -f 2 -d '='`
       fi
 
       if [ "x$HIVE_CONF_DIR" = "x" ]; then
-        HIVE_CONF_DIR=`echo $HIVE_VAR_OUT | tr ' ' '\n' | grep 'env:HIVE_CONF_DIR=' | cut -f 2 -d '='`
+        HIVE_CONF_DIR=`echo $HIVE_VAR_OUT | tr ' ' '\n' | grep '^env:HIVE_CONF_DIR=' | cut -f 2 -d '='`
       fi
 
       if [ "x$HADOOP_CONF_DIR" = "x" ]; then
-        HADOOP_CONF_DIR=`echo $HIVE_VAR_OUT | tr ' ' '\n' | grep 'env:HADOOP_CONF_DIR=' | cut -f 2 -d '='`
+        HADOOP_CONF_DIR=`echo $HIVE_VAR_OUT | tr ' ' '\n' | grep '^env:HADOOP_CONF_DIR=' | cut -f 2 -d '='`
       fi
     fi
   fi


### PR DESCRIPTION
The hive environment detection in the init scripts can sometimes blow up if multiple environment variables match the grep expression, for example `HIVE_HOME` and `CDH_HIVE_HOME`.

This PR just tightens up the grep expressions

```
$ hive -e 'set -v' 2>/dev/null | grep '^env:HIVE_HOME='
env:HIVE_HOME=/opt/cloudera/parcels/CDH-5.2.1-1.cdh5.2.1.p0.12/bin/../lib/hive
```
