### PR TITLE
Documentation Changes: Edits to Introduction and improvements to layout.

### DIFF
--- a/cdap-docs/_common/_source/index.rst
+++ b/cdap-docs/_common/_source/index.rst
@@ -1,7 +1,7 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: Introduction to the Cask Data Application Platform
-    :copyright: Copyright © 2014-2015 Cask Data, Inc.
+    :copyright: Copyright © 2014-2016 Cask Data, Inc.
 
 :hide-relations: true
 

--- a/cdap-docs/_common/_themes/cdap-intro/static/cdap-intro.css_t
+++ b/cdap-docs/_common/_themes/cdap-intro/static/cdap-intro.css_t
@@ -1,0 +1,18 @@
+/*
+ * cdap-intro.css_t
+ * ~~~~~~~~~~~~~~~~~
+ *
+ * Sphinx stylesheet -- CDAP theme for Intro manual.
+ *
+ *
+ */
+
+@import url("cdap.css");
+
+body {
+  background-color: white;
+}
+
+div.footer {
+  background-color: #4B5258;
+}

--- a/cdap-docs/_common/_themes/cdap-intro/theme.conf
+++ b/cdap-docs/_common/_themes/cdap-intro/theme.conf
@@ -1,6 +1,6 @@
 [theme]
 inherit = cdap
-stylesheet = cdap-faqs.css
+stylesheet = cdap-intro.css
 pygments_style = tango
 
 [options]

--- a/cdap-docs/_common/_themes/cdap/layout.html
+++ b/cdap-docs/_common/_themes/cdap/layout.html
@@ -260,16 +260,26 @@
 .tg a{font-weight:bold;}
 </style>
 <table class="tg" width= 100%>
+{#  Code to check relations, controlled by setting in the field list at the top :hide-relations: true #}
+{%- set hiderel = '' %}
+{%- set hiderel_key = 'hide-relations' %}
+{%- if meta is defined %}
+    {%- if hiderel_key in meta %}
+        {%- set hiderel = meta[hiderel_key] %}
+    {%- endif %}
+{%- endif %}
   <tr>
+    {%- if not hiderel %}
     <th class="tg-031e">
-    
     {%- if prev %}Previous Topic: 
     <a title="{{ prev.title|striptags|e }}" href="{{ prev.link|e }}" />{{ prev.title }}</a>&nbsp;&nbsp;
+    {%- else %}
+    &nbsp;&nbsp;
+    {%- endif %}
+    </th>
     {%- endif %}
     
-    </th>
     <th class="tg-s6z2">
-    
     {%- if show_copyright %}
       {%- if hasdoc('copyright') %}
         {% trans path=pathto('copyright'), copyright=copyright|e %}<a href="{{ path }}">Copyright</a> &copy; {{ copyright }}{% endtrans %}
@@ -281,17 +291,20 @@
       {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
     {%- endif %}
     {%- if show_sphinx %}
-      {% trans sphinx_version=sphinx_version|e %}Created using <a href="http://sphinx-doc.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %}
+      {% trans sphinx_version=sphinx_version|e %}&bull; Created using <a href="http://sphinx-doc.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %}
     {%- endif %}
-    
     </th>
-    <th class="tg-0ord">
     
+    {%- if not hiderel %}
+    <th class="tg-0ord">
     {%- if next %}&nbsp;&nbsp;Next Topic:
     <a title="{{ next.title|striptags|e }}" href="{{ next.link|e }}" />{{ next.title }}</a>
+    {%- else %}
+    &nbsp;&nbsp;
     {%- endif %}
-    
     </th>
+    {%- endif %}
+
   </tr>
 </table>
 

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -493,7 +493,7 @@ html_show_sourcelink = False
 html_copy_source = False
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-html_show_sphinx = False
+html_show_sphinx = True
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
 #html_show_copyright = True

--- a/cdap-docs/_common/tabbed-parsed-literal.py
+++ b/cdap-docs/_common/tabbed-parsed-literal.py
@@ -370,8 +370,10 @@ class TabbedParsedLiteral(ParsedLiteral):
             block = block.replace('\\', '\\\\')
             block = block.replace('\\|', '\\\ |')
             block = block.replace('*', '\*')
-            block = block.replace('|-', '\|-')
-            block = block.replace('|+', '\|+')
+            block = block.replace(' |-', ' \|-')
+            block = block.replace('\n|-', '\n\|-')
+            block = block.replace(' |+', ' \|+')
+            block = block.replace('\n|+', '\n\|+')
             if not block.endswith('\n'):
                 block += '\n'
             lines.append(block)

--- a/cdap-docs/_common/tabbed-parsed-literal.py
+++ b/cdap-docs/_common/tabbed-parsed-literal.py
@@ -369,6 +369,9 @@ class TabbedParsedLiteral(ParsedLiteral):
             block = '\n'.join(line_set).rstrip()
             block = block.replace('\\', '\\\\')
             block = block.replace('\\|', '\\\ |')
+            block = block.replace('*', '\*')
+            block = block.replace('|-', '\|-')
+            block = block.replace('|+', '\|+')
             if not block.endswith('\n'):
                 block += '\n'
             lines.append(block)

--- a/cdap-docs/developers-manual/source/getting-started/building-apps.rst
+++ b/cdap-docs/developers-manual/source/getting-started/building-apps.rst
@@ -122,12 +122,12 @@ Once CDAP is started, you can deploy an application using an example JAR by any 
 
   .. tabbed-parsed-literal::
   
-    $ curl -w'\n' localhost:10000/v3/namespaces/default/artifacts/|example| \
+    $ curl -w"\n" localhost:10000/v3/namespaces/default/artifacts/|example| \
       --data-binary @examples/|example-dir|/target/|example|-|release|.jar
     Artifact added successfully
 
-    $ curl -w'\n' -X PUT -H "Content-Type: application/json" localhost:10000/v3/namespaces/default/apps/<app name> \
-      -d '{ "artifact": { "name": "|example|", "version": "|release|", "scope": "user" }, "config": {} }'
+    $ curl -w"\n" -X PUT -H "Content-Type: application/json" localhost:10000/v3/namespaces/default/apps/<app name> \
+      -d "{ 'artifact': { 'name': '|example|', 'version': '|release|', 'scope': 'user' }, 'config': {} }"
     Deploy Complete
 
 

--- a/cdap-docs/faqs/source/conf.py
+++ b/cdap-docs/faqs/source/conf.py
@@ -10,14 +10,6 @@ import os
 sys.path.insert(0, os.path.abspath('../../_common'))
 from common_conf import * 
 
-# Override the common config
-
-html_short_title_toc = manuals_dict["faqs"]
-html_short_title = u'CDAP %s' % html_short_title_toc
-
-html_context = {"html_short_title_toc":html_short_title_toc}
-
-# Remove this guide from the mapping as it will fail as it has been deleted by clean
-intersphinx_mapping.pop("faqs", None)
+html_short_title_toc, html_short_title, html_context = set_conf_for_manual()
 
 html_theme = 'cdap-faqs'

--- a/cdap-docs/introduction/source/conf.py
+++ b/cdap-docs/introduction/source/conf.py
@@ -12,3 +12,5 @@ sys.path.insert(0, os.path.abspath('../../_common'))
 from common_conf import * 
 
 html_short_title_toc, html_short_title, html_context = set_conf_for_manual()
+
+html_theme = 'cdap-intro'

--- a/cdap-docs/introduction/source/index.rst
+++ b/cdap-docs/introduction/source/index.rst
@@ -1,8 +1,10 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: Introduction to the Cask Data Application Platform
-    :copyright: Copyright © 2015 Cask Data, Inc.
+    :copyright: Copyright © 2015-2016 Cask Data, Inc.
 
+
+:hide-relations: true
 
 .. _introduction-to-cdap:
 
@@ -27,7 +29,8 @@ technologies required, and then show an equivalent CDAP command with the resulti
 from the CDAP Command Line Interface. (Output has been reformatted to fit the webpage
 as required.)
 
-To try this yourself, :ref:`download a copy of CDAP SDK <standalone-index>`, install it
+To try this yourself, :ref:`download a copy of the CDAP SDK <standalone-index>`, 
+:ref:`install it <standalone-index>`,
 and then use the resources in its ``examples`` directory as you follow along.
 
 We'll look at these areas:
@@ -251,30 +254,26 @@ Data Exploration
  
             |cdap >| execute 'select * from stream_logEventStream limit 2'
            
-         .. container:: highlight
-       
-           ::
-            
-             +==============================================================================================================+
-             | stream_logeventstream.ts: | stream_logeventstream.hea | stream_logeventstream.body: STRING                   |
-             | BIGINT                    | ders: map<string,string>  |                                                      |
-             +==============================================================================================================+
-             | 1428969220987             | {"content.type":"text/pla | 69.181.160.120 - - [08/Feb/2015:04:36:40 +0000] "GET |
-             |                           | in"}                      |  /ajax/planStatusHistoryNeighbouringSummaries.action |
-             |                           |                           | ?planKey=COOP-DBT&buildNumber=284&_=1423341312519 HT |
-             |                           |                           | TP/1.1" 200 508 "http://builds.cask.co/browse/COOP-D |
-             |                           |                           | BT-284/log" "Mozilla/5.0 (Macintosh; Intel Mac OS X  |
-             |                           |                           | 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chro |
-             |                           |                           | me/38.0.2125.122 Safari/537.36"                      |
-             |--------------------------------------------------------------------------------------------------------------|
-             | 1428969220987             | {"content.type":"text/pla | 69.181.160.120 - - [08/Feb/2015:04:36:47 +0000] "GET |
-             |                           | in"}                      |  /rest/api/latest/server?_=1423341312520 HTTP/1.1" 2 |
-             |                           |                           | 00 45 "http://builds.cask.co/browse/COOP-DBT-284/log |
-             |                           |                           | " "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) A |
-             |                           |                           | ppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.21 |
-             |                           |                           | 25.122 Safari/537.36"                                |
-             +==============================================================================================================+
-             Fetched 2 rows
+            +==============================================================================================================+
+            | stream_logeventstream.ts: | stream_logeventstream.hea | stream_logeventstream.body: STRING                   |
+            | BIGINT                    | ders: map<string,string>  |                                                      |
+            +==============================================================================================================+
+            | 1428969220987             | {"content.type":"text/pla | 69.181.160.120 - - [08/Feb/2015:04:36:40 +0000] "GET |
+            |                           | in"}                      |  /ajax/planStatusHistoryNeighbouringSummaries.action |
+            |                           |                           | ?planKey=COOP-DBT&buildNumber=284&_=1423341312519 HT |
+            |                           |                           | TP/1.1" 200 508 "http://builds.cask.co/browse/COOP-D |
+            |                           |                           | BT-284/log" "Mozilla/5.0 (Macintosh; Intel Mac OS X  |
+            |                           |                           | 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chro |
+            |                           |                           | me/38.0.2125.122 Safari/537.36"                      |
+            |--------------------------------------------------------------------------------------------------------------|
+            | 1428969220987             | {"content.type":"text/pla | 69.181.160.120 - - [08/Feb/2015:04:36:47 +0000] "GET |
+            |                           | in"}                      |  /rest/api/latest/server?_=1423341312520 HTTP/1.1" 2 |
+            |                           |                           | 00 45 "http://builds.cask.co/browse/COOP-DBT-284/log |
+            |                           |                           | " "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) A |
+            |                           |                           | ppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.21 |
+            |                           |                           | 25.122 Safari/537.36"                                |
+            +==============================================================================================================+
+            Fetched 2 rows
 
 
 Data Exploration: Attaching a Schema
@@ -371,43 +370,49 @@ Data Exploration: Attaching a Schema
  
             |cdap >| execute 'select * from stream_logEventStream limit 2'
 
-         .. container:: highlight
-       
-           ::
-           
-            +==================================================================================================================================+
-            | stream_l | stream_l | stream_l | stream_l | stream_l | stream_l | stream_l | stream_l | stream_l | stream_l | stream_logeventstr |
-            | ogevents | ogevents | ogevents | ogevents | ogevents | ogevents | ogevents | ogevents | ogevents | ogevents | eam.user_agent: ST |
-            | tream.ts | tream.he | tream.re | tream.re | tream.au | tream.da | tream.re | tream.st | tream.co | tream.re | RING               |
-            | : BIGINT | aders: m | mote_hos | mote_log | th_user: | te: STRI | quest: S | atus: IN | ntent_le | ferrer:  |                    |
-            |          | ap<strin | t: STRIN | in: STRI |  STRING  | NG       | TRING    | T        | ngth: IN | STRING   |                    |
-            |          | g,string | G        | NG       |          |          |          |          | T        |          |                    |
-            |          | >        |          |          |          |          |          |          |          |          |                    |
-            +==================================================================================================================================+
-            | 14437238 | {"conten | 69.181.1 |          |          | 08/Feb/2 | GET /aja | 200      | 508      | http://b | Mozilla/5.0 (Macin |
-            | 45737    | t.type": | 60.120   |          |          | 015:04:3 | x/planSt |          |          | uilds.ca | tosh; Intel Mac OS |
-            |          | "text/pl |          |          |          | 6:40 +00 | atusHist |          |          | sk.co/br |  X 10_10_1) AppleW |
-            |          | ain"}    |          |          |          | 00       | oryNeigh |          |          | owse/COO | ebKit/537.36 (KHTM |
-            |          |          |          |          |          |          | bouringS |          |          | P-DBT-28 | L, like Gecko) Chr |
-            |          |          |          |          |          |          | ummaries |          |          | 4/log    | ome/38.0.2125.122  |
-            |          |          |          |          |          |          | .action? |          |          |          | Safari/537.36      |
-            |          |          |          |          |          |          | planKey= |          |          |          |                    |
-            |          |          |          |          |          |          | COOP-DBT |          |          |          |                    |
-            |          |          |          |          |          |          | &buildNu |          |          |          |                    |
-            |          |          |          |          |          |          | mber=284 |          |          |          |                    |
-            |          |          |          |          |          |          | &_=14233 |          |          |          |                    |
-            |          |          |          |          |          |          | 41312519 |          |          |          |                    |
-            |          |          |          |          |          |          |  HTTP/1. |          |          |          |                    |
-            |          |          |          |          |          |          | 1        |          |          |          |                    |
-            |----------------------------------------------------------------------------------------------------------------------------------|
-            | 14437238 | {"conten | 69.181.1 |          |          | 08/Feb/2 | GET /res | 200      | 45       | http://b | Mozilla/5.0 (Macin |
-            | 45737    | t.type": | 60.120   |          |          | 015:04:3 | t/api/la |          |          | uilds.ca | tosh; Intel Mac OS |
-            |          | "text/pl |          |          |          | 6:47 +00 | test/ser |          |          | sk.co/br |  X 10_10_1) AppleW |
-            |          | ain"}    |          |          |          | 00       | ver?_=14 |          |          | owse/COO | ebKit/537.36 (KHTM |
-            |          |          |          |          |          |          | 23341312 |          |          | P-DBT-28 | L, like Gecko) Chr |
-            |          |          |          |          |          |          | 520 HTTP |          |          | 4/log    | ome/38.0.2125.122  |
-            |          |          |          |          |          |          | /1.1     |          |          |          | Safari/537.36      |
-            +==================================================================================================================================+
+            +========================================================================================================================+
+            | stream_l | stream_l | stream_l | stream_l | stream_l | stream_l | stream_l | stream_l | stream_l | stream_l | stream_l |
+            | ogevents | ogevents | ogevents | ogevents | ogevents | ogevents | ogevents | ogevents | ogevents | ogevents | ogevents |
+            | tream.ts | tream.he | tream.re | tream.re | tream.au | tream.da | tream.re | tream.st | tream.co | tream.re | tream.us |
+            | : BIGINT | aders: m | mote_hos | mote_log | th_user: | te: STRI | quest: S | atus: IN | ntent_le | ferrer:  | er_agent |
+            |          | ap<strin | t: STRIN | in: STRI |  STRING  | NG       | TRING    | T        | ngth: IN | STRING   | : STRING |
+            |          | g,string | G        | NG       |          |          |          |          | T        |          |          |
+            |          | >        |          |          |          |          |          |          |          |          |          |
+            +========================================================================================================================+
+            | 14437238 | {"conten | 69.181.1 |          |          | 08/Feb/2 | GET /aja | 200      | 508      | http://b | Mozilla/ |
+            | 45737    | t.type": | 60.120   |          |          | 015:04:3 | x/planSt |          |          | uilds.ca | 5.0 (Mac |
+            |          | "text/pl |          |          |          | 6:40 +00 | atusHist |          |          | sk.co/br | intosh;  |
+            |          | ain"}    |          |          |          | 00       | oryNeigh |          |          | owse/COO | Intel Ma |
+            |          |          |          |          |          |          | bouringS |          |          | P-DBT-28 | c OS X 1 |
+            |          |          |          |          |          |          | ummaries |          |          | 4/log    | 0_10_1)  |
+            |          |          |          |          |          |          | .action? |          |          |          | AppleWeb |
+            |          |          |          |          |          |          | planKey= |          |          |          | Kit/537. |
+            |          |          |          |          |          |          | COOP-DBT |          |          |          | 36 (KHTM |
+            |          |          |          |          |          |          | &buildNu |          |          |          | L, like  |
+            |          |          |          |          |          |          | mber=284 |          |          |          | Gecko) C |
+            |          |          |          |          |          |          | &_=14233 |          |          |          | hrome/38 |
+            |          |          |          |          |          |          | 41312519 |          |          |          | .0.2125. |
+            |          |          |          |          |          |          |  HTTP/1. |          |          |          | 122 Safa |
+            |          |          |          |          |          |          | 1        |          |          |          | ri/537.3 |
+            |          |          |          |          |          |          |          |          |          |          | 6        |
+            |------------------------------------------------------------------------------------------------------------------------|
+            | 14437238 | {"conten | 69.181.1 |          |          | 08/Feb/2 | GET /res | 200      | 45       | http://b | Mozilla/ |
+            | 45737    | t.type": | 60.120   |          |          | 015:04:3 | t/api/la |          |          | uilds.ca | 5.0 (Mac |
+            |          | "text/pl |          |          |          | 6:47 +00 | test/ser |          |          | sk.co/br | intosh;  |
+            |          | ain"}    |          |          |          | 00       | ver?_=14 |          |          | owse/COO | Intel Ma |
+            |          |          |          |          |          |          | 23341312 |          |          | P-DBT-28 | c OS X 1 |
+            |          |          |          |          |          |          | 520 HTTP |          |          | 4/log    | 0_10_1)  |
+            |          |          |          |          |          |          | /1.1     |          |          |          | AppleWeb |
+            |          |          |          |          |          |          |          |          |          |          | Kit/537. |
+            |          |          |          |          |          |          |          |          |          |          | 36 (KHTM |
+            |          |          |          |          |          |          |          |          |          |          | L, like  |
+            |          |          |          |          |          |          |          |          |          |          | Gecko) C |
+            |          |          |          |          |          |          |          |          |          |          | hrome/38 |
+            |          |          |          |          |          |          |          |          |          |          | .0.2125. |
+            |          |          |          |          |          |          |          |          |          |          | 122 Safa |
+            |          |          |          |          |          |          |          |          |          |          | ri/537.3 |
+            |          |          |          |          |          |          |          |          |          |          | 6        |
+            +========================================================================================================================+
             Fetched 2 rows
           
 .. container:: table-block
@@ -433,10 +438,6 @@ Data Exploration: Attaching a Schema
  
             |cdap >| get stream-stats logEventStream limit 1000
 
-         .. container:: highlight
-       
-          ::
-          
             column: stream_logeventstream.remote_host, type: STRING
             Unique elements: 6
  
@@ -766,10 +767,6 @@ Advanced Data Exploration
  
             |cdap >| execute 'select remote_host, city, state, request from stream_logEventStream join stream_ip2geo on (stream_logEventStream.remote_host = stream_ip2geo.ip) limit 10'
  
-         .. container:: highlight
-       
-           ::
- 
             +======================================================================================================================+
             | remote_host: STRING | city: STRING | state: STRING | request: STRING                                                 |
             +======================================================================================================================+
@@ -1021,10 +1018,6 @@ Transforming Your Data
 
             |cdap >| get workflow schedules logEventStreamConverter.ETLWorkflow
  
-         .. container:: highlight
-       
-           ::
-
             +=================================================================================================================+
             | application | program     | program type | name        | type        | description | properties  | runtime args |
             +=================================================================================================================+
@@ -1196,10 +1189,6 @@ Transforming Your Data
  
             |cdap >| execute 'SELECT ts, request, status FROM dataset_logEventStream_converted LIMIT 2'
           
-         .. container:: highlight
-         
-           ::
-           
             +=====================================================================+
             | ts: BIGINT    | request: STRING                       | status: INT |
             +=====================================================================+
@@ -1683,10 +1672,6 @@ Building Real World Applications
 
             |cdap >| execute 'SELECT * FROM dataset_bouncecountstore LIMIT 5'
           
-         .. container:: highlight
-         
-          ::
-
             +===============================================================================================+
             | dataset_bouncecountstore.uri: STRING   | dataset_bouncecountstore  | dataset_bouncecountstore |
             |                                        | .totalvisits: BIGINT      | .bounces: BIGINT         |


### PR DESCRIPTION
Fixes problem with hiding relations in footer.
Fixes a problem in the Introduction (and elsewhere) in showing output samples that conflicted with the reST syntax for replacements (`|-`, `|+`).
Solves a problem with the tabbed-parsed-includes that prevented showing CLI output in cases where a table was being shown.
Corrected a grammatical mistake in the introduction.
Corrected an example of `curl` that was in a different style of quoting than our examples.

As we are now an Open Source project whose documentation depends heavily on the contributions of the open-source Sphinx team, per their request, adds `Created using Sphinx 1.3.1.` to the footer of each page, beside our copyright. Please comment if there are any issues with that.

Passes [Quick Build 4](http://builds.cask.co/browse/CDAP-DQB21-4)

[Revised Introduction](http://builds.cask.co/artifact/CDAP-DQB21/shared/build-4/Docs-HTML/3.5.0-SNAPSHOT/en/introduction/index.html)
