### PR TITLE
Adds multiple input schemas to Hydrator++ plugins in UI

### DIFF
--- a/cdap-ui/app/directives/plugin-functions/functions/get-schema/get-schema.js
+++ b/cdap-ui/app/directives/plugin-functions/functions/get-schema/get-schema.js
@@ -45,8 +45,7 @@ angular.module(PKG.name + '.commons')
         vm.openModal = function () {
           var modal = $uibModal.open({
             templateUrl: 'plugin-functions/functions/get-schema/get-schema-modal.html',
-            size: 'lg',
-            windowTopClass: 'hydrator-modal get-schema-modal',
+            windowClass: 'hydrator-modal node-config-modal',
             keyboard: true,
             controller: function ($scope, nodeInfo, $state) {
               var mvm = this;

--- a/cdap-ui/app/directives/plugin-functions/functions/output-schema/output-schema.js
+++ b/cdap-ui/app/directives/plugin-functions/functions/output-schema/output-schema.js
@@ -54,8 +54,7 @@ angular.module(PKG.name + '.commons')
         vm.openModal = function () {
           var modal = $uibModal.open({
             templateUrl: 'plugin-functions/functions/output-schema/output-schema-modal.html',
-            size: 'lg',
-            windowTopClass: 'hydrator-modal output-schema-modal',
+            windowClass: 'hydrator-modal node-config-modal',
             keyboard: true,
             controller: function ($scope, nodeInfo, $state, HydratorPlusPlusHydratorService) {
               var mvm = this;
@@ -65,7 +64,15 @@ angular.module(PKG.name + '.commons')
               mvm.fetchSchema = function () {
                 var config = mvm.node.plugin.properties;
                 // This is lame where we stringify the input schema from the formatOutputSchema function but again parse it here to send it as an object to the backend.
-                config.inputSchema = JSON.parse(HydratorPlusPlusHydratorService.formatOutputSchema(nodeInfo.inputSchema));
+                var firstNode = nodeInfo.inputSchema[0];
+                var fields;
+                try {
+                  fields = JSON.parse(firstNode.schema).fields || [];
+                  config.inputSchema = JSON.parse(HydratorPlusPlusHydratorService.formatOutputSchema(fields));
+                } catch(e) {
+                  config.inputSchema = '';
+                }
+
                 mvm.showLoading = true;
 
                 var params = {

--- a/cdap-ui/app/directives/validators/validator-ctrl.js
+++ b/cdap-ui/app/directives/validators/validator-ctrl.js
@@ -45,9 +45,13 @@ angular.module(PKG.name + '.commons')
 
     var validatorsList;
     var classNameList = [];
-
     // We just need to set the input schema as the output schema
-    $scope.outputSchema = HydratorPlusPlusHydratorService.formatOutputSchema($scope.inputSchema);
+    try {
+      $scope.inputSchema = JSON.parse($scope.inputSchema[0].schema);
+    } catch(e) {
+      $scope.inputSchema = {fields: []};
+    }
+    $scope.outputSchema = HydratorPlusPlusHydratorService.formatOutputSchema($scope.inputSchema.fields);
 
     myHydratorValidatorsApi.get()
       .$promise

--- a/cdap-ui/app/directives/validators/validators.html
+++ b/cdap-ui/app/directives/validators/validators.html
@@ -39,7 +39,7 @@
           <div class="list-group">
             <a href=""
                 class="list-group-item"
-                ng-repeat="field in inputSchema"
+                ng-repeat="field in inputSchema.fields"
                 ng-click="!isDisabled && ValidatorsCtrl.addFieldGroup(field.name)">
               {{field.name}}
             </a>

--- a/cdap-ui/app/directives/widget-container/widget-input-schema/widget-input-schema-ctrl.js
+++ b/cdap-ui/app/directives/widget-container/widget-input-schema/widget-input-schema-ctrl.js
@@ -15,8 +15,13 @@
 */
 angular.module(PKG.name + '.commons')
   .controller('MyInputSchemaCtrl', function($scope) {
+    this.doLoadNextSetOfInputSchemaRows = function() {
+      this.inputSchemaRowLimit += 10;
+    };
+    this.inputSchemaRowLimit = 15;
+    this.multipleInputs = ($scope.multipleInputs === 'true' ? true : false);
     try {
-      this.inputSchemas = JSON.parse($scope.inputschema);
+      this.inputSchemas = JSON.parse($scope.inputSchema);
     } catch(e) {
       this.inputSchemas = [];
     }

--- a/cdap-ui/app/directives/widget-container/widget-input-schema/widget-input-schema-ctrl.js
+++ b/cdap-ui/app/directives/widget-container/widget-input-schema/widget-input-schema-ctrl.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+angular.module(PKG.name + '.commons')
+  .controller('MyInputSchemaCtrl', function($scope) {
+    try {
+      this.inputSchemas = JSON.parse($scope.inputschema);
+    } catch(e) {
+      this.inputSchemas = [];
+    }
+    this.inputSchemas = this.inputSchemas
+      .map( function(node) {
+        var schema;
+        try {
+          schema = JSON.parse(node.schema);
+        } catch(e) {
+          schema = {
+            'name': 'etlSchemaBody',
+            'fields': []
+          };
+        }
+        return {
+          name: node.name,
+          schema: schema
+        };
+      });
+    this.currentIndex = 0;
+  });

--- a/cdap-ui/app/directives/widget-container/widget-input-schema/widget-input-schema.html
+++ b/cdap-ui/app/directives/widget-container/widget-input-schema/widget-input-schema.html
@@ -133,8 +133,8 @@
       -->
       <tbody infinite-scroll="MyInputSchemaCtrl.doLoadNextSetOfInputSchemaRows()"
              infinite-scroll-container="'.modal.hydrator-modal.node-config-modal .bottompanel-body'"
-             infinite-scroll-disabled="MyInputSchemaCtrl.inputSchemas[0].schema.fields <= MyInputSchemaCtrl.inputSchemaRowLimit">
-        <tr ng-repeat="field in ::MyInputSchemaCtrl.inputSchemas[0].schema.fields | limitTo: 10 track by $index">
+             infinite-scroll-disabled="MyInputSchemaCtrl.inputSchemas[0].schema.fields.length <= MyInputSchemaCtrl.inputSchemaRowLimit">
+        <tr ng-repeat="field in MyInputSchemaCtrl.inputSchemas[0].schema.fields | limitTo: MyInputSchemaCtrl.inputSchemaRowLimit track by $index">
           <td class="name">
             <span uib-tooltip="{{ ::field.name }}"
                   tooltip-ellipsis="{{ ::field.name }}"

--- a/cdap-ui/app/directives/widget-container/widget-input-schema/widget-input-schema.html
+++ b/cdap-ui/app/directives/widget-container/widget-input-schema/widget-input-schema.html
@@ -13,13 +13,101 @@
   License for the specific language governing permissions and limitations under
   the License.
 -->
-<div ng-repeat="inputschema in ::MyInputSchemaCtrl.inputSchemas">
-  <div ng-click="MyInputSchemaCtrl.currentIndex = $index" style="cursor:pointer" class="title">
-    <i class="fa" ng-class="{'fa-arrow-right': MyInputSchemaCtrl.currentIndex !== $index, 'fa-arrow-down': MyInputSchemaCtrl.currentIndex === $index}"></i>
-    <span>{{::inputschema.name}}</span>
+
+<!--
+  if input schemas?
+    if mutiple input schemas enabled?
+      for each input schema
+        if input schema?
+          show table
+        else
+          show 'no input schema'
+    else
+      if input schemas[0]?
+        show single table
+      else
+        show 'no input schemas'
+  else
+    show 'no input schemas'
+-->
+
+<!-- Section that shows input schema(s) -->
+<div ng-if="::(MyInputSchemaCtrl.inputSchemas.length > 0)">
+
+  <!-- Section that shows multiple inputs -->
+  <div ng-if="::(MyInputSchemaCtrl.multipleInputs)">
+    <div ng-repeat="inputschema in ::MyInputSchemaCtrl.inputSchemas">
+      <div ng-click="MyInputSchemaCtrl.currentIndex = $index" style="cursor:pointer" class="title">
+        <i class="fa" ng-class="{'fa-arrow-right': MyInputSchemaCtrl.currentIndex !== $index, 'fa-arrow-down': MyInputSchemaCtrl.currentIndex === $index}"></i>
+        <span>{{::inputschema.name}}</span>
+      </div>
+      <div class="content"
+          ng-class="{'hide': MyInputSchemaCtrl.currentIndex !== $index, '': MyInputSchemaCtrl.currentIndex === $index}">
+        <table class="table" ng-if="::(inputschema.schema.fields.length > 0)">
+          <thead>
+            <th>
+              <label class="control-label">Name</label>
+            </th>
+            <th>
+              <label class="control-label">Type</label>
+            </th>
+            <th>
+              <label class="control-label">Null</label>
+            </th>
+          </thead>
+          <!--
+            This is bad. If we change the container's css class then infinite scroll is not going to work.
+            The reason we are doing this today is because we need to have one scroll bar for all the three
+            sections of the node config modal (input-schema, config & output-schema) and that is technically
+            the container for the inifinite scroll here.
+
+            So container = bottompanel-body & element = table/tbody. As we scroll in the container
+            the ng-inifinite scroll is going to check whether the difference between element bottom & container
+            bottom is less than the scroll distance, if yes then its going to add additional elements.
+
+            The damage is restricted to the css classes we add to the modal and the uibModal service (windowClass)
+          -->
+          <tbody infinite-scroll="MyInputSchemaCtrl.doLoadNextSetOfInputSchemaRows()"
+                 infinite-scroll-container="'.modal.hydrator-modal.node-config-modal .bottompanel-body'"
+                 infinite-scroll-disabled="inputschema.schema.fields <= MyInputSchemaCtrl.inputSchemaRowLimit">
+            <tr ng-repeat="field in ::inputschema.schema.fields | limitTo: 10 track by $index">
+              <td class="name">
+                <span uib-tooltip="{{ ::field.name }}"
+                      tooltip-ellipsis="{{ ::field.name }}"
+                      data-ellipsis="isEllipsis"
+                      data-offset-value="20"
+                      tooltip-enable="isEllipsis"
+                      tooltip-append-to-body="true">
+                  {{::field.name}}
+                </span>
+              </td>
+              <td class="type">
+                <span ng-if="field.type.type !== 'map'">{{::field.type}}</span>
+                <span ng-if="field.type.type === 'map'">map&lt;string, string&gt; </span>
+              </td>
+              <td class="nullable text-center" >
+                <input type="checkbox" ng-model="field.nullable" disabled="disabled">
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div ng-if="::(inputschema.schema.fields.length === 0)">
+          <p>There is no input schema</p>
+        </div>
+      </div>
+    </div>
   </div>
-  <div class="content" ng-class="{'hide': MyInputSchemaCtrl.currentIndex !== $index, '': MyInputSchemaCtrl.currentIndex === $index}">
-    <table class="table">
+
+  <!-- End of section that shows multiple inputs -->
+
+  <!-- Section that shows single input schema-->
+
+  <div ng-if="::(!MyInputSchemaCtrl.multipleInputs)">
+    <!-- Section that shows single input schema table-->
+
+    <table class="table"
+      ng-if="::(MyInputSchemaCtrl.inputSchemas[0].schema.fields.length > 0)">
       <thead>
         <th>
           <label class="control-label">Name</label>
@@ -31,29 +119,65 @@
           <label class="control-label">Null</label>
         </th>
       </thead>
-      <!-- <tbody infinite-scroll="HydratorPlusPlusNodeConfigCtrl.doLoadNextSetOfInputSchemaRows()"
-             infinite-scroll-disabled="HydratorPlusPlusNodeConfigCtrl.state.node.inputSchema.length <= HydratorPlusPlusNodeConfigCtrl.inputSchemaRowLimit"> -->
-      <tbody>
-        <tr ng-repeat="schema in ::inputschema.schema.fields | limitTo: 10 track by $index">
+      <!--
+        This is bad. If we change the container's css class then infinite scroll is not going to work.
+        The reason we are doing this today is because we need to have one scroll bar for all the three
+        sections of the node config modal (input-schema, config & output-schema) and that is technically
+        the container for the inifinite scroll here.
+
+        So container = bottompanel-body & element = table/tbody. As we scroll in the container
+        the ng-inifinite scroll is going to check whether the difference between element bottom & container
+        bottom is less than the scroll distance, if yes then its going to add additional elements.
+
+        The damage is restricted to the css classes we add to the modal and the uibModal service (windowClass)
+      -->
+      <tbody infinite-scroll="MyInputSchemaCtrl.doLoadNextSetOfInputSchemaRows()"
+             infinite-scroll-container="'.modal.hydrator-modal.node-config-modal .bottompanel-body'"
+             infinite-scroll-disabled="MyInputSchemaCtrl.inputSchemas[0].schema.fields <= MyInputSchemaCtrl.inputSchemaRowLimit">
+        <tr ng-repeat="field in ::MyInputSchemaCtrl.inputSchemas[0].schema.fields | limitTo: 10 track by $index">
           <td class="name">
-            <span uib-tooltip="{{ schema.name }}"
-                  tooltip-ellipsis="{{ schema.name }}"
+            <span uib-tooltip="{{ ::field.name }}"
+                  tooltip-ellipsis="{{ ::field.name }}"
                   data-ellipsis="isEllipsis"
                   data-offset-value="20"
                   tooltip-enable="isEllipsis"
                   tooltip-append-to-body="true">
-              {{schema.name}}
+              {{::field.name}}
             </span>
           </td>
           <td class="type">
-            <span ng-if="schema.type.type !== 'map'">{{schema.type}}</span>
-            <span ng-if="schema.type.type === 'map'">map&lt;string, string&gt; </span>
+            <span ng-if="field.type.type !== 'map'">{{::field.type}}</span>
+            <span ng-if="field.type.type === 'map'">map&lt;string, string&gt; </span>
           </td>
           <td class="nullable text-center" >
-            <input type="checkbox" ng-model="schema.nullable" disabled="disabled">
+            <input type="checkbox" ng-model="field.nullable" disabled="disabled">
           </td>
         </tr>
       </tbody>
     </table>
+
+    <!-- End of section that shows single input schema table-->
+
+    <!-- Section that shows no input schema -->
+
+    <div ng-if="::(MyInputSchemaCtrl.inputSchemas[0].schema.fields.length === 0)">
+      <p>There is no input schema</p>
+    </div>
+
+    <!-- End of section that shows no input schema-->
+
   </div>
+
+  <!-- End of section that shows single input schema-->
+
 </div>
+
+<!-- End of section that shows input schema(s) -->
+
+<!-- Section that shows no input schema -->
+
+<div ng-if="::(MyInputSchemaCtrl.inputSchemas.length === 0)">
+  <p>There is no input schema</p>
+</div>
+
+<!-- End of section that shows no input schema -->

--- a/cdap-ui/app/directives/widget-container/widget-input-schema/widget-input-schema.html
+++ b/cdap-ui/app/directives/widget-container/widget-input-schema/widget-input-schema.html
@@ -1,0 +1,59 @@
+<!--
+  Copyright © 2016 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+<div ng-repeat="inputschema in ::MyInputSchemaCtrl.inputSchemas">
+  <div ng-click="MyInputSchemaCtrl.currentIndex = $index" style="cursor:pointer" class="title">
+    <i class="fa" ng-class="{'fa-arrow-right': MyInputSchemaCtrl.currentIndex !== $index, 'fa-arrow-down': MyInputSchemaCtrl.currentIndex === $index}"></i>
+    <span>{{::inputschema.name}}</span>
+  </div>
+  <div class="content" ng-class="{'hide': MyInputSchemaCtrl.currentIndex !== $index, '': MyInputSchemaCtrl.currentIndex === $index}">
+    <table class="table">
+      <thead>
+        <th>
+          <label class="control-label">Name</label>
+        </th>
+        <th>
+          <label class="control-label">Type</label>
+        </th>
+        <th>
+          <label class="control-label">Null</label>
+        </th>
+      </thead>
+      <!-- <tbody infinite-scroll="HydratorPlusPlusNodeConfigCtrl.doLoadNextSetOfInputSchemaRows()"
+             infinite-scroll-disabled="HydratorPlusPlusNodeConfigCtrl.state.node.inputSchema.length <= HydratorPlusPlusNodeConfigCtrl.inputSchemaRowLimit"> -->
+      <tbody>
+        <tr ng-repeat="schema in ::inputschema.schema.fields | limitTo: 10 track by $index">
+          <td class="name">
+            <span uib-tooltip="{{ schema.name }}"
+                  tooltip-ellipsis="{{ schema.name }}"
+                  data-ellipsis="isEllipsis"
+                  data-offset-value="20"
+                  tooltip-enable="isEllipsis"
+                  tooltip-append-to-body="true">
+              {{schema.name}}
+            </span>
+          </td>
+          <td class="type">
+            <span ng-if="schema.type.type !== 'map'">{{schema.type}}</span>
+            <span ng-if="schema.type.type === 'map'">map&lt;string, string&gt; </span>
+          </td>
+          <td class="nullable text-center" >
+            <input type="checkbox" ng-model="schema.nullable" disabled="disabled">
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/cdap-ui/app/directives/widget-container/widget-input-schema/widget-input-schema.js
+++ b/cdap-ui/app/directives/widget-container/widget-input-schema/widget-input-schema.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name + '.commons')
+  .directive('myInputSchema', function() {
+    return {
+      restrict: 'EA',
+      scope: {
+        inputschema: '@'
+      },
+      templateUrl: 'widget-container/widget-input-schema/widget-input-schema.html',
+      controller: 'MyInputSchemaCtrl',
+      controllerAs: 'MyInputSchemaCtrl'
+    };
+  });

--- a/cdap-ui/app/directives/widget-container/widget-input-schema/widget-input-schema.js
+++ b/cdap-ui/app/directives/widget-container/widget-input-schema/widget-input-schema.js
@@ -19,7 +19,8 @@ angular.module(PKG.name + '.commons')
     return {
       restrict: 'EA',
       scope: {
-        inputschema: '@'
+        inputSchema: '@',
+        multipleInputs: '@'
       },
       templateUrl: 'widget-container/widget-input-schema/widget-input-schema.html',
       controller: 'MyInputSchemaCtrl',

--- a/cdap-ui/app/directives/widget-container/widget-input-schema/widget-input-schema.less
+++ b/cdap-ui/app/directives/widget-container/widget-input-schema/widget-input-schema.less
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+my-input-schema {
+  .title {
+    margin: 10px 0;
+    cursor: pointer;
+  }
+  .content {
+    margin-left: 10px;
+  }
+}

--- a/cdap-ui/app/directives/widget-container/widget-schema-editor/widget-schema-editor.html
+++ b/cdap-ui/app/directives/widget-container/widget-schema-editor/widget-schema-editor.html
@@ -41,7 +41,21 @@
             </th>
             <th></th>
           </thead>
-          <tbody infinite-scroll="loadNextSetOfRows()" infinite-scroll-disabled="properties.length <= limitedToView">
+          <!--
+            This is bad. If we change the container's css class then infinite scroll is not going to work.
+            The reason we are doing this today is because we need to have one scroll bar for all the three
+            sections of the node config modal (input-schema, config & output-schema) and that is technically
+            the container for the inifinite scroll here.
+
+            So container = bottompanel-body & element = table/tbody. As we scroll in the container
+            the ng-inifinite scroll is going to check whether the difference between element bottom & container
+            bottom is less than the scroll distance, if yes then its going to add additional elements.
+
+            The damage is restricted to the css classes we add to the modal and the uibModal service (windowClass)
+          -->
+          <tbody infinite-scroll="loadNextSetOfRows()"
+                 infinite-scroll-container="'.modal.hydrator-modal.node-config-modal .bottompanel-body'"
+                 infinite-scroll-disabled="properties.length <= limitedToView">
             <tr ng-repeat="property in properties | limitTo: limitedToView track by $index" ng-keypress="enter($event, $index)" ng-click="emptyRowClick(property, $index)">
               <td class="name" ng-if="!property.empty" ng-class="{'active-cell': activeCell === true}">
                 <input

--- a/cdap-ui/app/features/hydratorplusplus/bottompanel.less
+++ b/cdap-ui/app/features/hydratorplusplus/bottompanel.less
@@ -306,7 +306,7 @@ body.theme-cdap.state-hydratorplusplus {
       td {
         border: 1px solid @table-border-color;
         border-collapse: collapse;
-        height: 30px;
+        height: 36px;
         padding: 0 5px;
         vertical-align: middle;
         div.select-wrapper:after {

--- a/cdap-ui/app/features/hydratorplusplus/controllers/create/canvas-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/create/canvas-ctrl.js
@@ -65,7 +65,7 @@ class HydratorPlusPlusCreateCanvasCtrl {
         .open({
           templateUrl: '/assets/features/hydratorplusplus/templates/partial/node-config-modal/popover.html',
           size: 'lg',
-          windowTopClass: 'node-config-modal hydrator-modal',
+          windowClass: 'node-config-modal hydrator-modal',
           controller: 'HydratorPlusPlusNodeConfigCtrl',
           controllerAs: 'HydratorPlusPlusNodeConfigCtrl',
           resolve: {

--- a/cdap-ui/app/features/hydratorplusplus/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/create/partials/nodeconfig-ctrl.js
@@ -190,7 +190,7 @@ class HydratorPlusPlusNodeConfigCtrl {
               );
             }
             if (!this.state.node.outputSchema) {
-              this.state.node.outputSchema = JSON.stringify({fields: this.state.node.inputSchema});
+              this.state.node.outputSchema = this.myHelpers.objectQuery(this.state.node, 'inputSchema', 0, 'schema') || JSON.stringify({'fields': []});
             }
             // Mark the configfetched to show that configurations have been received.
             this.state.configfetched = true;

--- a/cdap-ui/app/features/hydratorplusplus/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/create/partials/nodeconfig-ctrl.js
@@ -28,8 +28,6 @@ class HydratorPlusPlusNodeConfigCtrl {
     this.NonStorePipelineErrorFactory = NonStorePipelineErrorFactory;
     this.requiredPropertyError = this.GLOBALS.en.hydrator.studio.error['GENERIC-MISSING-REQUIRED-FIELDS'];
     this.showPropagateConfirm = false; // confirmation dialog in node config for schema propagation.
-    this.inputSchemaRowLimit = 15;
-    this.loadNextInputSchemaRows = _.debounce(this.doLoadNextSetOfInputSchemaRows.bind(this));
     this.$uibModal = $uibModal;
     this.ConfigStore = HydratorPlusPlusConfigStore;
     this.$scope.isDisabled = rDisabled;
@@ -113,10 +111,40 @@ class HydratorPlusPlusNodeConfigCtrl {
     this.HydratorPlusPlusConfigActions.propagateSchemaDownStream(this.state.node.name);
   }
   loadNewPlugin() {
+    const noJsonErrorHandler = (err) => {
+      var propertiesFromBackend = Object.keys(this.state.node._backendProperties);
+      // Didn't receive a configuration from the backend. Fallback to all textboxes.
+      switch(err) {
+        case 'NO_JSON_FOUND':
+          this.state.noConfigMessage = this.GLOBALS.en.hydrator.studio.info['NO-CONFIG'];
+          break;
+        case 'CONFIG_SYNTAX_JSON_ERROR':
+          this.state.noConfigMessage = this.GLOBALS.en.hydrator.studio.error['SYNTAX-CONFIG-JSON'];
+          break;
+        case 'CONFIG_SEMANTICS_JSON_ERROR':
+          this.state.noConfigMessage = this.GLOBALS.en.hydrator.studio.error['SEMANTIC-CONFIG-JSON'];
+          break;
+      }
+      this.state.noconfig = true;
+      this.state.configfetched = true;
+      propertiesFromBackend.forEach( (property) => {
+        this.state.node.plugin.properties[property] = this.state.node.plugin.properties[property] || '';
+      });
+      this.state.watchers.push(
+        this.$scope.$watch(
+          'HydratorPlusPlusNodeConfigCtrl.state.node',
+          () => {
+            this.validateNodeLabel(this);
+            this.HydratorPlusPlusConfigActions.editPlugin(this.state.node.name, this.state.node);
+          },
+          true
+        )
+      );
+    };
+
     this.state.noproperty = Object.keys(
       this.state.node._backendProperties || {}
     ).length;
-    this.inputSchemaRowLimit = 15;
     if (this.state.noproperty) {
       var artifactName = this.myHelpers.objectQuery(this.state.node, 'plugin', 'artifact', 'name');
       var artifactVersion = this.myHelpers.objectQuery(this.state.node, 'plugin', 'artifact', 'version');
@@ -129,7 +157,8 @@ class HydratorPlusPlusNodeConfigCtrl {
       )
         .then(
           (res) => {
-            this.state.groupsConfig = this.HydratorPlusPlusPluginConfigFactory.generateNodeConfig(this.state.node._backendProperties, res);
+            this.state.groupsConfig = this.HydratorPlusPlusPluginConfigFactory
+              .generateNodeConfig(this.state.node._backendProperties, res);
             if (res.errorDataset || this.state.node.errorDatasetName) {
               this.state.showErrorDataset = true;
               this.state.errorDatasetTooltip = res.errorDataset && res.errorDataset.errorDatasetTooltip || false;
@@ -197,36 +226,7 @@ class HydratorPlusPlusNodeConfigCtrl {
             this.state.config = res;
             this.state.noconfig = false;
           },
-          (err) => {
-            var propertiesFromBackend = Object.keys(this.state.node._backendProperties);
-            // Didn't receive a configuration from the backend. Fallback to all textboxes.
-            switch(err) {
-              case 'NO_JSON_FOUND':
-                this.state.noConfigMessage = this.GLOBALS.en.hydrator.studio.info['NO-CONFIG'];
-                break;
-              case 'CONFIG_SYNTAX_JSON_ERROR':
-                this.state.noConfigMessage = this.GLOBALS.en.hydrator.studio.error['SYNTAX-CONFIG-JSON'];
-                break;
-              case 'CONFIG_SEMANTICS_JSON_ERROR':
-                this.state.noConfigMessage = this.GLOBALS.en.hydrator.studio.error['SEMANTIC-CONFIG-JSON'];
-                break;
-            }
-            this.state.noconfig = true;
-            this.state.configfetched = true;
-            propertiesFromBackend.forEach( (property) => {
-              this.state.node.plugin.properties[property] = this.state.node.plugin.properties[property] || '';
-            });
-            this.state.watchers.push(
-              this.$scope.$watch(
-                'HydratorPlusPlusNodeConfigCtrl.state.node',
-                () => {
-                  this.validateNodeLabel(this);
-                  this.HydratorPlusPlusConfigActions.editPlugin(this.state.node.name, this.state.node);
-                },
-                true
-              )
-            );
-          }
+          noJsonErrorHandler
         );
     } else {
       this.state.configfetched = true;
@@ -286,9 +286,6 @@ class HydratorPlusPlusNodeConfigCtrl {
     if (fields.length !== unique.length) {
       error.push('There are two or more fields with the same name.');
     }
-  }
-  doLoadNextSetOfInputSchemaRows() {
-    this.inputSchemaRowLimit += 10;
   }
 }
 HydratorPlusPlusNodeConfigCtrl.$inject = ['$scope', '$timeout', '$state', 'HydratorPlusPlusPluginConfigFactory', 'EventPipe', 'GLOBALS', 'HydratorPlusPlusConfigActions', 'myHelpers', 'NonStorePipelineErrorFactory', '$uibModal', 'HydratorPlusPlusConfigStore', 'rPlugin', 'rDisabled'];

--- a/cdap-ui/app/features/hydratorplusplus/hydrator-modal.less
+++ b/cdap-ui/app/features/hydratorplusplus/hydrator-modal.less
@@ -98,7 +98,7 @@
       .modal-content {
         .modal-body {
           padding: 0 10px;
-          overflow-y: hidden;
+          overflow: auto;
 
           .console-type {
             border: 1px solid @table-border-color;

--- a/cdap-ui/app/features/hydratorplusplus/services/create/actions/config-actions.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/create/actions/config-actions.js
@@ -44,14 +44,8 @@ class HydratorPlusPlusConfigActions {
   saveAsDraft(config) {
     this.dispatcher.dispatch('onSaveAsDraft', config);
   }
-  setArtifact(artifact) {
-    this.dispatcher.dispatch('onArtifactSave', artifact);
-  }
   setEngine(engine) {
     this.dispatcher.dispatch('onEngineChange', engine);
-  }
-  addPlugin (plugin, type) {
-    this.dispatcher.dispatch('onPluginAdd', plugin, type);
   }
   editPlugin(pluginId, pluginProperties) {
     this.dispatcher.dispatch('onPluginEdit', pluginId, pluginProperties);

--- a/cdap-ui/app/features/hydratorplusplus/services/create/stores/config-store.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/create/stores/config-store.js
@@ -15,14 +15,13 @@
  */
 
 class HydratorPlusPlusConfigStore {
-  constructor(HydratorPlusPlusConfigDispatcher, HydratorPlusPlusCanvasFactory, GLOBALS, mySettings, HydratorPlusPlusConsoleActions, $stateParams, myHelpers, NonStorePipelineErrorFactory, HydratorPlusPlusHydratorService, $q, HydratorPlusPlusPluginConfigFactory, uuid, $state, HYDRATOR_DEFAULT_VALUES){
+  constructor(HydratorPlusPlusConfigDispatcher, HydratorPlusPlusCanvasFactory, GLOBALS, mySettings, HydratorPlusPlusConsoleActions, $stateParams, NonStorePipelineErrorFactory, HydratorPlusPlusHydratorService, $q, HydratorPlusPlusPluginConfigFactory, uuid, $state, HYDRATOR_DEFAULT_VALUES){
     this.state = {};
     this.mySettings = mySettings;
     this.HydratorPlusPlusConsoleActions = HydratorPlusPlusConsoleActions;
     this.HydratorPlusPlusCanvasFactory = HydratorPlusPlusCanvasFactory;
     this.GLOBALS = GLOBALS;
     this.$stateParams = $stateParams;
-    this.myHelpers = myHelpers;
     this.NonStorePipelineErrorFactory = NonStorePipelineErrorFactory;
     this.HydratorPlusPlusHydratorService = HydratorPlusPlusHydratorService;
     this.$q = $q;
@@ -35,9 +34,7 @@ class HydratorPlusPlusConfigStore {
     this.setDefaults();
     this.hydratorPlusPlusConfigDispatcher = HydratorPlusPlusConfigDispatcher.getDispatcher();
     this.hydratorPlusPlusConfigDispatcher.register('onEngineChange', this.setEngine.bind(this));
-    this.hydratorPlusPlusConfigDispatcher.register('onArtifactSave', this.setArtifact.bind(this));
     this.hydratorPlusPlusConfigDispatcher.register('onMetadataInfoSave', this.setMetadataInformation.bind(this));
-    this.hydratorPlusPlusConfigDispatcher.register('onPluginAdd', this.setConfig.bind(this));
     this.hydratorPlusPlusConfigDispatcher.register('onPluginEdit', this.editNodeProperties.bind(this));
     this.hydratorPlusPlusConfigDispatcher.register('onSetSchedule', this.setSchedule.bind(this));
     this.hydratorPlusPlusConfigDispatcher.register('onSetInstance', this.setInstance.bind(this));
@@ -503,21 +500,8 @@ class HydratorPlusPlusConfigStore {
     } catch (e) {}
     traverseMap(adjacencyMap[pluginId], outputSchema);
   }
-  addNode(node) {
-    this.state.__ui__.nodes.push(node);
-  }
   getNodes() {
     return this.getState().__ui__.nodes;
-  }
-  getNode(nodeId) {
-    let nodes = this.state.__ui__.nodes;
-    let match = nodes.filter( node => node.name === nodeId);
-    if (match.length) {
-      match = match[0];
-    } else {
-      match = null;
-    }
-    return angular.copy(match);
   }
   getSourceNodes(nodeId) {
     let nodesMap = {};
@@ -739,6 +723,6 @@ class HydratorPlusPlusConfigStore {
   }
 }
 
-HydratorPlusPlusConfigStore.$inject = ['HydratorPlusPlusConfigDispatcher', 'HydratorPlusPlusCanvasFactory', 'GLOBALS', 'mySettings', 'HydratorPlusPlusConsoleActions', '$stateParams', 'myHelpers', 'NonStorePipelineErrorFactory', 'HydratorPlusPlusHydratorService', '$q', 'HydratorPlusPlusPluginConfigFactory', 'uuid', '$state', 'HYDRATOR_DEFAULT_VALUES'];
+HydratorPlusPlusConfigStore.$inject = ['HydratorPlusPlusConfigDispatcher', 'HydratorPlusPlusCanvasFactory', 'GLOBALS', 'mySettings', 'HydratorPlusPlusConsoleActions', '$stateParams', 'NonStorePipelineErrorFactory', 'HydratorPlusPlusHydratorService', '$q', 'HydratorPlusPlusPluginConfigFactory', 'uuid', '$state', 'HYDRATOR_DEFAULT_VALUES'];
 angular.module(`${PKG.name}.feature.hydratorplusplus`)
   .service('HydratorPlusPlusConfigStore', HydratorPlusPlusConfigStore);

--- a/cdap-ui/app/features/hydratorplusplus/services/hydrator-node-service.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/hydrator-node-service.js
@@ -46,7 +46,10 @@ class HydratorPlusPlusNodeService {
         inputSchema = null;
       }
       if (typeof inputSchema === 'object' && isStreamSource) {
-        inputSchema.fields = inputSchema.fields.map( field => delete field.readOnly );
+        inputSchema.fields = inputSchema.fields.map( field => {
+          delete field.readonly;
+          return field;
+        });
       }
       return JSON.stringify(inputSchema);
     };

--- a/cdap-ui/app/features/hydratorplusplus/services/hydrator-node-service.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/hydrator-node-service.js
@@ -30,47 +30,34 @@ class HydratorPlusPlusNodeService {
     return promise.then((node) => this.configurePluginInfo(node, appType, sourceConn));
   }
   configurePluginInfo(node, appType, sourceConn) {
-      var input;
-      var sourceSchema = null;
+    const getSchema = (node) => {
+      var schema = node.outputSchema;
       var isStreamSource = false;
-
-      var source;
-      if (sourceConn && sourceConn.length) {
-        source = sourceConn[0];
-        sourceSchema = source.outputSchema;
-
-        if (source.plugin.name === 'Stream') {
-          isStreamSource = true;
-        }
-
-        if (Object.keys(this.IMPLICIT_SCHEMA).indexOf(source.plugin.properties.format) !== -1) {
-          sourceSchema = this.IMPLICIT_SCHEMA[source.plugin.properties.format];
-        }
-
-      } else {
-        sourceSchema = '';
+      var inputSchema;
+      if (node.plugin.name === 'Stream') {
+        isStreamSource = true;
       }
-
+      if (Object.keys(this.IMPLICIT_SCHEMA).indexOf(node.plugin.properties.format) !== -1) {
+        schema = this.IMPLICIT_SCHEMA[node.plugin.properties.format];
+      }
       try {
-        input = JSON.parse(sourceSchema);
-      } catch (e) {
-        input = null;
+        inputSchema = JSON.parse(schema);
+      } catch(e) {
+        inputSchema = null;
       }
+      if (typeof inputSchema === 'object' && isStreamSource) {
+        inputSchema.fields = inputSchema.fields.map( field => delete field.readOnly );
+      }
+      return JSON.stringify(inputSchema);
+    };
 
-      node.inputSchema = input ? input.fields : null;
-      angular.forEach(node.inputSchema, function (field) {
-        if (angular.isArray(field.type)) {
-          field.type = field.type[0];
-          field.nullable = true;
-        } else {
-          field.nullable = false;
-        }
-        if (isStreamSource) {
-          delete field.readonly;
-        }
-      });
-      return node;
-    }
+    node.inputSchema = sourceConn.map( source => ({
+      name: source.plugin.label,
+      schema: getSchema(source)
+    }));
+
+    return node;
+  }
 }
 HydratorPlusPlusNodeService.$inject = ['$q', 'HydratorPlusPlusHydratorService', 'IMPLICIT_SCHEMA'];
 

--- a/cdap-ui/app/features/hydratorplusplus/services/plugin-config-factory.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/plugin-config-factory.js
@@ -66,12 +66,29 @@ class HydratorPlusPlusPluginConfigFactory {
   }
 
   generateNodeConfig(backendProperties, nodeConfig) {
-    var isNewSpecVersion = this.myHelpers.objectQuery(nodeConfig, 'metadata', 'spec-version');
-    if (isNewSpecVersion) {
-      return this.generateConfigForNewSpec(backendProperties, nodeConfig);
-    } else {
-      return this.generateConfigForOlderSpec(backendProperties, nodeConfig);
+    var specVersion = this.myHelpers.objectQuery(nodeConfig, 'metadata', 'spec-version') || '0.0';
+    switch(specVersion) {
+      case '0.0':
+        return this.generateConfigForOlderSpec(backendProperties, nodeConfig);
+      case '1.0':
+      case '1.1':
+        return this.generateConfigForNewSpec(backendProperties, nodeConfig);
+      case '1.2':
+        return this.generateConfigFor12Spec(backendProperties, nodeConfig);
+      default: // No spec version which means
+        throw 'NO_JSON_FOUND';
     }
+  }
+
+  generateConfigFor12Spec(backendProperties, nodeConfig) {
+    var config = this.generateConfigForNewSpec(backendProperties, nodeConfig);
+    config.inputs = {};
+    if (typeof nodeConfig.inputs === 'object') {
+      if (nodeConfig.inputs.multipleInputs) {
+        config.input.multipleInputs = true;
+      }
+    }
+    return config;
   }
 
   generateConfigForNewSpec(backendProperties, nodeConfig) {

--- a/cdap-ui/app/features/hydratorplusplus/services/plugin-config-factory.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/plugin-config-factory.js
@@ -85,7 +85,7 @@ class HydratorPlusPlusPluginConfigFactory {
     config.inputs = {};
     if (typeof nodeConfig.inputs === 'object') {
       if (nodeConfig.inputs.multipleInputs) {
-        config.input.multipleInputs = true;
+        config.inputs.multipleInputs = true;
       }
     }
     return config;

--- a/cdap-ui/app/features/hydratorplusplus/templates/partial/node-config-modal/node-config/plugin-edit-input-schema.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/partial/node-config-modal/node-config/plugin-edit-input-schema.html
@@ -16,6 +16,8 @@
 <div class="input-schema">
   <div class="schema-inner" ng-if="::HydratorPlusPlusNodeConfigCtrl.state.node.inputSchema">
     <h4>Input Schema</h4>
-    <my-input-schema inputschema="{{::HydratorPlusPlusNodeConfigCtrl.state.node.inputSchema}}"></my-input-schema>
+    <my-input-schema
+        data-multiple-inputs="{{::(HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.inputs.multipleInputs === true)}}"
+        input-schema="{{::HydratorPlusPlusNodeConfigCtrl.state.node.inputSchema}}"></my-input-schema>
   </div>
 </div>

--- a/cdap-ui/app/features/hydratorplusplus/templates/partial/node-config-modal/node-config/plugin-edit-input-schema.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/partial/node-config-modal/node-config/plugin-edit-input-schema.html
@@ -13,42 +13,9 @@
   License for the specific language governing permissions and limitations under
   the License.
 -->
-
 <div class="input-schema">
-    <div class="schema-inner" ng-if="HydratorPlusPlusNodeConfigCtrl.state.node.inputSchema">
-      <h4>Input Schema</h4>
-      <table class="table">
-        <thead>
-          <th>
-            <label class="control-label">Name</label>
-          </th>
-          <th>
-            <label class="control-label">Type</label>
-          </th>
-          <th>
-            <label class="control-label">Null</label>
-          </th>
-        </thead>
-        <tbody infinite-scroll="HydratorPlusPlusNodeConfigCtrl.doLoadNextSetOfInputSchemaRows()" infinite-scroll-disabled="HydratorPlusPlusNodeConfigCtrl.state.node.inputSchema.length <= HydratorPlusPlusNodeConfigCtrl.inputSchemaRowLimit">
-          <tr ng-repeat="schema in HydratorPlusPlusNodeConfigCtrl.state.node.inputSchema | limitTo: HydratorPlusPlusNodeConfigCtrl.inputSchemaRowLimit track by $index" ng-keypress="enter($event, $last)">
-            <td class="name" ng-if="!schema.empty">
-              <span uib-tooltip="{{ schema.name }}" tooltip-ellipsis="{{ schema.name }}" data-ellipsis="isEllipsis" data-offset-value="20" tooltip-enable="isEllipsis" tooltip-append-to-body="true">
-                {{schema.name}}
-              </span>
-            </td>
-            <td class="type" ng-if="!schema.empty">
-              <span ng-if="schema.type.type !== 'map'">{{schema.type}}</span>
-              <span ng-if="schema.type.type === 'map'">map&lt;string, string&gt; </span>
-            </td>
-            <td class="nullable text-center" ng-if="!schema.empty">
-              <input type="checkbox" ng-model="schema.nullable" disabled="disabled">
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    <div class="empty-container" ng-if="!HydratorPlusPlusNodeConfigCtrl.state.node.inputSchema">
-      <h4>Input Schema</h4>
-      <p>There is no input schema</p>
-    </div>
+  <div class="schema-inner" ng-if="::HydratorPlusPlusNodeConfigCtrl.state.node.inputSchema">
+    <h4>Input Schema</h4>
+    <my-input-schema inputschema="{{::HydratorPlusPlusNodeConfigCtrl.state.node.inputSchema}}"></my-input-schema>
+  </div>
 </div>


### PR DESCRIPTION
- Adds multiple input schemas for plugins
- Will function based on an update to widget json spec (adding multiple input configuration per plugin)

Bamboo build: http://builds.cask.co/browse/CDAP-DRC3895-4
#### Things to do:
- Update widget json spec to include new multiple inputs flag
#### Note:
- By default all the nodes have multiple input schemas (as it is now today)
- By default we choose the first input schema (output schema of the node that was connected first) as it is today.
- We still need to handle the case where we need infinite scroll for multiple input schemas (not yet there as we don't have a concrete design yet).
