### PR TITLE
CDAP-6147-fix-error-message-principal-not-found

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/AuthorizationHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/AuthorizationHandlerTest.java
@@ -44,8 +44,8 @@ import co.cask.cdap.security.authorization.NoOpAdmin;
 import co.cask.cdap.security.authorization.NoOpDatasetContext;
 import co.cask.cdap.security.spi.authorization.AuthorizationContext;
 import co.cask.cdap.security.spi.authorization.Authorizer;
+import co.cask.cdap.security.spi.authorization.PrincipalNotFoundException;
 import co.cask.cdap.security.spi.authorization.RoleAlreadyExistsException;
-import co.cask.cdap.security.spi.authorization.RoleNotFoundException;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.http.NettyHttpService;
 import co.cask.tephra.TransactionFailureException;
@@ -332,7 +332,7 @@ public class AuthorizationHandlerTest {
     try {
       client.dropRole(admins);
       Assert.fail(String.format("Dropped a role %s which does not exists. Should have failed.", admins.getName()));
-    } catch (RoleNotFoundException expected) {
+    } catch (PrincipalNotFoundException expected) {
       // expected
     }
 
@@ -344,7 +344,7 @@ public class AuthorizationHandlerTest {
     try {
       client.addRoleToPrincipal(admins, spiderman);
       Assert.fail(String.format("Added role %s to principal %s. Should have failed.", admins, spiderman));
-    } catch (RoleNotFoundException expected) {
+    } catch (PrincipalNotFoundException expected) {
       // expected
     }
 
@@ -383,7 +383,7 @@ public class AuthorizationHandlerTest {
       client.removeRoleFromPrincipal(admins, spiderman);
       Assert.fail(String.format("Removed non-existing role %s from principal %s. Should have failed.", admins,
                                 spiderman));
-    } catch (RoleNotFoundException expected) {
+    } catch (PrincipalNotFoundException expected) {
       // expected
     }
   }

--- a/cdap-client/src/main/java/co/cask/cdap/client/AuthorizationClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/AuthorizationClient.java
@@ -213,10 +213,12 @@ public class AuthorizationClient extends AbstractAuthorizer {
     FeatureDisabledException, UnauthenticatedException, IOException, NotFoundException, UnauthorizedException {
     HttpResponse httpResponse = doExecuteRequest(request, HttpURLConnection.HTTP_NOT_FOUND);
     if (HttpURLConnection.HTTP_NOT_FOUND == httpResponse.getResponseCode()) {
-      if (!listAllRoles().contains(new Role(principal.getName()))) {
-        throw new NotFoundException("Role: " + principal.getName());
+      if (principal.getType().equals(Principal.PrincipalType.ROLE) &&
+        httpResponse.getResponseMessage().equals(String.format("%s not found.", principal.getName()))) {
+        throw new NotFoundException(principal.getName());
+      } else {
+        throw new NotFoundException(entityId);
       }
-      throw new NotFoundException(entityId);
     }
     return httpResponse;
   }

--- a/cdap-client/src/main/java/co/cask/cdap/client/AuthorizationClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/AuthorizationClient.java
@@ -103,7 +103,7 @@ public class AuthorizationClient extends AbstractAuthorizer {
 
     URL url = config.resolveURLV3(AUTHORIZATION_BASE + "/privileges/grant");
     HttpRequest request = HttpRequest.post(url).withBody(GSON.toJson(grantRequest)).build();
-    executePrivilegeRequest(entity, request);
+    executePrivilegeRequest(entity, principal, request);
   }
 
   @Override
@@ -184,7 +184,7 @@ public class AuthorizationClient extends AbstractAuthorizer {
     throws IOException, UnauthenticatedException, FeatureDisabledException, UnauthorizedException, NotFoundException {
     URL url = config.resolveURLV3(AUTHORIZATION_BASE + "/privileges/revoke");
     HttpRequest request = HttpRequest.post(url).withBody(GSON.toJson(revokeRequest)).build();
-    executePrivilegeRequest(revokeRequest.getEntity(), request);
+    executePrivilegeRequest(revokeRequest.getEntity(), revokeRequest.getPrincipal(), request);
   }
 
   private Set<Role> listRolesHelper(@Nullable Principal principal) throws IOException, FeatureDisabledException,
@@ -209,10 +209,13 @@ public class AuthorizationClient extends AbstractAuthorizer {
     }
   }
 
-  private HttpResponse executePrivilegeRequest(EntityId entityId, HttpRequest request) throws FeatureDisabledException,
-    UnauthenticatedException, IOException, NotFoundException, UnauthorizedException {
+  private HttpResponse executePrivilegeRequest(EntityId entityId, Principal principal, HttpRequest request) throws
+    FeatureDisabledException, UnauthenticatedException, IOException, NotFoundException, UnauthorizedException {
     HttpResponse httpResponse = doExecuteRequest(request, HttpURLConnection.HTTP_NOT_FOUND);
     if (HttpURLConnection.HTTP_NOT_FOUND == httpResponse.getResponseCode()) {
+      if (!listAllRoles().contains(new Role(principal.getName()))) {
+        throw new NotFoundException("Role: " + principal.getName());
+      }
       throw new NotFoundException(entityId);
     }
     return httpResponse;

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/Authorizer.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/Authorizer.java
@@ -101,7 +101,7 @@ public interface Authorizer extends PrivilegesFetcher, AuthorizationEnforcer {
    * Drop a role.
    *
    * @param role the {@link Role} to drop
-   * @throws RoleNotFoundException if the role to be dropped is not found
+   * @throws PrincipalNotFoundException if the role to be dropped is not found
    */
   void dropRole(Role role) throws Exception;
 
@@ -110,7 +110,7 @@ public interface Authorizer extends PrivilegesFetcher, AuthorizationEnforcer {
    *
    * @param role the {@link Role} to add to the specified group
    * @param principal the {@link Principal} to add the role to
-   * @throws RoleNotFoundException if the role to be added to the principals is not found
+   * @throws PrincipalNotFoundException if the role to be added to the principals is not found
    */
   void addRoleToPrincipal(Role role, Principal principal) throws Exception;
 
@@ -119,7 +119,7 @@ public interface Authorizer extends PrivilegesFetcher, AuthorizationEnforcer {
    *
    * @param role the {@link Role} to remove from the specified group
    * @param principal the {@link Principal} to remove the role from
-   * @throws RoleNotFoundException if the role to be removed to the principals is not found
+   * @throws PrincipalNotFoundException if the role to be removed to the principals is not found
    */
   void removeRoleFromPrincipal(Role role, Principal principal) throws Exception;
 

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/PrincipalNotFoundException.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/PrincipalNotFoundException.java
@@ -24,8 +24,8 @@ import java.net.HttpURLConnection;
 /**
  * Exception thrown when a {@link Role} is not found
  */
-public class RoleNotFoundException extends Exception implements HttpErrorStatusProvider {
-  public RoleNotFoundException(Role role) {
+public class PrincipalNotFoundException extends Exception implements HttpErrorStatusProvider {
+  public PrincipalNotFoundException(Role role) {
     super(String.format("%s not found.", role));
   }
 

--- a/cdap-security-spi/src/test/java/co/cask/cdap/security/spi/authorization/AuthorizerTest.java
+++ b/cdap-security-spi/src/test/java/co/cask/cdap/security/spi/authorization/AuthorizerTest.java
@@ -151,7 +151,7 @@ public abstract class AuthorizerTest {
     try {
       authorizer.dropRole(admins);
       Assert.fail(String.format("Dropped a role %s which does not exists. Should have failed.", admins.getName()));
-    } catch (RoleNotFoundException expected) {
+    } catch (PrincipalNotFoundException expected) {
       // expected
     }
 
@@ -163,7 +163,7 @@ public abstract class AuthorizerTest {
     try {
       authorizer.addRoleToPrincipal(admins, spiderman);
       Assert.fail(String.format("Added role %s to principal %s. Should have failed.", admins, spiderman));
-    } catch (RoleNotFoundException expected) {
+    } catch (PrincipalNotFoundException expected) {
       // expectedRoles
     }
 
@@ -206,7 +206,7 @@ public abstract class AuthorizerTest {
       authorizer.removeRoleFromPrincipal(admins, spiderman);
       Assert.fail(String.format("Removed non-existing role %s from principal %s. Should have failed.", admins,
                                 spiderman));
-    } catch (RoleNotFoundException expected) {
+    } catch (PrincipalNotFoundException expected) {
       // expectedRoles
     }
   }

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizerInstantiatorTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizerInstantiatorTest.java
@@ -231,6 +231,7 @@ public class AuthorizerInstantiatorTest extends AuthorizationTestBase {
   }
 
   public static final class ExceptionInInitialize extends NoOpAuthorizer {
+
     @Override
     public void initialize(AuthorizationContext context) throws Exception {
       throw new IllegalStateException("Testing exception during initialize");

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/InMemoryAuthorizer.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/InMemoryAuthorizer.java
@@ -24,8 +24,8 @@ import co.cask.cdap.proto.security.Role;
 import co.cask.cdap.security.spi.authorization.AbstractAuthorizer;
 import co.cask.cdap.security.spi.authorization.AuthorizationContext;
 import co.cask.cdap.security.spi.authorization.Authorizer;
+import co.cask.cdap.security.spi.authorization.PrincipalNotFoundException;
 import co.cask.cdap.security.spi.authorization.RoleAlreadyExistsException;
-import co.cask.cdap.security.spi.authorization.RoleNotFoundException;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import com.google.common.base.Splitter;
 import com.google.common.collect.HashBasedTable;
@@ -117,25 +117,25 @@ public class InMemoryAuthorizer extends AbstractAuthorizer {
   }
 
   @Override
-  public void dropRole(Role role) throws RoleNotFoundException {
+  public void dropRole(Role role) throws PrincipalNotFoundException {
     if (!roleToPrincipals.containsKey(role)) {
-      throw new RoleNotFoundException(role);
+      throw new PrincipalNotFoundException(role);
     }
     roleToPrincipals.remove(role);
   }
 
   @Override
-  public void addRoleToPrincipal(Role role, Principal principal) throws RoleNotFoundException {
+  public void addRoleToPrincipal(Role role, Principal principal) throws PrincipalNotFoundException {
     if (!roleToPrincipals.containsKey(role)) {
-      throw new RoleNotFoundException(role);
+      throw new PrincipalNotFoundException(role);
     }
     roleToPrincipals.get(role).add(principal);
   }
 
   @Override
-  public void removeRoleFromPrincipal(Role role, Principal principal) throws RoleNotFoundException {
+  public void removeRoleFromPrincipal(Role role, Principal principal) throws PrincipalNotFoundException {
     if (!roleToPrincipals.containsKey(role)) {
-      throw new RoleNotFoundException(role);
+      throw new PrincipalNotFoundException(role);
     }
     roleToPrincipals.get(role).remove(principal);
   }


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-6147
For the grant/revoke requests, if a NotFoundException is thrown, it can be either principal not found or entity not found. Check if the role in the request exists first or it will be an entity not found exception.
