### PR TITLE
Varioues unit-test improvements to speedup tests

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/PreferencesHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/PreferencesHttpHandlerTest.java
@@ -17,14 +17,19 @@
 package co.cask.cdap.internal.app.services.http.handlers;
 
 import co.cask.cdap.WordCountApp;
-import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.api.app.Application;
+import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.app.store.Store;
 import co.cask.cdap.gateway.handlers.PreferencesHttpHandler;
+import co.cask.cdap.internal.app.deploy.Specifications;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Map;
@@ -33,6 +38,18 @@ import java.util.Map;
  * Tests for {@link PreferencesHttpHandler}
  */
 public class PreferencesHttpHandlerTest extends AppFabricTestBase {
+
+  private static Store store;
+
+  @BeforeClass
+  public static void init() {
+    store = getInjector().getInstance(Store.class);
+  }
+
+  private void addApplication(String namespace, Application app) {
+    ApplicationSpecification appSpec = Specifications.from(app);
+    store.addApplication(new NamespaceId(namespace).app(appSpec.getName()).toId(), appSpec);
+  }
 
   @Test
   public void testInstance() throws Exception {
@@ -95,7 +112,7 @@ public class PreferencesHttpHandlerTest extends AppFabricTestBase {
 
   @Test
   public void testApplication() throws Exception {
-    deploy(WordCountApp.class, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE1);
+    addApplication(TEST_NAMESPACE1, new WordCountApp());
     Map<String, String> propMap = Maps.newHashMap();
     Assert.assertEquals(propMap, getProperty(getURI(TEST_NAMESPACE1, "WordCountApp"), false, 200));
     Assert.assertEquals(propMap, getProperty(getURI(TEST_NAMESPACE1, "WordCountApp"), true, 200));
@@ -124,7 +141,7 @@ public class PreferencesHttpHandlerTest extends AppFabricTestBase {
 
   @Test
   public void testProgram() throws Exception {
-    deploy(WordCountApp.class, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE2);
+    addApplication(TEST_NAMESPACE2, new WordCountApp());
     Map<String, String> propMap = Maps.newHashMap();
     Assert.assertEquals(propMap, getProperty(getURI(TEST_NAMESPACE2, "WordCountApp", "flows", "WordCountFlow"),
                                              false, 200));

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -485,7 +485,9 @@ public class TestBase {
    */
   protected static ApplicationManager deployApplication(Id.Application appId,
                                                         AppRequest appRequest) throws Exception {
-    return getTestManager().deployApplication(appId, appRequest);
+    ApplicationManager appManager = getTestManager().deployApplication(appId, appRequest);
+    applicationManagers.add(appManager);
+    return appManager;
   }
 
   /**

--- a/cdap-unit-test/src/test/java/co/cask/cdap/admin/AdminAppTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/admin/AdminAppTestRun.java
@@ -45,9 +45,12 @@ import com.google.gson.Gson;
 import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -61,12 +64,18 @@ public class AdminAppTestRun extends TestFrameworkTestBase {
   public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
   private static final Gson GSON = new Gson();
+  private static File artifactJar;
 
   private ApplicationManager appManager;
 
+  @BeforeClass
+  public static void init() throws IOException {
+    artifactJar = createArtifactJar(AdminApp.class);
+  }
+
   @Before
-  public void deploy() {
-    appManager = deployApplication(AdminApp.class);
+  public void deploy() throws Exception {
+    appManager = deployWithArtifact(AdminApp.class, artifactJar);
   }
 
   @Test

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/SparkFileSetTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/SparkFileSetTestRun.java
@@ -28,20 +28,25 @@ import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSetArguments;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.spark.app.ScalaFileCountSparkProgram;
 import co.cask.cdap.spark.app.SparkAppUsingFileSet;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.SparkManager;
+import co.cask.cdap.test.TestConfiguration;
 import co.cask.cdap.test.base.TestFrameworkTestBase;
 import co.cask.tephra.TransactionFailureException;
 import org.apache.twill.filesystem.Location;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
@@ -54,11 +59,20 @@ import java.util.concurrent.TimeUnit;
  */
 public class SparkFileSetTestRun extends TestFrameworkTestBase {
 
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
+
+  private static File artifactJar;
   private ApplicationManager applicationManager;
 
+  @BeforeClass
+  public static void init() throws IOException {
+    artifactJar = createArtifactJar(SparkAppUsingFileSet.class);
+  }
+
   @Before
-  public void init() {
-    applicationManager = deployApplication(SparkAppUsingFileSet.class);
+  public void deploy() throws Exception {
+    applicationManager = deployWithArtifact(SparkAppUsingFileSet.class, artifactJar);
   }
 
   @Test

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/ServiceLifeCycleTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/ServiceLifeCycleTestRun.java
@@ -29,6 +29,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.ServiceManager;
+import co.cask.cdap.test.TestConfiguration;
 import co.cask.cdap.test.base.TestFrameworkTestBase;
 import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
@@ -43,10 +44,11 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.gson.Gson;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -68,10 +70,16 @@ import java.util.concurrent.TimeUnit;
 public class ServiceLifeCycleTestRun extends TestFrameworkTestBase {
 
   @ClassRule
-  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
   private static final Gson GSON = new Gson();
   private static final Type STATES_TYPE = new TypeToken<List<ImmutablePair<Integer, String>>>() { }.getType();
+  private static File artifactJar;
+
+  @BeforeClass
+  public static void init() throws IOException {
+    artifactJar = createArtifactJar(ServiceLifecycleApp.class);
+  }
 
   @Test
   public void testLifecycleWithThreadTerminates() throws Exception {
@@ -81,7 +89,7 @@ public class ServiceLifeCycleTestRun extends TestFrameworkTestBase {
     System.setProperty(ServiceHttpServer.HANDLER_CLEANUP_PERIOD_MILLIS, "100");
 
     try {
-      ApplicationManager appManager = deployApplication(ServiceLifecycleApp.class);
+      ApplicationManager appManager = deployWithArtifact(ServiceLifecycleApp.class, artifactJar);
 
       final ServiceManager serviceManager = appManager.getServiceManager("test").start();
 
@@ -126,7 +134,7 @@ public class ServiceLifeCycleTestRun extends TestFrameworkTestBase {
     System.setProperty(ServiceHttpServer.HANDLER_CLEANUP_PERIOD_MILLIS, "100");
 
     try {
-      ApplicationManager appManager = deployApplication(ServiceLifecycleApp.class);
+      ApplicationManager appManager = deployWithArtifact(ServiceLifecycleApp.class, artifactJar);
 
       final ServiceManager serviceManager = appManager.getServiceManager("test").start();
 
@@ -183,7 +191,7 @@ public class ServiceLifeCycleTestRun extends TestFrameworkTestBase {
     System.setProperty(ServiceHttpServer.THREAD_POOL_SIZE, "1");
 
     try {
-      ApplicationManager appManager = deployApplication(ServiceLifecycleApp.class);
+      ApplicationManager appManager = deployWithArtifact(ServiceLifecycleApp.class, artifactJar);
 
       final ServiceManager serviceManager = appManager.getServiceManager("test").start();
       CountDownLatch uploadLatch = new CountDownLatch(1);
@@ -282,7 +290,7 @@ public class ServiceLifeCycleTestRun extends TestFrameworkTestBase {
     System.setProperty(ServiceHttpServer.THREAD_POOL_SIZE, "1");
 
     try {
-      ApplicationManager appManager = deployApplication(ServiceLifecycleApp.class);
+      ApplicationManager appManager = deployWithArtifact(ServiceLifecycleApp.class, artifactJar);
       final ServiceManager serviceManager = appManager.getServiceManager("test").start();
       final DataSetManager<KeyValueTable> datasetManager = getDataset(ServiceLifecycleApp.HANDLER_TABLE_NAME);
       // Clean up the dataset first to avoid being affected by other tests
@@ -334,7 +342,7 @@ public class ServiceLifeCycleTestRun extends TestFrameworkTestBase {
     System.setProperty(ServiceHttpServer.THREAD_POOL_SIZE, "1");
 
     try {
-      ApplicationManager appManager = deployApplication(ServiceLifecycleApp.class);
+      ApplicationManager appManager = deployWithArtifact(ServiceLifecycleApp.class, artifactJar);
       final ServiceManager serviceManager = appManager.getServiceManager("test").start();
       final DataSetManager<KeyValueTable> datasetManager = getDataset(ServiceLifecycleApp.HANDLER_TABLE_NAME);
       // Clean up the dataset first to avoid being affected by other tests
@@ -402,7 +410,7 @@ public class ServiceLifeCycleTestRun extends TestFrameworkTestBase {
 
   @Test
   public void testInvalidResponder() throws Exception {
-    ApplicationManager appManager = deployApplication(ServiceLifecycleApp.class);
+    ApplicationManager appManager = deployWithArtifact(ServiceLifecycleApp.class, artifactJar);
     final ServiceManager serviceManager = appManager.getServiceManager("test").start();
 
     CountDownLatch uploadLatch = new CountDownLatch(1);
@@ -414,7 +422,7 @@ public class ServiceLifeCycleTestRun extends TestFrameworkTestBase {
 
   @Test
   public void testInvalidContentProducer() throws Exception {
-    ApplicationManager appManager = deployApplication(ServiceLifecycleApp.class);
+    ApplicationManager appManager = deployWithArtifact(ServiceLifecycleApp.class, artifactJar);
     final ServiceManager serviceManager = appManager.getServiceManager("test").start();
 
     URL serviceURL = serviceManager.getServiceURL(10, TimeUnit.SECONDS);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/base/TestFrameworkTestBase.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/base/TestFrameworkTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,10 +16,22 @@
 
 package co.cask.cdap.test.base;
 
+import co.cask.cdap.api.app.Application;
+import co.cask.cdap.internal.test.AppJarHelper;
+import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.TestBase;
+import com.google.common.base.Throwables;
+import org.apache.twill.filesystem.LocalLocationFactory;
 import org.junit.After;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 
 /**
  * TestBase for all test framework tests
@@ -31,12 +43,65 @@ public class TestFrameworkTestBase extends TestBase {
   public void afterTest() throws Exception {
     try {
       super.afterTest();
-      // Sleep a second before clear. There is a race between removal of RuntimeInfo
-      // in the AbstractProgramRuntimeService class and the clear() method, which loops all RuntimeInfo.
-      // The reason for the race is because removal is done through callback.
-      TimeUnit.SECONDS.sleep(1);
     } finally {
-      clear();
+      reset();
+    }
+  }
+
+  /**
+   * Creates an artifact jar by tracing dependency from the given {@link Application} class.
+   */
+  protected static File createArtifactJar(Class<? extends Application> appClass) throws IOException {
+    return new File(AppJarHelper.createDeploymentJar(new LocalLocationFactory(TMP_FOLDER.newFolder()),
+                                                     appClass).toURI());
+  }
+
+  /**
+   * Deploys an {@link Application} using the given artifact jar.
+   */
+  protected static ApplicationManager deployWithArtifact(Class<? extends Application> appClass,
+                                                         File artifactJar) throws Exception {
+    return deployWithArtifact(appClass, artifactJar, null);
+  }
+
+  /**
+   * Deploys an {@link Application} using the given artifact jar with an optional config object.
+   */
+  protected static <T> ApplicationManager deployWithArtifact(Class<? extends Application> appClass,
+                                                             File artifactJar, @Nullable T config) throws Exception {
+    ArtifactId artifactId = new ArtifactId(NamespaceId.DEFAULT.getNamespace(),
+                                           appClass.getSimpleName(), "1.0-SNAPSHOT");
+    addArtifact(artifactId, artifactJar);
+    AppRequest<T> appRequest = new AppRequest<>(new ArtifactSummary(artifactId.getArtifact(), artifactId.getVersion()),
+                                                config);
+    return deployApplication(NamespaceId.DEFAULT.app(appClass.getSimpleName()).toId(), appRequest);
+  }
+
+  protected void reset() {
+    // Retry clear() multiple times. There is a race between removal of RuntimeInfo
+    // in the AbstractProgramRuntimeService class and the clear() method, which loops all RuntimeInfo.
+    // The reason for the race is because removal is done through callback.
+    try {
+      int failureCount = 0;
+      Exception exception = null;
+      while (failureCount < 10) {
+        try {
+          exception = null;
+          clear();
+          break;
+        } catch (Exception e) {
+          exception = e;
+          failureCount++;
+          TimeUnit.MILLISECONDS.sleep(200);
+        }
+      }
+      
+      if (exception != null) {
+        throw exception;
+      }
+    } catch (Exception e) {
+      // If really fail to do reset, propagate the exception
+      throw Throwables.propagate(e);
     }
   }
 }


### PR DESCRIPTION
- Make DefaultStoreTest faster
  - No need to deploy any app to test store.
  - Runtime drop from 21.7 sec to 2.9 sec
- Replace the mandatory sleep in TestFrameworkTestBase to a retry on failure
- Speedup AdminTestRun by not recreating the same app jar.
  - Runtime drop from 77.6 sec to 62.1 sec
- Speedup SparkFileSetTestRun by not recreating the same app jar
  - Runtime drop from 67.3 sec to 56.3 sec
- Speedup SparkTestRun by not recreating app jar
  - Runtime drop from 169.9 to 113.1 seconds
- Speedup PreferencesHttpHandlerTest by not deploying app
  - It just need store entry, no need to run the deployment pipeline
  - Runtime drop from 18.1 to 7.1 seconds
- Speedup ServiceLifeCycleTestRun by not recreating jar
- Fixed a bug in TestBase that the applicationManager is not stopped
  if deployed with an artifact jar.
