### PR TITLE
Avoid cancellation of delegation token when Explore-launched Spark job completes

### DIFF
--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -1322,6 +1322,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     if (UserGroupInformation.isSecurityEnabled()) {
       // make sure RM does not cancel delegation tokens after the query is run
       sessionConf.put("mapreduce.job.complete.cancel.delegation.tokens", "false");
+      sessionConf.put("spark.hadoop.mapreduce.job.complete.cancel.delegation.tokens", "false");
       // refresh delegations for the job - TWILL-170
       updateTokenStore();
     }


### PR DESCRIPTION
Avoid cancellation of delegation token when Explore-launched Spark job completes.

https://issues.cask.co/browse/CDAP-5855
http://builds.cask.co/browse/CDAP-DUT4129-2
