### PR TITLE
Disable explore, where possible.

### DIFF
--- a/cdap-app-templates/cdap-data-quality/src/test/java/co/cask/cdap/dq/test/DataQualityAppTest.java
+++ b/cdap-app-templates/cdap-data-quality/src/test/java/co/cask/cdap/dq/test/DataQualityAppTest.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scanner;
 import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.dq.AggregationTypeValue;
 import co.cask.cdap.dq.DataQualityApp;
 import co.cask.cdap.dq.DataQualityService;
@@ -80,7 +81,7 @@ public class DataQualityAppTest extends TestBase {
   private static final Integer WORKFLOW_SCHEDULE_MINUTES = 5;
 
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
   private static Id.Artifact appArtifact;
   private static boolean sentData = false;

--- a/cdap-app-templates/cdap-data-quality/src/test/java/co/cask/cdap/dq/test/DataQualityAppTest.java
+++ b/cdap-app-templates/cdap-data-quality/src/test/java/co/cask/cdap/dq/test/DataQualityAppTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -38,6 +38,7 @@ import co.cask.cdap.test.MapReduceManager;
 import co.cask.cdap.test.ServiceManager;
 import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequests;
 import co.cask.common.http.HttpResponse;
@@ -51,6 +52,7 @@ import org.apache.avro.mapred.AvroKey;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.lang.reflect.Type;
@@ -71,12 +73,14 @@ import javax.annotation.Nullable;
 public class DataQualityAppTest extends TestBase {
   private static final Gson GSON = new Gson();
   private static final Type TOKEN_TYPE_LIST_TIMESTAMP_VALUE = new TypeToken<ArrayList<TimestampValue>>() { }.getType();
-  private static final Type TOKEN_TYPE_DOUBLE = new TypeToken<Double>() { }.getType();
   private static final Type TOKEN_TYPE_MAP_STRING_INTEGER = new TypeToken<Map<String, Integer>>() { }.getType();
   private static final Type TOKEN_TYPE_LIST_AGGREGATION_TYPE_VALUES =
     new TypeToken<List<AggregationTypeValue>>() { }.getType();
   private static final Type TOKEN_TYPE_SET_FIELD_DETAIL = new TypeToken<HashSet<FieldDetail>>() { }.getType();
   private static final Integer WORKFLOW_SCHEDULE_MINUTES = 5;
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   private static Id.Artifact appArtifact;
   private static boolean sentData = false;
@@ -93,6 +97,12 @@ public class DataQualityAppTest extends TestBase {
 
   @Before
   public void beforeTest() throws Exception {
+    if (sentData) {
+      return;
+    }
+    sentData = true;
+
+    // getStreamManager is not available from a static context (from a beforeClass)
     StreamManager streamManager = getStreamManager("logStream");
     streamManager.createStream();
     String logData1 = "10.10.10.10 - - [01/Feb/2015:06:47:10 +0000] " +
@@ -107,12 +117,9 @@ public class DataQualityAppTest extends TestBase {
       " \"GET /browse/COOP-DBT-JOB1-238/artifact HTTP/1.1\"" +
       " 301 256 \"-\" \"Mozilla/5.0 (compatible; AhrefsBot/5.0; +http://ahrefs.com/robot/)\"";
 
-    if (!sentData) {
-      streamManager.send(logData1);
-      streamManager.send(logData2);
-      streamManager.send(logData3);
-      sentData = true;
-    }
+    streamManager.send(logData1);
+    streamManager.send(logData2);
+    streamManager.send(logData3);
   }
 
   @Test(expected = IllegalStateException.class)
@@ -123,7 +130,7 @@ public class DataQualityAppTest extends TestBase {
     testMap.put("content_length", new HashSet<String>());
 
     DataQualityApp.DataQualityConfig config = new DataQualityApp.DataQualityConfig(
-      50, getStreamSource(), "avg", null);
+      50, getStreamSource(), "avg", testMap);
 
     AppRequest<DataQualityApp.DataQualityConfig> appRequest = new AppRequest<>(
       new ArtifactSummary(appArtifact.getName(), appArtifact.getVersion().getVersion()), config);
@@ -206,10 +213,7 @@ public class DataQualityAppTest extends TestBase {
 
     List<TimestampValue> tsValueListActual = GSON.fromJson(response, TOKEN_TYPE_LIST_TIMESTAMP_VALUE);
     TimestampValue firstTimestampValue = tsValueListActual.get(0);
-    Object objActual = firstTimestampValue.getValue();
-    String actualJSON = GSON.toJson(objActual);
-    Double actualDouble = GSON.fromJson(actualJSON, TOKEN_TYPE_DOUBLE);
-    Assert.assertEquals(actualDouble, new Double(256.0));
+    Assert.assertEquals(256.0, firstTimestampValue.getValue());
     serviceManager.stop();
     serviceManager.waitForFinish(180, TimeUnit.SECONDS);
   }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
@@ -78,7 +78,7 @@ public class DataPipelineTest extends HydratorTestBase {
   protected static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("app", "1.0.0");
   private static int startCount = 0;
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
   @BeforeClass
   public static void setupTest() throws Exception {

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/batch/ETLBatchTestBase.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/batch/ETLBatchTestBase.java
@@ -18,6 +18,7 @@ package co.cask.cdap.etl.batch;
 
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.etl.mock.test.HydratorTestBase;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
 import co.cask.cdap.proto.id.ArtifactId;
@@ -46,7 +47,7 @@ public class ETLBatchTestBase extends HydratorTestBase {
   private static int startCount = 0;
 
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
   @BeforeClass
   public static void setupTest() throws Exception {

--- a/cdap-examples/FileSetExample/src/test/java/co/cask/cdap/examples/fileset/FileSetWordCountTest.java
+++ b/cdap-examples/FileSetExample/src/test/java/co/cask/cdap/examples/fileset/FileSetWordCountTest.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.common.RuntimeArguments;
 import co.cask.cdap.api.common.Scope;
 import co.cask.cdap.api.dataset.lib.FileSet;
 import co.cask.cdap.api.dataset.lib.FileSetArguments;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.MapReduceManager;
@@ -51,7 +52,7 @@ import java.util.concurrent.TimeUnit;
 public class FileSetWordCountTest extends TestBase {
 
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
   @Test
   public void testWordCountOnFileSet() throws Exception {

--- a/cdap-examples/HelloWorld/src/test/java/co/cask/cdap/examples/helloworld/HelloWorldTest.java
+++ b/cdap-examples/HelloWorld/src/test/java/co/cask/cdap/examples/helloworld/HelloWorldTest.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.examples.helloworld;
 
 import co.cask.cdap.api.metrics.RuntimeMetrics;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.FlowManager;
 import co.cask.cdap.test.ServiceManager;
@@ -39,7 +40,7 @@ import java.util.concurrent.TimeUnit;
 public class HelloWorldTest extends TestBase {
 
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
   @Test
   public void test() throws Exception {

--- a/cdap-examples/LogAnalysis/src/test/java/co/cask/cdap/examples/loganalysis/LogAnalysisAppTest.java
+++ b/cdap-examples/LogAnalysis/src/test/java/co/cask/cdap/examples/loganalysis/LogAnalysisAppTest.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.examples.loganalysis;
 
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.MapReduceManager;
 import co.cask.cdap.test.ServiceManager;
@@ -55,7 +56,7 @@ public class LogAnalysisAppTest extends TestBase {
   private static final Map<String, Integer> TPFS_RESULT = ImmutableMap.of("127.0.1.1", 1, "127.0.0.1", 2);
 
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
   @Test
   public void test() throws Exception {

--- a/cdap-examples/Purchase/src/test/java/co/cask/cdap/examples/purchase/PurchaseAppTest.java
+++ b/cdap-examples/Purchase/src/test/java/co/cask/cdap/examples/purchase/PurchaseAppTest.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.examples.purchase;
 
 import co.cask.cdap.api.metrics.RuntimeMetrics;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.FlowManager;
 import co.cask.cdap.test.MapReduceManager;
@@ -41,7 +42,7 @@ import java.util.concurrent.TimeUnit;
 public class PurchaseAppTest extends TestBase {
 
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
   private static final Gson GSON = new Gson();
 

--- a/cdap-examples/SpamClassifier/src/test/java/co/cask/cdap/examples/sparkstreaming/SpamClassifierTest.java
+++ b/cdap-examples/SpamClassifier/src/test/java/co/cask/cdap/examples/sparkstreaming/SpamClassifierTest.java
@@ -15,6 +15,7 @@
  */
 package co.cask.cdap.examples.sparkstreaming;
 
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.test.ApplicationManager;
@@ -57,7 +58,7 @@ import java.util.concurrent.TimeUnit;
 public class SpamClassifierTest extends TestBase {
 
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
   private static final String KAFKA_TOPIC = "someTopic";
   private static final String KAFKA_BROKER_ID = "1";

--- a/cdap-examples/SpamClassifier/src/test/java/co/cask/cdap/examples/sparkstreaming/SpamClassifierTest.java
+++ b/cdap-examples/SpamClassifier/src/test/java/co/cask/cdap/examples/sparkstreaming/SpamClassifierTest.java
@@ -22,6 +22,7 @@ import co.cask.cdap.test.ServiceManager;
 import co.cask.cdap.test.SparkManager;
 import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequests;
 import co.cask.common.http.HttpResponse;
@@ -35,6 +36,7 @@ import org.apache.twill.kafka.client.KafkaPublisher;
 import org.apache.twill.zookeeper.ZKClientService;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.BufferedReader;
@@ -53,6 +55,9 @@ import java.util.concurrent.TimeUnit;
  * Test for {@link SpamClassifier}
  */
 public class SpamClassifierTest extends TestBase {
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   private static final String KAFKA_TOPIC = "someTopic";
   private static final String KAFKA_BROKER_ID = "1";

--- a/cdap-examples/SparkKMeans/src/test/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansAppTest.java
+++ b/cdap-examples/SparkKMeans/src/test/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansAppTest.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.examples.sparkkmeans;
 
 import co.cask.cdap.api.metrics.RuntimeMetrics;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.FlowManager;
 import co.cask.cdap.test.ServiceManager;
@@ -41,7 +42,7 @@ import java.util.concurrent.TimeUnit;
 public class SparkKMeansAppTest extends TestBase {
 
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
   @Test
   public void test() throws Exception {

--- a/cdap-examples/SparkPageRank/src/test/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankAppTest.java
+++ b/cdap-examples/SparkPageRank/src/test/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankAppTest.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.examples.sparkpagerank;
 
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.MapReduceManager;
 import co.cask.cdap.test.ServiceManager;
@@ -45,7 +46,7 @@ public class SparkPageRankAppTest extends TestBase {
   private static final String TOTAL_PAGES = "1";
 
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
   @Test
   public void test() throws Exception {

--- a/cdap-examples/UserProfiles/src/test/java/co/cask/cdap/examples/profiles/UserProfilesTest.java
+++ b/cdap-examples/UserProfiles/src/test/java/co/cask/cdap/examples/profiles/UserProfilesTest.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.dataset.table.Get;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.metrics.RuntimeMetrics;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.FlowManager;
@@ -44,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 public class UserProfilesTest extends TestBase {
 
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
   @Test
   public void testUserProfiles() throws Exception {

--- a/cdap-examples/WebAnalytics/src/test/java/co/cask/cdap/examples/webanalytics/WebAnalyticsTest.java
+++ b/cdap-examples/WebAnalytics/src/test/java/co/cask/cdap/examples/webanalytics/WebAnalyticsTest.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.examples.webanalytics;
 
 import co.cask.cdap.api.metrics.RuntimeMetrics;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.FlowManager;
 import co.cask.cdap.test.StreamManager;
@@ -38,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 public class WebAnalyticsTest extends TestBase {
 
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
   @Test
   public void testWebAnalytics() throws Exception {

--- a/cdap-examples/WikipediaPipeline/src/test/java/co/cask/cdap/examples/wikipedia/WikipediaPipelineAppTest.java
+++ b/cdap-examples/WikipediaPipeline/src/test/java/co/cask/cdap/examples/wikipedia/WikipediaPipelineAppTest.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.artifact.ArtifactVersion;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.RunRecord;
@@ -51,7 +52,7 @@ import javax.annotation.Nullable;
 public class WikipediaPipelineAppTest extends TestBase {
   private static final Gson GSON = new Gson();
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
   private static final Id.Artifact ARTIFACT_ID =
     Id.Artifact.from(Id.Namespace.DEFAULT, "WikipediaPipelineArtifact", new ArtifactVersion("1.0"));

--- a/cdap-examples/WordCount/src/test/java/co/cask/cdap/examples/wordcount/WordCountTest.java
+++ b/cdap-examples/WordCount/src/test/java/co/cask/cdap/examples/wordcount/WordCountTest.java
@@ -19,6 +19,7 @@ package co.cask.cdap.examples.wordcount;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.metrics.RuntimeMetrics;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.FlowManager;
@@ -47,7 +48,7 @@ import java.util.concurrent.TimeUnit;
 public class WordCountTest extends TestBase {
 
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
   private static final Type STRING_MAP_TYPE = new TypeToken<Map<String, String>>() { }.getType();
   private static final Type OBJECT_MAP_TYPE = new TypeToken<Map<String, Object>>() { }.getType();

--- a/cdap-unit-test/src/test/java/co/cask/cdap/admin/AdminAppTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/admin/AdminAppTestRun.java
@@ -23,6 +23,7 @@ import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.dataset.table.Get;
 import co.cask.cdap.api.dataset.table.Put;
 import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.internal.guava.reflect.TypeToken;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
@@ -57,7 +58,7 @@ import java.util.concurrent.TimeUnit;
 public class AdminAppTestRun extends TestFrameworkTestBase {
 
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
   private static final Gson GSON = new Gson();
 

--- a/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
@@ -75,6 +75,9 @@ import java.util.concurrent.TimeUnit;
  */
 public class AuthorizationTest extends TestBase {
 
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
+
   private static final String OLD_USER = SecurityRequestContext.getUserId();
   private static final Principal ALICE = new Principal("alice", Principal.PrincipalType.USER);
   private static final Principal BOB = new Principal("bob", Principal.PrincipalType.USER);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/SparkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/SparkTestRun.java
@@ -97,7 +97,7 @@ public class SparkTestRun extends TestFrameworkTestBase {
   public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
 
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkTestRun.class);
 

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -1476,34 +1476,6 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     Assert.assertEquals("value1", new Gson().fromJson(response, String.class));
   }
 
-  @Test(timeout = 90000L)
-  public void testSQLQuery() throws Exception {
-    // Deploying app makes sure that the default namespace is available.
-    deployApplication(testSpace, DummyApp.class);
-    deployDatasetModule(testSpace, "my-kv", AppsWithDataset.KeyValueTableDefinition.Module.class);
-    deployApplication(testSpace, AppsWithDataset.AppWithAutoCreate.class);
-    DataSetManager<AppsWithDataset.KeyValueTableDefinition.KeyValueTable> myTableManager =
-      getDataset(testSpace, "myTable");
-    AppsWithDataset.KeyValueTableDefinition.KeyValueTable kvTable = myTableManager.get();
-    kvTable.put("a", "1");
-    kvTable.put("b", "2");
-    kvTable.put("c", "1");
-    myTableManager.flush();
-
-    try (
-      Connection connection = getQueryClient(testSpace);
-      ResultSet results = connection.prepareStatement("select first from dataset_mytable where second = '1'")
-                                    .executeQuery()
-    ) {
-      // run a query over the dataset
-      Assert.assertTrue(results.next());
-      Assert.assertEquals("a", results.getString(1));
-      Assert.assertTrue(results.next());
-      Assert.assertEquals("c", results.getString(1));
-      Assert.assertFalse(results.next());
-    }
-  }
-
   @Category(XSlowTests.class)
   @Test
   public void testByteCodeClassLoader() throws Exception {

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestSQLQueryTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestSQLQueryTestRun.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.app;
+
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.test.DataSetManager;
+import co.cask.cdap.test.base.TestFrameworkTestBase;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+
+/**
+ * Tests ability to perform SQL query on datasets.
+ */
+public class TestSQLQueryTestRun extends TestFrameworkTestBase {
+
+  private final Id.Namespace testSpace = Id.Namespace.from("testspace");
+
+  @Before
+  public void setUp() throws Exception {
+    getNamespaceAdmin().create(new NamespaceMeta.Builder().setName(testSpace).build());
+  }
+
+  @Test(timeout = 90000L)
+  public void testSQLQuery() throws Exception {
+    // Deploying app makes sure that the default namespace is available.
+    deployApplication(testSpace, DummyApp.class);
+    deployDatasetModule(testSpace, "my-kv", AppsWithDataset.KeyValueTableDefinition.Module.class);
+    deployApplication(testSpace, AppsWithDataset.AppWithAutoCreate.class);
+    DataSetManager<AppsWithDataset.KeyValueTableDefinition.KeyValueTable> myTableManager =
+      getDataset(testSpace, "myTable");
+    AppsWithDataset.KeyValueTableDefinition.KeyValueTable kvTable = myTableManager.get();
+    kvTable.put("a", "1");
+    kvTable.put("b", "2");
+    kvTable.put("c", "1");
+    myTableManager.flush();
+
+    try (
+      Connection connection = getQueryClient(testSpace);
+      ResultSet results = connection.prepareStatement("select first from dataset_mytable where second = '1'")
+        .executeQuery()
+    ) {
+      // run a query over the dataset
+      Assert.assertTrue(results.next());
+      Assert.assertEquals("a", results.getString(1));
+      Assert.assertTrue(results.next());
+      Assert.assertEquals("c", results.getString(1));
+      Assert.assertFalse(results.next());
+    }
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/base/TestFrameworkExploreTestSuite.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/base/TestFrameworkExploreTestSuite.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.base;
+
+import co.cask.cdap.partitioned.PartitionConsumingTestRun;
+import co.cask.cdap.test.XSlowTests;
+import co.cask.cdap.test.app.DummyBaseCloneTestRun;
+import co.cask.cdap.test.app.DummyBaseTestRun;
+import co.cask.cdap.test.app.TestSQLQueryTestRun;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * This is a test suite that runs all tests in the cdap-unit-test module that require explore to be enabled.
+ * This avoid starting/stopping app-fabric per test.
+ */
+@Category(XSlowTests.class)
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+  DummyBaseTestRun.class,
+  DummyBaseCloneTestRun.class,
+  PartitionConsumingTestRun.class,
+  TestSQLQueryTestRun.class
+})
+public class TestFrameworkExploreTestSuite extends TestFrameworkTestBase {
+
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/base/TestFrameworkTestSuite.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/base/TestFrameworkTestSuite.java
@@ -18,6 +18,7 @@ package co.cask.cdap.test.base;
 
 import co.cask.cdap.admin.AdminAppTestRun;
 import co.cask.cdap.batch.stream.BatchStreamIntegrationTestRun;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.flow.stream.FlowStreamIntegrationTestRun;
 import co.cask.cdap.mapreduce.MapReduceStreamInputTestRun;
 import co.cask.cdap.mapreduce.service.MapReduceServiceIntegrationTestRun;
@@ -63,6 +64,6 @@ public class TestFrameworkTestSuite extends TestFrameworkTestBase {
   // Note that setting the following configuration in any of the above Test classes is ignored, since
   // they are run as part of this TestSuite.
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
 }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/base/TestFrameworkTestSuite.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/base/TestFrameworkTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -21,7 +21,6 @@ import co.cask.cdap.batch.stream.BatchStreamIntegrationTestRun;
 import co.cask.cdap.flow.stream.FlowStreamIntegrationTestRun;
 import co.cask.cdap.mapreduce.MapReduceStreamInputTestRun;
 import co.cask.cdap.mapreduce.service.MapReduceServiceIntegrationTestRun;
-import co.cask.cdap.partitioned.PartitionConsumingTestRun;
 import co.cask.cdap.service.FileUploadServiceTestRun;
 import co.cask.cdap.spark.SparkFileSetTestRun;
 import co.cask.cdap.spark.SparkStreamingTestRun;
@@ -29,30 +28,28 @@ import co.cask.cdap.spark.SparkTestRun;
 import co.cask.cdap.spark.metrics.SparkMetricsIntegrationTestRun;
 import co.cask.cdap.spark.service.SparkServiceIntegrationTestRun;
 import co.cask.cdap.spark.stream.SparkStreamIntegrationTestRun;
+import co.cask.cdap.test.TestConfiguration;
 import co.cask.cdap.test.XSlowTests;
-import co.cask.cdap.test.app.DummyBaseCloneTestRun;
-import co.cask.cdap.test.app.DummyBaseTestRun;
 import co.cask.cdap.test.app.ServiceLifeCycleTestRun;
 import co.cask.cdap.test.app.TestFrameworkTestRun;
+import org.junit.ClassRule;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 /**
- * This is a test suite that runs all tests in the cdap-unit-test. This avoid starting/stopping app-fabric per test.
+ * This is a test suite that runs all tests in the cdap-unit-test module that don't require explore to be enabled.
+ * This avoid starting/stopping app-fabric per test.
  */
 @Category(XSlowTests.class)
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
   AdminAppTestRun.class,
   BatchStreamIntegrationTestRun.class,
-  DummyBaseTestRun.class,
-  DummyBaseCloneTestRun.class,
   FileUploadServiceTestRun.class,
   FlowStreamIntegrationTestRun.class,
   MapReduceStreamInputTestRun.class,
   MapReduceServiceIntegrationTestRun.class,
-  PartitionConsumingTestRun.class,
   ServiceLifeCycleTestRun.class,
   SparkFileSetTestRun.class,
   SparkMetricsIntegrationTestRun.class,
@@ -63,4 +60,9 @@ import org.junit.runners.Suite;
   TestFrameworkTestRun.class
 })
 public class TestFrameworkTestSuite extends TestFrameworkTestBase {
+  // Note that setting the following configuration in any of the above Test classes is ignored, since
+  // they are run as part of this TestSuite.
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+
 }


### PR DESCRIPTION
Disable explore for test cases where its not used, to speed up test runtimes.

It's hard to gauge the runtime of tests on develop since it varies, but comparing the build times, it seems like this improves the run times by ~15 minutes.

Edit: scratch that. It's hard to determine the exact runtime improvement, because I ran the same build twice and there's a ~10 minute deviation just between runs of the same code.

https://issues.cask.co/browse/CDAP-4693
http://builds.cask.co/browse/CDAP-DUT4144
