### PR TITLE
Resolve the issue where serviceWorkers do not have access to runtime arg...

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/ServiceComponentProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/ServiceComponentProgramRunner.java
@@ -113,7 +113,7 @@ public class ServiceComponentProgramRunner implements ProgramRunner {
 
       BasicServiceWorkerContext context = new BasicServiceWorkerContext(workerSpec, program, runId, instanceId,
                                                                         workerSpec.getInstances(),
-                                                                        options.getArguments(), cConf,
+                                                                        options.getUserArguments(), cConf,
                                                                         metricsCollectionService, datasetFramework,
                                                                         txClient, discoveryServiceClient);
       component = new ServiceWorkerDriver(program, workerSpec, context);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithServices.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithServices.java
@@ -69,6 +69,9 @@ public class AppWithServices extends AbstractApplication {
   public static final String DESTROY_KEY = "destroy";
   public static final String VALUE = "true";
 
+  public static final String WRITE_VALUE_RUN_KEY = "write.value.run";
+  public static final String WRITE_VALUE_STOP_KEY = "write.value.stop";
+
     @Override
     public void configure() {
       setName(APP_NAME);
@@ -205,6 +208,8 @@ public class AppWithServices extends AbstractApplication {
       private long sleepMs = 1000;
 
       private String dataset;
+      private String valueToWriteOnRun;
+      private String valueToWriteOnStop;
 
       public DatasetUpdateWorker(String dataset) {
         // Remember the dataset name so that it can set in configure time.
@@ -220,6 +225,8 @@ public class AppWithServices extends AbstractApplication {
       @Override
       public void initialize(ServiceWorkerContext context) throws Exception {
         super.initialize(context);
+        valueToWriteOnRun = context.getRuntimeArguments().get(WRITE_VALUE_RUN_KEY);
+        valueToWriteOnStop = context.getRuntimeArguments().get(WRITE_VALUE_STOP_KEY);
         getContext().execute(new TxRunnable() {
           @Override
           public void run(DatasetContext context) throws Exception {
@@ -235,7 +242,7 @@ public class AppWithServices extends AbstractApplication {
           @Override
           public void run(DatasetContext context) throws Exception {
             KeyValueTable table = context.getDataset(DATASET_NAME);
-            table.write(DATASET_TEST_KEY_STOP, DATASET_TEST_VALUE_STOP);
+            table.write(DATASET_TEST_KEY_STOP, valueToWriteOnStop);
           }
         });
         workerStopped = true;
@@ -252,7 +259,7 @@ public class AppWithServices extends AbstractApplication {
                 KeyValueTable table = context.getDataset(DATASET_NAME);
                 // Write only if the dataset instance is the same as the one gotten in initialize.
                 if (datasetHashCode == System.identityHashCode(table)) {
-                  table.write(DATASET_TEST_KEY, DATASET_TEST_VALUE);
+                  table.write(DATASET_TEST_KEY, valueToWriteOnRun);
                 }
               }
             });

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTest.java
@@ -397,8 +397,11 @@ public class TestFrameworkTest extends TestBase {
       // TestMetricsCollectionService
 
       LOG.info("DatasetUpdateService Started");
+      Map<String, String> args
+        = ImmutableMap.of(AppWithServices.WRITE_VALUE_RUN_KEY, AppWithServices.DATASET_TEST_VALUE,
+                          AppWithServices.WRITE_VALUE_STOP_KEY, AppWithServices.DATASET_TEST_VALUE_STOP);
       ServiceManager datasetWorkerServiceManager = applicationManager
-        .startService(AppWithServices.DATASET_WORKER_SERVICE_NAME);
+        .startService(AppWithServices.DATASET_WORKER_SERVICE_NAME, args);
       serviceStatusCheck(datasetWorkerServiceManager, true);
 
       ProcedureManager procedureManager = applicationManager.startProcedure("NoOpProcedure");


### PR DESCRIPTION
...uments.

Resolves: https://issues.cask.co/browse/CDAP-969

The resolution is a one-line change, but to ensure that this feature does not get lost in the future, I have changed an existing test case to utilize the feature.

Bamboo: https://builds.cask.co/browse/CDAP-RBT37
