### PR TITLE
CDAP-4293 CLI instructions for Plugin deployment verification

### DIFF
--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -77,7 +77,7 @@ API_JAVADOCS="${PROJECT_PATH}/target/site/${APIDOCS}"
 CHECK_INCLUDES=''
 
 if [[ "x${COLOR_LOGS}" != "x" ]]; then
-  SPHINX_COLOR=""
+  SPHINX_COLOR=''
   RED="$(tput setaf 1)"
   BOLD="$(tput bold)"
   RED_BOLD="$(tput setaf 1; tput bold)"
@@ -344,6 +344,11 @@ function set_version() {
   fi
   cd ${current_directory}
   IFS="${OIFS}"
+  
+  if [ "x${GIT_BRANCH_TYPE:0:7}" == "xdevelop" ]; then
+    GIT_BRANCH_CASK_HYDRATOR="develop"
+  fi
+  get_cask_hydrator_version ${GIT_BRANCH_CASK_HYDRATOR}
 }
 
 function display_version() {
@@ -355,7 +360,16 @@ function display_version() {
   echo "GIT_BRANCH: ${GIT_BRANCH}"
   echo "GIT_BRANCH_TYPE: ${GIT_BRANCH_TYPE}"
   echo "GIT_BRANCH_PARENT: ${GIT_BRANCH_PARENT}"
-  echo "GIT_BRANCH_CDAP_HYDRATOR: ${GIT_BRANCH_CDAP_HYDRATOR}"
+  echo "GIT_BRANCH_CASK_HYDRATOR: ${GIT_BRANCH_CASK_HYDRATOR}"
+  echo "CASK_HYDRATOR_VERSION: ${CASK_HYDRATOR_VERSION}"
+}
+
+function get_cask_hydrator_version() {
+  # $1 Branch of Hydrator Plugins to use
+  CASK_HYDRATOR_VERSION=$(curl --silent "https://raw.githubusercontent.com/caskdata/hydrator-plugins/${1}/pom.xml" | grep "<version>")
+  CASK_HYDRATOR_VERSION=${CASK_HYDRATOR_VERSION#*<version>}
+  CASK_HYDRATOR_VERSION=${CASK_HYDRATOR_VERSION%%</version>*}
+  export CASK_HYDRATOR_VERSION
 }
 
 function clear_messages_set_messages_file() {

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -296,6 +296,13 @@ if cask_tracker_version:
 
 """ % {'cask-tracker-version': cask_tracker_version}
 
+rst_epilog += """
+.. |cask-hydrator-version| replace:: %(cask-hydrator-version)s
+
+.. |literal-cask-hydrator-version| replace:: ``%(cask-hydrator-version)s``
+
+""" % {'cask-hydrator-version': os.environ.get('CASK_HYDRATOR_VERSION')}
+
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
 #today = ''

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -175,7 +175,7 @@ copyright = u'2014-%s Cask Data, Inc.' % current_year
 #
 # The X.Y.Z version
 # The X.Y short-version
-# The full version, including alpha/beta/rc tags, or release version.
+# The "full" version, which includes any alpha/beta/rc/SNAPSHOT tags, also called the "release" version.
 version, short_version, release, version_tuple = get_sdk_version()
 git_hash, git_timestamp = get_git_hash_timestamp()
 

--- a/cdap-docs/developers-manual/source/building-blocks/plugins.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/plugins.rst
@@ -376,8 +376,15 @@ For example, to retrieve detail about our ``custom-transforms`` artifact:
 
 .. tabbed-parsed-literal::
 
-  $ curl -w"\n" -X POST "localhost:10000/v3/namespaces/default/artifacts/custom-transforms/versions/1.0.0?scope=[system | user]
+  $ curl -w"\n" -X GET "localhost:10000/v3/namespaces/default/artifacts/custom-transforms/versions/1.0.0?scope=[system | user]
 
+Using the CLI:
+
+.. tabbed-parsed-literal::
+    :tabs: "CDAP CLI"
+ 
+    |cdap >| describe artifact properties custom-transforms 1.0.0 [system | user]
+    
 If you deployed the ``custom-transforms`` artifact as a system artifact, the scope is ``system``.
 If you deployed the ``custom-transforms`` artifact as a user artifact, the scope is ``user``.
 
@@ -388,8 +395,15 @@ specific type. For example, to check if ``cdap-etl-batch`` can access the plugin
 
 .. tabbed-parsed-literal::
 
-    $ curl -w"\n" -X POST "localhost:10000/v3/namespaces/default/artifacts/cdap-etl-batch/versions/|version|/extensions/transform?scope=system"
+    $ curl -w"\n" -X GET "localhost:10000/v3/namespaces/default/artifacts/cdap-etl-batch/versions/|version|/extensions/transform?scope=system"
 
+Using the CLI:
+
+.. tabbed-parsed-literal::
+    :tabs: "CDAP CLI"
+ 
+    |cdap >| list artifact plugins cdap-etl-batch |version| transform system
+    
 You can then check the list returned to see if your transforms are in the list. Note that
 the scope here refers to the scope of the parent artifact. In this example it is the ``system``
 scope because ``cdap-etl-batch`` is a system artifact. This is true even if you deployed

--- a/cdap-docs/developers-manual/source/building-blocks/workflows.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/workflows.rst
@@ -605,8 +605,8 @@ shared by all branches of the fork. Updates to the singleton are made thread-saf
 synchronized updates, guaranteeing that value you obtain from reading the token is the
 last value written at runtime. This is a time-based guarantee.
 
-Example
--------
+Examples
+--------
 
 This code sample shows how to obtain values from the token from within a custom action,
 and from within a workflow with a predicate, fork and joins::

--- a/cdap-docs/developers-manual/source/table-of-contents.rst
+++ b/cdap-docs/developers-manual/source/table-of-contents.rst
@@ -7,7 +7,7 @@ CDAP Developers’ Manual Table of Contents
 ============================================
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 4
 
     Introduction <index>
     Getting Started Developing <getting-started/index>

--- a/cdap-docs/reference-manual/source/http-restful-api/artifact.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/artifact.rst
@@ -164,7 +164,7 @@ To retrieve detail about a specific version of an artifact, submit an HTTP GET r
 
 This will return a JSON object that contains information about: classes in the artifact;
 the schema of the config object supported by the ``Application`` class; and the artifact name,
-version, and scope. Example output for version |release| of the ``WordCount``
+version, and scope. Example output for version |literal-release| of the ``WordCount``
 artifact (pretty-printed and reformatted to fit):
 
 .. container:: highlight
@@ -404,14 +404,13 @@ an HTTP GET request::
      - Optional scope filter. If not specified, defaults to 'user'.
   
 This will return a JSON array that lists the extensions (plugin types) available to the artifact.
-Example output for version |release| of the ``cdap-etl-batch``
-artifact (pretty-printed and reformatted to fit):
+Example output for version |literal-release| of the ``cdap-etl-batch`` artifact:
 
 .. container:: highlight
 
   .. parsed-literal::
-    |$| GET <base-url>/namespaces/default/artifact/WordCount/versions/|release|/extensions?scope=system
-    [ "transform", "validator", "batchsource", "batchsink" ]{
+    |$| GET <base-url>/namespaces/default/artifacts/cdap-etl-batch/versions/|release|/extensions?scope=system
+    "postaction","transform","batchaggregator","validator","realtimesource","batchsource","realtimesink","batchsink"]
 
 .. _http-restful-api-artifact-available-plugins:
 
@@ -442,7 +441,7 @@ an HTTP GET request::
 This will return a JSON array that lists the plugins of the specified type
 available to the artifact. Each element in the array is a JSON object containing
 the artifact that the plugin originated from, and the plugin's class name, description, 
-name, and type. Example output for plugins of type ``transform`` available to version |release|
+name, and type. Example output for plugins of type ``transform`` available to version |literal-release|
 of the ``cdap-etl-batch`` artifact (pretty-printed and reformatted to fit):
 
 .. container:: highlight
@@ -451,29 +450,23 @@ of the ``cdap-etl-batch`` artifact (pretty-printed and reformatted to fit):
     |$| GET <base-url>/namespaces/default/artifacts/cdap-etl-batch/versions/|release|/extensions/transform?scope=system
 
     [
-      {
-        "artifact": {
-          "name": "cdap-etl-lib",
-          "scope": "SYSTEM",
-          "version": "|release|-batch"
+        {
+            "name": "LogParser",
+            "type": "transform",
+            "description": "Parses logs from any input source for relevant information such as URI, IP, browser, device, HTTP status code, and timestamp.",
+            "className": "co.cask.hydrator.plugin.transform.LogParserTransform",
+            "artifact": {
+                "name": "core-plugins",
+                "version": "1.4.0-SNAPSHOT",
+                "scope": "SYSTEM"
+            }
         },
-        "className": "co.cask.cdap.etl.transform.LogParserTransform",
-        "description": "Parses logs from any input source for relevant information such as URI, IP, Browser, Device, HTTP status code, and timestamp.",
-        "name": "LogParser",
-        "type": "transform"
-      },
-      {
-        "artifact": {
-            "name": "cdap-etl-lib",
-            "scope": "SYSTEM",
-            "version": "|release|-batch"
+        {
+            "name": "JavaScript",
+            "type": "transform",
+            ...
         },
-        "className": "co.cask.cdap.etl.transform.ProjectionTransform",
-        "description": "Projection transform that lets you drop, rename, and cast fields to a different type.",
-        "name": "Projection",
-        "type": "transform"
-      },
-      ...
+        ...
     ]
 
 .. _http-restful-api-artifact-plugin-detail:
@@ -507,7 +500,7 @@ an HTTP GET request::
 This will return a JSON array that lists the plugins of the specified type and name
 available to the artifact. Each element in the array is a JSON object containing
 the artifact that the plugin originated from, and the plugin's class name, description, name, type, and properties.
-Example output for the ``ScriptFilter`` plugin available to version |release|
+Example output for the ``ScriptFilter`` plugin available to version |literal-release|
 of the ``cdap-etl-batch`` artifact (pretty-printed and reformatted to fit):
 
 .. container:: highlight
@@ -516,26 +509,36 @@ of the ``cdap-etl-batch`` artifact (pretty-printed and reformatted to fit):
     |$| GET <base-url>/namespaces/default/artifacts/cdap-etl-batch/versions/|release|/extensions/transform/plugins/ScriptFilter?scope=system
 
     [
-      {
-        "artifact": {
-            "name": "cdap-etl-lib",
-            "scope": "SYSTEM",
-            "version": "|release|-batch"
-        },
-        "className": "co.cask.cdap.etl.transform.ScriptFilterTransform",
-        "description": "A transform plugin that filters records using a custom JavaScript provided in the plugin's config.",
-        "name": "ScriptFilter",
-        "properties": {
-            "script": {
-                "description": "JavaScript that must implement a function 'shouldFilter' that takes a JSON object representation of the input record, and returns true if the input record should be filtered and false if not. For example: 'function shouldFilter(input) { return input.count > 100; }' will filter out any records whose 'count' field is greater than 100.",
-                "name": "script",
-                "required": true,
-                "type": "string"
+        {
+            "properties": {
+                "lookup": {
+                    "name": "lookup",
+                    "description": "Lookup tables to use during transform. Currently supports KeyValueTable.",
+                    "type": "string",
+                    "required": false
+                },
+                "script": {
+                    "name": "script",
+                    "description": "JavaScript that must implement a function 'shouldFilter' that takes a JSON object representation of the input record and a context object (which encapsulates CDAP metrics and logger) and returns true if the input record should be filtered and false if not. For example:\n'function shouldFilter(input, context) {\nif (input.count < 0) {\ncontext.getLogger().info(\"Got input record with negative count\");\ncontext.getMetrics().count(\"negative.count\", 1);\n}\nreturn input.count > 100;\n}\n' will filter out any records whose 'count' field is greater than 100.",
+                    "type": "string",
+                    "required": true
+                }
+            },
+            "endpoints": [
+
+            ],
+            "name": "ScriptFilter",
+            "type": "transform",
+            "description": "A transform plugin that filters records using a custom JavaScript provided in the plugin's config.",
+            "className": "co.cask.hydrator.plugin.transform.ScriptFilterTransform",
+            "artifact": {
+                "name": "core-plugins",
+                "version": "1.4.0-SNAPSHOT",
+                "scope": "SYSTEM"
             }
-        },
-        "type": "transform"
-      }
+        }
     ]
+
 
 .. _http-restful-api-artifact-delete:
 

--- a/cdap-docs/reference-manual/source/http-restful-api/artifact.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/artifact.rst
@@ -441,7 +441,10 @@ an HTTP GET request::
 This will return a JSON array that lists the plugins of the specified type
 available to the artifact. Each element in the array is a JSON object containing
 the artifact that the plugin originated from, and the plugin's class name, description, 
-name, and type. Example output for plugins of type ``transform`` available to version |literal-release|
+name, and type. Note that the details provided are a summary compared to those provided by
+the endpoint :ref:`http-restful-api-artifact-plugin-detail`.
+
+Example output for plugins of type ``transform`` available to version |literal-release|
 of the ``cdap-etl-batch`` artifact (pretty-printed and reformatted to fit):
 
 .. container:: highlight
@@ -453,11 +456,12 @@ of the ``cdap-etl-batch`` artifact (pretty-printed and reformatted to fit):
         {
             "name": "LogParser",
             "type": "transform",
-            "description": "Parses logs from any input source for relevant information such as URI, IP, browser, device, HTTP status code, and timestamp.",
+            "description": "Parses logs from any input source for relevant information such as 
+                URI, IP, browser, device, HTTP status code, and timestamp.",
             "className": "co.cask.hydrator.plugin.transform.LogParserTransform",
             "artifact": {
                 "name": "core-plugins",
-                "version": "1.4.0-SNAPSHOT",
+                "version": "|cask-hydrator-version|",
                 "scope": "SYSTEM"
             }
         },
@@ -498,8 +502,12 @@ an HTTP GET request::
      - Optional scope filter. If not specified, defaults to 'user'.
 
 This will return a JSON array that lists the plugins of the specified type and name
-available to the artifact. Each element in the array is a JSON object containing
-the artifact that the plugin originated from, and the plugin's class name, description, name, type, and properties.
+available to the artifact. As can been seen compared with the endpoint
+:ref:`http-restful-api-artifact-available-plugins`, this provides all details
+on the specified plugin. Each element in the array is a JSON object containing the
+artifact that the plugin originated from, and the plugin's class name, description, name,
+type, and properties.
+
 Example output for the ``ScriptFilter`` plugin available to version |literal-release|
 of the ``cdap-etl-batch`` artifact (pretty-printed and reformatted to fit):
 
@@ -519,7 +527,16 @@ of the ``cdap-etl-batch`` artifact (pretty-printed and reformatted to fit):
                 },
                 "script": {
                     "name": "script",
-                    "description": "JavaScript that must implement a function 'shouldFilter' that takes a JSON object representation of the input record and a context object (which encapsulates CDAP metrics and logger) and returns true if the input record should be filtered and false if not. For example:\n'function shouldFilter(input, context) {\nif (input.count < 0) {\ncontext.getLogger().info(\"Got input record with negative count\");\ncontext.getMetrics().count(\"negative.count\", 1);\n}\nreturn input.count > 100;\n}\n' will filter out any records whose 'count' field is greater than 100.",
+                    "description": "JavaScript that must implement a function
+                      'shouldFilter' that takes a JSON object representation of the input
+                      record and a context object (which encapsulates CDAP metrics and
+                      logger) and returns true if the input record should be filtered and
+                      false if not. For example:\n'function shouldFilter(input, context)
+                      {\nif (input.count < 0) {\ncontext.getLogger().info(\"Got input record
+                      with negative
+                      count\");\ncontext.getMetrics().count(\"negative.count\",
+                      1);\n}\nreturn input.count > 100;\n}\n' will filter out any records
+                      whose 'count' field is greater than 100.",
                     "type": "string",
                     "required": true
                 }
@@ -529,11 +546,12 @@ of the ``cdap-etl-batch`` artifact (pretty-printed and reformatted to fit):
             ],
             "name": "ScriptFilter",
             "type": "transform",
-            "description": "A transform plugin that filters records using a custom JavaScript provided in the plugin's config.",
+            "description": "A transform plugin that filters records using a custom
+                JavaScript provided in the plugin's config.",
             "className": "co.cask.hydrator.plugin.transform.ScriptFilterTransform",
             "artifact": {
                 "name": "core-plugins",
-                "version": "1.4.0-SNAPSHOT",
+                "version": "|cask-hydrator-version|",
                 "scope": "SYSTEM"
             }
         }

--- a/cdap-docs/vars
+++ b/cdap-docs/vars
@@ -30,7 +30,7 @@ BUILD_RST_HASH="6b6124e34febf8ff1259e923ce29b5f9"
 GIT_BRANCH_PARENT="develop"
 
 # Used by cdap-apps for Hydrator documentation
-GIT_BRANCH_CDAP_HYDRATOR="develop"
+GIT_BRANCH_CASK_HYDRATOR="develop"
 
 # Used by developers-manual
 CDAP_CLIENTS_RELEASE_VERSION="1.2.0"


### PR DESCRIPTION
Fix errors in artifacts RESTful API.
Adds to a comment in the Python config file.
Fixes a title in the workflow docs.
Expands the number of levels in the dev guide from three to four.
Adds a CLI example to the plugins documentation.

Passers [Quick Build 2](http://builds.cask.co/browse/CDAP-DQB28-2)

Fix for https://issues.cask.co/browse/CDAP-4293

Pages of interest:
- [Artifacts RESTful API](http://builds.cask.co/artifact/CDAP-DQB28/shared/build-2/Docs-HTML/3.5.0-SNAPSHOT/en/reference-manual/http-restful-api/artifact.html#list-extensions-plugin-types-available-to-an-artifact)
- [Building Blocks: Plugins](http://builds.cask.co/artifact/CDAP-DQB28/shared/build-2/Docs-HTML/3.5.0-SNAPSHOT/en/developers-manual/building-blocks/plugins.html#deployment-verification)
- [Building Blocks: Workflows](http://builds.cask.co/artifact/CDAP-DQB28/shared/build-2/Docs-HTML/3.5.0-SNAPSHOT/en/developers-manual/building-blocks/workflows.html)
