### PR TITLE
(CDAP-1086) Fix the Config tool only log with ERROR level

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Configuration.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Configuration.java
@@ -18,10 +18,10 @@ package co.cask.cdap.common.conf;
 
 import co.cask.cdap.common.utils.DirUtils;
 import com.google.common.base.Preconditions;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.codehaus.jackson.JsonFactory;
 import org.codehaus.jackson.JsonGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Comment;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
@@ -132,8 +132,7 @@ import javax.xml.transform.stream.StreamResult;
  * of the System property with that name.
  */
 public class Configuration implements Iterable<Map.Entry<String, String>> {
-  private static final Log LOG =
-    LogFactory.getLog(Configuration.class);
+  private static final Logger LOG = LoggerFactory.getLogger(Configuration.class);
 
   private boolean quietmode = true;
 
@@ -1637,7 +1636,7 @@ public class Configuration implements Iterable<Map.Entry<String, String>> {
         root = doc.getDocumentElement();
       }
       if (!"configuration".equals(root.getTagName())) {
-        LOG.fatal("bad conf file: top-level element not <configuration>");
+        LOG.error("bad conf file: top-level element not <configuration>");
       }
       NodeList props = root.getChildNodes();
       for (int i = 0; i < props.getLength(); i++) {
@@ -1690,16 +1689,16 @@ public class Configuration implements Iterable<Map.Entry<String, String>> {
         }
       }
     } catch (IOException e) {
-      LOG.fatal("error parsing conf file: " + e);
+      LOG.error("error parsing conf file.", e);
       throw new RuntimeException(e);
     } catch (DOMException e) {
-      LOG.fatal("error parsing conf file: " + e);
+      LOG.error("error parsing conf file.", e);
       throw new RuntimeException(e);
     } catch (SAXException e) {
-      LOG.fatal("error parsing conf file: " + e);
+      LOG.error("error parsing conf file.", e);
       throw new RuntimeException(e);
     } catch (ParserConfigurationException e) {
-      LOG.fatal("error parsing conf file: " + e);
+      LOG.error("error parsing conf file.", e);
       throw new RuntimeException(e);
     }
   }

--- a/cdap-common/src/test/java/co/cask/cdap/common/conf/ConfigurationJsonToolTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/conf/ConfigurationJsonToolTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.conf;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ *
+ */
+public class ConfigurationJsonToolTest {
+
+  @Test
+  public void testDeprecatedKeys() {
+    // Add a log appender to intercept logs from the Configuration object
+    ILoggerFactory loggerFactory = LoggerFactory.getILoggerFactory();
+    final AtomicBoolean logMessageReceived = new AtomicBoolean(false);
+
+    if (loggerFactory instanceof LoggerContext) {
+      LoggerContext loggerContext = (LoggerContext) loggerFactory;
+
+      AppenderBase<ILoggingEvent> appender = new AppenderBase<ILoggingEvent>() {
+        @Override
+        protected void append(ILoggingEvent eventObject) {
+          logMessageReceived.set(true);
+        }
+      };
+      loggerContext.getLogger(Configuration.class).addAppender(appender);
+      appender.setContext(loggerContext);
+      appender.start();
+    }
+
+    // Dump the configuration as json
+    StringBuilder builder = new StringBuilder();
+    ConfigurationJsonTool.exportToJson(SConfiguration.create(), builder);
+    String address = new Gson().fromJson(builder.toString(), JsonObject.class)
+                               .get("security.auth.server.bind.address").getAsString();
+    Assert.assertEquals("0.0.0.0", address);
+
+    // There shouldn't be any log message, even we access the deprecated key
+    Assert.assertFalse(logMessageReceived.get());
+
+    // If we access the deprecated key directly, there should still be deprecated key warning.
+    // That's because the log level shouldn't been reset.
+    SConfiguration.create().get("security.auth.server.bind.address");
+    Assert.assertTrue(logMessageReceived.get());
+  }
+}

--- a/cdap-common/src/test/resources/cdap-security.xml
+++ b/cdap-common/src/test/resources/cdap-security.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  ~ Copyright © 2014 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<configuration>
+  <property>
+    <name>security.auth.server.address</name>
+    <value>0.0.0.0</value>
+    <description>This key is deprecated. Use security.auth.server.bind.address instead.</description>
+  </property>
+</configuration>


### PR DESCRIPTION
This avoids the deprecated key warning affecting the dump output.
