### PR TITLE
CDAP-6270: Make MasterStartupTool use root of hdfs as basepath

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/guice/FileContextProvider.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/guice/FileContextProvider.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.common.guice;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import com.google.common.base.Throwables;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileContext;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.security.PrivilegedAction;
+
+/**
+ * Guice module for {@link FileContext} created created with {@link UserGroupInformation} of
+ * {@link Constants#CFG_HDFS_USER}
+ */
+public class FileContextProvider implements Provider<FileContext> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FileContextProvider.class);
+
+  private final CConfiguration cConf;
+  private final Configuration hConf;
+
+  @Inject
+  public FileContextProvider(CConfiguration cConf, Configuration hConf) {
+    this.cConf = cConf;
+    this.hConf = hConf;
+  }
+
+  @Override
+  public FileContext get() {
+    return createUGI().doAs(new PrivilegedAction<FileContext>() {
+      @Override
+      public FileContext run() {
+        try {
+          return FileContext.getFileContext(hConf);
+        } catch (Exception e) {
+          throw Throwables.propagate(e);
+        }
+      }
+    });
+  }
+
+  private UserGroupInformation createUGI() {
+    String hdfsUser = cConf.get(Constants.CFG_HDFS_USER);
+    try {
+      if (hdfsUser == null || UserGroupInformation.isSecurityEnabled()) {
+        if (hdfsUser != null) {
+          LOG.debug("Ignoring configuration {}={}, running on secure Hadoop", Constants.CFG_HDFS_USER, hdfsUser);
+        }
+        LOG.debug("Getting filesystem for current user");
+        return UserGroupInformation.getCurrentUser();
+      } else {
+        LOG.debug("Getting filesystem for user {}", hdfsUser);
+        return UserGroupInformation.createRemoteUser(hdfsUser);
+      }
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/guice/RootLocationFactoryProvider.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/guice/RootLocationFactoryProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.guice;
+
+import co.cask.cdap.common.io.RootLocationFactory;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileContext;
+import org.apache.twill.filesystem.FileContextLocationFactory;
+
+/**
+ * A Guice Provider for {@link RootLocationFactory}. This {@link RootLocationFactoryProvider} gives the location
+ * factory which is the root of the filesystem. To get a location factory based on {link Constants#CFG_HDFS_NAMESPACE}
+ * please refer providesLocationFactory in {@link LocationRuntimeModule#getDistributedModules()}
+ */
+public final class RootLocationFactoryProvider implements Provider<RootLocationFactory> {
+
+  private final FileContext fc;
+  private final Configuration hConf;
+
+  @Inject
+  public RootLocationFactoryProvider(FileContext fc, Configuration hConf) {
+    this.fc = fc;
+    this.hConf = hConf;
+  }
+
+  @Override
+  public RootLocationFactory get() {
+    return new RootLocationFactory(new FileContextLocationFactory(hConf, fc, "/"));
+  }
+}

--- a/cdap-master/src/main/java/co/cask/cdap/master/startup/FileSystemCheck.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/startup/FileSystemCheck.java
@@ -77,19 +77,19 @@ public class FileSystemCheck extends AbstractMasterCheck {
     if (rootExists) {
       // try creating a tmp file to check permissions
       try {
-        Location tmpFile = rootLocation.getTempFile("tmp");
+        Location tmpFile = rootLocation.append("newTempFile").getTempFile("tmp");
         if (!tmpFile.createNew()) {
           throw new RuntimeException(String.format(
-            "Could not make a temp file in directory %s on the FileSystem. " +
+            "Could not make a temp file %s in directory %s on the FileSystem. " +
               "Please check that user %s has permission to write to %s, " +
               "or create the directory manually with write permissions.",
-            rootPath, user, rootPath));
+            tmpFile, rootPath, user, rootPath));
         } else {
           tmpFile.delete();
         }
       } catch (IOException e) {
         throw new RuntimeException(String.format(
-          "Could not make a temp file in directory %s on the FileSystem. " +
+          "Could not make/delete a temp file in directory %s on the FileSystem. " +
             "Please check that user %s has permission to write to %s, " +
             "or create the directory manually with write permissions.",
           rootPath, user, rootPath), e);

--- a/cdap-master/src/test/java/co/cask/cdap/master/startup/MasterStartupToolTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/master/startup/MasterStartupToolTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.master.startup;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.junit.Test;
+
+/**
+ * Test Guice injector for {@link MasterStartupTool}
+ */
+public class MasterStartupToolTest {
+
+  @Test
+  public void testInjector() throws Exception {
+    MasterStartupTool.createInjector(CConfiguration.create(), HBaseConfiguration.create());
+    // should not throw exception
+  }
+}


### PR DESCRIPTION
- Makes MasterStartupTool use root of HDFS filesystem as basepath
- Issue: https://issues.cask.co/browse/CDAP-6270
- Build: http://builds.cask.co/browse/CDAP-DUT4261-1
