### PR TITLE
CDAP-5882 Remove condrestart

### DIFF
--- a/cdap-distributions/src/debian/scripts/postinst
+++ b/cdap-distributions/src/debian/scripts/postinst
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -39,14 +39,8 @@ case "$1" in
           unlink /opt/cdap/$package_name/bin/svc-$svcname
         fi
         ln -s /opt/cdap/$package_name/bin/service /opt/cdap/$package_name/bin/svc-$svcname
-        # conditional-restart each service
         if [ -x "/etc/init.d/cdap-$svcname" ]; then
           update-rc.d cdap-$svcname defaults >/dev/null
-          if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
-            invoke-rc.d cdap-$svcname condrestart || :
-          else
-            /etc/init.d/cdap-$svcname condrestart || :
-          fi
         fi
       done
     fi

--- a/cdap-distributions/src/debian/scripts/prerm
+++ b/cdap-distributions/src/debian/scripts/prerm
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -45,7 +45,6 @@ case "$1" in
             unlink /opt/cdap/$package_name/bin/svc-$svcname > /dev/null 2>&1 ||:
           fi
           rm -f /opt/cdap/$package_name/version ||:
-          # services will be condrestarted on new package postinstall
         done
       fi
     ;;

--- a/cdap-distributions/src/rpm/scripts/postrm
+++ b/cdap-distributions/src/rpm/scripts/postrm
@@ -1,5 +1,5 @@
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -18,15 +18,4 @@
 
 package_name="<%= project %>"
 version="<%= @version %>"
-
-# if remaining packages after uninstall, perform conditional restart
-if [ $1 -ge 1 ]; then 
-  if stat -t /opt/cdap/$package_name/conf/*-env.sh >/dev/null 2>&1 ; then
-    find -L /opt/cdap/$package_name/conf -name '*-env.sh' | xargs -n1 basename | sed 's/-env.sh//' | while read svcname; do
-      for svcname in `ls /opt/cdap/$package_name/conf/*-env.sh | xargs -n1 basename | sed 's/-env.sh//'` ; do
-        service cdap-$svcname condrestart > /dev/null 2>&1
-      done
-    done
-  fi
-fi
 


### PR DESCRIPTION
Since we recommend always running the upgrade tool, this no longer makes sense.
