### PR TITLE
CDAP-5866 AuthorizerInstantiator is no longer guava service and creation of underlying Authorizer happens through get lazily and deletion happens through close.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AuthorizationModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AuthorizationModule.java
@@ -28,7 +28,7 @@ import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
 import co.cask.cdap.internal.app.runtime.DefaultAdmin;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.authorization.AuthorizationContextFactory;
-import co.cask.cdap.security.authorization.AuthorizerInstantiatorService;
+import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.authorization.DefaultAuthorizationContext;
 import co.cask.cdap.security.spi.authorization.AuthorizationContext;
 import co.cask.cdap.security.spi.authorization.Authorizer;
@@ -56,8 +56,8 @@ import java.util.Properties;
  *
  * This module is part of the injector created in StandaloneMain and MasterServiceMain, which makes it available to
  * services. The requirements for this module are:
- * 1. This module is used for creating and exposing {@link AuthorizerInstantiatorService}.
- * 2. The {@link AuthorizerInstantiatorService} needs a {@link DefaultAuthorizationContext}.
+ * 1. This module is used for creating and exposing {@link AuthorizerInstantiator}.
+ * 2. The {@link AuthorizerInstantiator} needs a {@link DefaultAuthorizationContext}.
  * 3. The {@link DefaultAuthorizationContext} needs a {@link DatasetContext}, a {@link Admin} and a
  * {@link Transactional}.
  *
@@ -74,8 +74,8 @@ import java.util.Properties;
  * 5. Using the bound {@link DatasetContext}, {@link Admin} and {@link Transactional} to provide the injections for
  * {@link DefaultAuthorizationContext}, which is provided using a {@link Guice} {@link FactoryModuleBuilder} to
  * construct a {@link AuthorizationContextFactory}.
- * 6. Only exposing a {@link Singleton} binding to {@link AuthorizerInstantiatorService} from this module. The
- * {@link AuthorizerInstantiatorService} can just {@link Inject} the {@link AuthorizationContextFactory} and call
+ * 6. Only exposing a {@link Singleton} binding to {@link AuthorizerInstantiator} from this module. The
+ * {@link AuthorizerInstantiator} can just {@link Inject} the {@link AuthorizationContextFactory} and call
  * {@link AuthorizationContextFactory#create(Properties)} using an {@link Assisted} {@link Properties} object.
  */
 public class AuthorizationModule extends PrivateModule {
@@ -92,8 +92,8 @@ public class AuthorizationModule extends PrivateModule {
         .build(AuthorizationContextFactory.class)
     );
 
-    bind(AuthorizerInstantiatorService.class).in(Scopes.SINGLETON);
-    expose(AuthorizerInstantiatorService.class);
+    bind(AuthorizerInstantiator.class).in(Scopes.SINGLETON);
+    expose(AuthorizerInstantiator.class);
   }
 
   @Singleton

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AuthorizationHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AuthorizationHandler.java
@@ -33,7 +33,7 @@ import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.proto.security.RevokeRequest;
 import co.cask.cdap.proto.security.Role;
-import co.cask.cdap.security.authorization.AuthorizerInstantiatorService;
+import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import co.cask.cdap.security.spi.authorization.Authorizer;
 import co.cask.http.HttpResponder;
@@ -67,7 +67,7 @@ import javax.ws.rs.PathParam;
 public class AuthorizationHandler extends AbstractAppFabricHttpHandler {
 
   private static final Logger AUDIT_LOG = LoggerFactory.getLogger("authorization-access");
-  private final AuthorizerInstantiatorService authorizerInstantiatorService;
+  private final AuthorizerInstantiator authorizerInstantiator;
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(EntityId.class, new EntityIdTypeAdapter())
     .create();
@@ -77,9 +77,9 @@ public class AuthorizationHandler extends AbstractAppFabricHttpHandler {
   private final EntityExistenceVerifier entityExistenceVerifier;
 
   @Inject
-  AuthorizationHandler(AuthorizerInstantiatorService authorizerInstantiatorService, CConfiguration cConf,
+  AuthorizationHandler(AuthorizerInstantiator authorizerInstantiator, CConfiguration cConf,
                        EntityExistenceVerifier entityExistenceVerifier) {
-    this.authorizerInstantiatorService = authorizerInstantiatorService;
+    this.authorizerInstantiator = authorizerInstantiator;
     this.authenticationEnabled = cConf.getBoolean(Constants.Security.ENABLED);
     this.authorizationEnabled = cConf.getBoolean(Constants.Security.Authorization.ENABLED);
     this.entityExistenceVerifier = entityExistenceVerifier;
@@ -95,9 +95,9 @@ public class AuthorizationHandler extends AbstractAppFabricHttpHandler {
 
     Set<Action> actions = request.getActions() == null ? EnumSet.allOf(Action.class) : request.getActions();
     // enforce that the user granting access has admin privileges on the entity
-    authorizerInstantiatorService.get().enforce(request.getEntity(), SecurityRequestContext.toPrincipal(),
+    authorizerInstantiator.get().enforce(request.getEntity(), SecurityRequestContext.toPrincipal(),
                                                 Action.ADMIN);
-    authorizerInstantiatorService.get().grant(request.getEntity(), request.getPrincipal(), actions);
+    authorizerInstantiator.get().grant(request.getEntity(), request.getPrincipal(), actions);
 
     httpResponder.sendStatus(HttpResponseStatus.OK);
     createLogEntry(httpRequest, request, HttpResponseStatus.OK);
@@ -112,13 +112,13 @@ public class AuthorizationHandler extends AbstractAppFabricHttpHandler {
     verifyAuthRequest(request);
 
     // enforce that the user revoking access has admin privileges on the entity
-    authorizerInstantiatorService.get().enforce(request.getEntity(), SecurityRequestContext.toPrincipal(),
+    authorizerInstantiator.get().enforce(request.getEntity(), SecurityRequestContext.toPrincipal(),
                                                 Action.ADMIN);
     if (request.getPrincipal() == null && request.getActions() == null) {
-      authorizerInstantiatorService.get().revoke(request.getEntity());
+      authorizerInstantiator.get().revoke(request.getEntity());
     } else {
       Set<Action> actions = request.getActions() == null ? EnumSet.allOf(Action.class) : request.getActions();
-      authorizerInstantiatorService.get().revoke(request.getEntity(), request.getPrincipal(), actions);
+      authorizerInstantiator.get().revoke(request.getEntity(), request.getPrincipal(), actions);
     }
 
     httpResponder.sendStatus(HttpResponseStatus.OK);
@@ -132,7 +132,7 @@ public class AuthorizationHandler extends AbstractAppFabricHttpHandler {
                              @PathParam("principal-name") String principalName) throws Exception {
     ensureSecurityEnabled();
     Principal principal = new Principal(principalName, Principal.PrincipalType.valueOf(principalType.toUpperCase()));
-    httpResponder.sendJson(HttpResponseStatus.OK, authorizerInstantiatorService.get().listPrivileges(principal),
+    httpResponder.sendJson(HttpResponseStatus.OK, authorizerInstantiator.get().listPrivileges(principal),
                            PRIVILEGE_SET_TYPE, GSON);
     createLogEntry(httpRequest, null, HttpResponseStatus.OK);
   }
@@ -147,7 +147,7 @@ public class AuthorizationHandler extends AbstractAppFabricHttpHandler {
   public void createRole(HttpRequest httpRequest, HttpResponder httpResponder,
                          @PathParam("role-name") String roleName) throws Exception {
     ensureSecurityEnabled();
-    authorizerInstantiatorService.get().createRole(new Role(roleName));
+    authorizerInstantiator.get().createRole(new Role(roleName));
     httpResponder.sendStatus(HttpResponseStatus.OK);
     createLogEntry(httpRequest, null, HttpResponseStatus.OK);
   }
@@ -157,7 +157,7 @@ public class AuthorizationHandler extends AbstractAppFabricHttpHandler {
   public void dropRole(HttpRequest httpRequest, HttpResponder httpResponder,
                        @PathParam("role-name") String roleName) throws Exception {
     ensureSecurityEnabled();
-    authorizerInstantiatorService.get().dropRole(new Role(roleName));
+    authorizerInstantiator.get().dropRole(new Role(roleName));
     httpResponder.sendStatus(HttpResponseStatus.OK);
     createLogEntry(httpRequest, null, HttpResponseStatus.OK);
   }
@@ -166,7 +166,7 @@ public class AuthorizationHandler extends AbstractAppFabricHttpHandler {
   @GET
   public void listAllRoles(HttpRequest httpRequest, HttpResponder httpResponder) throws Exception {
     ensureSecurityEnabled();
-    httpResponder.sendJson(HttpResponseStatus.OK, authorizerInstantiatorService.get().listAllRoles());
+    httpResponder.sendJson(HttpResponseStatus.OK, authorizerInstantiator.get().listAllRoles());
     createLogEntry(httpRequest, null, HttpResponseStatus.OK);
   }
 
@@ -177,7 +177,7 @@ public class AuthorizationHandler extends AbstractAppFabricHttpHandler {
                         @PathParam("principal-name") String principalName) throws Exception {
     ensureSecurityEnabled();
     Principal principal = new Principal(principalName, Principal.PrincipalType.valueOf(principalType.toUpperCase()));
-    httpResponder.sendJson(HttpResponseStatus.OK, authorizerInstantiatorService.get().listRoles(principal));
+    httpResponder.sendJson(HttpResponseStatus.OK, authorizerInstantiator.get().listRoles(principal));
     createLogEntry(httpRequest, null, HttpResponseStatus.OK);
   }
 
@@ -188,7 +188,7 @@ public class AuthorizationHandler extends AbstractAppFabricHttpHandler {
                                  @PathParam("principal-name") String principalName,
                                  @PathParam("role-name") String roleName) throws Exception {
     ensureSecurityEnabled();
-    authorizerInstantiatorService.get().addRoleToPrincipal(new Role(roleName),
+    authorizerInstantiator.get().addRoleToPrincipal(new Role(roleName),
                                   new Principal(principalName,
                                                 Principal.PrincipalType.valueOf(principalType.toUpperCase())));
     httpResponder.sendStatus(HttpResponseStatus.OK);
@@ -202,7 +202,7 @@ public class AuthorizationHandler extends AbstractAppFabricHttpHandler {
                                       @PathParam("principal-name") String principalName,
                                       @PathParam("role-name") String roleName) throws Exception {
     ensureSecurityEnabled();
-    authorizerInstantiatorService.get().removeRoleFromPrincipal(new Role(roleName),
+    authorizerInstantiator.get().removeRoleFromPrincipal(new Role(roleName),
                                        new Principal(principalName,
                                                      Principal.PrincipalType.valueOf(principalType.toUpperCase())));
     httpResponder.sendStatus(HttpResponseStatus.OK);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalApplicationManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/LocalApplicationManager.java
@@ -42,7 +42,7 @@ import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
 import co.cask.cdap.pipeline.Pipeline;
 import co.cask.cdap.pipeline.PipelineFactory;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.security.authorization.AuthorizerInstantiatorService;
+import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
@@ -72,7 +72,7 @@ public class LocalApplicationManager<I, O> implements Manager<I, O> {
   private final UsageRegistry usageRegistry;
   private final ArtifactRepository artifactRepository;
   private final MetadataStore metadataStore;
-  private final AuthorizerInstantiatorService authorizerInstantiatorService;
+  private final AuthorizerInstantiator authorizerInstantiator;
 
   @Inject
   LocalApplicationManager(CConfiguration configuration, PipelineFactory pipelineFactory,
@@ -83,7 +83,7 @@ public class LocalApplicationManager<I, O> implements Manager<I, O> {
                           StreamAdmin streamAdmin, Scheduler scheduler,
                           @Assisted ProgramTerminator programTerminator, MetricStore metricStore,
                           UsageRegistry usageRegistry, ArtifactRepository artifactRepository,
-                          MetadataStore metadataStore, AuthorizerInstantiatorService authorizerInstantiatorService) {
+                          MetadataStore metadataStore, AuthorizerInstantiator authorizerInstantiator) {
     this.configuration = configuration;
     this.namespacedLocationFactory = namespacedLocationFactory;
     this.pipelineFactory = pipelineFactory;
@@ -99,7 +99,7 @@ public class LocalApplicationManager<I, O> implements Manager<I, O> {
     this.usageRegistry = usageRegistry;
     this.artifactRepository = artifactRepository;
     this.metadataStore = metadataStore;
-    this.authorizerInstantiatorService = authorizerInstantiatorService;
+    this.authorizerInstantiator = authorizerInstantiator;
   }
 
   @Override
@@ -113,9 +113,9 @@ public class LocalApplicationManager<I, O> implements Manager<I, O> {
     pipeline.addLast(new CreateStreamsStage(namespace, streamAdmin));
     pipeline.addLast(new DeletedProgramHandlerStage(store, programTerminator, streamConsumerFactory,
                                                     queueAdmin, metricStore, metadataStore,
-                                                    authorizerInstantiatorService.get()));
+                                                    authorizerInstantiator.get()));
     pipeline.addLast(new ProgramGenerationStage(configuration, namespacedLocationFactory,
-                                                authorizerInstantiatorService.get()));
+                                                authorizerInstantiator.get()));
     pipeline.addLast(new ApplicationRegistrationStage(store, usageRegistry));
     pipeline.addLast(new CreateSchedulesStage(scheduler));
     pipeline.addLast(new SystemMetadataWriterStage(metadataStore));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -45,7 +45,7 @@ import co.cask.cdap.proto.id.InstanceId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
-import co.cask.cdap.security.authorization.AuthorizerInstantiatorService;
+import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import co.cask.cdap.store.NamespaceStore;
 import com.google.common.base.Preconditions;
@@ -80,7 +80,7 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
   private final Scheduler scheduler;
   private final ApplicationLifecycleService applicationLifecycleService;
   private final ArtifactRepository artifactRepository;
-  private final AuthorizerInstantiatorService authorizerInstantiatorService;
+  private final AuthorizerInstantiator authorizerInstantiator;
   private final InstanceId instanceId;
   private final Pattern namespacePattern = Pattern.compile("[a-zA-Z0-9_]+");
 
@@ -91,7 +91,7 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
                         MetricStore metricStore, Scheduler scheduler,
                         ApplicationLifecycleService applicationLifecycleService,
                         ArtifactRepository artifactRepository,
-                        AuthorizerInstantiatorService authorizerInstantiatorService,
+                        AuthorizerInstantiator authorizerInstantiator,
                         CConfiguration cConf) {
     this.queueAdmin = queueAdmin;
     this.streamAdmin = streamAdmin;
@@ -105,7 +105,7 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
     this.metricStore = metricStore;
     this.applicationLifecycleService = applicationLifecycleService;
     this.artifactRepository = artifactRepository;
-    this.authorizerInstantiatorService = authorizerInstantiatorService;
+    this.authorizerInstantiator = authorizerInstantiator;
     this.instanceId = createInstanceId(cConf);
   }
 
@@ -171,7 +171,7 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
     // Skip authorization enforcement for the system user and the default namespace, so the DefaultNamespaceEnsurer
     // thread can successfully create the default namespace
     if (!(Principal.SYSTEM.equals(principal) && NamespaceId.DEFAULT.equals(namespace))) {
-      authorizerInstantiatorService.get().enforce(instanceId, principal, Action.ADMIN);
+      authorizerInstantiator.get().enforce(instanceId, principal, Action.ADMIN);
     }
 
     try {
@@ -183,7 +183,7 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
     nsStore.create(metadata);
     // Skip authorization grants for the system user
     if (!(Principal.SYSTEM.equals(principal) && NamespaceId.DEFAULT.equals(namespace))) {
-      authorizerInstantiatorService.get().grant(namespace, principal, ImmutableSet.of(Action.ALL));
+      authorizerInstantiator.get().grant(namespace, principal, ImmutableSet.of(Action.ALL));
     }
   }
 
@@ -210,8 +210,8 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
     }
 
     // Namespace can be deleted. Revoke all privileges first
-    authorizerInstantiatorService.get().enforce(namespace, SecurityRequestContext.toPrincipal(), Action.ADMIN);
-    authorizerInstantiatorService.get().revoke(namespace);
+    authorizerInstantiator.get().enforce(namespace, SecurityRequestContext.toPrincipal(), Action.ADMIN);
+    authorizerInstantiator.get().revoke(namespace);
 
     LOG.info("Deleting namespace '{}'.", namespaceId);
     try {
@@ -277,7 +277,7 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
     }
 
     // Namespace data can be deleted. Revoke all privileges first
-    authorizerInstantiatorService.get().enforce(namespaceId.toEntityId(), SecurityRequestContext.toPrincipal(),
+    authorizerInstantiator.get().enforce(namespaceId.toEntityId(), SecurityRequestContext.toPrincipal(),
                                                 Action.ADMIN);
     try {
       dsFramework.deleteAllInstances(namespaceId);
@@ -293,7 +293,7 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
     if (!exists(namespaceId)) {
       throw new NamespaceNotFoundException(namespaceId);
     }
-    authorizerInstantiatorService.get().enforce(namespaceId.toEntityId(), SecurityRequestContext.toPrincipal(),
+    authorizerInstantiator.get().enforce(namespaceId.toEntityId(), SecurityRequestContext.toPrincipal(),
                                                 Action.ADMIN);
     NamespaceMeta metadata = nsStore.get(namespaceId);
     NamespaceMeta.Builder builder = new NamespaceMeta.Builder(metadata);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
@@ -32,7 +32,6 @@ import co.cask.cdap.internal.app.runtime.plugin.PluginService;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
 import co.cask.cdap.notifications.service.NotificationService;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.security.authorization.AuthorizerInstantiatorService;
 import co.cask.http.HandlerHook;
 import co.cask.http.HttpHandler;
 import co.cask.http.NettyHttpService;
@@ -75,7 +74,6 @@ public class AppFabricServer extends AbstractIdleService {
   private final ProgramLifecycleService programLifecycleService;
   private final DefaultNamespaceEnsurer defaultNamespaceEnsurer;
   private final SystemArtifactLoader systemArtifactLoader;
-  private final AuthorizerInstantiatorService authorizerInstantiatorService;
   private final PluginService pluginService;
 
   private NettyHttpService httpService;
@@ -100,7 +98,6 @@ public class AppFabricServer extends AbstractIdleService {
                          @Named("appfabric.handler.hooks") Set<String> handlerHookNames,
                          DefaultNamespaceEnsurer defaultNamespaceEnsurer,
                          SystemArtifactLoader systemArtifactLoader,
-                         AuthorizerInstantiatorService authorizerInstantiatorService,
                          PluginService pluginService) {
     this.hostname = hostname;
     this.discoveryService = discoveryService;
@@ -117,7 +114,6 @@ public class AppFabricServer extends AbstractIdleService {
     this.programLifecycleService = programLifecycleService;
     this.defaultNamespaceEnsurer = defaultNamespaceEnsurer;
     this.systemArtifactLoader = systemArtifactLoader;
-    this.authorizerInstantiatorService = authorizerInstantiatorService;
     this.pluginService = pluginService;
   }
 
@@ -138,7 +134,6 @@ public class AppFabricServer extends AbstractIdleService {
         programRuntimeService.start(),
         streamCoordinatorClient.start(),
         programLifecycleService.start(),
-        authorizerInstantiatorService.start(),
         pluginService.start()
       )
     ).get();
@@ -227,7 +222,6 @@ public class AppFabricServer extends AbstractIdleService {
     systemArtifactLoader.stopAndWait();
     notificationService.stopAndWait();
     programLifecycleService.stopAndWait();
-    authorizerInstantiatorService.stopAndWait();
     pluginService.stopAndWait();
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
@@ -52,7 +52,7 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.cdap.proto.security.Action;
-import co.cask.cdap.security.authorization.AuthorizerInstantiatorService;
+import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.cdap.store.NamespaceStore;
@@ -105,13 +105,13 @@ public class ProgramLifecycleService extends AbstractIdleService {
   private final NamespacedLocationFactory namespacedLocationFactory;
   private final String appFabricDir;
   private final PreferencesStore preferencesStore;
-  private final AuthorizerInstantiatorService authorizerInstantiatorService;
+  private final AuthorizerInstantiator authorizerInstantiator;
 
   @Inject
   ProgramLifecycleService(Store store, NamespaceStore nsStore, ProgramRuntimeService runtimeService,
                           CConfiguration cConf, PropertiesResolver propertiesResolver,
                           NamespacedLocationFactory namespacedLocationFactory, PreferencesStore preferencesStore,
-                          AuthorizerInstantiatorService authorizerInstantiatorService) {
+                          AuthorizerInstantiator authorizerInstantiator) {
     this.store = store;
     this.nsStore = nsStore;
     this.runtimeService = runtimeService;
@@ -121,7 +121,7 @@ public class ProgramLifecycleService extends AbstractIdleService {
     this.scheduledExecutorService = Executors.newScheduledThreadPool(1);
     this.cConf = cConf;
     this.preferencesStore = preferencesStore;
-    this.authorizerInstantiatorService = authorizerInstantiatorService;
+    this.authorizerInstantiator = authorizerInstantiator;
   }
 
   @Override
@@ -281,7 +281,7 @@ public class ProgramLifecycleService extends AbstractIdleService {
    */
   public ProgramRuntimeService.RuntimeInfo start(final ProgramId programId, final Map<String, String> systemArgs,
                                                  final Map<String, String> userArgs, boolean debug) throws Exception {
-    authorizerInstantiatorService.get().enforce(programId, SecurityRequestContext.toPrincipal(), Action.EXECUTE);
+    authorizerInstantiator.get().enforce(programId, SecurityRequestContext.toPrincipal(), Action.EXECUTE);
     Program program = store.loadProgram(programId.toId());
     BasicArguments systemArguments = new BasicArguments(systemArgs);
     BasicArguments userArguments = new BasicArguments(userArgs);
@@ -395,7 +395,7 @@ public class ProgramLifecycleService extends AbstractIdleService {
    *                               program, a user requires {@link Action#EXECUTE} permission on the program.
    */
   public ListenableFuture<ProgramController> issueStop(ProgramId programId, @Nullable String runId) throws Exception {
-    authorizerInstantiatorService.get().enforce(programId, SecurityRequestContext.toPrincipal(), Action.EXECUTE);
+    authorizerInstantiator.get().enforce(programId, SecurityRequestContext.toPrincipal(), Action.EXECUTE);
     ProgramRuntimeService.RuntimeInfo runtimeInfo = findRuntimeInfo(programId, runId);
     if (runtimeInfo == null) {
       if (!store.applicationExists(programId.toId().getApplication())) {
@@ -432,7 +432,7 @@ public class ProgramLifecycleService extends AbstractIdleService {
    *                               {@link Action#ADMIN} privileges on the program.
    */
   public void saveRuntimeArgs(ProgramId programId, Map<String, String> runtimeArgs) throws Exception {
-    authorizerInstantiatorService.get().enforce(programId, SecurityRequestContext.toPrincipal(), Action.ADMIN);
+    authorizerInstantiator.get().enforce(programId, SecurityRequestContext.toPrincipal(), Action.ADMIN);
     if (!store.programExists(programId.toId())) {
       throw new NotFoundException(programId.toId());
     }
@@ -501,7 +501,7 @@ public class ProgramLifecycleService extends AbstractIdleService {
    *                               To set instances for a program, a user needs {@link Action#ADMIN} on the program.
    */
   public void setInstances(ProgramId programId, int instances, @Nullable String component) throws Exception {
-    authorizerInstantiatorService.get().enforce(programId, SecurityRequestContext.toPrincipal(), Action.ADMIN);
+    authorizerInstantiator.get().enforce(programId, SecurityRequestContext.toPrincipal(), Action.ADMIN);
     if (instances < 1) {
       throw new BadRequestException(String.format("Instance count should be greater than 0. Got %s.", instances));
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/StandaloneAppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/StandaloneAppFabricServer.java
@@ -28,7 +28,7 @@ import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
 import co.cask.cdap.internal.app.runtime.plugin.PluginService;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
 import co.cask.cdap.notifications.service.NotificationService;
-import co.cask.cdap.security.authorization.AuthorizerInstantiatorService;
+import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.http.HttpHandler;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -65,12 +65,11 @@ public class StandaloneAppFabricServer extends AppFabricServer {
                                    DefaultNamespaceEnsurer defaultNamespaceEnsurer,
                                    MetricStore metricStore,
                                    SystemArtifactLoader systemArtifactLoader,
-                                   AuthorizerInstantiatorService authorizerInstantiatorService,
                                    PluginService pluginService) {
     super(configuration, discoveryService, schedulerService, notificationService, hostname, handlers,
           metricsCollectionService, programRuntimeService, applicationLifecycleService,
           programLifecycleService, streamCoordinatorClient, servicesNames, handlerHookNames, defaultNamespaceEnsurer,
-          systemArtifactLoader, authorizerInstantiatorService, pluginService);
+          systemArtifactLoader, pluginService);
     this.metricStore = metricStore;
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/AuthorizationHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/AuthorizationHandlerTest.java
@@ -37,7 +37,7 @@ import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.proto.security.Role;
 import co.cask.cdap.security.authorization.AuthorizationContextFactory;
-import co.cask.cdap.security.authorization.AuthorizerInstantiatorService;
+import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.authorization.DefaultAuthorizationContext;
 import co.cask.cdap.security.authorization.NoOpAdmin;
 import co.cask.cdap.security.authorization.NoOpDatasetContext;
@@ -107,7 +107,7 @@ public class AuthorizationHandlerTest {
     auth.initialize(factory.create(properties));
     service = new CommonNettyHttpServiceBuilder(conf)
       .addHttpHandlers(ImmutableList.of(new AuthorizationHandler(
-        new AuthorizerInstantiatorService(conf, factory) {
+        new AuthorizerInstantiator(conf, factory) {
           @Override
           public Authorizer get() {
             return auth;
@@ -161,7 +161,7 @@ public class AuthorizationHandlerTest {
                             String configSetting) throws Exception {
     NettyHttpService service = new CommonNettyHttpServiceBuilder(cConf)
       .addHttpHandlers(ImmutableList.of(new AuthorizationHandler(
-        new AuthorizerInstantiatorService(cConf, factory) {
+        new AuthorizerInstantiator(cConf, factory) {
           @Override
           public Authorizer get() {
             return new InMemoryAuthorizer();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
@@ -39,7 +39,7 @@ import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.notifications.service.NotificationService;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
-import co.cask.cdap.security.authorization.AuthorizerInstantiatorService;
+import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.tephra.TransactionManager;
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
@@ -100,7 +100,6 @@ public class AppFabricTestHelper {
       injector.getInstance(StreamCoordinatorClient.class).startAndWait();
       injector.getInstance(NotificationService.class).startAndWait();
       injector.getInstance(MetricsCollectionService.class).startAndWait();
-      injector.getInstance(AuthorizerInstantiatorService.class).startAndWait();
     }
     return injector;
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/SystemArtifactsAuthorizationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/SystemArtifactsAuthorizationTest.java
@@ -27,7 +27,7 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
-import co.cask.cdap.security.authorization.AuthorizerInstantiatorService;
+import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import co.cask.cdap.security.spi.authorization.Authorizer;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
@@ -71,7 +71,7 @@ public class SystemArtifactsAuthorizationTest {
     cConf.set(Constants.Security.Authorization.EXTENSION_JAR_PATH, deploymentJar.toURI().getPath());
     Injector injector =  AppFabricTestHelper.getInjector(cConf);
     artifactRepository = injector.getInstance(ArtifactRepository.class);
-    AuthorizerInstantiatorService instantiatorService = injector.getInstance(AuthorizerInstantiatorService.class);
+    AuthorizerInstantiator instantiatorService = injector.getInstance(AuthorizerInstantiator.class);
     authorizer = instantiatorService.get();
     instance = new InstanceId(cConf.get(Constants.INSTANCE_NAME));
   }

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -78,6 +78,11 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-security</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-explore-client</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -60,6 +60,7 @@ import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModu
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.security.TokenSecureStoreUpdater;
+import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.store.guice.NamespaceStoreModule;
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
@@ -147,6 +148,7 @@ public class MasterServiceMain extends DaemonMain {
   private final ServiceStore serviceStore;
   private final LeaderElection leaderElection;
   private final TokenSecureStoreUpdater secureStoreUpdater;
+  private final AuthorizerInstantiator authorizerInstantiator;
 
   private volatile boolean stopped;
 
@@ -173,6 +175,7 @@ public class MasterServiceMain extends DaemonMain {
     this.metricsCollectionService = injector.getInstance(MetricsCollectionService.class);
     this.serviceStore = injector.getInstance(ServiceStore.class);
     this.secureStoreUpdater = baseInjector.getInstance(TokenSecureStoreUpdater.class);
+    this.authorizerInstantiator = baseInjector.getInstance(AuthorizerInstantiator.class);
     this.leaderElection = createLeaderElection();
     // leader election will normally stay running. Will only stop if there was some issue starting up.
     this.leaderElection.addListener(new ServiceListenerAdapter() {
@@ -245,6 +248,8 @@ public class MasterServiceMain extends DaemonMain {
     if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED)) {
       Closeables.closeQuietly(baseInjector.getInstance(ExploreClient.class));
     }
+
+    Closeables.closeQuietly(authorizerInstantiator);
   }
 
   @Override

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -62,6 +62,7 @@ import co.cask.cdap.metrics.guice.MetricsHandlerModule;
 import co.cask.cdap.metrics.query.MetricsQueryService;
 import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModule;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
+import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.guice.SecurityModules;
 import co.cask.cdap.security.server.ExternalAuthenticationServer;
 import co.cask.cdap.store.guice.NamespaceStoreModule;
@@ -124,6 +125,7 @@ public class StandaloneMain {
   private final ExternalJavaProcessExecutor kafkaProcessExecutor;
   private final ExternalJavaProcessExecutor zookeeperProcessExecutor;
   private final TrackerAppCreationService trackerAppCreationService;
+  private final AuthorizerInstantiator authorizerInstantiator;
 
   private ExternalAuthenticationServer externalAuthenticationServer;
   private ExploreExecutorService exploreExecutorService;
@@ -188,6 +190,7 @@ public class StandaloneMain {
 
     exploreClient = injector.getInstance(ExploreClient.class);
     metadataService = injector.getInstance(MetadataService.class);
+    authorizerInstantiator = injector.getInstance(AuthorizerInstantiator.class);
 
     Runtime.getRuntime().addShutdownHook(new Thread() {
       @Override
@@ -329,6 +332,8 @@ public class StandaloneMain {
       if (zkClient != null) {
         zkClient.stopAndWait();
       }
+
+      authorizerInstantiator.close();
     } catch (Throwable e) {
       halt = true;
       LOG.error("Exception during shutdown", e);


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-5866

`AuthorizerInstantiator` is no longer guava service. Creation of the underlying `Authorizer` happens lazily during `get` method. `AuthorizerInstantiator` also implements `Closeable` which allows releasing the resources.
