### PR TITLE
(CDAP-4388) Fix the race condition in resource coordinator

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/ZKExtOperations.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/ZKExtOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,6 +18,7 @@ package co.cask.cdap.common.zookeeper;
 import co.cask.cdap.common.async.AsyncFunctions;
 import co.cask.cdap.common.io.Codec;
 import com.google.common.base.Function;
+import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -51,17 +52,20 @@ public final class ZKExtOperations {
    *
    * @param zkClient The ZKClient to perform the operations.
    * @param path The path in ZK.
-   * @param data The content of the ZK node.
-   * @param result The result that will be set into the result future when completed successfully.
+   * @param dataSupplier The supplier to provide the content to be set to the node. The supplier may get invoked
+   *                     multiple times when the actual data is needed for creating or setting the content of
+   *                     the given node. The supplier can be invoked from the caller thread as well as the
+   *                     zookeeper event callback thread.
+   * @param codec A {@link Codec} for serializing the data into byte array.
    * @param maxFailure Maximum number of times to try to create/set the content.
-   * @param <V> Type of the result.
+   * @param <T> Type of the data.
    * @return A {@link ListenableFuture} that will be completed when node is created or data is set. The future will
    *         fail if failed to create and to set the data. Calling {@link ListenableFuture#cancel(boolean)} has
    *         no effect.
    */
-  public static <V> ListenableFuture<V> createOrSet(ZKClient zkClient, String path,
-                                                    byte[] data, V result, int maxFailure) {
-    return setContent(zkClient, path, data, result, maxFailure, true, null);
+  public static <T> ListenableFuture<T> createOrSet(ZKClient zkClient, String path, Supplier<T> dataSupplier,
+                                                    Codec<T> codec, int maxFailure) {
+    return createOrSetWithRetry(true, zkClient, path, dataSupplier, codec, null, maxFailure);
   }
 
   /**
@@ -71,42 +75,48 @@ public final class ZKExtOperations {
    *
    * @param zkClient The ZKClient to perform the operations.
    * @param path The path in ZK.
-   * @param data The content of the ZK node.
-   * @param result The result that will be set into the result future when completed successfully.
+   * @param dataSupplier The supplier to provide the content to be set to the node. The supplier may get invoked
+   *                     multiple times when the actual data is needed for creating or setting the content of
+   *                     the given node. The supplier can be invoked from the caller thread as well as the
+   *                     zookeeper event callback thread.
+   * @param codec A {@link Codec} for serializing the data into byte array.
    * @param maxFailure Maximum number of times to try to create/set the content.
-   * @param createAcl The access control list to set on the node, if it is created.
-   * @param <V> Type of the result.
+   * @param acls The access control list to set on the node, if it is created.
+   * @param <T> Type of the data.
    * @return A {@link ListenableFuture} that will be completed when node is created or data is set. The future will
    *         fail if failed to create and to set the data. Calling {@link ListenableFuture#cancel(boolean)} has
    *         no effect.
    */
-  public static <V> ListenableFuture<V> createOrSet(ZKClient zkClient, String path,
-                                                    byte[] data, V result, int maxFailure, List<ACL> createAcl) {
-    return setContent(zkClient, path, data, result, maxFailure, true, createAcl);
+  public static <T> ListenableFuture<T> createOrSet(ZKClient zkClient, String path, Supplier<T> dataSupplier,
+                                                    Codec<T> codec, int maxFailure, List<ACL> acls) {
+    return createOrSetWithRetry(true, zkClient, path, dataSupplier, codec, acls, maxFailure);
   }
 
   /**
-   * Attempts to set the content of the given node. If it failed due to node not exists
+   * Attempts to set the content of the given node. If it failed due to node doesn't exist
    * ({@link KeeperException.NoNodeException}), a persistent node will be created with the given content.
    * This method is suitable for cases where the node is expected to be existed.
    *
    * @param zkClient The ZKClient to perform the operations.
    * @param path The path in ZK.
-   * @param data The content of the ZK node.
-   * @param result The result that will be set into the result future when completed successfully.
+   * @param dataSupplier The supplier to provide the content to be set to the node. The supplier may get invoked
+   *                     multiple times when the actual data is needed for creating or setting the content of
+   *                     the given node. The supplier can be invoked from the caller thread as well as the
+   *                     zookeeper event callback thread.
+   * @param codec A {@link Codec} for serializing the data into byte array.
    * @param maxFailure Maximum number of times to try to create/set the content.
-   * @param <V> Type of the result.
+   * @param <T> Type of the data.
    * @return A {@link ListenableFuture} that will be completed when node is created or data is set. The future will
    *         fail if failed to create and to set the data. Calling {@link ListenableFuture#cancel(boolean)} has
    *         no effect.
    */
-  public static <V> ListenableFuture<V> setOrCreate(ZKClient zkClient, String path,
-                                                    byte[] data, V result, int maxFailure) {
-    return setContent(zkClient, path, data, result, maxFailure, false, null);
+  public static <T> ListenableFuture<T> setOrCreate(ZKClient zkClient, String path, Supplier<T> dataSupplier,
+                                                    Codec<T> codec, int maxFailure) {
+    return createOrSetWithRetry(false, zkClient, path, dataSupplier, codec, null, maxFailure);
   }
 
   /**
-   * Update the content of the given node. If the node doesn't exists, it will try to create the node. Same as calling
+   * Update the content of the given node. If the node doesn't exist, it will try to create the node. Same as calling
    *
    * {@link #updateOrCreate(ZKClient, String, Function, Codec, List)
    * updateOrCreate(zkClient, path, modifier, codec, null)}
@@ -119,7 +129,7 @@ public final class ZKExtOperations {
   }
 
   /**
-   * Update the content of the given node. If the node doesn't exists, it will try to create the node.
+   * Update the content of the given node. If the node doesn't exist, it will try to create the node.
    * The modifier will be executed in the ZooKeeper callback thread, hence no blocking operation should be performed
    * in it. If blocking operation is needed, use the async version of this method.
    *
@@ -135,7 +145,7 @@ public final class ZKExtOperations {
   }
 
   /**
-   * Update the content of the given node. If the node doesn't exists, it will try to create the node. Same as calling
+   * Update the content of the given node. If the node doesn't exist, it will try to create the node. Same as calling
    *
    * {@link #updateOrCreate(ZKClient, String, AsyncFunction, Codec, List)
    * updateOrCreate(zkClient, path, modifier, codec, null)}
@@ -148,7 +158,7 @@ public final class ZKExtOperations {
   }
 
   /**
-   * Update the content of the given node. If the node doesn't exists, it will try to create the node. If the node
+   * Update the content of the given node. If the node doesn't exist, it will try to create the node. If the node
    * exists, the existing content of the data will be provided to the modifier function to generate new content. A
    * conditional set will be performed which requires existing content the same as the one provided to the modifier
    * function. If the conditional set failed, the latest content will be fetched and fed to the modifier function
@@ -171,94 +181,6 @@ public final class ZKExtOperations {
                                                        @Nullable List<ACL> createAcl) {
     SettableFuture<V> resultFuture = SettableFuture.create();
     getAndSet(zkClient, path, modifier, codec, resultFuture, createAcl);
-    return resultFuture;
-  }
-
-  /**
-   * Attempts to set the content of the given node. If it failed due to node not exists
-   * ({@link KeeperException.NoNodeException}), a persistent node will be created with the given content.
-   * This method is suitable for cases where the node is expected to be existed.
-   *
-   * @param zkClient The ZKClient to perform the operations.
-   * @param path The path in ZK.
-   * @param data The content of the ZK node.
-   * @param result The result that will be set into the result future when completed successfully.
-   * @param maxFailure Maximum number of times to try to create/set the content.
-   * @param createAcl The access control list to set on the node, if it is created.
-   * @param <V> Type of the result.
-   * @return A {@link ListenableFuture} that will be completed when node is created or data is set. The future will
-   *         fail if failed to create and to set the data. Calling {@link ListenableFuture#cancel(boolean)} has
-   *         no effect.
-   */
-  public static <V> ListenableFuture<V> setOrCreate(ZKClient zkClient, String path,
-                                                    byte[] data, V result, int maxFailure, List<ACL> createAcl) {
-    return setContent(zkClient, path, data, result, maxFailure, false, createAcl);
-  }
-
-  /**
-   * Sets the content of a ZK node. Depends on the {@code createFirst} value,
-   * either {@link ZKClient#create(String, byte[], org.apache.zookeeper.CreateMode)} or
-   * {@link ZKClient#setData(String, byte[])} wil be called first.
-   *
-   * @param zkClient The ZKClient to perform the operations.
-   * @param path The path in ZK.
-   * @param data The content of the ZK node.
-   * @param result The result that will be set into the result future when completed successfully.
-   * @param maxFailure Maximum number of times to try to create/set the content.
-   * @param createFirst If true, create is called first, otherwise setData is called first.
-   * @param <V> Type of the result.
-   * @return A {@link ListenableFuture} that will be completed when node is created or data is set. The future will
-   *         fail if failed to create and to set the data. Calling {@link ListenableFuture#cancel(boolean)} has
-   *         no effect.
-   */
-  private static <V> ListenableFuture<V> setContent(final ZKClient zkClient, final String path,
-                                                    final byte[] data, final V result,
-                                                    final int maxFailure, boolean createFirst,
-                                                    final List<ACL> createAcls) {
-
-    final SettableFuture<V> resultFuture = SettableFuture.create();
-    final AtomicInteger failureCount = new AtomicInteger(0);
-
-    OperationFuture<?> operationFuture;
-
-    if (createFirst) {
-      if (createAcls != null) {
-        operationFuture = zkClient.create(path, data, CreateMode.PERSISTENT, createAcls);
-      } else {
-        operationFuture = zkClient.create(path, data, CreateMode.PERSISTENT);
-      }
-    } else {
-      operationFuture = zkClient.setData(path, data);
-    }
-
-    Futures.addCallback(operationFuture, new FutureCallback<Object>() {
-      @Override
-      public void onSuccess(Object zkResult) {
-        resultFuture.set(result);
-      }
-
-      @Override
-      public void onFailure(Throwable t) {
-        if (failureCount.getAndIncrement() > maxFailure) {
-          resultFuture.setException(new Exception("Failed more than " + maxFailure + "times", t));
-        } else if (t instanceof KeeperException.NoNodeException) {
-          // If node not exists, create it with the data
-          OperationFuture<?> createFuture;
-          if (createAcls != null) {
-            createFuture = zkClient.create(path, data, CreateMode.PERSISTENT, createAcls);
-          } else {
-            createFuture = zkClient.create(path, data, CreateMode.PERSISTENT);
-          }
-          Futures.addCallback(createFuture, this, Threads.SAME_THREAD_EXECUTOR);
-        } else if (t instanceof KeeperException.NodeExistsException) {
-          // If the node exists when trying to create, set data.
-          Futures.addCallback(zkClient.setData(path, data), this, Threads.SAME_THREAD_EXECUTOR);
-        } else {
-          resultFuture.setException(t);
-        }
-      }
-    }, Threads.SAME_THREAD_EXECUTOR);
-
     return resultFuture;
   }
 
@@ -309,7 +231,7 @@ public final class ZKExtOperations {
                       // If the version is not good, get and set again
                       getAndSet(zkClient, path, modifier, codec, resultFuture, createAcl);
                     } else if (t instanceof KeeperException.NoNodeException) {
-                      // If the node not exists, try to do create
+                      // If the node doesn't exist, try to do create
                       createOrGetAndSet(zkClient, path, modifier, codec, resultFuture, createAcl);
                     } else {
                       resultFuture.setException(t);
@@ -334,7 +256,7 @@ public final class ZKExtOperations {
 
       @Override
       public void onFailure(Throwable t) {
-        // If failed to get data because node not exists, try the create.
+        // If failed to get data because node doesn't exist, try the create.
         if (t instanceof KeeperException.NoNodeException) {
           createOrGetAndSet(zkClient, path, modifier, codec, resultFuture, createAcl);
         } else {
@@ -344,7 +266,6 @@ public final class ZKExtOperations {
     }, Threads.SAME_THREAD_EXECUTOR);
   }
 
-
   /**
    * Performs the create part as described in
    * {@link #updateOrCreate(ZKClient, String, Function, Codec, List)}. If the creation failed with
@@ -353,46 +274,247 @@ public final class ZKExtOperations {
    */
   private static <V> void createOrGetAndSet(final ZKClient zkClient, final String path,
                                             final AsyncFunction<V, V> modifier, final Codec<V> codec,
-                                            final SettableFuture<V> resultFuture, final List<ACL> createAcl) {
+                                            final SettableFuture<V> resultFuture, final List<ACL> acls) {
+
+    // Tries to create the node first.
+    ListenableFuture<V> createFuture = create(zkClient, path, new Supplier<ListenableFuture<V>>() {
+      @Override
+      public ListenableFuture<V> get() {
+        try {
+          return Futures.transform(modifier.apply(null), new Function<V, V>() {
+            @Override
+            public V apply(@Nullable V input) {
+              // If the modifier returns null, it means aborting the operation
+              // we throw an exception here so that it will be reflected in the "createFuture".
+              // The callback on the createFuture will handle this exception
+              if (input == null) {
+                throw new AbortModificationException();
+              } else {
+                return input;
+              }
+            }
+          }, Threads.SAME_THREAD_EXECUTOR);
+        } catch (Exception e) {
+          return Futures.immediateFailedFuture(e);
+        }
+      }
+    }, codec, acls, SettableFuture.<V>create());
+
     try {
-      Futures.addCallback(modifier.apply(null), new FutureCallback<V>() {
+      Futures.addCallback(createFuture, new FutureCallback<V>() {
         @Override
         public void onSuccess(final V content) {
-          if (content == null) {
+          resultFuture.set(content);
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+          if (t instanceof AbortModificationException) {
+            // The modifier decided to abort. Just set the result future to complete
             resultFuture.set(null);
-            return;
-          }
-
-          try {
-            byte[] data = codec.encode(content);
-
-            OperationFuture<String> future;
-            if (createAcl == null) {
-              future = zkClient.create(path, data, CreateMode.PERSISTENT);
-            } else {
-              future = zkClient.create(path, data, CreateMode.PERSISTENT, createAcl);
-            }
-
-            Futures.addCallback(future, new FutureCallback<String>() {
-              @Override
-              public void onSuccess(String result) {
-                resultFuture.set(content);
-              }
-
-              @Override
-              public void onFailure(Throwable t) {
-                if (t instanceof KeeperException.NodeExistsException) {
-                  // If failed to create due to node exists, try to do getAndSet.
-                  getAndSet(zkClient, path, modifier, codec, resultFuture, createAcl);
-                } else {
-                  resultFuture.setException(t);
-                }
-              }
-            }, Threads.SAME_THREAD_EXECUTOR);
-          } catch (Throwable t) {
+          } else if (t instanceof KeeperException.NodeExistsException) {
+            // If failed to create due to node exists, try to do getAndSet.
+            getAndSet(zkClient, path, modifier, codec, resultFuture, acls);
+          } else {
             resultFuture.setException(t);
           }
+        }
+      }, Threads.SAME_THREAD_EXECUTOR);
+    } catch (Throwable e) {
+      resultFuture.setException(e);
+    }
+  }
 
+  /**
+   * Actual implementation of the three public methods.
+   *
+   * @see #createOrSet(ZKClient, String, Supplier, Codec, int)
+   * @see #createOrSet(ZKClient, String, Supplier, Codec, int, List)
+   * @see #setOrCreate(ZKClient, String, Supplier, Codec, int)
+   */
+  private static <T> ListenableFuture<T> createOrSetWithRetry(final boolean createFirst, final ZKClient zkClient,
+                                                              final String path, final Supplier<T> dataSupplier,
+                                                              final Codec<T> codec, @Nullable final Iterable<ACL> acls,
+                                                              final int maxRetry) {
+    final SettableFuture<T> resultFuture = SettableFuture.create();
+    final AtomicInteger failures = new AtomicInteger(0);
+
+    Futures.addCallback(
+      doCreateOrSet(createFirst, zkClient, path, dataSupplier, codec, acls),
+      new FutureCallback<T>() {
+        @Override
+        public void onSuccess(T result) {
+          resultFuture.set(result);
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+          if (failures.getAndIncrement() < maxRetry) {
+            Futures.addCallback(doCreateOrSet(createFirst, zkClient, path, dataSupplier, codec, acls),
+                                this, Threads.SAME_THREAD_EXECUTOR);
+          } else {
+            resultFuture.setException(t);
+          }
+        }
+      }, Threads.SAME_THREAD_EXECUTOR
+    );
+
+    return resultFuture;
+  }
+
+  /**
+   * Tries create or set the content of a node. If {@code createFirst} is {@code true}, it will first try to create;
+   * and if it failed with NodeExists error, then will try to perform set.
+   * If {@code createFirst} is {@code false}, then it will first try to set and if it failed with NoNode error,
+   * then will try to perform create.
+   *
+   * @param createFirst if {@code true}, try create and then set; if {@code false}, try set and then create.
+   * @param zkClient The ZKClient to perform the operations.
+   * @param path The path in ZK.
+   * @param dataSupplier The supplier to provide the content to be set to the node.
+   * @param codec A {@link Codec} for serializing the data into byte array.
+   * @param acls The access control list to set on the node.
+   * @param <T> type of the data to set to the node
+   * @return A {@link ListenableFuture} that will be completed when node is created or data is set.
+   *         The future will carry the actual content being set into the node.
+   */
+  private static <T> ListenableFuture<T> doCreateOrSet(final boolean createFirst, final ZKClient zkClient,
+                                                       final String path, final Supplier<T> dataSupplier,
+                                                       final Codec<T> codec, @Nullable final Iterable<ACL> acls) {
+    final SettableFuture<T> resultFuture = SettableFuture.create();
+    final Supplier<ListenableFuture<T>> futureSupplier = createFutureSupplier(dataSupplier);
+    try {
+      // Do a create/set first based on the argument
+      ListenableFuture<T> future = createFirst
+        ? create(zkClient, path, futureSupplier, codec, acls, SettableFuture.<T>create())
+        : setData(zkClient, path, dataSupplier, codec, SettableFuture.<T>create());
+
+      Futures.addCallback(future, new FutureCallback<T>() {
+        @Override
+        public void onSuccess(T result) {
+          // If the operation completed, then we are done
+          resultFuture.set(result);
+        }
+
+        @Override
+        public void onFailure(Throwable failure) {
+          if (createFirst && failure instanceof KeeperException.NodeExistsException) {
+            // If failed to create due to node exists exception, set the value
+            setData(zkClient, path, dataSupplier, codec, resultFuture);
+          } else if (!createFirst && failure instanceof KeeperException.NoNodeException) {
+            // If failed to set due to no node exception, try to create the node
+            create(zkClient, path, futureSupplier, codec, acls, resultFuture);
+          } else {
+            resultFuture.setException(failure);
+          }
+        }
+      }, Threads.SAME_THREAD_EXECUTOR);
+    } catch (Exception e) {
+      resultFuture.setException(e);
+    }
+    return resultFuture;
+  }
+
+  /**
+   * Creates a zookeeper node with the given data with automatic parent node creation.
+   *
+   * @param zkClient The ZKClient to perform the operations.
+   * @param path The path in ZK.
+   * @param dataSupplier a {@link Supplier} to provide a {@link ListenableFuture} that will yield data to be used
+   *                     as the node content. The supplier may get invoked
+   *                     multiple times when the actual data is needed for creating the content of
+   *                     the given node. The supplier can be invoked from the caller thread as well as the
+   *                     zookeeper event callback thread.
+   * @param codec A {@link Codec} for serializing the data into byte array.
+   * @param acls The access control list to set on the node.
+   * @param resultFuture a {@link SettableFuture} for reflecting the operation result. If the create succeeded,
+   *                     the result future will contain the actual object being set to the node.
+   * @param <T> type of data content
+   * @return the same resultFuture as being passed from parameter
+   */
+  private static <T> SettableFuture<T> create(final ZKClient zkClient, final String path,
+                                              final Supplier<ListenableFuture<T>> dataSupplier, final Codec<T> codec,
+                                              @Nullable final Iterable<ACL> acls,
+                                              final SettableFuture<T> resultFuture) {
+    // Invoke the supplier to get a ListenableFuture and performs node create when the data is available
+    Futures.addCallback(dataSupplier.get(), new FutureCallback<T>() {
+      @Override
+      public void onSuccess(final T data) {
+        try {
+          // Try to create the node without creating parent. This is to make sure the latest data
+          // is being used if there are concurrent modification to the node (CDAP-4388)
+          OperationFuture<String> createFuture = (acls == null)
+            ? zkClient.create(path, codec.encode(data), CreateMode.PERSISTENT, false)
+            : zkClient.create(path, codec.encode(data), CreateMode.PERSISTENT, false, acls);
+
+          Futures.addCallback(createFuture, new FutureCallback<String>() {
+            @Override
+            public void onSuccess(String result) {
+              // If creation succeeded, the operation is completed
+              resultFuture.set(data);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+              if (t instanceof KeeperException.NoNodeException) {
+                // If failed with NoNode, it means parent path doesn't exist. Create the parent path first and retry
+                OperationFuture<String> createParentFuture = zkClient.create(getParent(path), null,
+                                                                             CreateMode.PERSISTENT);
+                Futures.addCallback(createParentFuture, new FutureCallback<String>() {
+                  @Override
+                  public void onSuccess(String result) {
+                    // If creation of parent path succeeded, try to create again.
+                    // We call the create method again so that the dataSupplier will be called to get the latest value.
+                    create(zkClient, path, dataSupplier, codec, acls, resultFuture);
+                  }
+
+                  @Override
+                  public void onFailure(Throwable t) {
+                    // If failed to create parent path, fail the operation
+                    resultFuture.setException(t);
+                  }
+                }, Threads.SAME_THREAD_EXECUTOR);
+              } else {
+                resultFuture.setException(t);
+              }
+            }
+          }, Threads.SAME_THREAD_EXECUTOR);
+        } catch (Exception e) {
+          resultFuture.setException(e);
+        }
+      }
+
+      @Override
+      public void onFailure(Throwable t) {
+        // If the supplier failed to give the node content, reflect the error in the result future.
+        resultFuture.setException(t);
+      }
+    }, Threads.SAME_THREAD_EXECUTOR);
+
+    return resultFuture;
+  }
+
+  /**
+   * Sets the data content of a zookeeper node
+   *
+   * @param zkClient The ZKClient to perform the operations.
+   * @param path The path in ZK.
+   * @param dataSupplier The supplier to provide the content to be set to the node.
+   * @param codec A {@link Codec} for serializing the data into byte array.
+   * @param resultFuture a {@link SettableFuture} for reflecting the operation result. If the setData succeeded,
+   *                     the result future will contain the actual object being set to the node.
+   * @param <T> type of data content
+   * @return the same resultFuture as being passed from parameter
+   */
+  private static <T> SettableFuture<T> setData(ZKClient zkClient, String path,
+                                               Supplier<T> dataSupplier, Codec<T> codec,
+                                               final SettableFuture<T> resultFuture) {
+    try {
+      final T data = dataSupplier.get();
+      Futures.addCallback(zkClient.setData(path, codec.encode(data)), new FutureCallback<Stat>() {
+        @Override
+        public void onSuccess(Stat state) {
+          resultFuture.set(data);
         }
 
         @Override
@@ -400,10 +522,44 @@ public final class ZKExtOperations {
           resultFuture.setException(t);
         }
       }, Threads.SAME_THREAD_EXECUTOR);
-    } catch (Throwable e) {
+    } catch (Exception e) {
       resultFuture.setException(e);
     }
+
+    return resultFuture;
   }
+
+  /**
+   * Creates a {@link Supplier} such that when invoked, it will invoke the given {@link Supplier} and wrap
+   * the result with a {@link ListenableFuture}.
+   */
+  private static <T> Supplier<ListenableFuture<T>> createFutureSupplier(final Supplier<T> supplier) {
+    return new Supplier<ListenableFuture<T>>() {
+      @Override
+      public ListenableFuture<T> get() {
+        return Futures.immediateFuture(supplier.get());
+      }
+    };
+  }
+
+  /**
+   * Gets the parent of the given path.
+   * @param path Path for computing its parent
+   * @return Parent of the given path, or empty string if the given path is the root path already.
+   */
+  private static String getParent(String path) {
+    String parentPath = path.substring(0, path.lastIndexOf('/'));
+    return (parentPath.isEmpty() && !"/".equals(path)) ? "/" : parentPath;
+  }
+
+  /**
+   * An exception to indicate that the modification operation is aborted. This exception won't get propagated to
+   * user, but instead used as a tagging exception for aborting the createOrGetAndSet operation.
+   */
+  private static final class AbortModificationException extends RuntimeException {
+    // No-op
+  }
+
 
   private ZKExtOperations() {
   }

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/ResourceCoordinatorClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/ResourceCoordinatorClient.java
@@ -20,6 +20,7 @@ import co.cask.cdap.common.zookeeper.ZKExtOperations;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.base.Objects;
+import com.google.common.base.Suppliers;
 import com.google.common.base.Throwables;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Maps;
@@ -92,15 +93,10 @@ public final class ResourceCoordinatorClient extends AbstractService {
    *         {@link ListenableFuture#cancel(boolean)} has no effect.
    */
   public ListenableFuture<ResourceRequirement> submitRequirement(ResourceRequirement requirement) {
-    try {
-      String zkPath = CoordinationConstants.REQUIREMENTS_PATH + "/" + requirement.getName();
-      byte[] data = CoordinationConstants.RESOURCE_REQUIREMENT_CODEC.encode(requirement);
-
-      return ZKExtOperations.createOrSet(zkClient, zkPath, data,
-                                         requirement, CoordinationConstants.MAX_ZK_FAILURE_RETRY);
-    } catch (Exception e) {
-      return Futures.immediateFailedFuture(e);
-    }
+    String zkPath = CoordinationConstants.REQUIREMENTS_PATH + "/" + requirement.getName();
+    return ZKExtOperations.createOrSet(zkClient, zkPath, Suppliers.ofInstance(requirement),
+                                       CoordinationConstants.RESOURCE_REQUIREMENT_CODEC,
+                                       CoordinationConstants.MAX_ZK_FAILURE_RETRY);
   }
 
   /**

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/store/ZKPropertyStore.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/store/ZKPropertyStore.java
@@ -20,6 +20,7 @@ import co.cask.cdap.common.conf.AbstractPropertyStore;
 import co.cask.cdap.common.conf.PropertyUpdater;
 import co.cask.cdap.common.io.Codec;
 import co.cask.cdap.common.zookeeper.ZKExtOperations;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -92,12 +93,8 @@ public final class ZKPropertyStore<T> extends AbstractPropertyStore<T> {
 
   @Override
   public ListenableFuture<T> set(String name, T property) {
-    try {
-      return ZKExtOperations.setOrCreate(zkClient, getPath(name),
-                                         codec.encode(property), property, MAX_ZK_FAILURE_RETRIES);
-    } catch (IOException e) {
-      return Futures.immediateFailedFuture(e);
-    }
+    return ZKExtOperations.setOrCreate(zkClient, getPath(name), Suppliers.ofInstance(property),
+                                       codec, MAX_ZK_FAILURE_RETRIES);
   }
 
   @Override

--- a/cdap-common/src/test/java/co/cask/cdap/common/zookeeper/ZKExtOperationsTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/zookeeper/ZKExtOperationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,6 +18,7 @@ package co.cask.cdap.common.zookeeper;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.common.io.Codec;
 import com.google.common.base.Function;
+import com.google.common.base.Suppliers;
 import com.google.common.base.Throwables;
 import org.apache.twill.internal.zookeeper.InMemoryZKServer;
 import org.apache.twill.zookeeper.ZKClientService;
@@ -138,6 +139,47 @@ public class ZKExtOperationsTest {
     zkClient2.stopAndWait();
   }
 
+  @Test
+  public void testCreateOrSet() throws Exception {
+    String path = "/parent/testCreateOrSet";
+    ZKClientService zkClient = ZKClientService.Builder.of(zkServer.getConnectionStr()).build();
+    zkClient.startAndWait();
+
+    // Create with "1"
+    Assert.assertEquals(1, ZKExtOperations.createOrSet(zkClient, path,
+                                                       Suppliers.ofInstance(1), INT_CODEC, 0).get().intValue());
+    // Should get "1" back
+    Assert.assertEquals(1, INT_CODEC.decode(zkClient.getData(path).get().getData()).intValue());
+
+    // Set with "2"
+    Assert.assertEquals(2, ZKExtOperations.createOrSet(zkClient, path,
+                                                       Suppliers.ofInstance(2), INT_CODEC, 0).get().intValue());
+    // Should get "2" back
+    Assert.assertEquals(2, INT_CODEC.decode(zkClient.getData(path).get().getData()).intValue());
+
+    zkClient.stopAndWait();
+  }
+
+  @Test
+  public void testSetOrCreate() throws Exception {
+    String path = "/parent/testSetOrCreate";
+    ZKClientService zkClient = ZKClientService.Builder.of(zkServer.getConnectionStr()).build();
+    zkClient.startAndWait();
+
+    // Create with "1"
+    Assert.assertEquals(1, ZKExtOperations.setOrCreate(zkClient, path,
+                                                       Suppliers.ofInstance(1), INT_CODEC, 0).get().intValue());
+    // Should get "1" back
+    Assert.assertEquals(1, INT_CODEC.decode(zkClient.getData(path).get().getData()).intValue());
+
+    // Set with "2"
+    Assert.assertEquals(2, ZKExtOperations.setOrCreate(zkClient, path,
+                                                       Suppliers.ofInstance(2), INT_CODEC, 0).get().intValue());
+    // Should get "2" back
+    Assert.assertEquals(2, INT_CODEC.decode(zkClient.getData(path).get().getData()).intValue());
+
+    zkClient.stopAndWait();
+  }
 
   @AfterClass
   public static void finish() {


### PR DESCRIPTION
- Fix the ZKExtOperations methods
  - Instead of using a fixed data value to be used in the retry operation,
    switched to use Supplier of data so that the latest copy of data is provided
    when the actual create / set happens
  - Don't use create node with auto parent path creation as it will have a side
    effect of "locking" the data value to the one when "create" method is called.
    - Create parent is a async operation, meaning at the time when parent path creation
      is completed, the actual value provided by the Supplier is already changed
    - This is the root cause of CDAP-4388
