### PR TITLE
[CDAP-5340] - Feature/ui widget label sidebar

### DIFF
--- a/cdap-ui/app/directives/group-side-panel/group-side-panel.html
+++ b/cdap-ui/app/directives/group-side-panel/group-side-panel.html
@@ -50,7 +50,7 @@
            ng-show="MySidePanel.openedGroup === null || MySidePanel.openedGroup === group.name">
         <div class="item-body" ng-class="{'view-icon': MySidePanel.view === 'icon', 'view-list': MySidePanel.view === 'list'}">
 
-          <div ng-if="MySidePanel.view === 'icon'" ng-repeat="plugin in group.filtered = (group.plugins | filter: {name: MySidePanel.searchText} | orderBy: 'templateName || name') track by $index"
+          <div ng-if="MySidePanel.view === 'icon'" ng-repeat="plugin in group.filtered = (group.plugins | filter: {label: MySidePanel.searchText} | orderBy: 'templateName || name') track by $index"
                class="plugin-item {{plugin.nodeClass}}"
                my-popover
                data-placement="right"

--- a/cdap-ui/app/directives/group-side-panel/group-side-panel.html
+++ b/cdap-ui/app/directives/group-side-panel/group-side-panel.html
@@ -75,7 +75,7 @@
                   data-template="plugin.template"
                   content-data="plugin"
                   data-popover-context="MySidePanel"
-            >{{ (plugin.name || plugin.pluginTemplate)}}</span>
+            >{{ plugin.label || plugin.name }}</span>
             <span class="plugin-badge">T</span>
           </div>
         </div>

--- a/cdap-ui/app/directives/group-side-panel/group-side-panel.html
+++ b/cdap-ui/app/directives/group-side-panel/group-side-panel.html
@@ -59,7 +59,7 @@
                data-popover-context="MySidePanel"
                ng-click="MySidePanel.onItemClicked($event, plugin)">
             <span ng-if="plugin.icon" class="text-center fa {{plugin.icon}}"></span>
-            <span class="name">{{ plugin.name }}</span>
+            <span class="name">{{ plugin.label || plugin.name }}</span>
             <span class="plugin-badge">T</span>
           </div>
           <div class="no-item-message" ng-if="group.filtered.length === 0">

--- a/cdap-ui/app/features/hydratorplusplus/controllers/create/leftpanel-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/create/leftpanel-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 class HydratorPlusPlusLeftPanelCtrl {
-  constructor($scope, $stateParams, rVersion, HydratorPlusPlusConfigStore, HydratorPlusPlusLeftPanelStore, HydratorPlusPlusPluginActions, DAGPlusPlusFactory, DAGPlusPlusNodesActionsFactory, NonStorePipelineErrorFactory, $uibModal, myAlertOnValium, $state, $q, rArtifacts, PluginTemplatesDirActions, HydratorPlusPlusOrderingFactory, LEFTPANELSTORE_ACTIONS, myHelpers, $timeout, mySettings, HydratorPlusPlusPluginsWidgetsActions, HydratorPlusPlusPluginWidgetsStore) {
+  constructor($scope, $stateParams, rVersion, HydratorPlusPlusConfigStore, HydratorPlusPlusLeftPanelStore, HydratorPlusPlusPluginActions, DAGPlusPlusFactory, DAGPlusPlusNodesActionsFactory, NonStorePipelineErrorFactory, $uibModal, myAlertOnValium, $state, $q, rArtifacts, PluginTemplatesDirActions, HydratorPlusPlusOrderingFactory, LEFTPANELSTORE_ACTIONS, myHelpers, $timeout, mySettings, HydratorPlusPlusPluginsWidgetsActions, HydratorPlusPlusPluginWidgetsStore, PLUGINS_WIDGETS_ACTIONS) {
     this.$state = $state;
     this.$scope = $scope;
     this.$stateParams = $stateParams;
@@ -34,6 +34,7 @@ class HydratorPlusPlusLeftPanelCtrl {
     this.myHelpers = myHelpers;
     this.mySettings = mySettings;
     this.pluginsWidgetsActions = HydratorPlusPlusPluginsWidgetsActions;
+    this.widgetActions = PLUGINS_WIDGETS_ACTIONS;
     this.pluginsWidgetsStore = HydratorPlusPlusPluginWidgetsStore;
 
     this.pluginsMap = [];
@@ -157,6 +158,7 @@ class HydratorPlusPlusLeftPanelCtrl {
     this.$uibModal = $uibModal;
     this.$scope.$on('$destroy', () => {
       this.leftpanelStore.dispatch({ type: this.LEFTPANELSTORE_ACTIONS.RESET});
+      this.pluginsWidgetsStore.dispatch({ type: this.widgetActions.RESET });
       leftpanelStoreSub();
       pluginsWidgetJSONSub();
     });
@@ -433,9 +435,9 @@ class HydratorPlusPlusLeftPanelCtrl {
           .map( plug => {
             let label = regExp.exec(plug.plugin.label) || [''];
             label = label[0].replace(/[\(\)]/g, '');
-            return parseInt(label) || 0;
+            return parseInt(label, 10) || 0;
           });
-        labelWithMaxId = labels.reduce( (prev, curr) => prev > curr? prev: (curr + 1) , 1) || 0;
+        labelWithMaxId = labels.reduce( (prev, curr) => prev > curr ? prev: (curr + 1) , 1) || 0;
       }
       return (labelWithMaxId === 0) ? returnLabel : returnLabel + '(' + labelWithMaxId  + ')';
     };
@@ -507,6 +509,6 @@ class HydratorPlusPlusLeftPanelCtrl {
   }
 }
 
-HydratorPlusPlusLeftPanelCtrl.$inject = ['$scope', '$stateParams', 'rVersion', 'HydratorPlusPlusConfigStore', 'HydratorPlusPlusLeftPanelStore', 'HydratorPlusPlusPluginActions', 'DAGPlusPlusFactory', 'DAGPlusPlusNodesActionsFactory', 'NonStorePipelineErrorFactory',  '$uibModal', 'myAlertOnValium', '$state', '$q', 'rArtifacts', 'PluginTemplatesDirActions', 'HydratorPlusPlusOrderingFactory', 'LEFTPANELSTORE_ACTIONS', 'myHelpers', '$timeout', 'mySettings', 'HydratorPlusPlusPluginsWidgetsActions', 'HydratorPlusPlusPluginWidgetsStore'];
+HydratorPlusPlusLeftPanelCtrl.$inject = ['$scope', '$stateParams', 'rVersion', 'HydratorPlusPlusConfigStore', 'HydratorPlusPlusLeftPanelStore', 'HydratorPlusPlusPluginActions', 'DAGPlusPlusFactory', 'DAGPlusPlusNodesActionsFactory', 'NonStorePipelineErrorFactory',  '$uibModal', 'myAlertOnValium', '$state', '$q', 'rArtifacts', 'PluginTemplatesDirActions', 'HydratorPlusPlusOrderingFactory', 'LEFTPANELSTORE_ACTIONS', 'myHelpers', '$timeout', 'mySettings', 'HydratorPlusPlusPluginsWidgetsActions', 'HydratorPlusPlusPluginWidgetsStore', 'PLUGINS_WIDGETS_ACTIONS'];
 angular.module(PKG.name + '.feature.hydratorplusplus')
   .controller('HydratorPlusPlusLeftPanelCtrl', HydratorPlusPlusLeftPanelCtrl);

--- a/cdap-ui/app/features/hydratorplusplus/controllers/create/leftpanel-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/create/leftpanel-ctrl.js
@@ -76,7 +76,7 @@ class HydratorPlusPlusLeftPanelCtrl {
                   let artifact = plug.artifact;
                   let key = `${artifact.name}-${artifact.version}-${artifact.scope}`;
                   let widgetKey = `widgets.${plug.name}-${plug.type}`;
-                  let pluginWidgetJson = widgetsJSONMap[key][widgetKey];
+                  let pluginWidgetJson = this.myHelpers.objectQuery(widgetsJSONMap, key, widgetKey);
                   let json;
                   if (!pluginWidgetJson && typeof pluginWidgetJson !== 'string') {
                     return;
@@ -87,8 +87,7 @@ class HydratorPlusPlusLeftPanelCtrl {
                     console.warn('ERROR in parsing widget JSON for', key);
                     return;
                   }
-                  console.info('setting ',ext, plugin.name, json.metadata.label);
-                  plug.label = json.metadata.label;
+                  plug.label = json.metadata.label || plug.name;
                   plugin.label = plug.label;
                 });
               });

--- a/cdap-ui/app/features/hydratorplusplus/services/create/actions/plugins-widgets-action-creator.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/create/actions/plugins-widgets-action-creator.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+class HydratorPlusPlusPluginsWidgetsActions {
+  constructor(PLUGINS_WIDGETS_ACTIONS, myPipelineApi) {
+    this.pluginsWidgetsActions = PLUGINS_WIDGETS_ACTIONS;
+    this.api = myPipelineApi;
+  }
+  fetchWidgetJson(namespace, artifact) {
+    let artifactName, artifactVersion, scope;
+    artifactName = artifact.name;
+    artifactVersion = artifact.version;
+    scope = artifact.scope;
+    
+    let key = `${artifactName}-${artifactVersion}-${scope}`;
+
+    return (dispatch) => {
+      dispatch({
+        type: this.pluginsWidgetsActions.WIDGET_JSON_FETCH_START,
+        payload: { key }
+      });
+
+      this.api
+          .fetchArtifactProperties({
+            namespace,
+            artifactName,
+            artifactVersion,
+            scope
+          })
+          .$promise
+          .then( res => {
+            dispatch({
+              type: this.pluginsWidgetsActions.WIDGET_JSON_FETCH,
+              payload: { key, res }
+            });
+          });
+    };
+  }
+}
+
+HydratorPlusPlusPluginsWidgetsActions.$inject = ['PLUGINS_WIDGETS_ACTIONS', 'myPipelineApi'];
+angular.module(`${PKG.name}.feature.hydratorplusplus`)
+  .service('HydratorPlusPlusPluginsWidgetsActions', HydratorPlusPlusPluginsWidgetsActions);

--- a/cdap-ui/app/features/hydratorplusplus/services/create/stores/left-panel-store.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/create/stores/left-panel-store.js
@@ -58,6 +58,7 @@ const getTemplatesWithAddedInfo = (templates = [], extension = '') => {
       nodeClass: 'plugin-templates',
       name: template.pluginTemplate,
       pluginName: template.pluginName,
+      label: template.pluginTemplate,
       type: extension,
       icon: _DAGPlusPlusFactory.getIcon(template.pluginName),
       template: popoverTemplate

--- a/cdap-ui/app/features/hydratorplusplus/services/create/stores/plugins-widgets-store.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/create/stores/plugins-widgets-store.js
@@ -54,6 +54,8 @@ var pluginsWidgetMap = (state = {}, action = {}) => {
         let {key} = action.payload;
         return Object.assign({}, state, {[key]: {}});
       }
+    case _PLUGINS_WIDGETS_ACTIONS.RESET:
+      return {};
     default:
       return state;
   }
@@ -81,6 +83,7 @@ HydratorPlusPlusPluginWidgetsStore.$inject = ['PLUGINS_WIDGETS_ACTIONS', 'Redux'
 angular.module(PKG.name + '.feature.hydratorplusplus')
   .constant('PLUGINS_WIDGETS_ACTIONS', {
     'WIDGET_JSON_FETCH_START': 'WIDGET_JSON_FETCH_START',
-    'WIDGET_JSON_FETCH': 'WIDGET_JSON_FETCH'
+    'WIDGET_JSON_FETCH': 'WIDGET_JSON_FETCH',
+    'RESET': 'WIDGET_JSON_RESET'
   })
   .factory('HydratorPlusPlusPluginWidgetsStore', HydratorPlusPlusPluginWidgetsStore);

--- a/cdap-ui/app/features/hydratorplusplus/services/create/stores/plugins-widgets-store.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/create/stores/plugins-widgets-store.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+/*
+  {
+    pluginsWidgetMap: {
+      <artifact-name>-<artifact-version>-<artifact-scope>: {
+        //widget-json-for-plugins
+        "widgets.<plugin-name>-<plugin-type>": "" // stringified json.
+      },
+      <artifact-name>-<artifact-version>-<artifact-scope>: {
+        //widget-json-for-plugins
+        "widgets.<plugin-name>-<plugin-type>": "" // stringified json.
+      },
+      <artifact-name>-<artifact-version>-<artifact-scope>: {
+        //widget-json-for-plugins
+        "widgets.<plugin-name>-<plugin-type>": "" // stringified json.
+      }
+    }
+  }
+
+*/
+
+var _PLUGINS_WIDGETS_ACTIONS;
+
+var pluginsWidgetMap = (state = {}, action = {}) => {
+  switch(action.type) {
+    case _PLUGINS_WIDGETS_ACTIONS.WIDGET_JSON_FETCH:
+      {
+        let {key, res} = action.payload;
+        let resObj = {};
+        angular.forEach(res, function(value, key) {
+          if (key.indexOf('widgets.') !== -1) {
+            resObj[key] = value;
+          }
+        });
+        return Object.assign({}, state, {[key]: resObj});
+      }
+    case _PLUGINS_WIDGETS_ACTIONS.WIDGET_JSON_FETCH_START:
+      {
+        let {key} = action.payload;
+        return Object.assign({}, state, {[key]: {}});
+      }
+    default:
+      return state;
+  }
+};
+
+var HydratorPlusPlusPluginWidgetsStore = (PLUGINS_WIDGETS_ACTIONS, Redux, ReduxThunk) => {
+  _PLUGINS_WIDGETS_ACTIONS = PLUGINS_WIDGETS_ACTIONS;
+  let {combineReducers, applyMiddleware} = Redux;
+
+  let combineReducer = combineReducers({
+    pluginsWidgetMap
+  });
+
+  return Redux.createStore(
+    combineReducer,
+    {},
+    Redux.compose(
+      applyMiddleware(ReduxThunk.default),
+      window.devToolsExtension ? window.devToolsExtension() : f => f
+    )
+  );
+};
+HydratorPlusPlusPluginWidgetsStore.$inject = ['PLUGINS_WIDGETS_ACTIONS', 'Redux', 'ReduxThunk'];
+
+angular.module(PKG.name + '.feature.hydratorplusplus')
+  .constant('PLUGINS_WIDGETS_ACTIONS', {
+    'WIDGET_JSON_FETCH_START': 'WIDGET_JSON_FETCH_START',
+    'WIDGET_JSON_FETCH': 'WIDGET_JSON_FETCH'
+  })
+  .factory('HydratorPlusPlusPluginWidgetsStore', HydratorPlusPlusPluginWidgetsStore);

--- a/cdap-ui/app/features/hydratorplusplus/templates/create/popovers/leftpanel-plugin-popover.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/create/popovers/leftpanel-plugin-popover.html
@@ -26,7 +26,7 @@
   <ul class="list-group">
     <li class="list-group-item">
       <h5>
-        <strong>{{ contentData.templateName || contentData.name }}</strong>
+        <strong>{{ contentData.templateName || contentData.label || contentData.name }}</strong>
         <a href="#" ng-if="!contentData.templateName" ng-click="delayClose(1) && popoverContext.onItemClicked($event,  {action: 'createTemplate', contentData: contentData})">
           <span class="fa fa-plus-circle"></span>
           <span>Template</span>


### PR DESCRIPTION
- Loads plugins in the left panel with label from widget json (batch call to get all widget jsons in an artifact).
- Adds `plugins-widget-store` to act as cache for plugin's widget json for each artifact.
- Enables the label to be used in nodes when added to canvas.
- Fixes loading widget json only once during initial load of canvas and subsequently calls fetches it from the local cache.

![labels-sidepanel](https://cloud.githubusercontent.com/assets/1452845/15342457/2cbdee4c-1c4a-11e6-8a3c-093361fff42e.gif)
##### Depends on this PR: https://github.com/caskdata/hydrator-plugins/pull/266
###### TODO:
- Need to add unit tests for new widget json store.
- May be rename `plugins-widget-store` to `plugin-info-store`? (we could add docs for each plugin as part of cache in the future)
