### PR TITLE
CDAP-5883 List of packages in upgrade documentation is outdated

### DIFF
--- a/cdap-docs/admin-manual/source/upgrading/packages.rst
+++ b/cdap-docs/admin-manual/source/upgrading/packages.rst
@@ -49,11 +49,11 @@ upgrade instructions for the earlier versions and upgrade first to
 
    - On RPM using Yum::
 
-       $ sudo yum install `rpm -qa --qf "%{NAME}\n" 'cdap*'`
+       $ sudo yum upgrade 'cdap*'
 
    - On Debian using APT::
 
-       $ sudo apt-get install `aptitude search '~ncdap-* ~i' -F '%p'`
+       $ sudo apt-get install --only-upgrade '^cdap.*'
 
 #. If you are upgrading a secure Hadoop cluster, you should authenticate with ``kinit``
    as the user that runs CDAP Master (the CDAP user)

--- a/cdap-docs/admin-manual/source/upgrading/packages.rst
+++ b/cdap-docs/admin-manual/source/upgrading/packages.rst
@@ -47,19 +47,13 @@ upgrade instructions for the earlier versions and upgrade first to
 
 #. Update the CDAP packages by running either of these methods:
 
-   - On RPM using Yum (on one line)::
+   - On RPM using Yum::
 
-       $ sudo yum install cdap cdap-gateway \
-             cdap-hbase-compat-0.96 cdap-hbase-compat-0.98 cdap-hbase-compat-1.0 \
-             cdap-hbase-compat-1.0-cdh cdap-hbase-compat-1.1 \
-             cdap-kafka cdap-master cdap-security cdap-ui
+       $ sudo yum install `rpm -qa --qf "%{NAME}\n" 'cdap*'`
 
-   - On Debian using APT (on one line)::
+   - On Debian using APT::
 
-       $ sudo apt-get install cdap cdap-gateway \
-             cdap-hbase-compat-0.96 cdap-hbase-compat-0.98 cdap-hbase-compat-1.0 \
-             cdap-hbase-compat-1.0-cdh cdap-hbase-compat-1.1 \
-             cdap-kafka cdap-master cdap-security cdap-ui
+       $ sudo apt-get install `aptitude search '~ncdap ~i' -F '%p'`
 
 #. If you are upgrading a secure Hadoop cluster, you should authenticate with ``kinit``
    as the user that runs CDAP Master (the CDAP user)

--- a/cdap-docs/admin-manual/source/upgrading/packages.rst
+++ b/cdap-docs/admin-manual/source/upgrading/packages.rst
@@ -53,7 +53,7 @@ upgrade instructions for the earlier versions and upgrade first to
 
    - On Debian using APT::
 
-       $ sudo apt-get install `aptitude search '~ncdap ~i' -F '%p'`
+       $ sudo apt-get install `aptitude search '~ncdap-* ~i' -F '%p'`
 
 #. If you are upgrading a secure Hadoop cluster, you should authenticate with ``kinit``
    as the user that runs CDAP Master (the CDAP user)


### PR DESCRIPTION
Updated update commands to no longer include explicit package names. Instead, relies on updating using the installed packages.

Running as [Quick Build 2](http://builds.cask.co/browse/CDAP-DQB13-2). Fails, as develop is currently broken until https://github.com/caskdata/cdap/pull/5791 is merged...

[Revised package update page](http://builds.cask.co/artifact/CDAP-DQB13/shared/build-2/Docs-HTML/3.5.0-SNAPSHOT/en/admin-manual/upgrading/packages.html#upgrading-cdap)
