### PR TITLE
CDAP-1545 Use Dockerfile ENTRYPOINT to support arguments

### DIFF
--- a/cdap-distributions/src/.dockerignore
+++ b/cdap-distributions/src/.dockerignore
@@ -1,0 +1,24 @@
+#
+# Copyright © 2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# Ignore directories we don't need
+debian/*
+emr/*
+etc/*
+hdinsight/*
+javadoc/*
+main/*
+parcel/*
+rpm/*

--- a/cdap-distributions/src/Dockerfile
+++ b/cdap-distributions/src/Dockerfile
@@ -24,9 +24,9 @@ MAINTAINER Cask Data <ops@cask.co>
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.7
 RUN set -x && \
-  wget -O /usr/local/bin/gosu \
+  curl -o /usr/local/bin/gosu \
     "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" && \
-  wget -O /usr/local/bin/gosu.asc \
+  curl -o /usr/local/bin/gosu.asc \
     "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" && \
   export GNUPGHOME="$(mktemp -d)" && \
   gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \

--- a/cdap-distributions/src/Dockerfile
+++ b/cdap-distributions/src/Dockerfile
@@ -21,10 +21,22 @@
 FROM ubuntu:12.04
 MAINTAINER Cask Data <ops@cask.co>
 
-# Copy scripts
-COPY packer/scripts /tmp/scripts
+# grab gosu for easy step-down from root
+ENV GOSU_VERSION 1.7
+RUN set -x && \
+  wget -O /usr/local/bin/gosu \
+    "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" && \
+  wget -O /usr/local/bin/gosu.asc \
+    "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" && \
+  export GNUPGHOME="$(mktemp -d)" && \
+  gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
+  gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
+  rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc && \
+  chmod +x /usr/local/bin/gosu && \
+  gosu nobody true
 
-# Copy json
+# Copy scripts and files before using them below
+COPY packer/scripts /tmp/scripts
 COPY packer/files /tmp/files
 
 # build cdap-standalone zip file, copy it to container and extract it

--- a/cdap-distributions/src/Dockerfile
+++ b/cdap-distributions/src/Dockerfile
@@ -24,6 +24,10 @@ MAINTAINER Cask Data <ops@cask.co>
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.7
 RUN set -x && \
+  apt-get update && \
+  apt-get install -y \
+    curl \
+    git && \
   curl -o /usr/local/bin/gosu \
     "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" && \
   curl -o /usr/local/bin/gosu.asc \
@@ -39,12 +43,8 @@ RUN set -x && \
 COPY packer/scripts /tmp/scripts
 COPY packer/files /tmp/files
 
-# build cdap-standalone zip file, copy it to container and extract it
-RUN apt-get update && \
-    apt-get install -y \
-      curl \
-      git && \
-    curl -L http://chef.io/chef/install.sh | bash && \
+# Install Chef, setup APT, run Chef cdap::sdk recipe, then clean up
+RUN curl -L http://chef.io/chef/install.sh | bash && \
     for i in apt-setup.sh cookbook-dir.sh cookbook-setup.sh ; do /tmp/scripts/$i ; done && \
     chef-solo -o cdap::sdk -j /tmp/files/cdap-sdk.json && \
     for i in remove-chef.sh sdk-cleanup.sh apt-cleanup.sh ; do /tmp/scripts/$i ; done && \

--- a/cdap-distributions/src/Dockerfile
+++ b/cdap-distributions/src/Dockerfile
@@ -28,10 +28,12 @@ RUN set -x && \
   apt-get install -y \
     curl \
     git && \
-  curl -o /usr/local/bin/gosu \
-    "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" && \
-  curl -o /usr/local/bin/gosu.asc \
-    "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" && \
+  curl -vL \
+    "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" > \
+    /usr/local/bin/gosu && \
+  curl -vL \
+    "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" > \
+    /usr/local/bin/gosu.asc && \
   export GNUPGHOME="$(mktemp -d)" && \
   gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
   gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \

--- a/cdap-distributions/src/Dockerfile
+++ b/cdap-distributions/src/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright © 2012-2014 Cask Data, Inc.
+# Copyright © 2012-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,18 +29,25 @@ COPY packer/files /tmp/files
 
 # build cdap-standalone zip file, copy it to container and extract it
 RUN apt-get update && \
-    apt-get install -y curl git && \
+    apt-get install -y \
+      curl \
+      git && \
     curl -L http://chef.io/chef/install.sh | bash && \
     for i in apt-setup.sh cookbook-dir.sh cookbook-setup.sh ; do /tmp/scripts/$i ; done && \
     chef-solo -o cdap::sdk -j /tmp/files/cdap-sdk.json && \
     for i in remove-chef.sh sdk-cleanup.sh apt-cleanup.sh ; do /tmp/scripts/$i ; done && \
     rm -rf /root/.m2 /var/cache/debconf/*-old /usr/share/{doc,man} /tmp/scripts /tmp/files \
-    /usr/share/locale/{a,b,c,d,e{l,o,s,t,u},f,g,h,i,j,k,lt,lv,m,n,o,p,r,s,t,u,v,w,x,z}*
+      /var/lib/apt/lists/* \
+      /usr/share/locale/{a,b,c,d,e{l,o,s,t,u},f,g,h,i,j,k,lt,lv,m,n,o,p,r,s,t,u,v,w,x,z}*
+
+ENV PATH /opt/cdap/sdk/bin:${PATH}
+
+# Copy entrypoint
+COPY docker-entrypoint.sh /
 
 # Expose Ports (9999 & 10000 for CDAP)
-EXPOSE 9999
-EXPOSE 10000
+EXPOSE 9999 10000
 
 # start CDAP in the background and tail in the foreground
-ENTRYPOINT /opt/cdap/sdk/bin/cdap.sh start && \
-    /usr/bin/tail -F /opt/cdap/sdk/logs/*.log
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["cdap.sh","start","--foreground"]

--- a/cdap-distributions/src/docker-entrypoint.sh
+++ b/cdap-distributions/src/docker-entrypoint.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Copyright © 2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# Shamelessly "borrowed" from https://github.com/docker-library/elasticsearch :-)
+
+set -e
+
+export PATH=${PATH}:/opt/cdap/sdk/bin
+
+# Add cdap.sh start as command if needed
+if [ "${1:0:1}" = '-' ]; then
+  set -- cdap.sh start --foreground "$@"
+fi
+
+# Drop root privileges if we are running cdap.sh
+# allow the container to be started with `--user`
+if [ "${1}" = 'cdap.sh' -a "$(id -u)" = '0' ]; then
+  # Change the ownership of /opt/cdap/sdk to cdap
+  chown -R cdap:cdap /opt/cdap/sdk
+fi
+
+# As argument is not related to cdap,
+# then assume that user wants to run his own process,
+# for example a `bash` shell to explore this image
+exec "$@"

--- a/cdap-distributions/src/docker-entrypoint.sh
+++ b/cdap-distributions/src/docker-entrypoint.sh
@@ -30,6 +30,7 @@ fi
 if [ "${1}" = 'cdap.sh' -a "$(id -u)" = '0' ]; then
   # Change the ownership of /opt/cdap/sdk to cdap
   chown -R cdap:cdap /opt/cdap/sdk
+  set -- gosu cdap.sh "$@"
 fi
 
 # As argument is not related to cdap,

--- a/cdap-distributions/src/docker-entrypoint.sh
+++ b/cdap-distributions/src/docker-entrypoint.sh
@@ -30,7 +30,7 @@ fi
 if [ "${1}" = 'cdap.sh' -a "$(id -u)" = '0' ]; then
   # Change the ownership of /opt/cdap/sdk to cdap
   chown -R cdap:cdap /opt/cdap/sdk
-  set -- gosu cdap.sh "$@"
+  set -- gosu cdap "$@"
 fi
 
 # As argument is not related to cdap,

--- a/cdap-standalone/bin/cdap.sh
+++ b/cdap-standalone/bin/cdap.sh
@@ -230,19 +230,16 @@ start() {
     if $foreground; then
         nice -1 "${JAVACMD}" ${JVM_OPTS[@]} ${ROUTER_OPTS} -classpath "${CLASSPATH}" co.cask.cdap.StandaloneMain \
               | tee -a "${APP_HOME}"/logs/cdap.log
-        background_process=$!
         ret=$?
         return ${ret}
     else
         nohup nice -1 "${JAVACMD}" ${JVM_OPTS[@]} ${ROUTER_OPTS} -classpath "${CLASSPATH}" co.cask.cdap.StandaloneMain \
               2>&1 < /dev/null >> "${APP_HOME}"/logs/cdap.log &
         background_process=$!
-        ret=$?
         echo $background_process > $pid
 
         echo -n "Starting Standalone CDAP ..."
 
-        background_process=$!
         while kill -0 $background_process >/dev/null 2>/dev/null ; do
           if grep '..* started successfully' "$APP_HOME/logs/cdap.log" > /dev/null 2>&1; then
             if $debug ; then


### PR DESCRIPTION
Use a special purpose shell script as ENTRYPOINT in Dockerfile. This allows the user to specify a command on the `docker run` command line and have it execute in the container image, rather than forcing the user to override with `--entrypoint` which is more in line with Docker best practices.

This allows for any arbitrary arguments to be sent to CDAP SDK, or simply run commands within the container.

Build:
http://builds.cask.co/browse/CDAP-DOB0-5
Testing:

``` bash
# Load into docker
$ curl http://builds.cask.co/browse/CDAP-DOB0-5/artifact/shared/Docker-image/cdap-standalone-docker-3.5.0.tar.gz | docker load
# Start SDK (in background)
$ docker run -d --name cdap-sdk caskdata/cdap-standalone
# Use CDAP CLI within above container
$ docker exec -ti cdap-sdk cdap-cli.sh
# Use CDAP CLI in its own container, against a remote CDAP
$ docker run -ti caskdata/cdap-standalone --name cdap-cli cdap-cli.sh -u http://${CDAP_HOST}:10000
# Use CDAP CLI in its own container, against above container using container linking
$ docker run -ti --link cdap-sdk:sdk --rm caskdata/cdap-standalone sh -c 'exec cdap-cli.sh -u http://${SDK_PORT_10000_TCP_ADDR}:${SDK_PORT_10000_TCP_PORT}'
# Stop SDK (and exit container)
$ docker exec -ti cdap-sdk cdap.sh stop
# Start SDK in foreground with ports forwarded and with --enable-debug
$ docker run -ti -p 9999:9999 -p 10000:10000 --name cdap-sdk caskdata/cdap-standalone cdap.sh start --foreground --enable-debug
```
