### PR TITLE
Lock Chef version to 12.11.17

### DIFF
--- a/cdap-distributions/src/Dockerfile
+++ b/cdap-distributions/src/Dockerfile
@@ -23,8 +23,7 @@ MAINTAINER Cask Data <ops@cask.co>
 
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.7
-RUN set -x && \
-  apt-get update && \
+RUN apt-get update && \
   apt-get install -y \
     curl \
     git && \
@@ -46,7 +45,7 @@ COPY packer/scripts /tmp/scripts
 COPY packer/files /tmp/files
 
 # Install Chef, setup APT, run Chef cdap::sdk recipe, then clean up
-RUN curl -L http://chef.io/chef/install.sh | bash && \
+RUN curl -vL http://chef.io/chef/install.sh | bash -- -v 12.11.17 && \
     for i in apt-setup.sh cookbook-dir.sh cookbook-setup.sh ; do /tmp/scripts/$i ; done && \
     chef-solo -o cdap::sdk -j /tmp/files/cdap-sdk.json && \
     for i in remove-chef.sh sdk-cleanup.sh apt-cleanup.sh ; do /tmp/scripts/$i ; done && \

--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -60,6 +60,7 @@
     },
     {
       "type": "chef-solo",
+      "install_command": "curl -L https://www.chef.io/chef/install.sh | {{if .Sudo}}sudo{{end}} bash -- -v 12.11.17",
       "remote_cookbook_paths": "/var/chef/cookbooks",
       "pause_before": "10s"
     },


### PR DESCRIPTION
This is the newest Chef version where `chef-solo` works as expected for our use case. Using a newer version will require updating our build setup for Docker and VM builds due to chef/chef#4919 changing the default behavior of `chef-solo` to be an alias for `chef-client -z`... in a patch version, no less.
