### PR TITLE
Fixed broken link.

### DIFF
--- a/cdap-docs/admin-manual/source/installation/installation.rst
+++ b/cdap-docs/admin-manual/source/installation/installation.rst
@@ -22,7 +22,7 @@ instructions for
 `installation <#installation>`__ and
 `verification <#verification>`__ of
 the CDAP components so they work with your existing Hadoop cluster. 
-There are specific instructions for :ref:`upgrading existing CDAP installations <install-upgrade>`.
+There are specific instructions for :ref:`upgrading existing CDAP installations<install-upgrade>`.
 
 These are the CDAP components:
 
@@ -504,8 +504,6 @@ We provide in our SDK pre-built ``.JAR`` files for convenience.
 
 .. _install-upgrade:
 
-.. highlight:: console
-
 Upgrading an Existing Version
 ---------------------------------
 When upgrading an existing CDAP installation from a previous version, you will need
@@ -513,6 +511,8 @@ to make sure the CDAP table definitions in HBase are up-to-date.
 
 These steps will stop CDAP, update the installation, run an upgrade tool for the table definitions,
 and then restart CDAP.
+
+.. highlight:: console
 
 1. Stop all CDAP processes::
 


### PR DESCRIPTION
Fix broken link to upgrade command in documentation. It appears having the highlight directive where it was broke the link. I will add that as note in the documentation on documentation. (https://issues.cask.co/browse/CDAP-424)
