### PR TITLE
Reduce chatty debug logs

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogCollectorCallback.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogCollectorCallback.java
@@ -134,7 +134,10 @@ public class LogCollectorCallback implements KafkaConsumer.MessageCallback {
       }
       ++count;
     }
-    LOG.debug("Got {} messages from kafka", count);
+    LOG.trace("Got {} messages from kafka", count);
+    if (count > 0) {
+      LOG.debug("Got {} messages from kafka", count);
+    }
   }
 
   @Override


### PR DESCRIPTION
- Reducing log level to debug in CDAP is almost useless with very chatty log levels from Log saver. Reducing the log level to trace and adding debug logs if the count > 0
