### PR TITLE
CDAP-4862 Log the Hadoop MapReduce jobId in MapReduce logs.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -151,7 +151,7 @@ public class BasicMapReduceContext extends AbstractContext implements MapReduceC
 
   @Override
   public String toString() {
-    return String.format("job=%s,=%s", spec.getName(), super.toString());
+    return String.format("name=%s, jobId=%s, %s", spec.getName(), job == null ? null : job.getJobID(), super.toString());
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -285,9 +285,10 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
         CConfiguration cConfCopy = cConf;
         contextConfig.set(context, cConfCopy, tx, programJar.toURI(), localizedUserResources);
 
-        LOG.info("Submitting MapReduce Job: {}", context);
         // submits job and returns immediately. Shouldn't need to set context ClassLoader.
         job.submit();
+        // log after the job.submit(), because the jobId is not assigned before then
+        LOG.info("Submitted MapReduce Job: {}.", context);
 
         this.job = job;
         this.transaction = tx;


### PR DESCRIPTION
Log the Hadoop MapReduce jobId in MapReduce logs.
Needed to move the log line before the submit, because only after submit() is the jobId assigned.

https://issues.cask.co/browse/CDAP-4862
http://builds.cask.co/browse/CDAP-DUT4142-3
