### PR TITLE
CDAP-2518 Restrict init scripts to CDAP_USER or root

### DIFF
--- a/cdap-distributions/src/debian/init.d/cdap-service
+++ b/cdap-distributions/src/debian/init.d/cdap-service
@@ -1,7 +1,6 @@
 #!/bin/bash
-
 #
-# Copyright © 2014-2015 Cask Data, Inc.
+# Copyright © 2014-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -38,11 +37,21 @@ if [[ -r /etc/default/cdap-@service.name@ ]]; then
   . /etc/default/cdap-@service.name@
 fi
 
-# drop permissions to cdap user and run service script
-
-if [[ $UID -eq 0 ]]; then
-    su cdap -c "$SVC_COMMAND"
-else
-    $SVC_COMMAND
+# source cdap-env.sh, if it exists
+CDAP_CONF_DIR=${CDAP_CONF_DIR:-/etc/cdap/conf}
+if [[ -r ${CDAP_CONF_DIR}/cdap-env.sh ]]; then
+  . "${CDAP_CONF_DIR}"/cdap-env.sh
 fi
 
+CDAP_USER=${CDAP_USER:-cdap}
+
+# drop permissions to cdap user and run service script
+
+if [[ ${UID} -eq 0 ]]; then
+    su ${CDAP_USER} -c "${SVC_COMMAND}"
+elif [[ ${USER} == ${CDAP_USER} ]]; then
+    ${SVC_COMMAND}
+else
+    echo "ERROR: Must run this script as root or ${CDAP_USER}!"
+    exit 1
+fi

--- a/cdap-distributions/src/rpm/init.d/cdap-service
+++ b/cdap-distributions/src/rpm/init.d/cdap-service
@@ -1,7 +1,6 @@
 #!/bin/bash
-
 #
-# Copyright © 2014-2015 Cask Data, Inc.
+# Copyright © 2014-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -38,11 +37,21 @@ if [[ -r /etc/default/cdap-@service.name@ ]]; then
   . /etc/default/cdap-@service.name@
 fi
 
-# drop permissions to cdap user and run service script
-
-if [[ $UID -eq 0 ]]; then
-    su cdap -c "$SVC_COMMAND"
-else
-    $SVC_COMMAND
+# source cdap-env.sh, if it exists
+CDAP_CONF_DIR=${CDAP_CONF_DIR:-/etc/cdap/conf}
+if [[ -r ${CDAP_CONF_DIR}/cdap-env.sh ]]; then
+  . "${CDAP_CONF_DIR}"/cdap-env.sh
 fi
 
+CDAP_USER=${CDAP_USER:-cdap}
+
+# drop permissions to cdap user and run service script
+
+if [[ ${UID} -eq 0 ]]; then
+    su ${CDAP_USER} -c "${SVC_COMMAND}"
+elif [[ ${USER} == ${CDAP_USER} ]]; then
+    ${SVC_COMMAND}
+else
+    echo "ERROR: Must run this script as root or ${CDAP_USER}!"
+    exit 1
+fi


### PR DESCRIPTION
This allows the user to configure a couple variables. First, a user may configure `CDAP_CONF_DIR` in `/etc/default/cdap-${service_name}` which will inform the init script where to find `cdap-env.sh` and optionally source it before launching CDAP. There is a `CDAP_USER` variable which can be set to override the default `cdap` user. This change will also prevent users that are _not_ `CDAP_USER` from using the script, to prevent issues where a user may not be able to read the PID file, or the PID file location may be incorrect, as we store PID files using `${service_name}-${USER}` on disk.
