### PR TITLE
Switch to Chef 12.4.3, same as in Coopr's chef_solo_automator

### DIFF
--- a/cdap-distributions/src/Dockerfile
+++ b/cdap-distributions/src/Dockerfile
@@ -45,7 +45,7 @@ COPY packer/scripts /tmp/scripts
 COPY packer/files /tmp/files
 
 # Install Chef, setup APT, run Chef cdap::sdk recipe, then clean up
-RUN curl -vL http://chef.io/chef/install.sh | bash -s -- -v 12.11.17 && \
+RUN curl -vL http://chef.io/chef/install.sh | bash -s -- -v 12.4.3 && \
     for i in apt-setup.sh cookbook-dir.sh cookbook-setup.sh ; do /tmp/scripts/$i ; done && \
     chef-solo -o cdap::sdk -j /tmp/files/cdap-sdk.json && \
     for i in remove-chef.sh sdk-cleanup.sh apt-cleanup.sh ; do /tmp/scripts/$i ; done && \

--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -60,7 +60,7 @@
     },
     {
       "type": "chef-solo",
-      "install_command": "curl -L https://www.chef.io/chef/install.sh | {{if .Sudo}}sudo{{end}} bash -s -- -v 12.11.17",
+      "install_command": "curl -L https://www.chef.io/chef/install.sh | {{if .Sudo}}sudo{{end}} bash -s -- -v 12.4.3",
       "remote_cookbook_paths": "/var/chef/cookbooks",
       "pause_before": "10s"
     },


### PR DESCRIPTION
It looks like Chef doesn't have an OmniTruck for Ubuntu for 12.11.17...

```
15-Jun-2016 04:03:06    ERROR 404
15-Jun-2016 04:03:06    Omnitruck artifact does not exist for version 12.11.17 on platform ubuntu
15-Jun-2016 04:03:06    
15-Jun-2016 04:03:06    Either this means:
15-Jun-2016 04:03:06       - We do not support ubuntu
15-Jun-2016 04:03:06       - We do not have an artifact for 12.11.17
```

This PR will switch to the version used by [Coopr's](caskdata/coopr-provisioner#119) `chef_solo_automator` Chef support.
