### PR TITLE
Fixes infinite scrolling on node-config-modal + style fixes

### DIFF
--- a/cdap-ui/app/directives/widget-container/widget-input-schema/widget-input-schema.html
+++ b/cdap-ui/app/directives/widget-container/widget-input-schema/widget-input-schema.html
@@ -68,7 +68,7 @@
             The damage is restricted to the css classes we add to the modal and the uibModal service (windowClass)
           -->
           <tbody infinite-scroll="MyInputSchemaCtrl.doLoadNextSetOfInputSchemaRows()"
-                 infinite-scroll-container="'.modal.hydrator-modal.node-config-modal .bottompanel-body'"
+                 infinite-scroll-container="'.modal.cdap-modal.node-config-modal .bottompanel-body'"
                  infinite-scroll-disabled="inputschema.schema.fields <= MyInputSchemaCtrl.inputSchemaRowLimit">
             <tr ng-repeat="field in ::inputschema.schema.fields | limitTo: 10 track by $index">
               <td class="name">
@@ -132,7 +132,7 @@
         The damage is restricted to the css classes we add to the modal and the uibModal service (windowClass)
       -->
       <tbody infinite-scroll="MyInputSchemaCtrl.doLoadNextSetOfInputSchemaRows()"
-             infinite-scroll-container="'.modal.hydrator-modal.node-config-modal .bottompanel-body'"
+             infinite-scroll-container="'.modal.cdap-modal.node-config-modal .bottompanel-body'"
              infinite-scroll-disabled="MyInputSchemaCtrl.inputSchemas[0].schema.fields.length <= MyInputSchemaCtrl.inputSchemaRowLimit">
         <tr ng-repeat="field in MyInputSchemaCtrl.inputSchemas[0].schema.fields | limitTo: MyInputSchemaCtrl.inputSchemaRowLimit track by $index">
           <td class="name">

--- a/cdap-ui/app/directives/widget-container/widget-schema-editor-stream/widget-schema-editor-stream.html
+++ b/cdap-ui/app/directives/widget-container/widget-schema-editor-stream/widget-schema-editor-stream.html
@@ -40,7 +40,10 @@
             </th>
             <th></th>
           </thead>
-          <tbody infinite-scroll="loadNextSetOfRows()" infinite-scroll-disabled="properties.length <= limitedToView">
+
+          <tbody infinite-scroll="loadNextSetOfRows()"
+                 infinite-scroll-container="'.modal.cdap-modal.node-config-modal .bottompanel-body'"
+                 infinite-scroll-disabled="properties.length <= limitedToView">
             <tr ng-repeat="property in properties | limitTo: limitedToView track by $index" ng-keypress="enter($event, $index)" ng-click="emptyRowClick(property, $index)">
               <td class="name" ng-if="!property.empty" ng-class="{'active-cell': activeCell === true}">
                 <input

--- a/cdap-ui/app/directives/widget-container/widget-schema-editor/widget-schema-editor.html
+++ b/cdap-ui/app/directives/widget-container/widget-schema-editor/widget-schema-editor.html
@@ -54,7 +54,7 @@
             The damage is restricted to the css classes we add to the modal and the uibModal service (windowClass)
           -->
           <tbody infinite-scroll="loadNextSetOfRows()"
-                 infinite-scroll-container="'.modal.hydrator-modal.node-config-modal .bottompanel-body'"
+                 infinite-scroll-container="'.modal.cdap-modal.node-config-modal .bottompanel-body'"
                  infinite-scroll-disabled="properties.length <= limitedToView">
             <tr ng-repeat="property in properties | limitTo: limitedToView track by $index" ng-keypress="enter($event, $index)" ng-click="emptyRowClick(property, $index)">
               <td class="name" ng-if="!property.empty" ng-class="{'active-cell': activeCell === true}">

--- a/cdap-ui/app/features/hydratorplusplus/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/create/partials/nodeconfig-ctrl.js
@@ -238,9 +238,7 @@ class HydratorPlusPlusNodeConfigCtrl {
     this.EventPipe.emit('schema.clear');
   }
   importSchema() {
-    this.$timeout(function() {
-      document.getElementById('schema-import-link').click();
-    });
+    document.getElementById('schema-import-link').click();
   }
   importFiles(files) {
     let reader = new FileReader();

--- a/cdap-ui/app/features/hydratorplusplus/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/create/partials/nodeconfig-ctrl.js
@@ -238,7 +238,9 @@ class HydratorPlusPlusNodeConfigCtrl {
     this.EventPipe.emit('schema.clear');
   }
   importSchema() {
-    document.getElementById('schema-import-link').click();
+    this.$timeout(function() {
+      document.getElementById('schema-import-link').click();
+    });
   }
   importFiles(files) {
     let reader = new FileReader();

--- a/cdap-ui/app/features/hydratorplusplus/hydrator-modal.less
+++ b/cdap-ui/app/features/hydratorplusplus/hydrator-modal.less
@@ -149,6 +149,7 @@
         .modal-body {
           padding: 0 10px;
           overflow: auto;
+          max-height: 100%;
 
           .console-type {
             border: 1px solid @table-border-color;

--- a/cdap-ui/bower.json
+++ b/cdap-ui/bower.json
@@ -41,9 +41,9 @@
     "angular-marked": "1.0.1",
     "js-beautify": "1.6.2",
     "angular-file-saver": "1.0.3",
-    "ngInfiniteScroll": "1.2.2",
     "d3-tip": "0.6.7",
-    "esprima": "2.0.0"
+    "esprima": "2.0.0",
+    "ngInfiniteScroll": "1.2.1"
   },
   "resolutions": {
     "angular": "1.4.3",


### PR DESCRIPTION
- Fixes the conatainer query selector being passed in for ng-infinite scroll
- Fixes max-height of the modal-content to be 100% to avoid multiple scrollbars in the modal.

Bamboo Build - http://builds.cask.co/browse/CDAP-DRC3915-1
Related JIRA for performance improvement: https://issues.cask.co/browse/CDAP-6302
