### PR TITLE
CDAP-5996 Documentation of Query RESTful API Errors

### DIFF
--- a/cdap-docs/examples-manual/source/examples/_includes/_building-running-base.txt
+++ b/cdap-docs/examples-manual/source/examples/_includes/_building-running-base.txt
@@ -1,0 +1,39 @@
+
+.. To use this include, define these replacements:
+.. example
+.. example-italic
+.. example-dir
+.. example-artifact
+.. application-overview-page
+
+.. |application-overview| replace:: |example-italic| |application-overview-page|
+
+Building and Starting
+=====================
+
+.. highlight:: console
+
+- You can either build the example (as described in :ref:`Building an Example Application 
+  <cdap-building-running-example>`) or use the pre-built JAR file included in the CDAP SDK
+  (as described in :ref:`Deploying an Application <cdap-building-running-deploying>`):
+  
+  .. tabbed-parsed-literal::
+
+    examples/|example-dir|/target/|example-artifact|-|release|.jar
+
+  
+- Start CDAP (as described in :ref:`Starting and Stopping CDAP <start-stop-cdap>`). 
+
+- Deploy the application, as described in :ref:`Deploying an Application <cdap-building-running-deploying>`.
+  For example, from the Standalone CDAP SDK directory, use the :ref:`Command Line Interface (CLI) <cli>`:
+
+  .. tabbed-parsed-literal::
+
+    $ cdap-cli.sh load artifact examples/|example-dir|/target/|example-artifact|-|release|.jar
+    
+    Successfully added artifact with name '|example-artifact|'
+
+    $ cdap-cli.sh create app |example| |example-artifact| |release| user
+    
+    Successfully created application
+  

--- a/cdap-docs/examples-manual/source/examples/_includes/_building-running.txt
+++ b/cdap-docs/examples-manual/source/examples/_includes/_building-running.txt
@@ -1,0 +1,10 @@
+
+.. To use this include, define these replacements:
+.. example
+.. example-italic
+.. application-overview-page
+
+.. |example-artifact| replace:: |example|
+.. |example-dir|      replace:: |example|
+
+.. include:: _includes/_building-running-base.txt

--- a/cdap-docs/examples-manual/source/examples/_includes/_building-starting-running-example-with-dir.txt
+++ b/cdap-docs/examples-manual/source/examples/_includes/_building-starting-running-example-with-dir.txt
@@ -14,5 +14,4 @@
   
 - Once all components are started, `run the example <#running-the-example>`__.
 
-- When finished, you can :ref:`stop <cdap-building-running-stopping>`
-  and :ref:`remove the application <cdap-building-running-removing>`.
+- When finished, you can `stop and remove the application <#stopping-and-removing-the-application>`__.

--- a/cdap-docs/examples-manual/source/examples/_includes/_building-starting-running-example-with-dir.txt
+++ b/cdap-docs/examples-manual/source/examples/_includes/_building-starting-running-example-with-dir.txt
@@ -4,38 +4,9 @@
 .. example-italic
 .. example-dir
 .. example-artifact
+.. application-overview-page
 
-.. |application-overview| replace:: |example-italic| |application-overview-page|
-
-Building and Starting
-=====================
-
-.. highlight:: console
-
-- You can either build the example (as described in :ref:`Building an Example Application 
-  <cdap-building-running-example>`) or use the pre-built JAR file included in the CDAP SDK
-  (as described in :ref:`Deploying an Application <cdap-building-running-deploying>`):
-  
-  .. tabbed-parsed-literal::
-
-    examples/|example-dir|/target/|example-artifact|-|release|.jar
-
-  
-- Start CDAP (as described in :ref:`Starting and Stopping CDAP <start-stop-cdap>`). 
-
-- Deploy the application, as described in :ref:`Deploying an Application <cdap-building-running-deploying>`.
-  For example, from the Standalone CDAP SDK directory, use the :ref:`Command Line Interface (CLI) <cli>`:
-
-  .. tabbed-parsed-literal::
-
-    $ cdap-cli.sh load artifact examples/|example-dir|/target/|example-artifact|-|release|.jar
-    
-    Successfully added artifact with name '|example-artifact|'
-
-    $ cdap-cli.sh create app |example| |example-artifact| |release| user
-    
-    Successfully created application
-  
+.. include:: _includes/_building-running-base.txt
   
 - Once the application has been deployed, you can start its components, as described in
   :ref:`Starting an Application <cdap-building-running-starting-application>`, and detailed at the 

--- a/cdap-docs/examples-manual/source/examples/_includes/_building-starting-running.txt
+++ b/cdap-docs/examples-manual/source/examples/_includes/_building-starting-running.txt
@@ -2,6 +2,7 @@
 .. To use this include, define these replacements:
 .. example
 .. example-italic
+.. application-overview-page
 
 .. |example-dir|      replace:: |example|
 .. |example-artifact| replace:: |example|

--- a/cdap-docs/examples-manual/source/examples/_includes/_stopping-removing-application-title.txt
+++ b/cdap-docs/examples-manual/source/examples/_includes/_stopping-removing-application-title.txt
@@ -1,5 +1,7 @@
 
 Stopping and Removing the Application
 =====================================
-Once done, you can stop the application as described in :ref:`Stopping an Application 
-<cdap-building-running-stopping>`. Here is an example-specific description of the steps:
+Once done, you can stop the application |---| if it hasn't stopped
+already |---| as described in :ref:`Stopping an Application
+<cdap-building-running-stopping>`. Here is an example-specific
+description of the steps:

--- a/cdap-docs/examples-manual/source/examples/_includes/_stopping-removing-application.txt
+++ b/cdap-docs/examples-manual/source/examples/_includes/_stopping-removing-application.txt
@@ -1,0 +1,2 @@
+.. include:: _includes/_stopping-removing-application-title.txt
+.. include:: _includes/_removing-application.txt

--- a/cdap-docs/examples-manual/source/examples/clicks-and-views.rst
+++ b/cdap-docs/examples-manual/source/examples/clicks-and-views.rst
@@ -70,8 +70,7 @@ to know which source each record came from. This is possible by calling the ``ge
 
 - Once the application has been deployed, `run the example <#running-the-example>`__.
 
-- When finished, you can :ref:`stop <cdap-building-running-stopping>`
-  and :ref:`remove the application <cdap-building-running-removing>`.
+- When finished, you can `remove the application <#removing-the-application>`__.
   
 Running the Example
 ===================
@@ -160,6 +159,7 @@ With our sample data, the click through rate is ``0.5``::
   +=============+
   Fetched 1 rows
 
-.. Stopping and Removing the Application
-.. =====================================
-.. include:: _includes/_stopping-removing-application.txt
+Removing the Application
+========================
+.. include:: _includes/_removing-application.txt
+  :start-after: **Removing the Application**

--- a/cdap-docs/examples-manual/source/examples/clicks-and-views.rst
+++ b/cdap-docs/examples-manual/source/examples/clicks-and-views.rst
@@ -63,9 +63,13 @@ to know which source each record came from. This is possible by calling the ``ge
 .. |example-italic| replace:: *ClicksAndViews*
 .. |application-overview-page| replace:: :cdap-ui-apps-programs:`application overview page, programs tab <ClicksAndViews>`
 
-.. include:: _includes/_building-starting-running.txt
+.. include:: _includes/_building-running.txt
 
+- Once the application has been deployed, `run the example <#running-the-example>`__.
 
+- When finished, you can :ref:`stop <cdap-building-running-stopping>`
+  and :ref:`remove the application <cdap-building-running-removing>`.
+  
 Running the Example
 ===================
 
@@ -111,7 +115,8 @@ Querying the Results
 --------------------
 .. highlight:: console
 
-To sample the *joined* ``PartitionedFileSet``, execute an explore query using the CDAP CLI:
+Once the MapReduce job has completed, you can sample the *joined* ``PartitionedFileSet``, 
+by executing an explore query using the CDAP CLI:
 
 .. tabbed-parsed-literal::
 
@@ -154,4 +159,4 @@ With our sample data, the click through rate is ``0.5``::
 
 .. Stopping and Removing the Application
 .. =====================================
-.. include:: _includes/_removing-application.txt
+.. include:: _includes/_stopping-removing-application.txt

--- a/cdap-docs/reference-manual/source/http-restful-api/query.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/query.rst
@@ -68,8 +68,9 @@ For example::
 
 .. rubric:: Comments
 
-If the query execution was successfully initiated, the body will contain a handle 
-used to identify the query in subsequent requests::
+If the query execution was successfully initiated, the body of the
+response will contain a handle that can be used to identify the query in
+subsequent requests::
 
   { "handle":"<query-handle>" }
 
@@ -153,7 +154,9 @@ Obtaining the Result Schema
 ---------------------------
 If the query's status is ``FINISHED`` and it has results, you can obtain the schema of the results::
 
-  GET <base-url>/namespaces/<namespace>/data/explore/queries/<query-handle>/schema
+  GET <base-url>/data/explore/queries/<query-handle>/schema
+
+**Note:** this endpoint is *not* namespaced, as all query-handles are globally unique.
 
 .. list-table::
    :widths: 20 80
@@ -215,7 +218,9 @@ Retrieving Query Results
 Query results can be retrieved in batches after the query is finished, optionally specifying the batch
 size in the body of the request::
 
-  POST <base-url>/namespaces/<namespace>/data/explore/queries/<query-handle>/next
+  POST <base-url>/data/explore/queries/<query-handle>/next
+
+**Note:** this endpoint is *not* namespaced, as all query-handles are globally unique.
 
 The body of the request can contain a JSON string specifying the batch size::
 
@@ -288,9 +293,11 @@ Closing a Query
 ---------------
 The query can be closed by issuing an HTTP DELETE against its URL::
 
-  DELETE <base-url>/namespaces/<namespace>/data/explore/queries/<query-handle>
+  DELETE <base-url>/data/explore/queries/<query-handle>
 
 This frees all resources that are held by this query.
+
+**Note:** this endpoint is *not* namespaced, as all query-handles are globally unique.
 
 .. list-table::
    :widths: 20 80

--- a/cdap-docs/reference-manual/source/http-restful-api/query.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/query.rst
@@ -1,7 +1,7 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: HTTP RESTful Interface to the Cask Data Application Platform
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2016 Cask Data, Inc.
 
 .. _http-restful-api-query:
 
@@ -40,7 +40,7 @@ To submit a SQL query, post the query string to the ``queries`` URL::
 The body of the request must contain a JSON string of the form::
 
   {
-    "query": "<SQL-query-string>"
+    "query":"<SQL-query-string>"
   }
 
 where ``<SQL-query-string>`` is the actual SQL query.
@@ -50,7 +50,7 @@ Non-reservedKeywordsandReservedKeywords>`__, you must enclose the column name in
 For example::
 
   {
-    "query": "select `date` from stream_events"
+    "query":"select `date` from stream_events"
   }
 
 .. rubric:: HTTP Responses
@@ -279,9 +279,9 @@ been retrieved, then the returned list is empty.
      - ``POST <base-url>/namespaces/default/data/explore/queries/57cf1b01-8dba-423a-a8b4-66cd29dd75e2/next``
    * - HTTP Response
      - | ``[{"columns": [ 10, 5]},``
-       | `` {"columns": [ 20, 27]},``
-       | `` {"columns": [ 50, 6]},``
-       | `` {"columns": [ 90, 30]},``
+       | `` {"columns": [ 20, 27]},``
+       | `` {"columns": [ 50, 6]},``
+       | `` {"columns": [ 90, 30]},``
        | `` {"columns": [ 95, 91]}]``
    * - Description
      - Retrieve the results of the query which has the handle 57cf1b01-8dba-423a-a8b4-66cd29dd75e2
@@ -305,8 +305,6 @@ This frees all resources that are held by this query.
 
    * - Parameter
      - Description
-   * - ``<namespace>``
-     - Namespace ID
    * - ``<query-handle>``
      - Handle obtained when the query was submitted
 
@@ -366,12 +364,12 @@ The results are returned as a JSON array, with each element containing informati
 
   [
     {
-        "timestamp": 1407192465183,
-        "statement": "SHOW TABLES",
-        "status": "FINISHED",
-        "query_handle": "319d9438-903f-49b8-9fff-ac71cf5d173d",
-        "has_results": true,
-        "is_active": false
+        "timestamp":1407192465183,
+        "statement":"SHOW TABLES",
+        "status":"FINISHED",
+        "query_handle":"319d9438-903f-49b8-9fff-ac71cf5d173d",
+        "has_results":true,
+        "is_active":false
     },
     ...
   ]
@@ -384,14 +382,14 @@ The results are returned as a JSON array, with each element containing informati
    * - HTTP Request
      - ``GET <base-url>/namespaces/default/data/explore/queries``
    * - HTTP Response
-     - | ``[{``
+     - | ``[ {``
        | `` "timestamp": 1411266478717,``
        | `` "statement": "SELECT * FROM dataset_mydataset",``
        | `` "status": "FINISHED",``
        | `` "query_handle": "57cf1b01-8dba-423a-a8b4-66cd29dd75e2",``
        | `` "has_results": true,``
        | `` "is_active": false``
-       | ``}]``
+       | ``} ]``
    * - Description
      - Retrieves all queries
 
@@ -400,7 +398,7 @@ The results are returned as a JSON array, with each element containing informati
 
 Count of Active Queries
 -----------------------
-To return the count of active queries, use::
+To return the count of **active** queries, use::
 
    GET <base-url>/namespaces/<namespace>/data/explore/queries/count
 
@@ -424,9 +422,11 @@ Download Query Results
 ----------------------
 To download the results of a query, use::
 
-  POST <base-url>/namespaces/<namespace>/data/explore/queries/<query-handle>/download
+  POST <base-url>/data/explore/queries/<query-handle>/download
 
 The results of the query are returned in CSV format.
+
+**Note:** this endpoint is *not* namespaced, as all query-handles are globally unique.
 
 .. list-table::
    :widths: 20 80
@@ -434,8 +434,6 @@ The results of the query are returned in CSV format.
 
    * - Parameter
      - Description
-   * - ``<namespace>``
-     - Namespace ID
    * - ``<query-handle>``
      - Handle obtained when the query was submitted or via a list of queries
 

--- a/cdap-docs/reference-manual/source/http-restful-api/query.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/query.rst
@@ -164,8 +164,6 @@ If the query's status is ``FINISHED`` and it has results, you can obtain the sch
 
    * - Parameter
      - Description
-   * - ``<namespace>``
-     - Namespace ID
    * - ``<query-handle>``
      - Handle obtained when the query was submitted
 
@@ -236,8 +234,6 @@ If the batch size is not specified, the default is 20.
 
    * - Parameter
      - Description
-   * - ``<namespace>``
-     - Namespace ID
    * - ``<query-handle>``
      - Handle obtained when the query was submitted
 


### PR DESCRIPTION
Passes [Quick Build 3](http://builds.cask.co/browse/CDAP-DQB17-3)

Fixes errors in:
- [Clicks and Views example](http://builds.cask.co/artifact/CDAP-DQB17/shared/build-3/Docs-HTML/3.5.0-SNAPSHOT/en/examples-manual/examples/clicks-and-views.html)
- [Query RESTful API](http://builds.cask.co/artifact/CDAP-DQB17/shared/build-3/Docs-HTML/3.5.0-SNAPSHOT/en/reference-manual/http-restful-api/query.html)

Fixes the _ClicksAndViews_ example by adding additional includes to handle the case of an example that doesn't start or stop any services.

It fixes **all** examples by replacing a link at the end of the "Building and Starting" section (which was linking to the _Developers' Guide_) with a link to the end of the current example page, which is much more useful:

```
- Once all components are started, `run the example <#running-the-example>`__.

- When finished, you can `stop and remove the application 
  <#stopping-and-removing-the-application>`__.
```

Fix for https://issues.cask.co/browse/CDAP-5996
