### PR TITLE
CDAP-5768 Fixing OOM exception for executor by setting executor memory

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/ETLSpark.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/ETLSpark.java
@@ -96,6 +96,7 @@ public class ETLSpark extends AbstractSpark {
     CompositeFinisher.Builder finishers = CompositeFinisher.builder();
 
     context.setSparkConf(new SparkConf().set("spark.driver.extraJavaOptions", "-XX:MaxPermSize=256m"));
+    context.setSparkConf(new SparkConf().set("spark.executor.extraJavaOptions", "-XX:MaxPermSize=256m"));
     Map<String, String> properties = context.getSpecification().getProperties();
     BatchPhaseSpec phaseSpec = GSON.fromJson(properties.get(Constants.PIPELINEID), BatchPhaseSpec.class);
     PipelinePluginInstantiator pluginInstantiator =


### PR DESCRIPTION
Fixing OOM exception for spark executor by setting executor memory

Issue: https://issues.cask.co/browse/CDAP-5768
