### PR TITLE
CDAP-2572 Fix documentation formatting errors

### DIFF
--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -717,18 +717,32 @@ def set_conf_for_manual():
 def source_read_handler(app, docname, source):
     doc_path = app.env.doc2path(docname)
     if doc_path.endswith(".md"):
-        # Cache the self.env.config.rst_epilog and rst_prolog
+        # Cache the self.env.config.rst_epilog, rst_prolog, highlight_language
         if app.env.config.rst_epilog:
             app.env.config.rst_epilog_cache = app.env.config.rst_epilog
             app.env.config.rst_epilog = None
         if app.env.config.rst_prolog:
             app.env.config.rst_prolog_cache = app.env.config.rst_prolog
             app.env.config.rst_prolog = None
+        if app.env.config.highlight_language:
+            app.env.config.highlight_language_cache = app.env.config.highlight_language
+            app.env.config.highlight_language = 'none'
     else:
-        if not app.env.config.rst_epilog and hasattr(app.env.config, 'rst_epilog_cache') and app.env.config.rst_epilog_cache:
+        if not app.env.config.rst_epilog and hasattr(app.env.config, 'rst_epilog_cache') and 
+                app.env.config.rst_epilog_cache:
             app.env.config.rst_epilog = app.env.config.rst_epilog_cache
-        if not app.env.config.rst_prolog and hasattr(app.env.config, 'rst_prolog_cache') and app.env.config.rst_prolog_cache:
+        if not app.env.config.rst_prolog and hasattr(app.env.config, 'rst_prolog_cache') and 
+                app.env.config.rst_prolog_cache:
             app.env.config.rst_prolog = app.env.config.rst_prolog_cache
+        if app.env.config.highlight_language == 'none' and 
+                hasattr(app.env.config, 'highlight_language_cache') and 
+                app.env.config.highlight_language_cache:
+            app.env.config.highlight_language = app.env.config.highlight_language_cache
+            
+
+# -- Configure Application --------------------------------------------------
 
 def setup(app):
-    app.connect('source-read', source_read_handler)
+    app.connect('source-read', source_read_handler) # Used for Markdown files
+    from jsonEllipsisLexer import JsonEllipsisLexer # Add JsonEllipsisLexer (json-ellipsis)
+    app.add_lexer("json-ellipsis", JsonEllipsisLexer())

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -728,15 +728,15 @@ def source_read_handler(app, docname, source):
             app.env.config.highlight_language_cache = app.env.config.highlight_language
             app.env.config.highlight_language = 'none'
     else:
-        if not app.env.config.rst_epilog and hasattr(app.env.config, 'rst_epilog_cache') and 
-                app.env.config.rst_epilog_cache:
+        if (not app.env.config.rst_epilog and hasattr(app.env.config, 'rst_epilog_cache') and 
+                app.env.config.rst_epilog_cache):
             app.env.config.rst_epilog = app.env.config.rst_epilog_cache
-        if not app.env.config.rst_prolog and hasattr(app.env.config, 'rst_prolog_cache') and 
-                app.env.config.rst_prolog_cache:
+        if (not app.env.config.rst_prolog and hasattr(app.env.config, 'rst_prolog_cache') and 
+                app.env.config.rst_prolog_cache):
             app.env.config.rst_prolog = app.env.config.rst_prolog_cache
-        if app.env.config.highlight_language == 'none' and 
+        if (app.env.config.highlight_language == 'none' and 
                 hasattr(app.env.config, 'highlight_language_cache') and 
-                app.env.config.highlight_language_cache:
+                app.env.config.highlight_language_cache):
             app.env.config.highlight_language = app.env.config.highlight_language_cache
             
 

--- a/cdap-docs/_common/jsonEllipsisLexer.py
+++ b/cdap-docs/_common/jsonEllipsisLexer.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""
+    json-ellipsis-lexer
+    ~~~~~~~~~~~~~~~~~~~~
+
+    JSON Lexer thta handles an ellipsis in the form of
+    three periods on a line of its own.
+
+    :copyright: Copyright 2016 Cask Data.
+    :license: Apache License.
+    
+"""
+
+from pygments.lexer import include, inherit, bygroups
+from pygments.lexers.data import JsonLexer
+from pygments.token import Text, Comment
+
+class JsonEllipsisLexer(JsonLexer):
+    """
+    For JSON examples with ellipses (three periods on a line of its own):
+    
+    ...
+    
+    """
+
+    name = 'JSON-E'
+    aliases = ['json-ellipsis']
+
+    tokens = {
+        'ellipsis': [
+            (r'(\s*)(\.{3})(\s*)', bygroups(Text, Comment, Text)),
+        ],
+
+        # a json value - either a simple value or a complex value (object or array)
+        'value': [
+            inherit,
+            include('ellipsis'),
+        ],
+    }

--- a/cdap-docs/admin-manual/source/installation/mapr.rst
+++ b/cdap-docs/admin-manual/source/installation/mapr.rst
@@ -110,7 +110,7 @@ that value instead for ``/cdap/tx.snapshot``.
 .. |hdfs-user| replace:: ``cdap``
 
 .. include:: /../target/_includes/mapr-configuration.rst
-    :end-before:   .. _mapr-configuration-options-may-need
+    :end-before:   .. _mapr-configuration-options-may-need:
 
 #. Due to an issue with the version of the Kafka ZooKeeper client shipped with MapR, 
    it is necessary to disable use of the embedded Kafka in CDAP by setting these properties:
@@ -129,9 +129,9 @@ that value instead for ``/cdap/tx.snapshot``.
         <value>OFF</value>
       </property>
       
-    As a consequence of this setting, the container logs will not be streamed back to the
-    master process log file. This issue is due to a `known Kafka issue 
-    <https://issues.apache.org/jira/browse/TWILL-139?focusedCommentId=14598628>`__.   
+   As a consequence of this setting, the container logs will not be streamed back to the
+   master process log file. This issue is due to a `known Kafka issue 
+   <https://issues.apache.org/jira/browse/TWILL-139?focusedCommentId=14598628>`__.   
     
 #. Depending on your installation, you may need to set these properties:
 

--- a/cdap-docs/cdap-apps/build.sh
+++ b/cdap-docs/cdap-apps/build.sh
@@ -133,8 +133,8 @@ function download_includes() {
   echo_red_bold "Using $hydrator_source"
   get_hydrator_version $base_target $hydrator_source
   
-  # 1:Includes dir 2:GitHub Hydrator source dir 3:Hydrator dir 4:Type 5:Target filename 6:Source Markdown filename
-
+  # Parameter          1            2                3                 4                      5
+  # Definition         base_target  base_source      source_dir        source_file_name       append_file (optional)
   download_md_doc_file $base_target $hydrator_source cassandra-plugins Cassandra-batchsink.md 
   download_md_doc_file $base_target $hydrator_source cassandra-plugins Cassandra-batchsource.md 
   download_md_doc_file $base_target $hydrator_source cassandra-plugins Cassandra-realtimesink.md 

--- a/cdap-docs/cdap-apps/source/data-quality/index.rst
+++ b/cdap-docs/cdap-apps/source/data-quality/index.rst
@@ -72,6 +72,8 @@ The application can be created from the ``cdap-data-quality`` system artifact by
 * ``datasetName``: Name of the destination dataset
 * ``fieldAggregations``: Map that relates each field value to a set of aggregation functions
 
+.. highlight:: console
+
 Deploying the Application
 -------------------------
 To deploy the application with the application configuration, issue a PUT curl call.

--- a/cdap-docs/cdap-apps/source/hydrator/custom.rst
+++ b/cdap-docs/cdap-apps/source/hydrator/custom.rst
@@ -1061,6 +1061,8 @@ The widget JSON is composed of two lists:
 - a list of property configuration groups and
 - a list of output properties.
 
+.. highlight:: json-ellipsis  
+
 For example::
 
   {
@@ -1072,9 +1074,10 @@ For example::
     "outputs": [
       {"ouput-property-1"},
       {"ouput-property-2"},
-      ...
     ]
   }
+
+.. highlight:: json
 
 Configuration Groups
 ....................
@@ -1098,10 +1101,9 @@ In the case of the *Batch Source* plugin, it could look like this::
         ]
       }
     ],
-    outputs: [
-      {output-property1},
-      {output-property2},
-      ..
+    "outputs": [
+      {"output-property1"},
+      {"output-property2"}
     ]
   }
 
@@ -1127,41 +1129,45 @@ available field names.)
 
 In the case of our *Batch Source* plugin example, the ``configuration-groups`` can be represented by::
 
-  "configuration-groups": [
-    {
-      "label": "Batch Source",
-      "properties": [
-        {
-          "widget-type": "dataset-selector",
-          "label": "Dataset Name",
-          "name": "name"
-        },
-        {
-          "widget-type": "textbox",
-          "label": "Dataset Base Path",
-          "name": "basePath"
-        },
-        {
-          "widget-type": "textbox",
-          "label": "Group By Fields",
-          "name": "groupByFields",
-          "plugin-function": {
-            "method": "POST",
-            "widget": "outputSchema",
-            "output-property": "schema",
-            "plugin-method": "outputSchema",
-            "required-fields": ["groupByFields", "aggregates"],
-            "missing-required-fields-message":
-              "'Group By Fields' & 'Aggregates' properties are required to fetch schema."
+  {
+    "configuration-groups": [
+      {
+        "label": "Batch Source",
+        "properties": [
+          {
+            "widget-type": "dataset-selector",
+            "label": "Dataset Name",
+            "name": "name"
+          },
+          {
+            "widget-type": "textbox",
+            "label": "Dataset Base Path",
+            "name": "basePath"
+          },
+          {
+            "widget-type": "textbox",
+            "label": "Group By Fields",
+            "name": "groupByFields",
+            "plugin-function": {
+              "method": "POST",
+              "widget": "outputSchema",
+              "output-property": "schema",
+              "plugin-method": "outputSchema",
+              "required-fields": ["groupByFields", "aggregates"],
+              "missing-required-fields-message":
+                "'Group By Fields' & 'Aggregates' properties are required to fetch schema."
+            }
+          },
+          {
+            "widget-type": "textbox",
+            "label": "Delay",
+            "name": "delay"
           }
-        },
-        {
-          "widget-type": "textbox",
-          "label": "Delay",
-          "name": "delay"
-        }
-      ]
-
+        ]
+      }
+    ]
+  }
+  
 .. _custom-widgets:
 
 Widgets
@@ -1288,60 +1294,63 @@ For example:
 The output properties of the Twitter real-time source, with an explicit, non-editable schema property,
 composed of the fields *id*, *time*, *favCount*, *rtCount*, *geoLat*, *geoLong*, and *isRetweet*::
 
-  "outputs": [
-    {
-      "widget-type": "non-editable-schema-editor",
-      "schema": {
-        "id": "long",
-        "message": "string",
-        "lang": [
-          "string",
-          "null"
-        ],
-        "time": [
-          "long",
-          "null"
-        ],
-        "favCount": "int",
-        "rtCount": "int",
-        "source": [
-          "string",
-          "null"
-        ],
-        "geoLat": [
-          "double",
-          "null"
-        ],
-        "geoLong": [
-          "double",
-          "null"
-        ],
-        "isRetweet": "boolean"
+  {
+    "outputs": [
+      {
+        "widget-type": "non-editable-schema-editor",
+        "schema": {
+          "id": "long",
+          "message": "string",
+          "lang": [
+            "string",
+            "null"
+          ],
+          "time": [
+            "long",
+            "null"
+          ],
+          "favCount": "int",
+          "rtCount": "int",
+          "source": [
+            "string",
+            "null"
+          ],
+          "geoLat": [
+            "double",
+            "null"
+          ],
+          "geoLong": [
+            "double",
+            "null"
+          ],
+          "isRetweet": "boolean"
+        }
       }
-    }
-  ]
+    ]
+  }
 
 In contrast, our "Batch Source" plugin could have a configurable output schema::
 
-  "outputs": [
-    {
-      "name": "schema",
-      "widget-type": "schema",
-      "widget-attributes": {
-        "schema-types": [
-          "boolean",
-          "int",
-          "long",
-          "float",
-          "double",
-          "string",
-          "map<string, string>"
-        ],
-        "schema-default-type": "string"
+  {
+    "outputs": [
+      {
+        "name": "schema",
+        "widget-type": "schema",
+        "widget-attributes": {
+          "schema-types": [
+            "boolean",
+            "int",
+            "long",
+            "float",
+            "double",
+            "string",
+            "map<string, string>"
+          ],
+          "schema-default-type": "string"
+        }
       }
-    }
-  ]
-
+    ]
+  }
 
 Widget types for output properties are limited to ensure that the schema that is propagated across
 different plugins in the CDAP UI is consistent.

--- a/cdap-docs/cdap-apps/source/hydrator/overview.rst
+++ b/cdap-docs/cdap-apps/source/hydrator/overview.rst
@@ -8,12 +8,6 @@
 ETL Overview 
 ============
 
-.. toctree::
-    :hidden:
-    :glob:
-
-    **
-
 A Quick Intro to ETL
 ====================
 

--- a/cdap-docs/cdap-apps/source/tracker/index.rst
+++ b/cdap-docs/cdap-apps/source/tracker/index.rst
@@ -95,6 +95,7 @@ or (Distributed CDAP):
 
 Tracker is built from a system artifact included with CDAP, |literal-cask-tracker-version-jar|.
 
+.. highlight:: xml  
 
 Installation
 ============
@@ -145,7 +146,9 @@ in the ``cdap-site.xml`` as described above, need to follow these steps:
     .. parsed-literal::
 
       |cdap >| load artifact target/|cask-tracker-version-jar|
-    
+
+.. highlight:: json  
+
 - Create an application configuration file (``appconfig.txt``) that contains the Kafka
   Audit Log reader configuration (the property ``auditLogKafkaConfig``). It is the Kafka
   Consumer Flowlet configuration information. For example::
@@ -338,6 +341,7 @@ connecting to a Navigator instance:
 Details on completing this form are described in CDAP's documentation on
 :ref:`Navigator Integration Application <navigator-integration>`.
 
+.. highlight:: console  
 
 Tracker HTTP RESTful API
 ========================
@@ -380,6 +384,8 @@ results available, plus the offset used for the set of results returned. This is
 for pagination through the results. Results are sorted so that the most recent audit event
 in the time range is returned first.
 
+.. highlight:: json  
+
 If there are no results, an empty set of results will be returned (pretty-printed here for
 display)::
 
@@ -390,9 +396,14 @@ display)::
   }
 
 
-Example::
+Example:
 
-  curl -w'\n' -X GET 'http://localhost:10000/v3/namespaces/default/apps/_Tracker/services/AuditLog/methods/auditlog/stream/who?limit=1&startTime=now-5d-12h&endTime=now-12h'
+.. tabbed-parsed-literal::
+
+  $ curl -w'\n' -X GET 'http://localhost:10000/v3/namespaces/default/apps/_Tracker/services/AuditLog/methods/auditlog/stream/who?limit=1&startTime=now-5d-12h&endTime=now-12h'
+
+
+.. highlight:: json-ellipsis
 
 Results (reformatted for display)::
 
@@ -437,9 +448,7 @@ Results (reformatted for display)::
           }
         }
       },
-      
-      . . .
-      
+      ...
       {
         "version": 1,
         "time": 1461266805404,

--- a/cdap-docs/developers-manual/source/building-blocks/artifacts.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/artifacts.rst
@@ -91,6 +91,8 @@ JSON config file must be provided to specify which artifacts it extends. In addi
 artifact is a third-party JAR, the plugins in the artifact can be explicitly listed in that same config
 file. 
 
+.. highlight:: json
+
 For example, suppose you want to add ``mysql-connector-java-5.1.3.jar`` as a system artifact. The
 artifact is the MySQL JDBC driver, and is a third-party JAR that we want to use as a JDBC plugin for
 the ``cdap-etl-batch`` artifact. You would place the JAR file in the artifacts directory along with a
@@ -112,6 +114,8 @@ This config file specifies that the artifact can be used by versions 3.2.0 (incl
 of the cdap-etl-batch artifact. It also specifies that there is one plugin of type ``jdbc`` and name
 ``mysql`` with class ``com.mysql.jdbc.Driver``. Once added, this system artifact would be usable by
 applications in all namespaces.
+
+.. highlight:: java
 
 Example Use Case: Configurable Applications
 ===========================================
@@ -185,6 +189,8 @@ Our development team writes code such as::
       table.put(put);
     }
   }
+
+.. highlight:: console
 
 Our build system creates a JAR named ``myapp-1.0.0.jar`` that contains the ``MyApp`` class.
 The JAR is deployed via the RESTful API::

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/fileset.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/fileset.rst
@@ -104,6 +104,8 @@ Using a FileSet as input or output of a MapReduce program is the same as for any
 The MapReduce program only needs to specify the names of the input and output datasets.
 Whether they are FileSets or another type of dataset is handled by the CDAP runtime system.
 
+.. highlight:: console
+
 However, you do need to tell CDAP the relative paths of the input and output files. Currently,
 this is only possible by specifying them as runtime arguments when the MapReduce program is started::
 
@@ -116,6 +118,8 @@ Note that for the input you can specify multiple paths separated by commas::
       "dataset.lines.input.paths":  "monday/lines.txt,tuesday/lines.txt"
 
 If you do not specify both the input and output paths, your MapReduce program will fail with an error.
+
+.. highlight:: java
 
 Using a FileSet Programmatically
 ================================

--- a/cdap-docs/faqs/source/cdap.rst
+++ b/cdap-docs/faqs/source/cdap.rst
@@ -13,6 +13,7 @@ FAQs: CDAP
 
 .. rubric:: Configuration: General
 
+.. highlight:: console
 
 .. _faq-installation-startup-memory-core-requirements:
 
@@ -70,8 +71,8 @@ you can add this location to your PATH to prevent the need for specifying the en
 **Note:** These commands will list the contents of the package ``cdap-cli``, once it has
 been installed::
 
-  rpm -ql cdap-cli
-  dpkg -L cdap-cli
+  $ rpm -ql cdap-cli
+  $ dpkg -L cdap-cli
 
 
 .. rubric:: Installation: YARN
@@ -212,7 +213,7 @@ One item to check is that your system's network setting is configured to exclude
 not be able to communicate with each other, and you'll see error messages such as these.
 You can set a system's network setting for a proxy by using::
 
-  export no_proxy="localhost,127.0.0.1"
+  $ export no_proxy="localhost,127.0.0.1"
 
 
 The HiveServer2 already listens on port 10000; what should I do?
@@ -241,16 +242,16 @@ Things to check as possible solutions:
 
 1. Check if the JDK being used is :ref:`supported by CDAP <admin-manual-install-java-runtime>`::
 
-    java -version
+    $ java -version
 
 #. Check if the CDAP user is using a :ref:`correct version of the JDK <admin-manual-install-java-runtime>`::
 
-    sudo su - <cdap-user> 
-    java -version
+    $ sudo su - <cdap-user> 
+    $ java -version
    
 #. Run this command to see if all the CDAP classpaths are included::
 
-    /opt/cdap/master/bin/svc-master classpath | tr ':' '\n'
+    $ /opt/cdap/master/bin/svc-master classpath | tr ':' '\n'
    
    Expect to see (where *<version>* is the appropriate ``hbase-compat`` version)::
 

--- a/cdap-docs/faqs/source/cloudera-manager.rst
+++ b/cdap-docs/faqs/source/cloudera-manager.rst
@@ -7,6 +7,8 @@
 
 .. _faqs-cloudera-manager:
 
+.. highlight:: console
+
 ======================
 FAQs: Cloudera Manager
 ======================

--- a/cdap-docs/integrations/source/partners/cloudera/ingesting.rst
+++ b/cdap-docs/integrations/source/partners/cloudera/ingesting.rst
@@ -32,6 +32,7 @@ When using CDAP with Impala:
 
 - |fileset|_ The **CDAP FileSet Datasets** can be explored through ad-hoc SQL-like queries.
 
+.. highlight:: console
 
 Ingesting and Exploring Data with Impala
 ========================================

--- a/cdap-docs/reference-manual/source/http-restful-api/configuration.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/configuration.rst
@@ -59,8 +59,8 @@ format, the output would be similar to (showing the first portion, reformatted t
     "security.token.digest.keylength": "128",
     "metrics.memory.mb": "256",
     "data.tx.server.io.threads": "2",
-    ...
-  }
+
+   }
 
 .. highlight:: console
 


### PR DESCRIPTION
Fixes a number of highlighting, formatting, and reST errors uncovered when running a local test of the documentation build under Sphinx 1.4.1.

Fix for https://issues.cask.co/browse/CDAP-2572. With this fixes, the documentation build could run under Sphinx 1.4.x. That version is better at surfacing errors in builds than the 1.3.x series.

Adds a new "json-ellipsis" lexer. Invoke in a reST document using:

```
.. highlight:: json-ellipsis
```

Then, a JSON file—that otherwise would be incorrect—will be colored correctly. For example (though this won't be colored, the actual result [is available](http://builds.cask.co/artifact/CDAP-DQB10/shared/build-3/Docs-HTML/3.5.0-SNAPSHOT/en/cdap-apps/hydrator/custom.html#plugin-widget-json)):

```
  {
    "configuration-groups": [
      {"group-1"},
      {"group-2"},
      ...
    ],
    "outputs": [
      {"ouput-property-1"},
      {"ouput-property-2"},
    ]
  }
```

Note that the JSON, aside from adding the line with the ellipsis (as three periods) must be syntactically correct. You can only use it to add as an additional element.

Passes [Quick Build 3](http://builds.cask.co/browse/CDAP-DQB10-3).
