### PR TITLE
CDAP-981 was incorrectly removing a jar needed by stream data

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -574,7 +574,6 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
     // Excludes libraries that are for sure not needed.
     // Hadoop - Available from the cluster
     // Spark - MR never uses Spark
-    // Fastutil - 16MB library that only used in tehpra server
     ApplicationBundler appBundler = new ApplicationBundler(ImmutableList.of("org.apache.hadoop",
                                                                             "org.apache.spark"),
                                                            ImmutableList.of("org.apache.hadoop.hbase",


### PR DESCRIPTION
file reader in mapreduce jobs. Putting it back.
