### PR TITLE
Standardize names

### DIFF
--- a/cdap-archetypes/cdap-app-archetype/pom.xml
+++ b/cdap-archetypes/cdap-app-archetype/pom.xml
@@ -26,5 +26,5 @@
 
   <artifactId>cdap-app-archetype</artifactId>
   <packaging>jar</packaging>
-  <name>Cask Data Application Platform (CDAP) Application Archetype</name>
+  <name>CDAP Application Archetype</name>
 </project>

--- a/cdap-archetypes/cdap-spark-scala-archetype/pom.xml
+++ b/cdap-archetypes/cdap-spark-scala-archetype/pom.xml
@@ -26,7 +26,7 @@
 
   <artifactId>cdap-spark-scala-archetype</artifactId>
   <packaging>jar</packaging>
-  <name>Cask Data Application Platform (CDAP) Spark Scala Archetype</name>
+  <name>CDAP Spark Scala Archetype</name>
 
   <build>
     <pluginManagement>

--- a/cdap-examples/deploy_pom.xml
+++ b/cdap-examples/deploy_pom.xml
@@ -23,7 +23,7 @@
   <artifactId>cdap-examples</artifactId>
   <version>@project.version@</version>
   <packaging>pom</packaging>
-  <name>Cask Data Application Platform (CDAP) Examples</name>
+  <name>CDAP Examples</name>
 
   <modules>
     <module>CountRandom</module>

--- a/cdap-examples/pom.xml
+++ b/cdap-examples/pom.xml
@@ -27,7 +27,7 @@
 
   <artifactId>cdap-examples</artifactId>
   <packaging>pom</packaging>
-  <name>Cask Data Application Platform (CDAP) Examples</name>
+  <name>CDAP Examples</name>
 
   <modules>
     <module>CountRandom</module>


### PR DESCRIPTION
Changes the names in these pom.xml files so that they follow the convention of all the other pom.xml files, and then the reporting in a command line will line up correctly and evenly.

Fixes this:

```
16-Dec-2014 18:16:12    [INFO] CDAP Spark Java Archetype ......................... SUCCESS [0.636s]
16-Dec-2014 18:16:12    [INFO] Cask Data Application Platform (CDAP) Spark Scala Archetype  SUCCESS [0.565s]
16-Dec-2014 18:16:12    [INFO] Cask Data Application Platform (CDAP) Application Archetype  SUCCESS [0.349s]
16-Dec-2014 18:16:12    [INFO] Cask Data Application Platform (CDAP) Examples .... SUCCESS [2.600s]
16-Dec-2014 18:16:12    [INFO] Count Random ...................................... SUCCESS [0.820s]
```

to this:

```
16-Dec-2014 18:16:12    [INFO] CDAP Spark Java Archetype ......................... SUCCESS [0.636s]
16-Dec-2014 18:16:12    [INFO] CDAP Spark Scala Archetype ........................ SUCCESS [0.565s]
16-Dec-2014 18:16:12    [INFO] CDAP Application Archetype ........................ SUCCESS [0.349s]
16-Dec-2014 18:16:12    [INFO] CDAP Examples ..................................... SUCCESS [2.600s]
16-Dec-2014 18:16:12    [INFO] Count Random ...................................... SUCCESS [0.820s]
```
