### PR TITLE
Fix broken perma-links from earlier PR

### DIFF
--- a/cdap-docs/_common/customHTML.py
+++ b/cdap-docs/_common/customHTML.py
@@ -23,7 +23,7 @@
 
     :copyright: Copyright 2016 by Cask Data, Inc.
     :license: Apache License, Version 2.0, see http://www.apache.org/licenses/LICENSE-2.0
-    :version: 0.1
+    :version: 0.2
 
 """
 
@@ -44,19 +44,18 @@ class CustomHTMLTranslator(HTMLTranslator):
         close = close_tag.rfind('>')
         if close != -1:
             h_level = close_tag[close-1]
-        if (self.permalink_text and self.builder.add_permalinks and
-            node.parent.hasattr('ids') and node.parent['ids']):
+        if (h_level and h_level.isdigit() and (close == close_tag.rfind('h%s>' % h_level) + 2) and self.permalink_text
+                and self.builder.add_permalinks and node.parent.hasattr('ids') and node.parent['ids']):
             aname = node.parent['ids'][0]
             tags = []
-            if h_level:
-                open_tag = "<h%s>" % h_level
-                # Walk back to find open_tag in body
-                for i in reversed(range(len(self.body))):
-                    tags.append(self.body.pop())
-                    if tags[-1] == open_tag:
-                        self.body.append(tags.pop())
-                        tags.reverse()
-                        break
+            open_tag = "<h%s>" % h_level
+            # Walk back to find open_tag in body
+            for i in reversed(range(len(self.body))):
+                tags.append(self.body.pop())
+                if tags[-1] == open_tag:
+                    self.body.append(tags.pop())
+                    tags.reverse()
+                    break
             
             # <h1>Manual Installation using Packages<a class="headerlink" href="#manual-installation-using-packages"
             # title="Permalink to this headline">¶</a></h1>
@@ -73,5 +72,3 @@ class CustomHTMLTranslator(HTMLTranslator):
             self.body = self.body + tags            
 
         BaseTranslator.depart_title(self, node)
-
-


### PR DESCRIPTION
Fix error in logic: only move the link if the tag is an "h-level". It must be a single digit preceded by an 'h'.

Passes [Quick Build 1](http://builds.cask.co/browse/CDAP-DQB33-1)

Correct Page (current): [License Page](http://docs.cask.co/cdap/current/en/reference-manual/licenses/cdap-standalone-dependencies.html)

Broken page (develop): [License Page](http://docs.cask.co/cdap/develop/en/reference-manual/licenses/cdap-standalone-dependencies.html)

Fixed page (this PR): [License Page](http://builds.cask.co/artifact/CDAP-DQB33/shared/build-1/Docs-HTML/3.5.0-SNAPSHOT/en/reference-manual/licenses/cdap-standalone-dependencies.html)

Error added in https://github.com/caskdata/cdap/pull/5832
