### PR TITLE
add TEMP_DIR variable, set TEMP_DIR and LOCAL_DIR via cdap-env.sh

### DIFF
--- a/cdap-common/bin/common-env.sh
+++ b/cdap-common/bin/common-env.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright © 2014-2015 Cask Data, Inc.
+# Copyright © 2014-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -48,7 +48,10 @@ export IDENT_STRING=${USER}
 export PID_DIR=/var/cdap/run
 
 # The directory serving as the user directory for master
-export LOCAL_DIR=/var/tmp/cdap
+export LOCAL_DIR=${LOCAL_DIR:-/var/tmp/cdap}
+
+# The directory serving as the java.io.tmpdir directory for master
+export TEMP_DIR=${TEMP_DIR:-/tmp}
 
 # Specifies the JAVA_HEAPMAX
 export JAVA_HEAPMAX=${JAVA_HEAPMAX:--Xmx128m}

--- a/cdap-common/bin/service
+++ b/cdap-common/bin/service
@@ -118,7 +118,7 @@ _start_java() {
   ulimit -a >>${loglog}
   echo "CLASSPATH=${CLASSPATH}" >>${loglog}
   # Start our JVM
-  local __defines="-Dcdap.service=${APP} ${JAVA_HEAPMAX} -Duser.dir=${LOCAL_DIR}"
+  local __defines="-Dcdap.service=${APP} ${JAVA_HEAPMAX} -Duser.dir=${LOCAL_DIR} -Djava.io.tmpdir=${TEMP_DIR}"
   __defines+=" -Dexplore.conf.files=${EXPLORE_CONF_FILES} -Dexplore.classpath=${EXPLORE_CLASSPATH}"
   __defines+=" ${OPTS}"
   nohup nice -n ${NICENESS} "${JAVA}" ${__defines} -cp ${CLASSPATH} ${MAIN_CLASS} ${MAIN_CLASS_ARGS} ${@} </dev/null >>${loglog} 2>&1 &
@@ -225,7 +225,7 @@ run() {
   else
     echo "Running class ${MAIN_CLASS}"
   fi
-  "${JAVA}" "${JAVA_HEAPMAX}" -Dhive.classpath=${HIVE_CLASSPATH} -Duser.dir=${LOCAL_DIR} ${OPTS} -cp ${CLASSPATH} ${MAIN_CLASS} ${@}
+  "${JAVA}" "${JAVA_HEAPMAX}" -Dhive.classpath=${HIVE_CLASSPATH} -Duser.dir=${LOCAL_DIR} -Djava.io.tmpdir=${TEMP_DIR} ${OPTS} -cp ${CLASSPATH} ${MAIN_CLASS} ${@}
 }
 
 case ${1} in

--- a/cdap-distributions/src/etc/cdap/conf.dist/cdap-env.sh
+++ b/cdap-distributions/src/etc/cdap/conf.dist/cdap-env.sh
@@ -1,4 +1,4 @@
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -21,3 +21,11 @@
 
 # Ensure SPARK_HOME is set for Spark support.
 # export SPARK_HOME="/usr/lib/spark"
+
+# LOCAL_DIR sets the JVM -Duser.dir property of the CDAP processes, and provides a
+# local working directory for application jars during startup if needed
+LOCAL_DIR="/var/tmp/cdap"
+
+# TEMP_DIR sets the JVM -Djava.io.tmpdir property of the CDAP processes, and provides
+# temporary storage for Apache Twill
+TEMP_DIR="/tmp"


### PR DESCRIPTION
- [x] fixes [CDAP-6246](https://issues.cask.co/browse/CDAP-6246) by adding a `TEMP_DIR` variable to  the cdap init scripts, passed in as the JVM flag `-Djava.io.tmpdir`
- [x] fixes [CDAP-6027](https://issues.cask.co/browse/CDAP-6027) by defining both `TEMP_DIR` and `LOCAL_DIR` in the example cdap-env.sh.
- [ ] I kept the current default locations the same as they currently are, but we should consider changing them for consistency.
