### PR TITLE
Adds back copy-paste from js/python editor from a published pipeline

### DIFF
--- a/cdap-ui/app/features/hydratorplusplus/templates/partial/node-config-modal/node-config/plugin-edit-properties-template.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/partial/node-config-modal/node-config/plugin-edit-properties-template.html
@@ -15,56 +15,89 @@
 -->
 
 <form plugin-property-edit-view>
-  <fieldset ng-disabled="isDisabled">
-      <h4>Configuration</h4>
-      <div class="form-group">
-        <label class="control-label">
-          Label
-          <span class="fa fa-asterisk"></span>
-          <small class="text-danger" ng-if="HydratorPlusPlusNodeConfigCtrl.state.nodeLabelError">{{HydratorPlusPlusNodeConfigCtrl.state.nodeLabelError}}</small>
-        </label>
-        <input type="text" class="form-control" ng-model="HydratorPlusPlusNodeConfigCtrl.state.node.plugin.label">
-      </div>
 
-      <div ng-repeat="group in HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.groups">
-        <div class="widget-group-container">
-          <h4>{{::group.display}}</h4>
-          <div ng-repeat="field in group.fields">
-            <div ng-if="field.name !== HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.outputSchema.schemaProperty">
+    <div class="form-group">
+      <label class="control-label">
+        Label
+        <span class="fa fa-asterisk"></span>
+        <small class="text-danger" ng-if="HydratorPlusPlusNodeConfigCtrl.state.nodeLabelError">{{HydratorPlusPlusNodeConfigCtrl.state.nodeLabelError}}</small>
+      </label>
+      <input type="text" class="form-control"
+             ng-disabled="isDisabled"
+             ng-model="HydratorPlusPlusNodeConfigCtrl.state.node.plugin.label">
+    </div>
 
-              <div class="form-group">
-                <label class="control-label">
-                  <span>{{::field.label}}</span>
-                  <span class="fa fa-info-circle" uib-tooltip="{{::field.description}}" tooltip-placement="right" tooltip-append-to-body="true">
-                  </span>
-                  <span class="fa fa-asterisk" ng-if="HydratorPlusPlusNodeConfigCtrl.state.node._backendProperties[field.name].required"></span>
-                  <small class="text-danger" ng-if="!HydratorPlusPlusNodeConfigCtrl.state.node.warning && HydratorPlusPlusNodeConfigCtrl.state.node._backendProperties[field.name].required && !HydratorPlusPlusNodeConfigCtrl.state.node.plugin.properties[field.name]">{{::HydratorPlusPlusNodeConfigCtrl.requiredPropertyError}}</small>
-                </label>
+    <div ng-repeat="group in HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.groups">
+      <div class="widget-group-container">
+        <h4>{{::group.display}}</h4>
+        <div ng-repeat="field in group.fields">
+          <div ng-if="field.name !== HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.outputSchema.schemaProperty">
 
-                <span ng-if="field['plugin-function']">
-                  <plugin-functions fn-config="field['plugin-function']" node="HydratorPlusPlusNodeConfigCtrl.state.node">
-                  </plugin-functions>
+            <div class="form-group">
+              <label class="control-label">
+                <span>{{::field.label}}</span>
+                <span class="fa fa-info-circle" uib-tooltip="{{::field.description}}" tooltip-placement="right" tooltip-append-to-body="true">
                 </span>
+                <span class="fa fa-asterisk" ng-if="HydratorPlusPlusNodeConfigCtrl.state.node._backendProperties[field.name].required"></span>
+                <small class="text-danger" ng-if="!HydratorPlusPlusNodeConfigCtrl.state.node.warning && HydratorPlusPlusNodeConfigCtrl.state.node._backendProperties[field.name].required && !HydratorPlusPlusNodeConfigCtrl.state.node.plugin.properties[field.name]">{{::HydratorPlusPlusNodeConfigCtrl.requiredPropertyError}}</small>
+              </label>
 
-                <div>
-                  <div data-name="field" class="my-widget-container" ng-class="{'select-wrapper': field.widget === 'select'}" data-model="HydratorPlusPlusNodeConfigCtrl.state.node.plugin.properties[field.name]" data-myconfig="field" data-properties="HydratorPlusPlusNodeConfigCtrl.state.node.plugin.properties" widget-disabled="HydratorPlusPlusNodeConfigCtrl.state.node.pluginTemplate && HydratorPlusPlusNodeConfigCtrl.state.node.lock[field.name]" widget-container>
+              <span ng-if="field['plugin-function']">
+                <plugin-functions fn-config="field['plugin-function']" node="HydratorPlusPlusNodeConfigCtrl.state.node">
+                </plugin-functions>
+              </span>
+
+              <div>
+                <!--
+                FIXME: We need to rename this widget to code-editor and have a mode.
+                -->
+                <fieldset ng-disabled="isDisabled" ng-if="(['javascript-editor', 'python-editor'].indexOf(field['widget-type']) === -1)">
+                  <div data-name="field"
+                       class="my-widget-container"
+                       ng-class="{'select-wrapper': field.widget === 'select'}"
+                       data-model="HydratorPlusPlusNodeConfigCtrl.state.node.plugin.properties[field.name]"
+                       data-myconfig="field"
+                       data-properties="HydratorPlusPlusNodeConfigCtrl.state.node.plugin.properties"
+                       widget-disabled="HydratorPlusPlusNodeConfigCtrl.state.node.pluginTemplate && HydratorPlusPlusNodeConfigCtrl.state.node.lock[field.name]"
+                       widget-container>
+                  </div>
+                </fieldset>
+                <!--
+                  We have a separate div for javascript editor and the reason for it as follows,
+
+                  ace-editor requires 'onFocus' event to enable copy paste functionality as part of the directive. When we wrap everything in <fieldset>
+                  and disable it in published mode the 'onFocus' event doesn't gets propagated to its children ergo ace-editor not knowing about 'onFocus' event. This prevents the user from copying the snippet (CMD + C) from the editor in published mode. Source JIRA: https://issues.cask.co/browse/CDAP-6074
+                -->
+                <div ng-if="(['javascript-editor', 'python-editor'].indexOf(field['widget-type']) !== -1)">
+                  <div data-name="field"
+                       class="my-widget-container"
+                       ng-class="{'select-wrapper': field.widget === 'select'}"
+                       data-model="HydratorPlusPlusNodeConfigCtrl.state.node.plugin.properties[field.name]"
+                       data-myconfig="field"
+                       disabled="isDisabled"
+                       data-properties="HydratorPlusPlusNodeConfigCtrl.state.node.plugin.properties"
+                       widget-disabled="HydratorPlusPlusNodeConfigCtrl.state.node.pluginTemplate && HydratorPlusPlusNodeConfigCtrl.state.node.lock[field.name]"
+                       widget-container>
                   </div>
                 </div>
               </div>
-
             </div>
+
           </div>
         </div>
       </div>
-      <br>
-      <div class="form-group" ng-if="HydratorPlusPlusNodeConfigCtrl.state.showErrorDataset">
-        <label class="control-label">
-          Error Dataset
-          <span class="fa fa-info-circle" ng-if="HydratorPlusPlusNodeConfigCtrl.state.errorDatasetTooltip" uib-tooltip="{{HydratorPlusPlusNodeConfigCtrl.state.errorDatasetTooltip}}" tooltip-placement="right"></span>
-        </label>
-        <input type="text" class="form-control" ng-model="HydratorPlusPlusNodeConfigCtrl.state.node.errorDatasetName">
-      </div>
+    </div>
+    <br>
+    <div class="form-group" ng-if="HydratorPlusPlusNodeConfigCtrl.state.showErrorDataset">
+      <label class="control-label">
+        Error Dataset
+        <span class="fa fa-info-circle" ng-if="HydratorPlusPlusNodeConfigCtrl.state.errorDatasetTooltip" uib-tooltip="{{HydratorPlusPlusNodeConfigCtrl.state.errorDatasetTooltip}}" tooltip-placement="right"></span>
+      </label>
+      <input type="text"
+             class="form-control"
+             ng-disabled="isDisabled"
+             ng-model="HydratorPlusPlusNodeConfigCtrl.state.node.errorDatasetName">
+    </div>
 
-  </fieldset>
 
 </form>


### PR DESCRIPTION
- While merging performance improvements [PR - 5901](https://github.com/caskdata/cdap/pull/5901) this got accidentally removed as the modifications were done to the old bottompanel code rather than the newer node-config modal.

PR that originally had the change for old bottom panel: #5869 

Bamboo build: http://builds.cask.co/browse/CDAP-DRC3898-1
