### PR TITLE
CDAP-6098 Changes to documentation version-menu

### DIFF
--- a/cdap-docs/_common/_themes/cdap/static/version-menu.js
+++ b/cdap-docs/_common/_themes/cdap/static/version-menu.js
@@ -42,18 +42,18 @@
     writeLink(dir, 'Version ' + label);
   });
   window.versionscallback = (function(data){
+    var ess;
     if (data) {
       document.write('<li class="versions">');
       document.write('<select id="' + versionID + '" onmousedown="window.currentversion=this.value;" onchange="window.gotoVersion(\'' + versionID + '\')">');
     }
-    var ess;
+    
     if (data.development && data.development.length > 0 && data.development[0]) {
       ess = (data.development.length == 1) ? "" : "s" ;
       document.write('<optgroup label="Development Release' + ess +'">');          
       if (data.development && data.development.length > 0) {
         var i;
         for (i in data.development) {
-          writeLink(data.development[i][0], 'Develop (' + data.development[i][1] + ')');
           writeVersionLink(data.development[i][0], data.development[i][1]);
         }
       }
@@ -61,26 +61,32 @@
     } else {
       writeLink('develop', 'Develop');
     }
+    
     document.write('<optgroup label="Current Release">');
     if (data.current && data.current.length > 1 && data.current[0]) {
-      writeLink('current', 'Current (' + data.current[1] + ')')
       writeVersionLink(data.current[0], data.current[1]);
     } else {
       writeLink('current', 'Current');
     }
     document.write('</optgroup>');
+    
     if (data.older && data.older.length > 0 && data.older[0]) {
       ess = (data.older.length == 1) ? "" : "s" ;
       document.write('<optgroup label="Older Release' + ess + '">');
       var j;
+      var r;
       for (j in data.older) {
-        if (parseInt(data.older[j][3]) === 1) {
-          writeVersionLink(data.older[j][0], data.older[j][1]);
+        r = data.older[j];
+        if (parseInt(r[3]) === 1) {
+          if (r.length === 4 || (r.length > 4 && !parseInt(r[4]) === 0)) {
+            writeVersionLink(r[0], r[1]);
+          }
         }
       }
       document.write('<option value="' + versionsURL + '">All Releases</option>');
       document.write('</optgroup>');
     }
+    
     if (data) {
       document.write('</select>');
     }

--- a/cdap-docs/_common/_themes/cdap/static/version-menu.js
+++ b/cdap-docs/_common/_themes/cdap/static/version-menu.js
@@ -78,9 +78,9 @@
           writeVersionLink(data.older[j][0], data.older[j][1]);
         }
       }
+      document.write('<option value="' + versionsURL + '">All Releases</option>');
       document.write('</optgroup>');
     }
-    document.write('<option value="' + versionsURL + '">All Releases</option>');
     if (data) {
       document.write('</select>');
     }

--- a/cdap-docs/_common/_themes/cdap/static/version-menu.js
+++ b/cdap-docs/_common/_themes/cdap/static/version-menu.js
@@ -46,11 +46,9 @@
       document.write('<li class="versions">');
       document.write('<select id="' + versionID + '" onmousedown="window.currentversion=this.value;" onchange="window.gotoVersion(\'' + versionID + '\')">');
     }
-    var ess = "s";
-    if (data.development && data.development.length > 0) {
-      if (data.development.length == 1) {
-        ess = "";
-      }
+    var ess;
+    if (data.development && data.development.length > 0 && data.development[0]) {
+      ess = (data.development.length == 1) ? "" : "s" ;
       document.write('<optgroup label="Development Release' + ess +'">');          
       if (data.development && data.development.length > 0) {
         var i;
@@ -58,24 +56,21 @@
           writeLink(data.development[i][0], 'Develop (' + data.development[i][1] + ')');
           writeVersionLink(data.development[i][0], data.development[i][1]);
         }
-      } else {
-        writeLink('develop', 'Develop');
       }
       document.write('</optgroup>');
+    } else {
+      writeLink('develop', 'Develop');
     }
     document.write('<optgroup label="Current Release">');
-    if (data.current && data.current.length > 0) {
+    if (data.current && data.current.length > 1 && data.current[0]) {
       writeLink('current', 'Current (' + data.current[1] + ')')
       writeVersionLink(data.current[0], data.current[1]);
     } else {
       writeLink('current', 'Current');
     }
     document.write('</optgroup>');
-    if (data.older && data.older.length > 0) {
-      ess = "s";
-      if (data.older.length == 1) {
-        ess = "";
-      }
+    if (data.older && data.older.length > 0 && data.older[0]) {
+      ess = (data.older.length == 1) ? "" : "s" ;
       document.write('<optgroup label="Older Release' + ess + '">');
       var j;
       for (j in data.older) {
@@ -83,9 +78,9 @@
           writeVersionLink(data.older[j][0], data.older[j][1]);
         }
       }
-      document.write('<option value="' + versionsURL + '">All Releases</option>');
       document.write('</optgroup>');
     }
+    document.write('<option value="' + versionsURL + '">All Releases</option>');
     if (data) {
       document.write('</select>');
     }

--- a/cdap-docs/_common/_themes/cdap/static/version-menu.js
+++ b/cdap-docs/_common/_themes/cdap/static/version-menu.js
@@ -4,7 +4,7 @@
  *
  * JavaScript for generating 
  *
- * :copyright: © Copyright 2015 Cask Data, Inc.
+ * :copyright: © Copyright 2015-2016 Cask Data, Inc.
  * :license: Apache License, Version 2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -21,11 +21,11 @@
  * 
  * Requires a JSONP file at http://docs.cask.co/cdap/json-versions.js in the format:
  * 
- *  versionscallback({ "development":[["2.7.0-SNAPSHOT", "2.7.0"], ["2.6.0-SNAPSHOT","2.6.0"],], "older": ["2.5.2", "2.5.2"], "versions": [["2.5.1", "2.5.1"], ["2.5.0", "2.5.0"],] });
+ * versionscallback({'development': [['3.5.0-SNAPSHOT', '3.5.0']], 'current': ['3.4.1', '3.4.1', '2016-05-12'], 'timeline': [['0', '3.4.0', '2016-04-29', ' (100 days)'], ['1', '3.4.1', '2016-05-12', ' (13 days)'], ['0', '3.3.0', '2016-01-20', ' (119 days)'], ['1', '3.3.1', '2016-02-19', ' (30 days)'], ['1', '3.3.2', '2016-03-07', ' (17 days)'], ['1', '3.3.3', '2016-04-15', ' (39 days)'], ['1', '3.3.4', '2016-05-19', ' (34 days)'], ['0', '3.2.0', '2015-09-23', ' (51 days)'], ['1', '3.2.1', '2015-10-21', ' (28 days)'], ... ['2.6.0', '2.6.0', '2015-01-10', '']]});
  * 
  * list of development versions; one current version; list of additional versions
  *
- * version 0.2
+ * version 0.3
  * 
  */
 
@@ -35,8 +35,11 @@
   var buildURL = (function(dir){
     return versionsURL + dir + '/en/';
   });
-  var writelink = (function(dir, label){
-    document.write('<option value="' + buildURL(dir) + '">Version ' + label + '</option>');
+  var writeLink = (function(dir, label){
+    document.write('<option value="' + buildURL(dir) + '">' + label + '</option>');
+  });
+  var writeVersionLink = (function(dir, label){
+    writeLink(dir, 'Version ' + label);
   });
   window.versionscallback = (function(data){
     if (data) {
@@ -49,17 +52,25 @@
         ess = "";
       }
       document.write('<optgroup label="Development Release' + ess +'">');          
-      var i;
-      for (i in data.development) {
-        writelink(data.development[i][0], data.development[i][1]);
+      if (data.development && data.development.length > 0) {
+        var i;
+        for (i in data.development) {
+          writeLink(data.development[i][0], 'Develop (' + data.development[i][1] + ')');
+          writeVersionLink(data.development[i][0], data.development[i][1]);
+        }
+      } else {
+        writeLink('develop', 'Develop');
       }
       document.write('</optgroup>');
     }
-      document.write('<optgroup label="Current Release">');
+    document.write('<optgroup label="Current Release">');
     if (data.current && data.current.length > 0) {
-      writelink(data.current[0], data.current[1]);
-      document.write('</optgroup>');
+      writeLink('current', 'Current (' + data.current[1] + ')')
+      writeVersionLink(data.current[0], data.current[1]);
+    } else {
+      writeLink('current', 'Current');
     }
+    document.write('</optgroup>');
     if (data.older && data.older.length > 0) {
       ess = "s";
       if (data.older.length == 1) {
@@ -68,8 +79,11 @@
       document.write('<optgroup label="Older Release' + ess + '">');
       var j;
       for (j in data.older) {
-        writelink(data.older[j][0], data.older[j][1]);
+        if (parseInt(data.older[j][3]) === 1) {
+          writeVersionLink(data.older[j][0], data.older[j][1]);
+        }
       }
+      document.write('<option value="' + versionsURL + '">All Releases</option>');
       document.write('</optgroup>');
     }
     if (data) {

--- a/cdap-docs/_common/_themes/cdap/static/version-menu.js
+++ b/cdap-docs/_common/_themes/cdap/static/version-menu.js
@@ -48,7 +48,7 @@
       document.write('<select id="' + versionID + '" onmousedown="window.currentversion=this.value;" onchange="window.gotoVersion(\'' + versionID + '\')">');
     }
     
-    if (data.development && data.development.length > 0 && data.development[0]) {
+    if (Array.isArray(data.development) && data.development.length && data.development[0].length) {
       ess = (data.development.length == 1) ? "" : "s" ;
       document.write('<optgroup label="Development Release' + ess +'">');          
       var i;
@@ -61,14 +61,14 @@
     }
     
     document.write('<optgroup label="Current Release">');
-    if (data.current && data.current.length > 1 && data.current[0]) {
+    if (Array.isArray(data.current) && data.current.length && data.current[0].length) {
       writeVersionLink(data.current[0], data.current[1]);
     } else {
       writeLink('current', 'Current');
     }
     document.write('</optgroup>');
-    
-    if (data.older && data.older.length > 0 && data.older[0]) {
+
+    if (Array.isArray(data.older) && data.older.length && data.older[0].length) {
       ess = (data.older.length == 1) ? "" : "s" ;
       document.write('<optgroup label="Older Release' + ess + '">');
       var j;

--- a/cdap-docs/_common/_themes/cdap/static/version-menu.js
+++ b/cdap-docs/_common/_themes/cdap/static/version-menu.js
@@ -51,11 +51,9 @@
     if (data.development && data.development.length > 0 && data.development[0]) {
       ess = (data.development.length == 1) ? "" : "s" ;
       document.write('<optgroup label="Development Release' + ess +'">');          
-      if (data.development && data.development.length > 0) {
-        var i;
-        for (i in data.development) {
-          writeVersionLink(data.development[i][0], data.development[i][1]);
-        }
+      var i;
+      for (i in data.development) {
+        writeVersionLink(data.development[i][0], data.development[i][1]);
       }
       document.write('</optgroup>');
     } else {


### PR DESCRIPTION
Supports specifying in the `conf.py` that generates the drop-down menu the versions displayed in the menu.
Reduces the "Other" links list to just the main releases in each minor version, and adds an "All Releases" link at the end.
Updates copyright and the included sample of the versions callback file required.

Fix for:
- https://issues.cask.co/browse/CDAP-4872
- https://issues.cask.co/browse/CDAP-6098

Passes [Quick Build 5](http://builds.cask.co/browse/CDAP-DQB29-5)

See example of:
- [current menu](http://docs.cask.co/cdap/develop/en/)
- [revised menu](http://builds.cask.co/artifact/CDAP-DQB29/shared/build-5/Docs-HTML/3.5.0-SNAPSHOT/en/index.html)

Current: 
![screen shot 2016-05-25 at 2 16 10 pm](https://cloud.githubusercontent.com/assets/6394794/15594534/3e214288-236b-11e6-8167-63441fe2078b.png)

Revised:
![screen shot 2016-05-26 at 5 57 49 pm](https://cloud.githubusercontent.com/assets/6394794/15594558/6b00b63a-236b-11e6-9943-95d5f24dc7b3.png)
