### PR TITLE
Writing of lineage and usage, through app fabric

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -55,7 +55,9 @@ import co.cask.cdap.gateway.handlers.UsageHandler;
 import co.cask.cdap.gateway.handlers.VersionHandler;
 import co.cask.cdap.gateway.handlers.WorkflowHttpHandler;
 import co.cask.cdap.gateway.handlers.WorkflowStatsSLAHttpHandler;
+import co.cask.cdap.gateway.handlers.meta.RemoteLineageWriterHandler;
 import co.cask.cdap.gateway.handlers.meta.RemoteRuntimeStoreHandler;
+import co.cask.cdap.gateway.handlers.meta.RemoteUsageRegistryHandler;
 import co.cask.cdap.internal.app.deploy.LocalApplicationManager;
 import co.cask.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
 import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
@@ -315,6 +317,8 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       handlerBinder.addBinding().to(WorkflowStatsSLAHttpHandler.class);
       handlerBinder.addBinding().to(AuthorizationHandler.class);
       handlerBinder.addBinding().to(RemoteRuntimeStoreHandler.class);
+      handlerBinder.addBinding().to(RemoteLineageWriterHandler.class);
+      handlerBinder.addBinding().to(RemoteUsageRegistryHandler.class);
 
       for (Class<? extends HttpHandler> handlerClass : handlerClasses) {
         handlerBinder.addBinding().to(handlerClass);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramRunnableModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramRunnableModule.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.guice;
+
+import co.cask.cdap.api.data.stream.StreamWriter;
+import co.cask.cdap.app.store.RuntimeStore;
+import co.cask.cdap.app.stream.DefaultStreamWriter;
+import co.cask.cdap.app.stream.StreamWriterFactory;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.guice.ConfigModule;
+import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
+import co.cask.cdap.common.guice.IOModule;
+import co.cask.cdap.common.guice.KafkaClientModule;
+import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.ZKClientModule;
+import co.cask.cdap.data.runtime.DataFabricModules;
+import co.cask.cdap.data.runtime.DataSetsModules;
+import co.cask.cdap.data.stream.StreamAdminModules;
+import co.cask.cdap.data.view.ViewAdminModules;
+import co.cask.cdap.data2.audit.AuditModule;
+import co.cask.cdap.data2.metadata.writer.LineageWriter;
+import co.cask.cdap.data2.registry.RuntimeUsageRegistry;
+import co.cask.cdap.explore.guice.ExploreClientModule;
+import co.cask.cdap.internal.app.queue.QueueReaderFactory;
+import co.cask.cdap.internal.app.store.remote.RemoteLineageWriter;
+import co.cask.cdap.internal.app.store.remote.RemoteRuntimeStore;
+import co.cask.cdap.internal.app.store.remote.RemoteRuntimeUsageRegistry;
+import co.cask.cdap.logging.guice.LoggingModules;
+import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
+import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
+import co.cask.cdap.security.authorization.DefaultAuthorizationEnforcementService;
+import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
+import com.google.inject.AbstractModule;
+import com.google.inject.Module;
+import com.google.inject.PrivateModule;
+import com.google.inject.Scopes;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.google.inject.name.Names;
+import com.google.inject.util.Modules;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.twill.api.ServiceAnnouncer;
+import org.apache.twill.api.TwillContext;
+import org.apache.twill.common.Cancellable;
+
+import java.net.InetAddress;
+
+/**
+ * Defines guice modules for distributed program runnables. For instance, AbstractProgramTwillRunnable, as well as
+ * mapreduce tasks / spark executors.
+ */
+public class DistributedProgramRunnableModule {
+
+  private final CConfiguration cConf;
+  private final Configuration hConf;
+
+  public DistributedProgramRunnableModule(CConfiguration cConf, Configuration hConf) {
+    this.cConf = cConf;
+    this.hConf = hConf;
+  }
+
+  // usable from any program runtime, such as mapreduce task, spark task, etc
+  public Module createModule() {
+    Module combined = Modules.combine(
+      new ConfigModule(cConf, hConf),
+      new IOModule(),
+      new ZKClientModule(),
+      new KafkaClientModule(),
+      new MetricsClientRuntimeModule().getDistributedModules(),
+      new LocationRuntimeModule().getDistributedModules(),
+      new LoggingModules().getDistributedModules(),
+      new DiscoveryRuntimeModule().getDistributedModules(),
+      new DataFabricModules().getDistributedModules(),
+      new DataSetsModules().getDistributedModules(),
+      new ExploreClientModule(),
+      new ViewAdminModules().getDistributedModules(),
+      new StreamAdminModules().getDistributedModules(),
+      new NotificationFeedClientModule(),
+      new AuditModule().getDistributedModules(),
+      new AuthorizationModule(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          // For Binding queue stuff
+          bind(QueueReaderFactory.class).in(Scopes.SINGLETON);
+
+          // For binding DataSet transaction stuff
+          install(new DataFabricFacadeModule());
+
+          bind(RuntimeStore.class).to(RemoteRuntimeStore.class);
+
+          // For binding StreamWriter
+          install(createStreamFactoryModule());
+
+          // also bind AuthorizationEnforcementService as a singleton. This binding is used while starting/stopping
+          // the service itself.
+          bind(AuthorizationEnforcementService.class).to(DefaultAuthorizationEnforcementService.class)
+            .in(Scopes.SINGLETON);
+          // bind AuthorizationEnforcer to AuthorizationEnforcementService
+          bind(AuthorizationEnforcer.class).to(AuthorizationEnforcementService.class).in(Scopes.SINGLETON);
+        }
+      }
+    );
+
+    return Modules.override(combined).with(new AbstractModule() {
+      @Override
+      protected void configure() {
+        bind(LineageWriter.class).to(RemoteLineageWriter.class);
+        bind(RuntimeUsageRegistry.class).to(RemoteRuntimeUsageRegistry.class).in(Scopes.SINGLETON);
+      }
+    });
+  }
+
+  // TODO(terence) make this works for different mode
+  // usable from anywhere a TwillContext is exposed
+  public Module createModule(final TwillContext context) {
+    return Modules.combine(createModule(),
+                           new AbstractModule() {
+                             @Override
+                             protected void configure() {
+                               bind(InetAddress.class).annotatedWith(Names.named(Constants.AppFabric.SERVER_ADDRESS))
+                                 .toInstance(context.getHost());
+
+                               bind(ServiceAnnouncer.class).toInstance(new ServiceAnnouncer() {
+                                 @Override
+                                 public Cancellable announce(String serviceName, int port) {
+                                   return context.announce(serviceName, port);
+                                 }
+                               });
+                             }
+                           });
+  }
+
+  private Module createStreamFactoryModule() {
+    return new PrivateModule() {
+      @Override
+      protected void configure() {
+        install(new FactoryModuleBuilder().implement(StreamWriter.class, DefaultStreamWriter.class)
+                  .build(StreamWriterFactory.class));
+        expose(StreamWriterFactory.class);
+      }
+    };
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/AbstractRemoteSystemOpsHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/AbstractRemoteSystemOpsHandler.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.handlers.meta;
+
+import co.cask.cdap.common.BadRequestException;
+import co.cask.cdap.internal.app.store.remote.MethodArgument;
+import co.cask.http.AbstractHttpHandler;
+import com.google.common.base.Charsets;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.reflect.TypeToken;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+
+import java.lang.reflect.Type;
+import java.util.Iterator;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * Implements common functionality for reading method arguments and deserializing them.
+ */
+class AbstractRemoteSystemOpsHandler extends AbstractHttpHandler {
+
+  private static final Gson GSON = new Gson();
+  private static final Type METHOD_ARGUMENT_LIST_TYPE = new TypeToken<List<MethodArgument>>() { }.getType();
+
+  // we don't share the same version as other handlers in app fabric, so we can upgrade/iterate faster
+  protected static final String VERSION = "/v1";
+
+  Iterator<MethodArgument> parseArguments(HttpRequest request) {
+    String body = request.getContent().toString(Charsets.UTF_8);
+    List<MethodArgument> arguments = GSON.fromJson(body, METHOD_ARGUMENT_LIST_TYPE);
+    return arguments.iterator();
+  }
+
+  @Nullable
+  <T> T deserializeNext(Iterator<MethodArgument> arguments) throws ClassNotFoundException, BadRequestException {
+    if (!arguments.hasNext()) {
+      throw new BadRequestException("Expected additional elements.");
+    }
+
+    MethodArgument argument = arguments.next();
+    if (argument == null) {
+      return null;
+    }
+    JsonElement value = argument.getValue();
+    if (value == null) {
+      return null;
+    }
+    return GSON.<T>fromJson(value, Class.forName(argument.getType()));
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteLineageWriterHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteLineageWriterHandler.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.handlers.meta;
+
+import co.cask.cdap.data2.metadata.lineage.AccessType;
+import co.cask.cdap.data2.metadata.writer.LineageWriter;
+import co.cask.cdap.internal.app.store.remote.MethodArgument;
+import co.cask.cdap.proto.Id;
+import co.cask.http.HttpResponder;
+import com.google.inject.Inject;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.Iterator;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+/**
+ * The {@link co.cask.http.HttpHandler} for handling REST calls to LineageStore.
+ */
+@Path(AbstractRemoteSystemOpsHandler.VERSION + "/execute")
+public class RemoteLineageWriterHandler extends AbstractRemoteSystemOpsHandler {
+
+  private final LineageWriter lineageWriter;
+
+  @Inject
+  public RemoteLineageWriterHandler(LineageWriter lineageWriter) {
+    this.lineageWriter = lineageWriter;
+  }
+
+  @POST
+  @Path("/addDatasetAccess")
+  public void addDatasetAccess(HttpRequest request, HttpResponder responder) throws Exception {
+    Iterator<MethodArgument> arguments = parseArguments(request);
+
+    Id.Run run = deserializeNext(arguments);
+    Id.DatasetInstance datasetInstance = deserializeNext(arguments);
+    AccessType accessType = deserializeNext(arguments);
+    Id.NamespacedId component = deserializeNext(arguments);
+    lineageWriter.addAccess(run, datasetInstance, accessType, component);
+
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  @POST
+  @Path("/addStreamAccess")
+  public void addStreamAccess(HttpRequest request, HttpResponder responder) throws Exception {
+    Iterator<MethodArgument> arguments = parseArguments(request);
+
+    Id.Run run = deserializeNext(arguments);
+    Id.Stream stream = deserializeNext(arguments);
+    AccessType accessType = deserializeNext(arguments);
+    Id.NamespacedId component = deserializeNext(arguments);
+    lineageWriter.addAccess(run, stream, accessType, component);
+
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteUsageRegistryHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteUsageRegistryHandler.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.handlers.meta;
+
+import co.cask.cdap.data2.registry.UsageRegistry;
+import co.cask.cdap.internal.app.store.remote.MethodArgument;
+import co.cask.cdap.proto.Id;
+import co.cask.http.HttpResponder;
+import com.google.inject.Inject;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.Iterator;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+/**
+ * The {@link co.cask.http.HttpHandler} for handling REST calls to UsageDataset.
+ */
+@Path(AbstractRemoteSystemOpsHandler.VERSION + "/execute")
+public class RemoteUsageRegistryHandler extends AbstractRemoteSystemOpsHandler {
+
+  private final UsageRegistry usageRegistry;
+
+  @Inject
+  public RemoteUsageRegistryHandler(UsageRegistry usageRegistry) {
+    this.usageRegistry = usageRegistry;
+  }
+
+  @POST
+  @Path("/registerDataset")
+  public void registerDataset(HttpRequest request, HttpResponder responder) throws Exception {
+    Iterator<MethodArgument> arguments = parseArguments(request);
+
+    Id.Program programId = deserializeNext(arguments);
+    Id.DatasetInstance datasetInstance = deserializeNext(arguments);
+    usageRegistry.register(programId, datasetInstance);
+
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  @POST
+  @Path("/registerStream")
+  public void registerStream(HttpRequest request, HttpResponder responder) throws Exception {
+    Iterator<MethodArgument> arguments = parseArguments(request);
+
+    Id.Program programId = deserializeNext(arguments);
+    Id.Stream streamId = deserializeNext(arguments);
+    usageRegistry.register(programId, streamId);
+
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -25,7 +25,6 @@ import co.cask.cdap.app.runtime.Arguments;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.store.RuntimeStore;
-import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
@@ -36,7 +35,6 @@ import co.cask.cdap.common.logging.common.LogWriter;
 import co.cask.cdap.common.logging.logback.CAppender;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.metadata.writer.ProgramContextAware;
-import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.internal.app.runtime.AbstractProgramRunnerWithPlugin;
 import co.cask.cdap.internal.app.runtime.DataSetFieldSetter;
@@ -92,7 +90,6 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final RuntimeStore runtimeStore;
   private final TransactionSystemClient txSystemClient;
   private final DiscoveryServiceClient discoveryServiceClient;
-  private final UsageRegistry usageRegistry;
 
   @Inject
   public MapReduceProgramRunner(Injector injector, CConfiguration cConf, Configuration hConf,
@@ -101,8 +98,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
                                 DatasetFramework datasetFramework,
                                 TransactionSystemClient txSystemClient,
                                 MetricsCollectionService metricsCollectionService,
-                                DiscoveryServiceClient discoveryServiceClient, RuntimeStore runtimeStore,
-                                UsageRegistry usageRegistry) {
+                                DiscoveryServiceClient discoveryServiceClient, RuntimeStore runtimeStore) {
     super(cConf);
     this.injector = injector;
     this.cConf = cConf;
@@ -114,7 +110,6 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.txSystemClient = txSystemClient;
     this.discoveryServiceClient = discoveryServiceClient;
     this.runtimeStore = runtimeStore;
-    this.usageRegistry = usageRegistry;
   }
 
   @Inject (optional = true)
@@ -186,7 +181,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
       final Service mapReduceRuntimeService = new MapReduceRuntimeService(injector, cConf, hConf, mapReduce, spec,
                                                                           context, program.getJarLocation(),
                                                                           locationFactory, streamAdmin,
-                                                                          txSystemClient, usageRegistry);
+                                                                          txSystemClient);
       mapReduceRuntimeService.addListener(
         createRuntimeServiceListener(program, runId, closeables, arguments, options.getUserArguments()),
         Threads.SAME_THREAD_EXECUTOR);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -40,7 +40,6 @@ import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.data.stream.StreamInputFormat;
 import co.cask.cdap.data.stream.StreamInputFormatProvider;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
-import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.data2.transaction.Transactions;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
@@ -64,6 +63,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
@@ -150,7 +150,6 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
   private final LocationFactory locationFactory;
   private final StreamAdmin streamAdmin;
   private final TransactionSystemClient txClient;
-  private final UsageRegistry usageRegistry;
 
   private Job job;
   private Transaction transaction;
@@ -165,8 +164,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
                           MapReduce mapReduce, MapReduceSpecification specification,
                           BasicMapReduceContext context,
                           Location programJarLocation, LocationFactory locationFactory,
-                          StreamAdmin streamAdmin, TransactionSystemClient txClient,
-                          UsageRegistry usageRegistry) {
+                          StreamAdmin streamAdmin, TransactionSystemClient txClient) {
     this.injector = injector;
     this.cConf = cConf;
     this.hConf = hConf;
@@ -177,7 +175,6 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
     this.streamAdmin = streamAdmin;
     this.txClient = txClient;
     this.context = context;
-    this.usageRegistry = usageRegistry;
   }
 
   @Override
@@ -701,7 +698,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
 
     Id.Stream streamId = streamProvider.getStreamId();
     try {
-      usageRegistry.register(context.getProgram().getId(), streamId);
+      streamAdmin.register(ImmutableList.of(context.getProgram().getId()), streamId);
       streamAdmin.addAccess(new Id.Run(context.getProgram().getId(), context.getRunId().getId()),
                             streamId, AccessType.READ);
     } catch (Exception e) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WorkflowTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WorkflowTwillRunnable.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.internal.app.runtime.distributed;
 
 import co.cask.cdap.app.guice.DefaultProgramRunnerFactory;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteLineageWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteLineageWriter.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.store.remote;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.data2.metadata.lineage.AccessType;
+import co.cask.cdap.data2.metadata.writer.BasicLineageWriter;
+import co.cask.cdap.data2.metadata.writer.LineageWriter;
+import co.cask.cdap.proto.Id;
+import com.google.inject.Inject;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.annotation.Nullable;
+
+/**
+ * Implementation of LineageWriter, which uses an HTTP Client to execute the actual lineage writing in a remote
+ * server.
+ */
+public class RemoteLineageWriter extends RemoteOpsClient implements LineageWriter {
+
+  private final ConcurrentMap<BasicLineageWriter.DataAccessKey, Boolean> registered = new ConcurrentHashMap<>();
+
+  @Inject
+  public RemoteLineageWriter(CConfiguration cConf, DiscoveryServiceClient discoveryClient) {
+    super(cConf, discoveryClient);
+  }
+
+  @Override
+  public void addAccess(Id.Run run, Id.DatasetInstance datasetInstance, AccessType accessType) {
+    // delegates on client side; so corresponding method is not required to be implemented on server side
+    addAccess(run, datasetInstance, accessType, null);
+  }
+
+  @Override
+  public void addAccess(Id.Run run, Id.DatasetInstance datasetInstance, AccessType accessType,
+                        @Nullable Id.NamespacedId component) {
+    if (alreadyRegistered(run, datasetInstance, accessType, component)) {
+      return;
+    }
+    executeRequest("addDatasetAccess", run, datasetInstance, accessType, component);
+  }
+
+  @Override
+  public void addAccess(Id.Run run, Id.Stream stream, AccessType accessType) {
+    // delegates on client side; so corresponding method is not required to be implemented on server side
+    addAccess(run, stream, accessType, null);
+  }
+
+  @Override
+  public void addAccess(Id.Run run, Id.Stream stream, AccessType accessType, @Nullable Id.NamespacedId component) {
+    if (alreadyRegistered(run, stream, accessType, component)) {
+      return;
+    }
+    executeRequest("addStreamAccess", run, stream, accessType, component);
+  }
+
+  private boolean alreadyRegistered(Id.Run run, Id.NamespacedId data, AccessType accessType,
+                                    @Nullable Id.NamespacedId component) {
+    return registered.putIfAbsent(new BasicLineageWriter.DataAccessKey(run, data, accessType, component), true) != null;
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeStore.java
@@ -23,19 +23,10 @@ import co.cask.cdap.proto.BasicThrowable;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.WorkflowNodeStateDetail;
-import co.cask.cdap.proto.WorkflowTokenDetail;
-import co.cask.cdap.proto.WorkflowTokenNodeDetail;
-import co.cask.cdap.proto.codec.BasicThrowableCodec;
-import co.cask.cdap.proto.codec.WorkflowTokenDetailCodec;
-import co.cask.cdap.proto.codec.WorkflowTokenNodeDetailCodec;
 import co.cask.cdap.proto.id.ProgramRunId;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -43,12 +34,7 @@ import javax.annotation.Nullable;
  * Implementation of RuntimeStore, which uses an HTTP Client to execute the actual store operations in a remote
  * server.
  */
-public class RemoteRuntimeStore extends RemoteStoreClient implements RuntimeStore {
-  private static final Gson GSON = new GsonBuilder()
-    .registerTypeAdapter(BasicThrowable.class, new BasicThrowableCodec())
-    .registerTypeAdapter(WorkflowTokenDetail.class, new WorkflowTokenDetailCodec())
-    .registerTypeAdapter(WorkflowTokenNodeDetail.class, new WorkflowTokenNodeDetailCodec())
-    .create();
+public class RemoteRuntimeStore extends RemoteOpsClient implements RuntimeStore {
 
   @Inject
   public RemoteRuntimeStore(CConfiguration cConf, DiscoveryServiceClient discoveryClient) {
@@ -97,22 +83,5 @@ public class RemoteRuntimeStore extends RemoteStoreClient implements RuntimeStor
   @Override
   public void addWorkflowNodeState(ProgramRunId workflowRunId, WorkflowNodeStateDetail nodeStateDetail) {
     executeRequest("addWorkflowNodeState", workflowRunId, nodeStateDetail);
-  }
-
-  private void executeRequest(String methodName, Object... arguments) {
-    doPost("execute/" + methodName, GSON.toJson(createArguments(arguments)));
-  }
-
-  private static List<MethodArgument> createArguments(Object... arguments) {
-    List<MethodArgument> methodArguments = new ArrayList<>();
-    for (Object arg : arguments) {
-      if (arg == null) {
-        methodArguments.add(null);
-      } else {
-        String type = arg.getClass().getName();
-        methodArguments.add(new MethodArgument(type, GSON.toJsonTree(arg)));
-      }
-    }
-    return methodArguments;
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeUsageRegistry.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeUsageRegistry.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.store.remote;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.data2.registry.DatasetUsageKey;
+import co.cask.cdap.data2.registry.RuntimeUsageRegistry;
+import co.cask.cdap.proto.Id;
+import com.google.inject.Inject;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Implementation of RuntimeUsageRegistry, which uses an HTTP Client to execute the actual usage dataset updates in a
+ * remote server.
+ */
+public class RemoteRuntimeUsageRegistry extends RemoteOpsClient implements RuntimeUsageRegistry {
+
+  private final ConcurrentMap<DatasetUsageKey, Boolean> registered = new ConcurrentHashMap<>();
+
+  @Inject
+  public RemoteRuntimeUsageRegistry(CConfiguration cConf, DiscoveryServiceClient discoveryClient) {
+    super(cConf, discoveryClient);
+  }
+
+  @Override
+  public void registerAll(Iterable<? extends Id> users, Id.Stream streamId) {
+    for (Id user : users) {
+      register(user, streamId);
+    }
+  }
+
+  @Override
+  public void register(Id user, Id.Stream streamId) {
+    if (user instanceof Id.Program) {
+      register((Id.Program) user, streamId);
+    }
+  }
+
+  @Override
+  public void registerAll(Iterable<? extends Id> users, Id.DatasetInstance datasetId) {
+    for (Id user : users) {
+      register(user, datasetId);
+    }
+  }
+
+  @Override
+  public void register(Id user, Id.DatasetInstance datasetId) {
+    if (user instanceof Id.Program) {
+      register((Id.Program) user, datasetId);
+    }
+  }
+
+  @Override
+  public void register(Id.Program programId, Id.DatasetInstance datasetInstanceId) {
+    if (alreadyRegistered(datasetInstanceId, programId)) {
+      return;
+    }
+    executeRequest("registerDataset", programId, datasetInstanceId);
+  }
+
+  @Override
+  public void register(Id.Program programId, Id.Stream streamId) {
+    executeRequest("registerStream", programId, streamId);
+  }
+
+  private boolean alreadyRegistered(Id.DatasetInstance dataset, Id.Program owner) {
+    return registered.putIfAbsent(new DatasetUsageKey(dataset, owner), true) != null;
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/RemoteLineageWriterTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/RemoteLineageWriterTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.store;
+
+import co.cask.cdap.common.app.RunIds;
+import co.cask.cdap.data2.metadata.lineage.AccessType;
+import co.cask.cdap.data2.metadata.lineage.LineageStore;
+import co.cask.cdap.data2.metadata.lineage.Relation;
+import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
+import co.cask.cdap.internal.app.store.remote.RemoteLineageWriter;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.proto.id.StreamId;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Injector;
+import org.apache.twill.api.RunId;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Tests implementation of {@link RemoteLineageWriter}, by using it to perform writes/updates, and then using a
+ * local {@link LineageStore} to verify the updates/writes.
+ */
+public class RemoteLineageWriterTest extends AppFabricTestBase {
+
+  private static LineageStore lineageStore;
+  private static RemoteLineageWriter remoteLineageWriter;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    Injector injector = getInjector();
+    lineageStore = injector.getInstance(LineageStore.class);
+    remoteLineageWriter = injector.getInstance(RemoteLineageWriter.class);
+  }
+
+  @Test
+  public void testSimpleCase() {
+    long now = System.currentTimeMillis();
+    ApplicationId appId = NamespaceId.DEFAULT.app("test_app");
+    ProgramId flowId = appId.flow("test_flow");
+    ProgramRunId runId = flowId.run(RunIds.generate(now).getId());
+    RunId twillRunId = RunIds.fromString(runId.getRun());
+    DatasetId datasetId = NamespaceId.DEFAULT.dataset("test_dataset");
+    StreamId streamId = NamespaceId.DEFAULT.stream("test_stream");
+
+    Set<Relation> expectedRelations = new HashSet<>();
+
+    // test null serialization
+    remoteLineageWriter.addAccess(runId.toId(), datasetId.toId(), AccessType.READ, null);
+    expectedRelations.add(new Relation(datasetId.toId(), flowId.toId(), AccessType.READ, twillRunId));
+
+    Assert.assertEquals(ImmutableSet.of(flowId.toId(), datasetId.toId()), lineageStore.getEntitiesForRun(runId.toId()));
+
+    Assert.assertEquals(expectedRelations,
+                        lineageStore.getRelations(flowId.toId(), now, now + 1, Predicates.<Relation>alwaysTrue()));
+
+    remoteLineageWriter.addAccess(runId.toId(), streamId.toId(), AccessType.READ);
+    expectedRelations.add(new Relation(streamId.toId(), flowId.toId(), AccessType.READ, twillRunId));
+
+    Assert.assertEquals(expectedRelations,
+                        lineageStore.getRelations(flowId.toId(), now, now + 1, Predicates.<Relation>alwaysTrue()));
+
+    remoteLineageWriter.addAccess(runId.toId(), streamId.toId(), AccessType.WRITE);
+    expectedRelations.add(new Relation(streamId.toId(), flowId.toId(), AccessType.WRITE, twillRunId));
+
+    Assert.assertEquals(expectedRelations,
+                        lineageStore.getRelations(flowId.toId(), now, now + 1, Predicates.<Relation>alwaysTrue()));
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/RemoteRuntimeUsageRegistryTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/RemoteRuntimeUsageRegistryTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.store;
+
+import co.cask.cdap.data2.registry.UsageRegistry;
+import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
+import co.cask.cdap.internal.app.store.remote.RemoteRuntimeStore;
+import co.cask.cdap.internal.app.store.remote.RemoteRuntimeUsageRegistry;
+import co.cask.cdap.proto.Id;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.inject.Injector;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Set;
+
+/**
+ * Tests implementation of {@link RemoteRuntimeUsageRegistry}, by using it to perform writes/updates, and then using a
+ * local {@link UsageRegistry} to verify the updates/writes.
+ */
+public class RemoteRuntimeUsageRegistryTest extends AppFabricTestBase {
+
+  private static UsageRegistry usageRegistry;
+  private static RemoteRuntimeUsageRegistry runtimeUsageRegistry;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    Injector injector = getInjector();
+    usageRegistry = injector.getInstance(UsageRegistry.class);
+    runtimeUsageRegistry = injector.getInstance(RemoteRuntimeUsageRegistry.class);
+  }
+
+  @Test
+  public void testSimpleCase() {
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "test_app");
+    Id.Flow flowId1 = Id.Flow.from(appId, "test_flow1");
+    Id.Flow flowId2 = Id.Flow.from(appId, "test_flow2");
+
+    // should be no data initially
+    Assert.assertEquals(0, usageRegistry.getDatasets(appId).size());
+    Assert.assertEquals(0, usageRegistry.getStreams(appId).size());
+
+    Assert.assertEquals(0, usageRegistry.getDatasets(flowId1).size());
+    Assert.assertEquals(0, usageRegistry.getStreams(flowId1).size());
+
+    Assert.assertEquals(0, usageRegistry.getDatasets(flowId2).size());
+    Assert.assertEquals(0, usageRegistry.getStreams(flowId2).size());
+
+    Id.DatasetInstance datasetId1 = Id.DatasetInstance.from(Id.Namespace.DEFAULT, "test_dataset1");
+    runtimeUsageRegistry.register(flowId1, datasetId1);
+
+    ImmutableSet<Id.DatasetInstance> datasetsUsedByFlow1 = ImmutableSet.of(datasetId1);
+    Assert.assertEquals(datasetsUsedByFlow1, usageRegistry.getDatasets(appId));
+    Assert.assertEquals(0, usageRegistry.getStreams(appId).size());
+
+    Assert.assertEquals(datasetsUsedByFlow1, usageRegistry.getDatasets(flowId1));
+    Assert.assertEquals(0, usageRegistry.getStreams(flowId1).size());
+
+    Assert.assertEquals(0, usageRegistry.getDatasets(flowId2).size());
+    Assert.assertEquals(0, usageRegistry.getStreams(flowId2).size());
+
+    Id.DatasetInstance datasetId2 = Id.DatasetInstance.from(Id.Namespace.DEFAULT, "test_dataset2");
+    Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, "test_stream");
+    runtimeUsageRegistry.register(flowId2, datasetId1);
+    runtimeUsageRegistry.register(flowId2, datasetId2);
+    runtimeUsageRegistry.register(flowId2, streamId);
+
+    ImmutableSet<Id.DatasetInstance> datasetsUsedByFlow2 = ImmutableSet.of(datasetId1, datasetId2);
+    ImmutableSet<Id.Stream> streamsUsedByFlow2 = ImmutableSet.of(streamId);
+    Assert.assertEquals(Sets.union(datasetsUsedByFlow1, datasetsUsedByFlow2), usageRegistry.getDatasets(appId));
+    Assert.assertEquals(streamsUsedByFlow2, usageRegistry.getStreams(appId));
+
+    Assert.assertEquals(datasetsUsedByFlow1, usageRegistry.getDatasets(flowId1));
+    Assert.assertEquals(0, usageRegistry.getStreams(flowId1).size());
+
+    Assert.assertEquals(datasetsUsedByFlow2, usageRegistry.getDatasets(flowId2));
+    Assert.assertEquals(streamsUsedByFlow2, usageRegistry.getStreams(flowId2));
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetsModules.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/DataSetsModules.java
@@ -35,6 +35,7 @@ import co.cask.cdap.data2.metadata.writer.BasicLineageWriter;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
 import co.cask.cdap.data2.metadata.writer.LineageWriterDatasetFramework;
 import co.cask.cdap.data2.registry.DefaultUsageRegistry;
+import co.cask.cdap.data2.registry.RuntimeUsageRegistry;
 import co.cask.cdap.data2.registry.UsageRegistry;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -74,6 +75,9 @@ public class DataSetsModules extends RuntimeModule {
 
         bind(UsageRegistry.class).to(DefaultUsageRegistry.class).in(Scopes.SINGLETON);
         expose(UsageRegistry.class);
+        bind(RuntimeUsageRegistry.class).to(DefaultUsageRegistry.class).in(Scopes.SINGLETON);
+        expose(RuntimeUsageRegistry.class);
+        bind(DefaultUsageRegistry.class).in(Scopes.SINGLETON);
 
         bind(DatasetFramework.class).to(LineageWriterDatasetFramework.class);
         expose(DatasetFramework.class);
@@ -106,6 +110,9 @@ public class DataSetsModules extends RuntimeModule {
 
         bind(UsageRegistry.class).to(DefaultUsageRegistry.class).in(Scopes.SINGLETON);
         expose(UsageRegistry.class);
+        bind(RuntimeUsageRegistry.class).to(DefaultUsageRegistry.class).in(Scopes.SINGLETON);
+        expose(RuntimeUsageRegistry.class);
+        bind(DefaultUsageRegistry.class).in(Scopes.SINGLETON);
 
         bind(DatasetFramework.class).to(LineageWriterDatasetFramework.class);
         expose(DatasetFramework.class);
@@ -138,6 +145,9 @@ public class DataSetsModules extends RuntimeModule {
 
         bind(UsageRegistry.class).to(DefaultUsageRegistry.class).in(Scopes.SINGLETON);
         expose(UsageRegistry.class);
+        bind(RuntimeUsageRegistry.class).to(DefaultUsageRegistry.class).in(Scopes.SINGLETON);
+        expose(RuntimeUsageRegistry.class);
+        bind(DefaultUsageRegistry.class).in(Scopes.SINGLETON);
 
         bind(DatasetFramework.class).to(LineageWriterDatasetFramework.class);
         expose(DatasetFramework.class);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/BasicLineageWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/BasicLineageWriter.java
@@ -83,7 +83,10 @@ public class BasicLineageWriter implements LineageWriter {
     return registered.putIfAbsent(new DataAccessKey(run, data, accessType, component), true) != null;
   }
 
-  private static final class DataAccessKey {
+  /**
+   * Key used to keep track of whether a particular access has been recorded already or not (for lineage).
+   */
+  public static final class DataAccessKey {
     private final Id.Run run;
     private final Id.NamespacedId data;
     private final AccessType accessType;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriterDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriterDatasetFramework.java
@@ -26,7 +26,7 @@ import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.ForwardingDatasetFramework;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
-import co.cask.cdap.data2.registry.UsageRegistry;
+import co.cask.cdap.data2.registry.RuntimeUsageRegistry;
 import co.cask.cdap.proto.Id;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -44,7 +44,7 @@ public class LineageWriterDatasetFramework extends ForwardingDatasetFramework im
 
   private static final Logger LOG = LoggerFactory.getLogger(LineageWriterDatasetFramework.class);
 
-  private final UsageRegistry usageRegistry;
+  private final RuntimeUsageRegistry runtimeUsageRegistry;
   private final LineageWriter lineageWriter;
   private final ProgramContext programContext = new ProgramContext();
 
@@ -54,10 +54,10 @@ public class LineageWriterDatasetFramework extends ForwardingDatasetFramework im
   public LineageWriterDatasetFramework(@Named(DataSetsModules.BASIC_DATASET_FRAMEWORK)
                                          DatasetFramework datasetFramework,
                                        LineageWriter lineageWriter,
-                                       UsageRegistry usageRegistry) {
+                                       RuntimeUsageRegistry runtimeUsageRegistry) {
     super(datasetFramework);
     this.lineageWriter = lineageWriter;
-    this.usageRegistry = usageRegistry;
+    this.runtimeUsageRegistry = runtimeUsageRegistry;
   }
 
   @SuppressWarnings("unused")
@@ -157,7 +157,7 @@ public class LineageWriterDatasetFramework extends ForwardingDatasetFramework im
       return;
     }
     try {
-      usageRegistry.registerAll(owners, datasetInstanceId);
+      runtimeUsageRegistry.registerAll(owners, datasetInstanceId);
     } catch (Exception e) {
       LOG.warn("Failed to register usage of {} -> {}", owners, datasetInstanceId, e);
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/DatasetUsageKey.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/DatasetUsageKey.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.registry;
+
+import co.cask.cdap.proto.Id;
+import com.google.common.base.Objects;
+
+/**
+ * Key used to keep track of whether a particular usage has been recorded already or not (for UsageRegistry).
+ */
+public class DatasetUsageKey {
+  private final Id.DatasetInstance dataset;
+  private final Id.Program owner;
+
+  public DatasetUsageKey(Id.DatasetInstance dataset, Id.Program owner) {
+    this.dataset = dataset;
+    this.owner = owner;
+  }
+
+  Id.DatasetInstance getDataset() {
+    return dataset;
+  }
+
+  Id.Program getOwner() {
+    return owner;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DatasetUsageKey that = (DatasetUsageKey) o;
+    return Objects.equal(dataset, that.dataset) &&
+      Objects.equal(owner, that.owner);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(dataset, owner);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/RuntimeUsageRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/RuntimeUsageRegistry.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015-2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.registry;
+
+import co.cask.cdap.proto.Id;
+
+import java.util.Set;
+
+/**
+ * Store program -> dataset/stream usage information. Differs from UsageRegistry in that UsageRegistry does not have
+ * a remote implementation, usable from program runtime.
+ */
+public interface RuntimeUsageRegistry {
+
+  /**
+   * Registers usage of a stream by multiple ids.
+   *
+   * @param users the users of the stream
+   * @param streamId the stream
+   */
+  void registerAll(final Iterable<? extends Id> users, final Id.Stream streamId);
+
+  /**
+   * Register usage of a stream by an id.
+   *
+   * @param user the user of the stream
+   * @param streamId the stream
+   */
+  void register(Id user, Id.Stream streamId);
+
+  /**
+   * Registers usage of a stream by multiple ids.
+   *
+   * @param users the users of the stream
+   * @param datasetId the stream
+   */
+  void registerAll(final Iterable<? extends Id> users, final Id.DatasetInstance datasetId);
+
+  /**
+   * Registers usage of a dataset by multiple ids.
+   *
+   * @param user the user of the dataset
+   * @param datasetId the dataset
+   */
+  void register(Id user, Id.DatasetInstance datasetId);
+
+  /**
+   * Registers usage of a dataset by a program.
+   *
+   * @param programId program
+   * @param datasetInstanceId dataset
+   */
+  void register(final Id.Program programId, final Id.DatasetInstance datasetInstanceId);
+
+  /**
+   * Registers usage of a stream by a program.
+   *
+   * @param programId program
+   * @param streamId  stream
+   */
+  void register(final Id.Program programId, final Id.Stream streamId);
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -23,58 +23,7 @@ import java.util.Set;
 /**
  * Store program -> dataset/stream usage information.
  */
-public interface UsageRegistry {
-
-  Id.DatasetInstance USAGE_INSTANCE_ID =
-    Id.DatasetInstance.from(Id.Namespace.SYSTEM, "usage.registry");
-
-  /**
-   * Registers usage of a stream by multiple ids.
-   *
-   * @param users    the users of the stream
-   * @param streamId the stream
-   */
-  void registerAll(final Iterable<? extends Id> users, final Id.Stream streamId);
-
-  /**
-   * Register usage of a stream by an id.
-   *
-   * @param user     the user of the stream
-   * @param streamId the stream
-   */
-  void register(Id user, Id.Stream streamId);
-
-  /**
-   * Registers usage of a stream by multiple ids.
-   *
-   * @param users     the users of the stream
-   * @param datasetId the stream
-   */
-  void registerAll(final Iterable<? extends Id> users, final Id.DatasetInstance datasetId);
-
-  /**
-   * Registers usage of a dataset by multiple ids.
-   *
-   * @param user      the user of the dataset
-   * @param datasetId the dataset
-   */
-  void register(Id user, Id.DatasetInstance datasetId);
-
-  /**
-   * Registers usage of a dataset by a program.
-   *
-   * @param programId         program
-   * @param datasetInstanceId dataset
-   */
-  void register(final Id.Program programId, final Id.DatasetInstance datasetInstanceId);
-
-  /**
-   * Registers usage of a stream by a program.
-   *
-   * @param programId program
-   * @param streamId  stream
-   */
-  void register(final Id.Program programId, final Id.Stream streamId);
+public interface UsageRegistry extends RuntimeUsageRegistry {
 
   /**
    * Unregisters all usage information of an application.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
@@ -38,7 +38,7 @@ import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.data2.metadata.system.StreamSystemMetadataWriter;
 import co.cask.cdap.data2.metadata.system.SystemMetadataWriter;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
-import co.cask.cdap.data2.registry.UsageRegistry;
+import co.cask.cdap.data2.registry.RuntimeUsageRegistry;
 import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.cdap.explore.utils.ExploreTableNaming;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
@@ -92,7 +92,7 @@ public class FileStreamAdmin implements StreamAdmin {
   private final StreamConsumerStateStoreFactory stateStoreFactory;
   private final NotificationFeedManager notificationFeedManager;
   private final String streamBaseDirPath;
-  private final UsageRegistry usageRegistry;
+  private final RuntimeUsageRegistry runtimeUsageRegistry;
   private final LineageWriter lineageWriter;
   private final StreamMetaStore streamMetaStore;
   private final ExploreTableNaming tableNaming;
@@ -108,7 +108,7 @@ public class FileStreamAdmin implements StreamAdmin {
                          StreamCoordinatorClient streamCoordinatorClient,
                          StreamConsumerStateStoreFactory stateStoreFactory,
                          NotificationFeedManager notificationFeedManager,
-                         UsageRegistry usageRegistry,
+                         RuntimeUsageRegistry runtimeUsageRegistry,
                          LineageWriter lineageWriter,
                          StreamMetaStore streamMetaStore,
                          ExploreTableNaming tableNaming,
@@ -120,7 +120,7 @@ public class FileStreamAdmin implements StreamAdmin {
     this.streamBaseDirPath = cConf.get(Constants.Stream.BASE_DIR);
     this.streamCoordinatorClient = streamCoordinatorClient;
     this.stateStoreFactory = stateStoreFactory;
-    this.usageRegistry = usageRegistry;
+    this.runtimeUsageRegistry = runtimeUsageRegistry;
     this.lineageWriter = lineageWriter;
     this.streamMetaStore = streamMetaStore;
     this.tableNaming = tableNaming;
@@ -453,7 +453,7 @@ public class FileStreamAdmin implements StreamAdmin {
 
   @Override
   public void register(Iterable<? extends Id> owners, Id.Stream streamId) {
-    usageRegistry.registerAll(owners, streamId);
+    runtimeUsageRegistry.registerAll(owners, streamId);
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/writer/BasicLineageWriterTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/writer/BasicLineageWriterTest.java
@@ -48,6 +48,7 @@ import java.util.concurrent.TimeUnit;
  * Tests BasicLineageWriter
  */
 public class BasicLineageWriterTest {
+
   @ClassRule
   public static DatasetFrameworkTestUtil dsFrameworkUtil = new DatasetFrameworkTestUtil();
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/registry/UsageRegistryTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/registry/UsageRegistryTest.java
@@ -141,7 +141,7 @@ public class UsageRegistryTest extends UsageDatasetTest {
    */
   private static class WrappedUsageDataset extends UsageDataset {
 
-    static int registerCount = 0;
+    private static int registerCount = 0;
 
     final UsageDataset uds;
 

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
@@ -17,37 +17,23 @@
 package co.cask.cdap.app.runtime.spark;
 
 import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.app.guice.DistributedProgramRunnableModule;
 import co.cask.cdap.app.program.DefaultProgram;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.program.ProgramDescriptor;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.guice.ConfigModule;
-import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.IOModule;
-import co.cask.cdap.common.guice.KafkaClientModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
-import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.lang.ClassLoaders;
 import co.cask.cdap.common.lang.ProgramClassLoader;
-import co.cask.cdap.data.runtime.DataFabricModules;
-import co.cask.cdap.data.runtime.DataSetsModules;
-import co.cask.cdap.data.stream.StreamAdminModules;
 import co.cask.cdap.data.stream.StreamCoordinatorClient;
-import co.cask.cdap.data.view.ViewAdminModules;
-import co.cask.cdap.data2.audit.AuditModule;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.metadata.writer.ProgramContextAware;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
-import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.internal.app.runtime.workflow.NameMappedDatasetFramework;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
 import co.cask.cdap.logging.appender.LogAppenderInitializer;
-import co.cask.cdap.logging.guice.LoggingModules;
-import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
-import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModule;
 import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.base.Preconditions;
@@ -231,23 +217,7 @@ public final class SparkRuntimeContextProvider {
   }
 
   private static Injector createInjector(CConfiguration cConf, Configuration hConf) {
-    return Guice.createInjector(
-      new ConfigModule(cConf, hConf),
-      new IOModule(),
-      new ZKClientModule(),
-      new KafkaClientModule(),
-      new LocationRuntimeModule().getDistributedModules(),
-      new DiscoveryRuntimeModule().getDistributedModules(),
-      new DataFabricModules().getDistributedModules(),
-      new DataSetsModules().getDistributedModules(),
-      new MetricsClientRuntimeModule().getDistributedModules(),
-      new LoggingModules().getDistributedModules(),
-      new ExploreClientModule(),
-      new ViewAdminModules().getDistributedModules(),
-      new StreamAdminModules().getDistributedModules(),
-      new NotificationFeedServiceRuntimeModule().getDistributedModules(),
-      new AuditModule().getDistributedModules()
-    );
+    return Guice.createInjector(new DistributedProgramRunnableModule(cConf, hConf).createModule());
   }
 
   /**


### PR DESCRIPTION
Similar approach as https://github.com/caskdata/cdap/pull/5910

Writing updates to usage and lineage (remotely) through app fabric.

Pending (which will come in a separate PR):
1. Scalability of this service/handler.
2. Not using deprecated `Id` classes in new code. This will come as a separate change, since the new interface shares methods with existing interface and implementation.

https://issues.cask.co/browse/CDAP-6250
http://builds.cask.co/browse/CDAP-DUT4255
