### PR TITLE
CDAP-6158 Enable cross-namespace dataset access

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/data/DatasetContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/DatasetContext.java
@@ -39,8 +39,21 @@ public interface DatasetContext {
    *         cannot be opened (for example, one of the underlying tables in the DataFabric
    *         cannot be accessed).
    */
-  <T extends Dataset> T getDataset(String name)
-    throws DatasetInstantiationException;
+  <T extends Dataset> T getDataset(String name) throws DatasetInstantiationException;
+
+  /**
+   * Get an instance of the specified Dataset.
+   *
+   * @param namespace The namespace of the Dataset
+   * @param name The name of the Dataset
+   * @param <T> The type of the Dataset
+   * @return An instance of the specified Dataset, never null.
+   * @throws DatasetInstantiationException If the Dataset cannot be instantiated: its class
+   *         cannot be loaded; the default constructor throws an exception; or the Dataset
+   *         cannot be opened (for example, one of the underlying tables in the DataFabric
+   *         cannot be accessed).
+   */
+  <T extends Dataset> T getDataset(String namespace, String name) throws DatasetInstantiationException;
 
   /**
    * Get an instance of the specified Dataset.
@@ -54,7 +67,22 @@ public interface DatasetContext {
    *         cannot be opened (for example, one of the underlying tables in the DataFabric
    *         cannot be accessed).
    */
-  <T extends Dataset> T getDataset(String name, Map<String, String> arguments)
+  <T extends Dataset> T getDataset(String name, Map<String, String> arguments) throws DatasetInstantiationException;
+
+  /**
+   * Get an instance of the specified Dataset.
+   *
+   * @param namespace The namespace of Dataset
+   * @param name The name of the Dataset
+   * @param arguments the arguments for this dataset instance
+   * @param <T> The type of the Dataset
+   * @return An instance of the specified Dataset, never null.
+   * @throws DatasetInstantiationException If the Dataset cannot be instantiated: its class
+   *         cannot be loaded; the default constructor throws an exception; or the Dataset
+   *         cannot be opened (for example, one of the underlying tables in the DataFabric
+   *         cannot be accessed).
+   */
+  <T extends Dataset> T getDataset(String namespace, String name, Map<String, String> arguments)
     throws DatasetInstantiationException;
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -169,9 +169,25 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
   }
 
   @Override
+  public <T extends Dataset> T getDataset(String namespace, String name) throws DatasetInstantiationException {
+    return getDataset(namespace, name, RuntimeArguments.NO_ARGUMENTS);
+  }
+
+  @Override
   public <T extends Dataset> T getDataset(String name, Map<String, String> arguments)
     throws DatasetInstantiationException {
     return getDataset(name, arguments, AccessType.UNKNOWN);
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String namespace, String name, Map<String, String> arguments)
+    throws DatasetInstantiationException {
+    return getDataset(namespace, name, arguments, AccessType.UNKNOWN);
+  }
+
+  protected <T extends Dataset> T getDataset(String namespace, String name, Map<String, String> arguments,
+                                             AccessType accessType) throws DatasetInstantiationException {
+    return datasetCache.getDataset(namespace, name, arguments, accessType);
   }
 
   protected <T extends Dataset> T getDataset(String name, Map<String, String> arguments, AccessType accessType)

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
@@ -113,9 +113,20 @@ public class MapReduceLifecycleContext<KEY, VALUE> implements MapReduceTaskConte
   }
 
   @Override
+  public <T extends Dataset> T getDataset(String namespace, String name) throws DatasetInstantiationException {
+    return delegate.getDataset(namespace, name);
+  }
+
+  @Override
   public <T extends Dataset> T getDataset(String name,
                                           Map<String, String> arguments) throws DatasetInstantiationException {
     return delegate.getDataset(name, arguments);
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String namespace, String name,
+                                          Map<String, String> arguments) throws DatasetInstantiationException {
+    return delegate.getDataset(namespace, name, arguments);
   }
 
   @Override

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRunnerTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRunnerTestBase.java
@@ -185,6 +185,10 @@ public class MapReduceRunnerTestBase {
     return AppFabricTestHelper.deployApplicationWithManager(appClass, TEMP_FOLDER_SUPPLIER);
   }
 
+  protected ApplicationWithPrograms deployApp(Id.Namespace namespace, Class<?> appClass) throws Exception {
+    return AppFabricTestHelper.deployApplicationWithManager(namespace, appClass, TEMP_FOLDER_SUPPLIER);
+  }
+
   // returns true if the program ran successfully
   protected boolean runProgram(ApplicationWithPrograms app, Class<?> programClass, Arguments args) throws Exception {
     return waitForCompletion(submit(app, programClass, args));

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
@@ -570,11 +570,22 @@ public class HttpHandlerGeneratorTest {
 
     @Override
     public <T extends Dataset> T getDataset(String name) throws DatasetInstantiationException {
-      return getDataset(name, null);
+      return getDataset(getNamespace(), name);
+    }
+
+    @Override
+    public <T extends Dataset> T getDataset(String namespace, String name) throws DatasetInstantiationException {
+      return getDataset(namespace, name, null);
     }
 
     @Override
     public <T extends Dataset> T getDataset(String name, Map<String, String> arguments)
+      throws DatasetInstantiationException {
+      return getDataset(getNamespace(), arguments);
+    }
+
+    @Override
+    public <T extends Dataset> T getDataset(String namespace, String name, Map<String, String> arguments)
       throws DatasetInstantiationException {
       throw new DatasetInstantiationException(
         String.format("Dataset '%s' cannot be instantiated. Operation not supported", name));

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/BasicSparkExecutionPluginContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/BasicSparkExecutionPluginContext.java
@@ -131,9 +131,20 @@ public class BasicSparkExecutionPluginContext extends AbstractTransformContext i
   }
 
   @Override
+  public <T extends Dataset> T getDataset(String namespace, String name) throws DatasetInstantiationException {
+    return datasetContext.getDataset(namespace, name);
+  }
+
+  @Override
   public <T extends Dataset> T getDataset(String name,
                                           Map<String, String> arguments) throws DatasetInstantiationException {
     return datasetContext.getDataset(name, arguments);
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String namespace, String name,
+                                          Map<String, String> arguments) throws DatasetInstantiationException {
+    return datasetContext.getDataset(namespace, name, arguments);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkBatchRuntimeContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkBatchRuntimeContext.java
@@ -61,7 +61,18 @@ public class SparkBatchRuntimeContext extends AbstractTransformContext implement
   }
 
   @Override
+  public <T extends Dataset> T getDataset(String namespace, String name) throws DatasetInstantiationException {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
   public <T extends Dataset> T getDataset(String name,
+                                          Map<String, String> arguments) throws DatasetInstantiationException {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String namespace, String name,
                                           Map<String, String> arguments) throws DatasetInstantiationException {
     throw new UnsupportedOperationException("Not supported");
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/AbstractBatchContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/AbstractBatchContext.java
@@ -92,12 +92,34 @@ public abstract class AbstractBatchContext extends AbstractTransformContext impl
   }
 
   @Override
+  public <T extends Dataset> T getDataset(final String namespace, final String name)
+    throws DatasetInstantiationException {
+    return LogContext.runWithoutLoggingUnchecked(new Callable<T>() {
+      @Override
+      public T call() throws Exception {
+        return datasetContext.getDataset(namespace, name);
+      }
+    });
+  }
+
+  @Override
   public <T extends Dataset> T getDataset(final String name,
                                           final Map<String, String> arguments) throws DatasetInstantiationException {
     return LogContext.runWithoutLoggingUnchecked(new Callable<T>() {
       @Override
       public T call() throws Exception {
         return datasetContext.getDataset(name, arguments);
+      }
+    });
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(final String namespace, final String name,
+                                          final Map<String, String> arguments) throws DatasetInstantiationException {
+    return LogContext.runWithoutLoggingUnchecked(new Callable<T>() {
+      @Override
+      public T call() throws Exception {
+        return datasetContext.getDataset(namespace, name, arguments);
       }
     });
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceRuntimeContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceRuntimeContext.java
@@ -78,12 +78,34 @@ public class MapReduceRuntimeContext extends AbstractTransformContext implements
   }
 
   @Override
+  public <T extends Dataset> T getDataset(final String namespace, final String name)
+    throws DatasetInstantiationException {
+    return LogContext.runWithoutLoggingUnchecked(new Callable<T>() {
+      @Override
+      public T call() throws DatasetInstantiationException {
+        return context.getDataset(namespace, name);
+      }
+    });
+  }
+
+  @Override
   public <T extends Dataset> T getDataset(final String name,
                                           final Map<String, String> arguments) throws DatasetInstantiationException {
     return LogContext.runWithoutLoggingUnchecked(new Callable<T>() {
       @Override
       public T call() throws DatasetInstantiationException {
         return context.getDataset(name, arguments);
+      }
+    });
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(final String namespace, final String name,
+                                          final Map<String, String> arguments) throws DatasetInstantiationException {
+    return LogContext.runWithoutLoggingUnchecked(new Callable<T>() {
+      @Override
+      public T call() throws DatasetInstantiationException {
+        return context.getDataset(namespace, name, arguments);
       }
     });
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/etl/realtime/DefaultDataWriter.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/etl/realtime/DefaultDataWriter.java
@@ -55,12 +55,34 @@ public class DefaultDataWriter implements DataWriter {
   }
 
   @Override
+  public <T extends Dataset> T getDataset(final String namespace, final String name)
+    throws DatasetInstantiationException {
+    return LogContext.runWithoutLoggingUnchecked(new Callable<T>() {
+      @Override
+      public T call() throws Exception {
+        return dsContext.getDataset(namespace, name);
+      }
+    });
+  }
+
+  @Override
   public <T extends Dataset> T getDataset(final String name, final Map<String, String> arguments)
     throws DatasetInstantiationException {
     return LogContext.runWithoutLoggingUnchecked(new Callable<T>() {
       @Override
       public T call() throws Exception {
         return dsContext.getDataset(name, arguments);
+      }
+    });
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(final String namespace, final String name,
+                                          final Map<String, String> arguments) throws DatasetInstantiationException {
+    return LogContext.runWithoutLoggingUnchecked(new Callable<T>() {
+      @Override
+      public T call() throws Exception {
+        return dsContext.getDataset(namespace, name, arguments);
       }
     });
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
@@ -53,6 +53,7 @@ import java.util.Map;
 
 public final class DatasetFrameworkTestUtil extends ExternalResource {
   public static final Id.Namespace NAMESPACE_ID = Id.Namespace.from("myspace");
+  public static final Id.Namespace NAMESPACE2_ID = Id.Namespace.from("myspace2");
 
   private Injector injector;
   private CConfiguration cConf;

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationContext.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationContext.java
@@ -95,9 +95,20 @@ public class DefaultAuthorizationContext implements AuthorizationContext {
   }
 
   @Override
+  public <T extends Dataset> T getDataset(String namespace, String name) throws DatasetInstantiationException {
+    return delegateDatasetContext.getDataset(namespace, name);
+  }
+
+  @Override
   public <T extends Dataset> T getDataset(String name, Map<String, String> arguments)
     throws DatasetInstantiationException {
     return delegateDatasetContext.getDataset(name, arguments);
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String namespace, String name, Map<String, String> arguments)
+    throws DatasetInstantiationException {
+    return delegateDatasetContext.getDataset(namespace, name, arguments);
   }
 
   @Override

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/NoOpDatasetContext.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/NoOpDatasetContext.java
@@ -32,7 +32,18 @@ public class NoOpDatasetContext implements DatasetContext {
   }
 
   @Override
+  public <T extends Dataset> T getDataset(String namespace, String name) throws DatasetInstantiationException {
+    throw new DatasetInstantiationException("NoOpDatasetContext cannot instantiate datasets");
+  }
+
+  @Override
   public <T extends Dataset> T getDataset(String name, Map<String, String> arguments)
+    throws DatasetInstantiationException {
+    throw new DatasetInstantiationException("NoOpDatasetContext cannot instantiate datasets");
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String namespace, String name, Map<String, String> arguments)
     throws DatasetInstantiationException {
     throw new DatasetInstantiationException("NoOpDatasetContext cannot instantiate datasets");
   }

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/BasicSparkClientContext.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/BasicSparkClientContext.java
@@ -154,9 +154,20 @@ final class BasicSparkClientContext implements SparkClientContext {
   }
 
   @Override
+  public <T extends Dataset> T getDataset(String namespace, String name) throws DatasetInstantiationException {
+    return sparkRuntimeContext.getDatasetCache().getDataset(namespace, name);
+  }
+
+  @Override
   public <T extends Dataset> T getDataset(String name,
                                           Map<String, String> arguments) throws DatasetInstantiationException {
     return sparkRuntimeContext.getDatasetCache().getDataset(name, arguments);
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String name, String namespace,
+                                          Map<String, String> arguments) throws DatasetInstantiationException {
+    return sparkRuntimeContext.getDatasetCache().getDataset(namespace, name, arguments);
   }
 
   @Override

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkDatasetContext.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkDatasetContext.java
@@ -40,4 +40,16 @@ public interface SparkDatasetContext extends DatasetContext {
   <T extends Dataset> T getDataset(String name, Map<String, String> arguments,
                                    AccessType accessType) throws DatasetInstantiationException;
 
+  /**
+   * Get an instance of the specified dataset, with the specified access type.
+   *
+   * @param namespace the namespace of the dataset
+   * @param name the name of the dataset
+   * @param arguments arguments for the dataset
+   * @param <T> the type of the dataset
+   * @param accessType the accessType
+   */
+  <T extends Dataset> T getDataset(String namespace, String name, Map<String, String> arguments,
+                                   AccessType accessType) throws DatasetInstantiationException;
+
 }


### PR DESCRIPTION
Add two APIs to Dataset Context Interface and add the implementations for all sub classes. 
1. `getDataset(String namespace, String name)`
2. `getDataset(String namespace, String name, Map<String, String> argument)`

Change `DatasetCacheKey` to carry namespace field and thus enable cross namespace dataset access.
