### PR TITLE
CDAP-5404 Add installation instructions for tar

### DIFF
--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -241,6 +241,7 @@ if short_version:
 .. |short-version| replace:: %(short_version)s
 .. |bold-short-version| replace:: **%(short_version)s**
 .. |literal-short-version| replace:: ``%(short_version)s``
+.. |literal-cdap-slash-short-version| replace:: ``cdap/%(short_version)s``
 .. |previous-short-version| replace:: %(previous_short_version)s
 .. |bold-previous-short-version| replace:: **%(previous_short_version)s**
 .. |literal-previous-short-version| replace:: ``%(previous_short_version)s``

--- a/cdap-docs/_common/tabbed-parsed-literal.py
+++ b/cdap-docs/_common/tabbed-parsed-literal.py
@@ -17,7 +17,7 @@
 """Simple, inelegant Sphinx extension which adds a directive for a
 tabbed parsed-literals that may be switched between in HTML.
 
-version: 0.2
+version: 0.3
 
 The directive adds these parameters, both optional:
 
@@ -48,7 +48,7 @@ For example, you could have a set of tabs:
     :mapping: linux,windows
     :dependent: linux-windows
     
-Clicking on a "Linux" tab in another tab-set woula activate the "Mac OS X" tab in this tab set.
+Clicking on a "Linux" tab in another tab-set would activate the "Mac OS X" tab in this tab set.
 
 Note that slightly different rule operate for replacements: a replacement such as
 "\|replace|" will work, and the backslash will be interpreted as a single backslash rather
@@ -365,10 +365,10 @@ class TabbedParsedLiteral(ParsedLiteral):
         line_counts = []
         lines = []
         for line_set in line_sets:
-#             block = '\n'.join(line_set).strip()
             block = '\n'.join(line_set).rstrip()
             block = block.replace('\\', '\\\\')
             block = block.replace('\\|', '\\\ |')
+            block = block.replace('*', '\*')            
             if not block.endswith('\n'):
                 block += '\n'
             lines.append(block)
@@ -401,14 +401,19 @@ class TabbedParsedLiteral(ParsedLiteral):
 
         line_counts, lines = self.cleanup_content()
         text = '\n'.join(lines)
-#         print "text:\n%s" % text
         # Sending text to state machine for inline text replacement
         text_nodes, messages = self.state.inline_text(text, self.lineno)
-        
-#         print "text_nodes:\n%s" % text_nodes
-#         for n in text_nodes:
-#             print "n:\n%s" % n
-#              n['classes'].append('snippet')
+ 
+# Debugging Code start
+#         if messages:
+#             print "text:\n%s" % text
+#             print "text_nodes:\n%s" % text_nodes
+#             for n in text_nodes:
+#                 print "n:\n%s" % n
+#             print 'messages:'
+#             for m in messages:
+#                 print m
+# Debugging Code end
         
         node = TabbedParsedLiteralNode(text, '', *text_nodes, **self.options)
         node.cleanup()

--- a/cdap-docs/admin-manual/source/_includes/installation/installation.txt
+++ b/cdap-docs/admin-manual/source/_includes/installation/installation.txt
@@ -82,6 +82,28 @@ Update your APT-cache::
 
 .. end_install-debian-using-apt
 
+.. _|distribution|-install-using-tar:
+
+Using Tar
+.........
+Download the appropriate CDAP tar file, and then unpack it to an appropriate directory (indicated by ``$dir``):
+
+.. tabbed-parsed-literal::
+  :tabs: RHEL,Ubuntu
+  :languages: console,console
+  :mapping: rhel,ubuntu
+  :dependent: rhel-ubuntu
+           
+  .. RHEL
+
+  $ curl |http:|//repository.cask.co/downloads/co/cask/cdap/cdap-distributed-rpm-bundle/|short-version|/cdap-distributed-rpm-bundle-|short-version|.tgz
+  $ tar xf cdap-distributed-rpm-bundle-|short-version|.tgz -C $dir
+  
+  .. Ubuntu
+
+  $ curl |http:|//repository.cask.co/downloads/co/cask/cdap/cdap-distributed-deb-bundle/|short-version|/cdap-distributed-deb-bundle-|short-version|.tgz
+  $ tar xf cdap-distributed-deb-bundle-|short-version|.tgz -C $dir
+
 
 .. _|distribution|-package-installation-title:
 
@@ -123,6 +145,28 @@ On Debian using APT
 
   $ sudo apt-get install cdap-gateway cdap-kafka cdap-master cdap-security cdap-ui
 
+  
+Using Tar
+.........
+Having :ref:`previously downloaded and unpacked <|distribution|-install-using-tar>` 
+the appropriate tar file to a directory ``$dir``, use:
+
+.. tabbed-parsed-literal::
+  :tabs: RHEL,Ubuntu
+  :languages: console,console
+  :mapping: rhel,ubuntu
+  :dependent: rhel-ubuntu
+       
+  .. RHEL
+
+  $ sudo yum localinstall $dir/*.rpm
+  
+  .. Ubuntu
+
+  $ sudo dpkg -i $dir/*.deb
+  $ sudo apt-get install -f
+  
+  
 .. _|distribution|-create-required-directories:
 
 Create Required Directories

--- a/cdap-docs/admin-manual/source/installation/ambari.rst
+++ b/cdap-docs/admin-manual/source/installation/ambari.rst
@@ -63,14 +63,13 @@ To install the ``cdap-ambari-service`` package, first add the appropriate CDAP r
 to your system’s package manager by following the steps below. These steps will install a
 Cask repository on your Ambari server.
 
-The **repository version** (shown in the commands below as ``"cdap/``\ |literal-short-version|\ ``"``) 
+The **repository version** (shown in the commands below as |literal-cdap-slash-short-version|) 
 must match the **CDAP series** which you’d like installed on your cluster. To install the
 **latest** version of the *CDAP 3.0 series,* you would install the *CDAP 3.0 repository.*
 The default (in the commands below) is to use **cdap/3.3**, which has the widest
 compatibility with the Ambari-supported Hadoop distributions.
 
-Replace |---| in the commands that follow on this page |---| all references to 
-``"cdap/``\ |literal-short-version|\ ``"`` 
+Replace |---| in the commands that follow on this page |---| all references to |literal-cdap-slash-short-version|
 with the CDAP Repository from the list below that you would like to use:
 
 .. _ambari-compatibility-matrix:
@@ -98,7 +97,7 @@ supplied from Hortonworks.
 
 .. include:: /../target/_includes/ambari-installation.rst
   :start-after: .. _ambari-install-rpm-using-yum:
-  :end-before: .. _ambari-package-installation-title:
+  :end-before: .. end_install-debian-using-apt
 
 
 Installing CDAP Ambari Service

--- a/cdap-docs/admin-manual/source/installation/mapr.rst
+++ b/cdap-docs/admin-manual/source/installation/mapr.rst
@@ -71,7 +71,7 @@ Preparing Package Managers
 
 .. include:: /../target/_includes/mapr-installation.rst
     :start-after: .. _mapr-preparing-package-managers:
-    :end-before: .. end_install-debian-using-apt
+    :end-before: .. _mapr-package-installation-title:
 
 
 Installing CDAP Services

--- a/cdap-docs/admin-manual/source/installation/packages.rst
+++ b/cdap-docs/admin-manual/source/installation/packages.rst
@@ -64,7 +64,7 @@ Preparing Package Managers
 
 .. include:: /../target/_includes/packages-installation.rst
     :start-after: .. _packages-preparing-package-managers:
-    :end-before: .. end_install-debian-using-apt
+    :end-before: .. _packages-package-installation-title:
 
 
 Installing CDAP Services


### PR DESCRIPTION
Fixes a problem with the tabbed parsed literal not handling asterisks correctly.
Cleans up the Amauri documentation by replacing an inline literal that wasn't formatting nicely with a replacement that works correctly.

Adds instructions for installing CDAP from tar balls to the MapR and Packages instances, leaving it off the Ambari and Cloudera.

Fix for https://issues.cask.co/browse/CDAP-5404

Ran as [Quick Build 1](http://builds.cask.co/browse/CDAP-DQB15-1), though failed as develop was broken at the time it was branched.

Pages of interest:
- MapR: [Downloading and Distributing Packages](http://builds.cask.co/artifact/CDAP-DQB15/shared/build-1/Docs-HTML/3.5.0-SNAPSHOT/en/admin-manual/installation/mapr.html#downloading-and-distributing-packages), [Installing](http://builds.cask.co/artifact/CDAP-DQB15/shared/build-1/Docs-HTML/3.5.0-SNAPSHOT/en/admin-manual/installation/mapr.html#installing-cdap-services)
- Packages: [Downloading and Distributing Packages](http://builds.cask.co/artifact/CDAP-DQB15/shared/build-1/Docs-HTML/3.5.0-SNAPSHOT/en/admin-manual/installation/packages.html#installing-cdap-services), [Installing](http://builds.cask.co/artifact/CDAP-DQB15/shared/build-1/Docs-HTML/3.5.0-SNAPSHOT/en/admin-manual/installation/packages.html#starting-cdap-services)
