### PR TITLE
[CDAP-6139] Fixed spacing and alignment for 'Null' and 'Trash' column

### DIFF
--- a/cdap-ui/app/directives/plugin-functions/functions/get-schema/get-schema-modal.html
+++ b/cdap-ui/app/directives/plugin-functions/functions/get-schema/get-schema-modal.html
@@ -39,13 +39,13 @@
         <thead>
           <th>Name</th>
           <th>Type</th>
-          <th>Null</th>
+          <th class="nullable">Null</th>
         </thead>
         <tbody>
           <tr ng-repeat="field in GetSchemaModalController.schema">
             <td>{{ field.name }}</td>
             <td>{{ field.type }}</td>
-            <td class="text-center">
+            <td class="text-center nullable">
               <input type="checkbox" ng-model="field.nullable" disabled>
             </td>
           </tr>

--- a/cdap-ui/app/directives/plugin-functions/functions/output-schema/output-schema-modal.html
+++ b/cdap-ui/app/directives/plugin-functions/functions/output-schema/output-schema-modal.html
@@ -32,13 +32,13 @@
         <thead>
           <th>Name</th>
           <th>Type</th>
-          <th>Null</th>
+          <th class="text-center">Null</th>
         </thead>
         <tbody>
           <tr ng-repeat="field in GetSchemaModalController.schema">
             <td>{{ field.name }}</td>
             <td>{{ field.type }}</td>
-            <td class="text-center">
+            <td class="text-center nullable">
               <input type="checkbox" ng-model="field.nullable" disabled>
             </td>
           </tr>

--- a/cdap-ui/app/directives/plugin-functions/functions/output-schema/output-schema.less
+++ b/cdap-ui/app/directives/plugin-functions/functions/output-schema/output-schema.less
@@ -23,3 +23,7 @@ output-schema {
     right: 0;
   }
 }
+
+.nullable {
+	width: 35px;
+}

--- a/cdap-ui/app/directives/plugin-functions/functions/output-schema/output-schema.less
+++ b/cdap-ui/app/directives/plugin-functions/functions/output-schema/output-schema.less
@@ -25,5 +25,5 @@ output-schema {
 }
 
 .nullable {
-	width: 35px;
+  width: 35px;
 }

--- a/cdap-ui/app/directives/widget-container/widget-schema-editor/widget-schema-editor.html
+++ b/cdap-ui/app/directives/widget-container/widget-schema-editor/widget-schema-editor.html
@@ -36,7 +36,7 @@
             <th>
               <label class="control-label">Type</label>
             </th>
-            <th>
+            <th class="text-center">
               <label class="control-label">Null</label>
             </th>
             <th></th>

--- a/cdap-ui/app/features/hydratorplusplus/bottompanel.less
+++ b/cdap-ui/app/features/hydratorplusplus/bottompanel.less
@@ -318,7 +318,6 @@ body.theme-cdap.state-hydratorplusplus {
 
         }
         &.type {
-
         }
         &.nullable {
           width: 35px;

--- a/cdap-ui/app/features/hydratorplusplus/bottompanel.less
+++ b/cdap-ui/app/features/hydratorplusplus/bottompanel.less
@@ -314,11 +314,6 @@ body.theme-cdap.state-hydratorplusplus {
         select.form-control {
           padding-right: 20px;
         }
-        &.name {
-
-        }
-        &.type {
-        }
         &.nullable {
           width: 35px;
         }

--- a/cdap-ui/app/features/hydratorplusplus/bottompanel.less
+++ b/cdap-ui/app/features/hydratorplusplus/bottompanel.less
@@ -318,16 +318,20 @@ body.theme-cdap.state-hydratorplusplus {
           padding-right: 20px;
         }
         &.name {
-          width: 35%;
+          width: 40%;
+          max-width: 45%;
         }
         &.type {
-          width: 30%;
+          max-width: 45%;
+          width: 40%;
         }
         &.nullable {
-          width: 20%;
+          width: 15px;
+          min-width: 15px;
         }
         &.trash {
-          width: 15%;
+          width: 15px;
+          min-width: 15px;
           a {
             padding-left: 0;
             padding-right: 0;

--- a/cdap-ui/app/features/hydratorplusplus/bottompanel.less
+++ b/cdap-ui/app/features/hydratorplusplus/bottompanel.less
@@ -297,9 +297,6 @@ body.theme-cdap.state-hydratorplusplus {
         border: 0;
         padding: 0;
 
-        @media (min-width: @screen-lg-min) {
-          padding-left: 10px;
-        }
         label {
           margin-bottom: 0;
           vertical-align: top;
@@ -324,10 +321,10 @@ body.theme-cdap.state-hydratorplusplus {
 
         }
         &.nullable {
-          width: 8%;
+          width: 35px;
         }
         &.trash {
-          width: 8%;
+          width: 35px;
           a {
             padding-left: 0;
             padding-right: 0;

--- a/cdap-ui/app/features/hydratorplusplus/bottompanel.less
+++ b/cdap-ui/app/features/hydratorplusplus/bottompanel.less
@@ -318,22 +318,16 @@ body.theme-cdap.state-hydratorplusplus {
           padding-right: 20px;
         }
         &.name {
-          width: 40%;
-          max-width: 45%;
+
         }
         &.type {
-          max-width: 45%;
-          width: 40%;
+
         }
         &.nullable {
-          width: 15px;
-          min-width: 15px;
-          max-width: 20px;
+          width: 8%;
         }
         &.trash {
-          width: 15px;
-          min-width: 15px;
-          max-width: 20px;
+          width: 8%;
           a {
             padding-left: 0;
             padding-right: 0;

--- a/cdap-ui/app/features/hydratorplusplus/bottompanel.less
+++ b/cdap-ui/app/features/hydratorplusplus/bottompanel.less
@@ -328,10 +328,12 @@ body.theme-cdap.state-hydratorplusplus {
         &.nullable {
           width: 15px;
           min-width: 15px;
+          max-width: 20px;
         }
         &.trash {
           width: 15px;
           min-width: 15px;
+          max-width: 20px;
           a {
             padding-left: 0;
             padding-right: 0;

--- a/cdap-ui/app/features/hydratorplusplus/controllers/list-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/list-ctrl.js
@@ -262,4 +262,3 @@ angular.module(PKG.name + '.feature.hydratorplusplus')
     };
 
   });
-

--- a/cdap-ui/app/features/hydratorplusplus/controllers/list-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/list-ctrl.js
@@ -262,3 +262,4 @@ angular.module(PKG.name + '.feature.hydratorplusplus')
     };
 
   });
+

--- a/cdap-ui/app/features/hydratorplusplus/templates/create/popovers/plugin-edit-input-schema.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/create/popovers/plugin-edit-input-schema.html
@@ -25,7 +25,7 @@
           <th>
             <label class="control-label">Type</label>
           </th>
-          <th>
+          <th class='text-center'>
             <label class="control-label">Null</label>
           </th>
         </thead>


### PR DESCRIPTION
Fix for: https://issues.cask.co/browse/CDAP-6139

Reformatted the output schema widget

Null Column:
- Header text is now centered
- Cell size has been reduced for better aesthetic 

Trash Column:
- Cell size has been reduced for better aesthetic 
