### PR TITLE
Fix doc build.

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -749,7 +749,8 @@
     <name>kafka.num.partitions</name>
     <value>${kafka.server.num.partitions}</value>
     <description>
-      Default number of partitions for a topic
+      Default number of partitions for a topic (deprecated: replaced with
+      kafka.server.num.partitions)
     </description>
   </property>
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="412edc8ed1a844b1c9f8226c732ea9d4"
+DEFAULT_XML_MD5_HASH="6882f19593d099a1634c4a15d0ce80b2"
 
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"


### PR DESCRIPTION
Passes a Quick Build: http://builds.cask.co/browse/CDAP-DQB39-1

Fixes an error in the `cdap-defaults.xml`, though there is still more work to be done: see
https://issues.cask.co/browse/CDAP-6317
