### PR TITLE
Fix Docker builds

### DIFF
--- a/cdap-standalone/bin/cdap.sh
+++ b/cdap-standalone/bin/cdap.sh
@@ -272,7 +272,7 @@ start() {
     rotate_log $APP_HOME/logs/cdap-debug.log
 
     if test -e /proc/1/cgroup && grep docker /proc/1/cgroup 2>&1 >/dev/null; then
-        ROUTER_OPTS="-Drouter.bind.address=`hostname -i` -Drouter.server.address=`hostname -i`"
+        ROUTER_OPTS="-Drouter.address=`hostname -i`"
     fi
 
     nohup nice -1 "$JAVACMD" "${JVM_OPTS[@]}" ${ROUTER_OPTS} -classpath "$CLASSPATH" co.cask.cdap.StandaloneMain \

--- a/cdap-standalone/src/main/resources/cdap-site.xml
+++ b/cdap-standalone/src/main/resources/cdap-site.xml
@@ -42,8 +42,14 @@
         Router configuration
     -->
     <property>
-        <name>router.bind.address</name>
+        <name>router.address</name>
         <value>127.0.0.1</value>
+        <description>Specifies a common address for both router and UI to bind to</description>
+    </property>
+
+    <property>
+        <name>router.bind.address</name>
+        <value>${router.address}</value>
         <description>Specifies the address for router server to bind to</description>
     </property>
 
@@ -51,6 +57,12 @@
         <name>router.forward.rule</name>
         <value>10000:gateway,20000:webapp/$HOST</value>
         <description>Forward rules for router (port:service -> forward port to service)</description>
+    </property>
+
+    <property>
+        <name>router.server.address</name>
+        <value>${router.address}</value>
+        <description>Specifies the address of the router for the UI to bind to</description>
     </property>
 
     <!--


### PR DESCRIPTION
Fixes CDAP-1080 (Docker builds and starts CDAP, but HelloWorld doesn't run). 

This creates a property (router.address) that can be set on the Java command line inside a Docker container to the correct IP address, yet at the same time it doesn't interfere with a regular Standalone installation from successfully using localhost (127.0.0.1) as the IP to bind to.

Tested on a Standalone and Docker build.
