### PR TITLE
Revert "CDAP-5553 Upgrade Workflow run records to separate out Workflow token and node states."

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
@@ -20,7 +20,6 @@ import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.stream.StreamSpecification;
 import co.cask.cdap.api.dataset.table.Table;
-import co.cask.cdap.api.workflow.NodeStatus;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.common.app.RunIds;
@@ -712,81 +711,5 @@ public class AppMetadataStore extends MetadataStoreDataset {
       }
       return true;
     }
-  }
-
-  /**
-   * Upgrade the Workflow run records. This method iterate over all Workflow run records
-   * and create new records for Workflow token and Workflow node states based on the properties.
-   */
-  public void upgradeWorkflowRunRecords() {
-    final String workflowTokenPropertyName = "workflowToken";
-    String runtimeArgsPropertyName = "runtimeArgs";
-    MDSKey startKey = new MDSKey.Builder().add(TYPE_RUN_RECORD_COMPLETED).build();
-    MDSKey endKey = new MDSKey(Bytes.stopKeyForPrefix(startKey.getKey()));
-    Predicate<RunRecordMeta> predicate = new Predicate<RunRecordMeta>() {
-      @Override
-      public boolean apply(@Nullable RunRecordMeta input) {
-        return input != null && input.getProperties().containsKey(workflowTokenPropertyName);
-      }
-    };
-
-    Map<MDSKey, RunRecordMeta> wfRunRecords = listKV(startKey, endKey, RunRecordMeta.class, Integer.MAX_VALUE,
-                                                     predicate);
-
-    for (Map.Entry<MDSKey, RunRecordMeta> wfRunRecord : wfRunRecords.entrySet()) {
-      String runId = wfRunRecord.getValue().getPid();
-      ProgramRunId workflowRunId = getProgramIdFromRunRecordKey(wfRunRecord.getKey()).run(runId);
-
-      Map<String, String> runRecordProperties = wfRunRecord.getValue().getProperties();
-
-      String workflowToken = runRecordProperties.get(workflowTokenPropertyName);
-      updateWorkflowToken(workflowRunId, GSON.fromJson(workflowToken, BasicWorkflowToken.class));
-
-      for (Map.Entry<String, String> property : runRecordProperties.entrySet()) {
-        if (property.getKey().equals(workflowTokenPropertyName) || property.getKey().equals(runtimeArgsPropertyName)) {
-          // property is for workflow token or runtime argument
-          continue;
-        }
-
-        // Property is of type - <program name, program run id>
-        String programName = property.getKey();
-        String programRunId = property.getValue();
-        ProgramId programId = Ids.namespace(workflowRunId.getNamespace()).app(workflowRunId.getApplication())
-          .mr(programName);
-        // Check if the current property is MapReduce program
-        RunRecordMeta completedRun = getCompletedRun(programId.toId(), programRunId);
-        if (completedRun == null) {
-          // Check if current property is for Spark program
-          programId = Ids.namespace(workflowRunId.getNamespace()).app(workflowRunId.getApplication())
-            .spark(programName);
-          completedRun = getCompletedRun(programId.toId(), programRunId);
-        }
-
-        if (completedRun == null) {
-          continue;
-        }
-
-        NodeStatus nodeStatus = ProgramRunStatus.toNodeStatus(completedRun.getStatus());
-        WorkflowNodeStateDetail nodeStateDetail = new WorkflowNodeStateDetail(programName, nodeStatus, programRunId,
-                                                                              null);
-        addWorkflowNodeState(workflowRunId, nodeStateDetail);
-      }
-    }
-  }
-
-  private ProgramId getProgramIdFromRunRecordKey(MDSKey key) {
-    MDSKey.Splitter splitter = key.split();
-    // Skip the RunRecord type.
-    splitter.skipString();
-    // Namespace id is the next part.
-    String namespaceId = splitter.getString();
-    // Application id is the next part.
-    String applicationId = splitter.getString();
-    // Program type is the next part.
-    String programType = splitter.getString();
-    // Program id is the next part.
-    String programId = splitter.getString();
-
-    return Ids.namespace(namespaceId).app(applicationId).program(ProgramType.valueOf(programType), programId);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -1185,15 +1185,4 @@ public class DefaultStore implements Store {
         }
       }, apps.get());
   }
-
-  public void upgrade() {
-    appsTx.get().executeUnchecked(
-      new TransactionExecutor.Function<AppMetadataStore, Void>() {
-        @Override
-        public Void apply(AppMetadataStore mds) throws Exception {
-          mds.upgradeWorkflowRunRecords();
-          return null;
-        }
-      }, apps.get());
-  }
 }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -109,7 +109,6 @@ public class UpgradeTool {
   private final ExistingEntitySystemMetadataWriter existingEntitySystemMetadataWriter;
   private final DatasetServiceManager datasetServiceManager;
   private final NamespaceStore nsStore;
-  private final DefaultStore store;
 
   /**
    * Set of Action available in this tool.
@@ -119,10 +118,9 @@ public class UpgradeTool {
               "  The upgrade tool upgrades the following: \n" +
               "  1. User and System Datasets (upgrades the coprocessor jars)\n" +
               "  2. Stream State Store\n" +
-              "  3. Workflow run records in Application Metadata Store\n" +
-              "  4. System metadata for all existing entities\n" +
-              "  5. Metadata indexes for all existing metadata\n" +
-              "  6. Any metadata that may have left behind for deleted datasets (This metadata will be removed).\n" +
+              "  3. System metadata for all existing entities\n" +
+              "  4. Metadata indexes for all existing metadata\n" +
+              "  5. Any metadata that may have left behind for deleted datasets (This metadata will be removed).\n" +
               "  Note: Once you run the upgrade tool you cannot rollback to the previous version."),
     UPGRADE_HBASE("After an HBase upgrade, updates the coprocessor jars of all user and \n" +
                     "system HBase tables to a version that is compatible with the new HBase \n" +
@@ -155,7 +153,6 @@ public class UpgradeTool {
     this.dsSpecUpgrader = injector.getInstance(DatasetSpecificationUpgrader.class);
     this.queueAdmin = injector.getInstance(QueueAdmin.class);
     this.nsStore = injector.getInstance(NamespaceStore.class);
-    this.store = injector.getInstance(DefaultStore.class);
 
     Runtime.getRuntime().addShutdownHook(new Thread() {
       @Override
@@ -386,9 +383,6 @@ public class UpgradeTool {
 
     LOG.info("Upgrading stream state store table...");
     streamStateStoreUpgrader.upgrade();
-
-    LOG.info("Upgrading Workflow run records in application metadata store table...");
-    store.upgrade();
 
     datasetServiceManager.startUp();
     LOG.info("Writing system metadata to existing entities...");


### PR DESCRIPTION
This reverts commit 0b50080875b52eb455cab2f69a28f8e6fa5e1f62.

In 3.4 we moved the WorkflowToken from Workflow run record to separate row. Also created the separate rows representing states of the nodes running inside the Workflow. 

The upgrade step was added to create node states and separate out Workflow token from pre 3.4 run records. 

This is not required in 3.5, as 3.4 Workflow runs will already have separate rows for WorkflowToken and node states and pre 3.4 run records would be taken care by upgrade path 3.3.x -> 3.4.y.
