### PR TITLE
[2.5] Fix for CDAP-1045 on Mac where /proc doesn't exist

### DIFF
--- a/cdap-standalone/bin/cdap.sh
+++ b/cdap-standalone/bin/cdap.sh
@@ -262,7 +262,7 @@ start() {
     rotate_log $APP_HOME/logs/cdap.log
     rotate_log $APP_HOME/logs/cdap-debug.log
 
-    if grep docker /proc/1/cgroup 2>&1 >/dev/null; then
+    if test -e /proc/1/cgroup && grep docker /proc/1/cgroup 2>&1 >/dev/null; then
         ROUTER_OPTS="-Drouter.bind.address=`hostname -i` -Drouter.server.address=`hostname -i`"
     fi
 


### PR DESCRIPTION
This does not require a new release as the offending code was merged post `2.5.2` release, so it only affected builds from this branch made after the change was implemented running on non-Linux.
