### PR TITLE
[CDAP-6110] - Fixes un-necessarily popping up the bottom panel in detailed view Hydrator++

### DIFF
--- a/cdap-ui/app/features/hydratorplusplus/controllers/create/bottompanel-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/create/bottompanel-ctrl.js
@@ -54,6 +54,7 @@ class HydratorPlusPlusBottomPanelCtrl {
   }
   selectTab(tab) {
     this.activeTab = this.tabs[tab];
+    this.toggleCollapse(false);
   }
   setIsCollapsed() {
     this.bottomPanelState = this.HydratorPlusPlusBottomPanelStore.getPanelState();

--- a/cdap-ui/app/features/hydratorplusplus/controllers/detail/bottom-panel-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/detail/bottom-panel-ctrl.js
@@ -76,9 +76,11 @@ angular.module(PKG.name + '.feature.hydratorplusplus')
     };
     HydratorPlusPlusBottomPanelStore.registerOnChangeListener(this.setIsCollapsed.bind(this));
     HydratorPlusPlusBottomPanelActions.expand();
-    DAGPlusPlusNodesStore.registerOnChangeListener(function() {
-      this.selectTab(5);
-    }.bind(this));
+    DAGPlusPlusNodesStore.registerOnChangeListener(() => {
+      if (DAGPlusPlusNodesStore.state.activeNodeId) {
+        this.selectTab(5);
+      }
+    });
 
     $scope.$on('$destroy', function() {
       HydratorPlusPlusBottomPanelActions.reset();


### PR DESCRIPTION
- Prevents bringing up the bottom panel from minimized state if the user just clicks on the canvas.
- Fixes the case when the bottom panel is minimized and a tab is clicked, to expand the bottom panel instead of remaining in the minimized state.
