### PR TITLE
CDAP-5900 Disable Metadata Change Publish to Kafka during Upgrade

### DIFF
--- a/cdap-docs/developers-manual/source/building-blocks/audit-logging.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/audit-logging.rst
@@ -18,9 +18,12 @@ entity's :ref:`metadata <metadata-lineage-metadata>`. For data entities (dataset
 streams), it includes access information used to generate the entity's :ref:`lineage
 <metadata-lineage-lineage>`. Audit logging is an especially important feature because it
 enables users to integrate CDAP with external data governance systems such as
-:ref:`Cloudera Navigator <audit-logging-navigator-integration>`. Please note that audit logs are not published during
-CDAP Upgrade. Hence, any application which uses CDAP audit logs to sync metadata will go out of sync. Please see
-`CDAP-5954 <https://issues.cask.co/browse/CDAP-5954>`__.
+:ref:`Cloudera Navigator <audit-logging-navigator-integration>`. 
+
+Please note that audit logs are not published during a CDAP upgrade, as CDAP services are
+not available. Hence, any application which uses CDAP audit logs to sync metadata will go 
+out of sync with respect to changes made during the upgrade. Please see 
+`CDAP-5954 <https://issues.cask.co/browse/CDAP-5954>`__ for details.
 
 .. _audit-logging-supported-audit-events:
 

--- a/cdap-docs/developers-manual/source/building-blocks/audit-logging.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/audit-logging.rst
@@ -18,7 +18,9 @@ entity's :ref:`metadata <metadata-lineage-metadata>`. For data entities (dataset
 streams), it includes access information used to generate the entity's :ref:`lineage
 <metadata-lineage-lineage>`. Audit logging is an especially important feature because it
 enables users to integrate CDAP with external data governance systems such as
-:ref:`Cloudera Navigator <audit-logging-navigator-integration>`.
+:ref:`Cloudera Navigator <audit-logging-navigator-integration>`. Please note that audit logs are not published during
+CDAP Upgrade. Hence, any application which uses CDAP audit logs to sync metadata will go out of sync. Please see
+`CDAP-5954 <https://issues.cask.co/browse/CDAP-5954>`__.
 
 .. _audit-logging-supported-audit-events:
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -48,6 +48,8 @@ import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
 import co.cask.cdap.data2.metadata.lineage.LineageStore;
+import co.cask.cdap.data2.metadata.publisher.MetadataChangePublisher;
+import co.cask.cdap.data2.metadata.publisher.NoOpMetadataChangePublisher;
 import co.cask.cdap.data2.metadata.store.DefaultMetadataStore;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
@@ -194,8 +196,9 @@ public class UpgradeTool {
             install(new FactoryModuleBuilder()
                       .implement(DatasetDefinitionRegistry.class, DefaultDatasetDefinitionRegistry.class)
                       .build(DatasetDefinitionRegistryFactory.class));
-            // Upgrade tool does not need to record lineage for now.
+            // CDAP-5954 Upgrade tool does not need to record lineage and metadata changes for now.
             bind(LineageWriter.class).to(NoOpLineageWriter.class);
+            bind(MetadataChangePublisher.class).to(NoOpMetadataChangePublisher.class);
           }
         }
       ),


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/CDAP-5900
Build: http://builds.cask.co/browse/CDAP-DUT4130-1

Verified on cluster. After this change the following  happens during metadata upgrade: 

> 2016-05-10 21:26:08,681 - INFO  [DatasetService:c.c.c.d.d.d.s.DatasetService@172] - DatasetService started successfully on /0:0:0:0:0:0:0:0:60563
> 2016-05-10 21:26:08,855 - INFO  [main:c.c.c.d.t.UpgradeTool@404] - Writing system metadata to existing entities...
> 2016-05-10 21:26:09,295 - INFO  [main:c.c.c.d.d.InMemoryDatasetFramework@247] - Created dataset dataset:system.system.metadata of type co.cask.cdap.data2.metadata.dataset.MetadataDataset
> 2016-05-10 21:26:09,362 - WARN  [main:c.c.c.d.a.AuditPublishers@120] - Audit publisher is null, audit information will not be published
> 2016-05-10 21:26:11,302 - INFO  [main:c.c.c.d.t.UpgradeTool@407] - Removing metadata for deleted datasets...
> 2016-05-10 21:26:11,671 - INFO  [main:c.c.c.d.d.InMemoryDatasetFramework@247] - Created dataset dataset:system.business.metadata of type co.cask.cdap.data2.metadata.dataset.MetadataDataset
> 2016-05-10 21:26:12,047 - INFO  [main:c.c.c.d.d.InMemoryDatasetFramework@247] - Created dataset dataset:system.system.metadata of type co.cask.cdap.data2.metadata.dataset.MetadataDataset
> 2016-05-10 21:26:12,569 - INFO  [main:c.c.c.d.t.UpgradeTool@411] - Deleting old metadata indexes...
> 2016-05-10 21:26:12,976 - INFO  [main:c.c.c.d.t.UpgradeTool@413] - Re-building metadata indexes...
> 2016-05-10 21:26:13,682 - INFO  [DatasetService:c.c.c.d.d.d.s.DatasetService@215] - Stopping DatasetService...
> 2016-05-10 21:26:16,696 - INFO  [NettyHttpService STOPPING:c.c.c.d.d.d.s.DatasetTypeHandler@88] - Stopping DatasetTypeHandler
> 
> Upgrade completed successfully.
