### PR TITLE
[CDAP-5685] Cache dataset meta in dataset service

### DIFF
--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/UsageHandlerTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/UsageHandlerTestRun.java
@@ -230,6 +230,31 @@ public class UsageHandlerTestRun extends ClientTestBase {
       Assert.assertEquals(0, getAppDatasetUsage(app).size());
       Assert.assertEquals(0, getDatasetProgramUsage(dataset).size());
     }
+
+    deployApp(AllProgramsApp.class);
+
+    try {
+      // the program will run and stop by itself.
+      startProgram(program);
+      waitState(program, ProgramStatus.STOPPED);
+
+      Assert.assertTrue(getAppStreamUsage(app).contains(stream));
+      Assert.assertTrue(getProgramStreamUsage(program).contains(stream));
+      Assert.assertTrue(getStreamProgramUsage(stream).contains(program));
+
+      Assert.assertTrue(getProgramDatasetUsage(program).contains(dataset));
+      Assert.assertTrue(getAppDatasetUsage(app).contains(dataset));
+      Assert.assertTrue(getDatasetProgramUsage(dataset).contains(program));
+    } finally {
+      deleteApp(app);
+
+      Assert.assertEquals(0, getAppStreamUsage(app).size());
+      Assert.assertEquals(0, getProgramStreamUsage(program).size());
+      Assert.assertEquals(0, getStreamProgramUsage(stream).size());
+
+      Assert.assertEquals(0, getAppDatasetUsage(app).size());
+      Assert.assertEquals(0, getDatasetProgramUsage(dataset).size());
+    }
   }
 
   @Test

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetsModules.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetsModules.java
@@ -36,6 +36,8 @@ import co.cask.cdap.data2.metadata.store.NoOpMetadataStore;
 import co.cask.cdap.data2.metadata.writer.BasicLineageWriter;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
 import co.cask.cdap.data2.metadata.writer.LineageWriterDatasetFramework;
+import co.cask.cdap.data2.registry.DefaultUsageRegistry;
+import co.cask.cdap.data2.registry.UsageRegistry;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Module;
@@ -75,6 +77,10 @@ public class DataSetsModules extends RuntimeModule {
 
         bind(LineageWriter.class).to(BasicLineageWriter.class);
         expose(LineageWriter.class);
+
+        bind(UsageRegistry.class).to(DefaultUsageRegistry.class).in(Scopes.SINGLETON);
+        expose(UsageRegistry.class);
+
         bind(DatasetFramework.class).to(LineageWriterDatasetFramework.class);
         expose(DatasetFramework.class);
 
@@ -107,6 +113,10 @@ public class DataSetsModules extends RuntimeModule {
 
         bind(LineageWriter.class).to(BasicLineageWriter.class);
         expose(LineageWriter.class);
+
+        bind(UsageRegistry.class).to(DefaultUsageRegistry.class).in(Scopes.SINGLETON);
+        expose(UsageRegistry.class);
+
         bind(DatasetFramework.class).to(LineageWriterDatasetFramework.class);
         expose(DatasetFramework.class);
 
@@ -139,6 +149,10 @@ public class DataSetsModules extends RuntimeModule {
 
         bind(LineageWriter.class).to(BasicLineageWriter.class);
         expose(LineageWriter.class);
+
+        bind(UsageRegistry.class).to(DefaultUsageRegistry.class).in(Scopes.SINGLETON);
+        expose(UsageRegistry.class);
+
         bind(DatasetFramework.class).to(LineageWriterDatasetFramework.class);
         expose(DatasetFramework.class);
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/DefaultUsageRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/DefaultUsageRegistry.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.registry;
+
+import co.cask.cdap.api.dataset.DatasetDefinition;
+import co.cask.cdap.api.dataset.DatasetManagementException;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.data.runtime.DataSetsModules;
+import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.transaction.Transactions;
+import co.cask.cdap.proto.Id;
+import co.cask.tephra.TransactionExecutor;
+import co.cask.tephra.TransactionExecutorFactory;
+import com.google.common.base.Objects;
+import com.google.common.base.Throwables;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * Store program -> dataset/stream usage information.
+ *
+ * TODO: Reduce duplication between this and {@link UsageDataset}.
+ */
+public class DefaultUsageRegistry implements UsageRegistry {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultUsageRegistry.class);
+
+  private static final Id.DatasetInstance USAGE_INSTANCE_ID =
+    Id.DatasetInstance.from(Id.Namespace.SYSTEM, "usage.registry");
+
+  private final TransactionExecutorFactory executorFactory;
+  private final DatasetFramework datasetFramework;
+
+  // this cache will avoid duplicate registration by the same owner if a program repeatedly gets the same dataset.
+  // for streams, that does not seem necessary, because programs register stream usage once at startup.
+  private final LoadingCache<DatasetUsageKey, Boolean> usageCache;
+
+  @Inject
+  public DefaultUsageRegistry(TransactionExecutorFactory executorFactory,
+                              @Named(DataSetsModules.BASIC_DATASET_FRAMEWORK) DatasetFramework datasetFramework) {
+    this.executorFactory = executorFactory;
+    this.datasetFramework = datasetFramework;
+
+    // using a max size of 1024: memory footprint is small, and still it is large enough to
+    // avoid repeated registration of the same program when it starts many containers concurrently.
+    // assuming that it is untypical that more than 1024 programs start at the sam time.
+    this.usageCache = CacheBuilder.newBuilder().maximumSize(1024).build(
+      new CacheLoader<DatasetUsageKey, Boolean>() {
+        @Override
+        public Boolean load(DatasetUsageKey key) throws Exception {
+          doRegister(key.getOwner(), key.getDataset());
+          return true;
+        }
+      }
+    );
+  }
+
+  private <T> T execute(TransactionExecutor.Function<UsageDataset, T> func) {
+    UsageDataset usageDataset = newUsageDataset();
+    return Transactions.createTransactionExecutor(executorFactory, usageDataset)
+      .executeUnchecked(func, usageDataset);
+  }
+
+  private void execute(TransactionExecutor.Procedure<UsageDataset> func) {
+    UsageDataset usageDataset = newUsageDataset();
+    Transactions.createTransactionExecutor(executorFactory, usageDataset)
+      .executeUnchecked(func, usageDataset);
+  }
+
+  private UsageDataset newUsageDataset() {
+    try {
+      return DatasetsUtil.getOrCreateDataset(
+        datasetFramework, USAGE_INSTANCE_ID, UsageDataset.class.getSimpleName(),
+        DatasetProperties.EMPTY, DatasetDefinition.NO_ARGUMENTS, null);
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  /**
+   * Registers usage of a stream by multiple ids.
+   *
+   * @param users    the users of the stream
+   * @param streamId the stream
+   */
+  @Override
+  public void registerAll(final Iterable<? extends Id> users, final Id.Stream streamId) {
+    for (Id user : users) {
+      register(user, streamId);
+    }
+  }
+
+  /**
+   * Register usage of a stream by an id.
+   *
+   * @param user     the user of the stream
+   * @param streamId the stream
+   */
+  @Override
+  public void register(Id user, Id.Stream streamId) {
+    if (user instanceof Id.Program) {
+      register((Id.Program) user, streamId);
+    }
+  }
+
+  /**
+   * Registers usage of a stream by multiple ids.
+   *
+   * @param users     the users of the stream
+   * @param datasetId the stream
+   */
+  @Override
+  public void registerAll(final Iterable<? extends Id> users, final Id.DatasetInstance datasetId) {
+    for (Id user : users) {
+      register(user, datasetId);
+    }
+  }
+
+  /**
+   * Registers usage of a dataset by multiple ids.
+   *
+   * @param user      the user of the dataset
+   * @param datasetId the dataset
+   */
+  @Override
+  public void register(Id user, Id.DatasetInstance datasetId) {
+    if (user instanceof Id.Program) {
+      register((Id.Program) user, datasetId);
+    }
+  }
+
+  /**
+   * Registers usage of a dataset by a program.
+   *
+   * @param programId         program
+   * @param datasetInstanceId dataset
+   */
+  @Override
+  public void register(final Id.Program programId, final Id.DatasetInstance datasetInstanceId) {
+    usageCache.getUnchecked(new DatasetUsageKey(datasetInstanceId, programId));
+  }
+
+  /**
+   * Internal method to register usage of a dataset by a program, called from the cache loader.
+   *
+   * @param programId program
+   * @param datasetInstanceId  dataset
+   */
+  private void doRegister(final Id.Program programId, final Id.DatasetInstance datasetInstanceId) {
+    execute(new TransactionExecutor.Procedure<UsageDataset>() {
+      @Override
+      public void apply(UsageDataset usageDataset) throws Exception {
+        usageDataset.register(programId, datasetInstanceId);
+      }
+    });
+  }
+
+  /**
+   * Registers usage of a stream by a program.
+   *
+   * @param programId program
+   * @param streamId  stream
+   */
+  @Override
+  public void register(final Id.Program programId, final Id.Stream streamId) {
+    execute(new TransactionExecutor.Procedure<UsageDataset>() {
+      @Override
+      public void apply(UsageDataset usageDataset) throws Exception {
+        usageDataset.register(programId, streamId);
+      }
+    });
+  }
+
+  /**
+   * Unregisters all usage information of an application.
+   *
+   * @param applicationId application
+   */
+  @Override
+  public void unregister(final Id.Application applicationId) {
+    execute(new TransactionExecutor.Procedure<UsageDataset>() {
+      @Override
+      public void apply(UsageDataset usageDataset) throws Exception {
+        usageDataset.unregister(applicationId);
+      }
+    });
+
+    // we must invalidate the cache for all programs of this application. Because if, for example, an
+    // application is deleted, its usage is removed from the registry. If it is redeployed later, we
+    // must register its usage again. That would not happen if the cache still holds these entries.
+    for (DatasetUsageKey key : usageCache.asMap().keySet()) {
+      if (applicationId.equals(key.getOwner().getApplication())) {
+        usageCache.invalidate(key);
+      }
+    }
+  }
+
+  @Override
+  public Set<Id.DatasetInstance> getDatasets(final Id.Application id) {
+    return execute(new TransactionExecutor.Function<UsageDataset, Set<Id.DatasetInstance>>() {
+      @Override
+      public Set<Id.DatasetInstance> apply(UsageDataset usageDataset) throws Exception {
+        return usageDataset.getDatasets(id);
+      }
+    });
+  }
+
+  @Override
+  public Set<Id.Stream> getStreams(final Id.Application id) {
+    return execute(new TransactionExecutor.Function<UsageDataset, Set<Id.Stream>>() {
+      @Override
+      public Set<Id.Stream> apply(UsageDataset usageDataset) throws Exception {
+        return usageDataset.getStreams(id);
+      }
+    });
+  }
+
+  @Override
+  public Set<Id.DatasetInstance> getDatasets(final Id.Program id) {
+    return execute(new TransactionExecutor.Function<UsageDataset, Set<Id.DatasetInstance>>() {
+      @Override
+      public Set<Id.DatasetInstance> apply(UsageDataset usageDataset) throws Exception {
+        return usageDataset.getDatasets(id);
+      }
+    });
+  }
+
+  @Override
+  public Set<Id.Stream> getStreams(final Id.Program id) {
+    return execute(new TransactionExecutor.Function<UsageDataset, Set<Id.Stream>>() {
+      @Override
+      public Set<Id.Stream> apply(UsageDataset usageDataset) throws Exception {
+        return usageDataset.getStreams(id);
+      }
+    });
+  }
+
+  @Override
+  public Set<Id.Program> getPrograms(final Id.Stream id) {
+    return execute(new TransactionExecutor.Function<UsageDataset, Set<Id.Program>>() {
+      @Override
+      public Set<Id.Program> apply(UsageDataset usageDataset) throws Exception {
+        return usageDataset.getPrograms(id);
+      }
+    });
+  }
+
+  @Override
+  public Set<Id.Program> getPrograms(final Id.DatasetInstance id) {
+    return execute(new TransactionExecutor.Function<UsageDataset, Set<Id.Program>>() {
+      @Override
+      public Set<Id.Program> apply(UsageDataset usageDataset) throws Exception {
+        return usageDataset.getPrograms(id);
+      }
+    });
+  }
+
+  /**
+   * Adds datasets and types to the given {@link DatasetFramework} used by usage registry.
+   *
+   * @param datasetFramework framework to add types and datasets to
+   */
+  public static void setupDatasets(DatasetFramework datasetFramework) throws IOException, DatasetManagementException {
+    datasetFramework.addInstance(UsageDataset.class.getName(), USAGE_INSTANCE_ID, DatasetProperties.EMPTY);
+  }
+
+  static class DatasetUsageKey {
+    private final Id.DatasetInstance dataset;
+    private final Id.Program owner;
+
+    DatasetUsageKey(Id.DatasetInstance dataset, Id.Program owner) {
+      this.dataset = dataset;
+      this.owner = owner;
+    }
+
+    Id.DatasetInstance getDataset() {
+      return dataset;
+    }
+
+    Id.Program getOwner() {
+      return owner;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      DatasetUsageKey that = (DatasetUsageKey) o;
+      return Objects.equal(dataset, that.dataset) &&
+        Objects.equal(owner, that.owner);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(dataset, owner);
+    }
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/NoOpUsageRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/NoOpUsageRegistry.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.registry;
+
+import co.cask.cdap.proto.Id;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * UsageRegistry that does nothing.
+ */
+public class NoOpUsageRegistry implements UsageRegistry {
+
+  @Override
+  public void registerAll(final Iterable<? extends Id> users, final Id.Stream streamId) { }
+
+  @Override
+  public void register(Id user, Id.Stream streamId) { }
+
+  @Override
+  public void registerAll(final Iterable<? extends Id> users, final Id.DatasetInstance datasetId) { }
+
+  @Override
+  public void register(Id user, Id.DatasetInstance datasetId) { }
+
+  @Override
+  public void register(final Id.Program programId, final Id.DatasetInstance datasetInstanceId) { }
+
+  @Override
+  public void register(final Id.Program programId, final Id.Stream streamId) { }
+
+  @Override
+  public void unregister(final Id.Application applicationId) { }
+
+  @Override
+  public Set<Id.DatasetInstance> getDatasets(final Id.Application id) {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public Set<Id.Stream> getStreams(final Id.Application id) {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public Set<Id.DatasetInstance> getDatasets(final Id.Program id) {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public Set<Id.Stream> getStreams(final Id.Program id) {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public Set<Id.Program> getPrograms(final Id.Stream id) {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public Set<Id.Program> getPrograms(final Id.DatasetInstance id) {
+    return Collections.emptySet();
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
@@ -16,257 +16,82 @@
 
 package co.cask.cdap.data2.registry;
 
-import co.cask.cdap.api.dataset.DatasetManagementException;
-import co.cask.cdap.api.dataset.DatasetProperties;
-import co.cask.cdap.api.dataset.table.Table;
-import co.cask.cdap.data2.datafabric.dataset.DatasetProvider;
-import co.cask.cdap.data2.dataset2.DatasetFramework;
-import co.cask.cdap.data2.dataset2.tx.Transactional;
 import co.cask.cdap.proto.Id;
-import co.cask.tephra.TransactionExecutor;
-import co.cask.tephra.TransactionExecutorFactory;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Supplier;
-import com.google.common.base.Throwables;
-import com.google.common.collect.Iterators;
-import com.google.inject.Inject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.Set;
 
 /**
  * Store program -> dataset/stream usage information.
- *
- * TODO: Reduce duplication between this and {@link UsageDataset}.
  */
-public class UsageRegistry {
+public interface UsageRegistry {
 
-  private static final Logger LOG = LoggerFactory.getLogger(UsageRegistry.class);
-
-  private static final Id.DatasetInstance USAGE_INSTANCE_ID =
+  Id.DatasetInstance USAGE_INSTANCE_ID =
     Id.DatasetInstance.from(Id.Namespace.SYSTEM, "usage.registry");
-
-  private final Transactional<UsageDatasetIterable, UsageDataset> txnl;
-
-  @Inject
-  public UsageRegistry(TransactionExecutorFactory txExecutorFactory,
-                       final DatasetProvider provider) {
-    txnl = Transactional.of(txExecutorFactory, new Supplier<UsageDatasetIterable>() {
-      @Override
-      public UsageDatasetIterable get() {
-        try {
-          Object usageDataset = Preconditions.checkNotNull(
-            provider.getOrCreate(USAGE_INSTANCE_ID, UsageDataset.class.getSimpleName(),
-                                 DatasetProperties.EMPTY, null, null),
-            "Couldn't get/create usage registry dataset");
-
-          // Backward compatible check for version <= 3.0.0
-          if (usageDataset instanceof UsageDataset) {
-            return new UsageDatasetIterable((UsageDataset) usageDataset);
-          }
-          return new UsageDatasetIterable(new UsageDataset((Table) usageDataset));
-        } catch (Exception e) {
-          LOG.error("Failed to access usage table", e);
-          throw Throwables.propagate(e);
-        }
-      }
-    });
-  }
 
   /**
    * Registers usage of a stream by multiple ids.
    *
-   * @param users the users of the stream
+   * @param users    the users of the stream
    * @param streamId the stream
    */
-  public void registerAll(final Iterable<? extends Id> users, final Id.Stream streamId) {
-    txnl.executeUnchecked(new TransactionExecutor.Function<UsageDatasetIterable, Void>() {
-      @Override
-      public Void apply(UsageDatasetIterable input) throws Exception {
-        for (Id user : users) {
-          // TODO: CDAP-2251: remove redundancy
-          if (user instanceof Id.Program) {
-            register((Id.Program) user, streamId);
-          }
-        }
-        return null;
-      }
-    });
-  }
+  void registerAll(final Iterable<? extends Id> users, final Id.Stream streamId);
 
   /**
    * Register usage of a stream by an id.
    *
-   * @param user the user of the stream
+   * @param user     the user of the stream
    * @param streamId the stream
    */
-  public void register(Id user, Id.Stream streamId) {
-    registerAll(Collections.singleton(user), streamId);
-  }
+  void register(Id user, Id.Stream streamId);
+
+  /**
+   * Registers usage of a stream by multiple ids.
+   *
+   * @param users     the users of the stream
+   * @param datasetId the stream
+   */
+  void registerAll(final Iterable<? extends Id> users, final Id.DatasetInstance datasetId);
 
   /**
    * Registers usage of a dataset by multiple ids.
    *
-   * @param users the users of the dataset
+   * @param user      the user of the dataset
    * @param datasetId the dataset
    */
-  public void registerAll(final Iterable<? extends Id> users, final Id.DatasetInstance datasetId) {
-    txnl.executeUnchecked(new TransactionExecutor.Function<UsageDatasetIterable, Void>() {
-      @Override
-      public Void apply(UsageDatasetIterable input) throws Exception {
-        for (Id user : users) {
-          // TODO: CDAP-2251: remove redundancy
-          if (user instanceof Id.Program) {
-            register((Id.Program) user, datasetId);
-          }
-        }
-        return null;
-      }
-    });
-  }
-
-  /**
-   * Registers usage of a dataset by multiple ids.
-   *
-   * @param user the user of the dataset
-   * @param datasetId the dataset
-   */
-  public void register(Id user, Id.DatasetInstance datasetId) {
-    registerAll(Collections.singleton(user), datasetId);
-  }
+  void register(Id user, Id.DatasetInstance datasetId);
 
   /**
    * Registers usage of a dataset by a program.
    *
-   * @param programId program
+   * @param programId         program
    * @param datasetInstanceId dataset
    */
-  public void register(final Id.Program programId, final Id.DatasetInstance datasetInstanceId) {
-    txnl.executeUnchecked(new TransactionExecutor.Function<UsageDatasetIterable, Void>() {
-      @Override
-      public Void apply(UsageDatasetIterable input) throws Exception {
-        input.getUsageDataset().register(programId, datasetInstanceId);
-        return null;
-      }
-    });
-  }
+  void register(final Id.Program programId, final Id.DatasetInstance datasetInstanceId);
 
   /**
    * Registers usage of a stream by a program.
    *
    * @param programId program
-   * @param streamId stream
+   * @param streamId  stream
    */
-  public void register(final Id.Program programId, final Id.Stream streamId) {
-    txnl.executeUnchecked(new TransactionExecutor.Function<UsageDatasetIterable, Void>() {
-      @Override
-      public Void apply(UsageDatasetIterable input) throws Exception {
-        input.getUsageDataset().register(programId, streamId);
-        return null;
-      }
-    });
-  }
+  void register(final Id.Program programId, final Id.Stream streamId);
 
   /**
    * Unregisters all usage information of an application.
    *
    * @param applicationId application
    */
-  public void unregister(final Id.Application applicationId) {
-    txnl.executeUnchecked(new TransactionExecutor.Function<UsageDatasetIterable, Void>() {
-      @Override
-      public Void apply(UsageDatasetIterable input) throws Exception {
-        input.getUsageDataset().unregister(applicationId);
-        return null;
-      }
-    });
-  }
+  void unregister(final Id.Application applicationId);
 
-  public Set<Id.DatasetInstance> getDatasets(final Id.Application id) {
-    return txnl.executeUnchecked(new TransactionExecutor.Function<UsageDatasetIterable, Set<Id.DatasetInstance>>() {
-      @Override
-      public Set<Id.DatasetInstance> apply(UsageDatasetIterable input) throws Exception {
-        return input.getUsageDataset().getDatasets(id);
-      }
-    });
-  }
+  Set<Id.DatasetInstance> getDatasets(final Id.Application id);
 
-  public Set<Id.Stream> getStreams(final Id.Application id) {
-    return txnl.executeUnchecked(new TransactionExecutor.Function<UsageDatasetIterable, Set<Id.Stream>>() {
-      @Override
-      public Set<Id.Stream> apply(UsageDatasetIterable input) throws Exception {
-        return input.getUsageDataset().getStreams(id);
-      }
-    });
-  }
+  Set<Id.Stream> getStreams(final Id.Application id);
 
-  public Set<Id.DatasetInstance> getDatasets(final Id.Program id) {
-    return txnl.executeUnchecked(new TransactionExecutor.Function<UsageDatasetIterable, Set<Id.DatasetInstance>>() {
-      @Override
-      public Set<Id.DatasetInstance> apply(UsageDatasetIterable input) throws Exception {
-        return input.getUsageDataset().getDatasets(id);
-      }
-    });
-  }
+  Set<Id.DatasetInstance> getDatasets(final Id.Program id);
 
-  public Set<Id.Stream> getStreams(final Id.Program id) {
-    return txnl.executeUnchecked(new TransactionExecutor.Function<UsageDatasetIterable, Set<Id.Stream>>() {
-      @Override
-      public Set<Id.Stream> apply(UsageDatasetIterable input) throws Exception {
-        return input.getUsageDataset().getStreams(id);
-      }
-    });
-  }
+  Set<Id.Stream> getStreams(final Id.Program id);
 
-  public Set<Id.Program> getPrograms(final Id.Stream id) {
-    return txnl.executeUnchecked(new TransactionExecutor.Function<UsageDatasetIterable, Set<Id.Program>>() {
-      @Override
-      public Set<Id.Program> apply(UsageDatasetIterable input) throws Exception {
-        return input.getUsageDataset().getPrograms(id);
-      }
-    });
-  }
+  Set<Id.Program> getPrograms(final Id.Stream id);
 
-  public Set<Id.Program> getPrograms(final Id.DatasetInstance id) {
-    return txnl.executeUnchecked(new TransactionExecutor.Function<UsageDatasetIterable, Set<Id.Program>>() {
-      @Override
-      public Set<Id.Program> apply(UsageDatasetIterable input) throws Exception {
-        return input.getUsageDataset().getPrograms(id);
-      }
-    });
-  }
-
-  /**
-   * For passing {@link UsageDataset} to {@link Transactional#of}.
-   */
-  public static final class UsageDatasetIterable implements Iterable<UsageDataset> {
-    private final UsageDataset usageDataset;
-
-    private UsageDatasetIterable(UsageDataset usageDataset) {
-      this.usageDataset = usageDataset;
-    }
-
-    public UsageDataset getUsageDataset() {
-      return usageDataset;
-    }
-
-    @Override
-    public Iterator<UsageDataset> iterator() {
-      return Iterators.singletonIterator(usageDataset);
-    }
-  }
-
-  /**
-   * Adds datasets and types to the given {@link DatasetFramework} used by usage registry.
-   *
-   * @param datasetFramework framework to add types and datasets to
-   */
-  public static void setupDatasets(DatasetFramework datasetFramework) throws IOException, DatasetManagementException {
-    datasetFramework.addInstance(Table.class.getName(), USAGE_INSTANCE_ID, DatasetProperties.EMPTY);
-  }
-
+  Set<Id.Program> getPrograms(final Id.DatasetInstance id);
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -136,8 +136,6 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
       new InMemoryDatasetOpExecutor(framework),
       exploreFacade,
       cConf,
-      txExecutorFactory,
-      registryFactory,
       NAMESPACE_STORE);
     instanceService.setAuditPublisher(inMemoryAuditPublisher);
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceServiceTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceServiceTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.datafabric.dataset.service;
+
+import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.proto.DatasetInstanceConfiguration;
+import co.cask.cdap.proto.DatasetMeta;
+import co.cask.cdap.proto.Id;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+public class DatasetInstanceServiceTest extends DatasetServiceTestBase {
+
+  @Test
+  public void testInstanceMetaCache() throws Exception {
+
+    // deploy a dataset
+    instanceService.create(Id.Namespace.DEFAULT.getId(), "testds",
+                           new DatasetInstanceConfiguration("table", new HashMap<String, String>()));
+
+    // get the dataset meta for two different owners, assert it is the same
+    DatasetMeta meta = instanceService.get(Id.DatasetInstance.from(Id.Namespace.DEFAULT, "testds"),
+                                           ImmutableList.<Id>of(Id.Flow.from("app1", "flow1")));
+    DatasetMeta met2 = instanceService.get(Id.DatasetInstance.from(Id.Namespace.DEFAULT, "testds"),
+                                           ImmutableList.<Id>of(Id.Flow.from("app2", "flow2")));
+    Assert.assertSame(meta, met2);
+
+    // update the dataset
+    instanceService.update(Id.DatasetInstance.from(Id.Namespace.DEFAULT, "testds"),
+                           ImmutableMap.of("ttl", "12345678"));
+
+    // get the dataset meta, validate it changed
+    met2 = instanceService.get(Id.DatasetInstance.from(Id.Namespace.DEFAULT, "testds"),
+                               ImmutableList.<Id>of(Id.Flow.from("app2", "flow2")));
+    Assert.assertNotSame(meta, met2);
+    Assert.assertEquals("12345678", met2.getSpec().getProperty("ttl"));
+
+    // delete the dataset
+    instanceService.drop(Id.DatasetInstance.from(Id.Namespace.DEFAULT, "testds"));
+
+    // get the dataset meta, validate not found
+    try {
+      instanceService.get(Id.DatasetInstance.from(Id.Namespace.DEFAULT, "testds"),
+                          ImmutableList.<Id>of(Id.Flow.from("app1", "flow2")));
+      Assert.fail("get() should have thrown NotFoundException");
+    } catch (NotFoundException e) {
+      // expected
+    }
+
+    // recreate the dataset
+    instanceService.create(Id.Namespace.DEFAULT.getId(), "testds",
+                           new DatasetInstanceConfiguration("table", new HashMap<String, String>()));
+
+    // get the dataset meta, validate it is up to date
+    met2 = instanceService.get(Id.DatasetInstance.from(Id.Namespace.DEFAULT, "testds"),
+                               ImmutableList.<Id>of(Id.Flow.from("app2", "flow2")));
+    Assert.assertEquals(meta.getSpec(), met2.getSpec());
+  }
+
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetFrameworkTest.java
@@ -39,6 +39,7 @@ import co.cask.cdap.data2.dataset2.lib.table.CoreDatasetsModule;
 import co.cask.cdap.data2.dataset2.module.lib.inmemory.InMemoryTableModule;
 import co.cask.cdap.data2.metadata.writer.LineageWriterDatasetFramework;
 import co.cask.cdap.data2.metadata.writer.NoOpLineageWriter;
+import co.cask.cdap.data2.registry.NoOpUsageRegistry;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
@@ -538,7 +539,7 @@ public abstract class AbstractDatasetFrameworkTest {
     // Access instance
     Id.Run runId = new Id.Run(Id.Program.from("ns", "app", ProgramType.FLOW, "flow"), RunIds.generate().getId());
     LineageWriterDatasetFramework lineageFramework =
-      new LineageWriterDatasetFramework(framework, new NoOpLineageWriter());
+      new LineageWriterDatasetFramework(framework, new NoOpLineageWriter(), new NoOpUsageRegistry());
     lineageFramework.initContext(runId);
     lineageFramework.setAuditPublisher(inMemoryAuditPublisher);
     lineageFramework.getDataset(MY_TABLE, null, getClass().getClassLoader());

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
@@ -170,6 +170,15 @@ public final class DatasetFrameworkTestUtil extends ExternalResource {
     return new DefaultTransactionExecutor(new InMemoryTxSystemClient(txManager), tables);
   }
 
+  /**
+   * @param tables the TransactionAwares over which the returned TransactionExecutor operates on.
+   * @return a TransactionExecutor that uses an in-memory implementation of a TransactionSystemClient.
+   */
+  public TransactionExecutor newInMemoryTransactionExecutor(Iterable<TransactionAware> tables) {
+    Preconditions.checkArgument(tables != null);
+    return new DefaultTransactionExecutor(new InMemoryTxSystemClient(txManager), tables);
+  }
+
   public TransactionManager getTxManager() {
     return txManager;
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/registry/UsageDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/registry/UsageDatasetTest.java
@@ -30,20 +30,20 @@ public class UsageDatasetTest {
   @ClassRule
   public static DatasetFrameworkTestUtil dsFrameworkUtil = new DatasetFrameworkTestUtil();
 
-  private final Id.Program flow11 = Id.Program.from("ns1", "app1", ProgramType.FLOW, "flow11");
-  private final Id.Program flow12 = Id.Program.from("ns1", "app1", ProgramType.FLOW, "flow12");
-  private final Id.Program service11 = Id.Program.from("ns1", "app1", ProgramType.SERVICE, "service11");
+  protected final Id.Program flow11 = Id.Program.from("ns1", "app1", ProgramType.FLOW, "flow11");
+  protected final Id.Program flow12 = Id.Program.from("ns1", "app1", ProgramType.FLOW, "flow12");
+  protected final Id.Program service11 = Id.Program.from("ns1", "app1", ProgramType.SERVICE, "service11");
 
-  private final Id.Program flow21 = Id.Program.from("ns1", "app2", ProgramType.FLOW, "flow21");
-  private final Id.Program flow22 = Id.Program.from("ns1", "app2", ProgramType.FLOW, "flow22");
-  private final Id.Program service21 = Id.Program.from("ns1", "app2", ProgramType.SERVICE, "service21");
+  protected final Id.Program flow21 = Id.Program.from("ns1", "app2", ProgramType.FLOW, "flow21");
+  protected final Id.Program flow22 = Id.Program.from("ns1", "app2", ProgramType.FLOW, "flow22");
+  protected final Id.Program service21 = Id.Program.from("ns1", "app2", ProgramType.SERVICE, "service21");
 
-  private final Id.DatasetInstance datasetInstance1 = Id.DatasetInstance.from("ns1", "ds1");
-  private final Id.DatasetInstance datasetInstance2 = Id.DatasetInstance.from("ns1", "ds2");
-  private final Id.DatasetInstance datasetInstance3 = Id.DatasetInstance.from("ns1", "ds3");
+  protected final Id.DatasetInstance datasetInstance1 = Id.DatasetInstance.from("ns1", "ds1");
+  protected final Id.DatasetInstance datasetInstance2 = Id.DatasetInstance.from("ns1", "ds2");
+  protected final Id.DatasetInstance datasetInstance3 = Id.DatasetInstance.from("ns1", "ds3");
 
-  private final Id.Stream stream1 = Id.Stream.from("ns1", "s1");
-  private final Id.Stream stream2 = Id.Stream.from("ns2", "s1");
+  protected final Id.Stream stream1 = Id.Stream.from("ns1", "s1");
+  protected final Id.Stream stream2 = Id.Stream.from("ns2", "s1");
 
   @Test
   public void testOneMapping() throws Exception {
@@ -191,7 +191,7 @@ public class UsageDatasetTest {
     Assert.assertEquals(ImmutableSet.<Id.Program>of(), usageDataset.getPrograms(stream2));
   }
 
-  private static UsageDataset getUsageDataset(String instanceId) throws Exception {
+  protected static UsageDataset getUsageDataset(String instanceId) throws Exception {
     Id.DatasetInstance id = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, instanceId);
     return DatasetsUtil.getOrCreateDataset(dsFrameworkUtil.getFramework(), id,
                                            UsageDataset.class.getSimpleName(), DatasetProperties.EMPTY, null, null);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/registry/UsageRegistryTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/registry/UsageRegistryTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.registry;
+
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetManagementException;
+import co.cask.cdap.api.metrics.MetricsCollector;
+import co.cask.cdap.data2.dataset2.ForwardingDatasetFramework;
+import co.cask.cdap.proto.Id;
+import co.cask.tephra.Transaction;
+import co.cask.tephra.TransactionAware;
+import co.cask.tephra.TransactionExecutor;
+import co.cask.tephra.TransactionExecutorFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+public class UsageRegistryTest extends UsageDatasetTest {
+
+  @Test
+  public void testUsageRegistry() {
+
+    // instantiate a usage registry
+    UsageRegistry registry = new DefaultUsageRegistry(
+      new TransactionExecutorFactory() {
+        @Override
+        public TransactionExecutor createExecutor(Iterable<TransactionAware> iterable) {
+          return dsFrameworkUtil.newInMemoryTransactionExecutor(iterable);
+        }
+      }, new ForwardingDatasetFramework(dsFrameworkUtil.getFramework()) {
+      @Nullable
+      @Override
+      public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId,
+                                              @Nullable Map<String, String> arguments,
+                                              @Nullable ClassLoader classLoader)
+        throws DatasetManagementException, IOException {
+
+        T t = super.getDataset(datasetInstanceId, arguments, classLoader);
+        if (t instanceof UsageDataset) {
+          @SuppressWarnings("unchecked")
+          T t1 = (T) new WrappedUsageDataset((UsageDataset) t);
+          return t1;
+        }
+        return t;
+      }
+    });
+
+    // register usage for a stream and a dataset for single and multiple "owners", including a non-program
+    registry.register(flow11, datasetInstance1);
+    registry.register(flow12, stream1);
+    registry.registerAll(ImmutableList.of(flow21, flow22), datasetInstance2);
+    registry.registerAll(ImmutableList.of(flow21, flow22), stream1);
+    int count = WrappedUsageDataset.registerCount;
+
+    // validate usage
+    Assert.assertEquals(ImmutableSet.of(datasetInstance1), registry.getDatasets(flow11));
+    Assert.assertEquals(ImmutableSet.of(stream1), registry.getStreams(flow12));
+    Assert.assertEquals(ImmutableSet.of(datasetInstance2), registry.getDatasets(flow21));
+    Assert.assertEquals(ImmutableSet.of(datasetInstance2), registry.getDatasets(flow22));
+    Assert.assertEquals(ImmutableSet.of(stream1), registry.getStreams(flow21));
+    Assert.assertEquals(ImmutableSet.of(stream1), registry.getStreams(flow22));
+    Assert.assertEquals(ImmutableSet.of(flow11), registry.getPrograms(datasetInstance1));
+    Assert.assertEquals(ImmutableSet.of(flow21, flow22), registry.getPrograms(datasetInstance2));
+    Assert.assertEquals(ImmutableSet.of(flow12, flow21, flow22), registry.getPrograms(stream1));
+
+    // register datasets again
+    registry.register(flow11, datasetInstance1);
+    registry.registerAll(ImmutableList.of(flow21, flow22), datasetInstance2);
+
+    // validate that this does not re-register previous usages (through code in wrapped usage dataset)
+    Assert.assertEquals(count, WrappedUsageDataset.registerCount);
+
+    // validate usage
+    Assert.assertEquals(ImmutableSet.of(datasetInstance1), registry.getDatasets(flow11));
+    Assert.assertEquals(ImmutableSet.of(stream1), registry.getStreams(flow12));
+    Assert.assertEquals(ImmutableSet.of(datasetInstance2), registry.getDatasets(flow21));
+    Assert.assertEquals(ImmutableSet.of(datasetInstance2), registry.getDatasets(flow22));
+    Assert.assertEquals(ImmutableSet.of(stream1), registry.getStreams(flow21));
+    Assert.assertEquals(ImmutableSet.of(stream1), registry.getStreams(flow22));
+    Assert.assertEquals(ImmutableSet.of(flow11), registry.getPrograms(datasetInstance1));
+    Assert.assertEquals(ImmutableSet.of(flow21, flow22), registry.getPrograms(datasetInstance2));
+    Assert.assertEquals(ImmutableSet.of(flow12, flow21, flow22), registry.getPrograms(stream1));
+
+    // unregister app
+    registry.unregister(flow11.getApplication());
+
+    // validate usage for that app is gone
+    Assert.assertEquals(ImmutableSet.of(), registry.getDatasets(flow11));
+    Assert.assertEquals(ImmutableSet.of(), registry.getStreams(flow12));
+    Assert.assertEquals(ImmutableSet.of(datasetInstance2), registry.getDatasets(flow21));
+    Assert.assertEquals(ImmutableSet.of(datasetInstance2), registry.getDatasets(flow22));
+    Assert.assertEquals(ImmutableSet.of(stream1), registry.getStreams(flow21));
+    Assert.assertEquals(ImmutableSet.of(stream1), registry.getStreams(flow22));
+    Assert.assertEquals(ImmutableSet.of(), registry.getPrograms(datasetInstance1));
+    Assert.assertEquals(ImmutableSet.of(flow21, flow22), registry.getPrograms(datasetInstance2));
+    Assert.assertEquals(ImmutableSet.of(flow21, flow22), registry.getPrograms(stream1));
+
+    // register application 1 again
+    registry.register(flow11, datasetInstance1);
+    registry.register(flow12, stream1);
+
+    // validate it was re-registered
+    Assert.assertEquals(ImmutableSet.of(datasetInstance1), registry.getDatasets(flow11));
+    Assert.assertEquals(ImmutableSet.of(stream1), registry.getStreams(flow12));
+    Assert.assertEquals(ImmutableSet.of(datasetInstance2), registry.getDatasets(flow21));
+    Assert.assertEquals(ImmutableSet.of(datasetInstance2), registry.getDatasets(flow22));
+    Assert.assertEquals(ImmutableSet.of(stream1), registry.getStreams(flow21));
+    Assert.assertEquals(ImmutableSet.of(stream1), registry.getStreams(flow22));
+    Assert.assertEquals(ImmutableSet.of(flow11), registry.getPrograms(datasetInstance1));
+    Assert.assertEquals(ImmutableSet.of(flow21, flow22), registry.getPrograms(datasetInstance2));
+    Assert.assertEquals(ImmutableSet.of(flow12, flow21, flow22), registry.getPrograms(stream1));
+
+    // validate that this actually re-registered previous usages (through code in wrapped usage dataset)
+    Assert.assertEquals(count + 2, WrappedUsageDataset.registerCount);
+  }
+
+  /**
+   * Usage dataset that delegates all operations to an embedded one,
+   * but also counts the number of register() calls in a static variable.
+   */
+  private static class WrappedUsageDataset extends UsageDataset {
+
+    static int registerCount = 0;
+
+    final UsageDataset uds;
+
+    public WrappedUsageDataset(UsageDataset uds) {
+      super(null);
+      this.uds = uds;
+    }
+
+    @Override
+    public void register(Id.Program programId, Id.DatasetInstance datasetInstanceId) {
+      registerCount++;
+      uds.register(programId, datasetInstanceId);
+    }
+
+    @Override
+    public void register(Id.Program programId, Id.Stream streamId) {
+      registerCount++;
+      uds.register(programId, streamId);
+    }
+
+    @Override
+    public void unregister(Id.Application applicationId) {
+      uds.unregister(applicationId);
+    }
+
+    @Override
+    public Set<Id.DatasetInstance> getDatasets(Id.Program programId) {
+      return uds.getDatasets(programId);
+    }
+
+    @Override
+    public Set<Id.DatasetInstance> getDatasets(Id.Application applicationId) {
+      return uds.getDatasets(applicationId);
+    }
+
+    @Override
+    public Set<Id.Stream> getStreams(Id.Program programId) {
+      return uds.getStreams(programId);
+    }
+
+    @Override
+    public Set<Id.Stream> getStreams(Id.Application applicationId) {
+      return uds.getStreams(applicationId);
+    }
+
+    @Override
+    public Set<Id.Program> getPrograms(Id.DatasetInstance datasetInstanceId) {
+      return uds.getPrograms(datasetInstanceId);
+    }
+
+    @Override
+    public Set<Id.Program> getPrograms(Id.Stream streamId) {
+      return uds.getPrograms(streamId);
+    }
+
+    @Override
+    public void close() throws IOException {
+      uds.close();
+    }
+
+    @Override
+    public void setMetricsCollector(MetricsCollector metricsCollector) {
+      uds.setMetricsCollector(metricsCollector);
+    }
+
+    @Override
+    public void startTx(Transaction tx) {
+      uds.startTx(tx);
+    }
+
+    @Override
+    public void updateTx(Transaction tx) {
+      uds.updateTx(tx);
+    }
+
+    @Override
+    public Collection<byte[]> getTxChanges() {
+      return uds.getTxChanges();
+    }
+
+    @Override
+    public boolean commitTx() throws Exception {
+      return uds.commitTx();
+    }
+
+    @Override
+    public void postTxCommit() {
+      uds.postTxCommit();
+    }
+
+    @Override
+    public boolean rollbackTx() throws Exception {
+      return uds.rollbackTx();
+    }
+
+    @Override
+    public String getTransactionAwareName() {
+      return uds.getTransactionAwareName();
+    }
+  }
+}

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -54,7 +54,7 @@ import co.cask.cdap.data2.metadata.store.DefaultMetadataStore;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
 import co.cask.cdap.data2.metadata.writer.NoOpLineageWriter;
-import co.cask.cdap.data2.registry.UsageRegistry;
+import co.cask.cdap.data2.registry.DefaultUsageRegistry;
 import co.cask.cdap.data2.transaction.TransactionSystemClientService;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.explore.guice.ExploreClientModule;
@@ -455,6 +455,6 @@ public class UpgradeTool {
     DefaultMetricDatasetFactory.setupDatasets(factory);
 
     // Usage registry
-    UsageRegistry.setupDatasets(datasetFramework);
+    DefaultUsageRegistry.setupDatasets(datasetFramework);
   }
 }


### PR DESCRIPTION
This also requires moving usage registry to the client side. The reason is that If DatasetService caches what usage it has already registered, it will not be aware of deletion of an app followed by redeploy. The deletion would also delete all usage records, and the redeploy would attempt to register it again. However, because of the cache, DatasetService would not register it again. If usage is registered fro the client side (the program runtimes), this is not an issue, because after redeploy, the programs have to be restarted (with an empty cache).

Thus:
- added a DatasetMeta cache to DatasetInstanceService
- removed usageRegistry from DatasetInstanceService
- converted UsageRegistry into an interface
- added two implementations: a no-op for testing, a tx + dataset framework based on for production
- fixed UsageRegistry bug that was starting nested transactions for each registerAll() call
- fixed a bug in UsageRegistry that was registering the usage dataset as a Table for the upgrade tool (it is UsageDataset - upgrade tool must always have skipped the usage dataset).  
- refactored UsageRegistry to be injectable easily by Giuce (using dsFramework instead of a dataset provider)
- added usage recording to LineageWriterDatasetFramework
- refactored some test code
- added new tests to validate:
  - usageRegistry caches what has been registered and does not register it again
  - usageRegistry clears the cache after a deregister() call (that is, app deletion)
  - dataset instance service caches dataset meta data; but invalidated the cache when the dataset is deleted or updated.
  - end-to-end in UsageHandlerTestRun: deploy app, run Spark, validate usage, delete app, redeploy, validate again.
