### PR TITLE
(CDAP-6052) Set the CFG_LOCAL_DATA_DIR to relative path for containers

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
@@ -366,6 +366,10 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
     // by the distributed ProgramRunner.
     CConfiguration copied = CConfiguration.copy(conf);
     copied.unset(Constants.AppFabric.RUNTIME_EXT_DIR);
+
+    // Set the CFG_LOCAL_DATA_DIR to a relative path as the data directory for the container should be relative to the
+    // container directory
+    copied.set(Constants.CFG_LOCAL_DATA_DIR, "data");
     try (Writer writer = Files.newWriter(file, Charsets.UTF_8)) {
       copied.writeXml(writer);
     }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -57,7 +57,7 @@
     <name>local.data.dir</name>
     <value>data</value>
     <description>
-      Data directory for standalone mode
+      Data directory for standalone mode and the master process in distributed CDAP
     </description>
   </property>
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -792,9 +792,13 @@ public class MasterServiceMain extends DaemonMain {
     return preparer;
   }
 
-  private Path saveCConf(CConfiguration conf, Path file) throws IOException {
+  private Path saveCConf(CConfiguration cConf, Path file) throws IOException {
+    CConfiguration copied = CConfiguration.copy(cConf);
+    // Set the CFG_LOCAL_DATA_DIR to a relative path as the data directory for the container should be relative to the
+    // container directory
+    copied.set(Constants.CFG_LOCAL_DATA_DIR, "data");
     try (Writer writer = Files.newBufferedWriter(file, Charsets.UTF_8)) {
-      conf.writeXml(writer);
+      copied.writeXml(writer);
     }
     return file;
   }


### PR DESCRIPTION
- For YARN containers, it should never have the CFG_LOCAL_DATA_DIR
  as absolute path, but should be relative to the container directory
