### PR TITLE
CDAP-5888 Fix Hydrator upgrade notes

### DIFF
--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -324,7 +324,9 @@ function set_version() {
     GIT_BRANCH_TYPE=${GIT_BRANCH}
   elif [ "${full_branch:0:4}" == "docs" ]; then
     GIT_BRANCH="${full_branch}"
-    if [ "x${GIT_BRANCH_TYPE}" == "x" ]; then
+    if [ "${GIT_BRANCH_PARENT:0:7}" == "develop" ]; then
+      GIT_BRANCH_TYPE="develop-feature"
+    elif [ "x${GIT_BRANCH_TYPE}" == "x" ]; then
       GIT_BRANCH_TYPE="release-feature"
     fi
   elif [ "${GIT_BRANCH:0:7}" == "release" ]; then

--- a/cdap-docs/admin-manual/source/security.rst
+++ b/cdap-docs/admin-manual/source/security.rst
@@ -391,8 +391,7 @@ within your CDAP installation (typically under ``/opt/cdap``).
 The Developers’ Manual :ref:`Custom Authentication <developers-custom-authentication>` section shows
 how to create a Custom Authentication Mechanism.
 
-
-.. _configuring_auth_exemptions:
+.. _configuring-auth-exemptions:
 
 Configuring Exemptions from Authentication
 ..........................................
@@ -419,6 +418,8 @@ posting to all streams in the default namespace::
   </property>
 
 This must be configured on every node that runs the CDAP Router.
+
+.. _testing-security:
 
 Testing Security
 ----------------

--- a/cdap-docs/cdap-apps/source/hydrator/upgrade.rst
+++ b/cdap-docs/cdap-apps/source/hydrator/upgrade.rst
@@ -25,9 +25,11 @@ run the command:
   
     |$| java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u \http://<host>:<port> -e /tmp/failedUpgrades upgrade
 
-The first argument is the host and port for the CDAP master. The second argument is a directory to write the configurations
-of any pipelines that could not be upgraded. A pipeline may fail to upgrade if the new version of a plugin used in the
-pipeline is not backwards compatible. For example, this may happen if the plugin added a new required property.
+The first argument is the host and port for the :ref:`CDAP router
+<appendix-cdap-default-router>`. The second argument is a directory to write the
+configurations of any pipelines that could not be upgraded. A pipeline may fail to upgrade
+if the new version of a plugin used in the pipeline is not backwards compatible. For
+example, this may happen if the plugin added a new required property.
 
 You can also upgrade just the ETL applications within a specific namespace:
 

--- a/cdap-docs/cdap-apps/source/hydrator/upgrade.rst
+++ b/cdap-docs/cdap-apps/source/hydrator/upgrade.rst
@@ -47,10 +47,20 @@ You can also upgrade just one ETL application:
   
     |$| java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u \http://<host>:<port> -n <namespace> -p <app-name> upgrade
 
-If you have authentication turned on, you also need to store an authentication token in a file and pass the file to the tool:
+If you have authentication turned on, you also need to store an access token in a file and pass the file to the tool:
 
 .. container:: highlight
 
   .. parsed-literal::
   
     |$| java -cp /opt/cdap/master/libexec/cdap-etl-tools-|version|.jar co.cask.cdap.etl.tool.UpgradeTool -u \http://<host>:<port> -a <tokenfile> upgrade
+
+For instance, if you have obtained an access token (as shown in the example in the
+`security documentation <testing-security>`) such as::
+
+    {"access_token":"AghjZGFwAI7e8p65Uo7OpfG5UrD87psGQE0u0sFDoqxtacdRR5GxEb6bkTypP7mXdqvqqnLmfxOS",
+      "token_type":"Bearer","expires_in":86400}
+
+The access token itself
+(``AghjZGFwAI7e8p65Uo7OpfG5UrD87psGQE0u0sFDoqxtacdRR5GxEb6bkTypP7mXdqvqqnLmfxOS``) would
+be placed in a file and then the file path used in the above command.

--- a/cdap-docs/cdap-apps/source/hydrator/upgrade.rst
+++ b/cdap-docs/cdap-apps/source/hydrator/upgrade.rst
@@ -61,6 +61,5 @@ For instance, if you have obtained an access token (as shown in the example in t
     {"access_token":"AghjZGFwAI7e8p65Uo7OpfG5UrD87psGQE0u0sFDoqxtacdRR5GxEb6bkTypP7mXdqvqqnLmfxOS",
       "token_type":"Bearer","expires_in":86400}
 
-The access token itself
-(``AghjZGFwAI7e8p65Uo7OpfG5UrD87psGQE0u0sFDoqxtacdRR5GxEb6bkTypP7mXdqvqqnLmfxOS``) would
-be placed in a file and then the file path used in the above command.
+The access token itself (``AghjZGFwAI7e8p65Uo7OpfG5UrD87psGQE0u0sFDoqxtacdRR5GxEb6bkTypP7mXdqvqqnLmfxOS``) 
+would be placed in a file and then the file's path would be used in the above command.


### PR DESCRIPTION
…and add link to details. Add fix for using docs as branch from develop.

Passes [Quick Build 2](http://builds.cask.co/browse/CDAP-DQB6-2)

[Hydrator Upgrade page](http://builds.cask.co/artifact/CDAP-DQB6/shared/build-2/Docs-HTML/3.5.0-SNAPSHOT/en/cdap-apps/hydrator/upgrade.html)

Fix for https://issues.cask.co/browse/CDAP-5888 and
https://issues.cask.co/browse/CDAP-5303
