### PR TITLE
Updated code to make sure unique column keys are generated in the test case.

### DIFF
--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/write/LogCleanupTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/write/LogCleanupTest.java
@@ -121,36 +121,17 @@ public class LogCleanupTest {
 
     Assert.assertFalse(notDelete.isEmpty());
 
-    List<Long> toDeleteListKeys = Lists.newArrayList();
-    while (toDeleteListKeys.size() < toDelete.size()) {
-      long key = deletionBoundary - RANDOM.nextInt(50000) - 10000;
-      if (!toDeleteListKeys.contains(key)) {
-        toDeleteListKeys.add(key);
-      }
-    }
-
-    Assert.assertEquals(toDelete.size(), toDeleteListKeys.size());
-
+    int counter = 0;
     for (Location location : toDelete) {
-      fileMetaDataManager.writeMetaData(dummyContext, toDeleteListKeys.get(0),
+      fileMetaDataManager.writeMetaData(dummyContext, deletionBoundary - counter - 10000,
                                         createFile(location));
-      toDeleteListKeys.remove(0);
+      counter++;
     }
-
-    List<Long> notDeleteListKeys = Lists.newArrayList();
-    while (notDeleteListKeys.size() < notDelete.size()) {
-      long key = deletionBoundary + RANDOM.nextInt(50000) + 10000;
-      if (!notDeleteListKeys.contains(key)) {
-        notDeleteListKeys.add(key);
-      }
-    }
-
-    Assert.assertEquals(notDelete.size(), notDeleteListKeys.size());
 
     for (Location location : notDelete) {
-      fileMetaDataManager.writeMetaData(dummyContext, notDeleteListKeys.get(0),
+      fileMetaDataManager.writeMetaData(dummyContext, deletionBoundary + counter + 10000,
                                         createFile(location));
-      notDeleteListKeys.remove(0);
+      counter++;
     }
 
     Assert.assertEquals(locationListsToString(toDelete, notDelete),


### PR DESCRIPTION
LogCleanupTest uses Random number generator to generate the metadata keys for files. With very very low probability it is possible that successive calls to the Random.nextInt(50000) return the same number causing the duplicate metadata key. Fix is added to ensure that we always generate the required number of unique metadata keys.
