### PR TITLE
CDAP-4883 On-hover links using a custom HTML translator

### DIFF
--- a/cdap-docs/_common/_themes/cdap/static/cdap.css_t
+++ b/cdap-docs/_common/_themes/cdap/static/cdap.css_t
@@ -215,14 +215,14 @@ a:hover {
 }
 
 a.headerlink {
-    color: #ff6600 !important;
+    color: #ff6600;
     font-size: 0.8em;
     padding-top: .25em;
     width: 1.5ex;
     margin-left: -3ex;
     display: block;
     text-align: center;
-    text-decoration: none !important;
+    text-decoration: none;
     float: left;
 }
 

--- a/cdap-docs/_common/_themes/cdap/static/cdap.css_t
+++ b/cdap-docs/_common/_themes/cdap/static/cdap.css_t
@@ -170,21 +170,7 @@ div.sphinxsidebar input[type=text]{
     margin-left: 20px;
 }
 
-a.current {
-    font-weight: bold;
-}
-
 /* -- body styles ----------------------------------------------------------- */
-
-a {
-    color: #ff6600;
-    text-decoration: none;
-}
-
-a:hover {
-    color: #005B81;
-    text-decoration: underline;
-}
 
 div.body h1,
 div.body h2,
@@ -214,17 +200,34 @@ div.body h4 { background-color: #EDEDED; margin: 30px 0px 10px 0px; }
 div.body h5 { background-color: #F2F2F2; margin: 30px 0px 10px 0px; }
 div.body h6 { background-color: #F2F2F2; }
 
-a.headerlink {
-    color: #c60f0f;
-    font-size: 0.8em;
-    padding: 0 4px 0 4px;
+a {
+    color: #ff6600;
     text-decoration: none;
-    display: none;
 }
 
-a.headerlink:hover {
-    background-color: #c60f0f;
-    color: white;
+a.current {
+    font-weight: bold;
+}
+
+a:hover {
+    color: #005B81;
+    text-decoration: underline;
+}
+
+a.headerlink {
+    color: #ff6600 !important;
+    font-size: 0.8em;
+    padding-top: .25em;
+    width: 1.5ex;
+    margin-left: -3ex;
+    display: block;
+    text-align: center;
+    text-decoration: none !important;
+    float: left;
+}
+
+h1:hover > a.headerlink {
+    margin-left: -2.5ex;
 }
 
 a.toc-backref {

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -514,6 +514,11 @@ htmlhelp_basename = 'CDAPdoc'
 # This is because it needs to be set as the last item.
 html_context = {'html_short_title_toc': html_short_title_toc}
 
+# Custom CustomHTMLTranslator to customize formatting of titles
+html_translator_class = 'customHTML.CustomHTMLTranslator'
+
+html_add_permalinks = u'\U0001F517' # HTML '&#128279;' # Link symbol: see http://www.fileformat.info/info/unicode/char/1f517/index.htm
+
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {

--- a/cdap-docs/_common/customHTML.py
+++ b/cdap-docs/_common/customHTML.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+"""
+    customHTML
+    ~~~~~~~~~~
+
+    Docutils writer that revises the handling of title nodes.
+    It reverses the structure so that the permalink precedes the headline text.
+
+    :copyright: Copyright 2016 by Cask Data, Inc.
+    :license: Apache License, Version 2.0, see http://www.apache.org/licenses/LICENSE-2.0
+    :version: 0.1
+
+"""
+
+from docutils import nodes
+from docutils.writers.html4css1 import HTMLTranslator as BaseTranslator
+
+from sphinx.locale import _
+from sphinx.writers.html import HTMLTranslator
+
+class CustomHTMLTranslator(HTMLTranslator):
+    """
+    Our custom, custom HTML translator.
+    """
+        
+    def depart_title(self, node):
+        h_level = 0
+        close_tag = self.context[-1]
+        close = close_tag.rfind('>')
+        if close != -1:
+            h_level = close_tag[close-1]
+        if (self.permalink_text and self.builder.add_permalinks and
+            node.parent.hasattr('ids') and node.parent['ids']):
+            aname = node.parent['ids'][0]
+            tags = []
+            if h_level:
+                open_tag = "<h%s>" % h_level
+                # Walk back to find open_tag in body
+                for i in reversed(range(len(self.body))):
+                    tags.append(self.body.pop())
+                    if tags[-1] == open_tag:
+                        self.body.append(tags.pop())
+                        tags.reverse()
+                        break
+            
+            # <h1>Manual Installation using Packages<a class="headerlink" href="#manual-installation-using-packages"
+            # title="Permalink to this headline">¶</a></h1>
+            # becomes
+            # <h1><a class="headerlink" href="#manual-installation-using-packages"
+            # title="Permalink to this headline">¶</a>Manual Installation using Packages</h1>
+            
+            if close_tag.startswith('</h'):
+                self.body.append(u'<a class="headerlink" href="#%s" ' % aname +
+                                 u'title="%s">%s</a>' % (_('Permalink to this heading 1'), self.permalink_text))
+            elif close_tag.startswith('</a></h'):
+                self.body.append(u'</a><a class="headerlink" href="#%s" ' % aname +
+                                 u'title="%s">%s' % (_('Permalink to this heading 2'), self.permalink_text))
+            self.body = self.body + tags            
+
+        BaseTranslator.depart_title(self, node)
+
+

--- a/cdap-docs/_common/customHTML.py
+++ b/cdap-docs/_common/customHTML.py
@@ -66,10 +66,10 @@ class CustomHTMLTranslator(HTMLTranslator):
             
             if close_tag.startswith('</h'):
                 self.body.append(u'<a class="headerlink" href="#%s" ' % aname +
-                                 u'title="%s">%s</a>' % (_('Permalink to this heading 1'), self.permalink_text))
+                                 u'title="%s">%s</a>' % (_('Perma-link to this heading'), self.permalink_text))
             elif close_tag.startswith('</a></h'):
                 self.body.append(u'</a><a class="headerlink" href="#%s" ' % aname +
-                                 u'title="%s">%s' % (_('Permalink to this heading 2'), self.permalink_text))
+                                 u'title="%s">%s' % (_('Perma-link to this heading'), self.permalink_text))
             self.body = self.body + tags            
 
         BaseTranslator.depart_title(self, node)


### PR DESCRIPTION
Adds an on-hover link icon to the left of headers in the documentation.

Passes [Quick Build 3](http://builds.cask.co/browse/CDAP-DQB24-3)

Fix for https://issues.cask.co/browse/CDAP-4883

Example page: [Artifact HTTP RESTful API](http://builds.cask.co/artifact/CDAP-DQB24/shared/build-3/Docs-HTML/3.5.0-SNAPSHOT/en/reference-manual/http-restful-api/artifact.html)
- Adds a custom HTML translator (`customHTML.py`)
- Implements it in the common `conf.py` (`common_conf.py`)
- Adds supporting CSS to the CDAP theme `cdap.css_t` and reorganizes the CSS to consolidate all `a` tag CSS in one location, without changing precedence.
