### PR TITLE
Adding inner join capability

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/DataPipelineApp.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/DataPipelineApp.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.api.schedule.Schedules;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.api.batch.BatchAggregator;
+import co.cask.cdap.etl.api.batch.BatchJoiner;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.api.batch.SparkCompute;
@@ -46,7 +47,7 @@ public class DataPipelineApp extends AbstractApplication<ETLBatchConfig> {
   public static final String SCHEDULE_NAME = "dataPipelineSchedule";
   public static final String DEFAULT_DESCRIPTION = "Data Pipeline Application";
   private static final Set<String> supportedPluginTypes = ImmutableSet.of(
-    BatchSource.PLUGIN_TYPE, BatchSink.PLUGIN_TYPE, Transform.PLUGIN_TYPE,
+    BatchSource.PLUGIN_TYPE, BatchSink.PLUGIN_TYPE, Transform.PLUGIN_TYPE, BatchJoiner.PLUGIN_TYPE,
     Constants.CONNECTOR_TYPE, BatchAggregator.PLUGIN_TYPE, SparkCompute.PLUGIN_TYPE, SparkSink.PLUGIN_TYPE);
 
   @Override
@@ -71,7 +72,7 @@ public class DataPipelineApp extends AbstractApplication<ETLBatchConfig> {
     BatchPipelineSpec spec = specGenerator.generateSpec(config);
 
     PipelinePlanner planner = new PipelinePlanner(supportedPluginTypes,
-                                                  ImmutableSet.of(BatchAggregator.PLUGIN_TYPE),
+                                                  ImmutableSet.of(BatchAggregator.PLUGIN_TYPE, BatchJoiner.PLUGIN_TYPE),
                                                   ImmutableSet.of(SparkCompute.PLUGIN_TYPE, SparkSink.PLUGIN_TYPE));
     PipelinePlan plan = planner.plan(spec);
 

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
@@ -33,7 +33,9 @@ import co.cask.cdap.etl.mock.batch.MockSource;
 import co.cask.cdap.etl.mock.batch.NodeStatesAction;
 import co.cask.cdap.etl.mock.batch.aggregator.FieldCountAggregator;
 import co.cask.cdap.etl.mock.batch.aggregator.IdentityAggregator;
+import co.cask.cdap.etl.mock.batch.joiner.Join;
 import co.cask.cdap.etl.mock.test.HydratorTestBase;
+import co.cask.cdap.etl.mock.transform.FieldsPrefixTransform;
 import co.cask.cdap.etl.mock.transform.IdentityTransform;
 import co.cask.cdap.etl.mock.transform.StringValueFilterTransform;
 import co.cask.cdap.etl.proto.Engine;
@@ -96,6 +98,117 @@ public class DataPipelineTest extends HydratorTestBase {
   @After
   public void cleanupTest() throws Exception {
     getMetricsManager().resetAll();
+  }
+
+
+  @Test
+  public void testInnerJoin() throws Exception {
+    Schema inputSchema1 = Schema.recordOf(
+      "customerRecord",
+      Schema.Field.of("customer_id", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("customer_name", Schema.of(Schema.Type.STRING))
+    );
+
+    Schema inputSchema2 = Schema.recordOf(
+      "itemRecord",
+      Schema.Field.of("item_id", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("item_price", Schema.of(Schema.Type.LONG)),
+      Schema.Field.of("cust_id", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("cust_name", Schema.of(Schema.Type.STRING))
+    );
+
+    Schema inputSchema3 = Schema.recordOf(
+      "transactionRecord",
+      Schema.Field.of("t_id", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("c_id", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("c_name", Schema.of(Schema.Type.STRING))
+    );
+
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+      .addStage(new ETLStage("source1", MockSource.getPlugin("source1Input")))
+      .addStage(new ETLStage("source2", MockSource.getPlugin("source2Input")))
+      .addStage(new ETLStage("source3", MockSource.getPlugin("source3Input")))
+      .addStage(new ETLStage("t1", FieldsPrefixTransform.getPlugin("", inputSchema1.toString())))
+      .addStage(new ETLStage("t2", FieldsPrefixTransform.getPlugin("", inputSchema2.toString())))
+      .addStage(new ETLStage("t3", FieldsPrefixTransform.getPlugin("", inputSchema3.toString())))
+      .addStage(new ETLStage("testJoiner", Join.getPlugin("t1.customer_id=t2.cust_id=t3.c_id," +
+                                                            "t1.customer_name=t2.cust_name=t3.c_name",
+                                                          "t1,t2,t3", "", "")))
+      .addStage(new ETLStage("sink1", MockSink.getPlugin("joinerOutput")))
+      .addConnection("source1", "t1")
+      .addConnection("source2", "t2")
+      .addConnection("source3", "t3")
+      .addConnection("t1", "testJoiner")
+      .addConnection("t2", "testJoiner")
+      .addConnection("t3", "testJoiner")
+      .addConnection("testJoiner", "sink1")
+      .setEngine(Engine.MAPREDUCE)
+      .build();
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig);
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "JoinerApp");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    Schema outSchema = Schema.recordOf(
+      "join.output",
+      Schema.Field.of("customer_id", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("customer_name", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("item_id", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("item_price", Schema.of(Schema.Type.LONG)),
+      Schema.Field.of("cust_id", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("cust_name", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("t_id", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("c_id", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("c_name", Schema.of(Schema.Type.STRING))
+    );
+
+    StructuredRecord recordSamuel = StructuredRecord.builder(inputSchema1).set("customer_id", "1")
+      .set("customer_name", "samuel").build();
+    StructuredRecord recordBob = StructuredRecord.builder(inputSchema1).set("customer_id", "2")
+      .set("customer_name", "bob").build();
+    StructuredRecord recordJane = StructuredRecord.builder(inputSchema1).set("customer_id", "3")
+      .set("customer_name", "jane").build();
+
+    StructuredRecord recordCar = StructuredRecord.builder(inputSchema2).set("item_id", "11").set("item_price", 10000L)
+      .set("cust_id", "1").set("cust_name", "samuel").build();
+    StructuredRecord recordBike = StructuredRecord.builder(inputSchema2).set("item_id", "22").set("item_price", 100L)
+      .set("cust_id", "3").set("cust_name", "jane").build();
+
+    StructuredRecord recordTrasCar = StructuredRecord.builder(inputSchema3).set("t_id", "1").set("c_id", "1")
+      .set("c_name", "samuel").build();
+    StructuredRecord recordTrasBike = StructuredRecord.builder(inputSchema3).set("t_id", "2").set("c_id", "3")
+      .set("c_name", "jane").build();
+
+    // write one record to each source
+    DataSetManager<Table> inputManager = getDataset(Id.Namespace.DEFAULT, "source1Input");
+    MockSource.writeInput(inputManager, ImmutableList.of(recordSamuel, recordBob, recordJane));
+    inputManager = getDataset(Id.Namespace.DEFAULT, "source2Input");
+    MockSource.writeInput(inputManager, ImmutableList.of(recordCar, recordBike));
+    inputManager = getDataset(Id.Namespace.DEFAULT, "source3Input");
+    MockSource.writeInput(inputManager, ImmutableList.of(recordTrasCar, recordTrasBike));
+
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+
+
+    StructuredRecord joinRecordSamuel = StructuredRecord.builder(outSchema)
+    .set("customer_id", "1").set("customer_name", "samuel")
+    .set("item_id", "11").set("item_price", 10000L).set("cust_id", "1").set("cust_name", "samuel")
+    .set("t_id", "1").set("c_id", "1").set("c_name", "samuel").build();
+
+    StructuredRecord joinRecordJane = StructuredRecord.builder(outSchema)
+      .set("customer_id", "3").set("customer_name", "jane")
+      .set("item_id", "22").set("item_price", 100L).set("cust_id", "3").set("cust_name", "jane")
+      .set("t_id", "2").set("c_id", "3").set("c_name", "jane").build();
+
+    DataSetManager<Table> sinkManager = getDataset("joinerOutput");
+    Set<StructuredRecord> expected = ImmutableSet.of(joinRecordSamuel, joinRecordJane);
+    Set<StructuredRecord> actual = Sets.newHashSet(MockSink.readOutput(sinkManager));
+    Assert.assertEquals(expected, actual);
+
+    validateMetric(2, appId, "testJoiner.records.out");
+    validateMetric(2, appId, "sink1.records.in");
   }
 
   @Test

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/JoinConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/JoinConfig.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.api;
+
+/**
+ * Join configuration to hold information about join to be performed
+ */
+public class JoinConfig {
+  private Iterable<String> requiredInputs;
+
+  /**
+   * Creates new instance of {@link JoinConfig}
+   * @param requiredInputs iterable of input stage names. This will be used to find out type of the join.
+   * If required inputs are empty, full outer join will be performed. Otherwise, all records from required inputs
+   * will be joined using inner join and records from non-required inputs will be present in join result only if they
+   * meet join criteria.
+   */
+  public JoinConfig(Iterable<String> requiredInputs) {
+    this.requiredInputs = requiredInputs;
+  }
+
+  /**
+   * Returns required inputs to be joined.
+   * @return iterable of required inputs
+   */
+  public Iterable<String> getRequiredInputs() {
+    return requiredInputs;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/JoinElement.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/JoinElement.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.api;
+
+/**
+ * Join element to hold join record per stage
+ * @param <INPUT_RECORD> type of input record from each stage
+ */
+public final class JoinElement<INPUT_RECORD> {
+  private final String stageName;
+  private final INPUT_RECORD inputRecord;
+
+  public JoinElement(String stageName, INPUT_RECORD inputRecord) {
+    this.stageName = stageName;
+    this.inputRecord = inputRecord;
+  }
+
+  /**
+   * Returns stage name to which input record belongs to
+   * @return stage name for input record
+   */
+  public String getStageName() {
+    return stageName;
+  }
+
+  /**
+   * Returns input record which is part of join result
+   * @return input record to be merged
+   */
+  public INPUT_RECORD getInputRecord() {
+    return inputRecord;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/Joiner.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/Joiner.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.api;
+
+import co.cask.cdap.api.annotation.Beta;
+
+/**
+ * Provides join keys on which join needs to be performed and merges the join results.
+ *
+ * @param <JOIN_KEY> type of the join key
+ * @param <INPUT_RECORD> type of input records to be joined
+ * @param <OUT> type of output object
+ */
+@Beta
+public interface Joiner<JOIN_KEY, INPUT_RECORD, OUT> {
+
+  /**
+   * Return value for the join key on which join will be performed
+   *
+   * @param stageName name of the stage to which records belongs to
+   * @param inputRecord input record to be joined
+   * @return returns join key
+   * @throws Exception if there is some error getting the join key
+   */
+  JOIN_KEY joinOn(String stageName, INPUT_RECORD inputRecord) throws Exception;
+
+
+  /**
+   * Creates join configuration which holds information about required inputs which are needed to decide
+   * type of the join and produce join result.
+   *
+   * @return instance of {@link JoinConfig} which includes information about join to be performed
+   * @throws Exception if there is some error getting the join config
+   */
+  JoinConfig getJoinConfig() throws Exception;
+
+  /**
+   * Merges records present in joinResult and returns merged output.
+   *
+   * @param joinKey join key on which join needs to be performed
+   * @param joinResult list of {@link JoinElement} which will be used to create merged output. It will have all the
+   *                   records after performing join operation
+   * @return merged output created from joinResult
+   * @throws Exception if there is some error while creating merged output
+   */
+  OUT merge(JOIN_KEY joinKey, Iterable<JoinElement<INPUT_RECORD>> joinResult) throws Exception;
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/StageConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/StageConfigurer.java
@@ -19,6 +19,7 @@ package co.cask.cdap.etl.api;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.schema.Schema;
 
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -34,6 +35,14 @@ public interface StageConfigurer {
    */
   @Nullable
   Schema getInputSchema();
+
+  /**
+   * get the input schemas for this stage, or null if its unknown
+   * @return map of input schemas
+   */
+  // TODO As per CDAP-6243 add another StageConfigurer which exposes multiple input schemas for supported plugins
+  @Nullable
+  Map<String, Schema> getInputSchemas();
 
   /**
    * set output schema for this stage, or null if its unknown

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/batch/BatchJoiner.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/batch/BatchJoiner.java
@@ -1,3 +1,4 @@
+
 /*
  * Copyright © 2016 Cask Data, Inc.
  *
@@ -17,34 +18,34 @@
 package co.cask.cdap.etl.api.batch;
 
 import co.cask.cdap.api.annotation.Beta;
-import co.cask.cdap.etl.api.Aggregator;
-import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.Joiner;
 import co.cask.cdap.etl.api.PipelineConfigurable;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageLifecycle;
 
-import java.util.Iterator;
+import java.util.List;
 
 /**
- * An {@link Aggregator} used in batch programs.
- * As it is used in batch programs, a BatchAggregator must be parameterized
- * with supported group key and value classes. Group keys and values can be a
+ * A {@link Joiner} used for batch programs.
+ * As it is used in batch programs, a BatchJoiner must be parameterized
+ * with supported join key and input record classes. Join keys and input records can be a
  * byte[], Boolean, Integer, Long, Float, Double, String, or StructuredRecord.
- * If the group key is not one of those types and is being used in mapreduce,
+ * If the join key is not one of those types and is being used in mapreduce,
  * it must implement Hadoop's org.apache.hadoop.io.WritableComparable interface.
- * If the group value is not one of those types and is being used in mapreduce,
+ * If the input record is not one of those types and is being used in mapreduce,
  * it must implement Hadoop's org.apache.hadoop.io.Writable interface.
- * If the aggregator is being used in spark, both the group key and value must implement the
+ * If the joiner is being used in spark, both the join key and input record must implement the
  * {@link java.io.Serializable} interface.
  *
- * @param <GROUP_KEY> group key type. Must be a supported type
- * @param <GROUP_VALUE> group value type. Must be a supported type
- * @param <OUT> output object type
+ *
+ * @param <JOIN_KEY> type of join key. Must be a supported type
+ * @param <INPUT_RECORD> type of input record. Must be a supported type
+ * @param <OUT> type of output object
  */
 @Beta
-public abstract class BatchAggregator<GROUP_KEY, GROUP_VALUE, OUT> extends BatchConfigurable<BatchAggregatorContext>
-  implements Aggregator<GROUP_KEY, GROUP_VALUE, OUT>, PipelineConfigurable, StageLifecycle<BatchRuntimeContext> {
-  public static final String PLUGIN_TYPE = "batchaggregator";
+public abstract class BatchJoiner<JOIN_KEY, INPUT_RECORD, OUT> extends BatchConfigurable<BatchJoinerContext>
+  implements Joiner<JOIN_KEY, INPUT_RECORD, OUT>, PipelineConfigurable, StageLifecycle<BatchJoinerRuntimeContext> {
+  public static final String PLUGIN_TYPE = "batchjoiner";
 
   /**
    * Configure the pipeline. This is run once when the pipeline is being published.
@@ -60,34 +61,34 @@ public abstract class BatchAggregator<GROUP_KEY, GROUP_VALUE, OUT> extends Batch
 
   /**
    * Prepare a pipeline run. This is run every time before a pipeline runs in order to help set up the run.
-   * This is where you would set things like the number of partitions to use when grouping, and setting the
-   * group key and value classes if they are not known at compile time.
+   * This is where you would set things like the number of partitions to use when joining, and setting the
+   * join key class if they are not known at compile time.
    *
    * @param context batch execution context
    * @throws Exception
    */
   @Override
-  public void prepareRun(BatchAggregatorContext context) throws Exception {
-    // no-op
+  public void prepareRun(BatchJoinerContext context) throws Exception {
+    //no-op
   }
 
   /**
-   * Initialize the Batch Aggregator. Executed inside the Batch Run. This method is guaranteed to be invoked
-   * before any calls to {@link #groupBy(Object, Emitter)} and {@link #aggregate(Object, Iterator, Emitter)} are made.
+   * Initialize the Batch Joiner. Executed inside the Batch Run. This method is guaranteed to be invoked
+   * before any calls to {@link #joinOn(String, Object)} and {@link #merge(Object, List)} are made.
    *
-   * @param context {@link BatchRuntimeContext}
+   * @param context runtime context for joiner which exposes input schemas and output schema for joiner
    * @throws Exception if there is any error during initialization
    */
   @Override
-  public void initialize(BatchRuntimeContext context) throws Exception {
-    // no-op
+  public void initialize(BatchJoinerRuntimeContext context) throws Exception {
+    //no-op
   }
 
   /**
-   * Destroy the Batch Aggregator. Executed at the end of the Batch Run.
+   * Destroy the Batch Joiner. Executed at the end of the Batch Run.
    */
   @Override
   public void destroy() {
-    // no-op
+    //no-op
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/batch/BatchJoinerContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/batch/BatchJoinerContext.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.api.batch;
+
+import co.cask.cdap.api.annotation.Beta;
+
+/**
+ * Context of a Batch Joiner
+ */
+@Beta
+public interface BatchJoinerContext extends BatchContext {
+  /**
+   * Set the number of partitions to use to join values. If none is set, the execution engine will decide
+   * how many partitions to use.
+   *
+   * @param numPartitions the number of partitions to use when joining.
+   */
+  void setNumPartitions(int numPartitions);
+
+  /**
+   * Set the join key class. This is not required if the joiner is parameterized with a concrete class
+   * for the join key. This method is required if the join key class is only known at configure time
+   * versus compile time. For example, an joiner may support joining on a configurable record field,
+   * and not know the type of that field until configure time.
+   *
+   * @param joinKeyClass the join key class
+   */
+  void setJoinKeyClass(Class<?> joinKeyClass);
+
+  /**
+   * Set the join input record class. This is not required if the joiner is parameterized with a concrete class
+   * for the join input. This method is required if the input record class is only known at configure time
+   * versus compile time.
+   *
+   * @param joinInputRecordClass the join input record class
+   */
+  void setJoinInputRecordClass(Class<?> joinInputRecordClass);
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/batch/BatchJoinerRuntimeContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/batch/BatchJoinerRuntimeContext.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.api.batch;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Runtime context for batch joiner
+ */
+public interface BatchJoinerRuntimeContext extends BatchRuntimeContext {
+
+  /**
+   * Returns a map of input schemas for joiner. If the input schema for an input is null, the map will have input
+   * name with null schema for that input
+   * @return a map of input stage name to input schema for all the inputs to joiner
+   */
+  Map<String, Schema> getInputSchemas();
+
+  /**
+   * Returns output schema configured in {@link BatchJoiner#configurePipeline(PipelineConfigurer)} at configure time.
+   * If not configured it will return null
+   * @return output schema {@link Schema} for joiner
+   */
+  @Nullable
+  Schema getOutputSchema();
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/join/Join.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/join/Join.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch.join;
+
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.JoinConfig;
+import co.cask.cdap.etl.api.JoinElement;
+import co.cask.cdap.etl.api.Joiner;
+import com.google.common.collect.Iterables;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Performs join operation
+ * @param <JOIN_KEY> type of join key
+ * @param <INPUT_RECORD> type of input record
+ * @param <OUT> type of output of mapreduce
+ */
+
+public class Join<JOIN_KEY, INPUT_RECORD, OUT> {
+  private Joiner<JOIN_KEY, INPUT_RECORD, OUT> joiner;
+  private JOIN_KEY joinKey;
+  private Iterator<JoinElement<INPUT_RECORD>> iterator;
+  private Emitter<OUT> emitter;
+  private final int numOfInputs;
+
+  public Join(Joiner<JOIN_KEY, INPUT_RECORD, OUT> joiner, JOIN_KEY joinKey,
+              Iterator<JoinElement<INPUT_RECORD>> iterator, int numOfInputs, Emitter<OUT> emitter) throws Exception {
+    this.joiner = joiner;
+    this.joinKey = joinKey;
+    this.iterator = iterator;
+    this.numOfInputs = numOfInputs;
+    this.emitter = emitter;
+  }
+
+  public void joinRecords() throws Exception {
+    Map<String, List<JoinElement<INPUT_RECORD>>> perStageJoinElements = getPerStageJoinElements();
+    JoinConfig joinConfig = joiner.getJoinConfig();
+    Iterable<String> requiredInputs = joinConfig.getRequiredInputs();
+    if (Iterables.size(requiredInputs) == numOfInputs) {
+      innerJoin(perStageJoinElements);
+    }
+  }
+
+  private Map<String, List<JoinElement<INPUT_RECORD>>> getPerStageJoinElements() {
+    Map<String, List<JoinElement<INPUT_RECORD>>> perStageJoinElements = new HashMap<>();
+    while (iterator.hasNext()) {
+      JoinElement<INPUT_RECORD> joinElement = iterator.next();
+      String stageName = joinElement.getStageName();
+      if (perStageJoinElements.get(stageName) == null) {
+        perStageJoinElements.put(stageName, new ArrayList<JoinElement<INPUT_RECORD>>());
+      }
+      perStageJoinElements.get(stageName).add(joinElement);
+    }
+    return perStageJoinElements;
+  }
+
+  private void innerJoin(Map<String, List<JoinElement<INPUT_RECORD>>> perStageJoinElements) throws Exception {
+    // As we get intersection of records from n stages in inner join, if the number of stages we got after reduce
+    // are not same as number of stages we are joining, then there is nothing to emit.
+    if (perStageJoinElements.size() != numOfInputs) {
+      return;
+    }
+
+    List<List<JoinElement<INPUT_RECORD>>> list = new ArrayList<>(perStageJoinElements.values());
+    ArrayList<JoinElement<INPUT_RECORD>> joinElements = new ArrayList<>();
+    getCartesianProduct(list, 0, numOfInputs, joinElements);
+  }
+
+  // TODO use iterative algorithm instead of recursion
+  private void getCartesianProduct(List<List<JoinElement<INPUT_RECORD>>> list, int index, int size,
+                                   List<JoinElement<INPUT_RECORD>> joinElements) throws Exception {
+    if (joinElements.size() == size) {
+      emitter.emit(joiner.merge(joinKey, joinElements));
+      return;
+    }
+
+    List<JoinElement<INPUT_RECORD>> joinElementList = list.get(index);
+    for (int i = 0; i < joinElementList.size(); i++) {
+      joinElements.add(joinElementList.get(i));
+      getCartesianProduct(list, index + 1, size, joinElements);
+      joinElements.remove(joinElements.size() - 1);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/TaggedWritable.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/TaggedWritable.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch.mapreduce;
+
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.ObjectWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableComparable;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/**
+ * Map output for which includes stageName and the record provided. This can be used to tag map output with stageName.
+ * @param <RECORD> Writable record to be serialized along with stageName
+ */
+public class TaggedWritable<RECORD extends Writable> implements
+  WritableComparable<TaggedWritable<RECORD>>, Configurable {
+  private String stageName;
+  private RECORD record;
+  private Configuration conf;
+  private ObjectWritable recordWritable;
+
+  // required by Hadoop
+  @SuppressWarnings("unused")
+  public TaggedWritable() {
+  }
+
+  public TaggedWritable(String stageName, RECORD record) {
+    this.stageName = stageName;
+    this.record = record;
+  }
+
+  public String getStageName() {
+    return stageName;
+  }
+
+  public RECORD getRecord() {
+    return record;
+  }
+
+  public void setStageName(String stageName) {
+    this.stageName = stageName;
+  }
+
+  public void setRecord(RECORD record) {
+    this.record = record;
+  }
+
+  @Override
+  public int compareTo(TaggedWritable o) {
+    return Integer.compare(hashCode(), o.hashCode());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TaggedWritable that = (TaggedWritable) o;
+    return that.stageName.equals(stageName) && that.record.equals(record);
+  }
+
+  @Override
+  public int hashCode() {
+    return (record != null && stageName != null) ? record.hashCode() + stageName.hashCode() : 0;
+  }
+
+  @Override
+  public void write(DataOutput out) throws IOException {
+    Text.writeString(out, stageName);
+    ObjectWritable recordWritable = new ObjectWritable(record);
+    recordWritable.write(out);
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    this.stageName = Text.readString(in);
+    this.recordWritable.readFields(in);
+    this.record = (RECORD) recordWritable.get();
+  }
+
+  @Override
+  public void setConf(Configuration conf) {
+    this.conf = conf;
+    recordWritable = new ObjectWritable();
+    // ObjectWritable does not set conf while reading fields
+    recordWritable.setConf(conf);
+  }
+
+  @Override
+  public Configuration getConf() {
+    return conf;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/TransformRunner.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/TransformRunner.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.etl.api.InvalidEntry;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.api.batch.BatchAggregator;
+import co.cask.cdap.etl.api.batch.BatchJoiner;
 import co.cask.cdap.etl.batch.BatchPhaseSpec;
 import co.cask.cdap.etl.batch.PipelinePluginInstantiator;
 import co.cask.cdap.etl.batch.TransformExecutorFactory;
@@ -90,17 +91,18 @@ public class TransformRunner<KEY, VALUE> {
     String sourceStage = (inputAliasName != null) ? inputAliasToStage.get(inputAliasName) : null;
 
     PipelinePhase phase = phaseSpec.getPhase();
-    Set<StageInfo> aggregators = phase.getStagesOfType(BatchAggregator.PLUGIN_TYPE);
-    if (!aggregators.isEmpty()) {
-      String aggregatorName = aggregators.iterator().next().getName();
+    Set<StageInfo> reducers = phase.getStagesOfType(BatchAggregator.PLUGIN_TYPE, BatchJoiner.PLUGIN_TYPE);
+    if (!reducers.isEmpty()) {
+      String reducerName = reducers.iterator().next().getName();
       // if we're in the mapper, get the part of the pipeline starting from sources and ending at aggregator
       if (jobContext instanceof Mapper.Context) {
-        phase = phase.subsetTo(ImmutableSet.of(aggregatorName));
+        phase = phase.subsetTo(ImmutableSet.of(reducerName));
       } else {
         // if we're in the reducer, get the part of the pipeline starting from the aggregator and ending at sinks
-        phase = phase.subsetFrom(ImmutableSet.of(aggregatorName));
+        phase = phase.subsetFrom(ImmutableSet.of(reducerName));
       }
     }
+
     TransformExecutorFactory<KeyValue<KEY, VALUE>> transformExecutorFactory =
       new MapReduceTransformExecutorFactory<>(context, pluginInstantiator, metrics, runtimeArgs, sourceStage);
     this.transformExecutor = transformExecutorFactory.create(phase);
@@ -120,10 +122,10 @@ public class TransformRunner<KEY, VALUE> {
   private OutputWriter<Object, Object> getSinkWriter(MapReduceTaskContext<Object, Object> context,
                                                      PipelinePhase pipelinePhase,
                                                      Configuration hConf) {
-    Set<StageInfo> aggregators = pipelinePhase.getStagesOfType(BatchAggregator.PLUGIN_TYPE);
-    if (!aggregators.isEmpty()) {
-      String aggregatorName = aggregators.iterator().next().getName();
-      if (pipelinePhase.getSinks().contains(aggregatorName)) {
+    Set<StageInfo> reducers = pipelinePhase.getStagesOfType(BatchAggregator.PLUGIN_TYPE, BatchJoiner.PLUGIN_TYPE);
+    if (!reducers.isEmpty()) {
+      String reducerName = reducers.iterator().next().getName();
+      if (pipelinePhase.getSinks().contains(reducerName)) {
         return new SingleOutputWriter<>(context);
       }
     }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkTransformExecutorFactory.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkTransformExecutorFactory.java
@@ -81,7 +81,7 @@ public class SparkTransformExecutorFactory<T> extends TransformExecutorFactory<T
       BatchRuntimeContext runtimeContext = createRuntimeContext(stageName);
       batchAggregator.initialize(runtimeContext);
       if (isFirstHalf) {
-        return getTrackedGroupStep(new PreGroupAggregatorTransformation(batchAggregator), stageMetrics);
+        return getTrackedEmitKeyStep(new PreGroupAggregatorTransformation(batchAggregator), stageMetrics);
       } else {
         return getTrackedAggregateStep(new PostGroupAggregatorTransformation(batchAggregator), stageMetrics);
       }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/AbstractJoinerContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/AbstractJoinerContext.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch;
+
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.etl.api.LookupProvider;
+import co.cask.cdap.etl.api.batch.BatchJoinerContext;
+
+import java.util.Map;
+
+/**
+ * Batch Joiner context
+ */
+public abstract class AbstractJoinerContext extends AbstractBatchContext implements BatchJoinerContext {
+  private Integer numPartitions;
+  private Class<?> joinKeyClass;
+  private Class<?> joinInputRecordClass;
+
+  protected AbstractJoinerContext(PluginContext pluginContext,
+                                  DatasetContext datasetContext,
+                                  Metrics metrics,
+                                  LookupProvider lookup,
+                                  String stageName,
+                                  long logicalStartTime,
+                                  Map<String, String> runtimeArgs) {
+    super(pluginContext, datasetContext, metrics, lookup, stageName, logicalStartTime, runtimeArgs);
+  }
+
+  @Override
+  public void setNumPartitions(int numPartitions) {
+    if (numPartitions < 1) {
+      throw new IllegalArgumentException(String.format(
+        "Invalid value for numPartitions %d. It must be a positive integer.", numPartitions));
+    }
+    this.numPartitions = numPartitions;
+  }
+
+  public Integer getNumPartitions() {
+    return numPartitions;
+  }
+
+  @Override
+  public void setJoinKeyClass(Class<?> joinKeyClass) {
+    this.joinKeyClass = joinKeyClass;
+  }
+
+  @Override
+  public void setJoinInputRecordClass(Class<?> joinInputRecordClass) {
+    this.joinInputRecordClass = joinInputRecordClass;
+  }
+
+  public Class<?> getJoinKeyClass() {
+    return joinKeyClass;
+  }
+
+  public Class<?> getJoinInputRecordClass() {
+    return joinInputRecordClass;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceJoinerContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceJoinerContext.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch.mapreduce;
+
+import co.cask.cdap.api.mapreduce.MapReduceContext;
+import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.etl.api.LookupProvider;
+import co.cask.cdap.etl.batch.AbstractJoinerContext;
+
+import java.util.Map;
+
+/**
+ * Map reduce context of joiner
+ */
+public class MapReduceJoinerContext extends AbstractJoinerContext {
+  private final MapReduceContext mrContext;
+
+  public MapReduceJoinerContext(MapReduceContext context, Metrics metrics, LookupProvider lookup,
+                                    String stageName,
+                                    Map<String, String> runtimeArgs) {
+    super(context, context, metrics, lookup, stageName, context.getLogicalStartTime(), runtimeArgs);
+    this.mrContext = context;
+  }
+
+  @Override
+  public <T> T getHadoopJob() {
+    return mrContext.getHadoopJob();
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceJoinerRuntimeContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceJoinerRuntimeContext.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch.mapreduce;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
+import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.etl.api.LookupProvider;
+import co.cask.cdap.etl.api.batch.BatchJoinerRuntimeContext;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+/**
+ * Mapreduce runtime context for batch joiner
+ */
+public class MapReduceJoinerRuntimeContext extends MapReduceRuntimeContext implements BatchJoinerRuntimeContext {
+  private final Map<String, Schema> inputSchemas;
+  private final Schema outputSchema;
+
+  public MapReduceJoinerRuntimeContext(MapReduceTaskContext context, Metrics metrics, LookupProvider lookup,
+                                            String stageName, Map<String, String> runtimeArgs,
+                                            Map<String, Schema> inputSchemas, Schema outputSchema) {
+    super(context, metrics, lookup, stageName, runtimeArgs);
+    this.inputSchemas = ImmutableMap.<String, Schema>copyOf(inputSchemas);
+    this.outputSchema = outputSchema;
+  }
+
+  @Override
+  public Map<String, Schema> getInputSchemas() {
+    return inputSchemas;
+  }
+
+  @Override
+  public Schema getOutputSchema() {
+    return outputSchema;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/DefaultStageConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/DefaultStageConfigurer.java
@@ -21,7 +21,8 @@ package co.cask.cdap.etl.common;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.etl.api.StageConfigurer;
 
-import java.util.Objects;
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 
@@ -32,13 +33,12 @@ import javax.annotation.Nullable;
  */
 public class DefaultStageConfigurer implements StageConfigurer {
   private Schema outputSchema;
-  private Schema inputSchema;
   private final String stageName;
-  boolean inputSchemaSet;
+  private Map<String, Schema> inputSchemas;
 
   public DefaultStageConfigurer(String stageName) {
     this.stageName = stageName;
-    this.inputSchemaSet = false;
+    this.inputSchemas = new HashMap<>();
   }
 
   @Nullable
@@ -49,7 +49,13 @@ public class DefaultStageConfigurer implements StageConfigurer {
   @Override
   @Nullable
   public Schema getInputSchema() {
-    return inputSchema;
+    return inputSchemas.entrySet().iterator().next().getValue();
+  }
+
+  @Nullable
+  @Override
+  public Map<String, Schema> getInputSchemas() {
+    return inputSchemas;
   }
 
   @Override
@@ -57,14 +63,8 @@ public class DefaultStageConfigurer implements StageConfigurer {
     this.outputSchema = outputSchema;
   }
 
-  public void setInputSchema(@Nullable Schema inputSchema) {
-    if (this.inputSchemaSet && !Objects.equals(this.inputSchema, inputSchema)) {
-      throw new IllegalArgumentException(
-        String.format("Two different input schema were set for stage %s. Schema1 = %s. Schema2 = %s.",
-                      stageName, this.inputSchema, inputSchema));
-    }
-    this.inputSchema = inputSchema;
-    this.inputSchemaSet = true;
+  public void addInputSchema(@Nullable String stageName, @Nullable Schema inputSchema) {
+    inputSchemas.put(stageName, inputSchema);
   }
 }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/PipelinePhase.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/PipelinePhase.java
@@ -61,6 +61,16 @@ public class PipelinePhase implements Iterable<StageInfo> {
     return Collections.unmodifiableSet(stageInfos == null ? new HashSet<StageInfo>() : stageInfos);
   }
 
+  public Set<StageInfo> getStagesOfType(String... pluginTypes) {
+    Set<StageInfo> stageInfos = new HashSet<>();
+    for (String pluginType: pluginTypes) {
+      if (stages.get(pluginType) != null) {
+        stageInfos.addAll(stages.get(pluginType));
+      }
+    }
+    return Collections.unmodifiableSet(stageInfos == null ? new HashSet<StageInfo>() : stageInfos);
+  }
+
   public Set<String> getStageOutputs(String stage) {
     Set<String> outputs = dag.getNodeOutputs(stage);
     return Collections.unmodifiableSet(outputs == null ? new HashSet<String>() : outputs);

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TrackedEmitter.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TrackedEmitter.java
@@ -36,6 +36,10 @@ public class TrackedEmitter<T> implements Emitter<T> {
     this.emitMetricName = emitMetricName;
   }
 
+  public Emitter<T> getEmitter() {
+    return delegate;
+  }
+
   @Override
   public void emit(T value) {
     delegate.emit(value);

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TrackedTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TrackedTransform.java
@@ -34,6 +34,7 @@ public class TrackedTransform<IN, OUT> implements Transformation<IN, OUT>, Destr
   public static final String RECORDS_IN = "records.in";
   public static final String RECORDS_OUT = "records.out";
   private final Transformation<IN, OUT> transform;
+  private String prevStage;
   private final StageMetrics metrics;
   private final String metricInName;
   private final String metricOutName;
@@ -50,9 +51,16 @@ public class TrackedTransform<IN, OUT> implements Transformation<IN, OUT>, Destr
     this.metricOutName = metricOutName;
   }
 
+  public String getPrevStage() {
+    return prevStage;
+  }
 
   @Override
   public void transform(IN input, Emitter<OUT> emitter) throws Exception {
+    if (emitter instanceof TransformDetail) {
+      prevStage = ((TransformDetail) emitter).getPrevStage();
+    }
+
     if (metricInName != null) {
       metrics.count(metricInName, 1);
     }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TransformDetail.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TransformDetail.java
@@ -25,33 +25,44 @@ import java.util.Collection;
 
 /**
  * Encapsulates {@link Transformation} list of next stages, current stage name, and {@link DefaultEmitter}.
+ * @param <T> the type of object to emit
  */
-public class TransformDetail implements Emitter<Object> {
+public class TransformDetail<T> implements Emitter<T> {
   private final Transformation transformation;
   private final Collection<String> nextStages;
-  private final DefaultEmitter<Object> defaultEmitter;
+  private String prevStage;
+  private final DefaultEmitter<T> defaultEmitter;
 
   public TransformDetail(Transformation transformation, Collection<String> nextStages) {
     this.transformation = transformation;
     this.nextStages = nextStages;
     this.defaultEmitter = new DefaultEmitter<>();
+    this.prevStage = "";
+  }
+
+  public String getPrevStage() {
+    return prevStage;
+  }
+
+  public void setPrevStage(String prevStage) {
+    this.prevStage = prevStage;
   }
 
   @Override
-  public void emit(Object value) {
+  public void emit(T value) {
     this.defaultEmitter.emit(value);
   }
 
   @Override
-  public void emitError(InvalidEntry<Object> invalidEntry) {
+  public void emitError(InvalidEntry<T> invalidEntry) {
     this.defaultEmitter.emitError(invalidEntry);
   }
 
-  public Collection<Object> getEntries() {
+  public Collection<T> getEntries() {
     return defaultEmitter.getEntries();
   }
 
-  public Collection<InvalidEntry<Object>> getErrors() {
+  public Collection<InvalidEntry<T>> getErrors() {
     return defaultEmitter.getErrors();
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TypeChecker.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TypeChecker.java
@@ -18,6 +18,7 @@ package co.cask.cdap.etl.common;
 
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.etl.api.Aggregator;
+import co.cask.cdap.etl.api.Joiner;
 import com.google.common.reflect.TypeToken;
 
 /**
@@ -30,10 +31,18 @@ public class TypeChecker {
 
   public static Class<?> getGroupKeyClass(Aggregator aggregator) {
     return getParameterClass(aggregator, Aggregator.class, 0);
-  }
+}
 
   public static Class<?> getGroupValueClass(Aggregator aggregator) {
     return getParameterClass(aggregator, Aggregator.class, 1);
+  }
+
+  public static Class<?> getJoinKeyClass(Joiner joiner) {
+    return getParameterClass(joiner, Joiner.class, 0);
+  }
+
+  public static Class<?> getJoinInputRecordClass(Joiner joiner) {
+    return getParameterClass(joiner, Joiner.class, 1);
   }
 
   public static Class getParameterClass(Object instance, Class instanceClass, int parameterNumber) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/PipelinePlanner.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/PipelinePlanner.java
@@ -148,14 +148,15 @@ public class PipelinePlanner {
 
       // add connectors
       if (connectors.contains(stageName)) {
-        phaseBuilder.addStage(Constants.CONNECTOR_TYPE, new StageInfo(stageName, null));
+        phaseBuilder.addStage(Constants.CONNECTOR_TYPE, new StageInfo(stageName));
         continue;
       }
 
       // add other plugin types
       StageSpec spec = specs.get(stageName);
       String pluginType = spec.getPlugin().getType();
-      StageInfo stageInfo = new StageInfo(stageName, spec.getErrorDatasetName());
+      StageInfo stageInfo = new StageInfo(stageName, spec.getInputs(), spec.getInputSchemas(), spec.getOutputs(),
+                                          spec.getOutputSchema(), spec.getErrorDatasetName());
       phaseBuilder.addStage(pluginType, stageInfo);
     }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/StageInfo.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/StageInfo.java
@@ -16,7 +16,12 @@
 
 package co.cask.cdap.etl.planner;
 
+import co.cask.cdap.api.data.schema.Schema;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -24,19 +29,53 @@ import javax.annotation.Nullable;
  */
 public class StageInfo {
   private final String name;
+  private final Set<String> inputs;
+  private final Map<String, Schema> inputSchemas;
+  private final Set<String> outputs;
+  private final Schema outputSchema;
   private final String errorDatasetName;
 
   public StageInfo(String name) {
-    this(name, null);
+    this.name = name;
+    this.inputs = null;
+    this.inputSchemas = null;
+    this.outputs = null;
+    this.outputSchema = null;
+    this.errorDatasetName = null;
   }
 
-  public StageInfo(String name, @Nullable String errorDatasetName) {
+  public StageInfo(String name, @Nullable Set<String> inputs, @Nullable Map<String, Schema> inputSchemas,
+                   @Nullable Set<String> outputs, @Nullable Schema outputSchema, @Nullable String errorDatasetName) {
     this.name = name;
+    this.inputSchemas = inputSchemas;
+    this.outputSchema = outputSchema;
+    this.inputs = ImmutableSet.copyOf(inputs);
+    this.outputs = ImmutableSet.copyOf(outputs);
     this.errorDatasetName = errorDatasetName;
   }
 
   public String getName() {
     return name;
+  }
+
+  @Nullable
+  public Set<String> getInputs() {
+    return inputs;
+  }
+
+  @Nullable
+  public Map<String, Schema> getInputSchemas() {
+    return inputSchemas;
+  }
+
+  @Nullable
+  public Set<String> getOutputs() {
+    return outputs;
+  }
+
+  @Nullable
+  public Schema getOutputSchema() {
+    return outputSchema;
   }
 
   @Nullable
@@ -56,18 +95,26 @@ public class StageInfo {
     StageInfo that = (StageInfo) o;
 
     return Objects.equals(name, that.name) &&
+      Objects.equals(inputs, that.inputs) &&
+      Objects.equals(inputSchemas, that.inputSchemas) &&
+      Objects.equals(outputs, that.outputs) &&
+      Objects.equals(outputSchema, that.outputSchema) &&
       Objects.equals(errorDatasetName, that.errorDatasetName);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, errorDatasetName);
+    return Objects.hash(name, inputs, inputSchemas, outputs, outputSchema, errorDatasetName);
   }
 
   @Override
   public String toString() {
     return "StageInfo{" +
       "name='" + name + '\'' +
+      "inputs='" + inputs + '\'' +
+      "inputSchemas='" + inputSchemas + '\'' +
+      "outputs='" + outputs + '\'' +
+      "outputSchema='" + outputSchema + '\'' +
       ", errorDatasetName='" + errorDatasetName + '\'' +
       '}';
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/StageSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/StageSpec.java
@@ -21,7 +21,9 @@ import co.cask.cdap.etl.proto.v2.ETLStage;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -37,17 +39,17 @@ public class StageSpec {
   private final String name;
   private final PluginSpec plugin;
   private final String errorDatasetName;
-  private final Schema inputSchema;
+  private final Map<String, Schema> inputSchemas;
   private final Schema outputSchema;
   private final Set<String> inputs;
   private final Set<String> outputs;
 
   private StageSpec(String name, PluginSpec plugin, String errorDatasetName,
-                    Schema inputSchema, Schema outputSchema, Set<String> inputs, Set<String> outputs) {
+                    Map<String, Schema> inputSchemas, Schema outputSchema, Set<String> inputs, Set<String> outputs) {
     this.name = name;
     this.plugin = plugin;
     this.errorDatasetName = errorDatasetName;
-    this.inputSchema = inputSchema;
+    this.inputSchemas = inputSchemas;
     this.outputSchema = outputSchema;
     this.inputs = ImmutableSet.copyOf(inputs);
     this.outputs = ImmutableSet.copyOf(outputs);
@@ -65,8 +67,8 @@ public class StageSpec {
     return errorDatasetName;
   }
 
-  public Schema getInputSchema() {
-    return inputSchema;
+  public Map<String, Schema> getInputSchemas() {
+    return inputSchemas;
   }
 
   public Schema getOutputSchema() {
@@ -95,7 +97,7 @@ public class StageSpec {
     return Objects.equals(name, that.name) &&
       Objects.equals(plugin, that.plugin) &&
       Objects.equals(errorDatasetName, that.errorDatasetName) &&
-      Objects.equals(inputSchema, that.inputSchema) &&
+      Objects.equals(inputSchemas, that.inputSchemas) &&
       Objects.equals(outputSchema, that.outputSchema) &&
       Objects.equals(inputs, that.inputs) &&
       Objects.equals(outputs, that.outputs);
@@ -103,7 +105,7 @@ public class StageSpec {
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, plugin, errorDatasetName, inputSchema, outputSchema, inputs, outputs);
+    return Objects.hash(name, plugin, errorDatasetName, inputSchemas, outputSchema, inputs, outputs);
   }
 
   @Override
@@ -112,7 +114,7 @@ public class StageSpec {
       "name='" + name + '\'' +
       ", plugin=" + plugin +
       ", errorDatasetName='" + errorDatasetName + '\'' +
-      ", inputSchema=" + inputSchema +
+      ", inputSchemas=" + inputSchemas +
       ", outputSchema=" + outputSchema +
       ", inputs=" + inputs +
       ", outputs=" + outputs +
@@ -130,7 +132,7 @@ public class StageSpec {
     private final String name;
     private final PluginSpec plugin;
     private String errorDatasetName;
-    private Schema inputSchema;
+    private Map<String, Schema> inputSchemas;
     private Schema outputSchema;
     private Set<String> inputs;
     private Set<String> outputs;
@@ -140,6 +142,7 @@ public class StageSpec {
       this.plugin = plugin;
       this.inputs = new HashSet<>();
       this.outputs = new HashSet<>();
+      this.inputSchemas = new HashMap<>();
     }
 
     public Builder setErrorDatasetName(String errorDatasetName) {
@@ -147,8 +150,13 @@ public class StageSpec {
       return this;
     }
 
-    public Builder setInputSchema(Schema inputSchema) {
-      this.inputSchema = inputSchema;
+    public Builder addInputSchema(String stageName, Schema schema) {
+      this.inputSchemas.put(stageName, schema);
+      return this;
+    }
+
+    public Builder addInputSchemas(Map<String, Schema> inputSchemas) {
+      this.inputSchemas.putAll(inputSchemas);
       return this;
     }
 
@@ -182,7 +190,7 @@ public class StageSpec {
     }
 
     public StageSpec build() {
-      return new StageSpec(name, plugin, errorDatasetName, inputSchema, outputSchema, inputs, outputs);
+      return new StageSpec(name, plugin, errorDatasetName, inputSchemas, outputSchema, inputs, outputs);
     }
 
   }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/joiner/Join.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/joiner/Join.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.batch.joiner;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginPropertyField;
+import co.cask.cdap.etl.api.JoinConfig;
+import co.cask.cdap.etl.api.JoinElement;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
+import co.cask.cdap.etl.api.batch.BatchJoiner;
+import co.cask.cdap.etl.api.batch.BatchJoinerRuntimeContext;
+import co.cask.cdap.etl.proto.v2.ETLPlugin;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import javax.annotation.Nullable;
+
+/**
+ * Join plugin to perform joins on structured records
+ */
+@Plugin(type = BatchJoiner.PLUGIN_TYPE)
+@Name("Join")
+public class Join extends BatchJoiner<StructuredRecord, StructuredRecord, StructuredRecord> {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
+  private final Config config;
+  private Map<String, Schema> inputSchemas;
+  private Schema outputSchema;
+
+  public Join(Config config) {
+    this.config = config;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+    Map<String, Schema> inputSchemas = stageConfigurer.getInputSchemas();
+    stageConfigurer.setOutputSchema(getOutputSchema(inputSchemas));
+    config.validateConfig();
+  }
+
+  @Override
+  public void initialize(BatchJoinerRuntimeContext context) throws Exception {
+    inputSchemas = context.getInputSchemas();
+    outputSchema = context.getOutputSchema();
+  }
+
+  @Override
+  public StructuredRecord joinOn(String stageName, StructuredRecord record) throws Exception {
+    List<Schema.Field> fields = new ArrayList<>();
+    Schema schema = record.getSchema();
+
+    // TODO create output record based on fields properties
+    Map<String, List<String>> stageToJoinKey = config.getJoinKeys();
+    List<String> joinKeys = stageToJoinKey.get(stageName);
+    int i = 1;
+    for (String joinKey : joinKeys) {
+      Schema.Field joinField = Schema.Field.of(String.valueOf(i++), schema.getField(joinKey).getSchema());
+      fields.add(joinField);
+    }
+    Schema keySchema = Schema.recordOf("join.key", fields);
+    StructuredRecord.Builder keyRecordBuilder = StructuredRecord.builder(keySchema);
+    i = 1;
+    for (String joinKey : joinKeys) {
+      keyRecordBuilder.set(String.valueOf(i++), record.get(joinKey));
+    }
+
+    return keyRecordBuilder.build();
+  }
+
+  @Override
+  public JoinConfig getJoinConfig() {
+    return new JoinConfig(config.getRequiredInputs());
+  }
+
+  @Override
+  public StructuredRecord merge(StructuredRecord joinKey, Iterable<JoinElement<StructuredRecord>> joinRow) {
+    StructuredRecord.Builder outRecordBuilder;
+    outRecordBuilder = StructuredRecord.builder(outputSchema);
+
+    for (JoinElement<StructuredRecord> joinElement : joinRow) {
+      StructuredRecord record = joinElement.getInputRecord();
+      for (Schema.Field field : record.getSchema().getFields()) {
+        outRecordBuilder.set(field.getName(), record.get(field.getName()));
+      }
+    }
+    return outRecordBuilder.build();
+  }
+
+  private Schema getOutputSchema(Map<String, Schema> inputSchemas) {
+    // sort the input schemas by input names to get the deterministic order of fields for output schema
+    Map<String, Schema> sortedMap = new TreeMap<>(inputSchemas);
+    List<Schema.Field> outputFields = new ArrayList<>();
+    Iterable<String> requiredInputs = config.getRequiredInputs();
+
+    // TODO use properties like fieldsToSelect and fieldsToRename to create output schema
+    for (Map.Entry<String, Schema> entry : sortedMap.entrySet()) {
+      Schema inputSchema = entry.getValue();
+      if (Iterables.contains(requiredInputs, entry.getKey())) {
+        for (Schema.Field inputField: inputSchema.getFields()) {
+          outputFields.add(Schema.Field.of(inputField.getName(), inputField.getSchema()));
+        }
+      } else { // mark fields as nullable
+        for (Schema.Field inputField: inputSchema.getFields()) {
+          outputFields.add(Schema.Field.of(inputField.getName(),
+                                        Schema.nullableOf(inputField.getSchema())));
+        }
+      }
+    }
+    return Schema.recordOf("join.output", outputFields);
+  }
+
+  /**
+   * Config for join plugin
+   */
+  public static class Config extends PluginConfig {
+    private final String joinKeys;
+    @Nullable
+    private final String fieldsToSelect;
+    @Nullable
+    private final String fieldsToRename;
+    @Nullable
+    private final String requiredInputs;
+
+
+    public Config() {
+      this.joinKeys = "joinKeys";
+      this.fieldsToSelect = "fieldsToSelect";
+      this.fieldsToRename = "fieldsToRename";
+      this.requiredInputs = "requiredInputs";
+    }
+
+    private void validateConfig() {
+      if (joinKeys == null || joinKeys.isEmpty()) {
+        throw new IllegalArgumentException(String.format(
+          "join keys can not be empty or null for plugin %s", PLUGIN_CLASS));
+      }
+
+      Iterable<String> multipleJoinKeys = Splitter.on(',').trimResults().omitEmptyStrings().split(joinKeys);
+      for (String key : multipleJoinKeys) {
+        Iterable<String> perStageJoinKeys = Splitter.on('=').trimResults().omitEmptyStrings().split(key);
+        for (String perStageKey : perStageJoinKeys) {
+          Iterable<String> stageKey = Splitter.on('.').trimResults().omitEmptyStrings().split(perStageKey);
+          if (Iterables.size(stageKey) != 2) {
+            throw new IllegalArgumentException(String.format("Join key should be specified in stageName.columnName " +
+                                                               "format for key %s of type %s",
+                                                             perStageKey, PLUGIN_TYPE));
+          }
+        }
+      }
+    }
+
+    /**
+     * Converts join keys to map of per stage join keys For example,
+     * customers.id=items.cust_id,customers.name=items.cust_name
+     * will get converted to customers -> (id,name) and items -> (cust_id,cust_name)
+     * @return
+     */
+    private Map<String, List<String>> getJoinKeys() {
+      Map<String, List<String>> stageToKey = new HashMap<>();
+      Iterable<String> multipleJoinKeys = Splitter.on(',').trimResults().omitEmptyStrings().split(joinKeys);
+      for (String key : multipleJoinKeys) {
+        Iterable<String> perStageJoinKeys = Splitter.on('=').trimResults().omitEmptyStrings().split(key);
+        for (String perStageKey : perStageJoinKeys) {
+          Iterable<String> stageKey = Splitter.on('.').trimResults().omitEmptyStrings().split(perStageKey);
+          String stageName = Iterables.get(stageKey, 0);
+          List<String> listOfKeys = stageToKey.get(stageName);
+          if (listOfKeys == null) {
+            listOfKeys = new ArrayList<>();
+            stageToKey.put(stageName, listOfKeys);
+          }
+          listOfKeys.add(Iterables.get(stageKey, 1));
+        }
+      }
+
+      return stageToKey;
+    }
+
+    private Iterable<String> getRequiredInputs() {
+      return Splitter.on(',').trimResults().omitEmptyStrings().split(requiredInputs);
+    }
+  }
+
+  public static ETLPlugin getPlugin(String joinKeys, String requiredInputs,
+                                    String fieldsToSelect, String fieldsToRename) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("joinKeys", joinKeys);
+    properties.put("requiredInputs", requiredInputs);
+    properties.put("fieldsToSelect", fieldsToSelect);
+    properties.put("fieldsToRename", fieldsToRename);
+    return new ETLPlugin("Join", BatchJoiner.PLUGIN_TYPE, properties, null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("joinKeys", new PluginPropertyField("joinKeys", "", "string", true, false));
+    properties.put("requiredInputs", new PluginPropertyField("requiredInputs", "", "string", true, false));
+    properties.put("fieldsToSelect", new PluginPropertyField("fieldsToSelect", "", "string", true, false));
+    properties.put("fieldsToRename", new PluginPropertyField("fieldsToRename", "", "string", true, false));
+    return new PluginClass(BatchJoiner.PLUGIN_TYPE, "Join", "", Join.class.getName(),
+                           "config", properties);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/test/HydratorTestBase.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/test/HydratorTestBase.java
@@ -25,11 +25,13 @@ import co.cask.cdap.etl.mock.batch.MockExternalSource;
 import co.cask.cdap.etl.mock.batch.NodeStatesAction;
 import co.cask.cdap.etl.mock.batch.aggregator.FieldCountAggregator;
 import co.cask.cdap.etl.mock.batch.aggregator.IdentityAggregator;
+import co.cask.cdap.etl.mock.batch.joiner.Join;
 import co.cask.cdap.etl.mock.realtime.LookupSource;
 import co.cask.cdap.etl.mock.realtime.MockSink;
 import co.cask.cdap.etl.mock.realtime.MockSource;
 import co.cask.cdap.etl.mock.transform.DoubleTransform;
 import co.cask.cdap.etl.mock.transform.ErrorTransform;
+import co.cask.cdap.etl.mock.transform.FieldsPrefixTransform;
 import co.cask.cdap.etl.mock.transform.IdentityTransform;
 import co.cask.cdap.etl.mock.transform.IntValueFilterTransform;
 import co.cask.cdap.etl.mock.transform.StringValueFilterTransform;
@@ -50,11 +52,11 @@ public class HydratorTestBase extends TestBase {
     IntValueFilterTransform.PLUGIN_CLASS, StringValueFilterTransform.PLUGIN_CLASS
   );
   private static final Set<PluginClass> BATCH_MOCK_PLUGINS = ImmutableSet.of(
-    FieldCountAggregator.PLUGIN_CLASS, IdentityAggregator.PLUGIN_CLASS,
+    FieldCountAggregator.PLUGIN_CLASS, IdentityAggregator.PLUGIN_CLASS, Join.PLUGIN_CLASS,
     co.cask.cdap.etl.mock.batch.MockSink.PLUGIN_CLASS, co.cask.cdap.etl.mock.batch.MockSource.PLUGIN_CLASS,
     MockExternalSource.PLUGIN_CLASS, MockExternalSink.PLUGIN_CLASS,
     DoubleTransform.PLUGIN_CLASS, ErrorTransform.PLUGIN_CLASS, IdentityTransform.PLUGIN_CLASS,
-    IntValueFilterTransform.PLUGIN_CLASS, StringValueFilterTransform.PLUGIN_CLASS
+    FieldsPrefixTransform.PLUGIN_CLASS, IntValueFilterTransform.PLUGIN_CLASS, StringValueFilterTransform.PLUGIN_CLASS
   );
 
   public HydratorTestBase() {
@@ -97,7 +99,7 @@ public class HydratorTestBase extends TestBase {
                       MockExternalSource.class, MockExternalSink.class,
                       DoubleTransform.class, ErrorTransform.class, IdentityTransform.class,
                       IntValueFilterTransform.class, StringValueFilterTransform.class,
-                      FieldCountAggregator.class, IdentityAggregator.class,
+                      FieldCountAggregator.class, IdentityAggregator.class, FieldsPrefixTransform.class,
                       NodeStatesAction.class);
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/FieldsPrefixTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/FieldsPrefixTransform.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.transform;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginPropertyField;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
+import co.cask.cdap.etl.api.Transform;
+import co.cask.cdap.etl.proto.v2.ETLPlugin;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Transform which adds prefix to all the fields of structured record for testing multi input schemas
+ */
+@Plugin(type = Transform.PLUGIN_TYPE)
+@Name("FieldsPrefixTransform")
+public class FieldsPrefixTransform extends Transform<StructuredRecord, StructuredRecord> {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
+
+  private final Config config;
+
+  public FieldsPrefixTransform(Config config) {
+    this.config = config;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
+    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+    try {
+      Schema outSchema = config.getOutputSchema(Schema.parseJson(config.schemaStr));
+      stageConfigurer.setOutputSchema(outSchema);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Invalid output schema: " + e.getMessage(), e);
+    }
+  }
+
+  @Override
+  public void transform(StructuredRecord input, Emitter<StructuredRecord> emitter) throws Exception {
+    Schema outSchema = config.getOutputSchema(input.getSchema());
+    StructuredRecord.Builder outputBuilder = StructuredRecord.builder(outSchema);
+
+    for (Schema.Field inField : input.getSchema().getFields()) {
+        outputBuilder.set(config.prefix + inField.getName(), input.get(inField.getName()));
+    }
+    emitter.emit(outputBuilder.build());
+  }
+
+  /**
+   * Config for join plugin
+   */
+  public static class Config extends PluginConfig {
+    private String prefix;
+    private String schemaStr;
+
+    public Config() {
+      prefix = "prefix";
+      schemaStr = "schemaStr";
+    }
+
+    private Schema getOutputSchema(Schema inputSchema) {
+      List<Schema.Field> outFields = new ArrayList<>();
+      List<Schema.Field> fields = inputSchema.getFields();
+      for (Schema.Field field : fields) {
+        outFields.add(Schema.Field.of(prefix + field.getName(), field.getSchema()));
+      }
+      return Schema.recordOf("prefixed.outfields", outFields);
+    }
+  }
+
+  public static ETLPlugin getPlugin(String prefix, String schemaStr) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("prefix", prefix);
+    properties.put("schemaStr", schemaStr);
+    return new ETLPlugin("FieldsPrefixTransform", Transform.PLUGIN_TYPE, properties, null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("prefix", new PluginPropertyField("prefix", "", "string", true, false));
+    properties.put("schemaStr", new PluginPropertyField("schemaStr", "", "string", true, false));
+    return new PluginClass(Transform.PLUGIN_TYPE, "FieldsPrefixTransform", "", FieldsPrefixTransform.class.getName(),
+                           "config", properties);
+  }
+
+}


### PR DESCRIPTION
Adding inner join capability in Hydrator app for mapreduce

Issue: https://issues.cask.co/browse/CDAP-6186
Build: http://builds.cask.co/browse/CDAP-DUT4330-4

Summary
- Allowing multiple input schemas in hydrator app
- Inner join for multiple join keys
- Mock Join cdap plugin 
- Testcases for multiple schemas and inner join with multiple schemas.

Will be sending out separate PR for outer joins. 
