### PR TITLE
Bump version to 3.3.5

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "sdk_version": "3.3.4"
+    "sdk_version": "3.3.5"
   },
   "builders": [
     {


### PR DESCRIPTION
Similar to https://github.com/caskdata/cdap/pull/5961, but missed one file.
