### PR TITLE
[CDAP-5000] Remove configurable number of instances for explore service

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -633,7 +633,7 @@
     <name>explore.executor.container.instances</name>
     <value>1</value>
     <description>
-      Number of explore executor instances
+      Number of explore executor instances (deprecated: instance count is always set to 1) 
     </description>
   </property>
 
@@ -657,7 +657,7 @@
     <name>explore.executor.max.instances</name>
     <value>1</value>
     <description>
-      Maximum number of explore executor instances
+      Maximum number of explore executor instances (deprecated: instance count is always set to 1)
     </description>
   </property>
 

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/service/ExploreServiceManager.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/service/ExploreServiceManager.java
@@ -22,11 +22,15 @@ import co.cask.cdap.common.twill.AbstractDistributedMasterServiceManager;
 import com.google.inject.Inject;
 import org.apache.twill.api.TwillRunnerService;
 import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Service manager for explore service in distributed mode.
  */
 public class ExploreServiceManager extends AbstractDistributedMasterServiceManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ExploreServiceManager.class);
 
   @Inject
   public ExploreServiceManager(CConfiguration cConf, TwillRunnerService twillRunnerService,
@@ -42,7 +46,12 @@ public class ExploreServiceManager extends AbstractDistributedMasterServiceManag
 
   @Override
   public int getMaxInstances() {
-    return cConf.getInt(Constants.Explore.MAX_INSTANCES, 1);
+    String configuredInstances = cConf.get(Constants.Explore.CONTAINER_INSTANCES);
+    if (configuredInstances != null) {
+      LOG.warn("Explore service instance count is set to {}, but this configuration is no longer supported " +
+                 "as it is always set to 1.", configuredInstances);
+    }
+    return 1; // max explore service container instances is 1 (non-configurable)
   }
 
   @Override

--- a/cdap-master/src/main/java/co/cask/cdap/common/MasterUtils.java
+++ b/cdap-master/src/main/java/co/cask/cdap/common/MasterUtils.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2014-2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.master.startup.ExploreServiceResourceKeys;
+import co.cask.cdap.master.startup.ServiceResourceKeys;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+/**
+ * Provides utility methods for CDAP master checks
+ */
+public final class MasterUtils {
+
+  /**
+   * Explicitly disallow default constructor for utility class
+   */
+  private MasterUtils(){}
+
+  /**
+   * Creates a set of system service resource keys
+   * @param cConf the configured CDAP settings
+   * @return a set of {@link ServiceResourceKeys} for all system services
+   */
+  public static Set<ServiceResourceKeys> createSystemServicesResourceKeysSet(CConfiguration cConf) {
+    ImmutableSet.Builder<ServiceResourceKeys> builder = ImmutableSet.<ServiceResourceKeys>builder()
+      .add(new ServiceResourceKeys(cConf,
+                                   Constants.Service.TRANSACTION,
+                                   Constants.Transaction.Container.MEMORY_MB,
+                                   Constants.Transaction.Container.NUM_CORES,
+                                   Constants.Transaction.Container.NUM_INSTANCES,
+                                   Constants.Transaction.Container.MAX_INSTANCES))
+      .add(new ServiceResourceKeys(cConf,
+                                   Constants.Service.STREAMS,
+                                   Constants.Stream.CONTAINER_MEMORY_MB,
+                                   Constants.Stream.CONTAINER_VIRTUAL_CORES,
+                                   Constants.Stream.CONTAINER_INSTANCES,
+                                   Constants.Stream.MAX_INSTANCES))
+      .add(new ServiceResourceKeys(cConf,
+                                   Constants.Service.METRICS,
+                                   Constants.Metrics.MEMORY_MB,
+                                   Constants.Metrics.NUM_CORES,
+                                   Constants.Metrics.NUM_INSTANCES,
+                                   Constants.Metrics.MAX_INSTANCES))
+      .add(new ServiceResourceKeys(cConf,
+                                   Constants.Service.METRICS_PROCESSOR,
+                                   Constants.MetricsProcessor.MEMORY_MB,
+                                   Constants.MetricsProcessor.NUM_CORES,
+                                   Constants.MetricsProcessor.NUM_INSTANCES,
+                                   Constants.MetricsProcessor.MAX_INSTANCES))
+      .add(new ServiceResourceKeys(cConf,
+                                   Constants.Service.LOGSAVER,
+                                   Constants.LogSaver.MEMORY_MB,
+                                   Constants.LogSaver.NUM_CORES,
+                                   Constants.LogSaver.NUM_INSTANCES,
+                                   Constants.LogSaver.MAX_INSTANCES))
+      .add(new ServiceResourceKeys(cConf,
+                                   Constants.Service.DATASET_EXECUTOR,
+                                   Constants.Dataset.Executor.CONTAINER_MEMORY_MB,
+                                   Constants.Dataset.Executor.CONTAINER_VIRTUAL_CORES,
+                                   Constants.Dataset.Executor.CONTAINER_INSTANCES,
+                                   Constants.Dataset.Executor.MAX_INSTANCES));
+    if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED)) {
+      builder.add(new ExploreServiceResourceKeys(cConf,
+                                                 Constants.Service.EXPLORE_HTTP_USER_SERVICE,
+                                                 Constants.Explore.CONTAINER_MEMORY_MB,
+                                                 Constants.Explore.CONTAINER_VIRTUAL_CORES,
+                                                 Constants.Explore.CONTAINER_INSTANCES,
+                                                 Constants.Explore.MAX_INSTANCES));
+    }
+    return builder.build();
+  }
+}

--- a/cdap-master/src/main/java/co/cask/cdap/master/startup/ExploreServiceResourceKeys.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/startup/ExploreServiceResourceKeys.java
@@ -16,21 +16,26 @@
 
 package co.cask.cdap.master.startup;
 
-import co.cask.cdap.common.MasterUtils;
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.startup.Check;
-
-import java.util.Set;
 
 /**
- * Base for master startup checks.
+ * Extends the ServiceResourceKeys class to override the number of instances for the explore service.
  */
-public abstract class AbstractMasterCheck extends Check {
-  protected final CConfiguration cConf;
-  protected final Set<ServiceResourceKeys> systemServicesResourceKeys;
+public class ExploreServiceResourceKeys extends ServiceResourceKeys {
 
-  protected AbstractMasterCheck(CConfiguration cConf) {
-    this.cConf = cConf;
-    this.systemServicesResourceKeys = MasterUtils.createSystemServicesResourceKeysSet(cConf);
+  public ExploreServiceResourceKeys(CConfiguration cConf, String serviceName, String memoryKey, String vcoresKey,
+                             String instancesKey, String maxInstancesKey) {
+    super(cConf, serviceName, memoryKey, vcoresKey, instancesKey, maxInstancesKey);
   }
+
+  @Override
+  public int getInstances() {
+    return 1;
+  }
+
+  @Override
+  public int getMaxInstances() {
+    return 1;
+  }
+
 }

--- a/cdap-master/src/main/java/co/cask/cdap/master/startup/ServiceResourceKeys.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/startup/ServiceResourceKeys.java
@@ -16,18 +16,22 @@
 
 package co.cask.cdap.master.startup;
 
+import co.cask.cdap.common.conf.CConfiguration;
+
 /**
  * Convenience class to group config keys for memory, cores, and instances for each system service.
  */
-class ServiceResourceKeys {
+public class ServiceResourceKeys {
   private final String serviceName;
   private final String memoryKey;
   private final String vcoresKey;
   private final String instancesKey;
   private final String maxInstancesKey;
+  protected final CConfiguration cConf;
 
-  ServiceResourceKeys(String serviceName, String memoryKey, String vcoresKey,
+  public ServiceResourceKeys(CConfiguration cConf, String serviceName, String memoryKey, String vcoresKey,
                              String instancesKey, String maxInstancesKey) {
+    this.cConf = cConf;
     this.serviceName = serviceName;
     this.memoryKey = memoryKey;
     this.vcoresKey = vcoresKey;
@@ -43,15 +47,31 @@ class ServiceResourceKeys {
     return memoryKey;
   }
 
+  public int getMemory() {
+    return cConf.getInt(memoryKey);
+  }
+
   public String getVcoresKey() {
     return vcoresKey;
+  }
+
+  public int getVcores() {
+    return cConf.getInt(vcoresKey);
   }
 
   public String getInstancesKey() {
     return instancesKey;
   }
 
+  public int getInstances() {
+    return cConf.getInt(instancesKey);
+  }
+
   public String getMaxInstancesKey() {
     return maxInstancesKey;
+  }
+
+  public int getMaxInstances() {
+    return cConf.getInt(maxInstancesKey);
   }
 }

--- a/cdap-master/src/main/java/co/cask/cdap/master/startup/YarnCheck.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/startup/YarnCheck.java
@@ -140,19 +140,19 @@ class YarnCheck extends AbstractMasterCheck {
       int vcores = 0;
 
       try {
-        instances = cConf.getInt(serviceResourceKeys.getInstancesKey());
+        instances = serviceResourceKeys.getInstances();
       } catch (Exception e) {
         invalidKeys.add(serviceResourceKeys.getInstancesKey());
         hasConfigError = true;
       }
       try {
-        memoryMB = cConf.getInt(serviceResourceKeys.getMemoryKey());
+        memoryMB = serviceResourceKeys.getMemory();
       } catch (Exception e) {
         invalidKeys.add(serviceResourceKeys.getMemoryKey());
         hasConfigError = true;
       }
       try {
-        vcores = cConf.getInt(serviceResourceKeys.getVcoresKey());
+        vcores = serviceResourceKeys.getVcores();
       } catch (Exception e) {
         invalidKeys.add(serviceResourceKeys.getVcoresKey());
         hasConfigError = true;


### PR DESCRIPTION
Extended ServiceResourceKeys class to be allow overriding service properties, specifically to remove configuration for the number of explore service instances and set it to 1. Also added the dataset service to AbstractMasterCheck (it was previously in MasterServiceMain but not AbstractMasterCheck).

Link to Bamboo build: http://builds.cask.co/browse/CDAP-DUT4246-7
