### PR TITLE
CDAP-3368 Add cdap-cli.sh location to PATH

### DIFF
--- a/cdap-cli/etc/profile.d/cdap-cli.sh
+++ b/cdap-cli/etc/profile.d/cdap-cli.sh
@@ -1,0 +1,15 @@
+# Copyright © 2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+export PATH=${PATH}:/opt/cdap/cli/bin

--- a/cdap-cli/pom.xml
+++ b/cdap-cli/pom.xml
@@ -116,10 +116,6 @@
   <profiles>
     <profile>
       <id>dist</id>
-      <!-- Override to not package non-existent etc dir for cdap-cli -->
-      <properties>
-        <package.dirs>opt</package.dirs>
-      </properties>
       <build>
         <plugins>
           <plugin>
@@ -180,6 +176,32 @@
               </execution>
             </executions>
           </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>2.6</version>
+            <executions>
+              <!-- Copy CLI profile.d file -->
+              <execution>
+                <id>copy-cli-etc</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration combine.self="override">
+                  <outputDirectory>${stage.dir}</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${project.parent.basedir}/cdap-cli/etc</directory>
+                      <targetPath>etc</targetPath>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>


### PR DESCRIPTION
Create `/etc/profile.d/cdap-cli.sh` file which extends the PATH to include the CDAP CLI package's `bin` directory.
