### PR TITLE
CDAP-5884 add explicit spark dependency to integration-test

### DIFF
--- a/cdap-integration-test/pom.xml
+++ b/cdap-integration-test/pom.xml
@@ -80,6 +80,11 @@
       <version>${project.version}</version>
       <type>test-jar</type>
     </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-spark-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <!-- In compile scope because this module should only be used in test scope -->
     <dependency>


### PR DESCRIPTION
For some reason, this dependency was not getting picked up when
an sdk build was happening. Adding it explicitly fixes the error.
