### PR TITLE
use numeric snapshot versions for parcels

### DIFF
--- a/cdap-distributions/bin/build_parcel.sh
+++ b/cdap-distributions/bin/build_parcel.sh
@@ -162,6 +162,11 @@ echo "Starting Parcel Build"
 
 validate_env
 
+# If detected version is a SNAPSHOT, convert it to numeric
+if [[ ${VERSION} =~ "-SNAPSHOT" ]] ; then
+  VERSION=${VERSION/-SNAPSHOT/.$(date +%s)}
+fi
+
 PARCEL_VERSION_ITERATION="${PARCEL_VERSION:-${VERSION}}-${PARCEL_ITERATION}"
 echo "Using version: ${PARCEL_VERSION_ITERATION}"
 PARCEL_ROOT_DIR="${PARCEL_BASE}-${PARCEL_VERSION_ITERATION}"


### PR DESCRIPTION
substitute numeric versions for `-SNAPSHOT` for parcel.  will make it easier to work with.  analagous to https://github.com/caskdata/cdap-ambari-service/pull/65

```
Starting Parcel Build
Using version: 3.5.0.1463087972-1
Generated /Users/derek/git/cdap/cdap-distributions/target/CDAP-3.5.0.1463087972-1-el6.parcel
```
