### PR TITLE
Add support for multiple inputs in ETLMapReduce and ETLSpark

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/ETLMapReduce.java
@@ -75,10 +75,12 @@ import java.util.Set;
 public class ETLMapReduce extends AbstractMapReduce {
   public static final String NAME = ETLMapReduce.class.getSimpleName();
   static final String RUNTIME_ARGS_KEY = "cdap.etl.runtime.args";
+  static final String INPUT_ALIAS_KEY = "cdap.etl.source.alias.key";
   static final String SINK_OUTPUTS_KEY = "cdap.etl.sink.outputs";
   static final String GROUP_KEY_CLASS = "cdap.etl.aggregator.group.key.class";
   static final String GROUP_VAL_CLASS = "cdap.etl.aggregator.group.val.class";
   static final Type RUNTIME_ARGS_TYPE = new TypeToken<Map<String, Map<String, String>>>() { }.getType();
+  static final Type INPUT_ALIAS_TYPE = new TypeToken<Map<String, String>>() { }.getType();
   static final Type SINK_OUTPUTS_TYPE = new TypeToken<Map<String, SinkOutput>>() { }.getType();
   private static final Logger LOG = LoggerFactory.getLogger(ETLMapReduce.class);
   private static final Gson GSON = new GsonBuilder()
@@ -105,12 +107,11 @@ public class ETLMapReduce extends AbstractMapReduce {
     setMapperResources(phaseSpec.getResources());
     setDriverResources(phaseSpec.getResources());
 
-    // These should never happen unless there is a bug in the planner. The planner is supposed to ensure this.
     Set<String> sources = phaseSpec.getPhase().getSources();
-    if (sources.size() != 1) {
+    // Planner should make sure this never happens
+    if (sources.isEmpty()) {
       throw new IllegalArgumentException(String.format(
-        "Pipeline phase '%s' must contain exactly one source but it has sources '%s'.",
-        phaseSpec.getPhaseName(), Joiner.on(',').join(sources)));
+        "Pipeline phase '%s' must contain at least one source but it has no sources.", phaseSpec.getPhaseName()));
     }
     if (phaseSpec.getPhase().getSinks().isEmpty()) {
       throw new IllegalArgumentException(String.format(
@@ -161,20 +162,23 @@ public class ETLMapReduce extends AbstractMapReduce {
     PipelinePhase phase = phaseSpec.getPhase();
     PipelinePluginInstantiator pluginInstantiator = new PipelinePluginInstantiator(context, phaseSpec);
 
-    // we checked at configure time that there is exactly one source
-    String sourceName = phaseSpec.getPhase().getSources().iterator().next();
-
-    BatchConfigurable<BatchSourceContext> batchSource = pluginInstantiator.newPluginInstance(sourceName);
-    batchSource = new LoggedBatchConfigurable<>(sourceName, batchSource);
-    BatchSourceContext sourceContext = new MapReduceSourceContext(context, mrMetrics,
-                                                                  new DatasetContextLookupProvider(context),
-                                                                  sourceName, context.getRuntimeArguments());
-    batchSource.prepareRun(sourceContext);
-    runtimeArgs.put(sourceName, sourceContext.getRuntimeArguments());
-    finishers.add(batchSource, sourceContext);
+    Map<String, String> inputAliasToStage = new HashMap<>();
+    for (String sourceName : phaseSpec.getPhase().getSources()) {
+      BatchConfigurable<BatchSourceContext> batchSource = pluginInstantiator.newPluginInstance(sourceName);
+      batchSource = new LoggedBatchConfigurable<>(sourceName, batchSource);
+      MapReduceSourceContext sourceContext = new MapReduceSourceContext(context, mrMetrics,
+                                                                        new DatasetContextLookupProvider(context),
+                                                                        sourceName, context.getRuntimeArguments());
+      batchSource.prepareRun(sourceContext);
+      runtimeArgs.put(sourceName, sourceContext.getRuntimeArguments());
+      for (String inputAlias : sourceContext.getInputNames()) {
+        inputAliasToStage.put(inputAlias, sourceName);
+      }
+      finishers.add(batchSource, sourceContext);
+    }
+    hConf.set(INPUT_ALIAS_KEY, GSON.toJson(inputAliasToStage));
 
     Map<String, SinkOutput> sinkOutputs = new HashMap<>();
-
     for (StageInfo stageInfo : Sets.union(phase.getStagesOfType(Constants.CONNECTOR_TYPE),
                                           phase.getStagesOfType(BatchSink.PLUGIN_TYPE))) {
       String sinkName = stageInfo.getName();

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceTransformExecutorFactory.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceTransformExecutorFactory.java
@@ -61,8 +61,9 @@ public class MapReduceTransformExecutorFactory<T> extends TransformExecutorFacto
   public MapReduceTransformExecutorFactory(MapReduceTaskContext taskContext,
                                            PipelinePluginInstantiator pluginInstantiator,
                                            Metrics metrics,
-                                           Map<String, Map<String, String>> pluginRuntimeArgs) {
-    super(pluginInstantiator, metrics);
+                                           Map<String, Map<String, String>> pluginRuntimeArgs,
+                                           String sourceStageName) {
+    super(pluginInstantiator, metrics, sourceStageName);
     this.taskContext = taskContext;
     this.pluginRuntimeArgs = pluginRuntimeArgs;
     JobContext hadoopContext = (JobContext) taskContext.getHadoopContext();

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/TransformRunner.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/TransformRunner.java
@@ -82,6 +82,13 @@ public class TransformRunner<KEY, VALUE> {
     Map<String, Map<String, String>> runtimeArgs = GSON.fromJson(
       hConf.get(ETLMapReduce.RUNTIME_ARGS_KEY), ETLMapReduce.RUNTIME_ARGS_TYPE);
 
+    // input alias name -> stage name mapping
+    Map<String, String> inputAliasToStage = GSON.fromJson(hConf.get(ETLMapReduce.INPUT_ALIAS_KEY),
+                                                          ETLMapReduce.INPUT_ALIAS_TYPE);
+    String inputAliasName = context.getInputName();
+    // inputAliasName can be null (in case of reducers)
+    String sourceStage = (inputAliasName != null) ? inputAliasToStage.get(inputAliasName) : null;
+
     PipelinePhase phase = phaseSpec.getPhase();
     Set<StageInfo> aggregators = phase.getStagesOfType(BatchAggregator.PLUGIN_TYPE);
     if (!aggregators.isEmpty()) {
@@ -95,7 +102,7 @@ public class TransformRunner<KEY, VALUE> {
       }
     }
     TransformExecutorFactory<KeyValue<KEY, VALUE>> transformExecutorFactory =
-      new MapReduceTransformExecutorFactory<>(context, pluginInstantiator, metrics, runtimeArgs);
+      new MapReduceTransformExecutorFactory<>(context, pluginInstantiator, metrics, runtimeArgs, sourceStage);
     this.transformExecutor = transformExecutorFactory.create(phase);
 
     // setup error dataset information

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkBatchSinkFactory.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkBatchSinkFactory.java
@@ -137,7 +137,7 @@ final class SparkBatchSinkFactory {
   <K, V> void writeFromRDD(JavaPairRDD<K, V> rdd, JavaSparkExecutionContext sec, String sinkName,
                            Class<K> keyClass, Class<V> valueClass) {
     Set<String> outputNames = sinkOutputs.get(sinkName);
-    if (outputNames == null || outputNames.size() == 0) {
+    if (outputNames == null || outputNames.isEmpty()) {
       // should never happen if validation happened correctly at pipeline configure time
       throw new IllegalArgumentException(sinkName + " has no outputs. " +
                                            "Please check that the sink calls addOutput at some point.");

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkBatchSourceContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkBatchSourceContext.java
@@ -19,6 +19,7 @@ package co.cask.cdap.etl.batch.spark;
 import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.batch.InputFormatProvider;
 import co.cask.cdap.api.data.batch.Split;
+import co.cask.cdap.api.data.format.FormatSpecification;
 import co.cask.cdap.api.data.stream.StreamBatchReadable;
 import co.cask.cdap.api.spark.SparkClientContext;
 import co.cask.cdap.etl.api.LookupProvider;
@@ -28,21 +29,32 @@ import co.cask.cdap.etl.common.ExternalDatasets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
+import java.util.UUID;
 
 /**
  * Default implementation of {@link BatchSourceContext} for spark contexts.
  */
 public class SparkBatchSourceContext extends AbstractSparkBatchContext implements BatchSourceContext {
-  private SparkBatchSourceFactory sourceFactory;
 
-  public SparkBatchSourceContext(SparkClientContext sparkContext, LookupProvider lookupProvider, String stageId) {
+  private final SparkBatchSourceFactory sourceFactory;
+
+  public SparkBatchSourceContext(SparkBatchSourceFactory sourceFactory, SparkClientContext sparkContext,
+                                 LookupProvider lookupProvider, String stageId) {
     super(sparkContext, lookupProvider, stageId);
+    this.sourceFactory = sourceFactory;
   }
 
   @Override
   public void setInput(StreamBatchReadable stream) {
-    sourceFactory = SparkBatchSourceFactory.create(stream);
+    FormatSpecification formatSpec = stream.getFormatSpecification();
+    Input input;
+    if (formatSpec == null) {
+      input = suffixInput(Input.ofStream(stream.getStreamName(), stream.getStartTime(), stream.getEndTime()));
+    } else {
+      input = suffixInput(Input.ofStream(stream.getStreamName(), stream.getStartTime(),
+                                         stream.getEndTime(), formatSpec));
+    }
+    sourceFactory.addInput(getStageName(), input);
   }
 
   @Override
@@ -62,22 +74,23 @@ public class SparkBatchSourceContext extends AbstractSparkBatchContext implement
 
   @Override
   public void setInput(String datasetName, Map<String, String> arguments, List<Split> splits) {
-    sourceFactory = SparkBatchSourceFactory.create(datasetName, arguments, splits);
+    sourceFactory.addInput(getStageName(), suffixInput(Input.ofDataset(datasetName, arguments, splits)));
   }
 
   @Override
   public void setInput(InputFormatProvider inputFormatProvider) {
-    sourceFactory = SparkBatchSourceFactory.create(inputFormatProvider);
+    sourceFactory.addInput(getStageName(), suffixInput(Input.of(inputFormatProvider.getInputFormatClassName(),
+                                                                inputFormatProvider)));
   }
 
   @Override
   public void setInput(Input input) {
-    Input trackableInput = ExternalDatasets.makeTrackable(sparkContext.getAdmin(), input);
-    sourceFactory = SparkBatchSourceFactory.create(trackableInput);
+    Input trackableInput = ExternalDatasets.makeTrackable(sparkContext.getAdmin(), suffixInput(input));
+    sourceFactory.addInput(getStageName(), trackableInput);
   }
 
-  @Nullable
-  SparkBatchSourceFactory getSourceFactory() {
-    return sourceFactory;
+  private Input suffixInput(Input input) {
+    String suffixedAlias = String.format("%s-%s", input.getAlias(), UUID.randomUUID());
+    return input.alias(suffixedAlias);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkTransformExecutorFactory.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkTransformExecutorFactory.java
@@ -59,8 +59,8 @@ public class SparkTransformExecutorFactory<T> extends TransformExecutorFactory<T
                                        PipelinePluginInstantiator pluginInstantiator,
                                        Metrics metrics, long logicalStartTime,
                                        Map<String, String> runtimeArgs,
-                                       boolean isFirstHalf) {
-    super(pluginInstantiator, metrics);
+                                       boolean isFirstHalf, String sourceStageName) {
+    super(pluginInstantiator, metrics, sourceStageName);
     this.pluginContext = pluginContext;
     this.logicalStartTime = logicalStartTime;
     this.runtimeArgs = runtimeArgs;

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/batch/BatchPhaseSpecTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/batch/BatchPhaseSpecTest.java
@@ -51,6 +51,6 @@ public class BatchPhaseSpecTest {
 
     BatchPhaseSpec phaseSpec =
       new BatchPhaseSpec("phase-1", builder.build(), new Resources(), false, Collections.<String, String>emptyMap());
-    Assert.assertEquals("Sources 'source2', 'source1' to sinks 'sink.connector'.", phaseSpec.getDescription());
+    Assert.assertEquals("Sources 'source1', 'source2' to sinks 'sink.connector'.", phaseSpec.getDescription());
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/Dag.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/Dag.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * A DAG (directed acyclic graph).
@@ -136,11 +137,11 @@ public class Dag {
   }
 
   public Set<String> getSources() {
-    return Collections.unmodifiableSet(sources);
+    return Collections.unmodifiableSet(new TreeSet<>(sources));
   }
 
   public Set<String> getSinks() {
-    return Collections.unmodifiableSet(sinks);
+    return Collections.unmodifiableSet(new TreeSet<>(sinks));
   }
 
   public Set<String> getNodeOutputs(String node) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/PipelinePlannerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/PipelinePlannerTest.java
@@ -162,63 +162,67 @@ public class PipelinePlannerTest {
 
     /*
         phase2:
-        n2.connector --- n2(r) --- n6.connector
+        n2.connector --- n2(r) --- n6 --- n7.connector
      */
     PipelinePhase phase2 = PipelinePhase.builder(pluginTypes)
       .addStage(AGGREGATOR, new StageInfo("n2"))
       .addStages(Constants.CONNECTOR_TYPE,
-                 ImmutableSet.of(new StageInfo("n2.connector"), new StageInfo("n6.connector")))
+                 ImmutableSet.of(new StageInfo("n2.connector"), new StageInfo("n7.connector")))
+      .addStage(NODE, new StageInfo("n6"))
       .addConnection("n2.connector", "n2")
-      .addConnection("n2", "n6.connector")
+      .addConnection("n2", "n6")
+      .addConnection("n6", "n7.connector")
       .build();
-    String phase2Name = getPhaseName("n2.connector", "n6.connector");
+    String phase2Name = getPhaseName("n2.connector", "n7.connector");
     phases.put(phase2Name, phase2);
 
     /*
         phase3:
-        n3.connector --- n3(r) --- n5 --- n6.connector
+        n3.connector --- n3(r) --- n5 --- n6 --- n7.connector
      */
     PipelinePhase phase3 = PipelinePhase.builder(pluginTypes)
-      .addStage(NODE, new StageInfo("n5"))
+      .addStages(NODE, ImmutableSet.of(new StageInfo("n5"), new StageInfo("n6")))
       .addStage(AGGREGATOR, new StageInfo("n3"))
       .addStages(Constants.CONNECTOR_TYPE,
-                 ImmutableSet.of(new StageInfo("n3.connector"), new StageInfo("n6.connector")))
+                 ImmutableSet.of(new StageInfo("n3.connector"), new StageInfo("n7.connector")))
       .addConnection("n3.connector", "n3")
       .addConnection("n3", "n5")
-      .addConnection("n5", "n6.connector")
+      .addConnection("n5", "n6")
+      .addConnection("n6", "n7.connector")
       .build();
-    String phase3Name = getPhaseName("n3.connector", "n6.connector");
+    String phase3Name = getPhaseName("n3.connector", "n7.connector");
     phases.put(phase3Name, phase3);
 
     /*
         phase4:
-        n4.connector --- n4(r) --- n6.connector
+        n4.connector --- n4(r) --- n6 --- n7.connector
      */
     PipelinePhase phase4 = PipelinePhase.builder(pluginTypes)
       .addStage(AGGREGATOR, new StageInfo("n4"))
       .addStages(Constants.CONNECTOR_TYPE,
-                 ImmutableSet.of(new StageInfo("n4.connector"), new StageInfo("n6.connector")))
+                 ImmutableSet.of(new StageInfo("n4.connector"), new StageInfo("n7.connector")))
+      .addStage(NODE, new StageInfo("n6"))
       .addConnection("n4.connector", "n4")
-      .addConnection("n4", "n6.connector")
+      .addConnection("n4", "n6")
+      .addConnection("n6", "n7.connector")
       .build();
-    String phase4Name = getPhaseName("n4.connector", "n6.connector");
+    String phase4Name = getPhaseName("n4.connector", "n7.connector");
     phases.put(phase4Name, phase4);
 
     /*
         phase5:
-        n6.connector --- n6 --- n7(r) --- n8 --- n9.connector
+        n7.connector --- n7(r) --- n8 --- n9.connector
      */
     PipelinePhase phase5 = PipelinePhase.builder(pluginTypes)
-      .addStages(NODE, ImmutableSet.of(new StageInfo("n6"), new StageInfo("n8")))
+      .addStage(NODE, new StageInfo("n8"))
       .addStage(AGGREGATOR, new StageInfo("n7"))
       .addStages(Constants.CONNECTOR_TYPE,
-                 ImmutableSet.of(new StageInfo("n6.connector"), new StageInfo("n9.connector")))
-      .addConnection("n6.connector", "n6")
-      .addConnection("n6", "n7")
+                 ImmutableSet.of(new StageInfo("n7.connector"), new StageInfo("n9.connector")))
+      .addConnection("n7.connector", "n7")
       .addConnection("n7", "n8")
       .addConnection("n8", "n9.connector")
       .build();
-    String phase5Name = getPhaseName("n6.connector", "n9.connector");
+    String phase5Name = getPhaseName("n7.connector", "n9.connector");
     phases.put(phase5Name, phase5);
 
     /*


### PR DESCRIPTION
JIRA : https://issues.cask.co/browse/CDAP-6193

Build : http://builds.cask.co/browse/CDAP-DUT4290

Summary : So far in cdap-data-pipeline (ETLMapReduce/ETLSpark), only one input per MR/Spark job was allowed. Since CDAP MR job supports multi-input, it can be utilized to reduce the number of MR/Spark jobs created for a particular logical pipeline. Three changes are required in order to achieve that goal:

i) Planner change: The ConenctorDag logic had to be changed to remove inserting connector nodes in the multiple inputs scenario. Dag generation was also changed to create DAGs with more than one startings points (aka multiple inputs)

ii) ETLMapReduce change: Firstly the sources' alias had to be made unique in a MapReduce job. This is so that we can differentiate where the mapper input data is coming from based on the alias name aka inputName. We also had to account for the case of multiple inputs per BatchSource plugin (though this is usually not the case). We have to maintain a map of alias names to stage name and send that to each mapper where we use the alias name in the mapper to figure out which stage name (aka starting point) to send the data to in the TransformExecutor.

iii) ETLSpark change: SparkBatchSourceFactory was changed (along the lines of SparkBatchSinkFactory) to support multiple BatchSource plugins (and multiple inputs per source plugin). Also, the createRDD method was changed to return a JavaPairRDD that is the union of all the inputs in that plugin (though we usually expect only one input per plugin). So we end up with N input RDDs (where N is the number of BatchSources per Spark job). We send data from each RDD down the transformExecutor starting at the starting point corresponding to the input stage name. And thus, we get N output RDDs and we take the union of them all for the final result RDD.
