### PR TITLE
Unignore TestFrameworkTestRun#testMultiInput

### DIFF
--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -792,8 +792,6 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
   @Category(XSlowTests.class)
   @Test(timeout = 240000)
-  @Ignore
-  // TODO: Investigate why this fails in Bamboo, but not locally
   public void testMultiInput() throws Exception {
     ApplicationManager applicationManager = deployApplication(JoinMultiStreamApp.class);
     FlowManager flowManager = applicationManager.getFlowManager("JoinMultiFlow").start();


### PR DESCRIPTION
Unignoring a test case - `TestFrameworkTestRun#testMultiInput`.

From a bamboo machine, I ran the test case 100x:

``` bash
for i in `seq 1 100`; do mvn test -Dtest=TestFrameworkTestRun#testMultiInput -DfailIfNoTests=false > ../$i.out; done
```

All 100 times, it passed:

``` bash
$ grep -r "BUILD SUCCESS" --include=*.out ../. | wc -l
100
```

``` bash
$ grep -r "BUILD FAILURE" --include=*.out ../. | wc -l
0
```

So, its not a flaky test.

http://builds.cask.co/browse/CDAP-DUT4097-2
