### PR TITLE
CDAP-6045 Use getNamespace() instead of getNamespaceId() to get the name of the program's namespace.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
@@ -184,7 +184,7 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
                             cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
     File dir = new File(tempDir, String.format("%s.%s.%s.%s.%s",
                                                programId.getType().name().toLowerCase(),
-                                               programId.getNamespaceId(), programId.getApplication(),
+                                               programId.getNamespace(), programId.getApplication(),
                                                programId.getProgram(), runId.getId()));
     dir.mkdirs();
     return dir;


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-6045
