### PR TITLE
CDAP-5875 Check SPARK_HOME for Hive on Spark

### DIFF
--- a/cdap-common/bin/common.sh
+++ b/cdap-common/bin/common.sh
@@ -260,6 +260,7 @@ cdap_set_hive_classpath() {
         HIVE_HOME=${HIVE_HOME:-$(echo -e "${HIVE_VARS}" | grep '^env:HIVE_HOME=' | cut -d= -f2)}
         HIVE_CONF_DIR=${HIVE_CONF_DIR:-$(echo -e "${HIVE_VARS}" | grep '^env:HIVE_CONF_DIR=' | cut -d= -f2)}
         HADOOP_CONF_DIR=${HADOOP_CONF_DIR:-$(echo -e "${HIVE_VARS}" | grep '^env:HADOOP_CONF_DIR=' | cut -d= -f2)}
+        HIVE_EXEC_ENGINE=${HIVE_EXEC_ENGINE:-$(echo -e "${HIVE_VARS}" | grep '^hive.execution.engine=' | cut -d= -f2)}
       fi
     fi
 
@@ -272,6 +273,10 @@ cdap_set_hive_classpath() {
         # tez-site.xml also need to be passed to explore service
         EXPLORE_CONF_FILES=${EXPLORE_CONF_FILES}:${TEZ_CONF_DIR}/tez-site.xml:
       fi
+      if [[ "${HIVE_EXEC_ENGINE}" == "spark" ]]; then
+        # We require SPARK_HOME to be set for CDAP to include the Spark assembly JAR for Explore
+        cdap_set_spark || die "Unable to get SPARK_HOME, but default Hive engine is Spark"
+      fi
       export EXPLORE_CONF_FILES EXPLORE_CLASSPATH
     fi
   fi
@@ -281,6 +286,7 @@ cdap_set_hive_classpath() {
 cdap_set_spark() {
   # First, see if we're set to something sane
   if [ -n "${SPARK_HOME}" -a -d "${SPARK_HOME}" ]; then
+    export SPARK_HOME
     return 0 # SPARK_HOME is set, already
   else
     if [[ $(which spark-shell 2>/dev/null) ]]; then

--- a/cdap-common/bin/service
+++ b/cdap-common/bin/service
@@ -97,12 +97,12 @@ _start_java() {
   # Setup Java
   cdap_set_java || exit 1
   if [ "${PKGNAME}" == "master" ]; then
+    # Determine SPARK_HOME
+    cdap_set_spark || logecho "Could not determine SPARK_HOME! Spark support unavailable!"
     # Master requires setting hive classpath
     cdap_set_hive_classpath || exit 1
     # Add proper HBase compatibility to CLASSPATH
     cdap_set_hbase || exit 1
-    # Determine SPARK_HOME
-    cdap_set_spark || logecho "Could not determine SPARK_HOME! Spark support unavailable!"
     # Master requires this local directory
     cdap_check_or_create_master_local_dir || die "Could not create Master local directory"
     logecho "Running startup checks -- this may take a few minutes"
@@ -209,10 +209,10 @@ run() {
   cdap_check_and_set_classpath_for_dev_environment "${CDAP_HOME}"
   # Setup classpaths.
   cdap_set_classpath "${COMPONENT_HOME}" "${CDAP_CONF}"
-  cdap_set_hive_classpath || exit 1
-  cdap_set_spark || logecho "Could not determine SPARK_HOME! Spark support unavailable!"
   # Setup Java
   cdap_set_java || exit 1
+  cdap_set_spark || logecho "Could not determine SPARK_HOME! Spark support unavailable!"
+  cdap_set_hive_classpath || exit 1
   # Add proper HBase compatibility to CLASSPATH
   cdap_set_hbase || exit 1
   # Master requires this local directory


### PR DESCRIPTION
If `hive.execution.engine` is `spark` then we require `SPARK_HOME` to be set so the Spark assembly JAR is included by the CDAP Master. Fixes CDAP-5875
