### PR TITLE
CDAP-6076 Adds data-pipeline as an artifact to examples

### DIFF
--- a/cdap-docs/developers-manual/source/building-blocks/plugins.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/plugins.rst
@@ -128,7 +128,7 @@ the plugins when deploying the artifact. For example, if you are using the RESTf
   $ curl -w"\n" -X POST "localhost:10000/v3/namespaces/default/artifacts/mysql-connector-java" \
   -H "Artifact-Plugins: [ { 'name': 'mysql', 'type': 'jdbc', 'className': 'com.mysql.jdbc.Driver' } ]" \
   -H "Artifact-Version: 5.1.35" \
-  -H "Artifact-Extends: system:cdap-etl-batch[|version|, |version|]/system:cdap-etl-realtime[|version|, |version|]" \
+  -H "Artifact-Extends: system:cdap-data-pipeline[|version|, |version|]/system:cdap-etl-batch[|version|, |version|]/system:cdap-etl-realtime[|version|, |version|]" \
   --data-binary @mysql-connector-java-5.1.35.jar
 
 Or, using the CDAP CLI:
@@ -147,7 +147,7 @@ where ``config.json`` contains:
 
   .. parsed-literal:: 
     {
-      "parents": [ "system:cdap-etl-batch\[|version|,\ |version|]", "system:cdap-etl-realtime[|version|,\ |version|]" ],
+      "parents": [ "system:cdap-data-pipeline\[|version|,\ |version|]", "system:cdap-etl-batch\[|version|,\ |version|]", "system:cdap-etl-realtime[|version|,\ |version|]" ],
       "plugins": [
         {
           "name": "mysql",
@@ -226,8 +226,8 @@ For each plugin JAR, there must also be a corresponding configuration file to sp
 can use the plugins. The file name must match the name of the JAR, except it must have the ``.json``
 extension instead of the ``.jar`` extension. For example, if your JAR file is named
 ``custom-transforms-1.0.0.jar``, there must be a corresponding ``custom-transforms-1.0.0.json`` file.
-If your ``custom-transforms-1.0.0.jar`` contains transforms that can be used by both the ``cdap-etl-batch``
-and ``cdap-etl-realtime`` artifacts, ``custom-transforms-1.0.0.json`` would contain:
+If your ``custom-transforms-1.0.0.jar`` contains transforms that can be used by the ``cdap-data-pipeline``, 
+``cdap-etl-batch``, or ``cdap-etl-realtime`` artifacts, ``custom-transforms-1.0.0.json`` would contain:
 
 .. highlight:: json
 
@@ -235,7 +235,7 @@ and ``cdap-etl-realtime`` artifacts, ``custom-transforms-1.0.0.json`` would cont
 
   .. parsed-literal:: 
     {
-      "parents": [ "cdap-etl-batch[|version|,\ |version|]", "cdap-etl-realtime[|version|,\ |version|]" ]
+      "parents": [ "cdap-data-pipeline[|version|,\ |version|]", "cdap-etl-batch[|version|,\ |version|]", "cdap-etl-realtime[|version|,\ |version|]" ]
     }
 
 This file specifies that the plugins in ``custom-transforms-1.0.0.jar`` can be used by version |version| of
@@ -262,7 +262,7 @@ list them in the configuration:
 
   .. parsed-literal:: 
     {
-      "parents": [ "cdap-etl-batch[3.2.0,4.0.0)", "cdap-etl-realtime[3.2.0,4.0.0)" ],
+      "parents": [ "cdap-data-pipeline[3.2.0,4.0.0)", "cdap-etl-batch[3.2.0,4.0.0)", "cdap-etl-realtime[3.2.0,4.0.0)" ],
       "plugins": [
         {
           "name": "mysql",
@@ -299,7 +299,7 @@ For example, to deploy ``custom-transforms-1.0.0.jar`` using the RESTful API:
 .. tabbed-parsed-literal::
 
     $ curl -w"\n" -X POST "localhost:10000/v3/namespaces/default/artifacts/custom-transforms" \
-    -H "Artifact-Extends: system:cdap-etl-batch[|version|, |version|]/system:cdap-etl-realtime[|version|, |version|]" \
+    -H "Artifact-Extends: system:cdap-data-pipeline[|version|, |version|]/system:cdap-etl-batch[|version|, |version|]/system:cdap-etl-realtime[|version|, |version|]" \
     --data-binary @/path/to/custom-transforms-1.0.0.jar
 
 Using the CLI:
@@ -317,7 +317,7 @@ where ``config.json`` contains:
 
   .. parsed-literal:: 
     {
-      "parents": [ "system:cdap-etl-batch[|version|,\ |version|]", "system:cdap-etl-realtime[|version|,\ |version|]" ]
+      "parents": [ "system:cdap-data-pipeline[|version|,\ |version|]", "system:cdap-etl-batch[|version|,\ |version|]", "system:cdap-etl-realtime[|version|,\ |version|]" ]
     }
 
 Note that when deploying a user artifact that extends a system artifact,
@@ -338,7 +338,7 @@ it needs to be set explicitly, as the JAR contents are uploaded without the file
   $ curl -w"\n" -X POST "localhost:10000/v3/namespaces/default/artifacts/mysql-connector-java" \
   -H "Artifact-Plugins: [ { 'name': 'mysql', 'type': 'jdbc', 'className': 'com.mysql.jdbc.Driver' } ]" \
   -H "Artifact-Version: 5.1.35" \
-  -H "Artifact-Extends: system:cdap-etl-batch[|version|, |version|]/system:cdap-etl-realtime[|version|, |version|]" \
+  -H "Artifact-Extends: system:cdap-data-pipeline[|version|, |version|]/system:cdap-etl-batch[|version|, |version|]/system:cdap-etl-realtime[|version|, |version|]" \
   --data-binary @mysql-connector-java-5.1.35.jar
 
 Using the CLI (note that the artifact version, if not explicitly set, is derived from the JAR filename):
@@ -356,7 +356,7 @@ where ``config.json`` contains:
 
   .. parsed-literal:: 
     {
-      "parents": [ "system:cdap-etl-batch\[|version|,\ |version|]", "system:cdap-etl-realtime[|version|,\ |version|]" ],
+      "parents": [ "system:cdap-data-pipeline\[|version|,\ |version|]", "system:cdap-etl-batch\[|version|,\ |version|]", "system:cdap-etl-realtime[|version|,\ |version|]" ],
       "plugins": [
         {
           "name": "mysql",


### PR DESCRIPTION
Passes [Quick Build 1](http://builds.cask.co/browse/CDAP-DQB23-1)

Fix for https://issues.cask.co/browse/CDAP-6076

Revised page: [Third-party plugins](http://builds.cask.co/artifact/CDAP-DQB23/shared/build-1/Docs-HTML/3.4.1/en/developers-manual/building-blocks/plugins.html#third-party-plugins)
