### PR TITLE
CDAP-1017: Fix bad links and link titles.

### DIFF
--- a/cdap-docs/developers-manual/source/testing/debugging.rst
+++ b/cdap-docs/developers-manual/source/testing/debugging.rst
@@ -6,7 +6,7 @@
 Debugging a CDAP Application
 ================================================
 
-.. _DebugCDAP:
+.. _debugging-cdap:
 
 Debugging an Application in Standalone CDAP
 ===========================================
@@ -168,7 +168,7 @@ You may need to adjust them for your installation or version.
 #. The control stops at the breakpoint and you can proceed with debugging.
 
 
-.. _TxDebugger:
+.. _tx-debugger:
 
 Debugging the Transaction Manager (Advanced Use)
 ================================================

--- a/cdap-docs/developers-manual/source/testing/index.rst
+++ b/cdap-docs/developers-manual/source/testing/index.rst
@@ -18,7 +18,7 @@ Testing and Debugging
 
 
 CDAP comes with a number of tools to make a developer's life easier. These tools
-help with testing, debugging and packaging CDAP applications:
+help with testing and debugging CDAP applications:
 
 .. list-table::
     :widths: 25 75
@@ -26,10 +26,10 @@ help with testing, debugging and packaging CDAP applications:
 
     * - Tool Name
       - Description
-    * - :ref:`Test Framework<TestFramework>`
-      - How you can take advantage of the test framework to test your CDAP applications before deploying.
+    * - :ref:`Test Framework<test-framework>`
+      - How you can take advantage of the **test framework** to test your CDAP applications before deploying.
         This makes catching bugs early and easy.
-    * - :ref:`Debugging<DebugCDAP>`
-      - How you can debug CDAP applications in Standalone mode and app containers in Distributed mode.
-    * - :ref:`Debugging the Transactions Manager<TxDebugger>`
-      - Covers snapshotting and inspecting the state of the Transaction Manager.
+    * - :ref:`Debugging<debugging-cdap>`
+      - How you can **debug CDAP applications** in Standalone mode and app containers in Distributed mode.
+    * - :ref:`Debugging the Transactions Manager<tx-debugger>`
+      - Covers snapshotting and inspecting the state of the **Transaction Manager**.

--- a/cdap-docs/developers-manual/source/testing/testing.rst
+++ b/cdap-docs/developers-manual/source/testing/testing.rst
@@ -2,16 +2,18 @@
     :author: Cask Data, Inc.
     :copyright: Copyright © 2014 Cask Data, Inc.
 
-.. _TestFramework:
+.. _test-cdap:
 
 ================================================
 Testing a CDAP Application
 ================================================
 
-Strategies in Testing Applications
-==================================
+.. _test-framework:
 
-CDAP comes with a convenient way to unit test your Applications.
+Strategies in Testing Applications: Test Framework
+==================================================
+
+CDAP comes with a convenient way to unit test your Applications with CDAP’s Test Framework.
 The base for these tests is ``TestBase``, which is packaged
 separately from the API in its own artifact because it depends on the
 CDAP’s runtime classes. You can include it in your test dependencies


### PR DESCRIPTION
Staged at http://stg-web101.sw.joyent.continuuity.net/cdap/2.6.0-SNAPSHOT-r2.6.0_debug_links/en/developers-manual/testing/index.html
