### PR TITLE
[CDAP-5951] optimize maven build process for UI

### DIFF
--- a/cdap-ui/pom.xml
+++ b/cdap-ui/pom.xml
@@ -156,7 +156,7 @@
                 </goals>
                 <configuration>
                   <nodeVersion>v0.12.0</nodeVersion>
-                  <npmVersion>2.15.1</npmVersion>
+                  <npmVersion>3.8.8</npmVersion>
                 </configuration>
               </execution>
               <execution>
@@ -166,7 +166,7 @@
                 </goals>
                 <!-- Optional configuration which provides for running any npm command -->
                 <configuration>
-                  <arguments>install</arguments>
+                  <arguments>install -s --progress=false</arguments>
                 </configuration>
               </execution>
               <execution>
@@ -188,15 +188,6 @@
                 </configuration>
               </execution>
               <execution>
-                <id>gulp clean</id>
-                <goals>
-                  <goal>gulp</goal>
-                </goals>
-                <configuration>
-                  <arguments>clean</arguments>
-                </configuration>
-              </execution>
-              <execution>
                 <id>gulp distribute</id>
                 <goals>
                   <goal>gulp</goal>
@@ -212,20 +203,6 @@
             <artifactId>exec-maven-plugin</artifactId>
             <version>1.3.1</version>
             <executions>
-              <execution>
-                <id>clean-node-modules</id>
-                <phase>process-resources</phase>
-                <goals>
-                  <goal>exec</goal>
-                </goals>
-                <configuration>
-                  <executable>rm</executable>
-                  <arguments>
-                    <argument>-rf</argument>
-                    <argument>node_modules</argument>
-                  </arguments>
-                </configuration>
-              </execution>
               <execution>
                 <id>clean-bower-components</id>
                 <phase>process-resources</phase>
@@ -250,7 +227,7 @@
                   <executable>${project.basedir}/node/node</executable>
                   <arguments>
                     <argument>${project.basedir}/node/npm/bin/npm-cli.js</argument>
-                    <argument>install</argument>
+                    <argument>prune</argument>
                     <argument>--production</argument>
                   </arguments>
                 </configuration>


### PR DESCRIPTION
List of changes:
- NPM 3.8.8 makes `npm install` ~45 seconds faster
- Make `npm install` a silent process
- Remove `gulp clean` process (because distribute already have clean method built in) (~5 seconds faster)
- Remove the cleaning up node_modules, and replace `node install --production` with `node prune --production`. This will remove the devDependencies instead of deleting everything and reinstalling the prod dependencies. (~15 seconds faster)

All in all, this is about 1 minute optimization...
