### PR TITLE
CDAP-6116: Capture MR syslog by excluding dependency tracing for 

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/twill/HadoopClassExcluder.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/twill/HadoopClassExcluder.java
@@ -27,7 +27,18 @@ public class HadoopClassExcluder extends ClassAcceptor {
   @Override
   public boolean accept(String className, URL classUrl, URL classPathUrl) {
     // exclude hadoop but not hbase and hive packages
-    return !(className.startsWith("org.apache.hadoop")
-      && !className.startsWith("org.apache.hadoop.hbase") && !className.startsWith("org.apache.hadoop.hive"));
+    if (className.startsWith("org.apache.hadoop.")) {
+      if (className.startsWith("org.apache.hadoop.hive.")) {
+        return true;
+      } else if (className.startsWith("org.apache.hadoop.hbase.")) {
+        // exclude tracing dependencies of classes that have dependencies on commons-logging implementation classes
+        // so that commons-logging jar is not packaged (this is required so that slf4j is used for log collection)
+        return !(className.startsWith("org.apache.hadoop.hbase.http.log.LogLevel")
+          || className.startsWith("org.apache.hadoop.hbase.http.HttpRequestLog"));
+      } else {
+        return false;
+      }
+    }
+    return true;
   }
 }


### PR DESCRIPTION
classes that depend on implementation classes in commons logging? HttpRequestLog, LogLevel classes have dependency on commons logging implementation classes, so exclude tracing dependencies for them.

JIRA : https://issues.cask.co/browse/CDAP-6116

Build : http://builds.cask.co/browse/CDAP-DUT4201
