### PR TITLE
Fix MD5 hash after checking file for changes.

### DIFF
--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="35b81e43a8203b26f484a1fb776b7496"
+DEFAULT_XML_MD5_HASH="a972cff7c79e00149bdb1ca4fe6d003e"
 
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"


### PR DESCRIPTION
Fixes broken build by updating the MD5 hash. No other changes required.

Passes [Quick Build 1](http://builds.cask.co/browse/CDAP-DQB25-1)
