### PR TITLE
CDAP-5887 write the update request on error instead of just the config

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/UpgradeTool.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/co/cask/cdap/etl/tool/UpgradeTool.java
@@ -150,7 +150,7 @@ public class UpgradeTool {
         LOG.error("Writing config for pipeline {} to {} for further manual investigation.",
                   appId, errorFile.getAbsolutePath());
         try (OutputStreamWriter outputStreamWriter = new OutputStreamWriter(new FileOutputStream(errorFile))) {
-          outputStreamWriter.write(GSON.toJson(config));
+          outputStreamWriter.write(GSON.toJson(updateRequest));
         }
       }
     }


### PR DESCRIPTION
Fix the Hydrator upgrade tool so that it writes out the update app
request body instead of just the config. This lets users use the
file directly without any changes.
