### PR TITLE
[CDAP-6096] - Fixes cloning pipeline in CDAP.

### DIFF
--- a/cdap-ui/app/features/hydratorplusplus/services/detail/actions/pipeline-detail-nodeconfig-actions.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/detail/actions/pipeline-detail-nodeconfig-actions.js
@@ -15,8 +15,8 @@
  */
 
 angular.module(PKG.name + '.feature.hydratorplusplus')
-  .service('HydratorPlusPlusNodeConfigActions', function(HydratorPlusPlusConfigDispatcher, HydratorPlusPlusBottomPanelActions) {
-    var dispatcher = HydratorPlusPlusConfigDispatcher.getDispatcher();
+  .service('HydratorPlusPlusNodeConfigActions', function(HydratorPlusPlusNodeConfigDispatcher, HydratorPlusPlusBottomPanelActions) {
+    var dispatcher = HydratorPlusPlusNodeConfigDispatcher.getDispatcher();
     this.choosePlugin = function(plugin) {
       dispatcher.dispatch('onPluginChange', plugin);
       HydratorPlusPlusBottomPanelActions.expand();

--- a/cdap-ui/app/features/hydratorplusplus/services/detail/dispatchers/pipeline-detail-nodeconfig-dispatcher.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/detail/dispatchers/pipeline-detail-nodeconfig-dispatcher.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.hydratorplusplus')
-  .service('HydratorPlusPlusConfigDispatcher', function(CaskAngularDispatcher) {
+  .service('HydratorPlusPlusNodeConfigDispatcher', function(CaskAngularDispatcher) {
     this.__dispatcher__ = null;
     this.destroyDispatcher = function() {
       delete this.__dispatcher__;

--- a/cdap-ui/app/features/hydratorplusplus/services/detail/stores/pipeline-detail-nodeconfig-store.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/detail/stores/pipeline-detail-nodeconfig-store.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.hydratorplusplus')
-  .service('HydratorPlusPlusNodeConfigStore', function(HydratorPlusPlusConfigDispatcher, $q, $filter, IMPLICIT_SCHEMA, GLOBALS, myPipelineApi, $state, $rootScope, HydratorPlusPlusConfigStore, HydratorPlusPlusDetailNonRunsStore, HydratorPlusPlusNodeConfigActions, HydratorPlusPlusHydratorService) {
+  .service('HydratorPlusPlusNodeConfigStore', function(HydratorPlusPlusNodeConfigDispatcher, $q, $filter, IMPLICIT_SCHEMA, GLOBALS, myPipelineApi, $state, $rootScope, HydratorPlusPlusConfigStore, HydratorPlusPlusDetailNonRunsStore, HydratorPlusPlusNodeConfigActions, HydratorPlusPlusHydratorService) {
 
     var dispatcher;
     this.changeListeners = [];
@@ -61,7 +61,7 @@ angular.module(PKG.name + '.feature.hydratorplusplus')
       // This is done here as DAGPlusPlusNodesStore is being reused between create and view pipelines states.
       // So we need to destroy the dispatcher updating all listeners of the store so when we switch states
       // one does not get notified if out of context.
-      HydratorPlusPlusConfigDispatcher.destroyDispatcher();
+      HydratorPlusPlusNodeConfigDispatcher.destroyDispatcher();
       this.changeListeners = [];
     };
     this.init = function() {
@@ -70,7 +70,7 @@ angular.module(PKG.name + '.feature.hydratorplusplus')
       } else if ($state.includes('hydratorplusplus.detail.**')) {
         this.ConfigStore = HydratorPlusPlusDetailNonRunsStore;
       }
-      dispatcher = HydratorPlusPlusConfigDispatcher.getDispatcher();
+      dispatcher = HydratorPlusPlusNodeConfigDispatcher.getDispatcher();
       dispatcher.register('onPluginChange', this.setState.bind(this));
       dispatcher.register('onPluginRemove', function() {
         this.setDefaults();


### PR DESCRIPTION
#### TL;DR -

  While cloning a pipeline, the UI was constantly failing when the user came from cdap (app status view). 
The reason for it was `ConfigStore` and `NodeConfigStore` were using same dispatchers. 

Renaming the dispatcher for `NodeConfigStore` fixed this problem.
#### Longer version -

  The detailed view and studio view of pipeline is sharing `NodeConfigStore` and this needs to be reset when switching between states. When the user is navigating from CDAP through pipeline detailed view to cloning a pipeline, resetting the store caused problems. The reason for it is we were using the same dispatcher for both `ConfigStore` and `NodeConfigStore`. It comes down to which store is first initialized and which dispatcher is initialized and which dispatcher is destroyed. When the  user clones navigating from cdap to hydrator to clone the wrong events (dispatcher) got destroyed and events that are supposed to be registered for initializing the store were missing. This is the reason why clone (which initializes the store with data) was failing.

No two stores can use the same dispatcher unless they are listening for the same events to be dispatched. In our case we should not have used the same dispatcher as those two stores are doing different things.
