### PR TITLE
[CDAP-5995] - Removes the usage of $filter from angular while ordering connections in hydrator++

### DIFF
--- a/cdap-ui/app/features/hydratorplusplus/services/canvas-factory.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/canvas-factory.js
@@ -16,7 +16,7 @@
  */
 
   angular.module(PKG.name + '.feature.hydratorplusplus')
-  .factory('HydratorPlusPlusCanvasFactory', function(myHelpers, $q, myAlertOnValium, GLOBALS, $filter) {
+  .factory('HydratorPlusPlusCanvasFactory', function(myHelpers, $q, myAlertOnValium, GLOBALS) {
 
     /*
       This is the inner utility function that is used once we have a source node to start our traversal.
@@ -94,7 +94,8 @@
       addConnectionsInOrder(source[0], finalConnections, originalConnections);
       if (finalConnections.length < originalConnections.length) {
         originalConnections.forEach(function(oConn) {
-          if ($filter('filter')(finalConnections, oConn).length === 0) {
+          var match = finalConnections.filter(fConn => fConn.from === oConn.from && fConn.to === oConn.to).length === 0;
+          if (match) {
             parallelConnections.push(oConn);
           }
         });


### PR DESCRIPTION
- While ordering connections (going from source or the first transform) in hydrator++ we do a filtering operation for already added connection. The filtering checks for base case, in the sense if there is `["string1 string2"]` and if I do a filter for `"string1"`, `"string1 string2"` gets returned back.

<img width="1184" alt="screen shot 2016-05-13 at 8 48 11 am" src="https://cloud.githubusercontent.com/assets/1452845/15257303/835af310-18fa-11e6-9b05-09d64ad0e219.png">
- Removes angular's `$filter` and replaced it with native `filter` method in JS.
