### PR TITLE
Fix log message in PurchaseHistoryBuilder

### DIFF
--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
@@ -129,7 +129,7 @@ public class PurchaseHistoryBuilder extends AbstractMapReduce {
           userProfile = new Gson().fromJson(response.getResponseBodyAsString(), UserProfile.class);
         }
       } catch (Exception e) {
-        LOG.warn("Error accessing user profile: {}", e.getCause());
+        LOG.warn("Error accessing user profile.", e);
       }
 
       PurchaseHistory purchases = new PurchaseHistory(customer.toString(), userProfile);


### PR DESCRIPTION
It was previously printing literal `{}` in the log message, because the second parameter is a Throwable.
