### PR TITLE
CDAP-1024 workaround to get around Hive issues when the hive-exec

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DistributedDatasetTypeClassLoaderFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DistributedDatasetTypeClassLoaderFactory.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.data2.datafabric.dataset.type;
 
+import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.lang.DirectoryClassLoader;
 import co.cask.cdap.common.lang.jar.BundleJarUtil;
@@ -23,7 +24,6 @@ import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.proto.DatasetModuleMeta;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.hash.HashCodes;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
 import com.google.inject.Inject;
@@ -109,7 +109,7 @@ public class DistributedDatasetTypeClassLoaderFactory implements DatasetTypeClas
       }
 
       // The folder name to expand to is formed by the module name and the checksum.
-      String dirName = String.format("%s.%s", moduleMeta.getName(), HashCodes.fromBytes(messageDigest.digest()));
+      String dirName = String.format("%s.%s", moduleMeta.getName(), Bytes.toStringBinary(messageDigest.digest()));
       File expandDir = new File(tmpJar.getParent(), dirName);
 
       if (!expandDir.isDirectory()) {


### PR DESCRIPTION
jar packages an incompatible version of guava. The guava version
in the hive-exec fat jar always gets used so we are removing a
guava13 call as a temporary workaround.
