### PR TITLE
[CDAP-6302] - Downgrades ng-infiniteScroll for performance improvements in hydrator++

### DIFF
--- a/cdap-ui/bower.json
+++ b/cdap-ui/bower.json
@@ -41,7 +41,7 @@
     "angular-marked": "1.0.1",
     "js-beautify": "1.6.2",
     "angular-file-saver": "1.0.3",
-    "ngInfiniteScroll": "1.2.2"
+    "ngInfiniteScroll": "1.2.1"
   },
   "resolutions": {
     "angular": "1.4.3",


### PR DESCRIPTION
This is due to a performance bug that was introduced in the latest version of `ng-inifiniteScroll` directive.

Corresponding issue in github: https://github.com/sroze/ngInfiniteScroll/issues/235
Corresponding JIRA: https://issues.cask.co/browse/CDAP-6302
Bamboo build: http://builds.cask.co/browse/CDAP-DRC3916-3
