### PR TITLE
Copy the Properties object instead of using inheritance since Kafka d…

### DIFF
--- a/cdap-app-fabric/src/main/java/org/apache/twill/internal/kafka/EmbeddedKafkaServer.java
+++ b/cdap-app-fabric/src/main/java/org/apache/twill/internal/kafka/EmbeddedKafkaServer.java
@@ -53,7 +53,8 @@ public final class EmbeddedKafkaServer extends AbstractIdleService {
   public EmbeddedKafkaServer(Properties properties) {
     this.startTimeoutRetries = Integer.parseInt(properties.getProperty(START_TIMEOUT_RETRIES,
                                                                        DEFAULT_START_TIMEOUT_RETRIES));
-    this.properties = new Properties(properties);
+    this.properties = new Properties();
+    this.properties.putAll(properties);
   }
 
   @Override


### PR DESCRIPTION
…oesn’t support it.

Cherry-pick: https://github.com/caskdata/cdap/pull/5949
