### PR TITLE
[CDAP-6231] - Temporary fix for gulp-header node module update

### DIFF
--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -21,6 +21,7 @@
     "del": "2.2.0",
     "es6-promise": "3.0.2",
     "gulp": "3.9.0",
+    "gulp-header": "1.8.2",
     "gulp-angular-templatecache": "1.8.0",
     "gulp-babel": "6.1.1",
     "gulp-concat": "2.6.0",


### PR DESCRIPTION
- Current build is using a fixed version of `gulp-angular-templateCache`, however `gulp-angular-templateCache` is internally using `1.x` version of `gulp-header` as its dependency. 
- `gulp-header` released a new minor version 3 days ago and that broke our current build as `1.x` now picks the latest release.

Hence the PR.
