### PR TITLE
CDAP-6258 Make sure the alias names are unique for outputs in ETLMapReduce/ETLSpark program

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/ETLSpark.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/ETLSpark.java
@@ -108,9 +108,7 @@ public class ETLSpark extends AbstractSpark {
 
     BatchConfigurable<BatchSourceContext> batchSource = pluginInstantiator.newPluginInstance(sourceName);
     DatasetContextLookupProvider lookProvider = new DatasetContextLookupProvider(context);
-    SparkBatchSourceContext sourceContext = new SparkBatchSourceContext(context,
-                                                                        lookProvider,
-                                                                        sourceName);
+    SparkBatchSourceContext sourceContext = new SparkBatchSourceContext(context, lookProvider, sourceName);
     batchSource.prepareRun(sourceContext);
 
     SparkBatchSourceFactory sourceFactory = sourceContext.getSourceFactory();

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkBatchSinkFactory.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkBatchSinkFactory.java
@@ -98,16 +98,6 @@ final class SparkBatchSinkFactory {
     }
   }
 
-  void addOutput(String stageName, String alias, OutputFormatProvider outputFormatProvider) {
-    addOutput(stageName, alias,
-              new BasicOutputFormatProvider(outputFormatProvider.getOutputFormatClassName(),
-                                            outputFormatProvider.getOutputFormatConfiguration()));
-  }
-
-  void addOutput(String stageName, String datasetName, Map<String, String> datasetArgs) {
-    addOutput(stageName, datasetName, datasetName, datasetArgs);
-  }
-
   private void addOutput(String stageName, String alias,
                          BasicOutputFormatProvider outputFormatProvider) {
     if (outputFormatProviders.containsKey(alias) || datasetInfos.containsKey(alias)) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkBatchSourceContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkBatchSourceContext.java
@@ -16,12 +16,10 @@
 
 package co.cask.cdap.etl.batch.spark;
 
-import co.cask.cdap.api.data.batch.BatchReadable;
 import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.batch.InputFormatProvider;
 import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.data.stream.StreamBatchReadable;
-import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.spark.SparkClientContext;
 import co.cask.cdap.etl.api.LookupProvider;
 import co.cask.cdap.etl.api.batch.BatchSourceContext;
@@ -36,7 +34,6 @@ import javax.annotation.Nullable;
  * Default implementation of {@link BatchSourceContext} for spark contexts.
  */
 public class SparkBatchSourceContext extends AbstractSparkBatchContext implements BatchSourceContext {
-
   private SparkBatchSourceFactory sourceFactory;
 
   public SparkBatchSourceContext(SparkClientContext sparkContext, LookupProvider lookupProvider, String stageId) {
@@ -50,17 +47,17 @@ public class SparkBatchSourceContext extends AbstractSparkBatchContext implement
 
   @Override
   public void setInput(String datasetName) {
-    sourceFactory = SparkBatchSourceFactory.create(datasetName);
+    setInput(datasetName, Collections.<String, String>emptyMap());
   }
 
   @Override
   public void setInput(String datasetName, Map<String, String> arguments) {
-    sourceFactory = SparkBatchSourceFactory.create(datasetName, arguments);
+    setInput(datasetName, arguments, null);
   }
 
   @Override
   public void setInput(String datasetName, List<Split> splits) {
-    sourceFactory = SparkBatchSourceFactory.create(datasetName, Collections.<String, String>emptyMap(), splits);
+    setInput(datasetName, Collections.<String, String>emptyMap(), splits);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkBatchSourceFactory.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkBatchSourceFactory.java
@@ -83,14 +83,6 @@ final class SparkBatchSourceFactory {
     return new SparkBatchSourceFactory(null, inputFormatProvider, null);
   }
 
-  static SparkBatchSourceFactory create(String datasetName) {
-    return create(datasetName, ImmutableMap.<String, String>of());
-  }
-
-  static SparkBatchSourceFactory create(String datasetName, Map<String, String> datasetArgs) {
-    return create(datasetName, datasetArgs, null);
-  }
-
   static SparkBatchSourceFactory create(String datasetName, Map<String, String> datasetArgs,
                                         @Nullable List<Split> splits) {
     return new SparkBatchSourceFactory(null, null, new DatasetInfo(datasetName, datasetArgs, splits));

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceSourceContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceSourceContext.java
@@ -28,12 +28,13 @@ import co.cask.cdap.etl.api.batch.BatchSourceContext;
 import co.cask.cdap.etl.common.ExternalDatasets;
 import co.cask.cdap.etl.log.LogContext;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
 /**
- * MapReduce Source Context.
+ * MapReduce Source Context. Delegates operations to MapReduce Context.
  */
 public class MapReduceSourceContext extends MapReduceBatchContext implements BatchSourceContext {
 
@@ -61,35 +62,17 @@ public class MapReduceSourceContext extends MapReduceBatchContext implements Bat
 
   @Override
   public void setInput(final String datasetName) {
-    LogContext.runWithoutLoggingUnchecked(new Callable<Void>() {
-      @Override
-      public Void call() throws Exception {
-        mrContext.addInput(Input.ofDataset(datasetName));
-        return null;
-      }
-    });
+    setInput(datasetName, Collections.<String, String>emptyMap());
   }
 
   @Override
   public void setInput(final String datasetName, final Map<String, String> arguments) {
-    LogContext.runWithoutLoggingUnchecked(new Callable<Void>() {
-      @Override
-      public Void call() throws Exception {
-        mrContext.addInput(Input.ofDataset(datasetName, arguments));
-        return null;
-      }
-    });
+    setInput(datasetName, arguments, null);
   }
 
   @Override
   public void setInput(final String datasetName, final List<Split> splits) {
-    LogContext.runWithoutLoggingUnchecked(new Callable<Void>() {
-      @Override
-      public Void call() throws Exception {
-        mrContext.addInput(Input.ofDataset(datasetName, splits));
-        return null;
-      }
-    });
+    setInput(datasetName, Collections.<String, String>emptyMap(), splits);
   }
 
   @Override


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-6258

Build: http://builds.cask.co/browse/CDAP-DUT4267

Summary: Outputs' aliases in a ETLMapReduce/ETLSpark job need to be unique. This needs to be enforced by ETLMapReduce/ETLSpark since plugins aren't aware of that and they might set the same alias for their corresponding outputs. So we will suffix it with existing alias name with a UUID so that the outputs are unique.
