### PR TITLE
CDAP-5856 Create CDAP SDK and Examples shortcuts in VM

### DIFF
--- a/cdap-distributions/src/packer/scripts/lxde.sh
+++ b/cdap-distributions/src/packer/scripts/lxde.sh
@@ -78,10 +78,34 @@ Icon=cdap
 Categories=GNOME;GTK;Development;
 EOF
 
+# CDAP SDK Menu Entry
+cat > /usr/share/applications/cdap-sdk.desktop << EOF
+[Desktop Entry]
+Encoding=UTF-8
+Name=CDAP SDK
+Comment=CDAP SDK directory
+Exec=xdg-open /opt/cdap/sdk
+Type=Application
+Icon=cdap
+Categories=GNOME;GTK;Development;
+EOF
+
+# CDAP Examples Menu Entry
+cat > /usr/share/applications/cdap-examples.desktop << EOF
+[Desktop Entry]
+Encoding=UTF-8
+Name=CDAP Examples
+Comment=CDAP Examples directory
+Exec=xdg-open /opt/cdap/sdk/examples
+Type=Application
+Icon=cdap
+Categories=GNOME;GTK;Development;
+EOF
+
 # Copy welcome.txt and some icons to the desktop
 mkdir -p ~cdap/Desktop
 cp /etc/welcome.txt ~cdap/Desktop
-for i in cdap-ui cdap-docs eclipse idea lxterminal ; do
+for i in cdap-ui cdap-sdk cdap-examples cdap-docs eclipse idea lxterminal ; do
   cp /usr/share/applications/${i}.desktop ~cdap/Desktop
 done
 


### PR DESCRIPTION
This adds links to the desktop for `CDAP SDK` and `CDAP Examples` which will open those folders in the file manager.

Icon:
<img width="141" alt="screen shot 2016-06-01 at 4 46 23 pm" src="https://cloud.githubusercontent.com/assets/380021/15725265/16debdf6-2819-11e6-807e-f3e3118960e7.png">

Opened:
<img width="647" alt="screen shot 2016-06-01 at 4 47 01 pm" src="https://cloud.githubusercontent.com/assets/380021/15725275/1e8863c2-2819-11e6-87d9-16eb38d17219.png">
