### PR TITLE
Exclude the IntelliJ generated iml files from rat checker validation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1510,6 +1510,7 @@
                   <exclude>*.rst</exclude>
                   <exclude>*.md</exclude>
                   <exclude>**/*.md</exclude>
+                  <exclude>**/*.iml</exclude>
                   <exclude>logs/**</exclude>
                   <exclude>cdap-docs/**</exclude>
                   <exclude>**/grok/patterns/**</exclude>


### PR DESCRIPTION
These files cause the build to fail.
