### PR TITLE
CDAP-5451 CDAP HA Installation Instructions

### DIFF
--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -48,12 +48,20 @@ function download_includes() {
   local pattern="\|distribution\|"  
   local distributions="cloudera ambari mapr packages"
   local types="installation configuration starting"
+  local type
   for dist in ${distributions}; do
     for type in ${types}; do
       rewrite_references_sed "${source_rst}/${type}.txt" "${target_includes_dir}/${dist}-${type}.rst" "${pattern}" "${dist}"
     done
     echo
   done
+
+  distributions="mapr packages"
+  for dist in ${distributions}; do
+    type="ha-installation"
+    rewrite_references_sed "${source_rst}/${type}.txt" "${target_includes_dir}/${dist}-${type}.rst" "${pattern}" "${dist}"
+  done
+  echo
 }
 
 run_command ${1}

--- a/cdap-docs/admin-manual/source/_includes/installation/ha-installation.txt
+++ b/cdap-docs/admin-manual/source/_includes/installation/ha-installation.txt
@@ -1,41 +1,74 @@
+.. _|distribution|-highly-available:
+
 Enabling CDAP HA
 ----------------
 In addition to having a :ref:`cluster architecture <admin-manual-install-deployment-architectures-ha>`
 that supports HA (high availability), these additional configuration steps need to followed and completed:
 
+CDAP Components
+...............
+For each of the CDAP components listed below (Master, Router, Kafka, UI, Authentication Server), these
+comments apply:
+
+- Sync the configuration files (such as ``cdap-site.xml`` and ``cdap-security.xml``) on all the nodes. 
+- While the default *bind.address* settings (``0.0.0.0``, used for ``app.bind.address``,
+  ``data.tx.bind.address``, ``router.bind.address``, and so on) can be synced across hosts,
+  if you customize them to a particular IP address, they will |---| as a result |---| be
+  different on different hosts.
+- Starting services is described in :ref:`|distribution|-starting-services`.
+
 CDAP Master
 ...........
-- Install multiple instances of the CDAP Master on different nodes.
-- The instances coordinate amongst themselves, setting a leader and followers.
+The CDAP Master service primarily performs coordination tasks and can be scaled for redundancy. The
+instances coordinate amongst themselves, electing one as a leader at all times.
+
+- Install the ``cdap-master`` package on different nodes.
+- Ensure they are configured identically (``/etc/cdap/conf/cdap-site.xml``). 
+- Start the ``cdap-master`` service on each node.
 
 CDAP Router
 ...........
-- Install multiple instances of the CDAP Router on different nodes.
-- Sync the configuration files (``cdap-site.xml``, ``cdap-security.xml``) on the nodes.
-- Place a load balancer, if desired, in front of these nodes.
-- The CDAP Router is stateless, and simply routes requests to the appropriate service.
+The CDAP Router service is a stateless API endpoint for CDAP, and simply routes requests to the
+appropriate service. It can be scaled horizontally for performance. A load balancer, if
+desired, can be placed in front of the nodes running the service.
+
+- Install the ``cdap-gateway`` package on different nodes.
+- The ``router.bind.address`` may need to be customized on each box if it is not set to
+  the default wildcard address (``0.0.0.0``).
+- Start the ``cdap-router`` service on each node.
 
 CDAP Kafka
 ..........
+- Install the ``cdap-kafka`` package on different nodes.
 - Two properties need to be set in the ``cdap-site.xml`` files on each node.
-- The **Kafka brokers list** is comma-separated and followed by ``/${root.namespace}``:
+- The **Kafka brokers list** is a comma-separated list of hosts, followed by ``/${root.namespace}``:
 
-    ``kafka.seed.brokers``: ``127.0.0.1:9092,.../${root.namespace}`` 
+    ``kafka.seed.brokers``: ``myhost.example.com:9092,.../${root.namespace}``
+    
+  Substitute appropriate addresses for ``myhost.example.com`` in the above example.
   
 - The **replication factor** is used to replicate Kafka messages across multiple
   machines to prevent data loss in the event of a hardware failure:
   
     ``kafka.default.replication.factor``: 2
 
-- The recommended setting is to run at least two Kafka servers; set this property
-  to the number of Kafka servers.
+- The recommended setting is to run at least two Kafka servers with a minimum replication
+  factor of two; set this property to the maximum number of tolerated machine failures
+  plus one (assuming you have that number of servers). For example, if you were running
+  five Kafka servers, and would tolerate two of those failing, you would set the
+  replication factor to three. The number of seed brokers listed should always be equal to
+  or greater than the replication factor.
+- Start the ``cdap-kafka`` service on each node.
 
 CDAP UI
 .......
-- Install multiple instances of the CDAP UI on different nodes.
+- Install the ``cdap-ui`` package on different nodes.
+- Start the ``cdap-ui`` service on each node.
+
 
 CDAP Authentication Server
 ..........................
-- Install multiple instances of the CDAP Authentication Server on different nodes.
+- Install the ``cdap-security`` package (the CDAP Authentication Server) on different nodes.
 - When an initial request is made to the Authentication Server, instead
   of returning a single VIP (virtual IP), it will return a list of routes.
+- Start the ``cdap-security`` service on each node.

--- a/cdap-docs/admin-manual/source/_includes/installation/ha-installation.txt
+++ b/cdap-docs/admin-manual/source/_includes/installation/ha-installation.txt
@@ -3,7 +3,7 @@
 Enabling CDAP HA
 ----------------
 In addition to having a :ref:`cluster architecture <admin-manual-install-deployment-architectures-ha>`
-that supports HA (high availability), these additional configuration steps need to followed and completed:
+that supports HA (high availability), these additional configuration steps need to be followed and completed:
 
 CDAP Components
 ...............
@@ -40,23 +40,24 @@ desired, can be placed in front of the nodes running the service.
 CDAP Kafka
 ..........
 - Install the ``cdap-kafka`` package on different nodes.
-- Two properties need to be set in the ``cdap-site.xml`` files on each node.
-- The **Kafka brokers list** is a comma-separated list of hosts, followed by ``/${root.namespace}``:
+- Two properties need to be set in the ``cdap-site.xml`` files on each node:
 
-    ``kafka.seed.brokers``: ``myhost.example.com:9092,.../${root.namespace}``
+  - The **Kafka seed brokers list** is a comma-separated list of hosts, followed by ``/${root.namespace}``:
+
+      ``kafka.seed.brokers``: ``myhost.example.com:9092,.../${root.namespace}``
     
-  Substitute appropriate addresses for ``myhost.example.com`` in the above example.
+    Substitute appropriate addresses for ``myhost.example.com`` in the above example.
   
-- The **replication factor** is used to replicate Kafka messages across multiple
-  machines to prevent data loss in the event of a hardware failure:
+  - The **replication factor** is used to replicate Kafka messages across multiple
+    machines to prevent data loss in the event of a hardware failure:
   
-    ``kafka.default.replication.factor``: 2
+      ``kafka.default.replication.factor``: 2
 
-- The recommended setting is to run at least two Kafka servers with a minimum replication
+- The recommended setting is to run at least two Kafka brokers with a minimum replication
   factor of two; set this property to the maximum number of tolerated machine failures
-  plus one (assuming you have that number of servers). For example, if you were running
-  five Kafka servers, and would tolerate two of those failing, you would set the
-  replication factor to three. The number of seed brokers listed should always be equal to
+  plus one (assuming you have that number of machines). For example, if you were running
+  five Kafka brokers, and would tolerate two of those failing, you would set the
+  replication factor to three. The number of Kafka brokers listed should always be equal to
   or greater than the replication factor.
 - Start the ``cdap-kafka`` service on each node.
 
@@ -69,6 +70,6 @@ CDAP UI
 CDAP Authentication Server
 ..........................
 - Install the ``cdap-security`` package (the CDAP Authentication Server) on different nodes.
-- When an initial request is made to the Authentication Server, instead
-  of returning a single VIP (virtual IP), it will return a list of routes.
 - Start the ``cdap-security`` service on each node.
+- Note that when an unauthenticated request is made in a secure HA setup, a list of all
+  running authentication endpoints will be returned in the body of the request.

--- a/cdap-docs/admin-manual/source/_includes/installation/ha-installation.txt
+++ b/cdap-docs/admin-manual/source/_includes/installation/ha-installation.txt
@@ -1,0 +1,41 @@
+Enabling CDAP HA
+----------------
+In addition to having a :ref:`cluster architecture <admin-manual-install-deployment-architectures-ha>`
+that supports HA (high availability), these additional configuration steps need to followed and completed:
+
+CDAP Master
+...........
+- Install multiple instances of the CDAP Master on different nodes.
+- The instances coordinate amongst themselves, setting a leader and followers.
+
+CDAP Router
+...........
+- Install multiple instances of the CDAP Router on different nodes.
+- Sync the configuration files (``cdap-site.xml``, ``cdap-security.xml``) on the nodes.
+- Place a load balancer, if desired, in front of these nodes.
+- The CDAP Router is stateless, and simply routes requests to the appropriate service.
+
+CDAP Kafka
+..........
+- Two properties need to be set in the ``cdap-site.xml`` files on each node.
+- The **Kafka brokers list** is comma-separated and followed by ``/${root.namespace}``:
+
+    ``kafka.seed.brokers``: ``127.0.0.1:9092,.../${root.namespace}`` 
+  
+- The **replication factor** is used to replicate Kafka messages across multiple
+  machines to prevent data loss in the event of a hardware failure:
+  
+    ``kafka.default.replication.factor``: 2
+
+- The recommended setting is to run at least two Kafka servers; set this property
+  to the number of Kafka servers.
+
+CDAP UI
+.......
+- Install multiple instances of the CDAP UI on different nodes.
+
+CDAP Authentication Server
+..........................
+- Install multiple instances of the CDAP Authentication Server on different nodes.
+- When an initial request is made to the Authentication Server, instead
+  of returning a single VIP (virtual IP), it will return a list of routes.

--- a/cdap-docs/admin-manual/source/installation/ambari.rst
+++ b/cdap-docs/admin-manual/source/installation/ambari.rst
@@ -324,6 +324,7 @@ the address of the node running the CDAP UI service at port 9999.
 
 .. include:: /_includes/installation/smoke-test-cdap.txt
 
+.. _ambari-installation-advanced-topics:
 
 Advanced Topics
 ===============

--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -534,3 +534,14 @@ For Kerberos-enabled Hadoop clusters:
     rm -rf /yarn/nm/usercache/cdap
 
   Restart CDAP after removing the usercache(s).
+
+.. _cloudera-configuration-highly-available:
+
+Enabling CDAP HA
+----------------
+
+In addition to having a :ref:`cluster architecture admin-manual-install-deployment-architectures-ha>`
+that supports HA (high availability), these additional configuration steps need to followed and completed:
+
+
+

--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -543,38 +543,72 @@ Enabling CDAP HA
 In addition to having a :ref:`cluster architecture <admin-manual-install-deployment-architectures-ha>`
 that supports HA (high availability), these additional configuration steps need to followed and completed:
 
+CDAP Components
+...............
+For each of the CDAP components listed below (Master, Router, Kafka, UI, Authentication Server), these
+comments apply:
+
+- Sync the configuration files (such as ``cdap-site.xml`` and ``cdap-security.xml``) on all the nodes. 
+  Though the Cloudera Manager UI will do this for you, as any customization of individual can over-ride this, 
+  it is important to keep this in mind as the end-goal when you make changes.
+- While the default *bind.address* settings (``0.0.0.0``, used for ``app.bind.address``,
+  ``data.tx.bind.address``, ``router.bind.address``, and so on) can be synced across hosts,
+  if you customize them to a particular IP address, they will |---| as a result |---| be
+  different on different hosts. This can be controlled by the settings for an individual *Role Instance*.
+
 CDAP Master
 ...........
-- Install multiple instances of the CDAP Master on different nodes.
-- The instances coordinate amongst themselves, setting a leader and followers.
+The CDAP Master service primarily performs coordination tasks and can be scaled for redundancy. The
+instances coordinate amongst themselves, electing one as a leader at all times.
+
+- Using the Cloudera Manager UI, add additional *Role Instances* of the role ``CDAP Master
+  Service`` to additional machines.
+- Ensure each machine has all required Gateway roles.
+- Start each ``CDAP Master Service`` role.
 
 CDAP Router
 ...........
-- Install multiple instances of the CDAP Router on different nodes.
-- Sync the configuration files (``cdap-site.xml``, ``cdap-security.xml``) on the nodes.
-- Place a load balancer, if desired, in front of these nodes.
-- The CDAP Router is stateless, and simply routes requests to the appropriate service.
+The CDAP Router service is a stateless API endpoint for CDAP, and simply routes requests to the
+appropriate service. It can be scaled horizontally for performance. A load balancer, if
+desired, can be placed in front of the nodes running the service.
+
+- Using the Cloudera Manager UI, add *Role Instances* of the role ``CDAP Gateway/Router
+  Service`` to additional machines.
+- Start each ``CDAP Gateway/Router Service`` role.
 
 CDAP Kafka
 ..........
-- Two properties govern the Kafka setting in the cluster.
-- The **list of Kafka seed brokers** is generated automatically, but the
-  replication factor (``kafka.default.replication.factor``) is not set
-  automatically. Instead, it needs to be set manually.
-- The **replication factor** is used to replicate Kafka messages across
-  multiple machines to prevent data loss in the event of a hardware
-  failure.
-- The recommended setting is to run at least two Kafka servers; set this
-  property to the number of Kafka servers.
+- Using the Cloudera Manager UI, add *Role Instances* of the role ``CDAP Kafka Service``
+  to additional machines.
+- Two properties govern the Kafka setting in the cluster:
+
+  - The **list of Kafka seed brokers** is generated automatically, but the
+    replication factor (``kafka.default.replication.factor``) is not set
+    automatically. Instead, it needs to be set manually.
+  - The **replication factor** is used to replicate Kafka messages across
+    multiple machines to prevent data loss in the event of a hardware
+    failure.
+
+- The recommended setting is to run **at least two** Kafka servers with a **minimum replication
+  factor of two**; set this property to the maximum number of tolerated machine failures
+  plus one (assuming you have that number of servers). For example, if you were running
+  five Kafka servers, and would tolerate two of those failing, you would set the
+  replication factor to three. The number of seed brokers listed should always be equal to
+  or greater than the replication factor.
+- Start each ``CDAP Kafka Service`` role.
 
 CDAP UI
 .......
-- Install multiple instances of the CDAP UI on different nodes.
+- Using the Cloudera Manager UI, add *Role Instances* of the role ``CDAP UI Service``
+  to additional machines.
 - For Cloudera Manager, the CDAP UI and the CDAP Router need to be on
   the same node so that the UI talks to the correct (the same) Router.
+- Start each ``CDAP UI Service`` role. 
 
 CDAP Authentication Server
 ..........................
-- Install multiple instances of the CDAP Authentication Server on different nodes.
+- Using the Cloudera Manager UI, add *Role Instances* of the role ``CDAP Security Auth
+  Service`` (the CDAP Authentication Server) to additional machines.
 - When an initial request is made to the Authentication Server, instead
   of returning a single VIP (virtual IP), it will return a list of routes.
+- Start each ``CDAP Security Auth Service`` role.  

--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -539,7 +539,7 @@ For Kerberos-enabled Hadoop clusters:
 
 Enabling CDAP HA
 ----------------
-In addition to having a :ref:`cluster architecture admin-manual-install-deployment-architectures-ha>`
+In addition to having a :ref:`cluster architecture <admin-manual-install-deployment-architectures-ha>`
 that supports HA (high availability), these additional configuration steps need to followed and completed:
 
 CDAP Master

--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -541,7 +541,7 @@ For Kerberos-enabled Hadoop clusters:
 Enabling CDAP HA
 ----------------
 In addition to having a :ref:`cluster architecture <admin-manual-install-deployment-architectures-ha>`
-that supports HA (high availability), these additional configuration steps need to followed and completed:
+that supports HA (high availability), these additional configuration steps need to be followed and completed:
 
 CDAP Components
 ...............
@@ -549,8 +549,6 @@ For each of the CDAP components listed below (Master, Router, Kafka, UI, Authent
 comments apply:
 
 - Sync the configuration files (such as ``cdap-site.xml`` and ``cdap-security.xml``) on all the nodes. 
-  Though the Cloudera Manager UI will do this for you, as any customization of individual can over-ride this, 
-  it is important to keep this in mind as the end-goal when you make changes.
 - While the default *bind.address* settings (``0.0.0.0``, used for ``app.bind.address``,
   ``data.tx.bind.address``, ``router.bind.address``, and so on) can be synced across hosts,
   if you customize them to a particular IP address, they will |---| as a result |---| be
@@ -561,7 +559,7 @@ CDAP Master
 The CDAP Master service primarily performs coordination tasks and can be scaled for redundancy. The
 instances coordinate amongst themselves, electing one as a leader at all times.
 
-- Using the Cloudera Manager UI, add additional *Role Instances* of the role ``CDAP Master
+- Using the Cloudera Manager UI, add additional *Role Instances* of the role type ``CDAP Master
   Service`` to additional machines.
 - Ensure each machine has all required Gateway roles.
 - Start each ``CDAP Master Service`` role.
@@ -572,13 +570,13 @@ The CDAP Router service is a stateless API endpoint for CDAP, and simply routes 
 appropriate service. It can be scaled horizontally for performance. A load balancer, if
 desired, can be placed in front of the nodes running the service.
 
-- Using the Cloudera Manager UI, add *Role Instances* of the role ``CDAP Gateway/Router
+- Using the Cloudera Manager UI, add *Role Instances* of the role type ``CDAP Gateway/Router
   Service`` to additional machines.
 - Start each ``CDAP Gateway/Router Service`` role.
 
 CDAP Kafka
 ..........
-- Using the Cloudera Manager UI, add *Role Instances* of the role ``CDAP Kafka Service``
+- Using the Cloudera Manager UI, add *Role Instances* of the role type ``CDAP Kafka Service``
   to additional machines.
 - Two properties govern the Kafka setting in the cluster:
 
@@ -589,26 +587,26 @@ CDAP Kafka
     multiple machines to prevent data loss in the event of a hardware
     failure.
 
-- The recommended setting is to run **at least two** Kafka servers with a **minimum replication
+- The recommended setting is to run **at least two** Kafka brokers with a **minimum replication
   factor of two**; set this property to the maximum number of tolerated machine failures
-  plus one (assuming you have that number of servers). For example, if you were running
-  five Kafka servers, and would tolerate two of those failing, you would set the
-  replication factor to three. The number of seed brokers listed should always be equal to
+  plus one (assuming you have that number of machines). For example, if you were running
+  five Kafka brokers, and would tolerate two of those failing, you would set the
+  replication factor to three. The number of Kafka brokers listed should always be equal to
   or greater than the replication factor.
 - Start each ``CDAP Kafka Service`` role.
 
 CDAP UI
 .......
-- Using the Cloudera Manager UI, add *Role Instances* of the role ``CDAP UI Service``
+- Using the Cloudera Manager UI, add *Role Instances* of the role type ``CDAP UI Service``
   to additional machines.
-- For Cloudera Manager, the CDAP UI and the CDAP Router need to be on
-  the same node so that the UI talks to the correct (the same) Router.
+- For Cloudera Manager, the CDAP UI and the CDAP Router currently need to be colocated on
+  the same node.
 - Start each ``CDAP UI Service`` role. 
 
 CDAP Authentication Server
 ..........................
-- Using the Cloudera Manager UI, add *Role Instances* of the role ``CDAP Security Auth
+- Using the Cloudera Manager UI, add *Role Instances* of the role type ``CDAP Security Auth
   Service`` (the CDAP Authentication Server) to additional machines.
-- When an initial request is made to the Authentication Server, instead
-  of returning a single VIP (virtual IP), it will return a list of routes.
 - Start each ``CDAP Security Auth Service`` role.  
+- Note that when an unauthenticated request is made in a secure HA setup, a list of all
+  running authentication endpoints will be returned in the body of the request.

--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -490,6 +490,7 @@ port ``9999`` of the host where the UI role instance is running.
 
 .. include:: /_includes/installation/smoke-test-cdap.txt
 
+.. _cloudera-installation-advanced-topics:
 
 Advanced Topics
 ===============
@@ -544,37 +545,36 @@ that supports HA (high availability), these additional configuration steps need 
 
 CDAP Master
 ...........
-- Install and start multiple instances of the CDAP Master on different nodes.
+- Install multiple instances of the CDAP Master on different nodes.
 - The instances coordinate amongst themselves, setting a leader and followers.
 
 CDAP Router
 ...........
-- Install and start multiple instances of the CDAP Router on different nodes.
+- Install multiple instances of the CDAP Router on different nodes.
 - Sync the configuration files (``cdap-site.xml``, ``cdap-security.xml``) on the nodes.
 - Place a load balancer, if desired, in front of these nodes.
 - The CDAP Router is stateless, and simply routes requests to the appropriate service.
 
 CDAP Kafka
 ..........
-- The seed brokers are used to replicate Kafka messages across multiple machines to prevent data loss in 
-  the event of a hardware failure.
-- The list of Kafka seed brokers is generated automatically, but the
+- Two properties govern the Kafka setting in the cluster.
+- The **list of Kafka seed brokers** is generated automatically, but the
   replication factor (``kafka.default.replication.factor``) is not set
   automatically. Instead, it needs to be set manually.
+- The **replication factor** is used to replicate Kafka messages across
+  multiple machines to prevent data loss in the event of a hardware
+  failure.
 - The recommended setting is to run at least two Kafka servers; set this
-  to the number of Kafka servers.
+  property to the number of Kafka servers.
 
 CDAP UI
 .......
-- Install and start multiple instances of the CDAP UI on different nodes.
+- Install multiple instances of the CDAP UI on different nodes.
 - For Cloudera Manager, the CDAP UI and the CDAP Router need to be on
   the same node so that the UI talks to the correct (the same) Router.
 
 CDAP Authentication Server
 ..........................
-- Install and start multiple instances of the CDAP Authentication Server on different nodes.
+- Install multiple instances of the CDAP Authentication Server on different nodes.
 - When an initial request is made to the Authentication Server, instead
   of returning a single VIP (virtual IP), it will return a list of routes.
-
-
-

--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -539,9 +539,42 @@ For Kerberos-enabled Hadoop clusters:
 
 Enabling CDAP HA
 ----------------
-
 In addition to having a :ref:`cluster architecture admin-manual-install-deployment-architectures-ha>`
 that supports HA (high availability), these additional configuration steps need to followed and completed:
+
+CDAP Master
+...........
+- Install and start multiple instances of the CDAP Master on different nodes.
+- The instances coordinate amongst themselves, setting a leader and followers.
+
+CDAP Router
+...........
+- Install and start multiple instances of the CDAP Router on different nodes.
+- Sync the configuration files (``cdap-site.xml``, ``cdap-security.xml``) on the nodes.
+- Place a load balancer, if desired, in front of these nodes.
+- The CDAP Router is stateless, and simply routes requests to the appropriate service.
+
+CDAP Kafka
+..........
+- The seed brokers are used to replicate Kafka messages across multiple machines to prevent data loss in 
+  the event of a hardware failure.
+- The list of Kafka seed brokers is generated automatically, but the
+  replication factor (``kafka.default.replication.factor``) is not set
+  automatically. Instead, it needs to be set manually.
+- The recommended setting is to run at least two Kafka servers; set this
+  to the number of Kafka servers.
+
+CDAP UI
+.......
+- Install and start multiple instances of the CDAP UI on different nodes.
+- For Cloudera Manager, the CDAP UI and the CDAP Router need to be on
+  the same node so that the UI talks to the correct (the same) Router.
+
+CDAP Authentication Server
+..........................
+- Install and start multiple instances of the CDAP Authentication Server on different nodes.
+- When an initial request is made to the Authentication Server, instead
+  of returning a single VIP (virtual IP), it will return a list of routes.
 
 
 

--- a/cdap-docs/admin-manual/source/installation/index.rst
+++ b/cdap-docs/admin-manual/source/installation/index.rst
@@ -22,17 +22,30 @@ Installation and configuration instructions for either **specific distributions*
 
 - :ref:`Installation using Cloudera Manager <admin-installation-cloudera>`
 
+  - :ref:`Advanced Topics: <cloudera-installation-advanced-topics>`
+    enabling perimeter security, Kerberos, and CDAP high availability
+
 ..
 
 - :ref:`Installation using Apache Ambari <admin-installation-ambari>`
+
+  - Enabling perimeter security, Kerberos, and CDAP high
+    availability are currently not available for Ambari
 
 ..
 
 - :ref:`Installation for MapR <admin-installation-mapr>`
 
+  - :ref:`Advanced Topics: <mapr-installation-advanced-topics>`
+    enabling perimeter security and CDAP high availability;
+    enabling Kerberos is currently not available for MapR
+
 ..
 
 - :ref:`Manual Installation using Packages <admin-installation-packages>`
+
+  - :ref:`Advanced Topics: <packages-installation-advanced-topics>`
+    enabling perimeter security, Kerberos, and CDAP high availability
 
 ..
 

--- a/cdap-docs/admin-manual/source/installation/mapr.rst
+++ b/cdap-docs/admin-manual/source/installation/mapr.rst
@@ -186,6 +186,8 @@ Verification
 .. include:: /_includes/installation/smoke-test-cdap.txt
 
 
+.. _mapr-installation-advanced-topics:
+
 Advanced Topics
 ===============
 
@@ -206,3 +208,7 @@ Kerberos is currently not supported by CDAP on secure MapR clusters.
 .. .. include:: /../target/_includes/mapr-configuration.rst
 ..     :start-after: .. configuration-enabling-kerberos:
 ..     :end-before: .. _mapr-configuration-eps:
+
+.. _mapr-highly-available:
+
+.. include:: ../_includes/installation/ha-installation.txt

--- a/cdap-docs/admin-manual/source/installation/mapr.rst
+++ b/cdap-docs/admin-manual/source/installation/mapr.rst
@@ -209,6 +209,4 @@ Kerberos is currently not supported by CDAP on secure MapR clusters.
 ..     :start-after: .. configuration-enabling-kerberos:
 ..     :end-before: .. _mapr-configuration-eps:
 
-.. _mapr-highly-available:
-
-.. include:: ../_includes/installation/ha-installation.txt
+.. include:: /../target/_includes/mapr-ha-installation.rst

--- a/cdap-docs/admin-manual/source/installation/packages.rst
+++ b/cdap-docs/admin-manual/source/installation/packages.rst
@@ -96,6 +96,8 @@ Verification
 .. include:: /_includes/installation/smoke-test-cdap.txt
 
 
+.. _packages-installation-advanced-topics:
+
 Advanced Topics
 ===============
 
@@ -116,18 +118,4 @@ Advanced Topics
 
 .. _packages-highly-available:
 
-Enabling CDAP HA
-----------------
-Repeat the installation steps on additional boxes. The configuration settings (in
-``cdap-site.xml``, *property:value*) needed to support high-availability are:
-
-- ``kafka.seed.brokers``: ``127.0.0.1:9092,.../${root.namespace}`` 
-  
-  - Kafka brokers list (comma-separated), followed by ``/${root.namespace}``
-  
-- ``kafka.default.replication.factor``: 2
-
-  - Used to replicate Kafka messages across multiple machines to prevent data loss in 
-    the event of a hardware failure.
-  - The recommended setting is to run at least two Kafka servers.
-  - Set this to the number of Kafka servers.
+.. include:: ../_includes/installation/ha-installation.txt

--- a/cdap-docs/admin-manual/source/installation/packages.rst
+++ b/cdap-docs/admin-manual/source/installation/packages.rst
@@ -116,8 +116,8 @@ Advanced Topics
 
 .. _packages-highly-available:
 
-CDAP HA setup
--------------
+Enabling CDAP HA
+----------------
 Repeat the installation steps on additional boxes. The configuration settings (in
 ``cdap-site.xml``, *property:value*) needed to support high-availability are:
 

--- a/cdap-docs/admin-manual/source/installation/packages.rst
+++ b/cdap-docs/admin-manual/source/installation/packages.rst
@@ -116,6 +116,5 @@ Advanced Topics
     :start-after: .. configuration-enabling-kerberos:
     :end-before: .. _packages-configuration-eps:
 
-.. _packages-highly-available:
+.. include:: /../target/_includes/packages-ha-installation.rst
 
-.. include:: ../_includes/installation/ha-installation.txt

--- a/cdap-docs/admin-manual/source/upgrading/packages.rst
+++ b/cdap-docs/admin-manual/source/upgrading/packages.rst
@@ -27,9 +27,9 @@ version to a higher |short-version|\.x version.
 
 Upgrading CDAP Major/Minor Release Versions
 -------------------------------------------
-Upgrading between major versions of CDAP refers to upgrading from a
+Upgrading between major/minor versions of CDAP refers to upgrading from a
 |previous-short-version|\.x version to |short-version|\.x. Upgrades
-between multiple Major/Minor versions must be done consecutively, and a
+between multiple major/minor versions must be done consecutively, and a
 version cannot be skipped unless otherwise noted.
 
 Upgrade Steps

--- a/cdap-docs/admin-manual/source/upgrading/packages.rst
+++ b/cdap-docs/admin-manual/source/upgrading/packages.rst
@@ -15,13 +15,27 @@ Upgrading CDAP
 When upgrading an existing CDAP installation from a previous version, you will need
 to make sure the CDAP table definitions in HBase are up-to-date.
 
-These steps will stop CDAP, update the installation, run an upgrade tool for the table definitions,
-and then restart CDAP.
-
 **These steps will upgrade from CDAP** |bold-previous-short-version|\ **.x to**
 |bold-version|\ **.** If you are on an earlier version of CDAP, please follow the
 upgrade instructions for the earlier versions and upgrade first to
 |previous-short-version|\.x before proceeding.
+
+Upgrading CDAP Patch Release Versions
+-------------------------------------
+Upgrading between patch versions of CDAP refers to upgrading from one |short-version|\.x
+version to a higher |short-version|\.x version.
+
+Upgrading CDAP Major/Minor Release Versions
+-------------------------------------------
+Upgrading between major versions of CDAP refers to upgrading from a
+|previous-short-version|\.x version to |short-version|\.x. Upgrades
+between multiple Major/Minor versions must be done consecutively, and a
+version cannot be skipped unless otherwise noted.
+
+Upgrade Steps
+-------------
+These steps will stop CDAP, update the installation, run an upgrade tool for the table definitions,
+and then restart CDAP:
 
 .. highlight:: console
 


### PR DESCRIPTION
Passes [Quick Build 3](http://builds.cask.co/browse/CDAP-DQB19-3)

Adds sections on adding CDAP HA to each of the installation instruction sets.

Fix for https://issues.cask.co/browse/CDAP-5451

Pages of interest:
- [Installation Page](http://builds.cask.co/artifact/CDAP-DQB19/shared/build-3/Docs-HTML/3.5.0-SNAPSHOT/en/admin-manual/installation/index.html)
- [Cloudera (Advanced Topics)](http://builds.cask.co/artifact/CDAP-DQB19/shared/build-3/Docs-HTML/3.5.0-SNAPSHOT/en/admin-manual/installation/cloudera.html#cloudera-installation-advanced-topics)
- [Ambari (Advanced Topics)](http://builds.cask.co/artifact/CDAP-DQB19/shared/build-3/Docs-HTML/3.5.0-SNAPSHOT/en/admin-manual/installation/ambari.html#advanced-topics)
- [MapR (Advanced Topics)](http://builds.cask.co/artifact/CDAP-DQB19/shared/build-3/Docs-HTML/3.5.0-SNAPSHOT/en/admin-manual/installation/mapr.html#advanced-topics)
- [Packages (Advanced Topics)](http://builds.cask.co/artifact/CDAP-DQB19/shared/build-3/Docs-HTML/3.5.0-SNAPSHOT/en/admin-manual/installation/packages.html#advanced-topics)
