### PR TITLE
Update version for SDK installation for VM

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -127,7 +127,7 @@
       "json": {
         "cdap": {
           "comment": "DO NOT PUT SNAPHOT IN THE VERSION BELOW, THIS CONTROLS CDAP COOKBOOK CODE",
-          "version": "3.4.0-1",
+          "version": "3.4.1-1",
           "sdk": {
             "comment": "COPY SDK ZIP TO files/cdap-sdk.zip BEFORE RUNNING ME",
             "url": "file:///tmp/cdap-sdk.zip"


### PR DESCRIPTION
Otherwise, Chef fails:

```
* Chef::Exceptions::ChecksumMismatch occurred in chef run: remote_file[/var/chef/cache/sdk-3.4.0.zip] (/var/chef/cookbooks/ark/providers/default.rb line 41) had an error: Chef::Exceptions::ChecksumMismatch: Checksum on resource (187667) does not match checksum on content (b50623)
```
