### PR TITLE
Porting critical fixes back to release/3.3

### DIFF
--- a/cdap-app-fabric/src/main/java/org/apache/twill/internal/yarn/AbstractYarnTwillService.java
+++ b/cdap-app-fabric/src/main/java/org/apache/twill/internal/yarn/AbstractYarnTwillService.java
@@ -17,10 +17,16 @@
  */
 package org.apache.twill.internal.yarn;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DFSUtil;
+import org.apache.hadoop.hdfs.HAUtil;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.twill.api.RunId;
+import org.apache.twill.filesystem.ForwardingLocationFactory;
+import org.apache.twill.filesystem.HDFSLocationFactory;
 import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
 import org.apache.twill.internal.AbstractTwillService;
 import org.apache.twill.internal.Constants;
 import org.apache.twill.internal.state.Message;
@@ -32,8 +38,14 @@ import org.slf4j.LoggerFactory;
 import java.io.BufferedInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.Map;
 
 /**
+ * TODO: copied from Twill 0.7 AbstractYarnTwillService for CDAP-5844.
+ * Remove after this fix is moved to Twill (TWILL-171).
+ *
  * Abstract class for implementing {@link com.google.common.util.concurrent.Service} that runs in
  * YARN container which provides methods to handle secure token updates.
  */
@@ -88,6 +100,9 @@ public abstract class AbstractYarnTwillService extends AbstractTwillService {
       }
 
       UserGroupInformation.getCurrentUser().addCredentials(credentials);
+
+      // CDAP-5844 Workaround for HDFS-9276, to update HDFS delegation token for long running application in HA mode
+      cloneHaNnCredentials(location, UserGroupInformation.getCurrentUser());
       this.credentials = credentials;
 
       LOG.info("Secure store updated from {}.", location);
@@ -97,5 +112,41 @@ public abstract class AbstractYarnTwillService extends AbstractTwillService {
     }
 
     return true;
+  }
+
+  private static void cloneHaNnCredentials(Location location, UserGroupInformation ugi) throws IOException {
+    Configuration hConf = getConfiguration(location.getLocationFactory());
+    String scheme = location.toURI().getScheme();
+
+    Map<String, Map<String, InetSocketAddress>> nsIdMap = DFSUtil.getHaNnRpcAddresses(hConf);
+    for (Map.Entry<String, Map<String, InetSocketAddress>> entry : nsIdMap.entrySet()) {
+      String nsId = entry.getKey();
+      Map<String, InetSocketAddress> addressesInNN = entry.getValue();
+      if (!HAUtil.isHAEnabled(hConf, nsId) || addressesInNN == null || addressesInNN.isEmpty()) {
+        continue;
+      }
+      // The client may have a delegation token set for the logical
+      // URI of the cluster. Clone this token to apply to each of the
+      // underlying IPC addresses so that the IPC code can find it.
+
+      URI uri = URI.create(scheme + "://" + nsId);
+      LOG.info("Cloning delegation token for uri {}", uri);
+      HAUtil.cloneDelegationTokenForLogicalUri(ugi, uri, addressesInNN.values());
+    }
+  }
+
+  /**
+   * Gets the Hadoop Configuration from LocationFactory.
+   */
+  private static Configuration getConfiguration(LocationFactory locationFactory) throws IOException {
+    LOG.debug("getFileSystem(): locationFactory is a {}", locationFactory.getClass());
+    if (locationFactory instanceof HDFSLocationFactory) {
+      return ((HDFSLocationFactory) locationFactory).getFileSystem().getConf();
+    }
+    if (locationFactory instanceof ForwardingLocationFactory) {
+      return getConfiguration(((ForwardingLocationFactory) locationFactory).getDelegate());
+    }
+    throw new IllegalArgumentException(String.format("Unknown LocationFactory type: %s",
+                                                     locationFactory.getClass().getName()));
   }
 }

--- a/cdap-app-fabric/src/main/java/org/apache/twill/internal/yarn/AbstractYarnTwillService.java
+++ b/cdap-app-fabric/src/main/java/org/apache/twill/internal/yarn/AbstractYarnTwillService.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.twill.internal.yarn;
+
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.twill.api.RunId;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.internal.AbstractTwillService;
+import org.apache.twill.internal.Constants;
+import org.apache.twill.internal.state.Message;
+import org.apache.twill.internal.state.SystemMessages;
+import org.apache.twill.zookeeper.ZKClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+
+/**
+ * Abstract class for implementing {@link com.google.common.util.concurrent.Service} that runs in
+ * YARN container which provides methods to handle secure token updates.
+ */
+public abstract class AbstractYarnTwillService extends AbstractTwillService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractYarnTwillService.class);
+  protected final Location applicationLocation;
+  protected volatile Credentials credentials;
+
+  protected AbstractYarnTwillService(ZKClient zkClient, RunId runId, Location applicationLocation) {
+    super(zkClient, runId);
+    this.applicationLocation = applicationLocation;
+  }
+
+  /**
+   * Returns the location of the secure store, or {@code null} if either not running in secure mode or an error
+   * occur when trying to acquire the location.
+   */
+  protected final Location getSecureStoreLocation() {
+    if (!UserGroupInformation.isSecurityEnabled()) {
+      return null;
+    }
+    try {
+      return applicationLocation.append(Constants.Files.CREDENTIALS);
+    } catch (IOException e) {
+      LOG.error("Failed to create secure store location.", e);
+      return null;
+    }
+  }
+
+  /**
+   * Attempts to handle secure store update.
+   *
+   * @param message The message received
+   * @return {@code true} if the message requests for secure store update, {@code false} otherwise.
+   */
+  protected final boolean handleSecureStoreUpdate(Message message) {
+    if (!SystemMessages.SECURE_STORE_UPDATED.equals(message)) {
+      return false;
+    }
+
+    // If not in secure mode, simply ignore the message.
+    if (!UserGroupInformation.isSecurityEnabled()) {
+      return true;
+    }
+
+    try {
+      Credentials credentials = new Credentials();
+      Location location = getSecureStoreLocation();
+      try (DataInputStream input = new DataInputStream(new BufferedInputStream(location.getInputStream()))) {
+        credentials.readTokenStorageStream(input);
+      }
+
+      UserGroupInformation.getCurrentUser().addCredentials(credentials);
+      this.credentials = credentials;
+
+      LOG.info("Secure store updated from {}.", location);
+
+    } catch (Throwable t) {
+      LOG.error("Failed to update secure store.", t);
+    }
+
+    return true;
+  }
+}

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -66,7 +66,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.io.Closeables;
-import com.google.common.io.Files;
 import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.gson.Gson;
@@ -80,6 +79,7 @@ import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hive.service.auth.HiveAuthFactory;
 import org.apache.hive.service.cli.CLIService;
@@ -97,6 +97,7 @@ import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
@@ -105,6 +106,13 @@ import java.io.Reader;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
@@ -668,7 +676,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
 
     try {
       // Even with the "IF NOT EXISTS" in the create command, Hive still logs a non-fatal warning internally
-      // when attempting to create the "default" namsepace (since it already exists in Hive).
+      // when attempting to create the "default" namespace (since it already exists in Hive).
       // This check prevents the extra warn log.
       if (Id.Namespace.DEFAULT.equals(namespace)) {
         return QueryHandle.NO_OP;
@@ -860,7 +868,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
       File previewFile = operationInfo.getPreviewFile();
       if (previewFile != null) {
         try {
-          Reader reader = Files.newReader(previewFile, Charsets.UTF_8);
+          Reader reader = com.google.common.io.Files.newReader(previewFile, Charsets.UTF_8);
           try {
             return GSON.fromJson(reader, new TypeToken<List<QueryResult>>() { }.getType());
           } finally {
@@ -925,7 +933,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     return listBuilder.build();
   }
 
-  protected void setCurrentDatabase(String dbName) throws Throwable {
+  private void setCurrentDatabase(String dbName) throws Throwable {
     SessionState.get().setCurrentDatabase(dbName);
   }
 
@@ -1057,7 +1065,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     while (count < secondsToWait) {
       try {
         datasetFramework.getInstances(Id.Namespace.DEFAULT);
-        LOG.info("Dataset service is up and running, proceding with explore upgrade.");
+        LOG.info("Dataset service is up and running, proceeding with explore upgrade.");
         return;
       } catch (Exception e) {
         count++;
@@ -1221,7 +1229,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     }
   }
 
-  private String getHiveDatabase(String namespace) {
+  private String getHiveDatabase(@Nullable String namespace) {
     // null namespace implies that the operation happens across all databases
     if (namespace == null) {
       return null;
@@ -1235,12 +1243,17 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
    * @return configuration for a hive session that contains a transaction, and serialized CDAP configuration and
    * HBase configuration. This will be used by the map-reduce tasks started by Hive.
    * @throws IOException
+   * @throws ExploreException
    */
-  protected Map<String, String> startSession() throws IOException {
+  protected Map<String, String> startSession() throws IOException, ExploreException {
     return startSession(null);
   }
 
-  protected Map<String, String> startSession(Id.Namespace namespace) throws IOException {
+  protected Map<String, String> startSession(Id.Namespace namespace) throws IOException, ExploreException {
+    if (UserGroupInformation.isSecurityEnabled()) {
+      updateTokenStore();
+    }
+
     Map<String, String> sessionConf = Maps.newHashMap();
 
     QueryHandle queryHandle = QueryHandle.generate();
@@ -1259,6 +1272,37 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     ConfigurationUtil.set(sessionConf, Constants.Explore.HCONF_KEY, HConfCodec.INSTANCE, hConf);
 
     return sessionConf;
+  }
+
+  /**
+   * Updates the token store to be used for the hive job, based upon the Explore container's credentials.
+   * This is because twill doesn't update the container_tokens on upon token refresh.
+   * See: https://issues.apache.org/jira/browse/TWILL-170
+   */
+  private void updateTokenStore() throws IOException, ExploreException {
+    String hadoopTokenFileLocation = System.getenv(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION);
+    if (hadoopTokenFileLocation == null) {
+      LOG.warn("Skipping update of token store due to failure to find environment variable '{}'.",
+               UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION);
+      return;
+    }
+
+    Path credentialsFile = Paths.get(hadoopTokenFileLocation);
+
+    FileAttribute<Set<PosixFilePermission>> originalPermissionAttributes =
+      PosixFilePermissions.asFileAttribute(Files.getPosixFilePermissions(credentialsFile));
+
+    Path tmpFile = Files.createTempFile(credentialsFile.getParent(), "credentials.store", null,
+                                        originalPermissionAttributes);
+    LOG.debug("Writing to temporary file: {}", tmpFile);
+
+    try (DataOutputStream os = new DataOutputStream(Files.newOutputStream(tmpFile))) {
+      Credentials credentials = UserGroupInformation.getCurrentUser().getCredentials();
+      credentials.writeTokenStorageToStream(os);
+    }
+
+    Files.move(tmpFile, credentialsFile, StandardCopyOption.ATOMIC_MOVE);
+    LOG.debug("Secure store saved to {}", credentialsFile);
   }
 
   protected QueryHandle getQueryHandle(Map<String, String> sessionConf) throws HandleNotFoundException {

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -1250,10 +1250,6 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
   }
 
   protected Map<String, String> startSession(Id.Namespace namespace) throws IOException, ExploreException {
-    if (UserGroupInformation.isSecurityEnabled()) {
-      updateTokenStore();
-    }
-
     Map<String, String> sessionConf = Maps.newHashMap();
 
     QueryHandle queryHandle = QueryHandle.generate();
@@ -1270,6 +1266,13 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     ConfigurationUtil.set(sessionConf, Constants.Explore.TX_QUERY_KEY, TxnCodec.INSTANCE, tx);
     ConfigurationUtil.set(sessionConf, Constants.Explore.CCONF_KEY, CConfCodec.INSTANCE, cConf);
     ConfigurationUtil.set(sessionConf, Constants.Explore.HCONF_KEY, HConfCodec.INSTANCE, hConf);
+
+    if (UserGroupInformation.isSecurityEnabled()) {
+      // make sure RM does not cancel delegation tokens after the query is run
+      sessionConf.put("mapreduce.job.complete.cancel.delegation.tokens", "false");
+      // refresh delegations for the job - TWILL-170
+      updateTokenStore();
+    }
 
     return sessionConf;
   }


### PR DESCRIPTION
Porting critical fixes to release/3.3:

Failure to update HDFS delegation token for long running application in HA mode
https://issues.cask.co/browse/CDAP-5844 
PR https://github.com/caskdata/cdap/pull/5697

Explore should use updated credentials while launching Hive jobs
https://issues.cask.co/browse/CDAP-5793
PR https://github.com/caskdata/cdap/pull/5683

HDFS delegation token of CDAP Master is getting cancelled by RM after an explore query run
https://issues.cask.co/browse/CDAP-5855
PR https://github.com/caskdata/cdap/pull/5708

Done:
- Verification that this resolves the issues against CDAP 3.3.2/3.3.3.

http://builds.cask.co/browse/CDAP-DUT4080-3
