### PR TITLE
CDAP-4109 Kerberos is now supported, so update docs

### DIFF
--- a/cdap-docs/admin-manual/source/installation/ambari.rst
+++ b/cdap-docs/admin-manual/source/installation/ambari.rst
@@ -22,7 +22,6 @@ Installation using Apache Ambari
   **not** with Ambari.
 - These features are **currently not included** in the CDAP Apache Ambari Service (though they may in the future):
   
-  - `Kerberos-enabled clusters <https://issues.cask.co/browse/CDAP-4109>`__ are currently not supported;
   - The CDAP Apache Ambari Service is not integrated with the `CDAP Authentication Server <https://issues.cask.co/browse/CDAP-4110>`__;
   - CDAP component `high-availability <https://issues.cask.co/browse/CDAP-4107>`__  is not supported;
 
@@ -345,8 +344,9 @@ support :ref:`CDAP Security <admin-security>` will be erased by Ambari.
 
 Enabling Kerberos
 -----------------
-Ambari-managed `Kerberos-enabled clusters <https://issues.cask.co/browse/CDAP-4109>`__ are
-currently not supported in CDAP.
+Kerberos support in CDAP is automatically enabled when enabling Kerberos security on your
+cluster via Ambari. Consult the appropriate Ambari documentation for instructions on enabling
+Kerberos support for your cluster.
 
 CDAP HA Setup
 -------------

--- a/cdap-docs/admin-manual/source/installation/index.rst
+++ b/cdap-docs/admin-manual/source/installation/index.rst
@@ -29,7 +29,7 @@ Installation and configuration instructions for either **specific distributions*
 
 - :ref:`Installation using Apache Ambari <admin-installation-ambari>`
 
-  - Enabling perimeter security, Kerberos, and CDAP high
+  - Enabling perimeter security and CDAP high
     availability are currently not available for Ambari
 
 ..

--- a/cdap-docs/admin-manual/source/installation/index.rst
+++ b/cdap-docs/admin-manual/source/installation/index.rst
@@ -29,8 +29,9 @@ Installation and configuration instructions for either **specific distributions*
 
 - :ref:`Installation using Apache Ambari <admin-installation-ambari>`
 
-  - Enabling perimeter security and CDAP high
-    availability are currently not available for Ambari
+  - :ref:`Advanced Topics: <ambari-installation-advanced-topics>`
+    enabling Kerberos; enabling perimeter security and CDAP high availability
+    are currently not available for Ambari
 
 ..
 


### PR DESCRIPTION
Kerberos is now supported in the CDAP Ambari service. See caskdata/cdap-ambari-service/#6

Quick Build: http://builds.cask.co/browse/CDAP-DQB42-1
