### PR TITLE
Set kafka host.name property to Kafka server's FQDN.

### DIFF
--- a/cdap-kafka/src/main/java/co/cask/cdap/kafka/run/KafkaServerMain.java
+++ b/cdap-kafka/src/main/java/co/cask/cdap/kafka/run/KafkaServerMain.java
@@ -94,9 +94,9 @@ public class KafkaServerMain extends DaemonMain {
     Preconditions.checkState(port > 0, "Port number is invalid.");
 
     String hostname = kafkaProperties.getProperty("host.name");
-    InetAddress address = Networks.resolve(hostname, null);
-    if (hostname == null) {
-      if (address != null && address.isAnyLocalAddress()) {
+    InetAddress address = Networks.resolve(hostname, new InetSocketAddress("localhost", 0).getAddress());
+    if (hostname != null) {
+      if (address.isAnyLocalAddress()) {
         kafkaProperties.remove("host.name");
       } else {
         hostname = address.getCanonicalHostName();


### PR DESCRIPTION
Fix logical error introduced in the https://github.com/caskdata/cdap/pull/5888.
We do not set the Kafka `host.name` property to FQDN which causes broker's hostname in the zookeeper to be registered as `0.0.0.0`. If metrics.processor container is running on the separate node than the node where Kafka server is running, then it fails to publish since it uses `0.0.0.0` address to connect to the Kafka server.
