### PR TITLE
Remote store implementation

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -53,6 +53,7 @@ import co.cask.cdap.gateway.handlers.UsageHandler;
 import co.cask.cdap.gateway.handlers.VersionHandler;
 import co.cask.cdap.gateway.handlers.WorkflowHttpHandler;
 import co.cask.cdap.gateway.handlers.WorkflowStatsSLAHttpHandler;
+import co.cask.cdap.gateway.handlers.meta.RemoteRuntimeStoreHandler;
 import co.cask.cdap.internal.app.deploy.LocalApplicationManager;
 import co.cask.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
 import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
@@ -307,6 +308,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       handlerBinder.addBinding().to(ArtifactHttpHandler.class);
       handlerBinder.addBinding().to(WorkflowStatsSLAHttpHandler.class);
       handlerBinder.addBinding().to(AuthorizationHandler.class);
+      handlerBinder.addBinding().to(RemoteRuntimeStoreHandler.class);
 
       for (Class<? extends HttpHandler> handlerClass : handlerClasses) {
         handlerBinder.addBinding().to(handlerClass);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -20,6 +20,7 @@ import co.cask.cdap.app.deploy.ManagerFactory;
 import co.cask.cdap.app.mapreduce.DistributedMRJobInfoFetcher;
 import co.cask.cdap.app.mapreduce.LocalMRJobInfoFetcher;
 import co.cask.cdap.app.mapreduce.MRJobInfoFetcher;
+import co.cask.cdap.app.store.RuntimeStore;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
@@ -72,6 +73,7 @@ import co.cask.cdap.internal.app.services.AppFabricServer;
 import co.cask.cdap.internal.app.services.ProgramLifecycleService;
 import co.cask.cdap.internal.app.services.StandaloneAppFabricServer;
 import co.cask.cdap.internal.app.store.DefaultStore;
+import co.cask.cdap.internal.app.store.remote.RemoteRuntimeStore;
 import co.cask.cdap.internal.pipeline.SynchronousPipelineFactory;
 import co.cask.cdap.logging.run.InMemoryAppFabricServiceManager;
 import co.cask.cdap.logging.run.InMemoryDatasetExecutorServiceManager;
@@ -275,7 +277,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       install(
         new FactoryModuleBuilder()
           .implement(new TypeLiteral<Manager<AppDeploymentInfo, ApplicationWithPrograms>>() {
-          },
+                     },
                      new TypeLiteral<LocalApplicationManager<AppDeploymentInfo, ApplicationWithPrograms>>() {
                      })
           .build(new TypeLiteral<ManagerFactory<AppDeploymentInfo, ApplicationWithPrograms>>() {
@@ -283,6 +285,8 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       );
 
       bind(Store.class).to(DefaultStore.class);
+      // we can simply use DefaultStore for RuntimeStore, when its not running in a separate container
+      bind(RuntimeStore.class).to(DefaultStore.class);
       bind(ArtifactStore.class).in(Scopes.SINGLETON);
       bind(ProgramLifecycleService.class).in(Scopes.SINGLETON);
       bind(NamespaceAdmin.class).to(DefaultNamespaceAdmin.class).in(Scopes.SINGLETON);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/RuntimeStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/RuntimeStore.java
@@ -24,13 +24,12 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.WorkflowNodeStateDetail;
 import co.cask.cdap.proto.id.ProgramRunId;
-import com.google.common.annotations.VisibleForTesting;
 
 import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
- * Manages the runtime lifecycle of a {@link Program}.
+ * A store for runtime information of a {@link Program}.
  */
 public interface RuntimeStore {
 
@@ -38,20 +37,20 @@ public interface RuntimeStore {
    * Compare and set operation that allow to compare and set expected and update status.
    * Implementation of this method should guarantee that the operation is atomic or in transaction.
    *
-   * @param id              Info about program
-   * @param pid             The run id
-   * @param expectedStatus  The expected value
-   * @param updateStatus    The new value
+   * @param id id of the program
+   * @param pid the run id
+   * @param expectedStatus the expected value
+   * @param newStatus the new value
    */
-  void compareAndSetStatus(Id.Program id, String pid, ProgramRunStatus expectedStatus, ProgramRunStatus updateStatus);
+  void compareAndSetStatus(Id.Program id, String pid, ProgramRunStatus expectedStatus, ProgramRunStatus newStatus);
 
   /**
    * Logs start of program run.
    *
-   * @param id         Info about program
-   * @param pid        run id
-   * @param startTime  start timestamp in seconds; if run id is time-based pass the time from the run id
-   * @param twillRunId twill run id
+   * @param id id of the program
+   * @param pid run id
+   * @param startTime start timestamp in seconds; if run id is time-based pass the time from the run id
+   * @param twillRunId Twill run id
    * @param runtimeArgs the runtime arguments for this program run
    * @param systemArgs the system arguments for this program run
    */
@@ -59,33 +58,22 @@ public interface RuntimeStore {
                 Map<String, String> runtimeArgs, Map<String, String> systemArgs);
 
   /**
-   * Logs start of program run. This is a convenience method for testing, actual run starts should be recorded using
-   * {@link #setStart(Id.Program, String, long, String, Map, Map)}.
-   *
-   * @param id        Info about program
-   * @param pid       run id
-   * @param startTime start timestamp in seconds; if run id is time-based pass the time from the run id
-   */
-  @VisibleForTesting
-  void setStart(Id.Program id, String pid, long startTime);
-
-  /**
    * Logs end of program run.
    *
-   * @param id      id of program
-   * @param pid     run id
+   * @param id id of the program
+   * @param pid run id
    * @param endTime end timestamp in seconds
-   * @param runStatus   {@link ProgramRunStatus} of program run
+   * @param runStatus {@link ProgramRunStatus} of program run
    */
   void setStop(Id.Program id, String pid, long endTime, ProgramRunStatus runStatus);
 
   /**
    * Logs end of program run.
    *
-   * @param id      id of program
-   * @param pid     run id
+   * @param id id of the program
+   * @param pid run id
    * @param endTime end timestamp in seconds
-   * @param runStatus   {@link ProgramRunStatus} of program run
+   * @param runStatus {@link ProgramRunStatus} of program run
    * @param failureCause failure cause if the program failed to execute
    */
   void setStop(Id.Program id, String pid, long endTime, ProgramRunStatus runStatus,
@@ -93,15 +81,17 @@ public interface RuntimeStore {
 
   /**
    * Logs suspend of a program run.
-   * @param id      id of the program
-   * @param pid     run id
+   *
+   * @param id id of the program
+   * @param pid run id
    */
   void setSuspend(Id.Program id, String pid);
 
   /**
    * Logs resume of a program run.
-   * @param id      id of the program
-   * @param pid     run id
+   *
+   * @param id id of the program
+   * @param pid run id
    */
   void setResume(Id.Program id, String pid);
 
@@ -116,6 +106,7 @@ public interface RuntimeStore {
   /**
    * Add node state for the given {@link Workflow} run. This method is used to update the
    * state of the custom actions started by Workflow.
+   *
    * @param workflowRunId the Workflow run
    * @param nodeStateDetail the node state to be added for the Workflow run
    */

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/RuntimeStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/RuntimeStore.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.store;
+
+import co.cask.cdap.api.workflow.Workflow;
+import co.cask.cdap.api.workflow.WorkflowToken;
+import co.cask.cdap.app.program.Program;
+import co.cask.cdap.proto.BasicThrowable;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.WorkflowNodeStateDetail;
+import co.cask.cdap.proto.id.ProgramRunId;
+import com.google.common.annotations.VisibleForTesting;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Manages the runtime lifecycle of a {@link Program}.
+ */
+public interface RuntimeStore {
+
+  /**
+   * Compare and set operation that allow to compare and set expected and update status.
+   * Implementation of this method should guarantee that the operation is atomic or in transaction.
+   *
+   * @param id              Info about program
+   * @param pid             The run id
+   * @param expectedStatus  The expected value
+   * @param updateStatus    The new value
+   */
+  void compareAndSetStatus(Id.Program id, String pid, ProgramRunStatus expectedStatus, ProgramRunStatus updateStatus);
+
+  /**
+   * Logs start of program run.
+   *
+   * @param id         Info about program
+   * @param pid        run id
+   * @param startTime  start timestamp in seconds; if run id is time-based pass the time from the run id
+   * @param twillRunId twill run id
+   * @param runtimeArgs the runtime arguments for this program run
+   * @param systemArgs the system arguments for this program run
+   */
+  void setStart(Id.Program id, String pid, long startTime, @Nullable String twillRunId,
+                Map<String, String> runtimeArgs, Map<String, String> systemArgs);
+
+  /**
+   * Logs start of program run. This is a convenience method for testing, actual run starts should be recorded using
+   * {@link #setStart(Id.Program, String, long, String, Map, Map)}.
+   *
+   * @param id        Info about program
+   * @param pid       run id
+   * @param startTime start timestamp in seconds; if run id is time-based pass the time from the run id
+   */
+  @VisibleForTesting
+  void setStart(Id.Program id, String pid, long startTime);
+
+  /**
+   * Logs end of program run.
+   *
+   * @param id      id of program
+   * @param pid     run id
+   * @param endTime end timestamp in seconds
+   * @param runStatus   {@link ProgramRunStatus} of program run
+   */
+  void setStop(Id.Program id, String pid, long endTime, ProgramRunStatus runStatus);
+
+  /**
+   * Logs end of program run.
+   *
+   * @param id      id of program
+   * @param pid     run id
+   * @param endTime end timestamp in seconds
+   * @param runStatus   {@link ProgramRunStatus} of program run
+   * @param failureCause failure cause if the program failed to execute
+   */
+  void setStop(Id.Program id, String pid, long endTime, ProgramRunStatus runStatus,
+               @Nullable BasicThrowable failureCause);
+
+  /**
+   * Logs suspend of a program run.
+   * @param id      id of the program
+   * @param pid     run id
+   */
+  void setSuspend(Id.Program id, String pid);
+
+  /**
+   * Logs resume of a program run.
+   * @param id      id of the program
+   * @param pid     run id
+   */
+  void setResume(Id.Program id, String pid);
+
+  /**
+   * Updates the {@link WorkflowToken} for a specified run of a workflow.
+   *
+   * @param workflowRunId workflow run for which the {@link WorkflowToken} is to be updated
+   * @param token the {@link WorkflowToken} to update
+   */
+  void updateWorkflowToken(ProgramRunId workflowRunId, WorkflowToken token);
+
+  /**
+   * Add node state for the given {@link Workflow} run. This method is used to update the
+   * state of the custom actions started by Workflow.
+   * @param workflowRunId the Workflow run
+   * @param nodeStateDetail the node state to be added for the Workflow run
+   */
+  void addWorkflowNodeState(ProgramRunId workflowRunId, WorkflowNodeStateDetail nodeStateDetail);
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/ServiceStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/ServiceStore.java
@@ -51,7 +51,7 @@ public interface ServiceStore extends Service {
    * @param instanceId The instance Id to be restarted.
    */
   void setRestartInstanceRequest(String serviceName, long startTime, long endTime, boolean isSuccess,
-                                  int instanceId);
+                                 int instanceId);
 
   /**
    * Update the service instances restart request.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.app.store;
 
 import co.cask.cdap.api.ProgramSpecification;
+import co.cask.cdap.api.app.Application;
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.data.stream.StreamSpecification;
 import co.cask.cdap.api.flow.FlowSpecification;
@@ -35,6 +36,7 @@ import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.WorkflowNodeStateDetail;
 import co.cask.cdap.proto.WorkflowStatistics;
 import co.cask.cdap.proto.id.ProgramRunId;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
 import org.apache.twill.api.RunId;
 
@@ -46,8 +48,7 @@ import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
- * {@link Store} operates on a {@link Program}. It's responsible
- * for managing the lifecycle of a {@link Program}.
+ * Responsible for managing {@link Program} and {@link Application} metadata.
  */
 public interface Store extends RuntimeStore {
 
@@ -62,10 +63,21 @@ public interface Store extends RuntimeStore {
                                                            ProgramNotFoundException;
 
   /**
+   * Logs start of program run. This is a convenience method for testing, actual run starts should be recorded using
+   * {@link #setStart(Id.Program, String, long, String, Map, Map)}.
+   *
+   * @param id        id of the program
+   * @param pid       run id
+   * @param startTime start timestamp in seconds; if run id is time-based pass the time from the run id
+   */
+  @VisibleForTesting
+  void setStart(Id.Program id, String pid, long startTime);
+
+  /**
    * Fetches run records for particular program. Returns only finished runs.
    * Returned ProgramRunRecords are sorted by their startTime.
    *
-   * @param id        program id.
+   * @param id        id of the program
    * @param status    status of the program running/completed/failed or all
    * @param startTime fetch run history that has started after the startTime in seconds
    * @param endTime   fetch run history that has started before the endTime in seconds
@@ -78,7 +90,7 @@ public interface Store extends RuntimeStore {
    * Fetches run records for particular program. Returns only finished runs.
    * Returned ProgramRunRecords are sorted by their startTime.
    *
-   * @param id        program id.
+   * @param id        id of the program
    * @param status    status of the program running/completed/failed or all
    * @param startTime fetch run history that has started after the startTime in seconds
    * @param endTime   fetch run history that has started before the endTime in seconds
@@ -100,7 +112,7 @@ public interface Store extends RuntimeStore {
   /**
    * Fetches the run record for particular run of a program.
    *
-   * @param id        program id
+   * @param id        id of the program
    * @param runid     run id of the program
    * @return          run record for the specified program and runid, null if not found
    */
@@ -186,14 +198,14 @@ public interface Store extends RuntimeStore {
   /**
    * Sets the number of instances of a service.
    *
-   * @param id program id
+   * @param id id of the program
    * @param instances number of instances
    */
   void setServiceInstances(Id.Program id, int instances);
 
   /**
    * Returns the number of instances of a service.
-   * @param id program id
+   * @param id id of the program
    * @return number of instances
    */
   int getServiceInstances(Id.Program id);
@@ -201,7 +213,7 @@ public interface Store extends RuntimeStore {
   /**
    * Sets the number of instances of a {@link Worker}
    *
-   * @param id program id
+   * @param id id of the program
    * @param instances number of instances
    */
   void setWorkerInstances(Id.Program id, int instances);
@@ -209,7 +221,7 @@ public interface Store extends RuntimeStore {
   /**
    * Gets the number of instances of a {@link Worker}
    *
-   * @param id program id
+   * @param id id of the program
    * @return number of instances
    */
   int getWorkerInstances(Id.Program id);
@@ -267,7 +279,7 @@ public interface Store extends RuntimeStore {
 
   /**
    * Check if a program exists.
-   * @param id id of program.
+   * @param id id of the program
    * @return true if the program exists, false otherwise.
    */
   boolean programExists(Id.Program id);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteRuntimeStoreHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteRuntimeStoreHandler.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.handlers.meta;
+
+import co.cask.cdap.api.workflow.WorkflowToken;
+import co.cask.cdap.app.store.Store;
+import co.cask.cdap.internal.app.store.remote.MethodArgument;
+import co.cask.cdap.proto.BasicThrowable;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.WorkflowNodeStateDetail;
+import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.http.AbstractHttpHandler;
+import co.cask.http.HttpResponder;
+import com.google.common.base.Charsets;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.reflect.TypeToken;
+import com.google.inject.Inject;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+/**
+ * The {@link co.cask.http.HttpHandler} for handling REST calls to meta stores.
+ */
+// we don't share the same version as other handlers, so we can upgrade/iterate faster
+@Path("/v1/execute")
+public class RemoteRuntimeStoreHandler extends AbstractHttpHandler {
+
+  private static final Gson GSON = new Gson();
+  private static final Type METHOD_ARGUMENT_LIST_TYPE = new TypeToken<List<MethodArgument>>() { }.getType();
+
+  private final Store store;
+
+  @Inject
+  public RemoteRuntimeStoreHandler(Store store) {
+    this.store = store;
+  }
+
+  @POST
+  @Path("/compareAndSetStatus")
+  public void compareAndSetStatus(HttpRequest request, HttpResponder responder) throws ClassNotFoundException {
+    List<MethodArgument> arguments = parseArguments(request);
+
+    Id.Program program = deserialize(arguments.get(0));
+    String pid = deserialize(arguments.get(1));
+    ProgramRunStatus expectedStatus = deserialize(arguments.get(2));
+    ProgramRunStatus updateStatus = deserialize(arguments.get(3));
+    store.compareAndSetStatus(program, pid, expectedStatus, updateStatus);
+
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  @POST
+  @Path("/setStartWithTwillRunId")
+  public void setStartWithTwillRunId(HttpRequest request, HttpResponder responder) throws ClassNotFoundException {
+    List<MethodArgument> arguments = parseArguments(request);
+
+    Id.Program program = deserialize(arguments.get(0));
+    String pid = deserialize(arguments.get(1));
+    long startTime = deserialize(arguments.get(2));
+    String twillRunId = deserialize(arguments.get(3));
+    Map<String, String> runtimeArgs = deserialize(arguments.get(4));
+    Map<String, String> systemArgs = deserialize(arguments.get(5));
+    store.setStart(program, pid, startTime, twillRunId, runtimeArgs, systemArgs);
+
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  @POST
+  @Path("/setStart")
+  public void setStart(HttpRequest request, HttpResponder responder) throws ClassNotFoundException {
+    List<MethodArgument> arguments = parseArguments(request);
+
+    Id.Program program = deserialize(arguments.get(0));
+    String pid = deserialize(arguments.get(1));
+    long startTime = deserialize(arguments.get(2));
+    store.setStart(program, pid, startTime);
+
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  @POST
+  @Path("/setStop")
+  public void setStop(HttpRequest request, HttpResponder responder) throws ClassNotFoundException {
+    List<MethodArgument> arguments = parseArguments(request);
+
+    Id.Program program = deserialize(arguments.get(0));
+    String pid = deserialize(arguments.get(1));
+    long endTime = deserialize(arguments.get(2));
+    ProgramRunStatus runStatus = deserialize(arguments.get(3));
+    BasicThrowable failureCause = deserialize(arguments.get(4));
+    store.setStop(program, pid, endTime, runStatus, failureCause);
+
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  @POST
+  @Path("/setSuspend")
+  public void setSuspend(HttpRequest request, HttpResponder responder) throws ClassNotFoundException {
+    List<MethodArgument> arguments = parseArguments(request);
+
+    Id.Program program = deserialize(arguments.get(0));
+    String pid = deserialize(arguments.get(1));
+    store.setSuspend(program, pid);
+
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  @POST
+  @Path("/setResume")
+  public void setResume(HttpRequest request, HttpResponder responder) throws ClassNotFoundException {
+    List<MethodArgument> arguments = parseArguments(request);
+
+    Id.Program program = deserialize(arguments.get(0));
+    String pid = deserialize(arguments.get(1));
+    store.setResume(program, pid);
+
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+
+  @POST
+  @Path("/updateWorkflowToken")
+  public void updateWorkflowToken(HttpRequest request, HttpResponder responder) throws ClassNotFoundException {
+    List<MethodArgument> arguments = parseArguments(request);
+
+    ProgramRunId workflowRunId = deserialize(arguments.get(0));
+    WorkflowToken token = deserialize(arguments.get(1));
+    store.updateWorkflowToken(workflowRunId, token);
+
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  @POST
+  @Path("/addWorkflowNodeState")
+  public void addWorkflowNodeState(HttpRequest request, HttpResponder responder) throws ClassNotFoundException {
+    List<MethodArgument> arguments = parseArguments(request);
+
+    ProgramRunId workflowRunId = deserialize(arguments.get(0));
+    WorkflowNodeStateDetail nodeStateDetail = deserialize(arguments.get(1));
+    store.addWorkflowNodeState(workflowRunId, nodeStateDetail);
+
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  private List<MethodArgument> parseArguments(HttpRequest request) {
+    String body = request.getContent().toString(Charsets.UTF_8);
+    return GSON.fromJson(body, METHOD_ARGUMENT_LIST_TYPE);
+  }
+
+  @Nullable
+  private <T> T deserialize(@Nullable MethodArgument argument) throws ClassNotFoundException {
+    if (argument == null) {
+      return null;
+    }
+    JsonElement value = argument.getValue();
+    if (value == null) {
+      return null;
+    }
+    return GSON.<T>fromJson(value, Class.forName(argument.getType()));
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/package-info.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Classes to handle REST calls to meta stores.
+ */
+package co.cask.cdap.gateway.handlers.meta;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/package-info.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * Classes to handle REST calls to meta stores.
+ * Classes to handle REST calls to meta data stores.
  */
 package co.cask.cdap.gateway.handlers.meta;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
@@ -112,20 +112,11 @@ public abstract class AbstractAppFabricHttpHandler extends AbstractHttpHandler {
   }
 
   protected Map<String, String> decodeArguments(HttpRequest request) throws JsonSyntaxException {
-    ChannelBuffer content = request.getContent();
-    if (!content.readable()) {
+    Map<String, String> args = parseBody(request, STRING_MAP_TYPE);
+    if (args == null) {
       return ImmutableMap.of();
     }
-    Reader reader = new InputStreamReader(new ChannelBufferInputStream(content), Charsets.UTF_8);
-    try {
-      Map<String, String> args = GSON.fromJson(reader, STRING_MAP_TYPE);
-      return args == null ? ImmutableMap.<String, String>of() : args;
-    } catch (JsonSyntaxException e) {
-      LOG.info("Failed to parse runtime arguments on {}", request.getUri(), e);
-      throw e;
-    } finally {
-      Closeables.closeQuietly(reader);
-    }
+    return args;
   }
 
   protected final void programList(HttpResponder responder, String namespaceId, ProgramType type,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ApplicationSpecificationAdapter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ApplicationSpecificationAdapter.java
@@ -32,7 +32,8 @@ import co.cask.cdap.api.workflow.WorkflowNode;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
 import co.cask.cdap.internal.io.SchemaGenerator;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
-import co.cask.cdap.proto.WorkflowNodeThrowable;
+import co.cask.cdap.proto.BasicThrowable;
+import co.cask.cdap.proto.codec.BasicThrowableCodec;
 import co.cask.cdap.proto.codec.FlowSpecificationCodec;
 import co.cask.cdap.proto.codec.FlowletSpecificationCodec;
 import co.cask.cdap.proto.codec.MapReduceSpecificationCodec;
@@ -41,7 +42,6 @@ import co.cask.cdap.proto.codec.SparkSpecificationCodec;
 import co.cask.cdap.proto.codec.WorkerSpecificationCodec;
 import co.cask.cdap.proto.codec.WorkflowActionSpecificationCodec;
 import co.cask.cdap.proto.codec.WorkflowNodeCodec;
-import co.cask.cdap.proto.codec.WorkflowNodeThrowableCodec;
 import co.cask.cdap.proto.codec.WorkflowSpecificationCodec;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -94,7 +94,7 @@ public final class ApplicationSpecificationAdapter {
       .registerTypeAdapter(ScheduleSpecification.class, new ScheduleSpecificationCodec())
       .registerTypeAdapter(ServiceSpecification.class, new ServiceSpecificationCodec())
       .registerTypeAdapter(WorkerSpecification.class, new WorkerSpecificationCodec())
-      .registerTypeAdapter(WorkflowNodeThrowable.class, new WorkflowNodeThrowableCodec())
+      .registerTypeAdapter(BasicThrowable.class, new BasicThrowableCodec())
       .registerTypeAdapterFactory(new AppSpecTypeAdapterFactory());
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -46,6 +46,7 @@ import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.internal.app.runtime.workflow.NameMappedDatasetFramework;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
 import co.cask.cdap.internal.lang.Reflections;
+import co.cask.cdap.proto.BasicThrowable;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
@@ -248,7 +249,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
       public void failed(Service.State from, @Nullable Throwable failure) {
         closeAllQuietly(closeables);
         store.setStop(program.getId(), runId.getId(), TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()),
-                      ProgramController.State.ERROR.getRunStatus(), failure);
+                      ProgramController.State.ERROR.getRunStatus(), new BasicThrowable(failure));
       }
     };
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
@@ -27,6 +27,7 @@ import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramResourceReporter;
 import co.cask.cdap.app.runtime.ProgramRunner;
+import co.cask.cdap.app.store.RuntimeStore;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.app.stream.DefaultStreamWriter;
 import co.cask.cdap.app.stream.StreamWriterFactory;
@@ -56,6 +57,7 @@ import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
 import co.cask.cdap.internal.app.runtime.codec.ArgumentsCodec;
 import co.cask.cdap.internal.app.runtime.codec.ProgramOptionsCodec;
 import co.cask.cdap.internal.app.store.DefaultStore;
+import co.cask.cdap.internal.app.store.remote.RemoteRuntimeStore;
 import co.cask.cdap.logging.appender.LogAppenderInitializer;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
@@ -447,7 +449,7 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
             }
           });
 
-          bind(Store.class).to(DefaultStore.class);
+          bind(RuntimeStore.class).to(RemoteRuntimeStore.class);
           bind(NamespaceStore.class).to(DefaultNamespaceStore.class);
 
           // For binding StreamWriter

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -59,9 +59,9 @@ import co.cask.cdap.internal.app.workflow.DefaultWorkflowActionConfigurer;
 import co.cask.cdap.internal.dataset.DatasetCreationSpec;
 import co.cask.cdap.internal.workflow.ProgramWorkflowAction;
 import co.cask.cdap.logging.context.WorkflowLoggingContext;
+import co.cask.cdap.proto.BasicThrowable;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.WorkflowNodeStateDetail;
-import co.cask.cdap.proto.WorkflowNodeThrowable;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.http.NettyHttpService;
@@ -427,7 +427,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
       store.updateWorkflowToken(workflowRunId, token);
       NodeStatus status = failureCause == null ? NodeStatus.COMPLETED : NodeStatus.FAILED;
       nodeStates.put(node.getNodeId(), new WorkflowNodeState(node.getNodeId(), status, null, failureCause));
-      WorkflowNodeThrowable defaultThrowable = failureCause == null ? null : new WorkflowNodeThrowable(failureCause);
+      BasicThrowable defaultThrowable = failureCause == null ? null : new BasicThrowable(failureCause);
       store.addWorkflowNodeState(workflowRunId, new WorkflowNodeStateDetail(node.getNodeId(), status, null,
                                                                             defaultThrowable));
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.internal.app.runtime.workflow;
 
 import co.cask.cdap.api.Predicate;
@@ -42,7 +43,7 @@ import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.Arguments;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunnerFactory;
-import co.cask.cdap.app.store.Store;
+import co.cask.cdap.app.store.RuntimeStore;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
@@ -120,29 +121,30 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
   private final ProgramWorkflowRunnerFactory workflowProgramRunnerFactory;
   private final Map<String, WorkflowActionNode> status = new ConcurrentHashMap<>();
   private final LoggingContext loggingContext;
-  private NettyHttpService httpService;
-  private volatile Thread runningThread;
-  private boolean suspended;
-  private Lock lock;
-  private Condition condition;
+  private final Lock lock;
+  private final Condition condition;
   private final MetricsCollectionService metricsCollectionService;
   private final NameMappedDatasetFramework datasetFramework;
   private final DiscoveryServiceClient discoveryServiceClient;
   private final TransactionSystemClient txClient;
-  private final Store store;
+  private final RuntimeStore runtimeStore;
   private final ProgramRunId workflowRunId;
-  private Workflow workflow;
   private final BasicWorkflowContext basicWorkflowContext;
   private final BasicWorkflowToken basicWorkflowToken;
   private final Map<String, WorkflowNodeState> nodeStates = new ConcurrentHashMap<>();
   @Nullable
   private final PluginInstantiator pluginInstantiator;
 
+  private NettyHttpService httpService;
+  private volatile Thread runningThread;
+  private boolean suspended;
+  private Workflow workflow;
+
   WorkflowDriver(Program program, ProgramOptions options, InetAddress hostname,
                  WorkflowSpecification workflowSpec, ProgramRunnerFactory programRunnerFactory,
                  MetricsCollectionService metricsCollectionService,
                  DatasetFramework datasetFramework, DiscoveryServiceClient discoveryServiceClient,
-                 TransactionSystemClient txClient, Store store, CConfiguration cConf,
+                 TransactionSystemClient txClient, RuntimeStore runtimeStore, CConfiguration cConf,
                  @Nullable PluginInstantiator pluginInstantiator) {
     this.program = program;
     this.hostname = hostname;
@@ -162,7 +164,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
                                                            workflowRunId.getRun());
     this.discoveryServiceClient = discoveryServiceClient;
     this.txClient = txClient;
-    this.store = store;
+    this.runtimeStore = runtimeStore;
     this.workflowProgramRunnerFactory = new ProgramWorkflowRunnerFactory(cConf, workflowSpec, programRunnerFactory,
                                                                          program, options);
 
@@ -214,7 +216,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
         } finally {
           ClassLoaders.setContextClassLoader(oldClassLoader);
         }
-        store.updateWorkflowToken(workflowRunId, basicWorkflowToken);
+        runtimeStore.updateWorkflowToken(workflowRunId, basicWorkflowToken);
       }
     } catch (Throwable t) {
       LOG.error(String.format("Failed to initialize the Workflow %s", workflowRunId), t);
@@ -290,7 +292,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
         } finally {
           ClassLoaders.setContextClassLoader(oldClassLoader);
         }
-        store.updateWorkflowToken(workflowRunId, basicWorkflowToken);
+        runtimeStore.updateWorkflowToken(workflowRunId, basicWorkflowToken);
       }
       transactionContext.finish();
     } catch (Throwable t) {
@@ -333,7 +335,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
       executorTerminateLatch.await();
       status.remove(node.getNodeId());
     }
-    store.updateWorkflowToken(workflowRunId, token);
+    runtimeStore.updateWorkflowToken(workflowRunId, token);
   }
 
   private WorkflowActionSpecification getActionSpecification(WorkflowActionNode node,
@@ -402,7 +404,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
       }
     } finally {
       // Update the WorkflowToken after the execution of the FORK node completes.
-      store.updateWorkflowToken(workflowRunId, token);
+      runtimeStore.updateWorkflowToken(workflowRunId, token);
       executorService.shutdownNow();
       // Wait for the executor termination
       executorTerminateLatch.await();
@@ -415,7 +417,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
     CustomActionExecutor customActionExecutor = new CustomActionExecutor(workflowRunId, context,
                                                                          instantiator, classLoader);
     status.put(node.getNodeId(), node);
-    store.addWorkflowNodeState(workflowRunId, new WorkflowNodeStateDetail(node.getNodeId(), NodeStatus.RUNNING));
+    runtimeStore.addWorkflowNodeState(workflowRunId, new WorkflowNodeStateDetail(node.getNodeId(), NodeStatus.RUNNING));
     Throwable failureCause = null;
     try {
       customActionExecutor.execute();
@@ -424,11 +426,11 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
       throw t;
     } finally {
       status.remove(node.getNodeId());
-      store.updateWorkflowToken(workflowRunId, token);
+      runtimeStore.updateWorkflowToken(workflowRunId, token);
       NodeStatus status = failureCause == null ? NodeStatus.COMPLETED : NodeStatus.FAILED;
       nodeStates.put(node.getNodeId(), new WorkflowNodeState(node.getNodeId(), status, null, failureCause));
       BasicThrowable defaultThrowable = failureCause == null ? null : new BasicThrowable(failureCause);
-      store.addWorkflowNodeState(workflowRunId, new WorkflowNodeStateDetail(node.getNodeId(), status, null,
+      runtimeStore.addWorkflowNodeState(workflowRunId, new WorkflowNodeStateDetail(node.getNodeId(), status, null,
                                                                             defaultThrowable));
     }
   }
@@ -480,7 +482,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
     // If a workflow updates its token at a condition node, it will be persisted after the execution of the next node.
     // However, the call below ensures that even if the workflow fails/crashes after a condition node, updates from the
     // condition node are also persisted.
-    store.updateWorkflowToken(workflowRunId, token);
+    runtimeStore.updateWorkflowToken(workflowRunId, token);
     executeAll(iterator, appSpec, instantiator, classLoader, token);
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramRunner.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.internal.app.runtime.workflow;
 
 import co.cask.cdap.api.app.ApplicationSpecification;
@@ -24,7 +25,7 @@ import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.app.runtime.ProgramRunnerFactory;
-import co.cask.cdap.app.store.Store;
+import co.cask.cdap.app.store.RuntimeStore;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
@@ -57,7 +58,7 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final DatasetFramework datasetFramework;
   private final DiscoveryServiceClient discoveryServiceClient;
   private final TransactionSystemClient txClient;
-  private final Store store;
+  private final RuntimeStore runtimeStore;
   private final CConfiguration cConf;
 
   @Inject
@@ -65,7 +66,7 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
                                @Named(Constants.AppFabric.SERVER_ADDRESS) InetAddress hostname,
                                MetricsCollectionService metricsCollectionService, DatasetFramework datasetFramework,
                                DiscoveryServiceClient discoveryServiceClient, TransactionSystemClient txClient,
-                               Store store, CConfiguration cConf) {
+                               RuntimeStore runtimeStore, CConfiguration cConf) {
     super(cConf);
     this.programRunnerFactory = programRunnerFactory;
     this.serviceAnnouncer = serviceAnnouncer;
@@ -74,7 +75,7 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.datasetFramework = datasetFramework;
     this.discoveryServiceClient = discoveryServiceClient;
     this.txClient = txClient;
-    this.store = store;
+    this.runtimeStore = runtimeStore;
     this.cConf = cConf;
   }
 
@@ -103,7 +104,7 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
     PluginInstantiator pluginInstantiator = createPluginInstantiator(options, program.getClassLoader());
     WorkflowDriver driver = new WorkflowDriver(program, options, hostname, workflowSpec, programRunnerFactory,
                                                metricsCollectionService, datasetFramework, discoveryServiceClient,
-                                               txClient, store, cConf,
+                                               txClient, runtimeStore, cConf,
                                                pluginInstantiator);
     // Controller needs to be created before starting the driver so that the state change of the driver
     // service can be fully captured by the controller.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
@@ -41,6 +41,7 @@ import co.cask.cdap.internal.app.runtime.BasicArguments;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
 import co.cask.cdap.internal.app.store.RunRecordMeta;
+import co.cask.cdap.proto.BasicThrowable;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramStatus;
@@ -327,7 +328,7 @@ public class ProgramLifecycleService extends AbstractIdleService {
         public void error(Throwable cause) {
           LOG.info("Program stopped with error {}, {}", programId, runId, cause);
           store.setStop(programId.toId(), runId, TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()),
-                        ProgramController.State.ERROR.getRunStatus(), cause);
+                        ProgramController.State.ERROR.getRunStatus(), new BasicThrowable(cause));
         }
       }, Threads.SAME_THREAD_EXECUTOR);
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/AppMetadataStore.java
@@ -29,12 +29,12 @@ import co.cask.cdap.data2.dataset2.lib.table.MetadataStoreDataset;
 import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.workflow.BasicWorkflowToken;
+import co.cask.cdap.proto.BasicThrowable;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.WorkflowNodeStateDetail;
-import co.cask.cdap.proto.WorkflowNodeThrowable;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.Ids;
 import co.cask.cdap.proto.id.ProgramId;
@@ -172,7 +172,7 @@ public class AppMetadataStore extends MetadataStoreDataset {
   }
 
   private void addWorkflowNodeState(ProgramId programId, String pid, Map<String, String> systemArgs,
-                                    ProgramRunStatus status, @Nullable Throwable failureCause) {
+                                    ProgramRunStatus status, @Nullable BasicThrowable failureCause) {
     String workflowNodeId = systemArgs.get(ProgramOptionConstants.WORKFLOW_NODE_ID);
     String workflowName = systemArgs.get(ProgramOptionConstants.WORKFLOW_NAME);
     String workflowRun = systemArgs.get(ProgramOptionConstants.WORKFLOW_RUN_ID);
@@ -185,10 +185,9 @@ public class AppMetadataStore extends MetadataStoreDataset {
     MDSKey key = getProgramKeyBuilder(TYPE_WORKFLOW_NODE_STATE, workflowRunId.getParent().toId())
       .add(workflowRun).add(workflowNodeId).build();
 
-    WorkflowNodeThrowable defaultThrowable = failureCause == null ? null : new WorkflowNodeThrowable(failureCause);
     WorkflowNodeStateDetail nodeStateDetail = new WorkflowNodeStateDetail(workflowNodeId,
                                                                           ProgramRunStatus.toNodeStatus(status),
-                                                                          pid, defaultThrowable);
+                                                                          pid, failureCause);
 
     write(key, nodeStateDetail);
 
@@ -286,7 +285,7 @@ public class AppMetadataStore extends MetadataStoreDataset {
   }
 
   public void recordProgramStop(Id.Program program, String pid, long stopTs, ProgramRunStatus runStatus,
-                                @Nullable Throwable failureCause) {
+                                @Nullable BasicThrowable failureCause) {
     MDSKey key = new MDSKey.Builder()
       .add(TYPE_RUN_RECORD_STARTED)
       .add(program.getNamespaceId())

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -211,9 +211,9 @@ public class DefaultStore implements Store {
 
   @Override
   public void compareAndSetStatus(final Id.Program id, final String pid, final ProgramRunStatus expectedStatus,
-                                  final ProgramRunStatus updateStatus) {
+                                  final ProgramRunStatus newStatus) {
     Preconditions.checkArgument(expectedStatus != null, "Expected of program run should be defined");
-    Preconditions.checkArgument(updateStatus != null, "Updated state of program run should be defined");
+    Preconditions.checkArgument(newStatus != null, "New state of program run should be defined");
     appsTx.get().executeUnchecked(new TransactionExecutor.Function<AppMetadataStore, Void>() {
       @Override
       public Void apply(AppMetadataStore mds) throws Exception {
@@ -221,7 +221,7 @@ public class DefaultStore implements Store {
         if (target.getStatus() == expectedStatus) {
           long now = System.currentTimeMillis();
           long nowSecs = TimeUnit.MILLISECONDS.toSeconds(now);
-          switch (updateStatus) {
+          switch (newStatus) {
             case RUNNING:
               Map<String, String> runtimeArgs = GSON.fromJson(target.getProperties().get("runtimeArgs"),
                                                               STRING_MAP_TYPE);
@@ -241,10 +241,10 @@ public class DefaultStore implements Store {
             case COMPLETED:
             case KILLED:
             case FAILED:
-              BasicThrowable failureCause = updateStatus == ProgramRunStatus.FAILED
+              BasicThrowable failureCause = newStatus == ProgramRunStatus.FAILED
                 ? new BasicThrowable(new Throwable("Marking run record as failed since no running program found."))
                 : null;
-              mds.recordProgramStop(id, pid, nowSecs, updateStatus, failureCause);
+              mds.recordProgramStop(id, pid, nowSecs, newStatus, failureCause);
               break;
             default:
               break;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -48,6 +48,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
 import co.cask.cdap.internal.app.ForwardingApplicationSpecification;
 import co.cask.cdap.internal.app.ForwardingFlowSpecification;
+import co.cask.cdap.proto.BasicThrowable;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
@@ -242,7 +243,7 @@ public class DefaultStore implements Store {
             case FAILED:
               Throwable failureCause = updateStatus == ProgramRunStatus.FAILED
                 ? new Throwable("Marking run record as failed since no running program found.") : null;
-              mds.recordProgramStop(id, pid, nowSecs, updateStatus, failureCause);
+              mds.recordProgramStop(id, pid, nowSecs, updateStatus, new BasicThrowable(failureCause));
               break;
             default:
               break;
@@ -278,7 +279,7 @@ public class DefaultStore implements Store {
 
   @Override
   public void setStop(final Id.Program id, final String pid, final long endTime, final ProgramRunStatus runStatus,
-                      final Throwable failureCause) {
+                      final BasicThrowable failureCause) {
     Preconditions.checkArgument(runStatus != null, "Run state of program run should be defined");
     appsTx.get().executeUnchecked(new TransactionExecutor.Function<AppMetadataStore, Void>() {
       @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -241,9 +241,10 @@ public class DefaultStore implements Store {
             case COMPLETED:
             case KILLED:
             case FAILED:
-              Throwable failureCause = updateStatus == ProgramRunStatus.FAILED
-                ? new Throwable("Marking run record as failed since no running program found.") : null;
-              mds.recordProgramStop(id, pid, nowSecs, updateStatus, new BasicThrowable(failureCause));
+              BasicThrowable failureCause = updateStatus == ProgramRunStatus.FAILED
+                ? new BasicThrowable(new Throwable("Marking run record as failed since no running program found."))
+                : null;
+              mds.recordProgramStop(id, pid, nowSecs, updateStatus, failureCause);
               break;
             default:
               break;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/MethodArgument.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/MethodArgument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,8 +14,30 @@
  * the License.
  */
 
-/**
- * Classes to handle data fabric requests.
- */
-package co.cask.cdap.gateway.handlers.dataset;
+package co.cask.cdap.internal.app.store.remote;
 
+import com.google.gson.JsonElement;
+
+import javax.annotation.Nullable;
+
+/**
+ * Allows for simple serialization/deserialization of a method argument.
+ */
+public final class MethodArgument {
+  private final String type;
+  private final JsonElement value;
+
+  public MethodArgument(String type, JsonElement value) {
+    this.type = type;
+    this.value = value;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  @Nullable
+  public JsonElement getValue() {
+    return value;
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeStore.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.store.remote;
+
+import co.cask.cdap.api.workflow.WorkflowToken;
+import co.cask.cdap.app.store.RuntimeStore;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.proto.BasicThrowable;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.WorkflowNodeStateDetail;
+import co.cask.cdap.proto.WorkflowTokenDetail;
+import co.cask.cdap.proto.WorkflowTokenNodeDetail;
+import co.cask.cdap.proto.codec.BasicThrowableCodec;
+import co.cask.cdap.proto.codec.WorkflowTokenDetailCodec;
+import co.cask.cdap.proto.codec.WorkflowTokenNodeDetailCodec;
+import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.common.http.HttpResponse;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.inject.Inject;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+
+import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Implementation of RuntimeStore, which uses an HTTP Client to execute the actual store operations in a remote
+ * server.
+ */
+public class RemoteRuntimeStore extends RemoteStoreClient implements RuntimeStore {
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(BasicThrowable.class, new BasicThrowableCodec())
+    .registerTypeAdapter(WorkflowTokenDetail.class, new WorkflowTokenDetailCodec())
+    .registerTypeAdapter(WorkflowTokenNodeDetail.class, new WorkflowTokenNodeDetailCodec())
+    .create();
+
+  @Inject
+  public RemoteRuntimeStore(CConfiguration cConf, DiscoveryServiceClient discoveryClient) {
+    super(cConf, discoveryClient);
+  }
+
+  @Override
+  public void compareAndSetStatus(Id.Program id, String pid, ProgramRunStatus expectedStatus,
+                                  ProgramRunStatus updateStatus) {
+    executeRequest("compareAndSetStatus",
+                   id, pid, expectedStatus, updateStatus);
+  }
+
+  @Override
+  public void setStart(Id.Program id, String pid, long startTime, @Nullable String twillRunId,
+                       Map<String, String> runtimeArgs, Map<String, String> systemArgs) {
+    executeRequest("setStartWithTwillRunId",
+                   id, pid, startTime, twillRunId, runtimeArgs, systemArgs);
+  }
+
+  @Override
+  public void setStart(Id.Program id, String pid, long startTime) {
+    executeRequest("setStart",
+                   id, pid, startTime);
+  }
+
+  @Override
+  public void setStop(Id.Program id, String pid, long endTime, ProgramRunStatus runStatus) {
+    // delegates on client side; so corresponding method is not required to be implemented on server side
+    setStop(id, pid, endTime, runStatus, null);
+  }
+
+  @Override
+  public void setStop(Id.Program id, String pid, long endTime, ProgramRunStatus runStatus,
+                      @Nullable BasicThrowable failureCause) {
+    executeRequest("setStop",
+                   id, pid, endTime, runStatus, failureCause);
+  }
+
+  @Override
+  public void setSuspend(Id.Program id, String pid) {
+    executeRequest("setSuspend",
+                   id, pid);
+  }
+
+  @Override
+  public void setResume(Id.Program id, String pid) {
+    executeRequest("setResume",
+                   id, pid);
+  }
+
+  @Override
+  public void updateWorkflowToken(ProgramRunId workflowRunId, WorkflowToken token) {
+    executeRequest("updateWorkflowToken",
+                   workflowRunId, token);
+  }
+
+  @Override
+  public void addWorkflowNodeState(ProgramRunId workflowRunId, WorkflowNodeStateDetail nodeStateDetail) {
+    executeRequest("addWorkflowNodeState",
+                   workflowRunId, nodeStateDetail);
+  }
+
+  private void executeRequest(String methodName, Object... arguments) {
+    doPost("execute/" + methodName, GSON.toJson(createRequest(arguments)));
+  }
+
+  private List<MethodArgument> createRequest(Object... arguments) {
+    List<MethodArgument> methodArguments = new ArrayList<>();
+    for (Object param : arguments) {
+      if (param == null) {
+        methodArguments.add(null);
+      } else {
+        String type = param.getClass().getName();
+        methodArguments.add(new MethodArgument(type, GSON.toJsonTree(param)));
+      }
+    }
+    return methodArguments;
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteStoreClient.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteStoreClient.java
@@ -1,0 +1,114 @@
+/*
+* Copyright © 2016 Cask Data, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy of
+* the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations under
+* the License.
+*/
+
+package co.cask.cdap.internal.app.store.remote;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.discovery.EndpointStrategy;
+import co.cask.cdap.common.discovery.RandomEndpointStrategy;
+import co.cask.common.http.HttpMethod;
+import co.cask.common.http.HttpRequest;
+import co.cask.common.http.HttpRequestConfig;
+import co.cask.common.http.HttpRequests;
+import co.cask.common.http.HttpResponse;
+import com.google.common.base.Joiner;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.inject.Inject;
+import org.apache.twill.discovery.Discoverable;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Implements functionality common to making requests from implementations of remote stores.
+ */
+public class RemoteStoreClient {
+
+  private final Supplier<EndpointStrategy> endpointStrategySupplier;
+  private final HttpRequestConfig httpRequestConfig;
+
+  @Inject
+  public RemoteStoreClient(CConfiguration cConf, final DiscoveryServiceClient discoveryClient) {
+    this.endpointStrategySupplier = Suppliers.memoize(new Supplier<EndpointStrategy>() {
+      @Override
+      public EndpointStrategy get() {
+        return new RandomEndpointStrategy(discoveryClient.discover(Constants.Service.APP_FABRIC_HTTP));
+      }
+    });
+
+    int httpClientTimeoutMs = cConf.getInt(Constants.HTTP_CLIENT_TIMEOUT_MS);
+    this.httpRequestConfig = new HttpRequestConfig(httpClientTimeoutMs, httpClientTimeoutMs);
+  }
+
+  private InetSocketAddress getAppFabricServiceAddress() {
+    Discoverable discoverable = endpointStrategySupplier.get().pick(3L, TimeUnit.SECONDS);
+    if (discoverable != null) {
+      return discoverable.getSocketAddress();
+    }
+    throw new RuntimeException(
+      String.format("Cannot discover service %s", Constants.Service.APP_FABRIC_HTTP));
+  }
+
+  private String resolve(String resource) {
+    InetSocketAddress addr = getAppFabricServiceAddress();
+    return String.format("http://%s:%s%s/%s",
+                         addr.getHostName(), addr.getPort(), "/v1", resource);
+  }
+
+  protected HttpResponse doPost(String resource, String body) {
+    return doRequest(resource, "POST", null, body);
+  }
+
+  protected HttpResponse doRequest(String resource, String requestMethod,
+                                   @Nullable Map<String, String> headers, @Nullable String body) {
+    String resolvedUrl = resolve(resource);
+    try {
+      URL url = new URL(resolvedUrl);
+      HttpRequest.Builder builder = HttpRequest.builder(HttpMethod.valueOf(requestMethod), url).addHeaders(headers);
+      if (body != null) {
+        builder.withBody(body);
+      }
+      HttpResponse response = HttpRequests.execute(builder.build(), httpRequestConfig);
+      if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
+        return response;
+      }
+      throw new RuntimeException(String.format("%s Response: %s.",
+                                               createErrorMessage(resolvedUrl, requestMethod, headers, body),
+                                               response));
+    } catch (IOException e) {
+      // throw diff type of Exception?
+      throw new RuntimeException(createErrorMessage(resolvedUrl, requestMethod, headers, body),
+                                 e);
+    }
+  }
+
+  // creates error message, encoding details about the request
+  private String createErrorMessage(String resolvedUrl, String requestMethod,
+                                    @Nullable Map<String, String> headers, @Nullable String body) {
+    return String.format("Error making request to AppFabric Service at %s while doing %s with headers %s and body %s.",
+                         resolvedUrl, requestMethod,
+                         headers == null ? "null" : Joiner.on(",").withKeyValueSeparator("=").join(headers),
+                         body == null ? "null" : body);
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
@@ -59,12 +59,12 @@ import co.cask.cdap.internal.DefaultId;
 import co.cask.cdap.internal.app.deploy.Specifications;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
+import co.cask.cdap.proto.BasicThrowable;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.WorkflowNodeStateDetail;
-import co.cask.cdap.proto.WorkflowNodeThrowable;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.Ids;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -211,7 +211,8 @@ public class DefaultStoreTest {
     // stop the Spark program with failure
     NullPointerException npe = new NullPointerException("dataset not found");
     IllegalArgumentException iae = new IllegalArgumentException("illegal argument", npe);
-    store.setStop(sparkProgram.toId(), sparkRunId.getId(), currentTime + 100, ProgramRunStatus.FAILED, iae);
+    store.setStop(sparkProgram.toId(), sparkRunId.getId(), currentTime + 100, ProgramRunStatus.FAILED,
+                  new BasicThrowable(iae));
 
     // stop Workflow
     store.setStop(workflowRun.getParent().toId(), workflowRun.getRun(), currentTime + 110, ProgramRunStatus.FAILED);
@@ -233,7 +234,7 @@ public class DefaultStoreTest {
     Assert.assertEquals(sparkName, nodeStateDetail.getNodeId());
     Assert.assertEquals(NodeStatus.FAILED, nodeStateDetail.getNodeStatus());
     Assert.assertEquals(sparkRunId.getId(), nodeStateDetail.getRunId());
-    WorkflowNodeThrowable failureCause = nodeStateDetail.getFailureCause();
+    BasicThrowable failureCause = nodeStateDetail.getFailureCause();
     Assert.assertNotNull(failureCause);
     Assert.assertTrue("illegal argument".equals(failureCause.getMessage()));
     Assert.assertTrue("java.lang.IllegalArgumentException".equals(failureCause.getClassName()));

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
@@ -181,8 +181,8 @@ public class DefaultStoreTest {
     ProgramId sparkProgram = appId.spark(sparkName);
 
     long currentTime = System.currentTimeMillis();
-    RunId workflowRunId = RunIds.generate(currentTime);
-    ProgramRunId workflowRun = appId.workflow(workflowName).run(workflowRunId.getId());
+    String workflowRunId = RunIds.generate(currentTime).getId();
+    ProgramRunId workflowRun = appId.workflow(workflowName).run(workflowRunId);
 
     // start Workflow
     store.setStart(workflowRun.getParent().toId(), workflowRun.getRun(), currentTime);
@@ -190,7 +190,7 @@ public class DefaultStoreTest {
     // start MapReduce as a part of Workflow
     Map<String, String> systemArgs = ImmutableMap.of(ProgramOptionConstants.WORKFLOW_NODE_ID, mapReduceName,
                                                      ProgramOptionConstants.WORKFLOW_NAME, workflowName,
-                                                     ProgramOptionConstants.WORKFLOW_RUN_ID, workflowRunId.getId());
+                                                     ProgramOptionConstants.WORKFLOW_RUN_ID, workflowRunId);
 
     RunId mapReduceRunId = RunIds.generate(currentTime + 10);
     store.setStart(mapReduceProgram.toId(), mapReduceRunId.getId(), currentTime + 10, null,
@@ -202,7 +202,7 @@ public class DefaultStoreTest {
     // start Spark program as a part of Workflow
     systemArgs = ImmutableMap.of(ProgramOptionConstants.WORKFLOW_NODE_ID, sparkName,
                                  ProgramOptionConstants.WORKFLOW_NAME, workflowName,
-                                 ProgramOptionConstants.WORKFLOW_RUN_ID, workflowRunId.getId());
+                                 ProgramOptionConstants.WORKFLOW_RUN_ID, workflowRunId);
 
     RunId sparkRunId = RunIds.generate(currentTime + 60);
     store.setStart(sparkProgram.toId(), sparkRunId.getId(), currentTime + 60, null,

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/RemoteRuntimeStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/RemoteRuntimeStoreTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.store;
+
+import co.cask.cdap.api.workflow.NodeStatus;
+import co.cask.cdap.common.app.RunIds;
+import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
+import co.cask.cdap.internal.app.store.remote.RemoteRuntimeStore;
+import co.cask.cdap.proto.BasicThrowable;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.WorkflowNodeStateDetail;
+import co.cask.cdap.proto.id.ProgramRunId;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Injector;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests implementation of {@link RemoteRuntimeStore}, by using it to perform writes/updates, and then using a
+ * local {@link DefaultStore} to verify the updates/writes.
+ */
+public class RemoteRuntimeStoreTest extends AppFabricTestBase {
+
+  private static DefaultStore store;
+  private static RemoteRuntimeStore runtimeStore;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    Injector injector = getInjector();
+    store = injector.getInstance(DefaultStore.class);
+    runtimeStore = injector.getInstance(RemoteRuntimeStore.class);
+  }
+
+  @Test
+  public void testSimpleCase() {
+    Id.Program flowId = Id.Flow.from(Id.Namespace.DEFAULT, "test_app", "test_flow");
+    long stopTime = System.currentTimeMillis() / 2000;
+    long startTime = stopTime - 20;
+    String pid = RunIds.generate(startTime * 1000).getId();
+    // to test null serialization (setStart can take in nullable)
+    String twillRunId = null;
+    Map<String, String> runtimeArgs = ImmutableMap.of();
+    Map<String, String> properties = ImmutableMap.of("runtimeArgs", GSON.toJson(runtimeArgs));
+    Map<String, String> systemArgs = ImmutableMap.of("a", "b");
+    RunRecordMeta initialRunRecord =
+      new RunRecordMeta(pid, startTime, null, ProgramRunStatus.RUNNING, properties, systemArgs, twillRunId);
+
+    runtimeStore.setStart(flowId, pid, startTime, twillRunId, runtimeArgs, systemArgs);
+    RunRecordMeta runMeta = store.getRun(flowId, pid);
+    Assert.assertEquals(initialRunRecord, runMeta);
+
+
+    runtimeStore.setSuspend(flowId, pid);
+    Assert.assertEquals(new RunRecordMeta(initialRunRecord, null, ProgramRunStatus.SUSPENDED),
+                        store.getRun(flowId, pid));
+
+    runtimeStore.setResume(flowId, pid);
+    Assert.assertEquals(initialRunRecord,
+                        store.getRun(flowId, pid));
+
+    // this should be a no-op, since the status is actually RUNNING, and not SUSPENDED
+    runtimeStore.compareAndSetStatus(flowId, pid, ProgramRunStatus.SUSPENDED, ProgramRunStatus.COMPLETED);
+    Assert.assertEquals(initialRunRecord,
+                        store.getRun(flowId, pid));
+
+    // this call to compareAndSetStatus will correctly mark it as COMPLETED.
+    // we don't do direct equals comparison on the run record objects, because the method internally sets the stopTime
+    runtimeStore.compareAndSetStatus(flowId, pid, ProgramRunStatus.RUNNING, ProgramRunStatus.COMPLETED);
+    RunRecordMeta runRecordMeta = store.getRun(flowId, pid);
+    Assert.assertEquals(initialRunRecord.getStartTs(), runRecordMeta.getStartTs());
+    Assert.assertEquals(initialRunRecord.getPid(), runRecordMeta.getPid());
+    Assert.assertEquals(initialRunRecord.getTwillRunId(), runRecordMeta.getTwillRunId());
+    Assert.assertEquals(ProgramRunStatus.COMPLETED, runRecordMeta.getStatus());
+  }
+
+  @Test
+  public void testWorkflowMethods() {
+    Id.Workflow workflowId = Id.Workflow.from(Id.Namespace.DEFAULT, "test_app", "test_workflow");
+    long stopTime = System.currentTimeMillis() / 1000;
+    long startTime = stopTime - 20;
+    String pid = RunIds.generate(startTime * 1000).getId();
+    String twillRunId = "twill_run_id";
+    Map<String, String> runtimeArgs = ImmutableMap.of();
+    Map<String, String> properties = ImmutableMap.of("runtimeArgs", GSON.toJson(runtimeArgs));
+    Map<String, String> systemArgs = ImmutableMap.of();
+    RunRecordMeta initialRunRecord =
+      new RunRecordMeta(pid, startTime, null, ProgramRunStatus.RUNNING, properties, systemArgs, twillRunId);
+
+    runtimeStore.setStart(workflowId, pid, startTime, twillRunId, runtimeArgs, systemArgs);
+    Assert.assertEquals(initialRunRecord, store.getRun(workflowId, pid));
+
+
+    Id.Program mapreduceId = Id.Program.from(workflowId.getApplication(), ProgramType.MAPREDUCE, "test_mr");
+    String mapreducePid = RunIds.generate(startTime * 1000).getId();
+    // these system properties just have to be set on the system arguments of the program, in order for it to be
+    // understood as a program in a workflow node
+    Map<String, String> mrSystemArgs = ImmutableMap.of(ProgramOptionConstants.WORKFLOW_NODE_ID, "test_node_id",
+                                                       ProgramOptionConstants.WORKFLOW_NAME, workflowId.getId(),
+                                                       ProgramOptionConstants.WORKFLOW_RUN_ID, pid);
+    runtimeStore.setStart(mapreduceId, mapreducePid, startTime, twillRunId, runtimeArgs, mrSystemArgs);
+
+    BasicThrowable failureCause =
+      new BasicThrowable(new IllegalArgumentException("failure", new RuntimeException("oops")));
+    runtimeStore.setStop(mapreduceId, mapreducePid, stopTime, ProgramRunStatus.FAILED, failureCause);
+
+    runtimeStore.setStop(workflowId, pid, stopTime, ProgramRunStatus.FAILED);
+
+    RunRecordMeta completedWorkflowRecord = store.getRun(workflowId, pid);
+    // we're not comparing properties, since runtime (such as starting/stopping inner programs) modifies it
+    Assert.assertEquals(pid, completedWorkflowRecord.getPid());
+    Assert.assertEquals(initialRunRecord.getStartTs(), completedWorkflowRecord.getStartTs());
+    Assert.assertEquals((Long) stopTime, completedWorkflowRecord.getStopTs());
+    Assert.assertEquals(ProgramRunStatus.FAILED, completedWorkflowRecord.getStatus());
+    Assert.assertEquals(twillRunId, completedWorkflowRecord.getTwillRunId());
+    Assert.assertEquals(systemArgs, completedWorkflowRecord.getSystemArgs());
+
+    // test that the BasicThrowable was serialized properly by RemoteRuntimeStore
+    ProgramRunId workflowRunId = workflowId.toEntityId().run(pid);
+    List<WorkflowNodeStateDetail> workflowNodeStates = store.getWorkflowNodeStates(workflowRunId);
+    Assert.assertEquals(1, workflowNodeStates.size());
+    WorkflowNodeStateDetail workflowNodeStateDetail = workflowNodeStates.get(0);
+    Assert.assertEquals("test_node_id", workflowNodeStateDetail.getNodeId());
+    Assert.assertEquals(mapreducePid, workflowNodeStateDetail.getRunId());
+    Assert.assertEquals(NodeStatus.FAILED, workflowNodeStateDetail.getNodeStatus());
+    Assert.assertEquals(failureCause, workflowNodeStateDetail.getFailureCause());
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/RemoteRuntimeStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/RemoteRuntimeStoreTest.java
@@ -70,7 +70,6 @@ public class RemoteRuntimeStoreTest extends AppFabricTestBase {
     RunRecordMeta runMeta = store.getRun(flowId, pid);
     Assert.assertEquals(initialRunRecord, runMeta);
 
-
     runtimeStore.setSuspend(flowId, pid);
     Assert.assertEquals(new RunRecordMeta(initialRunRecord, null, ProgramRunStatus.SUSPENDED),
                         store.getRun(flowId, pid));

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/BasicThrowable.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/BasicThrowable.java
@@ -13,31 +13,32 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.proto;
 
-import co.cask.cdap.proto.codec.WorkflowNodeThrowableCodec;
+import co.cask.cdap.proto.codec.BasicThrowableCodec;
 
 import javax.annotation.Nullable;
 
 /**
- * Carries {@link Throwable} information in {@link WorkflowNodeStateDetail}.
+ * Maintains basic information about a {@link Throwable}, for easy serialization/deserialization.
  */
-public final class WorkflowNodeThrowable {
+public final class BasicThrowable {
   private final String className;
   private final String message;
   private final StackTraceElement[] stackTraces;
-  private final WorkflowNodeThrowable cause;
+  private final BasicThrowable cause;
 
   /**
-   * This constructor is used by {@link WorkflowNodeThrowableCodec} during de-serialization.
+   * This constructor is used by {@link BasicThrowableCodec} during de-serialization.
    *
    * @param className the name of the Throwable
    * @param message the message inside the Throwable
    * @param stackTraces stack traces associated with the Throwable
    * @param cause cause associated with the Throwable
    */
-  public WorkflowNodeThrowable(String className, String message, StackTraceElement[] stackTraces,
-                               @Nullable WorkflowNodeThrowable cause) {
+  public BasicThrowable(String className, String message, StackTraceElement[] stackTraces,
+                        @Nullable BasicThrowable cause) {
     this.className = className;
     this.message = message;
     this.stackTraces = stackTraces;
@@ -49,7 +50,7 @@ public final class WorkflowNodeThrowable {
    *
    * @param throwable the instance of Throwable to be serialize
    */
-  public WorkflowNodeThrowable(Throwable throwable) {
+  public BasicThrowable(Throwable throwable) {
     this.className = throwable.getClass().getName();
     this.message = throwable.getMessage();
 
@@ -57,7 +58,7 @@ public final class WorkflowNodeThrowable {
     this.stackTraces = new StackTraceElement[stackTraceElements.length];
     System.arraycopy(stackTraceElements, 0, stackTraces, 0, stackTraceElements.length);
 
-    this.cause = (throwable.getCause() == null) ? null : new WorkflowNodeThrowable(throwable.getCause());
+    this.cause = (throwable.getCause() == null) ? null : new BasicThrowable(throwable.getCause());
   }
 
   /**
@@ -85,7 +86,7 @@ public final class WorkflowNodeThrowable {
    * Return the cause of Throwable if it is available, otherwise {@code null}.
    */
   @Nullable
-  public WorkflowNodeThrowable getCause() {
+  public BasicThrowable getCause() {
     return cause;
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/BasicThrowable.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/BasicThrowable.java
@@ -112,8 +112,7 @@ public final class BasicThrowable {
     if (!Arrays.equals(stackTraces, that.stackTraces)) {
       return false;
     }
-    return !(cause != null ? !cause.equals(that.cause) : that.cause != null);
-
+    return cause != null ? cause.equals(that.cause) : that.cause == null;
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/BasicThrowable.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/BasicThrowable.java
@@ -18,6 +18,7 @@ package co.cask.cdap.proto;
 
 import co.cask.cdap.proto.codec.BasicThrowableCodec;
 
+import java.util.Arrays;
 import javax.annotation.Nullable;
 
 /**
@@ -88,5 +89,39 @@ public final class BasicThrowable {
   @Nullable
   public BasicThrowable getCause() {
     return cause;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    BasicThrowable that = (BasicThrowable) o;
+
+    if (!className.equals(that.className)) {
+      return false;
+    }
+    if (!message.equals(that.message)) {
+      return false;
+    }
+
+    if (!Arrays.equals(stackTraces, that.stackTraces)) {
+      return false;
+    }
+    return !(cause != null ? !cause.equals(that.cause) : that.cause != null);
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = className.hashCode();
+    result = 31 * result + message.hashCode();
+    result = 31 * result + Arrays.hashCode(stackTraces);
+    result = 31 * result + (cause != null ? cause.hashCode() : 0);
+    return result;
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/WorkflowNodeStateDetail.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/WorkflowNodeStateDetail.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.proto;
 
 import co.cask.cdap.api.workflow.NodeStatus;
@@ -28,7 +29,7 @@ public final class WorkflowNodeStateDetail {
   private final String nodeId;
   private final NodeStatus nodeStatus;
   private final String runId;
-  private final WorkflowNodeThrowable failureCause;
+  private final BasicThrowable failureCause;
 
   /**
    * Create a new instance.
@@ -49,7 +50,7 @@ public final class WorkflowNodeStateDetail {
    * @param failureCause cause of failure, {code null} if execution of the node succeeded
    */
   public WorkflowNodeStateDetail(String nodeId, NodeStatus nodeStatus, @Nullable String runId,
-                                 @Nullable WorkflowNodeThrowable failureCause) {
+                                 @Nullable BasicThrowable failureCause) {
     this.nodeId = nodeId;
     this.nodeStatus = nodeStatus;
     this.runId = runId;
@@ -83,7 +84,7 @@ public final class WorkflowNodeStateDetail {
    * Return the detail message string for failure if node execution failed, otherwise {@code null} is returned.
    */
   @Nullable
-  public WorkflowNodeThrowable getFailureCause() {
+  public BasicThrowable getFailureCause() {
     return failureCause;
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/BasicThrowableCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/BasicThrowableCodec.java
@@ -13,9 +13,10 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.proto.codec;
 
-import co.cask.cdap.proto.WorkflowNodeThrowable;
+import co.cask.cdap.proto.BasicThrowable;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonElement;
@@ -26,22 +27,22 @@ import com.google.gson.JsonSerializationContext;
 import java.lang.reflect.Type;
 
 /**
- * Codec for {@link WorkflowNodeThrowable}.
+ * Codec for {@link BasicThrowable}.
  */
-public final class WorkflowNodeThrowableCodec extends AbstractSpecificationCodec<WorkflowNodeThrowable> {
+public final class BasicThrowableCodec extends AbstractSpecificationCodec<BasicThrowable> {
 
   @Override
-  public JsonElement serialize(WorkflowNodeThrowable src, Type typeOfSrc, JsonSerializationContext context) {
+  public JsonElement serialize(BasicThrowable src, Type typeOfSrc, JsonSerializationContext context) {
     JsonObject json = new JsonObject();
     json.addProperty("className", src.getClassName());
     json.addProperty("message", src.getMessage());
     json.add("stackTraces", context.serialize(src.getStackTraces(), StackTraceElement[].class));
-    json.add("cause", context.serialize(src.getCause(), WorkflowNodeThrowable.class));
+    json.add("cause", context.serialize(src.getCause(), BasicThrowable.class));
     return json;
   }
 
   @Override
-  public WorkflowNodeThrowable deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+  public BasicThrowable deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
     throws JsonParseException {
     JsonObject jsonObj = json.getAsJsonObject();
     String className = jsonObj.get("className").getAsString();
@@ -49,10 +50,10 @@ public final class WorkflowNodeThrowableCodec extends AbstractSpecificationCodec
     JsonArray stackTraces = jsonObj.get("stackTraces").getAsJsonArray();
     StackTraceElement[] stackTraceElements = context.deserialize(stackTraces, StackTraceElement[].class);
     JsonElement cause = jsonObj.get("cause");
-    WorkflowNodeThrowable dfc = null;
+    BasicThrowable basicThrowable = null;
     if (cause != null) {
-      dfc = context.deserialize(cause, WorkflowNodeThrowable.class);
+      basicThrowable = context.deserialize(cause, BasicThrowable.class);
     }
-    return new WorkflowNodeThrowable(className, message, stackTraceElements, dfc);
+    return new BasicThrowable(className, message, stackTraceElements, basicThrowable);
   }
 }

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRunner.java
@@ -48,6 +48,7 @@ import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.internal.app.runtime.workflow.NameMappedDatasetFramework;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
 import co.cask.cdap.internal.lang.Reflections;
+import co.cask.cdap.proto.BasicThrowable;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
@@ -276,7 +277,7 @@ final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
       public void failed(Service.State from, @Nullable Throwable failure) {
         closeAll(closeables);
         store.setStop(programId, runId.getId(), TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()),
-                      ProgramController.State.ERROR.getRunStatus(), failure);
+                      ProgramController.State.ERROR.getRunStatus(), new BasicThrowable(failure));
       }
     };
   }


### PR DESCRIPTION
I think its useful to review the commits separately:
1. Moves methods from Store interface into a RuntimeStore interface. These are methods that would be needed from program runtime (i.e. when a workflow or mapreduce is running, it needs to perform some updates to the meta store).
2. Create an implementation of RuntimeStore that makes HTTP requests to app fabric, so that the CDAP system can perform the actual store operations.
3. Update MapReduceProgramRunner, SparkProgramRunner, and WorkflowProgramRunner to use RemoteRuntimeStore.

We need this because CDAP programs (workflow/mapreduce/etc) may no longer have permission to write to system HBase tables, once impersonation is implemented.
See: https://wiki.cask.co/display/CE/Secure+Impersonation+-+Security+3.5#SecureImpersonation-Security3.5-ProblemsEncountered
https://issues.cask.co/browse/CDAP-6250

Pending (which will come in a separate PR):
1. Remote versions of usage and lineage stores.
2. Scalability of this service/handler.
3. Not using deprecated `Id` classes in new code. This will come as a separate change, since the new interface shares methods with existing interface and implementation.

Build: http://builds.cask.co/browse/CDAP-DUT4241
