### PR TITLE
Lock Chef version to 12.11.17 (backport #5874)

### DIFF
--- a/cdap-distributions/src/Dockerfile
+++ b/cdap-distributions/src/Dockerfile
@@ -30,7 +30,7 @@ COPY packer/files /tmp/files
 # build cdap-standalone zip file, copy it to container and extract it
 RUN apt-get update && \
     apt-get install -y curl git && \
-    curl -L http://chef.io/chef/install.sh | bash -- -v 12.11.17 && \
+    curl -L http://chef.io/chef/install.sh | bash -s -- -v 12.11.17 && \
     for i in apt-setup.sh cookbook-dir.sh cookbook-setup.sh ; do /tmp/scripts/$i ; done && \
     chef-solo -o cdap::sdk -j /tmp/files/cdap-sdk.json && \
     for i in remove-chef.sh sdk-cleanup.sh apt-cleanup.sh ; do /tmp/scripts/$i ; done && \

--- a/cdap-distributions/src/Dockerfile
+++ b/cdap-distributions/src/Dockerfile
@@ -30,7 +30,7 @@ COPY packer/files /tmp/files
 # build cdap-standalone zip file, copy it to container and extract it
 RUN apt-get update && \
     apt-get install -y curl git && \
-    curl -L http://chef.io/chef/install.sh | bash && \
+    curl -L http://chef.io/chef/install.sh | bash -- -v 12.11.17 && \
     for i in apt-setup.sh cookbook-dir.sh cookbook-setup.sh ; do /tmp/scripts/$i ; done && \
     chef-solo -o cdap::sdk -j /tmp/files/cdap-sdk.json && \
     for i in remove-chef.sh sdk-cleanup.sh apt-cleanup.sh ; do /tmp/scripts/$i ; done && \
@@ -38,8 +38,7 @@ RUN apt-get update && \
     /usr/share/locale/{a,b,c,d,e{l,o,s,t,u},f,g,h,i,j,k,lt,lv,m,n,o,p,r,s,t,u,v,w,x,z}*
 
 # Expose Ports (9999 & 10000 for CDAP)
-EXPOSE 9999
-EXPOSE 10000
+EXPOSE 9999 10000
 
 # start CDAP in the background and tail in the foreground
 ENTRYPOINT /opt/cdap/sdk/bin/cdap.sh start && \

--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -59,7 +59,7 @@
     },
     {
       "type": "chef-solo",
-      "install_command": "curl -L https://www.chef.io/chef/install.sh | {{if .Sudo}}sudo{{end}} bash -- -v 12.11.17",
+      "install_command": "curl -L https://www.chef.io/chef/install.sh | {{if .Sudo}}sudo{{end}} bash -s -- -v 12.11.17",
       "remote_cookbook_paths": "/var/chef/cookbooks",
       "pause_before": "10s"
     },

--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -59,6 +59,7 @@
     },
     {
       "type": "chef-solo",
+      "install_command": "curl -L https://www.chef.io/chef/install.sh | {{if .Sudo}}sudo{{end}} bash -- -v 12.11.17",
       "remote_cookbook_paths": "/var/chef/cookbooks",
       "pause_before": "10s"
     },


### PR DESCRIPTION
This is a backport.
