### PR TITLE
CDAP-5415 Return the programs that are still running

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
@@ -300,22 +300,18 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
   }
 
   @Override
-  public boolean checkAnyRunning(Predicate<Id.Program> predicate, ProgramType... types) {
+  public List<RuntimeInfo> listAll(ProgramType... types) {
+    List<RuntimeInfo> runningPrograms = new ArrayList<>();
     for (ProgramType type : types) {
-      for (Map.Entry<RunId, ProgramRuntimeService.RuntimeInfo> entry :  list(type).entrySet()) {
+      for (Map.Entry<RunId, ProgramRuntimeService.RuntimeInfo> entry : list(type).entrySet()) {
         ProgramController.State programState = entry.getValue().getController().getState();
         if (programState.isDone()) {
           continue;
         }
-        Id.Program programId = entry.getValue().getProgramId();
-        if (predicate.apply(programId)) {
-          LOG.trace("Program still running in checkAnyRunning: {} {} {} {}",
-                    programId.getApplicationId(), type, programId.getId(), entry.getValue().getController().getRunId());
-          return true;
-        }
+        runningPrograms.add(entry.getValue());
       }
     }
-    return false;
+    return runningPrograms;
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramRuntimeService.java
@@ -20,10 +20,10 @@ import co.cask.cdap.app.program.ProgramDescriptor;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramLiveInfo;
 import co.cask.cdap.proto.ProgramType;
-import com.google.common.base.Predicate;
 import com.google.common.util.concurrent.Service;
 import org.apache.twill.api.RunId;
 
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -87,12 +87,11 @@ public interface ProgramRuntimeService extends Service {
   ProgramLiveInfo getLiveInfo(Id.Program programId);
 
   /**
-   * Check if any program that satisfy the given {@link Predicate} is running.
+   * Get information about running programs.
    * Protected only to support v2 APIs
    *
-   * @param predicate Get call on each running {@link Id.Program}.
    * @param types Types of program to check
-   * returns True if a program is running as defined by the predicate.
+   * returns List of info about running programs.
    */
-  boolean checkAnyRunning(Predicate<Id.Program> predicate, ProgramType... types);
+  List<RuntimeInfo> listAll(ProgramType... types);
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -24,7 +24,6 @@ import co.cask.cdap.common.ApplicationNotFoundException;
 import co.cask.cdap.common.ArtifactAlreadyExistsException;
 import co.cask.cdap.common.ArtifactNotFoundException;
 import co.cask.cdap.common.BadRequestException;
-import co.cask.cdap.common.CannotBeDeletedException;
 import co.cask.cdap.common.InvalidArtifactException;
 import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.NotFoundException;
@@ -206,13 +205,8 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                         @PathParam("namespace-id") String namespaceId,
                         @PathParam("app-id") String appId) throws Exception {
     Id.Application id = validateApplicationId(namespaceId, appId);
-    try {
-      applicationLifecycleService.removeApplication(id);
-      responder.sendStatus(HttpResponseStatus.OK);
-    } catch (CannotBeDeletedException e) {
-      // Keeping this for backward compatibility. Ideally this should return conflict, not forbidden.
-      responder.sendString(HttpResponseStatus.FORBIDDEN, "Program is still running");
-    }
+    applicationLifecycleService.removeApplication(id);
+    responder.sendStatus(HttpResponseStatus.OK);
   }
 
   /**
@@ -223,13 +217,8 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   public void deleteAllApps(HttpRequest request, HttpResponder responder,
                             @PathParam("namespace-id") String namespaceId) throws Exception {
     Id.Namespace id = validateNamespace(namespaceId);
-    try {
-      applicationLifecycleService.removeAll(id);
-      responder.sendStatus(HttpResponseStatus.OK);
-    } catch (CannotBeDeletedException e) {
-      // Keeping this for backward compatibility. Ideally this should return conflict, not forbidden.
-      responder.sendString(HttpResponseStatus.FORBIDDEN, "Program is still running");
-    }
+    applicationLifecycleService.removeAll(id);
+    responder.sendStatus(HttpResponseStatus.OK);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -52,6 +52,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
@@ -311,12 +312,15 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
   }
 
   private boolean checkProgramsRunning(final NamespaceId namespaceId) {
-    return runtimeService.checkAnyRunning(new Predicate<Id.Program>() {
+    Iterable<ProgramRuntimeService.RuntimeInfo> runtimeInfos =
+      Iterables.filter(runtimeService.listAll(ProgramType.values()),
+                       new Predicate<ProgramRuntimeService.RuntimeInfo>() {
       @Override
-      public boolean apply(Id.Program program) {
-        return program.getNamespaceId().equals(namespaceId.getNamespace());
+      public boolean apply(ProgramRuntimeService.RuntimeInfo info) {
+        return info.getProgramId().getNamespaceId().equals(namespaceId.getNamespace());
       }
-    }, ProgramType.values());
+    });
+    return !Iterables.isEmpty(runtimeInfos);
   }
 
   private InstanceId createInstanceId(CConfiguration cConf) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerTestBase.java
@@ -34,6 +34,7 @@ import co.cask.cdap.proto.ProgramType;
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
+import com.google.common.collect.Iterables;
 import com.google.inject.Injector;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -195,13 +196,15 @@ public abstract class SchedulerTestBase {
     }, timeoutSeconds, TimeUnit.SECONDS, 50, TimeUnit.MILLISECONDS);
   }
 
-
   private boolean isProgramRunning(ProgramRuntimeService runtimeService, final Id.Program program) {
-    return runtimeService.checkAnyRunning(new Predicate<Id.Program>() {
+    Iterable<ProgramRuntimeService.RuntimeInfo> runtimeInfos =
+      Iterables.filter(runtimeService.listAll(ProgramType.values()),
+                       new Predicate<ProgramRuntimeService.RuntimeInfo>() {
       @Override
-      public boolean apply(Id.Program programId) {
-        return programId.equals(program);
+      public boolean apply(ProgramRuntimeService.RuntimeInfo runtimeInfo) {
+        return runtimeInfo.getProgramId().toEntityId().equals(program);
       }
-    }, ProgramType.values());
+    });
+    return !Iterables.isEmpty(runtimeInfos);
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
@@ -271,6 +271,22 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
     response = doDelete(getVersionedAPIPath("apps/WordCountApp", Constants.Gateway.API_VERSION_3_TOKEN,
                                             TEST_NAMESPACE1));
     Assert.assertEquals(403, response.getStatusLine().getStatusCode());
+    Assert.assertEquals("'" + program.getApplication() +
+                          "' could not be deleted. Reason: The following programs are still running: "
+                          + program.getId(), readResponse(response));
+
+    stopProgram(program);
+    waitState(program, "STOPPED");
+
+    startProgram(program);
+    waitState(program, "RUNNING");
+    // Try to delete all Apps while flow is running
+    response = doDelete(getVersionedAPIPath("apps", Constants.Gateway.API_VERSION_3_TOKEN,
+                                            TEST_NAMESPACE1));
+    Assert.assertEquals(403, response.getStatusLine().getStatusCode());
+    Assert.assertEquals("'" + program.getNamespace() +
+                          "' could not be deleted. Reason: The following programs are still running: "
+                          + program.getApplicationId() + ": " + program.getId(), readResponse(response));
 
     stopProgram(program);
     waitState(program, "STOPPED");


### PR DESCRIPTION
when a request to delete an app fails
JIRA: https://issues.cask.co/browse/CDAP-5415
Build: http://builds.cask.co/browse/CDAP-DUT4182
Description: added a method getAnyRunning to replace method checkAnyRunning in runtimeService to collect all running programs of the application when it is requested to delete. Methods which call 
