### PR TITLE
Fix broken Doc build.

### DIFF
--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -168,7 +168,7 @@ function download_includes() {
   
   test_an_include b58bab093dbf5035c93b334fbf0857fc ../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
 
-  test_an_include 02ac96187846a269f65f9b1a21723df3 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/SportResults.java
+  test_an_include 1dff2aa10d09f384965e343be7f83f76 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/SportResults.java
   test_an_include c488b6ad3b5708977a8a913460e4e650 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java
   test_an_include 68df90a54f61ff3c63317aeed865f686 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/ScoreCounter.java
   

--- a/cdap-docs/examples-manual/source/examples/sport-results.rst
+++ b/cdap-docs/examples-manual/source/examples/sport-results.rst
@@ -48,7 +48,10 @@ The ``configure()`` method creates the two PartitionedFileSet datasets used in t
        2011/9/9,Philadelphia Eagles,Cleveland Browns,17,16
        2011/9/9,New England Patriots,Tennessee Titans,34,13
 
-  We have included some sample data in the ``resources`` directory.
+  We have included some sample data in the ``resources`` directory. Note that because the
+  column name ``date`` is a `Hive reserved keyword
+  <https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-Keywords,Non-reservedKeywordsandReservedKeywords>`__, 
+  it has been enclosed in single back-ticks in the Explore schema declaration.
 - The *totals* dataset stores aggregates across all seasons and thus has the league as its single
   partitioning field. Each record has, for an individual team, the total number of games won and lost
   and the total number of points scored and conceded.


### PR DESCRIPTION
Update hash for guarded file. No material change in file. Added an explanatory note to the `SportResults` example.

Passes [Quick Build 1](http://builds.cask.co/browse/CDAP-DQB7-1).
