### PR TITLE
Refactor Master service guice bindings to get rid of child injector

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
@@ -40,6 +40,7 @@ import co.cask.cdap.data.view.ViewAdminModules;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerException;
+import co.cask.cdap.logging.guice.LogReaderRuntimeModules;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.metadata.MetadataServiceModule;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
@@ -100,6 +101,7 @@ public final class AppFabricTestModule extends AbstractModule {
     install(new ProgramRunnerRuntimeModule().getInMemoryModules());
     install(new LocationRuntimeModule().getInMemoryModules());
     install(new LoggingModules().getInMemoryModules());
+    install(new LogReaderRuntimeModules().getInMemoryModules());
     install(new MetricsHandlerModule());
     install(new MetricsClientRuntimeModule().getInMemoryModules());
     install(new ExploreClientModule());

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/StreamHandlerRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/StreamHandlerRunnable.java
@@ -40,6 +40,7 @@ import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.logging.appender.LogAppenderInitializer;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
+import co.cask.cdap.metrics.guice.MetricsStoreModule;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.proto.Id;
@@ -86,6 +87,7 @@ public class StreamHandlerRunnable extends AbstractMasterTwillRunnable {
         new DiscoveryRuntimeModule().getDistributedModules(),
         new LocationRuntimeModule().getDistributedModules(),
         new MetricsClientRuntimeModule().getDistributedModules(),
+        new MetricsStoreModule(),
         new DataFabricModules().getDistributedModules(),
         new DataSetsModules().getDistributedModules(),
         new LoggingModules().getDistributedModules(),

--- a/cdap-master/src/test/java/co/cask/cdap/data/runtime/main/MasterServiceMainTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/data/runtime/main/MasterServiceMainTest.java
@@ -16,10 +16,18 @@
 
 package co.cask.cdap.data.runtime.main;
 
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
+import co.cask.cdap.internal.app.services.AppFabricServer;
+import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
+import com.google.inject.Injector;
 import com.google.inject.multibindings.MapBinder;
 import com.google.inject.name.Names;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.twill.zookeeper.ZKClientService;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -29,7 +37,14 @@ public class MasterServiceMainTest {
 
   @Test
   public void testInjector() {
-    new MasterServiceMain();
+    Injector baseInjector = MasterServiceMain.createProcessInjector(CConfiguration.create(), new Configuration());
+    Injector injector = MasterServiceMain.createLeaderInjector(baseInjector.getInstance(CConfiguration.class),
+                                                               baseInjector.getInstance(Configuration.class),
+                                                               baseInjector.getInstance(ZKClientService.class));
+
+    Assert.assertNotNull(injector.getInstance(AuthorizerInstantiator.class));
+    Assert.assertNotNull(injector.getInstance(DatasetService.class));
+    Assert.assertNotNull(injector.getInstance(AppFabricServer.class));
   }
 
   @Test

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -54,6 +54,7 @@ import co.cask.cdap.gateway.router.NettyRouter;
 import co.cask.cdap.gateway.router.RouterModules;
 import co.cask.cdap.internal.app.services.AppFabricServer;
 import co.cask.cdap.logging.appender.LogAppenderInitializer;
+import co.cask.cdap.logging.guice.LogReaderRuntimeModules;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.metadata.MetadataService;
 import co.cask.cdap.metadata.MetadataServiceModule;
@@ -489,6 +490,7 @@ public class StandaloneMain {
       new DataSetServiceModules().getStandaloneModules(),
       new MetricsClientRuntimeModule().getStandaloneModules(),
       new LoggingModules().getStandaloneModules(),
+      new LogReaderRuntimeModules().getStandaloneModules(),
       new RouterModules().getStandaloneModules(),
       new SecurityModules().getStandaloneModules(),
       new StreamServiceRuntimeModule().getStandaloneModules(),

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -70,6 +70,7 @@ import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.explore.guice.ExploreRuntimeModule;
 import co.cask.cdap.gateway.handlers.AuthorizationHandler;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
+import co.cask.cdap.logging.guice.LogReaderRuntimeModules;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.metrics.guice.MetricsHandlerModule;
@@ -230,6 +231,7 @@ public class TestBase {
       new MetricsHandlerModule(),
       new MetricsClientRuntimeModule().getInMemoryModules(),
       new LoggingModules().getInMemoryModules(),
+      new LogReaderRuntimeModules().getInMemoryModules(),
       new ExploreRuntimeModule().getInMemoryModules(),
       new ExploreClientModule(),
       new NotificationFeedServiceRuntimeModule().getInMemoryModules(),

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/guice/LogReaderRuntimeModules.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/guice/LogReaderRuntimeModules.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.guice;
+
+import co.cask.cdap.common.runtime.RuntimeModule;
+import co.cask.cdap.logging.read.DistributedLogReader;
+import co.cask.cdap.logging.read.FileLogReader;
+import co.cask.cdap.logging.read.LogReader;
+import com.google.inject.AbstractModule;
+import com.google.inject.Module;
+
+/**
+ * A {@link RuntimeModule} for providing guice modules for {@link LogReader}.
+ */
+public final class LogReaderRuntimeModules extends RuntimeModule {
+
+  @Override
+  public Module getInMemoryModules() {
+    return new AbstractModule() {
+      @Override
+      protected void configure() {
+        bind(LogReader.class).to(FileLogReader.class);
+      }
+    };
+  }
+
+  @Override
+  public Module getStandaloneModules() {
+    return new AbstractModule() {
+      @Override
+      protected void configure() {
+        bind(LogReader.class).to(FileLogReader.class);
+      }
+    };
+  }
+
+  @Override
+  public Module getDistributedModules() {
+    return new AbstractModule() {
+      @Override
+      protected void configure() {
+        bind(LogReader.class).to(DistributedLogReader.class);
+      }
+    };
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/guice/LogSaverServiceModule.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/guice/LogSaverServiceModule.java
@@ -18,6 +18,9 @@ package co.cask.cdap.logging.guice;
 
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.gateway.handlers.CommonHandlers;
+import co.cask.cdap.logging.save.KafkaLogProcessor;
+import co.cask.cdap.logging.save.KafkaLogWriterPlugin;
+import co.cask.cdap.logging.save.LogMetricsPlugin;
 import co.cask.cdap.logging.save.LogSaverFactory;
 import co.cask.cdap.logging.service.LogSaverStatusService;
 import co.cask.http.HttpHandler;
@@ -34,6 +37,11 @@ public class LogSaverServiceModule extends PrivateModule {
 
   @Override
   protected void configure() {
+    Multibinder<KafkaLogProcessor> logProcessorBinder = Multibinder.newSetBinder
+      (binder(), KafkaLogProcessor.class, Names.named(Constants.LogSaver.MESSAGE_PROCESSORS));
+    logProcessorBinder.addBinding().to(KafkaLogWriterPlugin.class);
+    logProcessorBinder.addBinding().to(LogMetricsPlugin.class);
+
     Multibinder<HttpHandler> handlerBinder = Multibinder.newSetBinder
       (binder(), HttpHandler.class, Names.named(Constants.LogSaver.LOG_SAVER_STATUS_HANDLER));
     CommonHandlers.add(handlerBinder);

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/guice/LoggingModules.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/guice/LoggingModules.java
@@ -23,11 +23,7 @@ import co.cask.cdap.logging.appender.LogAppender;
 import co.cask.cdap.logging.appender.file.FileLogAppender;
 import co.cask.cdap.logging.appender.kafka.KafkaLogAppender;
 import co.cask.cdap.logging.appender.standalone.StandaloneLogAppender;
-import co.cask.cdap.logging.read.DistributedLogReader;
-import co.cask.cdap.logging.read.FileLogReader;
-import co.cask.cdap.logging.read.LogReader;
 import co.cask.cdap.logging.save.KafkaLogProcessor;
-import co.cask.cdap.logging.save.KafkaLogWriterPlugin;
 import co.cask.cdap.logging.save.LogMetricsPlugin;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
@@ -50,7 +46,6 @@ public class LoggingModules extends RuntimeModule {
     return new AbstractModule() {
       @Override
       protected void configure() {
-        bind(LogReader.class).to(FileLogReader.class);
         bind(LogAppender.class).toProvider(LogAppenderProvider.class).in(Scopes.SINGLETON);
         Multibinder<KafkaLogProcessor> handlerBinder = Multibinder.newSetBinder
           (binder(), KafkaLogProcessor.class, Names.named(Constants.LogSaver.MESSAGE_PROCESSORS));
@@ -64,7 +59,6 @@ public class LoggingModules extends RuntimeModule {
     return new AbstractModule() {
       @Override
       protected void configure() {
-        bind(LogReader.class).to(FileLogReader.class);
         bind(LogAppender.class).toProvider(LogAppenderProvider.class).in(Scopes.SINGLETON);
         Multibinder<KafkaLogProcessor> handlerBinder = Multibinder.newSetBinder
           (binder(), KafkaLogProcessor.class, Names.named(Constants.LogSaver.MESSAGE_PROCESSORS));
@@ -78,12 +72,7 @@ public class LoggingModules extends RuntimeModule {
     return new AbstractModule() {
       @Override
       protected void configure() {
-        bind(LogReader.class).to(DistributedLogReader.class);
         bind(LogAppender.class).to(KafkaLogAppender.class);
-        Multibinder<KafkaLogProcessor> handlerBinder = Multibinder.newSetBinder
-          (binder(), KafkaLogProcessor.class, Names.named(Constants.LogSaver.MESSAGE_PROCESSORS));
-        handlerBinder.addBinding().to(KafkaLogWriterPlugin.class);
-        handlerBinder.addBinding().to(LogMetricsPlugin.class);
       }
     };
   }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/DistributedMetricsClientModule.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/DistributedMetricsClientModule.java
@@ -40,13 +40,12 @@ import com.google.inject.name.Named;
  * Requires binding from {@link co.cask.cdap.common.guice.KafkaClientModule} and
  * {@link co.cask.cdap.common.guice.IOModule}.
  */
-public final class DistributedMetricsClientModule extends PrivateModule {
+final class DistributedMetricsClientModule extends PrivateModule {
+
+  private static final TypeToken<MetricValues> METRIC_RECORD_TYPE = TypeToken.of(MetricValues.class);
 
   @Override
   protected void configure() {
-    bind(MetricDatasetFactory.class).to(DefaultMetricDatasetFactory.class).in(Scopes.SINGLETON);
-    bind(MetricStore.class).to(DefaultMetricStore.class);
-    expose(MetricStore.class);
     bind(MetricsCollectionService.class).to(KafkaMetricsCollectionService.class).in(Scopes.SINGLETON);
     expose(MetricsCollectionService.class);
   }
@@ -61,8 +60,7 @@ public final class DistributedMetricsClientModule extends PrivateModule {
   public DatumWriter<MetricValues> providesDatumWriter(SchemaGenerator schemaGenerator,
                                                         DatumWriterFactory datumWriterFactory) {
     try {
-      TypeToken<MetricValues> metricRecordType = TypeToken.of(MetricValues.class);
-      return datumWriterFactory.create(metricRecordType, schemaGenerator.generate(metricRecordType.getType()));
+      return datumWriterFactory.create(METRIC_RECORD_TYPE, schemaGenerator.generate(METRIC_RECORD_TYPE.getType()));
     } catch (UnsupportedTypeException e) {
       throw Throwables.propagate(e);
     }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/MetricsClientRuntimeModule.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/MetricsClientRuntimeModule.java
@@ -21,9 +21,6 @@ import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.common.runtime.RuntimeModule;
 import co.cask.cdap.metrics.collect.AggregatedMetricsCollectionService;
 import co.cask.cdap.metrics.collect.LocalMetricsCollectionService;
-import co.cask.cdap.metrics.store.DefaultMetricDatasetFactory;
-import co.cask.cdap.metrics.store.DefaultMetricStore;
-import co.cask.cdap.metrics.store.MetricDatasetFactory;
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 import com.google.inject.PrivateModule;
@@ -41,11 +38,14 @@ public final class MetricsClientRuntimeModule extends RuntimeModule {
     return new PrivateModule() {
       @Override
       protected void configure() {
-        bind(MetricDatasetFactory.class).to(DefaultMetricDatasetFactory.class).in(Scopes.SINGLETON);
-        bind(MetricStore.class).to(DefaultMetricStore.class);
+        // Install the MetricsStoreModule as private bindings and expose the MetricStore.
+        // Both LocalMetricsCollectionService and the AppFabricService needs it
+        install(new MetricsStoreModule());
         expose(MetricStore.class);
+
         bind(MetricsCollectionService.class).to(LocalMetricsCollectionService.class).in(Scopes.SINGLETON);
         expose(MetricsCollectionService.class);
+
       }
     };
   }
@@ -55,9 +55,11 @@ public final class MetricsClientRuntimeModule extends RuntimeModule {
     return new PrivateModule() {
       @Override
       protected void configure() {
-        bind(MetricDatasetFactory.class).to(DefaultMetricDatasetFactory.class).in(Scopes.SINGLETON);
-        bind(MetricStore.class).to(DefaultMetricStore.class);
+        // Install the MetricsStoreModule as private bindings and expose the MetricStore.
+        // Both LocalMetricsCollectionService and the AppFabricService needs it
+        install(new MetricsStoreModule());
         expose(MetricStore.class);
+
         bind(MetricsCollectionService.class).to(LocalMetricsCollectionService.class).in(Scopes.SINGLETON);
         expose(MetricsCollectionService.class);
       }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/MetricsStoreModule.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/guice/MetricsStoreModule.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metrics.guice;
+
+import co.cask.cdap.api.metrics.MetricStore;
+import co.cask.cdap.metrics.store.DefaultMetricDatasetFactory;
+import co.cask.cdap.metrics.store.DefaultMetricStore;
+import co.cask.cdap.metrics.store.MetricDatasetFactory;
+import com.google.inject.PrivateModule;
+import com.google.inject.Scopes;
+
+/**
+ * Guice module for providing bindings for {@link MetricStore}.
+ */
+public final class MetricsStoreModule extends PrivateModule {
+
+  @Override
+  protected void configure() {
+    bind(MetricDatasetFactory.class).to(DefaultMetricDatasetFactory.class).in(Scopes.SINGLETON);
+    bind(MetricStore.class).to(DefaultMetricStore.class);
+    expose(MetricStore.class);
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsProcessorTwillRunnable.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsProcessorTwillRunnable.java
@@ -36,6 +36,7 @@ import co.cask.cdap.logging.appender.LogAppenderInitializer;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.metrics.guice.MetricsProcessorStatusServiceModule;
+import co.cask.cdap.metrics.guice.MetricsStoreModule;
 import co.cask.cdap.metrics.process.KafkaMetricsProcessorServiceFactory;
 import co.cask.cdap.metrics.process.MessageCallbackFactory;
 import co.cask.cdap.metrics.process.MetricsMessageCallbackFactory;
@@ -128,6 +129,7 @@ public final class MetricsProcessorTwillRunnable extends AbstractMasterTwillRunn
       new ZKClientModule(),
       new KafkaClientModule(),
       new MetricsClientRuntimeModule().getDistributedModules(),
+      new MetricsStoreModule(),
       new DiscoveryRuntimeModule().getDistributedModules(),
       new LoggingModules().getDistributedModules(),
       new LocationRuntimeModule().getDistributedModules(),

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsTwillRunnable.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsTwillRunnable.java
@@ -32,9 +32,11 @@ import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data2.audit.AuditModule;
 import co.cask.cdap.logging.appender.LogAppenderInitializer;
+import co.cask.cdap.logging.guice.LogReaderRuntimeModules;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.metrics.guice.MetricsHandlerModule;
+import co.cask.cdap.metrics.guice.MetricsStoreModule;
 import co.cask.cdap.metrics.query.MetricsQueryService;
 import co.cask.cdap.proto.Id;
 import com.google.common.base.Throwables;
@@ -114,8 +116,10 @@ public class MetricsTwillRunnable extends AbstractMasterTwillRunnable {
       new LocationRuntimeModule().getDistributedModules(),
       new DiscoveryRuntimeModule().getDistributedModules(),
       new LoggingModules().getDistributedModules(),
+      new LogReaderRuntimeModules().getDistributedModules(),
       new MetricsHandlerModule(),
       new MetricsClientRuntimeModule().getDistributedModules(),
+      new MetricsStoreModule(),
       new AuditModule().getDistributedModules()
     );
   }

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/KafkaTestBase.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/KafkaTestBase.java
@@ -16,19 +16,25 @@
 
 package co.cask.cdap.logging;
 
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data.runtime.TransactionExecutorModule;
 import co.cask.cdap.kafka.KafkaTester;
 import co.cask.cdap.logging.guice.LoggingModules;
+import co.cask.cdap.logging.save.KafkaLogProcessor;
+import co.cask.cdap.logging.save.KafkaLogWriterPlugin;
+import co.cask.cdap.logging.save.LogMetricsPlugin;
 import co.cask.cdap.logging.save.LogSaverFactory;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.tephra.runtime.TransactionModules;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.inject.PrivateModule;
+import com.google.inject.AbstractModule;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.google.inject.multibindings.Multibinder;
+import com.google.inject.name.Names;
 import org.junit.ClassRule;
 
 /**
@@ -56,11 +62,15 @@ public abstract class KafkaTestBase {
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new MetricsClientRuntimeModule().getInMemoryModules(),
       new LoggingModules().getDistributedModules(),
-      new PrivateModule() {
+      new AbstractModule() {
         @Override
         protected void configure() {
+          Multibinder<KafkaLogProcessor> logProcessorBinder = Multibinder.newSetBinder
+            (binder(), KafkaLogProcessor.class, Names.named(Constants.LogSaver.MESSAGE_PROCESSORS));
+          logProcessorBinder.addBinding().to(KafkaLogWriterPlugin.class);
+          logProcessorBinder.addBinding().to(LogMetricsPlugin.class);
+
           install(new FactoryModuleBuilder().build(LogSaverFactory.class));
-          expose(LogSaverFactory.class);
         }
       }
     ),


### PR DESCRIPTION
- Using child injector is problematic since JIT injection are done on the parent injector
- Refactor the code to use two different injectors, one for the process, one for leader
- Also refactor some guice modules to provide better granularity
