### PR TITLE
CDAP-693 handle case where webapp address is not explicitly given

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
@@ -409,8 +409,8 @@ public final class DistributedProgramRuntimeService extends AbstractProgramRunti
         setting = YarnConfiguration.RM_PREFIX + "hostname";
         if (rmID != null) {
           setting += "." + rmID;
-          addrStr = hConf.get(setting) + ":" + YarnConfiguration.DEFAULT_RM_WEBAPP_PORT;
         }
+        addrStr = hConf.get(setting) + ":" + YarnConfiguration.DEFAULT_RM_WEBAPP_PORT;
       }
       addrStr = "http://" + addrStr + RM_CLUSTER_METRICS_PATH;
       LOG.trace("Adding {} as a rm address.", addrStr);


### PR DESCRIPTION
in HA mode for the resource manager.
