### PR TITLE
make sure master restarts dsService if twill services are already running

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetServiceModules.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetServiceModules.java
@@ -185,6 +185,8 @@ public class DataSetServiceModules {
         Multibinder.newSetBinder(binder(), DatasetMetricsReporter.class)
           .addBinding().to(HBaseDatasetMetricsReporter.class);
 
+        // NOTE: this cannot be a singleton, because MasterServiceMain needs to obtain a new instance
+        //       every time it becomes leader and starts a dataset service.
         bind(DatasetService.class);
         expose(DatasetService.class);
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -386,6 +386,8 @@ public class MasterServiceMain extends DaemonMain {
       // we have to start the dataset service. Because twill services are already running,
       // it will not be started by the service listener callback below.
       if (!dsService.isRunning()) {
+        // we need a new dataset service (the old one may have run before and can't be restarted)
+        dsService = baseInjector.getInstance(DatasetService.class); // not a singleton
         LOG.info("Starting Dataset service");
         dsService.startAndWait();
       }


### PR DESCRIPTION
Issue is this: If the master becomes leader, it checks whether twill services are running. 
- If not, it starts the twill services, and once they are running also starts the dsService
- I yes, it simply leaves them running and does nothing. But it must start the dsService. 
