### PR TITLE
(CDAP-1088) Added support for String type as StreamEventDecoder

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/decoder/BytesStreamEventDecoder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/decoder/BytesStreamEventDecoder.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.cdap.data.stream;
+package co.cask.cdap.data.stream.decoder;
 
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.stream.StreamEventDecoder;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/decoder/IdentityStreamEventDecoder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/decoder/IdentityStreamEventDecoder.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.stream.decoder;
+
+import co.cask.cdap.api.flow.flowlet.StreamEvent;
+import co.cask.cdap.api.stream.StreamEventDecoder;
+import org.apache.hadoop.io.LongWritable;
+
+/**
+ * A {@link StreamEventDecoder} that decodes a {@link StreamEvent} into {@link LongWritable} as key and
+ * {@link StreamEvent} as value. The key carries the event timestamp, while the value contains the
+ * entire {@link StreamEvent}.
+ */
+public final class IdentityStreamEventDecoder implements StreamEventDecoder<LongWritable, StreamEvent> {
+
+  private final LongWritable key = new LongWritable();
+
+  @Override
+  public DecodeResult<LongWritable, StreamEvent> decode(StreamEvent event,
+                                                        DecodeResult<LongWritable, StreamEvent> result) {
+    key.set(event.getTimestamp());
+    return result.setKey(key).setValue(event);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/decoder/StringStreamEventDecoder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/decoder/StringStreamEventDecoder.java
@@ -14,28 +14,25 @@
  * the License.
  */
 
-package co.cask.cdap.data.stream;
+package co.cask.cdap.data.stream.decoder;
 
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.stream.StreamEventDecoder;
 import com.google.common.base.Charsets;
 import org.apache.hadoop.io.LongWritable;
-import org.apache.hadoop.io.Text;
 
 /**
- * A {@link StreamEventDecoder} that decodes {@link StreamEvent} into {@link LongWritable} as key and {@link Text} as
+ * A {@link StreamEventDecoder} that decodes {@link StreamEvent} into {@link LongWritable} as key and {@link String} as
  * value for Mapper input. The key carries the event timestamp, while the text value is a UTF-8 decode of the
  * event body.
  */
-public final class TextStreamEventDecoder implements StreamEventDecoder<LongWritable, Text> {
+public class StringStreamEventDecoder implements StreamEventDecoder<LongWritable, String> {
 
   private final LongWritable key = new LongWritable();
-  private final Text value = new Text();
 
   @Override
-  public DecodeResult<LongWritable, Text> decode(StreamEvent event, DecodeResult<LongWritable, Text> result) {
+  public DecodeResult<LongWritable, String> decode(StreamEvent event, DecodeResult<LongWritable, String> result) {
     key.set(event.getTimestamp());
-    value.set(Charsets.UTF_8.decode(event.getBody()).toString());
-    return result.setKey(key).setValue(value);
+    return result.setKey(key).setValue(Charsets.UTF_8.decode(event.getBody()).toString());
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/decoder/TextStreamEventDecoder.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/decoder/TextStreamEventDecoder.java
@@ -14,25 +14,28 @@
  * the License.
  */
 
-package co.cask.cdap.data.stream;
+package co.cask.cdap.data.stream.decoder;
 
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.stream.StreamEventDecoder;
+import com.google.common.base.Charsets;
 import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
 
 /**
- * A {@link StreamEventDecoder} that decodes a {@link StreamEvent} into {@link LongWritable} as key and
- * {@link StreamEvent} as value. The key carries the event timestamp, while the value contains the
- * entire {@link StreamEvent}.
+ * A {@link StreamEventDecoder} that decodes {@link StreamEvent} into {@link LongWritable} as key and {@link Text} as
+ * value for Mapper input. The key carries the event timestamp, while the text value is a UTF-8 decode of the
+ * event body.
  */
-public final class IdentityStreamEventDecoder implements StreamEventDecoder<LongWritable, StreamEvent> {
+public final class TextStreamEventDecoder implements StreamEventDecoder<LongWritable, Text> {
 
   private final LongWritable key = new LongWritable();
+  private final Text value = new Text();
 
   @Override
-  public DecodeResult<LongWritable, StreamEvent> decode(StreamEvent event,
-                                                        DecodeResult<LongWritable, StreamEvent> result) {
+  public DecodeResult<LongWritable, Text> decode(StreamEvent event, DecodeResult<LongWritable, Text> result) {
     key.set(event.getTimestamp());
-    return result.setKey(key).setValue(event);
+    value.set(Charsets.UTF_8.decode(event.getBody()).toString());
+    return result.setKey(key).setValue(value);
   }
 }

--- a/cdap-examples/SparkKMeans/src/main/java/co/cask/cdap/examples/sparkkmeans/Point.java
+++ b/cdap-examples/SparkKMeans/src/main/java/co/cask/cdap/examples/sparkkmeans/Point.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.examples.sparkkmeans;
+
+import java.io.Serializable;
+
+/**
+ * Represents a point in space.
+ */
+public class Point implements Serializable {
+
+  private final double x;
+  private final double y;
+  private final double z;
+
+  /**
+   * Creates an instance with the given coordinates.
+   */
+  public Point(double x, double y, double z) {
+    this.x = x;
+    this.y = y;
+    this.z = z;
+  }
+
+  public double getX() {
+    return x;
+  }
+
+  public double getY() {
+    return y;
+  }
+
+  public double getZ() {
+    return z;
+  }
+}

--- a/cdap-examples/SparkKMeans/src/main/scala/co/cask/cdap/examples/sparkkmeans/SparkKMeansProgram.scala
+++ b/cdap-examples/SparkKMeans/src/main/scala/co/cask/cdap/examples/sparkkmeans/SparkKMeansProgram.scala
@@ -22,15 +22,11 @@
 
 package co.cask.cdap.examples.sparkkmeans
 
-import breeze.linalg.DenseVector
-import breeze.linalg.squaredDistance
-import breeze.linalg.Vector
-import co.cask.cdap.api.spark.ScalaSparkProgram
-import co.cask.cdap.api.spark.SparkContext
+import breeze.linalg.{DenseVector, Vector, squaredDistance}
+import co.cask.cdap.api.spark.{ScalaSparkProgram, SparkContext}
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.NewHadoopRDD
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 
 /**
  * Implementation of KMeans Clustering Spark Program.
@@ -38,8 +34,8 @@ import org.slf4j.LoggerFactory
 class SparkKMeansProgram extends ScalaSparkProgram {
   private final val LOG: Logger = LoggerFactory.getLogger(classOf[SparkKMeansProgram])
 
-  def parseVector(line: String): Vector[Double] = {
-    DenseVector(line.split(' ').map(_.toDouble))
+  def pointVector(point: Point): Vector[Double] = {
+    DenseVector(Array(point.getX, point.getX, point.getZ).map(_.doubleValue()))
   }
 
   def closestPoint(p: Vector[Double], centers: Array[Vector[Double]]): Int = {
@@ -66,10 +62,10 @@ class SparkKMeansProgram extends ScalaSparkProgram {
 
     LOG.info("Processing points data")
 
-    val linesDataset: NewHadoopRDD[Array[Byte], String] =
-      sc.readFromDataset("points", classOf[Array[Byte]], classOf[String])
+    val linesDataset: NewHadoopRDD[Array[Byte], Point] =
+      sc.readFromDataset("points", classOf[Array[Byte]], classOf[Point])
     val lines = linesDataset.values
-    val data = lines.map(parseVector).cache()
+    val data = lines.map(pointVector).cache()
 
     LOG.info("Calculating centers")
 

--- a/cdap-examples/SparkKMeans/src/test/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansAppTest.java
+++ b/cdap-examples/SparkKMeans/src/test/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansAppTest.java
@@ -43,10 +43,9 @@ public class SparkKMeansAppTest extends TestBase {
   public void test() throws Exception {
     // Deploy the Application
     ApplicationManager appManager = deployApplication(SparkKMeansApp.class);
-
-    // Start the Flow
-    FlowManager flowManager = appManager.startFlow("PointsFlow");
     try {
+      // Start the Flow
+      FlowManager flowManager = appManager.startFlow("PointsFlow");
       // Send a few points to the stream
       StreamWriter streamWriter = appManager.getStreamWriter("pointsStream");
       streamWriter.send("10.6 519.2 110.3");
@@ -62,35 +61,35 @@ public class SparkKMeansAppTest extends TestBase {
       // Start a Spark Program
       SparkManager sparkManager = appManager.startSpark("SparkKMeansProgram");
       sparkManager.waitForFinish(60, TimeUnit.SECONDS);
-    } finally {
+
       flowManager.stop();
-    }
 
-    // Start CentersService
-    ServiceManager serviceManager = appManager.startService(SparkKMeansApp.CentersService.SERVICE_NAME);
+      // Start CentersService
+      ServiceManager serviceManager = appManager.startService(SparkKMeansApp.CentersService.SERVICE_NAME);
 
-    // Wait service startup
-    serviceStatusCheck(serviceManager, true);
+      // Wait service startup
+      serviceStatusCheck(serviceManager, true);
 
-    // Request data and verify it
-    String response = requestService(new URL(serviceManager.getServiceURL(15, TimeUnit.SECONDS), "centers/1"));
-    String[] coordinates = response.split(",");
-    Assert.assertTrue(coordinates.length == 3);
-    for (String coordinate : coordinates) {
-      double value = Double.parseDouble(coordinate);
-      Assert.assertTrue(value > 0);
-    }
+      // Request data and verify it
+      String response = requestService(new URL(serviceManager.getServiceURL(15, TimeUnit.SECONDS), "centers/1"));
+      String[] coordinates = response.split(",");
+      Assert.assertTrue(coordinates.length == 3);
+      for (String coordinate : coordinates) {
+        double value = Double.parseDouble(coordinate);
+        Assert.assertTrue(value > 0);
+      }
 
-    // Request data by incorrect index and verify response
-    URL url = new URL(serviceManager.getServiceURL(15, TimeUnit.SECONDS), "centers/10");
-    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-    try {
-      Assert.assertEquals(HttpURLConnection.HTTP_NO_CONTENT, conn.getResponseCode());
+      // Request data by incorrect index and verify response
+      URL url = new URL(serviceManager.getServiceURL(15, TimeUnit.SECONDS), "centers/10");
+      HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+      try {
+        Assert.assertEquals(HttpURLConnection.HTTP_NO_CONTENT, conn.getResponseCode());
+      } finally {
+        conn.disconnect();
+      }
     } finally {
-      conn.disconnect();
+      appManager.stopAll();
     }
-
-    appManager.stopAll();
   }
 
   private String requestService(URL url) throws IOException {

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/stream/TestSparkStreamIntegrationApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/stream/TestSparkStreamIntegrationApp.java
@@ -54,13 +54,13 @@ public class TestSparkStreamIntegrationApp extends AbstractApplication {
   public static class SparkStreamProgram implements JavaSparkProgram {
     @Override
     public void run(SparkContext context) {
-      JavaPairRDD<LongWritable, Text> rdd = context.readFromStream("testStream", Text.class);
-      JavaPairRDD<byte[], byte[]> resultRDD = rdd.mapToPair(new PairFunction<Tuple2<LongWritable, Text>,
+      JavaPairRDD<LongWritable, String> rdd = context.readFromStream("testStream", String.class);
+      JavaPairRDD<byte[], byte[]> resultRDD = rdd.mapToPair(new PairFunction<Tuple2<LongWritable, String>,
         byte[], byte[]>() {
         @Override
-        public Tuple2<byte[], byte[]> call(Tuple2<LongWritable, Text> longWritableTextTuple2) throws Exception {
-          return new Tuple2<byte[], byte[]>(Bytes.toBytes(longWritableTextTuple2._2().toString()),
-                                            Bytes.toBytes(longWritableTextTuple2._2().toString()));
+        public Tuple2<byte[], byte[]> call(Tuple2<LongWritable, String> longWritableTextTuple2) throws Exception {
+          return new Tuple2<byte[], byte[]>(Bytes.toBytes(longWritableTextTuple2._2()),
+                                            Bytes.toBytes(longWritableTextTuple2._2()));
         }
       });
       context.writeToDataset(resultRDD, "result", byte[].class, byte[].class);


### PR DESCRIPTION
In MR and Spark it can consume stream body as String object.

Also reorganize the code in StreamInputFormat a bit to make code easier to read.
And also remove the need of Flow in the SparkKMeans test to speed up test.
