### PR TITLE
CDAP-5729 Make rubric headings consistent with other heading levels

### DIFF
--- a/cdap-docs/_common/_themes/cdap-faqs/static/cdap-faqs.css_t
+++ b/cdap-docs/_common/_themes/cdap-faqs/static/cdap-faqs.css_t
@@ -12,8 +12,8 @@
 @import url("cdap.css");
 
 div.toctree-wrapper.compound ul {
-  padding-left: 0px;
-  padding-top: 0px;
+  padding-left: 0;
+  padding-top: 0;
 }
 
 div.toctree-wrapper.compound li.toctree-l1 a.reference.internal {
@@ -22,9 +22,9 @@ div.toctree-wrapper.compound li.toctree-l1 a.reference.internal {
   display: block;
   font-size: 150%;
   font-weight: bold;
-  margin: 15px 0px 10px -15px;
-  padding: 5px 0px 5px 15px;
-  text-shadow: 0px 1px 0px white;
+  margin: 15px 0 10px -15px;
+  padding: 5px 0 5px 15px;
+  text-shadow: 0 1px 0 white;
 }
 
 div.toctree-wrapper.compound li.toctree-l1 + li {
@@ -50,8 +50,8 @@ div.toctree-wrapper.compound li.toctree-l2 a.reference.internal {
   color: #ff6600;
   font-size: 100%;
   font-weight: normal;
-  margin: 0px;
-  padding: 0px;
+  margin: 0;
+  padding: 0;
 }
 
 div.toctree-wrapper.compound li.toctree-l2 a.reference.internal:hover {

--- a/cdap-docs/_common/_themes/cdap/static/cdap.css_t
+++ b/cdap-docs/_common/_themes/cdap/static/cdap.css_t
@@ -301,13 +301,13 @@ p.admonition-title:after {
 }
 
 p.rubric {
-    background-color: #E0E0E0;
-    font-size: 120%;
-    font-weight: normal;
+    background-color: #EDEDED; 
     color: #111;
+    font-size: 110%; 
+    font-weight:normal;
     margin: 30px 0px 10px 0px;
-    padding: 5px 0 5px 15px;
-    text-shadow: 0px 1px 0 white
+    padding: 5px 0px  5px  15px;
+    text-shadow: 0px 1px 0px white;
 }
 
 .sidebar20.sidebar {

--- a/cdap-docs/_common/_themes/cdap/static/cdap.css_t
+++ b/cdap-docs/_common/_themes/cdap/static/cdap.css_t
@@ -304,7 +304,7 @@ p.rubric {
     background-color: #EDEDED; 
     color: #111;
     font-size: 110%; 
-    font-weight:normal;
+    font-weight: normal;
     margin: 30px 0 10px 0;
     padding: 5px 0  5px  15px;
     text-shadow: 0 1px 0 white;

--- a/cdap-docs/_common/_themes/cdap/static/cdap.css_t
+++ b/cdap-docs/_common/_themes/cdap/static/cdap.css_t
@@ -72,7 +72,7 @@ div.related {
     background-color: #303840;
     line-height: 32px;
     color: #fff;
-    text-shadow: 0px 1px 0 #444;
+    text-shadow: 0 1px 0 #444;
     font-size: 0.9em;
     width: auto;
     background-image: url(./doc_logo.png);
@@ -195,9 +195,9 @@ div.body h6 {
     background-color: #EEE;
     font-weight: normal;
     color: #111;
-    margin: 30px 0px 10px -15px;
-    padding: 5px 0px  5px  15px;
-    text-shadow: 0px 1px 0px white;
+    margin: 30px 0 10px -15px;
+    padding: 5px 0  5px  15px;
+    text-shadow: 0 1px 0 white;
 }
 
 div.body h1 { border-top: 20px solid white; margin-top: 0; font-size: 180%; font-weight:bold;}
@@ -209,9 +209,9 @@ div.body h6 { font-size: 100%; font-weight:normal;}
 
 div.body h1 { background-color: #E0E0E0; }
 div.body h2 { background-color: #E0E0E0; }
-div.body h3 { background-color: #E0E0E0; margin: 30px 0px 10px 0px; }
-div.body h4 { background-color: #EDEDED; margin: 30px 0px 10px 0px; }
-div.body h5 { background-color: #F2F2F2; margin: 30px 0px 10px 0px; }
+div.body h3 { background-color: #E0E0E0; margin: 30px 0 10px 0; }
+div.body h4 { background-color: #EDEDED; margin: 30px 0 10px 0; }
+div.body h5 { background-color: #F2F2F2; margin: 30px 0 10px 0; }
 div.body h6 { background-color: #F2F2F2; }
 
 a.headerlink {
@@ -245,8 +245,8 @@ div.admonition p.admonition-title + p {
 
 div.highlight{
     background-color: white;
-    margin-left: 0px;
-    margin-right: 0px;
+    margin-left: 0;
+    margin-right: 0;
 }
 
 div.note {
@@ -256,7 +256,7 @@ div.note {
 
 div.related ul {
     margin-left: -5px;
-    padding-left: 0px;
+    padding-left: 0;
 }
 
 div.seealso {
@@ -305,9 +305,9 @@ p.rubric {
     color: #111;
     font-size: 110%; 
     font-weight:normal;
-    margin: 30px 0px 10px 0px;
-    padding: 5px 0px  5px  15px;
-    text-shadow: 0px 1px 0px white;
+    margin: 30px 0 10px 0;
+    padding: 5px 0  5px  15px;
+    text-shadow: 0 1px 0 white;
 }
 
 .sidebar20.sidebar {
@@ -391,9 +391,9 @@ ul.simple {
 
 td .docutils.literal {
   background: #ffffff;
-  border: 0px;
-  border-radius: 0px;
-  padding: 0px;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
 }
 
 /* -- Table styles used in Introduction page -------------------------------------- */
@@ -450,7 +450,7 @@ div.table-block.container table.triple-table.docutils tr:first-of-type th.stub {
 div.table-block-example.container {
   border-style: solid;
   border-width: 1px;
-  margin-left: 0px;
+  margin-left: 0;
   margin-top: 20px;
   margin-bottom: 30px;
   border-color: #aaa;
@@ -506,12 +506,12 @@ table.faq-table.docutils tr.row-odd td {
 
 table.faq-table.docutils tr.row-even th.stub {
     padding-top: 5px;
-    border-bottom: 0px;
+    border-bottom: 0;
 }
 
 table.faq-table.docutils tr.row-even td {
     padding-top: 5px;
-    border-bottom: 0px;
+    border-bottom: 0;
 }
 
 table.faq-table.docutils tr.row-odd div.highlight pre {
@@ -522,7 +522,7 @@ table.faq-table.docutils tr.row-odd div.highlight pre {
 /* -- Styles to hide navigation ----------------------------------------------- */
 
 div.documentwrapper-hidden {
-    margin-top: 0px;
+    margin-top: 0;
 }
 
 div.bodywrapper-hidden {
@@ -532,7 +532,7 @@ div.bodywrapper-hidden {
 /* -- Styles for tabbed parsed literals -------------------------------------- */
 
 div.code.code-tab div.highlight pre {
-    margin-top: 0px;
+    margin-top: 0;
     margin-right: 14px;
     margin-left: 14px;
     margin-bottom: 16px;
@@ -548,4 +548,3 @@ div.code.code-tab {
 div.tab-contents {
     padding-bottom: 16px;
 }
-


### PR DESCRIPTION
Make the rubric style equivalent to an H4 heading level, as that is the lowest level we use.

Passes [Quick Build 2](http://builds.cask.co/browse/CDAP-DQB26-2)

Current Rubric: ["Notes" under Apache Ambari](http://docs.cask.co/cdap/develop/en/admin-manual/installation/ambari.html#admin-installation-ambari)

New Rubric: ["Notes" under Apache Ambari](http://builds.cask.co/artifact/CDAP-DQB26/shared/build-2/Docs-HTML/3.5.0-SNAPSHOT/en/admin-manual/installation/ambari.html) (now lighter and same weight as an H4 heading, such as "[On RPM using Yum](http://builds.cask.co/artifact/CDAP-DQB26/shared/build-2/Docs-HTML/3.5.0-SNAPSHOT/en/admin-manual/installation/ambari.html#downloading-and-distributing-packages)")

Fix for https://issues.cask.co/browse/CDAP-5729
