### PR TITLE
Feature/cdap default cleanup

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -875,6 +875,16 @@
     </property>
 
     <property>
+        <name>dashboard.ssl.bind.port</name>
+        <value>9443</value>
+    </property>
+
+    <property>
+        <name>dashboard.ssl.disable.cert.check</name>
+        <value>false</value>
+    </property>
+
+    <property>
         <name>router.server.address</name>
         <value>localhost</value>
     </property>
@@ -1037,18 +1047,6 @@
   <property>
     <name>security.auth.server.ssl.bind.port</name>
     <value>10010</value>
-  </property>
-
-  <!-- Frontend configuration -->
-
-  <property>
-    <name>dashboard.ssl.bind.port</name>
-    <value>9443</value>
-  </property>
-
-  <property>
-    <name>dashboard.ssl.disable.cert.check</name>
-    <value>false</value>
   </property>
 
 </configuration>


### PR DESCRIPTION
cdap-default.xml has two entries duplicated, across redundant sections "Web-App" and "Frontend".  Cleaning this up.

prior to this PR:

```
$ cat cdap-default.xml | grep '<name>' | sed -e 's#^.*<name>##' | sed -e 's#</name>##' | sort | uniq -c | head
   2 dashboard.bind.port
   2 router.server.address
```
