### PR TITLE
CDAP-3750 escape hive column names

### DIFF
--- a/cdap-docs/developers-manual/source/data-exploration/filesets.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/filesets.rst
@@ -68,6 +68,25 @@ A ``PartitionedFileSet`` using the ``text`` format, with ``\n`` as the record de
     .setExploreFormat("text")
     .setExploreFormatProperty("delimiter", "\n")
     .setExploreSchema("record STRING")
+    .build()
+
+If you are running a version of Hive that reserves keywords and any of your column names is a `Hive reserved keyword
+<https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-Keywords,
+Non-reservedKeywordsandReservedKeywords>`__, you will need to enclose the column name in backticks.
+For example::
+
+    PartitionedFileSetProperties.builder()
+    // Properties for partitioning
+    .setPartitioning(Partitioning.builder().addLongField("time").build())
+    // Properties for file set
+    .setInputFormat(TextInputFormat.class)
+    .setOutputFormat(TextOutputFormat.class)
+    .setOutputProperty(TextOutputFormat.SEPERATOR, ",")
+    // enable CDAP Explore
+    .setEnableExploreOnCreate(true)
+    .setExploreFormat("text")
+    .setExploreFormatProperty("delimiter", "\n")
+    .setExploreSchema("`date` STRING")
     .build() 
 
 These dataset properties map directly to table properties in Hive. In the case of the

--- a/cdap-docs/reference-manual/source/http-restful-api/query.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/query.rst
@@ -44,6 +44,14 @@ The body of the request must contain a JSON string of the form::
   }
 
 where ``<SQL-query-string>`` is the actual SQL query.
+If you are running a version of Hive that uses reserved keywords, and a column in your query is a `Hive reserved keyword
+<https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-Keywords,
+Non-reservedKeywordsandReservedKeywords>`__, you must enclose the column name in backticks.
+For example::
+
+  {
+    "query": "select `date` from stream_events"
+  }
 
 .. rubric:: HTTP Responses
 .. list-table::

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreServiceUtils.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreServiceUtils.java
@@ -132,6 +132,22 @@ public class ExploreServiceUtils {
     return hiveVersion.getHiveExploreServiceClass();
   }
 
+  public static boolean shouldEscapeColumns(Configuration hConf) {
+    // backtick support was added in Hive13.
+    ExploreServiceUtils.HiveSupport hiveSupport = ExploreServiceUtils.checkHiveSupport(hConf.getClassLoader());
+    if (hiveSupport == ExploreServiceUtils.HiveSupport.HIVE_12) {
+      return false;
+    }
+
+    // if this is set to false, we don't need to escape the columns.
+    if (!hConf.getBoolean("hive.support.sql11.reserved.keywords", true)) {
+      return false;
+    }
+
+    // otherwise, if this setting is set to 'column', escape all column names
+    return "column".equalsIgnoreCase(hConf.get("hive.support.quoted.identifiers", "column"));
+  }
+
   public static HiveSupport checkHiveSupport() {
     return checkHiveSupport(ExploreUtils.getExploreClassloader());
   }
@@ -168,7 +184,7 @@ public class ExploreServiceUtils {
     }
 
     String hiveVersion = getHiveVersion(hiveClassLoader);
-    LOG.info("Client Hive version: {}", hiveVersion);
+    LOG.debug("Client Hive version: {}", hiveVersion);
     if (hiveVersion.startsWith("0.12.")) {
       return HiveSupport.HIVE_12;
     } else if (hiveVersion.startsWith("0.13.")) {

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreTableManager.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreTableManager.java
@@ -470,7 +470,8 @@ public class ExploreTableManager {
       String quote = fieldValue instanceof String ? "'" : "";
       builder.append(sep);
       if (shouldEscapeColumns) {
-        builder.append('`').append(fieldName).append('`');
+        // a literal backtick(`) is just a double backtick(``)
+        builder.append('`').append(fieldName.replace("`", "``")).append('`');
       } else {
         builder.append(fieldName);
       }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreTableManager.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreTableManager.java
@@ -53,6 +53,7 @@ import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
@@ -81,14 +82,17 @@ public class ExploreTableManager {
   private final ExploreService exploreService;
   private final SystemDatasetInstantiatorFactory datasetInstantiatorFactory;
   private final ExploreTableNaming tableNaming;
+  private final boolean shouldEscapeColumns;
 
   @Inject
   public ExploreTableManager(ExploreService exploreService,
                              SystemDatasetInstantiatorFactory datasetInstantiatorFactory,
-                             ExploreTableNaming tableNaming) {
+                             ExploreTableNaming tableNaming,
+                             Configuration hConf) {
     this.exploreService = exploreService;
     this.datasetInstantiatorFactory = datasetInstantiatorFactory;
     this.tableNaming = tableNaming;
+    this.shouldEscapeColumns = ExploreServiceUtils.shouldEscapeColumns(hConf);
   }
 
   /**
@@ -122,7 +126,7 @@ public class ExploreTableManager {
       Constants.Explore.STREAM_NAMESPACE, streamID.getNamespaceId(),
       Constants.Explore.FORMAT_SPEC, GSON.toJson(formatSpec));
 
-    String createStatement = new CreateStatementBuilder(streamName, tableName)
+    String createStatement = new CreateStatementBuilder(streamName, tableName, shouldEscapeColumns)
       .setSchema(schema)
       .setTableComment("CDAP Stream")
       .buildWithStorageHandler(StreamStorageHandler.class.getName(), serdeProperties);
@@ -204,10 +208,11 @@ public class ExploreTableManager {
 
         // otherwise, derive the schema from the record type
         LOG.debug("Enabling explore for dataset instance {}", datasetName);
-        createStatement = new CreateStatementBuilder(datasetName, tableNaming.getTableName(datasetId))
-          .setSchema(hiveSchemaFor(recordType))
-          .setTableComment("CDAP Dataset")
-          .buildWithStorageHandler(DatasetStorageHandler.class.getName(), serdeProperties);
+        createStatement =
+          new CreateStatementBuilder(datasetName, tableNaming.getTableName(datasetId), shouldEscapeColumns)
+            .setSchema(hiveSchemaFor(recordType))
+            .setTableComment("CDAP Dataset")
+            .buildWithStorageHandler(DatasetStorageHandler.class.getName(), serdeProperties);
       } else if (dataset instanceof FileSet || dataset instanceof PartitionedFileSet) {
         Map<String, String> properties = spec.getProperties();
         if (FileSetProperties.isExploreEnabled(properties)) {
@@ -246,10 +251,11 @@ public class ExploreTableManager {
 
     try {
       Schema schema = Schema.parseJson(schemaStr);
-      String createStatement = new CreateStatementBuilder(datasetID.getId(), tableNaming.getTableName(datasetID))
-        .setSchema(schema)
-        .setTableComment("CDAP Dataset")
-        .buildWithStorageHandler(DatasetStorageHandler.class.getName(), serdeProperties);
+      String createStatement =
+        new CreateStatementBuilder(datasetID.getId(), tableNaming.getTableName(datasetID), shouldEscapeColumns)
+          .setSchema(schema)
+          .setTableComment("CDAP Dataset")
+          .buildWithStorageHandler(DatasetStorageHandler.class.getName(), serdeProperties);
 
       return exploreService.execute(datasetID.getNamespace(), createStatement);
     } catch (IOException e) {
@@ -407,10 +413,11 @@ public class ExploreTableManager {
       baseLocation = ((FileSet) dataset).getBaseLocation();
     }
 
-    CreateStatementBuilder createStatementBuilder = new CreateStatementBuilder(datasetID.getId(), tableName)
-      .setLocation(baseLocation)
-      .setPartitioning(partitioning)
-      .setTableProperties(tableProperties);
+    CreateStatementBuilder createStatementBuilder =
+      new CreateStatementBuilder(datasetID.getId(), tableName, shouldEscapeColumns)
+        .setLocation(baseLocation)
+        .setPartitioning(partitioning)
+        .setTableProperties(tableProperties);
 
     String schema = FileSetProperties.getExploreSchema(properties);
     String format = FileSetProperties.getExploreFormat(properties);
@@ -461,7 +468,13 @@ public class ExploreTableManager {
       String fieldName = entry.getKey();
       Comparable fieldValue = entry.getValue();
       String quote = fieldValue instanceof String ? "'" : "";
-      builder.append(sep).append(fieldName).append("=").append(quote).append(fieldValue.toString()).append(quote);
+      builder.append(sep);
+      if (shouldEscapeColumns) {
+        builder.append('`').append(fieldName).append('`');
+      } else {
+        builder.append(fieldName);
+      }
+      builder.append("=").append(quote).append(fieldValue.toString()).append(quote);
       sep = ", ";
     }
     builder.append(")");

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -192,7 +192,8 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     this.metastoreClientReferenceQueue = new ReferenceQueue<>();
     this.datasetFramework = datasetFramework;
     this.streamAdmin = streamAdmin;
-    this.exploreTableManager = new ExploreTableManager(this, datasetInstantiatorFactory, new ExploreTableNaming());
+    this.exploreTableManager = new ExploreTableManager(this, datasetInstantiatorFactory,
+                                                       new ExploreTableNaming(), hConf);
     this.datasetInstantiatorFactory = datasetInstantiatorFactory;
     this.tableNaming = tableNaming;
 

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/table/SchemaConverter.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/table/SchemaConverter.java
@@ -29,8 +29,11 @@ import java.util.Map;
  */
 public class SchemaConverter {
   private static final ReflectionSchemaGenerator schemaGenerator = new ReflectionSchemaGenerator();
+  private final boolean escapeColumns;
 
-  private SchemaConverter() { }
+  public SchemaConverter(boolean escapeColumns) {
+    this.escapeColumns = escapeColumns;
+  }
 
   /**
    * Create a hive schema from the given type using reflection.
@@ -39,7 +42,7 @@ public class SchemaConverter {
    * @return hive schema that can be used in a create statement.
    * @throws UnsupportedTypeException if there is an unsupported type.
    */
-  public static String toHiveSchema(Type type) throws UnsupportedTypeException {
+  public String toHiveSchema(Type type) throws UnsupportedTypeException {
     // false is to disallow recursive schemas, which hive can't handle
     return toHiveSchema(schemaGenerator.generate(type, false));
   }
@@ -50,7 +53,7 @@ public class SchemaConverter {
    * @param schema schema to translate.
    * @return hive schema that can be used in a create statement.
    */
-  public static String toHiveSchema(Schema schema) throws UnsupportedTypeException {
+  public String toHiveSchema(Schema schema) throws UnsupportedTypeException {
     if (schema.getType() != Schema.Type.RECORD || schema.getFields().size() < 1) {
       throw new UnsupportedTypeException("Schema must be of type record and have at least one field.");
     }
@@ -70,7 +73,7 @@ public class SchemaConverter {
     return builder.toString();
   }
 
-  private static void appendType(StringBuilder builder, Schema schema) throws UnsupportedTypeException {
+  private void appendType(StringBuilder builder, Schema schema) throws UnsupportedTypeException {
     switch (schema.getType()) {
       case NULL:
         break;
@@ -135,10 +138,14 @@ public class SchemaConverter {
     }
   }
 
-  private static void appendField(StringBuilder builder, Schema.Field field, boolean inStruct)
+  private void appendField(StringBuilder builder, Schema.Field field, boolean inStruct)
     throws UnsupportedTypeException {
     String name = field.getName();
-    builder.append(name);
+    if (escapeColumns) {
+      builder.append('`').append(name).append('`');
+    } else {
+      builder.append(name);
+    }
     // structs look like "struct<name1:string,name2:array<int>>"
     // outside a struct fields look like "name1 string, name2 array<int>"
     builder.append(inStruct ? ":" : " ");

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/table/SchemaConverter.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/table/SchemaConverter.java
@@ -142,7 +142,8 @@ public class SchemaConverter {
     throws UnsupportedTypeException {
     String name = field.getName();
     if (escapeColumns) {
-      builder.append('`').append(name).append('`');
+      // a literal backtick(`) is represented as a double backtick(``)
+      builder.append('`').append(name.replace("`", "``")).append('`');
     } else {
       builder.append(name);
     }

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceStreamTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceStreamTest.java
@@ -228,7 +228,7 @@ public class HiveExploreServiceStreamTest extends BaseHiveExploreServiceTest {
     try {
       Schema schema = Schema.recordOf(
         "purchase",
-        Schema.Field.of("userid", Schema.of(Schema.Type.STRING)),
+        Schema.Field.of("user", Schema.of(Schema.Type.STRING)),
         Schema.Field.of("num", Schema.of(Schema.Type.INT)),
         Schema.Field.of("price", Schema.of(Schema.Type.DOUBLE))
       );
@@ -252,12 +252,12 @@ public class HiveExploreServiceStreamTest extends BaseHiveExploreServiceTest {
 
       ExploreExecutionResult result = exploreClient.submit(
         NAMESPACE_ID,
-        "SELECT userid, sum(num) as total_num, sum(price * num) as total_price " +
-          "FROM " + getTableName(streamId) + " GROUP BY userid ORDER BY total_price DESC").get();
+        "SELECT `user`, sum(num) as total_num, sum(price * num) as total_price " +
+          "FROM " + getTableName(streamId) + " GROUP BY `user` ORDER BY total_price DESC").get();
 
       Assert.assertTrue(result.hasNext());
       Assert.assertEquals(
-        Lists.newArrayList(new ColumnDesc("userid", "STRING", 1, null),
+        Lists.newArrayList(new ColumnDesc("user", "STRING", 1, null),
                            new ColumnDesc("total_num", "BIGINT", 2, null),
                            new ColumnDesc("total_price", "DOUBLE", 3, null)),
         result.getResultSchema());

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/table/CreateStatementBuilderTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/table/CreateStatementBuilderTest.java
@@ -53,7 +53,7 @@ public class CreateStatementBuilderTest {
       Constants.Explore.STREAM_NAME, "purchases",
       Constants.Explore.STREAM_NAMESPACE, "default");
 
-    String actual = new CreateStatementBuilder("purchases", "stream_purchases")
+    String actual = new CreateStatementBuilder("purchases", "stream_purchases", false)
       .setSchema(schema)
       .setLocation("hdfs://namenode/my/path")
       .setTableProperties(ImmutableMap.of("somekey", "someval"))
@@ -76,7 +76,7 @@ public class CreateStatementBuilderTest {
       .addIntField("f2")
       .build();
 
-    String actual = new CreateStatementBuilder("myfiles", "dataset_myfiles")
+    String actual = new CreateStatementBuilder("myfiles", "dataset_myfiles", false)
       .setSchema(hiveSchema)
       .setLocation("hdfs://namenode/my/path")
       .setTableComment("CDAP Dataset")
@@ -101,7 +101,7 @@ public class CreateStatementBuilderTest {
       .addIntField("f2")
       .build();
 
-    String actual = new CreateStatementBuilder("myfiles", "dataset_myfiles")
+    String actual = new CreateStatementBuilder("myfiles", "dataset_myfiles", false)
       .setSchema(hiveSchema)
       .setLocation("hdfs://namenode/my/path")
       .setTableComment("CDAP Dataset")
@@ -133,7 +133,7 @@ public class CreateStatementBuilderTest {
       .addIntField("f2")
       .build();
 
-    String actual = new CreateStatementBuilder("myfiles", "dataset_myfiles")
+    String actual = new CreateStatementBuilder("myfiles", "dataset_myfiles", false)
       .setSchema(schema)
       .setTableProperties(ImmutableMap.of("avro.schema.literal", schema.toString()))
       .setLocation("hdfs://namenode/my/path")

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/table/SchemaConverterTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/table/SchemaConverterTest.java
@@ -183,18 +183,33 @@ public class SchemaConverterTest {
 
   @Test
   public void testHiveSchemaFor() throws Exception {
+    SchemaConverter schemaConverter = new SchemaConverter(false);
     Assert.assertEquals("(a int, b bigint, c boolean, d float, e double, f string, g binary, " +
                           "h array<string>, i array<boolean>, j map<int,string>)",
-                        SchemaConverter.toHiveSchema(Record.class));
+                        schemaConverter.toHiveSchema(Record.class));
 
     Assert.assertEquals("(key string, value struct<ints:array<int>,name:string>)",
-                        SchemaConverter.toHiveSchema(KeyValue.class));
+                        schemaConverter.toHiveSchema(KeyValue.class));
 
     Assert.assertEquals("(i3 int, record2 struct<" +
                           "record:struct<a:int,b:bigint,c:boolean,d:float,e:double,f:string,g:binary," +
                             "h:array<string>,i:array<boolean>,j:map<int,string>>," +
                           "s2:string>)",
-                        SchemaConverter.toHiveSchema(Record3.class));
+                        schemaConverter.toHiveSchema(Record3.class));
+
+    schemaConverter = new SchemaConverter(true);
+    Assert.assertEquals("(`a` int, `b` bigint, `c` boolean, `d` float, `e` double, `f` string, `g` binary, " +
+                          "`h` array<string>, `i` array<boolean>, `j` map<int,string>)",
+                        schemaConverter.toHiveSchema(Record.class));
+
+    Assert.assertEquals("(`key` string, `value` struct<`ints`:array<int>,`name`:string>)",
+                        schemaConverter.toHiveSchema(KeyValue.class));
+
+    Assert.assertEquals("(`i3` int, `record2` struct<" +
+                          "`record`:struct<`a`:int,`b`:bigint,`c`:boolean,`d`:float,`e`:double,`f`:string,`g`:binary," +
+                          "`h`:array<string>,`i`:array<boolean>,`j`:map<int,string>>," +
+                          "`s2`:string>)",
+                        schemaConverter.toHiveSchema(Record3.class));
   }
 
   @Test
@@ -210,13 +225,13 @@ public class SchemaConverterTest {
   @Test
   public void testSupportedTypes() throws Exception {
     // Should not throw an exception
-    SchemaConverter.toHiveSchema(NotRecursive.class);
+    new SchemaConverter(false).toHiveSchema(NotRecursive.class);
   }
 
   private void verifyUnsupportedSchema(Type type) {
     String schema;
     try {
-      schema = SchemaConverter.toHiveSchema(type);
+      schema = new SchemaConverter(false).toHiveSchema(type);
     } catch (UnsupportedTypeException e) {
       // expected
       return;

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ExploreServiceTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ExploreServiceTwillRunnable.java
@@ -55,6 +55,7 @@ import org.apache.twill.zookeeper.ZKClientService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URL;
 import java.util.List;
 
 /**
@@ -74,6 +75,13 @@ public class ExploreServiceTwillRunnable extends AbstractMasterTwillRunnable {
   protected void doInit(TwillContext context) {
     CConfiguration cConf = getCConfiguration();
     Configuration hConf = getConfiguration();
+    URL hiveSiteURL = getClass().getClassLoader().getResource("hive-site.xml");
+    if (hiveSiteURL == null) {
+      // should not happen, as its added as a twill resource in MasterServiceMain
+      LOG.warn("hive-site.xml could not be found as a resource.");
+    } else {
+      hConf.addResource(hiveSiteURL);
+    }
 
     // NOTE: twill client will try to load all the classes present here - including hive classes but it
     // will fail since Hive classes are not in master classpath, and ignore those classes silently


### PR DESCRIPTION
Some common column names, like 'user', are reserved Hive keywords.
Depending on the version of Hive used and various configuration
settings, ddl statements need to have their columns escaped with
backticks in case one of the reserved keywords is used.
