### PR TITLE
Reverts pull #5888

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Configuration.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Configuration.java
@@ -20,7 +20,6 @@ import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.common.utils.DirUtils;
 import com.google.common.base.Preconditions;
 import com.google.gson.stream.JsonWriter;
-import kafka.Kafka;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Comment;
@@ -233,14 +232,6 @@ public class Configuration implements Iterable<Map.Entry<String, String>> {
   private static Map<String, DeprecatedKeyInfo> deprecatedKeyMap = new HashMap<String, DeprecatedKeyInfo>() {
     {
       put(Constants.Security.AUTH_SERVER_ADDRESS, new DeprecatedKeyInfo(Constants.Security.AUTH_SERVER_BIND_ADDRESS));
-      put(KafkaConstants.ConfigKeys.REPLICATION_FACTOR_DEPRECATED,
-          new DeprecatedKeyInfo(KafkaConstants.ConfigKeys.REPLICATION_FACTOR));
-      put(KafkaConstants.ConfigKeys.LOG_DIRS_DEPRECATED,
-          new DeprecatedKeyInfo(KafkaConstants.ConfigKeys.LOG_DIRS));
-      put(KafkaConstants.ConfigKeys.PORT_CONFIG_DEPRECATED,
-          new DeprecatedKeyInfo(KafkaConstants.ConfigKeys.PORT_CONFIG));
-      put(KafkaConstants.ConfigKeys.HOSTNAME_CONFIG_DEPRECATED,
-          new DeprecatedKeyInfo(KafkaConstants.ConfigKeys.HOSTNAME_CONFIG));
     }
   };
 
@@ -250,14 +241,6 @@ public class Configuration implements Iterable<Map.Entry<String, String>> {
   private static Map<String, String[]> reverseDeprecatedKeyMap = new HashMap<String, String[]>() {
     {
       put(Constants.Security.AUTH_SERVER_BIND_ADDRESS, new String[] { Constants.Security.AUTH_SERVER_ADDRESS });
-      put(KafkaConstants.ConfigKeys.REPLICATION_FACTOR,
-          new String[] {KafkaConstants.ConfigKeys.REPLICATION_FACTOR_DEPRECATED});
-      put(KafkaConstants.ConfigKeys.LOG_DIRS,
-          new String[] {KafkaConstants.ConfigKeys.LOG_DIRS_DEPRECATED});
-      put(KafkaConstants.ConfigKeys.PORT_CONFIG,
-          new String[] {KafkaConstants.ConfigKeys.PORT_CONFIG_DEPRECATED});
-      put(KafkaConstants.ConfigKeys.HOSTNAME_CONFIG,
-          new String[] {KafkaConstants.ConfigKeys.HOSTNAME_CONFIG_DEPRECATED});
     }
   };
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/KafkaConstants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/KafkaConstants.java
@@ -25,15 +25,15 @@ public final class KafkaConstants {
    * Keys for configuration parameters.
    */
   public static final class ConfigKeys {
-    public static final String NUM_PARTITIONS_CONFIG = "kafka.server.num.partitions";
-    public static final String PORT_CONFIG = "kafka.server.port";
-    public static final String PORT_CONFIG_DEPRECATED = "kafka.bind.port";
-    public static final String HOSTNAME_CONFIG = "kafka.server.host.name";
-    public static final String HOSTNAME_CONFIG_DEPRECATED = "kafka.bind.address";
+
+    public static final String PORT_CONFIG = "kafka.bind.port";
+    public static final String NUM_PARTITIONS_CONFIG = "kafka.num.partitions";
+    public static final String LOG_DIR_CONFIG = "kafka.log.dir";
+    public static final String HOSTNAME_CONFIG = "kafka.bind.address";
     public static final String ZOOKEEPER_NAMESPACE_CONFIG = "kafka.zookeeper.namespace";
-    public static final String REPLICATION_FACTOR = "kafka.server.default.replication.factor";
-    public static final String REPLICATION_FACTOR_DEPRECATED = "kafka.default.replication.factor";
-    public static final String LOG_DIRS = "kafka.server.log.dirs";
-    public static final String LOG_DIRS_DEPRECATED = "kafka.log.dirs";
+    public static final String REPLICATION_FACTOR = "kafka.default.replication.factor";
   }
+
+  public static final int DEFAULT_NUM_PARTITIONS = 10;
+  public static final int DEFAULT_REPLICATION_FACTOR = 1;
 }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -737,17 +737,44 @@
   <!-- Kafka Server Configuration -->
 
   <property>
-    <name>kafka.log.retention.hours</name>
-    <value>${kafka.server.log.retention.hours}</value>
+    <name>kafka.bind.address</name>
+    <value>0.0.0.0</value>
     <description>
-      The number of hours to keep a log file before deleting it (deprecated: replaced with
-      kafka.server.log.retention.hours)
+      CDAP Kafka service bind address
+    </description>
+  </property>
+
+  <property>
+    <name>kafka.bind.port</name>
+    <value>9092</value>
+    <description>
+      CDAP Kafka service bind port
+    </description>
+  </property>
+
+  <property>
+    <name>kafka.default.replication.factor</name>
+    <value>1</value>
+    <description>
+      CDAP Kafka service replication factor; used to replicate Kafka messages across
+      multiple machines to prevent data loss in the event of a hardware
+      failure. The recommended setting is to run at least two CDAP Kafka servers.
+      If you are running two CDAP Kafka servers, set this value to 2; otherwise,
+      set it to the number of CDAP Kafka servers.
+    </description>
+  </property>
+
+  <property>
+    <name>kafka.log.dir</name>
+    <value>/tmp/kafka-logs</value>
+    <description>
+      CDAP Kafka service log storage directory
     </description>
   </property>
 
   <property>
     <name>kafka.num.partitions</name>
-    <value>${kafka.server.num.partitions}</value>
+    <value>10</value>
     <description>
       Default number of partitions for a topic
     </description>
@@ -757,86 +784,8 @@
     <name>kafka.seed.brokers</name>
     <value>127.0.0.1:9092</value>
     <description>
-      Comma-separated list of CDAP Kafka service brokers; for distributed CDAP,
-      replace with list of FQDN:port brokers (deprecated: replaced with kafka.server.seed.brokers)
-    </description>
-  </property>
-
-  <property>
-    <name>kafka.server.default.replication.factor</name>
-    <value>1</value>
-    <description>
-      CDAP Kafka service replication factor; used to replicate Kafka messages across
-      multiple machines to prevent data loss in the event of a hardware
-      failure. The recommended setting is to run at least two CDAP Kafka servers.
-      If you are running two CDAP Kafka servers, set this value to 2; otherwise,
-      set it to the maximum number of tolerated machine failures
-      plus one (assuming you have that number of machines).
-    </description>
-  </property>
-
-  <property>
-    <name>kafka.server.host.name</name>
-    <value>0.0.0.0</value>
-    <description>
-      CDAP Kafka service bind address
-    </description>
-  </property>
-
-  <property>
-    <name>kafka.server.log.dirs</name>
-    <value>/tmp/kafka-logs</value>
-    <description>
-      CDAP Kafka service log storage directory
-    </description>
-  </property>
-
-  <property>
-    <name>kafka.server.log.flush.interval.messages</name>
-    <value>10000</value>
-    <description>
-      The interval length at which will force an fsync of data written to the log.
-    </description>
-  </property>
-
-  <property>
-    <name>kafka.server.log.retention.hours</name>
-    <value>24</value>
-    <description>
-      The number of hours to keep a log file before deleting it
-    </description>
-  </property>
-
-  <property>
-    <name>kafka.server.num.partitions</name>
-    <value>10</value>
-    <description>
-      Default number of partitions for a topic
-    </description>
-  </property>
-
-  <property>
-    <name>kafka.server.port</name>
-    <value>9092</value>
-    <description>
-      CDAP Kafka service bind port
-    </description>
-  </property>
-
-  <property>
-    <name>kafka.server.zookeeper.connection.timeout.ms</name>
-    <value>1000000</value>
-    <description>
-      The maximum time (in milliseconds) that the client will wait to establish a connection to Zookeeper
-    </description>
-  </property>
-
-  <property>
-    <name>kafka.zookeeper.connection.timeout.ms</name>
-    <value>${kafka.server.zookeeper.connection.timeout.ms}</value>
-    <description>
-      The maximum time (in milliseconds) that the client will wait to establish a connection to Zookeeper (deprecated:
-      replaced with kafka.server.zookeeper.connection.timeout.ms)
+      Comma-separated list of CDAP Kafka service brokers; for distributed CDAP, 
+      replace with list of FQDN:port brokers
     </description>
   </property>
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="412edc8ed1a844b1c9f8226c732ea9d4"
+DEFAULT_XML_MD5_HASH="a972cff7c79e00149bdb1ca4fe6d003e"
 
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"

--- a/cdap-kafka/src/main/java/co/cask/cdap/kafka/run/KafkaServerMain.java
+++ b/cdap-kafka/src/main/java/co/cask/cdap/kafka/run/KafkaServerMain.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
-import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -55,9 +54,32 @@ public class KafkaServerMain extends DaemonMain {
   @Override
   public void init(String[] args) {
     CConfiguration cConf = CConfiguration.create();
-
     String zkConnectStr = cConf.get(Constants.Zookeeper.QUORUM);
     String zkNamespace = cConf.get(KafkaConstants.ConfigKeys.ZOOKEEPER_NAMESPACE_CONFIG);
+
+    int port = cConf.getInt(KafkaConstants.ConfigKeys.PORT_CONFIG, -1);
+    String hostname = cConf.get(KafkaConstants.ConfigKeys.HOSTNAME_CONFIG);
+
+    InetAddress address = Networks.resolve(hostname, new InetSocketAddress("localhost", 0).getAddress());
+    if (address.isAnyLocalAddress()) {
+      try {
+        address = InetAddress.getLocalHost();
+      } catch (UnknownHostException e) {
+        throw Throwables.propagate(e);
+      }
+    }
+    if (address.isLoopbackAddress()) {
+      LOG.warn("Binding to loopback address!");
+    }
+    hostname = address.getCanonicalHostName();
+
+    int numPartitions = cConf.getInt(KafkaConstants.ConfigKeys.NUM_PARTITIONS_CONFIG,
+                                     KafkaConstants.DEFAULT_NUM_PARTITIONS);
+    String logDir = cConf.get(KafkaConstants.ConfigKeys.LOG_DIR_CONFIG);
+
+    int replicationFactor = cConf.getInt(KafkaConstants.ConfigKeys.REPLICATION_FACTOR,
+                                         KafkaConstants.DEFAULT_REPLICATION_FACTOR);
+    LOG.info("Using replication factor {}", replicationFactor);
 
     if (zkNamespace != null) {
       ZKClientService client = ZKClientService.Builder.of(zkConnectStr).build();
@@ -80,32 +102,11 @@ public class KafkaServerMain extends DaemonMain {
       }
     }
 
-    kafkaProperties = generateKafkaConfig(cConf);
+    int brokerId = generateBrokerId(address);
+    LOG.info(String.format("Initializing server with broker id %d", brokerId));
 
-    Preconditions.checkState(Integer.parseInt(
-      kafkaProperties.getProperty(KafkaConstants.ConfigKeys.NUM_PARTITIONS_CONFIG)) > 0,
-                             "Num partitions should be greater than zero.");
-    int port = Integer.getInteger(kafkaProperties.getProperty(KafkaConstants.ConfigKeys.PORT_CONFIG), -1);
-    Preconditions.checkState(port > 0, "Port number is invalid.");
-
-    String hostname = kafkaProperties.getProperty("host.name");
-    InetAddress address = Networks.resolve(hostname, null);
-    if (hostname == null) {
-      if (address != null && address.isAnyLocalAddress()) {
-        kafkaProperties.remove("host.name");
-      } else {
-        hostname = address.getCanonicalHostName();
-        kafkaProperties.setProperty("host.name", hostname);
-      }
-    }
-    if (kafkaProperties.get("broker.id") == null) {
-      int brokerId = generateBrokerId(address);
-      LOG.info(String.format("Initializing server with broker id %d", brokerId));
-      kafkaProperties.setProperty("broker.id", Integer.toString(brokerId));
-    }
-    if (kafkaProperties.getProperty("zookeeper.connect") == null) {
-      kafkaProperties.setProperty("zookeeper.connect", zkConnectStr);
-    }
+    kafkaProperties = generateKafkaConfig(brokerId, zkConnectStr, hostname, port, numPartitions,
+                                          replicationFactor, logDir);
   }
 
   @Override
@@ -135,15 +136,29 @@ public class KafkaServerMain extends DaemonMain {
     // Nothing to do
   }
 
-  private Properties generateKafkaConfig(CConfiguration cConf) {
-    Properties prop = new Properties();
+  private Properties generateKafkaConfig(int brokerId, String zkConnectStr, String hostname, int port,
+                                         int numPartitions, int replicationFactor, String logDir) {
+    Preconditions.checkState(port > 0, "Port number is invalid.");
+    Preconditions.checkState(numPartitions > 0, "Num partitions should be greater than zero.");
 
-    Map<String, String> propConfigs = cConf.getValByRegex("^(kafka\\..server\\.*)$");
-    for (Map.Entry<String, String> pair : propConfigs.entrySet()) {
-      String key = pair.getKey();
-      String trimmedKey = key.substring(13);
-      prop.setProperty(trimmedKey, pair.getValue());
+    Properties prop = new Properties();
+    prop.setProperty("broker.id", Integer.toString(brokerId));
+    if (hostname != null) {
+      prop.setProperty("host.name", hostname);
     }
+    prop.setProperty("port", Integer.toString(port));
+    prop.setProperty("socket.send.buffer.bytes", "1048576");
+    prop.setProperty("socket.receive.buffer.bytes", "1048576");
+    prop.setProperty("socket.request.max.bytes", "104857600");
+    prop.setProperty("log.dir", logDir);
+    prop.setProperty("num.partitions", Integer.toString(numPartitions));
+    prop.setProperty("log.retention.hours", "24");
+    prop.setProperty("log.flush.interval.messages", "10000");
+    prop.setProperty("log.flush.interval.ms", "1000");
+    prop.setProperty("log.segment.bytes", "536870912");
+    prop.setProperty("zookeeper.connect", zkConnectStr);
+    prop.setProperty("zookeeper.connection.timeout.ms", "1000000");
+    prop.setProperty("default.replication.factor", Integer.toString(replicationFactor));
     return prop;
   }
 


### PR DESCRIPTION
This reverts https://github.com/caskdata/cdap/pull/5888 because cdap-kafka-server no longer starts up after this change. It seems the main cause is that the PR removed default values for a few parameters.
Reverting to unblock integration tests as well as other developers.

![image](https://cloud.githubusercontent.com/assets/2440977/16296709/629cc326-38e2-11e6-9809-13726c19f40b.png)

---

Revert "CDAP-5264: allow for users to set any Kafka configuration. Renames configuration keys with prefix "kafka.server." so the respective keys with prefix "kafka." are officially deprecated."

This reverts commit aae786cabb4d6e0c8265c01b9b334f75672cdc0a.
