### PR TITLE
Fix documentation build.

### DIFF
--- a/cdap-docs/developers-manual/build.sh
+++ b/cdap-docs/developers-manual/build.sh
@@ -83,13 +83,13 @@ function download_includes() {
   echo_red_bold "Check included example files for changes"
   test_an_include 9e137848822e63101b699af03af7f45e ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
 
-  test_an_include 273e0c1d2ff47c6a7a79d2c5d5de4203 ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
+  test_an_include edb7973c5d75f56162eb26e039784e72 ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
   test_an_include 80216a08a2b3d480e4a081722408222f ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryService.java
   test_an_include 29fe1471372678115e643b0ad431b28d ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseStore.java
 
-  test_an_include b58bab093dbf5035c93b334fbf0857fc ../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
+  test_an_include 0844143b24553469697dd78ed1a27adf ../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
 
-  test_an_include ade59884cbd176f1c69a72d571db0cc3 ../../cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/TopNMapReduce.java
+  test_an_include ee6e217f149066751363064d5c913c8d ../../cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/TopNMapReduce.java
 
   test_an_include 8c24858e8d168c0909fd554e96a2aba9 ../../cdap-examples/WikipediaPipeline/src/main/scala/co/cask/cdap/examples/wikipedia/ClusteringUtils.scala
 }

--- a/cdap-docs/developers-manual/source/building-blocks/workflows.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/workflows.rst
@@ -300,7 +300,7 @@ Here is an example, taken from the
 
 .. literalinclude:: /../../../cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/TopNMapReduce.java
    :language: java
-   :lines: 111-125
+   :lines: 110-128
 
 **Note:** The test of ``workflowToken != null`` is only required because this Reducer could
 be used outside of a workflow. When run from within a workflow, the token is guaranteed to

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -138,7 +138,7 @@ function download_includes() {
   # Group alphabetically each example separately, files from each example together
 
   test_an_include 0d1fdc6d75995c3c417886786ccc8997 ../../cdap-examples/ClicksAndViews/src/main/java/co/cask/cdap/examples/clicksandviews/ClicksAndViews.java
-  test_an_include 9c4cd5ce267ac0714abc5a4b724d303a ../../cdap-examples/ClicksAndViews/src/main/java/co/cask/cdap/examples/clicksandviews/ClicksAndViewsMapReduce.java
+  test_an_include 9bea51ff9b9139ee2a636f11ffd4a50a ../../cdap-examples/ClicksAndViews/src/main/java/co/cask/cdap/examples/clicksandviews/ClicksAndViewsMapReduce.java
 
   test_an_include 45cbe451f2821eddf2f1245eff468cee ../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/CountRandom.java
   test_an_include 9dcf41f03ee52e42b77588fe18f542d5 ../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/CountRandomFlow.java
@@ -147,11 +147,11 @@ function download_includes() {
   test_an_include 9f963a17090976d2c15a4d092bd9e8de ../../cdap-examples/CountRandom/src/main/java/co/cask/cdap/examples/countrandom/NumberCounter.java
 
   test_an_include fa746b8f3423736310316f2d48b0fe7d ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansing.java
-  test_an_include 0f13c7ad968facfcea78af2178a29fc4 ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
+  test_an_include fa7c9f6dc0cbd567bbe22b7592c24e9c ../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
 
   test_an_include fe679b53a1dc757a15fd3fcafc2046fd ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetExample.java
   test_an_include 9e137848822e63101b699af03af7f45e ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
-  test_an_include f5f12f77bcbf940a96a3d51ced5488a9 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
+  test_an_include 8dcc2caeda8a76a7ec00bc24d0a7925e ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
   
   test_an_include 4255a2e3d417e928ac5182ddd932139f ../../cdap-examples/HelloWorld/src/main/java/co/cask/cdap/examples/helloworld/HelloWorld.java
 
@@ -159,21 +159,21 @@ function download_includes() {
 
   test_an_include f90e4e4ce08851f45bdbe2563efb51dd ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
   test_an_include 29fe1471372678115e643b0ad431b28d ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseStore.java
-  test_an_include 273e0c1d2ff47c6a7a79d2c5d5de4203 ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
+  test_an_include edb7973c5d75f56162eb26e039784e72 ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
   test_an_include 80216a08a2b3d480e4a081722408222f ../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryService.java
 
   test_an_include 04abc21d3a3423cecc3b9c9619aa960d ../../cdap-examples/SpamClassifier/src/main/java/co/cask/cdap/examples/sparkstreaming/SpamClassifier.java
 
   test_an_include 3f25e035b2de8bd2d127733df1c58ff1 ../../cdap-examples/SparkKMeans/src/main/java/co/cask/cdap/examples/sparkkmeans/SparkKMeansApp.java
   
-  test_an_include b58bab093dbf5035c93b334fbf0857fc ../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
+  test_an_include 0844143b24553469697dd78ed1a27adf ../../cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
 
   test_an_include 1dff2aa10d09f384965e343be7f83f76 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/SportResults.java
   test_an_include c488b6ad3b5708977a8a913460e4e650 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/UploadService.java
-  test_an_include 68df90a54f61ff3c63317aeed865f686 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/ScoreCounter.java
+  test_an_include 58dbd509483bd7a117682d8a3a8ff017 ../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/ScoreCounter.java
   
   test_an_include 6e407b943f7d6c92877023628dceef96 ../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionApp.java
-  test_an_include d52b5c161371b838dc95570a12784c57 ../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
+  test_an_include 1b0e447ff4413f7fbe53052794abf40f ../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
 
   test_an_include 58fe002977ee1a5613f465cc784d769d ../../cdap-examples/UserProfiles/src/main/java/co/cask/cdap/examples/profiles/UserProfiles.java
 
@@ -183,7 +183,7 @@ function download_includes() {
   
   test_an_include 38789a70a89c188443f7cfd05b2ea0db ../../cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/WikipediaPipelineApp.java
   
-  test_an_include 62fdac3280bd99afdf20a8e671ddfe4e ../../cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/WordCount.java
+  test_an_include 5154138de03f9fab4311858225f18dca ../../cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/WordCount.java
 }
 
 run_command ${1}

--- a/cdap-docs/examples-manual/source/examples/clicks-and-views.rst
+++ b/cdap-docs/examples-manual/source/examples/clicks-and-views.rst
@@ -32,7 +32,7 @@ of the application are tied together by the class ``ClicksAndViews``:
 
 Data Storage
 ------------
-- *views* input``Stream`` contains ad views, representing an advertisement displayed on a viewer's screen.
+- *views* input ``Stream`` contains ad views, representing an advertisement displayed on a viewer's screen.
 - *clicks* input ``Stream`` contains ad clicks, representing when a viewer clicks on an advertisement.
 - *joined* output ``PartitionedFileSetFileSet`` contains the joined ad views, which additionally contains the
   count of clicks each ad view has. This Dataset is partitioned on the logical start time of the MapReduce.
@@ -45,7 +45,8 @@ two streams as input and sets up the ``PartitionedFileSet`` as output, with the 
 
 .. literalinclude:: /../../../cdap-examples/ClicksAndViews/src/main/java/co/cask/cdap/examples/clicksandviews/ClicksAndViewsMapReduce.java
    :language: java
-   :lines: 58-73
+   :lines: 58-79
+   :dedent: 2
 
 The Mapper class then keys each of the records based upon the ``viewId``. That results in all clicks and views
 for a particular ``viewId`` going to a single Reducer for joining. In order to do the join properly, the Reducer needs
@@ -54,7 +55,9 @@ to know which source each record came from. This is possible by calling the ``ge
 
 .. literalinclude:: /../../../cdap-examples/ClicksAndViews/src/main/java/co/cask/cdap/examples/clicksandviews/ClicksAndViewsMapReduce.java
    :language: java
-   :lines: 85-95
+   :lines: 86-96
+   :dedent: 2
+   :append: ...
 
 
 .. Building and Starting

--- a/cdap-docs/examples-manual/source/examples/data-cleansing.rst
+++ b/cdap-docs/examples-manual/source/examples/data-cleansing.rst
@@ -128,8 +128,8 @@ Otherwise, this is the default schema that is matched against the records:
 
 .. literalinclude:: /../../../cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
     :language: java
-    :lines: 129-133
-    :dedent: 2
+    :lines: 132-136
+    :dedent: 4
 
 Querying the Results
 --------------------

--- a/cdap-docs/examples-manual/source/examples/fileset-example.rst
+++ b/cdap-docs/examples-manual/source/examples/fileset-example.rst
@@ -93,7 +93,7 @@ dataset can also be given as runtime arguments:
 
 .. literalinclude:: /../../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
     :language: java
-    :lines: 41-64
+    :lines: 33-65
     :append: ...
 
 It is worth mentioning that nothing in ``WordCount`` is specifically programmed to use a FileSet. Instead of

--- a/cdap-docs/examples-manual/source/examples/index.rst
+++ b/cdap-docs/examples-manual/source/examples/index.rst
@@ -1,7 +1,7 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: Examples
-    :copyright: Copyright © 2014-2015 Cask Data, Inc.
+    :copyright: Copyright © 2014-2016 Cask Data, Inc.
 
 :hide-toc: true
 
@@ -44,6 +44,8 @@ In addition to the :ref:`Getting Started's <getting-started-index>`
   * - :doc:`Hello World <hello-world>`
     - A simple HelloWorld App that's written using CDAP. It introduces how the components stream, flow, dataset,
       and service are used in a CDAP application.
+  * - :doc:`Clicks and Views <clicks-and-views>`
+    - An application that demonstrates a reduce-side join across two streams using a MapReduce program.
   * - :doc:`Count Random <count-random>`
     - An application that demonstrates the ``@Tick`` feature of flows. It uses a tick method to generate random
       numbers which are then counted by downstream flowlets.

--- a/cdap-docs/examples-manual/source/examples/purchase.rst
+++ b/cdap-docs/examples-manual/source/examples/purchase.rst
@@ -97,7 +97,8 @@ default values used in configuration and as runtime arguments:
 
 .. literalinclude:: /../../../cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
    :language: java
-   :lines: 47-77
+   :lines: 47-78
+   :append: ...
 
 *PurchaseHistoryService* Service
 --------------------------------

--- a/cdap-docs/examples-manual/source/examples/sport-results.rst
+++ b/cdap-docs/examples-manual/source/examples/sport-results.rst
@@ -94,7 +94,7 @@ Let's take a closer look at the upload method:
 MapReduce over File Partitions
 ==============================
 ``ScoreCounter`` is a simple MapReduce that reads from the *results* PartitionedFileSet and writes to
-the *totals* PartitionedFileSet. The ``beforeSubmit`` method prepares the MapReduce program for this:
+the *totals* PartitionedFileSet. The ``initialize`` method prepares the MapReduce program for this:
 
 - It reads the league that it is supposed to process from the runtime arguments.
 - It constructs a partition filter for the input using the league as the only condition, and instantiates
@@ -104,8 +104,8 @@ the *totals* PartitionedFileSet. The ``beforeSubmit`` method prepares the MapRed
 
 .. literalinclude:: /../../../cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/ScoreCounter.java
     :language: java
-    :lines: 58-84
-    :dedent: 2
+    :lines: 48-86
+    :append: ...
 
 It is worth mentioning that nothing else in ``ScoreCounter`` is specifically programmed to use file partitions.
 Instead of *results* and *totals*, it could use any other dataset as long as the key and value types match.

--- a/cdap-docs/examples-manual/source/examples/stream-conversion.rst
+++ b/cdap-docs/examples-manual/source/examples/stream-conversion.rst
@@ -58,35 +58,35 @@ and it configures the *events* stream as its input and the *converted* dataset a
 
   .. literalinclude:: /../../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
      :language: java
-     :lines: 65-70
+     :lines: 66-71
      :dedent: 4
      
 - Based on the logical start time, the MapReduce determines the range of events to read from the stream:
 
   .. literalinclude:: /../../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
      :language: java
-     :lines: 72-74
+     :lines: 73-75
      :dedent: 4
 
 - Each MapReduce run writes its output to a partition with the logical start time:
 
   .. literalinclude:: /../../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
      :language: java
-     :lines: 77-79
+     :lines: 78-79
      :dedent: 4
 
 - Note that the output file path is derived from the output partition time by the dataset itself:
 
   .. literalinclude:: /../../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
      :language: java
-     :lines: 81-82
+     :lines: 81-83
      :dedent: 4
 
 - The Mapper itself is straight-forward: for each event, it emits an Avro record:
 
   .. literalinclude:: /../../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
      :language: java
-     :lines: 88-100
+     :lines: 89-101
      :dedent: 2
 
 

--- a/cdap-docs/examples-manual/source/examples/word-count.rst
+++ b/cdap-docs/examples-manual/source/examples/word-count.rst
@@ -47,10 +47,10 @@ Data Storage
 ------------
 The application uses these datasets by default:
 
-- ``wordStats`` stores the global statistics of total count of words and the total length of words received.
-- ``wordCounts`` stores the word and the corresponding count in a key value table.
-- ``uniqueCount`` is a custom dataset that stores the total count of unique words received so far.
-- ``wordAssocs`` is a custom dataset that stores the count for word associations.
+- ``wordStatsTable`` stores the global statistics of total count of words and the total length of words received.
+- ``wordCountTable`` stores the word and the corresponding count in a key value table.
+- ``uniqueCountTable`` is a custom dataset that stores the total count of unique words received so far.
+- ``wordAssocTable`` is a custom dataset that stores the count for word associations.
 
 However, the names of these datasets can be configured to be different from their defaults by providing a
 configuration at application deployment time. All programs rely on this configuration to instantiate their
@@ -139,6 +139,8 @@ To query the ``RetrieveCounts`` service, either:
 
     $ curl -w"\n" -X GET "http://localhost:10000/v3/namespaces/default/apps/WordCount/services/RetrieveCounts/methods/count/CDAP"
 
+.. highlight:: json
+
 The word count and top-10 associations words for that word will be displayed in JSON
 format (example reformatted to fit; results will depend on what you have submitted)::
 
@@ -151,6 +153,8 @@ format (example reformatted to fit; results will depend on what you have submitt
     "count":6,
     "word":"CDAP"
   }
+
+.. highlight:: console
 
 You can also make requests to the other endpoints available in this service, as 
 :ref:`described above <word-count-service-requests>`.

--- a/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/WordCount.java
+++ b/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/WordCount.java
@@ -94,7 +94,7 @@ public class WordCount extends AbstractApplication<WordCount.WordCountConfig> {
     // Ingest data into the Application via Streams
     addStream(new Stream(config.getStream()));
 
-    // Store processed data in Datasetss
+    // Store processed data in Datasets
     createDataset(config.getWordStatsTable(), Table.class,
                   DatasetProperties.builder().setDescription("Stats of total counts and lengths of words").build());
     createDataset(config.getWordCountTable(), KeyValueTable.class,


### PR DESCRIPTION
Fixes MD5 hashes and changes made in various example files.

Corrects a typo in one of the example files, and adds to the main example table a missing example.

Passes [Quick Build 2](http://builds.cask.co/browse/CDAP-DQB12-2).
