### PR TITLE
CDAP-6071 Optionally call ProgramLifeCycle methods but call the deprecated methods always for 3.5

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/ProgramState.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/ProgramState.java
@@ -48,4 +48,13 @@ public class ProgramState {
   public String getFailureInfo() {
     return failureInfo;
   }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder("ProgramState{");
+    sb.append("status=").append(status);
+    sb.append(", failureInfo='").append(failureInfo).append('\'');
+    sb.append('}');
+    return sb.toString();
+  }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/AbstractMapReduce.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/AbstractMapReduce.java
@@ -19,13 +19,9 @@ package co.cask.cdap.api.mapreduce;
 import co.cask.cdap.api.ProgramLifecycle;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.data.batch.Input;
-import co.cask.cdap.api.data.batch.Output;
 import co.cask.cdap.api.data.stream.StreamBatchReadable;
 import co.cask.cdap.internal.api.AbstractPluginConfigurable;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -107,7 +103,7 @@ public abstract class AbstractMapReduce extends AbstractPluginConfigurable<MapRe
    * Sets the name of the Dataset used as input for the {@link MapReduce}.
    *
    * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)}
-   * in {@link #initialize}, instead.
+   * in {@link #initialize()}, instead.
    */
   @Deprecated
   protected final void setInputDataset(String dataset) {
@@ -119,7 +115,7 @@ public abstract class AbstractMapReduce extends AbstractPluginConfigurable<MapRe
    *
    * @param stream Name of the stream
    * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)}
-   *             in {@link #initialize}, instead.
+   *             in {@link #initialize()}, instead.
    */
   @Deprecated
   protected final void useStreamInput(String stream) {
@@ -133,7 +129,7 @@ public abstract class AbstractMapReduce extends AbstractPluginConfigurable<MapRe
    * @see StreamBatchReadable
    *
    * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)}
-   *             in {@link #initialize}, instead.
+   *             in {@link #initialize()}, instead.
    */
   @Deprecated
   protected final void useStreamInput(String stream, long startTime, long endTime) {
@@ -146,7 +142,7 @@ public abstract class AbstractMapReduce extends AbstractPluginConfigurable<MapRe
    * @see StreamBatchReadable
    *
    * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)}
-   *             in {@link #initialize}, instead.
+   *             in {@link #initialize()}, instead.
    */
   @Deprecated
   protected final void useStreamInput(StreamBatchReadable streamBatchReadable) {
@@ -166,8 +162,18 @@ public abstract class AbstractMapReduce extends AbstractPluginConfigurable<MapRe
   }
 
   @Override
-  public void initialize(MapReduceContext context) throws Exception {
+  public final void initialize(MapReduceContext context) throws Exception {
     this.context = context;
+  }
+
+  /**
+   * Classes derived from {@link AbstractMapReduce} can override this method to initialize the {@link MapReduce}.
+   * {@link MapReduceContext} will be available in this method using {@link AbstractMapReduce#getContext}.
+   * Default implementation of this method calls the deprecated {@link AbstractMapReduce#beforeSubmit} method.
+   * @throws Exception if there is any error in initializing the MapReduce
+   */
+  public void initialize() throws Exception {
+    beforeSubmit(context);
   }
 
   @Override

--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/WorkflowApp.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/WorkflowApp.java
@@ -84,8 +84,8 @@ public class WorkflowApp extends AbstractApplication {
     }
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
-      super.initialize(context);
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Map<String, String> args = context.getRuntimeArguments();
       String inputPath = args.get("inputPath");
       String outputPath = args.get("outputPath");

--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/WorkflowAppWithScopedParameters.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/WorkflowAppWithScopedParameters.java
@@ -71,7 +71,8 @@ public class WorkflowAppWithScopedParameters extends AbstractApplication {
   public static class OneMR extends AbstractMapReduce {
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Map<String, String> args = context.getRuntimeArguments();
 
       Preconditions.checkArgument(args.size() == 18);
@@ -92,9 +93,9 @@ public class WorkflowAppWithScopedParameters extends AbstractApplication {
   public static class AnotherMR extends AbstractMapReduce {
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Map<String, String> args = context.getRuntimeArguments();
-
       Preconditions.checkArgument(args.size() == 18);
       Preconditions.checkArgument(args.get("input.path").contains("AnotherMRInput"));
       Preconditions.checkArgument(args.get("output.path").contains("ProgramOutput"));

--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/WorkflowTokenTestPutApp.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/WorkflowTokenTestPutApp.java
@@ -87,8 +87,8 @@ public class WorkflowTokenTestPutApp extends AbstractApplication {
     }
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
-      super.initialize(context);
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       job.setMapperClass(MyMapper.class);
       job.setReducerClass(MyReducer.class);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.data.batch.DatasetOutputCommitter;
 import co.cask.cdap.api.data.batch.InputFormatProvider;
 import co.cask.cdap.api.data.batch.OutputFormatProvider;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
+import co.cask.cdap.api.mapreduce.AbstractMapReduce;
 import co.cask.cdap.api.mapreduce.MapReduce;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
@@ -357,9 +358,8 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
       try {
         if (mapReduce instanceof ProgramLifecycle) {
           destroy(success, failureInfo);
-        } else {
-          onFinish(success);
         }
+        onFinish(success);
       } finally {
         context.close();
         cleanupTask.run();
@@ -482,10 +482,10 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
           context.setState(new ProgramState(ProgramStatus.INITIALIZING, null));
           if (mapReduce instanceof ProgramLifecycle) {
             ((ProgramLifecycle) mapReduce).initialize(context);
+            ((AbstractMapReduce) mapReduce).initialize();
           } else {
             mapReduce.beforeSubmit(context);
           }
-
           // once the initialize method is executed, set the status of the MapReduce to RUNNING
           context.setState(new ProgramState(ProgramStatus.RUNNING, null));
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/AllProgramsApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/AllProgramsApp.java
@@ -174,7 +174,8 @@ public class AllProgramsApp extends AbstractApplication {
     }
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       job.setMapperClass(NoOpMapper.class);
       job.setReducerClass(NoOpReducer.class);
@@ -195,7 +196,8 @@ public class AllProgramsApp extends AbstractApplication {
     }
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       context.addInput(Input.ofDataset(DATASET_NAME2));
       context.addOutput(Output.ofDataset(DATASET_NAME));
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithWorkflow.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/AppWithWorkflow.java
@@ -160,7 +160,8 @@ public class AppWithWorkflow extends AbstractApplication {
     }
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Map<String, String> args = context.getRuntimeArguments();
       String inputPath = args.get("inputPath");
       String outputPath = args.get("outputPath");

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/ConditionalWorkflowApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/ConditionalWorkflowApp.java
@@ -117,7 +117,8 @@ public class ConditionalWorkflowApp extends AbstractApplication {
     }
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       job.setMapperClass(MyVerifier.class);
       String inputPath = context.getRuntimeArguments().get("inputPath");
@@ -158,7 +159,8 @@ public class ConditionalWorkflowApp extends AbstractApplication {
     }
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Map<String, String> args = context.getRuntimeArguments();
       String inputPath = args.get("inputPath");
       String outputPath = args.get("outputPath");

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/DummyAppWithTrackingTable.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/DummyAppWithTrackingTable.java
@@ -127,7 +127,8 @@ public class DummyAppWithTrackingTable extends AbstractApplication {
     }
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       job.setMapperClass(DummyMapper.class);
       job.setReducerClass(DummyReducer.class);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowFailureInForkApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowFailureInForkApp.java
@@ -81,7 +81,8 @@ public class WorkflowFailureInForkApp extends AbstractApplication {
 
     @Override
     @SuppressWarnings("ConstantConditions")
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Map<String, String> args = context.getRuntimeArguments();
       String inputPath = args.get("inputPath");
       String outputPath = args.get("outputPath");

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithLocalFiles.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithLocalFiles.java
@@ -66,7 +66,8 @@ public class AppWithLocalFiles extends AbstractApplication {
   public static class MapReduceWithLocalFiles extends AbstractMapReduce {
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Map<String, String> args = context.getRuntimeArguments();
       if (args.containsKey(STOPWORDS_FILE_ARG)) {
         context.localize(STOPWORDS_FILE_ALIAS, URI.create(args.get(STOPWORDS_FILE_ARG)));

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduce.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduce.java
@@ -63,11 +63,10 @@ public class AppWithMapReduce extends AbstractApplication {
     }
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
-      super.initialize(context);
+    public void initialize() throws Exception {
       String inputPath = Bytes.toString(table.read(Bytes.toBytes("inputPath")));
       String outputPath = Bytes.toString(table.read(Bytes.toBytes("outputPath")));
-      WordCount.configureJob((Job) context.getHadoopJob(), inputPath, outputPath);
+      WordCount.configureJob((Job) getContext().getHadoopJob(), inputPath, outputPath);
     }
   }
 
@@ -85,8 +84,8 @@ public class AppWithMapReduce extends AbstractApplication {
     private Metrics metrics;
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
-      super.initialize(context);
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       metrics.count("beforeSubmit", 1);
       Job hadoopJob = context.getHadoopJob();
       AggregateMetricsByTag.configureJob(hadoopJob);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingAvroDynamicPartitioner.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingAvroDynamicPartitioner.java
@@ -120,7 +120,8 @@ public class AppWithMapReduceUsingAvroDynamicPartitioner extends AbstractApplica
                                                                        "post.-final", "actually.final.value");
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       context.addInput(Input.ofDataset(INPUT_DATASET));
 
       Map<String, String> outputDatasetArgs = new HashMap<>();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingFileSet.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingFileSet.java
@@ -66,7 +66,8 @@ public class AppWithMapReduceUsingFileSet extends AbstractApplication {
   public static final class ComputeSum extends AbstractMapReduce {
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       job.setReducerClass(FileReducer.class);
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingObjectStore.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingObjectStore.java
@@ -55,7 +55,8 @@ public class AppWithMapReduceUsingObjectStore extends AbstractApplication {
   public static final class ComputeCounts extends AbstractMapReduce {
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       job.setMapperClass(ObjectStoreMapper.class);
       job.setReducerClass(KeyValueStoreReducer.class);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingRuntimeDatasets.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingRuntimeDatasets.java
@@ -75,7 +75,8 @@ public class AppWithMapReduceUsingRuntimeDatasets extends AbstractApplication {
     }
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       job.setMapperClass(FileMapper.class);
       job.setReducerClass(FileReducer.class);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithPartitionedFileSet.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithPartitionedFileSet.java
@@ -77,7 +77,8 @@ public class AppWithPartitionedFileSet extends AbstractApplication {
   public static final class PartitionWriter extends AbstractMapReduce {
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       job.setMapperClass(SimpleMapper.class);
       job.setNumReduceTasks(0);
@@ -102,7 +103,8 @@ public class AppWithPartitionedFileSet extends AbstractApplication {
   public static final class PartitionReader extends AbstractMapReduce {
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       job.setMapperClass(ReaderMapper.class);
       job.setNumReduceTasks(0);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithTimePartitionedFileSet.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithTimePartitionedFileSet.java
@@ -78,8 +78,8 @@ public class AppWithTimePartitionedFileSet extends AbstractApplication {
   public static final class PartitionWriter extends AbstractMapReduce {
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
-      super.initialize(context);
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       job.setMapperClass(SimpleMapper.class);
       job.setNumReduceTasks(0);
@@ -118,7 +118,8 @@ public class AppWithTimePartitionedFileSet extends AbstractApplication {
   public static final class PartitionReader extends AbstractMapReduce {
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       job.setMapperClass(ReaderMapper.class);
       job.setNumReduceTasks(0);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithTxAware.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithTxAware.java
@@ -56,7 +56,8 @@ public class AppWithTxAware extends AbstractApplication {
    */
   public static class PedanticMapReduce extends AbstractMapReduce {
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       job.setMapperClass(DummyMapper.class);
       job.setNumReduceTasks(0);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/AppWithMapReduceUsingInconsistentMappers.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/AppWithMapReduceUsingInconsistentMappers.java
@@ -52,7 +52,8 @@ public class AppWithMapReduceUsingInconsistentMappers extends AbstractApplicatio
    */
   private abstract static class BaseMapReduce extends AbstractMapReduce {
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       // the inputs will be set in child classes
       context.addOutput(Output.ofDataset("output"));
       Job job = context.getHadoopJob();
@@ -65,10 +66,11 @@ public class AppWithMapReduceUsingInconsistentMappers extends AbstractApplicatio
    */
   public static final class MapReduceWithConsistentMapperTypes extends BaseMapReduce {
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       context.addInput(Input.ofDataset("input1"), OriginalMapper.class);
       context.addInput(Input.ofDataset("input2"), ConsistentMapper.class);
-      super.initialize(context);
+      super.initialize();
     }
   }
 
@@ -77,14 +79,15 @@ public class AppWithMapReduceUsingInconsistentMappers extends AbstractApplicatio
    */
   public static final class MapReduceWithInconsistentMapperTypes extends BaseMapReduce {
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       context.addInput(Input.ofDataset("input1"), OriginalMapper.class);
       context.addInput(Input.ofDataset("input2"), InconsistentMapper.class);
 
       Job job = context.getHadoopJob();
       // none of the inputs default to the job-defined mapper, so an inconsistent mapper defined here gives no issue
       job.setMapperClass(InconsistentMapper.class);
-      super.initialize(context);
+      super.initialize();
     }
   }
 
@@ -94,13 +97,14 @@ public class AppWithMapReduceUsingInconsistentMappers extends AbstractApplicatio
    */
   public static final class MapReduceWithInconsistentMapperTypes2 extends BaseMapReduce {
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       context.addInput(Input.ofDataset("input1"), OriginalMapper.class);
       context.addInput(Input.ofDataset("input2"));
 
       Job job = context.getHadoopJob();
       job.setMapperClass(InconsistentMapper.class);
-      super.initialize(context);
+      super.initialize();
     }
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/AppWithMapReduceUsingMultipleInputs.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/AppWithMapReduceUsingMultipleInputs.java
@@ -77,7 +77,8 @@ public class AppWithMapReduceUsingMultipleInputs extends AbstractApplication {
   public static class ComputeSum extends AbstractMapReduce {
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Map<String, String> inputArgs = new HashMap<>();
       FileSetArguments.setInputPath(inputArgs, "inputFile");
 
@@ -102,9 +103,8 @@ public class AppWithMapReduceUsingMultipleInputs extends AbstractApplication {
    */
   public static final class InvalidMapReduce extends ComputeSum {
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
-      super.initialize(context);
-      context.addInput(Input.ofDataset(PURCHASES, ImmutableMap.of("key", "value")));
+    public void initialize() throws Exception {
+      getContext().addInput(Input.ofDataset(PURCHASES, ImmutableMap.of("key", "value")));
     }
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/AppWithMapReduceUsingMultipleOutputs.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/AppWithMapReduceUsingMultipleOutputs.java
@@ -67,7 +67,8 @@ public class AppWithMapReduceUsingMultipleOutputs extends AbstractApplication {
   public static class SeparatePurchases extends AbstractMapReduce {
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Map<String, String> inputArgs = new HashMap<>();
       FileSetArguments.setInputPath(inputArgs, "inputFile");
 
@@ -93,9 +94,9 @@ public class AppWithMapReduceUsingMultipleOutputs extends AbstractApplication {
    */
   public static class InvalidMapReduce extends SeparatePurchases {
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
-      super.initialize(context);
-      context.addOutput(Output.ofDataset(SEPARATED_PURCHASES).alias("small_purchases"));
+    public void initialize() throws Exception {
+      super.initialize();
+      getContext().addOutput(Output.ofDataset(SEPARATED_PURCHASES).alias("small_purchases"));
     }
   }
 

--- a/cdap-app-templates/cdap-data-quality/src/main/java/co/cask/cdap/dq/DataQualityApp.java
+++ b/cdap-app-templates/cdap-data-quality/src/main/java/co/cask/cdap/dq/DataQualityApp.java
@@ -176,7 +176,8 @@ public class DataQualityApp extends AbstractApplication<DataQualityApp.DataQuali
     }
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       job.setMapperClass(AggregationMapper.class);
       job.setReducerClass(AggregationReducer.class);

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
@@ -143,8 +143,8 @@ public class ETLMapReduce extends AbstractMapReduce {
   }
 
   @Override
-  public void initialize(MapReduceContext context) throws Exception {
-    super.initialize(context);
+  public void initialize() throws Exception {
+    MapReduceContext context = getContext();
     if (Boolean.valueOf(context.getSpecification().getProperty(Constants.STAGE_LOGGING_ENABLED))) {
       LogStageInjector.start();
     }

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/app/AllProgramsApp.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/app/AllProgramsApp.java
@@ -177,7 +177,8 @@ public class AllProgramsApp extends AbstractApplication {
     }
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       job.setMapperClass(NoOpMapper.class);
       job.setReducerClass(NoOpReducer.class);
@@ -198,7 +199,8 @@ public class AllProgramsApp extends AbstractApplication {
     }
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       context.addInput(Input.ofDataset(DATASET_NAME2));
       context.addOutput(Output.ofDataset(DATASET_NAME));
     }

--- a/cdap-examples/ClicksAndViews/src/main/java/co/cask/cdap/examples/clicksandviews/ClicksAndViewsMapReduce.java
+++ b/cdap-examples/ClicksAndViews/src/main/java/co/cask/cdap/examples/clicksandviews/ClicksAndViewsMapReduce.java
@@ -56,8 +56,8 @@ public class ClicksAndViewsMapReduce extends AbstractMapReduce {
   }
 
   @Override
-  public void initialize(MapReduceContext context) throws Exception {
-    super.initialize(context);
+  public void initialize() throws Exception {
+    MapReduceContext context = getContext();
     context.addInput(Input.ofStream(ClicksAndViews.CLICKS));
     context.addInput(Input.ofStream(ClicksAndViews.VIEWS));
 

--- a/cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
+++ b/cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduce.java
@@ -19,7 +19,6 @@ package co.cask.cdap.examples.datacleansing;
 import co.cask.cdap.api.ProgramLifecycle;
 import co.cask.cdap.api.ProgramStatus;
 import co.cask.cdap.api.Resources;
-import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.batch.Output;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.lib.DynamicPartitioner;
@@ -63,8 +62,8 @@ public class DataCleansingMapReduce extends AbstractMapReduce {
   }
 
   @Override
-  public void initialize(MapReduceContext context) throws Exception {
-    super.initialize(context);
+  public void initialize() throws Exception {
+    MapReduceContext context = getContext();
     partitionCommitter =
       PartitionBatchInput.setInput(context, DataCleansing.RAW_RECORDS,
                                    new KVTableStatePersistor(DataCleansing.CONSUMING_STATE, "state.key"));

--- a/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
+++ b/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/WordCount.java
@@ -47,8 +47,8 @@ public class WordCount extends AbstractMapReduce {
   }
 
   @Override
-  public void initialize(MapReduceContext context) throws Exception {
-    super.initialize(context);
+  public void initialize() throws Exception {
+    MapReduceContext context = getContext();
     Job job = context.getHadoopJob();
     job.setMapperClass(Tokenizer.class);
     job.setReducerClass(Counter.class);

--- a/cdap-examples/LogAnalysis/src/main/java/co/cask/cdap/examples/loganalysis/HitCounterProgram.java
+++ b/cdap-examples/LogAnalysis/src/main/java/co/cask/cdap/examples/loganalysis/HitCounterProgram.java
@@ -19,7 +19,6 @@ package co.cask.cdap.examples.loganalysis;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.batch.Output;
-import co.cask.cdap.api.data.stream.StreamBatchReadable;
 import co.cask.cdap.api.mapreduce.AbstractMapReduce;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import org.apache.hadoop.io.IntWritable;
@@ -37,8 +36,8 @@ import java.io.IOException;
 public class HitCounterProgram extends AbstractMapReduce {
 
   @Override
-  public void initialize(MapReduceContext context) throws Exception {
-    super.initialize(context);
+  public void initialize() throws Exception {
+    MapReduceContext context = getContext();
     Job job = context.getHadoopJob();
     job.setMapperClass(Emitter.class);
     job.setReducerClass(Counter.class);

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryBuilder.java
@@ -57,8 +57,8 @@ public class PurchaseHistoryBuilder extends AbstractMapReduce {
   }
 
   @Override
-  public void initialize(MapReduceContext context) throws Exception {
-    super.initialize(context);
+  public void initialize() throws Exception {
+    MapReduceContext context = getContext();
     Job job = context.getHadoopJob();
     job.setReducerClass(PerUserReducer.class);
 

--- a/cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
+++ b/cdap-examples/SparkPageRank/src/main/java/co/cask/cdap/examples/sparkpagerank/SparkPageRankApp.java
@@ -193,8 +193,8 @@ public class SparkPageRankApp extends AbstractApplication {
   public static class RanksCounter extends AbstractMapReduce {
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
-      super.initialize(context);
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       job.setMapperClass(Emitter.class);
       job.setReducerClass(Counter.class);

--- a/cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/ScoreCounter.java
+++ b/cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/ScoreCounter.java
@@ -56,8 +56,8 @@ public class ScoreCounter extends AbstractMapReduce {
   }
 
   @Override
-  public void initialize(MapReduceContext context) throws Exception {
-    super.initialize(context);
+  public void initialize() throws Exception {
+    MapReduceContext context = getContext();
     Job job = context.getHadoopJob();
     job.setMapperClass(ResultsMapper.class);
     job.setReducerClass(TeamCounter.class);

--- a/cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
+++ b/cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
@@ -20,7 +20,6 @@ import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.batch.Output;
-import co.cask.cdap.api.data.stream.StreamBatchReadable;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSetArguments;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
@@ -61,8 +60,8 @@ public class StreamConversionMapReduce extends AbstractMapReduce {
   }
 
   @Override
-  public void initialize(MapReduceContext context) throws Exception {
-    super.initialize(context);
+  public void initialize() throws Exception {
+    MapReduceContext context = getContext();
     Job job = context.getHadoopJob();
     job.setMapperClass(StreamConversionMapper.class);
     job.setNumReduceTasks(0);

--- a/cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/StreamToDataset.java
+++ b/cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/StreamToDataset.java
@@ -58,8 +58,8 @@ public class StreamToDataset extends AbstractMapReduce {
   }
 
   @Override
-  public void initialize(MapReduceContext context) throws Exception {
-    super.initialize(context);
+  public void initialize() throws Exception {
+    MapReduceContext context = getContext();
     Job job = context.getHadoopJob();
     job.setNumReduceTasks(0);
     WorkflowToken workflowToken = context.getWorkflowToken();

--- a/cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/TopNMapReduce.java
+++ b/cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/TopNMapReduce.java
@@ -57,8 +57,8 @@ public class TopNMapReduce extends AbstractMapReduce {
   }
 
   @Override
-  public void initialize(MapReduceContext context) throws Exception {
-    super.initialize(context);
+  public void initialize() throws Exception {
+    MapReduceContext context = getContext();
     Map<String, String> runtimeArguments = context.getRuntimeArguments();
     Job job = context.getHadoopJob();
     WorkflowToken workflowToken = context.getWorkflowToken();

--- a/cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/WikiContentValidatorAndNormalizer.java
+++ b/cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/WikiContentValidatorAndNormalizer.java
@@ -63,8 +63,8 @@ public class WikiContentValidatorAndNormalizer extends AbstractMapReduce {
   }
 
   @Override
-  public void initialize(MapReduceContext context) throws Exception {
-    super.initialize(context);
+  public void initialize() throws Exception {
+    MapReduceContext context = getContext();
     Job job = context.getHadoopJob();
     job.setMapperClass(FilterNormalizerMapper.class);
     job.setNumReduceTasks(0);

--- a/cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/WikipediaDataDownloader.java
+++ b/cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/WikipediaDataDownloader.java
@@ -53,8 +53,8 @@ public class WikipediaDataDownloader extends AbstractMapReduce {
   }
 
   @Override
-  public void initialize(MapReduceContext context) throws Exception {
-    super.initialize(context);
+  public void initialize() throws Exception {
+    MapReduceContext context = getContext();
     Job job = context.getHadoopJob();
     job.setMapperClass(WikipediaDataDownloaderMapper.class);
     job.setNumReduceTasks(0);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/admin/AdminApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/admin/AdminApp.java
@@ -334,8 +334,8 @@ public class AdminApp extends AbstractApplication {
     }
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
-
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       job.setMapperClass(Tokenizer.class);
       job.setReducerClass(Counter.class);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/NoMapperApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/NoMapperApp.java
@@ -48,7 +48,8 @@ public class NoMapperApp extends AbstractApplication {
   public static final class NoMapperMapReduce extends AbstractMapReduce {
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       job.setReducerClass(NoMapperReducer.class);
       context.addInput(Input.ofStream("nomapper"));

--- a/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/TestBatchStreamIntegrationApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/batch/stream/TestBatchStreamIntegrationApp.java
@@ -64,7 +64,8 @@ public class TestBatchStreamIntegrationApp extends AbstractApplication {
   public static class StreamTestBatch extends AbstractMapReduce {
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       setMapperClass(job);
       job.setReducerClass(StreamTestBatchReducer.class);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/AppWithMapReduceUsingStream.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/AppWithMapReduceUsingStream.java
@@ -25,7 +25,6 @@ import co.cask.cdap.api.data.format.Formats;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.data.stream.Stream;
-import co.cask.cdap.api.data.stream.StreamBatchReadable;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.mapreduce.AbstractMapReduce;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
@@ -63,7 +62,8 @@ public class AppWithMapReduceUsingStream extends AbstractApplication {
   public static final class BodyTracker extends AbstractMapReduce {
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       job.setMapperClass(TickerMapper.class);
       job.setReducerClass(PriceCounter.class);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/service/TestMapReduceServiceIntegrationApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/mapreduce/service/TestMapReduceServiceIntegrationApp.java
@@ -83,7 +83,8 @@ public class TestMapReduceServiceIntegrationApp extends AbstractApplication {
     }
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       job.setMapperClass(MyMapper.class);
       job.setMapOutputKeyClass(BytesWritable.class);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/AppWithPartitionConsumers.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/AppWithPartitionConsumers.java
@@ -212,8 +212,8 @@ public class AppWithPartitionConsumers extends AbstractApplication {
     }
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
-      super.initialize(context);
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       batchPartitionCommitter =
         PartitionBatchInput.setInput(context, "lines", new KVTableStatePersistor("consumingState", "state.key"));
 

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DatasetWithMRApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DatasetWithMRApp.java
@@ -49,7 +49,8 @@ public class DatasetWithMRApp extends AbstractApplication {
     }
 
     @Override
-    public void initialize(MapReduceContext context) {
+    public void initialize() {
+      MapReduceContext context = getContext();
       context.addInput(Input.ofDataset(context.getRuntimeArguments().get(INPUT_KEY)));
       context.addOutput(Output.ofDataset(context.getRuntimeArguments().get(OUTPUT_KEY)));
       Job hadoopJob = context.getHadoopJob();

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/WordCountApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/WordCountApp.java
@@ -260,7 +260,8 @@ public class WordCountApp extends AbstractApplication {
     }
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       job.setMapperClass(MyMapper.class);
       job.setReducerClass(MyReducer.class);
@@ -307,7 +308,8 @@ public class WordCountApp extends AbstractApplication {
     }
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       job.setMapperClass(StreamMapper.class);
       job.setMapOutputKeyClass(Text.class);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/WorkflowAppWithLocalDatasets.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/WorkflowAppWithLocalDatasets.java
@@ -148,7 +148,8 @@ public class WorkflowAppWithLocalDatasets extends AbstractApplication {
    */
   public static class WordCount extends AbstractMapReduce {
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       String inputPath = context.getRuntimeArguments().get("output.path");
       Map<String, String> fileSetArgs = new HashMap<>();
       FileSetArguments.addInputPath(fileSetArgs, inputPath);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/artifacts/AppWithPlugin.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/artifacts/AppWithPlugin.java
@@ -21,7 +21,6 @@ import co.cask.cdap.api.app.AbstractApplication;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.batch.Output;
-import co.cask.cdap.api.data.stream.StreamBatchReadable;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.dataset.table.Put;
 import co.cask.cdap.api.dataset.table.Table;
@@ -144,8 +143,8 @@ public class AppWithPlugin extends AbstractApplication {
     }
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
-      super.initialize(context);
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       Job job = context.getHadoopJob();
       job.setMapperClass(SimpleMapper.class);
       job.setNumReduceTasks(0);

--- a/cdap-unit-test/src/test/java/net/fake/test/app/BundleJarApp.java
+++ b/cdap-unit-test/src/test/java/net/fake/test/app/BundleJarApp.java
@@ -175,11 +175,11 @@ public class BundleJarApp extends AbstractApplication {
 
     /**
      * Define a MapReduce job.
-     * @param context the context of a MapReduce job
      * @throws Exception
      */
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
       LOG.info("Hello " + loadTestClasses());
 
       Job job = context.getHadoopJob();


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-6071

Always call `beforeSubmit` and `onFinish` method on the MapReduce program since the `cdap-api` has provided dependency.
