### PR TITLE
Lock Chef version to 12.11.17 (backport #5874)

### DIFF
--- a/cdap-distributions/src/Dockerfile
+++ b/cdap-distributions/src/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright © 2012-2014 Cask Data, Inc.
+# Copyright © 2012-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ COPY packer/files /tmp/files
 # build cdap-standalone zip file, copy it to container and extract it
 RUN apt-get update && \
     apt-get install -y curl git && \
-    curl -L http://chef.io/chef/install.sh | bash -- -v 12.11.17 && \
+    curl -L http://chef.io/chef/install.sh | bash -s -- -v 12.11.17 && \
     for i in apt-setup.sh cookbook-dir.sh cookbook-setup.sh ; do /tmp/scripts/$i ; done && \
     chef-solo -o cdap::sdk -j /tmp/files/cdap-sdk.json && \
     for i in remove-chef.sh sdk-cleanup.sh apt-cleanup.sh ; do /tmp/scripts/$i ; done && \

--- a/cdap-distributions/src/Dockerfile
+++ b/cdap-distributions/src/Dockerfile
@@ -30,7 +30,7 @@ COPY packer/files /tmp/files
 # build cdap-standalone zip file, copy it to container and extract it
 RUN apt-get update && \
     apt-get install -y curl git && \
-    curl -L http://chef.io/chef/install.sh | bash && \
+    curl -L http://chef.io/chef/install.sh | bash -- -v 12.11.17 && \
     for i in apt-setup.sh cookbook-dir.sh cookbook-setup.sh ; do /tmp/scripts/$i ; done && \
     chef-solo -o cdap::sdk -j /tmp/files/cdap-sdk.json && \
     for i in remove-chef.sh sdk-cleanup.sh apt-cleanup.sh ; do /tmp/scripts/$i ; done && \

--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -60,6 +60,7 @@
     {
       "type": "chef-solo",
       "remote_cookbook_paths": "/var/chef/cookbooks",
+      "install_command": "curl -L https://www.chef.io/chef/install.sh | {{if .Sudo}}sudo{{end}} bash -- -v 12.11.17",
       "pause_before": "10s"
     },
     {

--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -60,7 +60,7 @@
     {
       "type": "chef-solo",
       "remote_cookbook_paths": "/var/chef/cookbooks",
-      "install_command": "curl -L https://www.chef.io/chef/install.sh | {{if .Sudo}}sudo{{end}} bash -- -v 12.11.17",
+      "install_command": "curl -L https://www.chef.io/chef/install.sh | {{if .Sudo}}sudo{{end}} bash -s -- -v 12.11.17",
       "pause_before": "10s"
     },
     {


### PR DESCRIPTION
This is a backport.
