### PR TITLE
Remove building of SDK from docs build script

### DIFF
--- a/cdap-docs/vars
+++ b/cdap-docs/vars
@@ -20,6 +20,7 @@ WITH_JAVADOCS="$WITHOUT"
 
 MANUALS="introduction developers-manual cdap-apps admin-manual integrations examples-manual reference-manual faqs"
 
+# Used to monitor any changes in building of Javadocs
 # BUILD.rst
 BUILD_RST="BUILD.rst"
 BUILD_RST_HASH_LOCATION="cdap-docs/vars"


### PR DESCRIPTION
Remove command to build the SDK from the documentation build, as it is now incomplete and doesn't work at building an SDK anymore. Cleaned up paths to remove redirects, to make them easier to read and check.

Passes [Quick Build](http://builds.cask.co/browse/CDAP-DQB3-1).

Passes a full doc build to check... http://builds.cask.co/browse/CDAP-DDB40-1
