### PR TITLE
CDAP-5884 add explicit spark dependency to cdap-integration-test

### DIFF
--- a/cdap-integration-test/pom.xml
+++ b/cdap-integration-test/pom.xml
@@ -80,6 +80,11 @@
       <version>${project.version}</version>
       <type>test-jar</type>
     </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-spark-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <!-- In compile scope because this module should only be used in test scope -->
     <dependency>


### PR DESCRIPTION
When the dist profile is used, the dependency on cdap-spark-core
in cdap-standalone is set to provided scope, which is intended.
Dependencies of provided dependencies are not included by newer
versions of maven, so cdap-spark-core is not getting picked up
during sdk builds. Adding it explicitly fixes the error.
