### PR TITLE
CDAP-5279 Deprecated the beforeSubmit and onFinish methods in the MapReduce.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/ProgramState.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/ProgramState.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.api;
+
+import javax.annotation.Nullable;
+
+/**
+ * Class to represent the state of the program.
+ */
+public class ProgramState {
+  private final ProgramStatus status;
+  private final String failureInfo;
+
+  /**
+   * Creates a new instance.
+   * @param status status of the program
+   * @param failureInfo cause of failure, null if the program execution is succeeded
+   */
+  public ProgramState(ProgramStatus status, @Nullable String failureInfo) {
+    this.status = status;
+    this.failureInfo = failureInfo;
+  }
+
+  /**
+   * Return the {@link ProgramStatus} of the program.
+   */
+  public ProgramStatus getStatus() {
+    return status;
+  }
+
+  /**
+   * Return any available information on the reason of failure of the program.
+   */
+  @Nullable
+  public String getFailureInfo() {
+    return failureInfo;
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/ProgramStatus.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/ProgramStatus.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.api;
+
+/**
+ * Represents the runtime status of program.
+ */
+public enum ProgramStatus {
+  INITIALIZING,
+  RUNNING,
+  COMPLETED,
+  FAILED,
+  KILLED
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimeseriesTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/TimeseriesTable.java
@@ -261,7 +261,7 @@ public class TimeseriesTable extends TimeseriesDataset
     throw new UnsupportedOperationException("Cannot use TimeSeriesTable as input for Batch directly. " +
                                               "Use getInput(...) and call " +
                                               "MapReduceContext.setInput(tsTable, splits) in the " +
-                                              "beforeSubmit(MapReduceContext context) method of the MapReduce app.");
+                                              "initialize(MapReduceContext context) method of the MapReduce app.");
   }
 
   @Override

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/partitioned/PartitionBatchInput.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/partitioned/PartitionBatchInput.java
@@ -47,7 +47,7 @@ public class PartitionBatchInput {
   }
 
   /**
-   * Used from the beforeSubmit method of the implementing batch job to configure as input a PartitionedFileSet that has
+   * Used from the initialize method of the implementing batch job to configure as input a PartitionedFileSet that has
    * specified a set of {@link Partition}s of a {@link PartitionedFileSet} to be processed by the run of the batch job.
    * It does this by reading back the previous state, determining the new partitions to read, computing the new
    * state, and persisting this new state. It then configures this dataset as input to the mapreduce context that is

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/AbstractMapReduce.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/AbstractMapReduce.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.api.mapreduce;
 
+import co.cask.cdap.api.ProgramLifecycle;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.batch.Output;
@@ -31,9 +32,10 @@ import java.util.Map;
  * This abstract class provides a default implementation of {@link MapReduce} methods for easy extension.
  */
 public abstract class AbstractMapReduce extends AbstractPluginConfigurable<MapReduceConfigurer>
-  implements MapReduce {
+  implements MapReduce, ProgramLifecycle<MapReduceContext> {
 
   private MapReduceConfigurer configurer;
+  private MapReduceContext context;
 
   @Override
   public final void configure(MapReduceConfigurer configurer) {
@@ -105,7 +107,7 @@ public abstract class AbstractMapReduce extends AbstractPluginConfigurable<MapRe
    * Sets the name of the Dataset used as input for the {@link MapReduce}.
    *
    * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)}
-   * in {@link #beforeSubmit}, instead.
+   * in {@link #initialize}, instead.
    */
   @Deprecated
   protected final void setInputDataset(String dataset) {
@@ -117,7 +119,7 @@ public abstract class AbstractMapReduce extends AbstractPluginConfigurable<MapRe
    *
    * @param stream Name of the stream
    * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)}
-   *             in {@link #beforeSubmit}, instead.
+   *             in {@link #initialize}, instead.
    */
   @Deprecated
   protected final void useStreamInput(String stream) {
@@ -131,7 +133,7 @@ public abstract class AbstractMapReduce extends AbstractPluginConfigurable<MapRe
    * @see StreamBatchReadable
    *
    * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)}
-   *             in {@link #beforeSubmit}, instead.
+   *             in {@link #initialize}, instead.
    */
   @Deprecated
   protected final void useStreamInput(String stream, long startTime, long endTime) {
@@ -144,7 +146,7 @@ public abstract class AbstractMapReduce extends AbstractPluginConfigurable<MapRe
    * @see StreamBatchReadable
    *
    * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)}
-   *             in {@link #beforeSubmit}, instead.
+   *             in {@link #initialize}, instead.
    */
   @Deprecated
   protected final void useStreamInput(StreamBatchReadable streamBatchReadable) {
@@ -152,12 +154,31 @@ public abstract class AbstractMapReduce extends AbstractPluginConfigurable<MapRe
   }
 
   @Override
+  @Deprecated
   public void beforeSubmit(MapReduceContext context) throws Exception {
     // Do nothing by default
   }
 
   @Override
+  @Deprecated
   public void onFinish(boolean succeeded, MapReduceContext context) throws Exception {
     // Do nothing by default
+  }
+
+  @Override
+  public void initialize(MapReduceContext context) throws Exception {
+    this.context = context;
+  }
+
+  @Override
+  public void destroy() {
+    // Do nothing by default
+  }
+
+  /**
+   * Return an instance of the {@link MapReduceContext}.
+   */
+  protected final MapReduceContext getContext() {
+    return context;
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduce.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduce.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.api.mapreduce;
 
+import co.cask.cdap.api.ProgramLifecycle;
+
 /**
  * Defines an interface for the MapReduce job. Use it for easy integration (re-use) of existing MapReduce jobs
  * that rely on the Hadoop MapReduce APIs.
@@ -36,7 +38,10 @@ public interface MapReduce {
    *
    * @param context job execution context
    * @throws Exception if there's an error during this method invocation
+   * @deprecated Deprecated as of 3.5.0. Please use {@link ProgramLifecycle#initialize} instead, to initialize
+   * the MapReduce program.
    */
+  @Deprecated
   void beforeSubmit(MapReduceContext context) throws Exception;
 
   /**
@@ -52,6 +57,9 @@ public interface MapReduce {
    * @param succeeded defines the result of job execution: true if job succeeded, false otherwise
    * @param context job execution context
    * @throws Exception if there's an error during this method invocation.
+   * @deprecated Deprecated as of 3.5.0. Please use {@link ProgramLifecycle#destroy} instead to execute the code once
+   * MapReduce program is completed either successfully or on failure.
    */
+  @Deprecated
   void onFinish(boolean succeeded, MapReduceContext context) throws Exception;
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
@@ -17,18 +17,17 @@
 package co.cask.cdap.api.mapreduce;
 
 import co.cask.cdap.api.ClientLocalizationContext;
+import co.cask.cdap.api.ProgramState;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.RuntimeContext;
 import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.data.DatasetContext;
-import co.cask.cdap.api.data.batch.BatchReadable;
 import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.batch.InputFormatProvider;
 import co.cask.cdap.api.data.batch.Output;
 import co.cask.cdap.api.data.batch.OutputFormatProvider;
 import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.data.stream.StreamBatchReadable;
-import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.workflow.WorkflowInfoProvider;
 
@@ -193,4 +192,9 @@ public interface MapReduceContext extends RuntimeContext, DatasetContext, Servic
    * @param resources Resources that each reducer should use.
    */
   void setReducerResources(Resources resources);
+
+  /**
+   * Return the state of the MapReduce program.
+   */
+  ProgramState getState();
 }

--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/WorkflowApp.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/WorkflowApp.java
@@ -84,7 +84,8 @@ public class WorkflowApp extends AbstractApplication {
     }
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
+      super.initialize(context);
       Map<String, String> args = context.getRuntimeArguments();
       String inputPath = args.get("inputPath");
       String outputPath = args.get("outputPath");
@@ -92,8 +93,8 @@ public class WorkflowApp extends AbstractApplication {
     }
 
     @Override
-    public void onFinish(boolean succeeded, MapReduceContext context) throws Exception {
-      context.getWorkflowToken().put("completed", context.getWorkflowInfo().getNodeId());
+    public void destroy() {
+      getContext().getWorkflowToken().put("completed", getContext().getWorkflowInfo().getNodeId());
     }
   }
 

--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/WorkflowAppWithScopedParameters.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/WorkflowAppWithScopedParameters.java
@@ -71,7 +71,7 @@ public class WorkflowAppWithScopedParameters extends AbstractApplication {
   public static class OneMR extends AbstractMapReduce {
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Map<String, String> args = context.getRuntimeArguments();
 
       Preconditions.checkArgument(args.size() == 18);
@@ -92,7 +92,7 @@ public class WorkflowAppWithScopedParameters extends AbstractApplication {
   public static class AnotherMR extends AbstractMapReduce {
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Map<String, String> args = context.getRuntimeArguments();
 
       Preconditions.checkArgument(args.size() == 18);

--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/WorkflowTokenTestPutApp.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/WorkflowTokenTestPutApp.java
@@ -57,8 +57,8 @@ public class WorkflowTokenTestPutApp extends AbstractApplication {
   @Override
   public void configure() {
     setName(NAME);
-    setDescription("Application to test the put operation on the Workflow in beforeSubmit, " +
-                     "onFinish, map, and reduce methods of the MapReduce program.");
+    setDescription("Application to test the put operation on the Workflow in initialize, " +
+                     "destroy, map, and reduce methods of the MapReduce program.");
     addMapReduce(new RecordCounter());
     addSpark(new SparkTestApp());
     addWorkflow(new WorkflowTokenTestPut());
@@ -87,7 +87,8 @@ public class WorkflowTokenTestPutApp extends AbstractApplication {
     }
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
+      super.initialize(context);
       Job job = context.getHadoopJob();
       job.setMapperClass(MyMapper.class);
       job.setReducerClass(MyReducer.class);
@@ -109,11 +110,11 @@ public class WorkflowTokenTestPutApp extends AbstractApplication {
     }
 
     @Override
-    public void onFinish(boolean succeeded, MapReduceContext context) throws Exception {
-      WorkflowToken workflowToken = context.getWorkflowToken();
+    public void destroy() {
+      WorkflowToken workflowToken = getContext().getWorkflowToken();
       workflowToken.put("end.time", Value.of(System.currentTimeMillis()));
 
-      WorkflowInfo workflowInfo = context.getWorkflowInfo();
+      WorkflowInfo workflowInfo = getContext().getWorkflowInfo();
       Preconditions.checkNotNull(workflowInfo);
       Preconditions.checkArgument(workflowInfo.getRunId().getId()
                                     .equals(workflowToken.get("wf.runid").toString()));

--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -1377,7 +1377,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     // This should succeed. The programs inside the workflow will attempt to write to the workflow token
     // from the Mapper's and Reducer's methods as well as from a Spark closure, and they will throw an exception
     // if that succeeds.
-    // The MapReduce's beforeSubmit will record the workflow run id in the token, and the onFinish as well
+    // The MapReduce's initialize will record the workflow run id in the token, and the destroy as well
     // as the mapper and the reducer will validate that they have the same workflow run id.
     String outputPath = new File(tmpFolder.newFolder(), "output").getAbsolutePath();
     startProgram(workflowId, ImmutableMap.of("inputPath", createInputForRecordVerification("sixthInput"),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.internal.app.runtime.batch;
 
+import co.cask.cdap.api.ProgramState;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.batch.InputFormatProvider;
@@ -90,6 +91,7 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
   private Job job;
   private Resources mapperResources;
   private Resources reducerResources;
+  private ProgramState state;
 
   public BasicMapReduceContext(Program program,
                                RunId runId,
@@ -415,5 +417,17 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
       tags.put(Constants.Metrics.Tag.NODE, workflowProgramInfo.getNodeId());
     }
     return service.getContext(tags);
+  }
+
+  /**
+   * Sets the current state of the program.
+   */
+  void setState(ProgramState state) {
+    this.state = state;
+  }
+
+  @Override
+  public ProgramState getState() {
+    return state;
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
@@ -17,6 +17,8 @@ package co.cask.cdap.internal.app.runtime.batch;
  */
 
 import co.cask.cdap.api.Admin;
+import co.cask.cdap.api.ProgramState;
+import co.cask.cdap.api.ProgramStatus;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.data.DatasetInstantiationException;
@@ -250,6 +252,12 @@ public class MapReduceLifecycleContext<KEY, VALUE> implements MapReduceTaskConte
   @Override
   public void setReducerResources(Resources resources) {
     LOG.warn(UNSUPPORTED_OPERATION_MESSAGE);
+  }
+
+  @Override
+  public ProgramState getState() {
+    // In MapperWrapper and ReducerWrapper the status would be RUNNING
+    return new ProgramState(ProgramStatus.RUNNING, null);
   }
 
   @Override

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/AllProgramsApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/AllProgramsApp.java
@@ -174,7 +174,7 @@ public class AllProgramsApp extends AbstractApplication {
     }
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Job job = context.getHadoopJob();
       job.setMapperClass(NoOpMapper.class);
       job.setReducerClass(NoOpReducer.class);
@@ -195,7 +195,7 @@ public class AllProgramsApp extends AbstractApplication {
     }
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       context.addInput(Input.ofDataset(DATASET_NAME2));
       context.addOutput(Output.ofDataset(DATASET_NAME));
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithWorkflow.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithWorkflow.java
@@ -160,8 +160,7 @@ public class AppWithWorkflow extends AbstractApplication {
     }
 
     @Override
-    @SuppressWarnings("ConstantConditions")
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Map<String, String> args = context.getRuntimeArguments();
       String inputPath = args.get("inputPath");
       String outputPath = args.get("outputPath");

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/ConditionalWorkflowApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/ConditionalWorkflowApp.java
@@ -117,7 +117,7 @@ public class ConditionalWorkflowApp extends AbstractApplication {
     }
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Job job = context.getHadoopJob();
       job.setMapperClass(MyVerifier.class);
       String inputPath = context.getRuntimeArguments().get("inputPath");
@@ -158,7 +158,7 @@ public class ConditionalWorkflowApp extends AbstractApplication {
     }
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Map<String, String> args = context.getRuntimeArguments();
       String inputPath = args.get("inputPath");
       String outputPath = args.get("outputPath");

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/DummyAppWithTrackingTable.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/DummyAppWithTrackingTable.java
@@ -127,7 +127,7 @@ public class DummyAppWithTrackingTable extends AbstractApplication {
     }
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Job job = context.getHadoopJob();
       job.setMapperClass(DummyMapper.class);
       job.setReducerClass(DummyReducer.class);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowFailureInForkApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowFailureInForkApp.java
@@ -81,7 +81,7 @@ public class WorkflowFailureInForkApp extends AbstractApplication {
 
     @Override
     @SuppressWarnings("ConstantConditions")
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Map<String, String> args = context.getRuntimeArguments();
       String inputPath = args.get("inputPath");
       String outputPath = args.get("outputPath");
@@ -99,7 +99,7 @@ public class WorkflowFailureInForkApp extends AbstractApplication {
         file = new File(args.get("wait.file"));
         //noinspection ResultOfMethodCallIgnored
         file.createNewFile();
-        throw new RuntimeException("Exception in beforeSubmit()");
+        throw new RuntimeException("Exception in initialize()");
       }
       File file = new File(args.get("sync.file"));
       //noinspection ResultOfMethodCallIgnored

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithLocalFiles.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithLocalFiles.java
@@ -66,7 +66,7 @@ public class AppWithLocalFiles extends AbstractApplication {
   public static class MapReduceWithLocalFiles extends AbstractMapReduce {
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Map<String, String> args = context.getRuntimeArguments();
       if (args.containsKey(STOPWORDS_FILE_ARG)) {
         context.localize(STOPWORDS_FILE_ALIAS, URI.create(args.get(STOPWORDS_FILE_ARG)));

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduce.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduce.java
@@ -63,15 +63,11 @@ public class AppWithMapReduce extends AbstractApplication {
     }
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
+      super.initialize(context);
       String inputPath = Bytes.toString(table.read(Bytes.toBytes("inputPath")));
       String outputPath = Bytes.toString(table.read(Bytes.toBytes("outputPath")));
       WordCount.configureJob((Job) context.getHadoopJob(), inputPath, outputPath);
-    }
-
-    @Override
-    public void onFinish(boolean succeeded, MapReduceContext context) throws Exception {
-      System.out.println("Action taken on MapReduce job " + (succeeded ? "" : "un") + "successful completion");
     }
   }
 
@@ -89,7 +85,8 @@ public class AppWithMapReduce extends AbstractApplication {
     private Metrics metrics;
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
+      super.initialize(context);
       metrics.count("beforeSubmit", 1);
       Job hadoopJob = context.getHadoopJob();
       AggregateMetricsByTag.configureJob(hadoopJob);
@@ -110,9 +107,8 @@ public class AppWithMapReduce extends AbstractApplication {
     }
 
     @Override
-    public void onFinish(boolean succeeded, MapReduceContext context) throws Exception {
+    public void destroy() {
       metrics.count("onFinish", 1);
-      System.out.println("Action taken on MapReduce job " + (succeeded ? "" : "un") + "successful completion");
       onFinishTable.write(Bytes.toBytes("onFinish"), Bytes.toBytes("onFinish:done"));
       metrics.count("onFinish", 1);
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingAvroDynamicPartitioner.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingAvroDynamicPartitioner.java
@@ -120,7 +120,7 @@ public class AppWithMapReduceUsingAvroDynamicPartitioner extends AbstractApplica
                                                                        "post.-final", "actually.final.value");
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       context.addInput(Input.ofDataset(INPUT_DATASET));
 
       Map<String, String> outputDatasetArgs = new HashMap<>();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingFileSet.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingFileSet.java
@@ -66,7 +66,7 @@ public class AppWithMapReduceUsingFileSet extends AbstractApplication {
   public static final class ComputeSum extends AbstractMapReduce {
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Job job = context.getHadoopJob();
       job.setReducerClass(FileReducer.class);
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingObjectStore.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingObjectStore.java
@@ -55,16 +55,12 @@ public class AppWithMapReduceUsingObjectStore extends AbstractApplication {
   public static final class ComputeCounts extends AbstractMapReduce {
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Job job = context.getHadoopJob();
       job.setMapperClass(ObjectStoreMapper.class);
       job.setReducerClass(KeyValueStoreReducer.class);
       context.addInput(Input.ofDataset("keys"));
       context.addOutput(Output.ofDataset("count"));
-    }
-
-    @Override
-    public void onFinish(boolean succeeded, MapReduceContext context) throws Exception {
     }
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingRuntimeDatasets.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingRuntimeDatasets.java
@@ -74,7 +74,7 @@ public class AppWithMapReduceUsingRuntimeDatasets extends AbstractApplication {
     }
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Job job = context.getHadoopJob();
       job.setMapperClass(FileMapper.class);
       job.setReducerClass(FileReducer.class);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithPartitionedFileSet.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithPartitionedFileSet.java
@@ -77,7 +77,7 @@ public class AppWithPartitionedFileSet extends AbstractApplication {
   public static final class PartitionWriter extends AbstractMapReduce {
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Job job = context.getHadoopJob();
       job.setMapperClass(SimpleMapper.class);
       job.setNumReduceTasks(0);
@@ -102,7 +102,7 @@ public class AppWithPartitionedFileSet extends AbstractApplication {
   public static final class PartitionReader extends AbstractMapReduce {
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Job job = context.getHadoopJob();
       job.setMapperClass(ReaderMapper.class);
       job.setNumReduceTasks(0);
@@ -111,7 +111,6 @@ public class AppWithPartitionedFileSet extends AbstractApplication {
       context.addInput(Input.ofDataset(PARTITIONED));
       context.addOutput(Output.ofDataset(OUTPUT));
     }
-
   }
 
   public static class ReaderMapper extends Mapper<LongWritable, Text, byte[], Put> {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithTxAware.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithTxAware.java
@@ -52,12 +52,11 @@ public class AppWithTxAware extends AbstractApplication {
   }
 
   /**
-   * This m/r fails if its beforeSubmit() is not run in the same transaction as getSplits().
+   * This m/r fails if its initialize() is not run in the same transaction as getSplits().
    */
   public static class PedanticMapReduce extends AbstractMapReduce {
-
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Job job = context.getHadoopJob();
       job.setMapperClass(DummyMapper.class);
       job.setNumReduceTasks(0);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
@@ -92,7 +92,7 @@ public class MapReduceProgramRunnerTest extends MapReduceRunnerTestBase {
   };
 
   /**
-   * Tests that beforeSubmit() and getSplits() are called in the same transaction,
+   * Tests that initialize() and getSplits() are called in the same transaction,
    * and with the same instance of the input dataset.
    */
   @Test
@@ -504,7 +504,7 @@ public class MapReduceProgramRunnerTest extends MapReduceRunnerTestBase {
   // TODO: this tests failure in Map tasks. We also need to test: failure in Reduce task, kill of a job by user.
   private void testFailure(boolean frequentFlushing) throws Exception {
     // We want to verify that when mapreduce job fails:
-    // * things written in beforeSubmit() remains and visible to others
+    // * things written in initialize() remains and visible to others
     // * things written in tasks not visible to others TODO AAA: do invalidate
     // * things written in onfinish() remains and visible to others
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceWithPartitionedTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceWithPartitionedTest.java
@@ -118,7 +118,7 @@ public class MapReduceWithPartitionedTest extends MapReduceRunnerTestBase {
     // now run the m/r again with a new partition time, say 5 minutes later
     TimePartitionedFileSetArguments.setOutputPartitionTime(outputArgs, time5);
     runtimeArguments.putAll(RuntimeArguments.addScope(Scope.DATASET, TIME_PARTITIONED, outputArgs));
-    // make the mapreduce add the partition in onFinish, to validate that this does not fail the job
+    // make the mapreduce add the partition in destroy, to validate that this does not fail the job
     runtimeArguments.put(AppWithTimePartitionedFileSet.COMPAT_ADD_PARTITION, "true");
     runProgram(app, AppWithTimePartitionedFileSet.PartitionWriter.class, new BasicArguments(runtimeArguments));
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/AppWithMapReduceUsingInconsistentMappers.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/AppWithMapReduceUsingInconsistentMappers.java
@@ -51,13 +51,10 @@ public class AppWithMapReduceUsingInconsistentMappers extends AbstractApplicatio
    * Performs no data operations, but simply runs to test mapper output type checking.
    */
   private abstract static class BaseMapReduce extends AbstractMapReduce {
-
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       // the inputs will be set in child classes
-
       context.addOutput(Output.ofDataset("output"));
-
       Job job = context.getHadoopJob();
       job.setReducerClass(SomeReducer.class);
     }
@@ -67,12 +64,11 @@ public class AppWithMapReduceUsingInconsistentMappers extends AbstractApplicatio
    * MapReduce job that has two mapper classes, both with the same output types.
    */
   public static final class MapReduceWithConsistentMapperTypes extends BaseMapReduce {
-
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       context.addInput(Input.ofDataset("input1"), OriginalMapper.class);
       context.addInput(Input.ofDataset("input2"), ConsistentMapper.class);
-      super.beforeSubmit(context);
+      super.initialize(context);
     }
   }
 
@@ -80,16 +76,15 @@ public class AppWithMapReduceUsingInconsistentMappers extends AbstractApplicatio
    * MapReduce job that has two mapper classes, each with different output types, both set through the CDAP APIs.
    */
   public static final class MapReduceWithInconsistentMapperTypes extends BaseMapReduce {
-
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       context.addInput(Input.ofDataset("input1"), OriginalMapper.class);
       context.addInput(Input.ofDataset("input2"), InconsistentMapper.class);
 
       Job job = context.getHadoopJob();
       // none of the inputs default to the job-defined mapper, so an inconsistent mapper defined here gives no issue
       job.setMapperClass(InconsistentMapper.class);
-      super.beforeSubmit(context);
+      super.initialize(context);
     }
   }
 
@@ -98,16 +93,14 @@ public class AppWithMapReduceUsingInconsistentMappers extends AbstractApplicatio
    * directly on the job).
    */
   public static final class MapReduceWithInconsistentMapperTypes2 extends BaseMapReduce {
-
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       context.addInput(Input.ofDataset("input1"), OriginalMapper.class);
       context.addInput(Input.ofDataset("input2"));
 
-
       Job job = context.getHadoopJob();
       job.setMapperClass(InconsistentMapper.class);
-      super.beforeSubmit(context);
+      super.initialize(context);
     }
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/AppWithMapReduceUsingMultipleInputs.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/AppWithMapReduceUsingMultipleInputs.java
@@ -77,7 +77,7 @@ public class AppWithMapReduceUsingMultipleInputs extends AbstractApplication {
   public static class ComputeSum extends AbstractMapReduce {
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Map<String, String> inputArgs = new HashMap<>();
       FileSetArguments.setInputPath(inputArgs, "inputFile");
 
@@ -102,8 +102,8 @@ public class AppWithMapReduceUsingMultipleInputs extends AbstractApplication {
    */
   public static final class InvalidMapReduce extends ComputeSum {
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
-      super.beforeSubmit(context);
+    public void initialize(MapReduceContext context) throws Exception {
+      super.initialize(context);
       context.addInput(Input.ofDataset(PURCHASES, ImmutableMap.of("key", "value")));
     }
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/AppWithMapReduceUsingMultipleOutputs.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/AppWithMapReduceUsingMultipleOutputs.java
@@ -67,7 +67,7 @@ public class AppWithMapReduceUsingMultipleOutputs extends AbstractApplication {
   public static class SeparatePurchases extends AbstractMapReduce {
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Map<String, String> inputArgs = new HashMap<>();
       FileSetArguments.setInputPath(inputArgs, "inputFile");
 
@@ -93,8 +93,8 @@ public class AppWithMapReduceUsingMultipleOutputs extends AbstractApplication {
    */
   public static class InvalidMapReduce extends SeparatePurchases {
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
-      super.beforeSubmit(context);
+    public void initialize(MapReduceContext context) throws Exception {
+      super.initialize(context);
       context.addOutput(Output.ofDataset(SEPARATED_PURCHASES).alias("small_purchases"));
     }
   }

--- a/cdap-app-templates/cdap-data-quality/src/main/java/co/cask/cdap/dq/DataQualityApp.java
+++ b/cdap-app-templates/cdap-data-quality/src/main/java/co/cask/cdap/dq/DataQualityApp.java
@@ -176,7 +176,7 @@ public class DataQualityApp extends AbstractApplication<DataQualityApp.DataQuali
     }
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Job job = context.getHadoopJob();
       job.setMapperClass(AggregationMapper.class);
       job.setReducerClass(AggregationReducer.class);

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.etl.batch.mapreduce;
 
 import co.cask.cdap.api.ProgramLifecycle;
+import co.cask.cdap.api.ProgramStatus;
 import co.cask.cdap.api.data.batch.Output;
 import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSetArguments;
@@ -142,7 +143,8 @@ public class ETLMapReduce extends AbstractMapReduce {
   }
 
   @Override
-  public void beforeSubmit(MapReduceContext context) throws Exception {
+  public void initialize(MapReduceContext context) throws Exception {
+    super.initialize(context);
     if (Boolean.valueOf(context.getSpecification().getProperty(Constants.STAGE_LOGGING_ENABLED))) {
       LogStageInjector.start();
     }
@@ -268,9 +270,10 @@ public class ETLMapReduce extends AbstractMapReduce {
   }
 
   @Override
-  public void onFinish(boolean succeeded, MapReduceContext context) throws Exception {
-    finisher.onFinish(succeeded);
-    LOG.info("Batch Run finished : succeeded = {}", succeeded);
+  public void destroy() {
+    boolean isSuccessful = getContext().getState().getStatus() == ProgramStatus.COMPLETED;
+    finisher.onFinish(isSuccessful);
+    LOG.info("Batch Run finished : status = {}", getContext().getState());
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/TransformRunner.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/TransformRunner.java
@@ -123,7 +123,7 @@ public class TransformRunner<KEY, VALUE> {
 
     String sinkOutputsStr = hConf.get(ETLMapReduce.SINK_OUTPUTS_KEY);
 
-    // should never happen, this is set in beforeSubmit
+    // should never happen, this is set in initialize
     Preconditions.checkNotNull(sinkOutputsStr, "Sink outputs not found in Hadoop conf.");
     Map<String, SinkOutput> sinkOutputs = GSON.fromJson(sinkOutputsStr, ETLMapReduce.SINK_OUTPUTS_TYPE);
     return hasSingleOutput(pipelinePhase.getStagesOfType(Transform.PLUGIN_TYPE), sinkOutputs) ?

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/UsageHandlerTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/UsageHandlerTestRun.java
@@ -167,7 +167,7 @@ public class UsageHandlerTestRun extends ClientTestBase {
     Assert.assertEquals(0, getDatasetProgramUsage(dataset).size());
 
     deployApp(AllProgramsApp.class);
-    // now that we only support dynamic dataset instantiation in beforeSubmit (and not in configure as before),
+    // now that we only support dynamic dataset instantiation in initialize (and not in configure as before),
     // we must run the mapreduce program to register its usage
     startProgram(program);
     waitState(program, ProgramStatus.STOPPED);

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/app/AllProgramsApp.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/app/AllProgramsApp.java
@@ -177,7 +177,7 @@ public class AllProgramsApp extends AbstractApplication {
     }
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Job job = context.getHadoopJob();
       job.setMapperClass(NoOpMapper.class);
       job.setReducerClass(NoOpReducer.class);
@@ -198,7 +198,7 @@ public class AllProgramsApp extends AbstractApplication {
     }
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       context.addInput(Input.ofDataset(DATASET_NAME2));
       context.addOutput(Output.ofDataset(DATASET_NAME));
     }

--- a/cdap-examples/ClicksAndViews/src/main/java/co/cask/cdap/examples/clicksandviews/ClicksAndViewsMapReduce.java
+++ b/cdap-examples/ClicksAndViews/src/main/java/co/cask/cdap/examples/clicksandviews/ClicksAndViewsMapReduce.java
@@ -56,7 +56,8 @@ public class ClicksAndViewsMapReduce extends AbstractMapReduce {
   }
 
   @Override
-  public void beforeSubmit(MapReduceContext context) throws Exception {
+  public void initialize(MapReduceContext context) throws Exception {
+    super.initialize(context);
     context.addInput(Input.ofStream(ClicksAndViews.CLICKS));
     context.addInput(Input.ofStream(ClicksAndViews.VIEWS));
 

--- a/cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
+++ b/cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.examples.datacleansing;
 
 import co.cask.cdap.api.ProgramLifecycle;
+import co.cask.cdap.api.ProgramStatus;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.batch.Output;
@@ -62,7 +63,8 @@ public class DataCleansingMapReduce extends AbstractMapReduce {
   }
 
   @Override
-  public void beforeSubmit(MapReduceContext context) throws Exception {
+  public void initialize(MapReduceContext context) throws Exception {
+    super.initialize(context);
     partitionCommitter =
       PartitionBatchInput.setInput(context, DataCleansing.RAW_RECORDS,
                                    new KVTableStatePersistor(DataCleansing.CONSUMING_STATE, "state.key"));
@@ -96,8 +98,9 @@ public class DataCleansingMapReduce extends AbstractMapReduce {
   }
 
   @Override
-  public void onFinish(boolean succeeded, MapReduceContext context) throws Exception {
-    partitionCommitter.onFinish(succeeded);
+  public void destroy() {
+    boolean isSuccessful = getContext().getState().getStatus() == ProgramStatus.COMPLETED;
+    partitionCommitter.onFinish(isSuccessful);
   }
 
   /**

--- a/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
+++ b/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
@@ -47,7 +47,8 @@ public class WordCount extends AbstractMapReduce {
   }
 
   @Override
-  public void beforeSubmit(MapReduceContext context) throws Exception {
+  public void initialize(MapReduceContext context) throws Exception {
+    super.initialize(context);
     Job job = context.getHadoopJob();
     job.setMapperClass(Tokenizer.class);
     job.setReducerClass(Counter.class);

--- a/cdap-examples/LogAnalysis/src/main/java/co/cask/cdap/examples/loganalysis/HitCounterProgram.java
+++ b/cdap-examples/LogAnalysis/src/main/java/co/cask/cdap/examples/loganalysis/HitCounterProgram.java
@@ -37,7 +37,8 @@ import java.io.IOException;
 public class HitCounterProgram extends AbstractMapReduce {
 
   @Override
-  public void beforeSubmit(MapReduceContext context) throws Exception {
+  public void initialize(MapReduceContext context) throws Exception {
+    super.initialize(context);
     Job job = context.getHadoopJob();
     job.setMapperClass(Emitter.class);
     job.setReducerClass(Counter.class);

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
@@ -57,7 +57,8 @@ public class PurchaseHistoryBuilder extends AbstractMapReduce {
   }
 
   @Override
-  public void beforeSubmit(MapReduceContext context) throws Exception {
+  public void initialize(MapReduceContext context) throws Exception {
+    super.initialize(context);
     Job job = context.getHadoopJob();
     job.setReducerClass(PerUserReducer.class);
 

--- a/cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
+++ b/cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
@@ -193,7 +193,8 @@ public class SparkPageRankApp extends AbstractApplication {
   public static class RanksCounter extends AbstractMapReduce {
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
+      super.initialize(context);
       Job job = context.getHadoopJob();
       job.setMapperClass(Emitter.class);
       job.setReducerClass(Counter.class);

--- a/cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/ScoreCounter.java
+++ b/cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/ScoreCounter.java
@@ -56,7 +56,8 @@ public class ScoreCounter extends AbstractMapReduce {
   }
 
   @Override
-  public void beforeSubmit(MapReduceContext context) throws Exception {
+  public void initialize(MapReduceContext context) throws Exception {
+    super.initialize(context);
     Job job = context.getHadoopJob();
     job.setMapperClass(ResultsMapper.class);
     job.setReducerClass(TeamCounter.class);

--- a/cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
+++ b/cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
@@ -61,7 +61,8 @@ public class StreamConversionMapReduce extends AbstractMapReduce {
   }
 
   @Override
-  public void beforeSubmit(MapReduceContext context) throws Exception {
+  public void initialize(MapReduceContext context) throws Exception {
+    super.initialize(context);
     Job job = context.getHadoopJob();
     job.setMapperClass(StreamConversionMapper.class);
     job.setNumReduceTasks(0);

--- a/cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/StreamToDataset.java
+++ b/cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/StreamToDataset.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.examples.wikipedia;
 
+import co.cask.cdap.api.ProgramStatus;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.stream.StreamBatchReadable;
@@ -57,7 +58,8 @@ public class StreamToDataset extends AbstractMapReduce {
   }
 
   @Override
-  public void beforeSubmit(MapReduceContext context) throws Exception {
+  public void initialize(MapReduceContext context) throws Exception {
+    super.initialize(context);
     Job job = context.getHadoopJob();
     job.setNumReduceTasks(0);
     WorkflowToken workflowToken = context.getWorkflowToken();
@@ -81,10 +83,11 @@ public class StreamToDataset extends AbstractMapReduce {
   }
 
   @Override
-  public void onFinish(boolean succeeded, MapReduceContext context) throws Exception {
-    WorkflowToken workflowToken = context.getWorkflowToken();
+  public void destroy() {
+    WorkflowToken workflowToken = getContext().getWorkflowToken();
     if (workflowToken != null) {
-      workflowToken.put("result", Value.of(succeeded));
+      boolean isSuccessful = getContext().getState().getStatus() == ProgramStatus.COMPLETED;
+      workflowToken.put("result", Value.of(isSuccessful));
     }
   }
 

--- a/cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/TopNMapReduce.java
+++ b/cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/TopNMapReduce.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.examples.wikipedia;
 
 import co.cask.cdap.api.ProgramLifecycle;
+import co.cask.cdap.api.ProgramStatus;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.batch.Input;
@@ -56,7 +57,8 @@ public class TopNMapReduce extends AbstractMapReduce {
   }
 
   @Override
-  public void beforeSubmit(MapReduceContext context) throws Exception {
+  public void initialize(MapReduceContext context) throws Exception {
+    super.initialize(context);
     Map<String, String> runtimeArguments = context.getRuntimeArguments();
     Job job = context.getHadoopJob();
     WorkflowToken workflowToken = context.getWorkflowToken();
@@ -79,10 +81,11 @@ public class TopNMapReduce extends AbstractMapReduce {
   }
 
   @Override
-  public void onFinish(boolean succeeded, MapReduceContext context) throws Exception {
-    WorkflowToken workflowToken = context.getWorkflowToken();
+  public void destroy() {
+    WorkflowToken workflowToken = getContext().getWorkflowToken();
     if (workflowToken != null) {
-      workflowToken.put("result", Value.of(succeeded));
+      boolean isSuccessful = getContext().getState().getStatus() == ProgramStatus.COMPLETED;
+      workflowToken.put("result", Value.of(isSuccessful));
     }
   }
 

--- a/cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/WikipediaDataDownloader.java
+++ b/cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/WikipediaDataDownloader.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.examples.wikipedia;
 
+import co.cask.cdap.api.ProgramStatus;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.batch.Input;
@@ -52,7 +53,8 @@ public class WikipediaDataDownloader extends AbstractMapReduce {
   }
 
   @Override
-  public void beforeSubmit(MapReduceContext context) throws Exception {
+  public void initialize(MapReduceContext context) throws Exception {
+    super.initialize(context);
     Job job = context.getHadoopJob();
     job.setMapperClass(WikipediaDataDownloaderMapper.class);
     job.setNumReduceTasks(0);
@@ -61,10 +63,11 @@ public class WikipediaDataDownloader extends AbstractMapReduce {
   }
 
   @Override
-  public void onFinish(boolean succeeded, MapReduceContext context) throws Exception {
-    WorkflowToken workflowToken = context.getWorkflowToken();
+  public void destroy() {
+    WorkflowToken workflowToken = getContext().getWorkflowToken();
     if (workflowToken != null) {
-      workflowToken.put("result", Value.of(succeeded));
+      boolean isSuccessful = getContext().getState().getStatus() == ProgramStatus.COMPLETED;
+      workflowToken.put("result", Value.of(isSuccessful));
     }
   }
 

--- a/cdap-unit-test/src/test/java/co/cask/cdap/admin/AdminApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/admin/AdminApp.java
@@ -334,7 +334,7 @@ public class AdminApp extends AbstractApplication {
     }
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
 
       Job job = context.getHadoopJob();
       job.setMapperClass(Tokenizer.class);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/NoMapperApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/NoMapperApp.java
@@ -48,7 +48,7 @@ public class NoMapperApp extends AbstractApplication {
   public static final class NoMapperMapReduce extends AbstractMapReduce {
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Job job = context.getHadoopJob();
       job.setReducerClass(NoMapperReducer.class);
       context.addInput(Input.ofStream("nomapper"));

--- a/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/TestBatchStreamIntegrationApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/TestBatchStreamIntegrationApp.java
@@ -64,7 +64,7 @@ public class TestBatchStreamIntegrationApp extends AbstractApplication {
   public static class StreamTestBatch extends AbstractMapReduce {
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Job job = context.getHadoopJob();
       setMapperClass(job);
       job.setReducerClass(StreamTestBatchReducer.class);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/AppWithMapReduceUsingStream.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/AppWithMapReduceUsingStream.java
@@ -63,7 +63,7 @@ public class AppWithMapReduceUsingStream extends AbstractApplication {
   public static final class BodyTracker extends AbstractMapReduce {
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Job job = context.getHadoopJob();
       job.setMapperClass(TickerMapper.class);
       job.setReducerClass(PriceCounter.class);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/service/TestMapReduceServiceIntegrationApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/service/TestMapReduceServiceIntegrationApp.java
@@ -83,7 +83,7 @@ public class TestMapReduceServiceIntegrationApp extends AbstractApplication {
     }
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Job job = context.getHadoopJob();
       job.setMapperClass(MyMapper.class);
       job.setMapOutputKeyClass(BytesWritable.class);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/AppWithPartitionConsumers.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/AppWithPartitionConsumers.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.partitioned;
 
 import co.cask.cdap.api.ProgramLifecycle;
+import co.cask.cdap.api.ProgramStatus;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.annotation.UseDataSet;
@@ -211,7 +212,8 @@ public class AppWithPartitionConsumers extends AbstractApplication {
     }
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
+      super.initialize(context);
       batchPartitionCommitter =
         PartitionBatchInput.setInput(context, "lines", new KVTableStatePersistor("consumingState", "state.key"));
 
@@ -232,8 +234,9 @@ public class AppWithPartitionConsumers extends AbstractApplication {
     }
 
     @Override
-    public void onFinish(boolean succeeded, MapReduceContext context) throws Exception {
-      batchPartitionCommitter.onFinish(succeeded);
+    public void destroy() {
+      boolean isSuccessful = getContext().getState().getStatus() == ProgramStatus.COMPLETED;
+      batchPartitionCommitter.onFinish(isSuccessful);
     }
 
     /**

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DatasetWithMRApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DatasetWithMRApp.java
@@ -50,7 +50,7 @@ public class DatasetWithMRApp extends AbstractApplication {
     }
 
     @Override
-    public void beforeSubmit(MapReduceContext context) {
+    public void initialize(MapReduceContext context) {
       context.addInput(Input.ofDataset(context.getRuntimeArguments().get(INPUT_KEY)));
       context.addOutput(Output.ofDataset(context.getRuntimeArguments().get(OUTPUT_KEY)));
       Job hadoopJob = context.getHadoopJob();

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/WordCountApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/WordCountApp.java
@@ -260,7 +260,7 @@ public class WordCountApp extends AbstractApplication {
     }
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Job job = context.getHadoopJob();
       job.setMapperClass(MyMapper.class);
       job.setReducerClass(MyReducer.class);
@@ -307,7 +307,7 @@ public class WordCountApp extends AbstractApplication {
     }
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       Job job = context.getHadoopJob();
       job.setMapperClass(StreamMapper.class);
       job.setMapOutputKeyClass(Text.class);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/WorkflowAppWithLocalDatasets.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/WorkflowAppWithLocalDatasets.java
@@ -148,7 +148,7 @@ public class WorkflowAppWithLocalDatasets extends AbstractApplication {
    */
   public static class WordCount extends AbstractMapReduce {
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       String inputPath = context.getRuntimeArguments().get("output.path");
       Map<String, String> fileSetArgs = new HashMap<>();
       FileSetArguments.addInputPath(fileSetArgs, inputPath);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/artifacts/AppWithPlugin.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/artifacts/AppWithPlugin.java
@@ -144,8 +144,8 @@ public class AppWithPlugin extends AbstractApplication {
     }
 
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
-      super.beforeSubmit(context);
+    public void initialize(MapReduceContext context) throws Exception {
+      super.initialize(context);
       Job job = context.getHadoopJob();
       job.setMapperClass(SimpleMapper.class);
       job.setNumReduceTasks(0);

--- a/cdap-unit-test/src/test/java/net/fake/test/app/BundleJarApp.java
+++ b/cdap-unit-test/src/test/java/net/fake/test/app/BundleJarApp.java
@@ -179,7 +179,7 @@ public class BundleJarApp extends AbstractApplication {
      * @throws Exception
      */
     @Override
-    public void beforeSubmit(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceContext context) throws Exception {
       LOG.info("Hello " + loadTestClasses());
 
       Job job = context.getHadoopJob();


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-5279

Following changes are done:
1. Deprecate `beforeSubmit` and `onFinish` methods of the `MapReduce`
2. Added `initialize` and `destroy` methods in `AbstractMapReduce` by making it implement the `ProgramLifecycle<MapReduceContext>`.
3. Added `isSuccessful` method to `MapReduceContext` interface so that `destroy` method of `MapReduce` can figure out whether the program was successful or not.
4. `destroy` method catches all the exceptions and just logs warning without propagating it.
5. Updated unit test cases to use the `initialize` and `destroy`.

Things to be done in next PRs:
1. Deprecate `beforeSubmit` and `onFinish` methods of `Spark`.
2. Update the cdap-examples and guides.
3. Doc changes. 
