### PR TITLE
(CDAP-5684) Don’t stop Worker in the test.

### DIFF
--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/AbstractClientTest.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/AbstractClientTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.client;
+
+import co.cask.cdap.StandaloneTester;
+import co.cask.cdap.cli.util.InstanceURIParser;
+import co.cask.cdap.client.config.ClientConfig;
+import co.cask.cdap.client.config.ConnectionConfig;
+import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.common.ProgramNotFoundException;
+import co.cask.cdap.common.UnauthenticatedException;
+import co.cask.cdap.internal.test.AppJarHelper;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramRecord;
+import co.cask.cdap.proto.ProgramType;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import org.apache.twill.filesystem.LocalLocationFactory;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.jar.Manifest;
+
+/**
+ * Base class for writing client unit-test. It provides common functionality for writing client tests.
+ */
+public abstract class AbstractClientTest {
+
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+  protected ClientConfig clientConfig;
+
+  protected abstract StandaloneTester getStandaloneTester();
+
+  @Before
+  public void setUp() throws Throwable {
+    StandaloneTester standalone = getStandaloneTester();
+    ConnectionConfig connectionConfig = InstanceURIParser.DEFAULT.parse(standalone.getBaseURI().toString());
+    clientConfig = new ClientConfig.Builder()
+      .setDefaultReadTimeout(60 * 1000)
+      .setUploadReadTimeout(120 * 1000)
+      .setConnectionConfig(connectionConfig).build();
+  }
+
+  protected ClientConfig getClientConfig() {
+    return clientConfig;
+  }
+
+  protected void verifyProgramNames(List<String> expected, List<ProgramRecord> actual) {
+    Assert.assertEquals(expected.size(), actual.size());
+    for (ProgramRecord actualProgram : actual) {
+      Assert.assertTrue(expected.contains(actualProgram.getName()));
+    }
+  }
+
+  protected void verifyProgramRecords(List<String> expected, Map<ProgramType, List<ProgramRecord>> map) {
+    verifyProgramNames(expected, Lists.newArrayList(Iterables.concat(map.values())));
+  }
+
+  protected void assertFlowletInstances(ProgramClient programClient, Id.Flow.Flowlet flowlet, int numInstances)
+    throws IOException, NotFoundException, UnauthenticatedException {
+
+    int actualInstances;
+    int numTries = 0;
+    int maxTries = 5;
+    do {
+      actualInstances = programClient.getFlowletInstances(flowlet);
+      numTries++;
+    } while (actualInstances != numInstances && numTries <= maxTries);
+    Assert.assertEquals(numInstances, actualInstances);
+  }
+
+  protected void assertProgramRunning(ProgramClient programClient, Id.Program program)
+    throws IOException, ProgramNotFoundException, UnauthenticatedException, InterruptedException {
+
+    assertProgramStatus(programClient, program, "RUNNING");
+  }
+
+  protected void assertProgramStopped(ProgramClient programClient, Id.Program program)
+    throws IOException, ProgramNotFoundException, UnauthenticatedException, InterruptedException {
+
+    assertProgramStatus(programClient, program, "STOPPED");
+  }
+
+  protected void assertProgramStatus(ProgramClient programClient, Id.Program program, String programStatus)
+    throws IOException, ProgramNotFoundException, UnauthenticatedException, InterruptedException {
+
+    try {
+      programClient.waitForStatus(program, programStatus, 60, TimeUnit.SECONDS);
+    } catch (TimeoutException e) {
+      // NO-OP
+    }
+
+    Assert.assertEquals(programStatus, programClient.getStatus(program));
+  }
+
+  protected File createAppJarFile(Class<?> cls) throws IOException {
+    return createArtifactJarFile(cls, new Manifest());
+  }
+
+  protected File createAppJarFile(Class<?> cls, String name, String version) throws IOException {
+    return createArtifactJarFile(cls, name, version, new Manifest());
+  }
+
+  protected File createArtifactJarFile(Class<?> cls, Manifest manifest) throws IOException {
+    return createArtifactJarFile(cls, cls.getSimpleName(),
+                                 String.format("1.0.%d-SNAPSHOT", System.currentTimeMillis()), manifest);
+  }
+
+  protected File createArtifactJarFile(Class<?> cls, String name,
+                                       String version, Manifest manifest) throws IOException {
+
+    File tmpJarFolder = TMP_FOLDER.newFolder();
+    LocationFactory locationFactory = new LocalLocationFactory(tmpJarFolder);
+    Location deploymentJar = AppJarHelper.createDeploymentJar(locationFactory, cls, manifest);
+
+    File appJarFile = new File(tmpJarFolder, String.format("%s-%s.jar", name, version));
+    try {
+      Files.createLink(appJarFile.toPath(), Paths.get(deploymentJar.toURI()));
+    } catch (Exception e) {
+      Files.copy(appJarFile.toPath(), Paths.get(deploymentJar.toURI()));
+    }
+    return appJarFile;
+  }
+}

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/ClientTestsSuite.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/ClientTestsSuite.java
@@ -39,7 +39,6 @@ import org.junit.runners.Suite;
   NamespaceClientTestRun.class,
   PreferencesClientTestRun.class,
   ProgramClientTestRun.class,
-  QueryClientTestRun.class,
   ScheduleClientTestRun.class,
   ServiceClientTestRun.class,
   StreamClientTestRun.class,

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/QueryClientTest.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/QueryClientTest.java
@@ -16,21 +16,24 @@
 
 package co.cask.cdap.client;
 
+import co.cask.cdap.StandaloneTester;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.client.app.FakeApp;
 import co.cask.cdap.client.app.FakeFlow;
-import co.cask.cdap.client.common.ClientTestBase;
 import co.cask.cdap.client.config.ConnectionConfig;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.explore.client.ExploreExecutionResult;
 import co.cask.cdap.explore.client.FixedAddressExploreClient;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.QueryResult;
+import co.cask.cdap.test.SingletonExternalResource;
 import co.cask.cdap.test.XSlowTests;
 import com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
@@ -43,14 +46,25 @@ import java.util.concurrent.ExecutionException;
  * Test for {@link QueryClient}.
  */
 @Category(XSlowTests.class)
-public class QueryClientTestRun extends ClientTestBase {
-  private static final Logger LOG = LoggerFactory.getLogger(QueryClientTestRun.class);
+public class QueryClientTest extends AbstractClientTest {
+
+  @ClassRule
+  public static final SingletonExternalResource STANDALONE = new SingletonExternalResource(
+    new StandaloneTester(Constants.Explore.EXPLORE_ENABLED, true));
+
+  private static final Logger LOG = LoggerFactory.getLogger(QueryClientTest.class);
+
   private ApplicationClient appClient;
   private QueryClient queryClient;
   private NamespaceClient namespaceClient;
   private ProgramClient programClient;
   private StreamClient streamClient;
   private ExploreClient exploreClient;
+
+  @Override
+  protected StandaloneTester getStandaloneTester() {
+    return STANDALONE.get();
+  }
 
   @Before
   public void setUp() throws Throwable {

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/UsageHandlerTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/UsageHandlerTestRun.java
@@ -129,8 +129,8 @@ public class UsageHandlerTestRun extends ClientTestBase {
 
     try {
       startProgram(program);
+      // Wait for the worker to run and then stop.
       waitState(program, ProgramStatus.RUNNING);
-      stopProgram(program);
       waitState(program, ProgramStatus.STOPPED);
 
       Assert.assertTrue(getAppStreamUsage(app).contains(stream));

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/common/ClientTestBase.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/common/ClientTestBase.java
@@ -17,139 +17,22 @@
 package co.cask.cdap.client.common;
 
 import co.cask.cdap.StandaloneTester;
-import co.cask.cdap.cli.util.InstanceURIParser;
-import co.cask.cdap.client.ProgramClient;
-import co.cask.cdap.client.config.ClientConfig;
-import co.cask.cdap.client.config.ConnectionConfig;
-import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.common.ProgramNotFoundException;
-import co.cask.cdap.common.UnauthenticatedException;
-import co.cask.cdap.internal.test.AppJarHelper;
-import co.cask.cdap.proto.Id;
-import co.cask.cdap.proto.ProgramRecord;
-import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.client.AbstractClientTest;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.test.SingletonExternalResource;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import org.apache.twill.filesystem.LocalLocationFactory;
-import org.apache.twill.filesystem.Location;
-import org.apache.twill.filesystem.LocationFactory;
-import org.junit.Assert;
-import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.rules.TemporaryFolder;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.jar.Manifest;
 
 /**
- *
+ * Common base test class for all client unit-tests that doesn't need explore service.
  */
-public abstract class ClientTestBase {
+public abstract class ClientTestBase extends AbstractClientTest {
 
   @ClassRule
-  public static final SingletonExternalResource STANDALONE = new SingletonExternalResource(new StandaloneTester());
+  public static final SingletonExternalResource STANDALONE = new SingletonExternalResource(
+    new StandaloneTester(Constants.Explore.EXPLORE_ENABLED, false));
 
-  @ClassRule
-  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
-
-  protected ClientConfig clientConfig;
-
-  @Before
-  public void setUp() throws Throwable {
-    StandaloneTester standalone = STANDALONE.get();
-    ConnectionConfig connectionConfig = InstanceURIParser.DEFAULT.parse(standalone.getBaseURI().toString());
-    clientConfig = new ClientConfig.Builder()
-      .setDefaultReadTimeout(60 * 1000)
-      .setUploadReadTimeout(120 * 1000)
-      .setConnectionConfig(connectionConfig).build();
-  }
-
-  protected ClientConfig getClientConfig() {
-    return clientConfig;
-  }
-
-  protected void verifyProgramNames(List<String> expected, List<ProgramRecord> actual) {
-    Assert.assertEquals(expected.size(), actual.size());
-    for (ProgramRecord actualProgram : actual) {
-      Assert.assertTrue(expected.contains(actualProgram.getName()));
-    }
-  }
-
-  protected void verifyProgramRecords(List<String> expected, Map<ProgramType, List<ProgramRecord>> map) {
-    verifyProgramNames(expected, Lists.newArrayList(Iterables.concat(map.values())));
-  }
-
-  protected void assertFlowletInstances(ProgramClient programClient, Id.Flow.Flowlet flowlet, int numInstances)
-    throws IOException, NotFoundException, UnauthenticatedException {
-
-    int actualInstances;
-    int numTries = 0;
-    int maxTries = 5;
-    do {
-      actualInstances = programClient.getFlowletInstances(flowlet);
-      numTries++;
-    } while (actualInstances != numInstances && numTries <= maxTries);
-    Assert.assertEquals(numInstances, actualInstances);
-  }
-
-  protected void assertProgramRunning(ProgramClient programClient, Id.Program program)
-    throws IOException, ProgramNotFoundException, UnauthenticatedException, InterruptedException {
-
-    assertProgramStatus(programClient, program, "RUNNING");
-  }
-
-  protected void assertProgramStopped(ProgramClient programClient, Id.Program program)
-    throws IOException, ProgramNotFoundException, UnauthenticatedException, InterruptedException {
-
-    assertProgramStatus(programClient, program, "STOPPED");
-  }
-
-  protected void assertProgramStatus(ProgramClient programClient, Id.Program program, String programStatus)
-    throws IOException, ProgramNotFoundException, UnauthenticatedException, InterruptedException {
-
-    try {
-      programClient.waitForStatus(program, programStatus, 60, TimeUnit.SECONDS);
-    } catch (TimeoutException e) {
-      // NO-OP
-    }
-
-    Assert.assertEquals(programStatus, programClient.getStatus(program));
-  }
-
-  protected File createAppJarFile(Class<?> cls) throws IOException {
-    return createArtifactJarFile(cls, new Manifest());
-  }
-
-  protected File createAppJarFile(Class<?> cls, String name, String version) throws IOException {
-    return createArtifactJarFile(cls, name, version, new Manifest());
-  }
-
-  protected File createArtifactJarFile(Class<?> cls, Manifest manifest) throws IOException {
-    return createArtifactJarFile(cls, cls.getSimpleName(),
-                                 String.format("1.0.%d-SNAPSHOT", System.currentTimeMillis()), manifest);
-  }
-
-  protected File createArtifactJarFile(Class<?> cls, String name,
-                                       String version, Manifest manifest) throws IOException {
-
-    File tmpJarFolder = TMP_FOLDER.newFolder();
-    LocationFactory locationFactory = new LocalLocationFactory(tmpJarFolder);
-    Location deploymentJar = AppJarHelper.createDeploymentJar(locationFactory, cls, manifest);
-
-    File appJarFile = new File(tmpJarFolder, String.format("%s-%s.jar", name, version));
-    try {
-      Files.createLink(appJarFile.toPath(), Paths.get(deploymentJar.toURI()));
-    } catch (Exception e) {
-      Files.copy(appJarFile.toPath(), Paths.get(deploymentJar.toURI()));
-    }
-    return appJarFile;
+  @Override
+  protected StandaloneTester getStandaloneTester() {
+    return STANDALONE.get();
   }
 }


### PR DESCRIPTION
Also speed up client tests by
making most client tests not to have explore enabled.
