### PR TITLE
CDAP-5889 New IdleThreadService to create and start Tracker if Audit is enabled in Standalone

### DIFF
--- a/cdap-standalone/src/main/java/co/cask/cdap/TrackerAppCreationService.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/TrackerAppCreationService.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap;
+
+import co.cask.cdap.api.artifact.ArtifactVersion;
+import co.cask.cdap.common.ArtifactNotFoundException;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.utils.Tasks;
+import co.cask.cdap.internal.app.deploy.ProgramTerminator;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import co.cask.cdap.internal.app.services.ApplicationLifecycleService;
+import co.cask.cdap.internal.app.services.ProgramLifecycleService;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramId;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.AbstractExecutionThreadService;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Create Tracker App in Default Namespace and start its Programs during Standalone startup.
+ */
+public class TrackerAppCreationService extends AbstractExecutionThreadService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TrackerAppCreationService.class);
+  private static final String TRACKER_CONFIG = "tracker.app.config";
+  private static final ApplicationId TRACKER_APPID = new ApplicationId(NamespaceId.DEFAULT.getNamespace(), "_Tracker");
+  private static final ProgramId AUDIT_FLOWID = new ProgramId(TRACKER_APPID.getNamespace(),
+                                                              TRACKER_APPID.getApplication(), ProgramType.FLOW,
+                                                              "AuditLogFlow");
+  private static final ProgramId AUDIT_SERVICEID = new ProgramId(TRACKER_APPID.getNamespace(),
+                                                                 TRACKER_APPID.getApplication(), ProgramType.SERVICE,
+                                                                 "AuditLog");
+
+  private final CConfiguration cConf;
+  private final ArtifactRepository artifactRepository;
+  private final ApplicationLifecycleService applicationLifecycleService;
+  private final ProgramLifecycleService programLifecycleService;
+
+  @Inject
+  public TrackerAppCreationService(CConfiguration cConf, ArtifactRepository artifactRepository,
+                                   ApplicationLifecycleService applicationLifecycleService,
+                                   ProgramLifecycleService programLifecycleService) {
+    this.cConf = cConf;
+    this.artifactRepository = artifactRepository;
+    this.applicationLifecycleService = applicationLifecycleService;
+    this.programLifecycleService = programLifecycleService;
+  }
+
+  @Override
+  protected void run() throws Exception {
+    try {
+      // Wait until tracker artifact is available
+      Tasks.waitFor(true, new Callable<Boolean>() {
+        @Override
+        public Boolean call() throws Exception {
+          List<ArtifactSummary> artifacts = null;
+          try {
+            artifacts = artifactRepository.getArtifacts(NamespaceId.SYSTEM, "tracker");
+          } catch (ArtifactNotFoundException ex) {
+            // expected, so suppress it
+          }
+          return artifacts != null && !artifacts.isEmpty();
+        }
+      }, 5, TimeUnit.MINUTES, 5, TimeUnit.SECONDS, "Waiting for Tracker Artifact to become available.");
+      // Find the latest tracker artifact based on the version
+      List<ArtifactSummary> artifacts = new ArrayList<>(artifactRepository.getArtifacts(NamespaceId.SYSTEM, "tracker"));
+      ArtifactSummary artifactSummary = artifacts.remove(0);
+      for (ArtifactSummary artifact : artifacts) {
+        ArtifactVersion old = new ArtifactVersion(artifactSummary.getVersion());
+        ArtifactVersion current = new ArtifactVersion(artifact.getVersion());
+        if (current.compareTo(old) > 0) {
+          artifactSummary = artifact;
+        }
+      }
+      createAndStartTracker(artifactSummary);
+    } catch (Exception ex) {
+      // Not able to create Tracker App is not catastrophic, hence don't propagate exception
+      LOG.warn("Got an exception while trying to create and start Tracker App. ", ex);
+    }
+  }
+
+  private void createAndStartTracker(ArtifactSummary artifactSummary) throws Exception {
+    String trackerAppConfig = cConf.get(TRACKER_CONFIG);
+    LOG.info("Creating and starting Tracker App with config : {}", trackerAppConfig);
+    applicationLifecycleService.deployApp(
+      Id.Namespace.from(TRACKER_APPID.getNamespace()), TRACKER_APPID.getApplication(),
+      Id.Artifact.from(Id.Namespace.SYSTEM, artifactSummary.getName(), artifactSummary.getVersion()),
+      trackerAppConfig, new TrackerProgramTerminator(programLifecycleService));
+    try {
+      programLifecycleService.start(AUDIT_FLOWID, ImmutableMap.<String, String>of(), false);
+    } catch (IOException ex) {
+      // Might happen if the program is being started in parallel through UI
+      LOG.debug("Error while trying to start Tracker's AuditFlow. {}", ex.getMessage());
+    }
+    try {
+      programLifecycleService.start(AUDIT_SERVICEID, ImmutableMap.<String, String>of(), false);
+    } catch (IOException ex) {
+      // Might happen if the program is being started in parallel through UI
+      LOG.debug("Error while trying to start Tracker's AuditService. {}", ex.getMessage());
+    }
+  }
+
+  private class TrackerProgramTerminator implements ProgramTerminator {
+    private final ProgramLifecycleService programLifecycleService;
+
+    TrackerProgramTerminator(ProgramLifecycleService programLifecycleService) {
+      this.programLifecycleService = programLifecycleService;
+    }
+
+    @Override
+    public void stop(Id.Program programId) throws Exception {
+      switch (programId.getType()) {
+        case FLOW:
+          programLifecycleService.stop(AUDIT_FLOWID);
+          break;
+        case SERVICE:
+          programLifecycleService.stop(AUDIT_SERVICEID);
+          break;
+        default:
+          LOG.warn("Found an unexpected program {} in TrackerApp.", programId);
+      }
+    }
+  }
+}

--- a/cdap-standalone/src/main/resources/cdap-site.xml
+++ b/cdap-standalone/src/main/resources/cdap-site.xml
@@ -182,4 +182,19 @@
     </description>
   </property>
 
+  <property>
+    <name>tracker.app.config</name>
+    <value>{
+             "auditLogKafkaConfig" : {
+               "topic" : "${audit.kafka.topic}",
+               "zookeeperString" :
+                     "${router.bind.address}:${local.zkserver.port}/${root.namespace}/${kafka.zookeeper.namespace}"
+             }
+           }
+    </value>
+    <description>
+      Application configuration for Tracker
+    </description>
+  </property>
+
 </configuration>


### PR DESCRIPTION
If Audit is enabled, we want to create and start Tracker app in default namespace when CDAP is starting in SDK.
- Doing this in StandaloneMain (java) instead of shell/bat scripts (as described in the JIRA) for ease, code maintenance and platform portability.
- We start a service that waits until Tracker artifact becomes available and then creates the app and starts the programs.
- This is done asynchronously since waiting until tracker artifact is available will more than double the startup time. But this also introduces the possibility of the user still navigating the tracker ui and finding the 'enable tracker' button.

JIRA : https://issues.cask.co/browse/CDAP-5889

Build : http://builds.cask.co/browse/CDAP-DUT4108
