### PR TITLE
Namespace-level configurable impersonation (programs)

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
@@ -118,7 +118,7 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
       return runtimeInfo;
     } catch (Exception e) {
       cleanUpTask.run();
-      LOG.error("Exception while trying to createPluginSnapshot", e);
+      LOG.error("Exception while trying to run program", e);
       throw Throwables.propagate(e);
     }
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/scheduler/SchedulerQueueResolver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/scheduler/SchedulerQueueResolver.java
@@ -23,6 +23,7 @@ import co.cask.cdap.proto.NamespaceConfig;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.store.NamespaceStore;
 import com.google.common.base.Strings;
+import com.google.inject.Inject;
 
 import javax.annotation.Nullable;
 
@@ -34,9 +35,7 @@ public class SchedulerQueueResolver {
   private final String defaultQueue;
   private final NamespaceStore store;
 
-  /**
-   * Construct SchedulerQueueResolver with CConfiguration and Store.
-   */
+  @Inject
   public SchedulerQueueResolver(CConfiguration cConf, NamespaceStore store) {
     this.defaultQueue = cConf.get(Constants.AppFabric.APP_SCHEDULER_QUEUE, "");
     this.store = store;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
@@ -113,8 +113,17 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
       }
 
       NamespaceConfig config = metadata.getConfig();
-      if (config != null && !Strings.isNullOrEmpty(config.getSchedulerQueueName())) {
-        builder.setSchedulerQueueName(config.getSchedulerQueueName());
+      if (config != null) {
+        if (!Strings.isNullOrEmpty(config.getSchedulerQueueName())) {
+          builder.setSchedulerQueueName(config.getSchedulerQueueName());
+        }
+        // both or none of the following two must be set
+        if (!Strings.isNullOrEmpty(config.getPrincipal())) {
+          builder.setPrincipal(config.getPrincipal());
+        }
+        if (!Strings.isNullOrEmpty(config.getKeytabPath())) {
+          builder.setKeytabPath(config.getKeytabPath());
+        }
       }
     }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
@@ -117,7 +117,6 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
         if (!Strings.isNullOrEmpty(config.getSchedulerQueueName())) {
           builder.setSchedulerQueueName(config.getSchedulerQueueName());
         }
-        // both or none of the following two must be set
         if (!Strings.isNullOrEmpty(config.getPrincipal())) {
           builder.setPrincipal(config.getPrincipal());
         }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -68,4 +68,12 @@ public final class ProgramOptionConstants {
    * Option to a local file path of a JAR file containing plugins artifacts.
    */
   public static final String PLUGIN_ARCHIVE = "pluginArchive";
+
+  /**
+   * Options for impersonation
+   */
+  public static final String PRINCIPAL = "principal";
+
+  public static final String KEYTAB_PATH = "keytabPath";
+
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramRunners.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramRunners.java
@@ -64,6 +64,22 @@ public final class ProgramRunners {
   }
 
   /**
+   * Impersonates as a particular UGI to execute a callable.
+   *
+   * @param ugi the UGI to execute the callable as
+   * @param callable the callable to execute
+   */
+  public static <T> T runAsUGI(UserGroupInformation ugi,
+                               final Callable<T> callable) throws IOException, InterruptedException {
+    return ugi.doAs(new PrivilegedExceptionAction<T>() {
+      @Override
+      public T run() throws Exception {
+        return callable.call();
+      }
+    });
+  }
+
+  /**
    * Updates the given arguments to always have the logical start time set.
    *
    * @param arguments the runtime arguments

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ImpersonationUserResolver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ImpersonationUserResolver.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.services;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.NamespaceConfig;
+import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.store.NamespaceStore;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+
+/**
+ * Helper class to resolve the principal which CDAP will launch programs as.
+ */
+class ImpersonationUserResolver {
+  private final NamespaceStore store;
+
+  private final String defaultPrincipal;
+  private final String defaultKeytabPath;
+
+  /**
+   * Construct SchedulerQueueResolver with CConfiguration and Store.
+   */
+  ImpersonationUserResolver(CConfiguration cConf, NamespaceStore store) {
+    this.defaultPrincipal = cConf.get(Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL);
+    this.defaultKeytabPath = cConf.get(Constants.Security.CFG_CDAP_MASTER_KRB_KEYTAB_PATH);
+    this.store = store;
+  }
+
+  /**
+   * Get Impersonated user at namespace level. If it is empty, returns the default principal.
+   *
+   * @param programId NamespaceId
+   * @return configured principal.
+   */
+  String getPrincipal(Id.Program programId) {
+    String namespaceUserSetting = getNamespaceConfig(programId.getNamespace()).getPrincipal();
+    if (!Strings.isNullOrEmpty(namespaceUserSetting)) {
+      return namespaceUserSetting;
+    }
+    return defaultPrincipal;
+  }
+
+  /**
+   * Get configured keytab path at namespace level. If it is empty, returns the default keytab path.
+   *
+   * @param programId NamespaceId
+   * @return configured keytab path.
+   */
+  String getKeytabPath(Id.Program programId) {
+    String keytabPathSetting = getNamespaceConfig(programId.getNamespace()).getKeytabPath();
+    if (!Strings.isNullOrEmpty(keytabPathSetting)) {
+      return keytabPathSetting;
+    }
+    return defaultKeytabPath;
+  }
+
+  private NamespaceConfig getNamespaceConfig(Id.Namespace namespaceId) {
+    NamespaceMeta meta = store.get(namespaceId);
+    Preconditions.checkNotNull(meta, "Failed to retrieve namespace meta for namespace id {}", namespaceId.getId());
+    return meta.getConfig();
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
@@ -236,14 +236,14 @@ public class ProgramLifecycleService extends AbstractIdleService {
    * @throws Exception if there were other exceptions checking if the current user is authorized to start the program
    */
   public synchronized void start(ProgramId programId, Map<String, String> overrides, boolean debug) throws Exception {
+    if (isRunning(programId) && !isConcurrentRunsAllowed(programId.getType())) {
+      throw new ConflictException(String.format("Program %s is already running", programId));
+    }
+
     Map<String, String> sysArgs = propertiesResolver.getSystemProperties(programId.toId());
     Map<String, String> userArgs = propertiesResolver.getUserProperties(programId.toId());
     if (overrides != null) {
       userArgs.putAll(overrides);
-    }
-
-    if (isRunning(programId) && !isConcurrentRunsAllowed(programId.getType())) {
-      throw new ConflictException(String.format("Program %s is already running", programId));
     }
 
     ProgramRuntimeService.RuntimeInfo runtimeInfo = start(programId, sysArgs, userArgs, debug);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
@@ -56,6 +56,7 @@ import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.cdap.store.NamespaceStore;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Collections2;
@@ -576,6 +577,7 @@ public class ProgramLifecycleService extends AbstractIdleService {
    * @param programType The type of program the run records need to validate and update.
    * @param processedInvalidRunRecordIds the {@link Set} of processed invalid run record ids.
    */
+  @VisibleForTesting
   void validateAndCorrectRunningRunRecords(final ProgramType programType, Set<String> processedInvalidRunRecordIds) {
     final Map<RunId, RuntimeInfo> runIdToRuntimeInfo = runtimeService.list(programType);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/PropertiesResolver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/PropertiesResolver.java
@@ -35,11 +35,13 @@ public class PropertiesResolver {
 
   private final PreferencesStore prefStore;
   private final SchedulerQueueResolver queueResolver;
+  private final ImpersonationUserResolver impersonationUserResolver;
 
   @Inject
   PropertiesResolver(PreferencesStore prefStore, NamespaceStore store, CConfiguration cConf) {
     this.prefStore = prefStore;
     this.queueResolver = new SchedulerQueueResolver(cConf, store);
+    this.impersonationUserResolver = new ImpersonationUserResolver(cConf, store);
   }
 
   public Map<String, String> getUserProperties(Id.Program id) {
@@ -52,6 +54,8 @@ public class PropertiesResolver {
   public Map<String, String> getSystemProperties(Id.Program id) {
     Map<String, String> systemArgs = Maps.newHashMap();
     systemArgs.put(Constants.AppFabric.APP_SCHEDULER_QUEUE, queueResolver.getQueue(id.getNamespace()));
+    systemArgs.put(ProgramOptionConstants.PRINCIPAL, impersonationUserResolver.getPrincipal(id));
+    systemArgs.put(ProgramOptionConstants.KEYTAB_PATH, impersonationUserResolver.getKeytabPath(id));
     return systemArgs;
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -768,10 +768,15 @@ public final class Constants {
       public static final String DEFAULT_SSL_KEYSTORE_TYPE = "JKS";
     }
 
-    /** Path to the Kerberos keytab file used by CDAP */
+    /** Path to the Kerberos keytab file used by CDAP master */
     public static final String CFG_CDAP_MASTER_KRB_KEYTAB_PATH = "cdap.master.kerberos.keytab";
-    /** Kerberos principal used by CDAP */
+    /** Kerberos principal used by CDAP master */
     public static final String CFG_CDAP_MASTER_KRB_PRINCIPAL = "cdap.master.kerberos.principal";
+
+    /** Path to the Kerberos keytab file used by CDAP programs */
+    public static final String CFG_CDAP_PROGRAMS_KRB_KEYTAB_PATH = "cdap.programs.kerberos.keytab";
+    /** Kerberos principal used by CDAP programs */
+    public static final String CFG_CDAP_PROGRAMS_KRB_PRINCIPAL = "cdap.programs.kerberos.principal";
   }
 
   /**

--- a/cdap-common/src/main/java/co/cask/cdap/common/kerberos/SecurityUtil.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/kerberos/SecurityUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -73,19 +73,13 @@ public final class SecurityUtil {
                                 Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL + " is not configured");
 
     String principal = cConf.get(Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL);
-    principal = SecurityUtil.expandPrincipal(principal);
+    principal = expandPrincipal(principal);
 
     Preconditions.checkArgument(cConf.get(Constants.Security.CFG_CDAP_MASTER_KRB_KEYTAB_PATH) != null,
                                 "Kerberos authentication is enabled, but " +
                                 Constants.Security.CFG_CDAP_MASTER_KRB_KEYTAB_PATH + " is not configured");
 
-    File keyTabFile = new File(cConf.get(Constants.Security.CFG_CDAP_MASTER_KRB_KEYTAB_PATH));
-    Preconditions.checkArgument(keyTabFile.exists(),
-                                "Kerberos keytab file does not exist: " + keyTabFile.getAbsolutePath());
-    Preconditions.checkArgument(keyTabFile.isFile(),
-                                "Kerberos keytab file should be a file: " + keyTabFile.getAbsolutePath());
-    Preconditions.checkArgument(keyTabFile.canRead(),
-                                "Kerberos keytab file cannot be read: " + keyTabFile.getAbsolutePath());
+    File keyTabFile = validateKeytabPath(cConf.get(Constants.Security.CFG_CDAP_MASTER_KRB_KEYTAB_PATH));
 
     LOG.info("Using Kerberos principal {} and keytab {}", principal, keyTabFile.getAbsolutePath());
 
@@ -115,6 +109,18 @@ public final class SecurityUtil {
     Configuration.setConfiguration(configuration);
   }
 
+  // validates that the path specified exists and is a readable file
+  private static File validateKeytabPath(String keytabPath) {
+    File keytabFile = new File(keytabPath);
+    Preconditions.checkArgument(keytabFile.exists(),
+                                "Kerberos keytab file does not exist: " + keytabFile.getAbsolutePath());
+    Preconditions.checkArgument(keytabFile.isFile(),
+                                "Kerberos keytab file should be a file: " + keytabFile.getAbsolutePath());
+    Preconditions.checkArgument(keytabFile.canRead(),
+                                "Kerberos keytab file cannot be read: " + keytabFile.getAbsolutePath());
+    return keytabFile;
+  }
+
   /**
    * Expands _HOST in principal name with local hostname.
    *
@@ -142,12 +148,14 @@ public final class SecurityUtil {
   }
 
   public static void loginForMasterService(CConfiguration cConf) throws IOException, LoginException {
-    String principal = SecurityUtil.expandPrincipal(cConf.get(Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL));
+    String principal = cConf.get(Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL);
     String keytabPath = cConf.get(Constants.Security.CFG_CDAP_MASTER_KRB_KEYTAB_PATH);
 
     if (UserGroupInformation.isSecurityEnabled()) {
+      validateKeytabPath(keytabPath);
+      String expandedPrincipal = SecurityUtil.expandPrincipal(principal);
       LOG.info("Logging in as: principal={}, keytab={}", principal, keytabPath);
-      UserGroupInformation.loginUserFromKeytab(principal, keytabPath);
+      UserGroupInformation.loginUserFromKeytab(expandedPrincipal, keytabPath);
 
       long delaySec = cConf.getLong(Constants.Security.KERBEROS_KEYTAB_RELOGIN_INTERVAL);
       Executors.newSingleThreadScheduledExecutor(Threads.createDaemonThreadFactory("Kerberos keytab renewal"))

--- a/cdap-common/src/main/java/co/cask/cdap/common/kerberos/SecurityUtil.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/kerberos/SecurityUtil.java
@@ -153,7 +153,7 @@ public final class SecurityUtil {
 
     if (UserGroupInformation.isSecurityEnabled()) {
       validateKeytabPath(keytabPath);
-      String expandedPrincipal = SecurityUtil.expandPrincipal(principal);
+      String expandedPrincipal = expandPrincipal(principal);
       LOG.info("Logging in as: principal={}, keytab={}", principal, keytabPath);
       UserGroupInformation.loginUserFromKeytab(expandedPrincipal, keytabPath);
 

--- a/cdap-common/src/main/java/org/apache/twill/internal/yarn/Hadoop21YarnAppClient.java
+++ b/cdap-common/src/main/java/org/apache/twill/internal/yarn/Hadoop21YarnAppClient.java
@@ -20,6 +20,7 @@ package org.apache.twill.internal.yarn;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.AbstractIdleService;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.api.protocolrecords.GetNewApplicationResponse;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
@@ -38,7 +39,10 @@ import org.apache.twill.internal.appmaster.ApplicationSubmitter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -50,21 +54,44 @@ import javax.annotation.Nullable;
  * </p>
  */
 // TODO: This is a copy from Twill, and can be removed when TWILL-119 is fixed. CDAP-4923 tracks Twill-0.8.0 upgrade.
+// After copying, we have removed the addRMToken() method. That functionality is in YarnTokenUtils.
+// Additionally, we have updated it to not have a single YarnClient, but instead a collection of YarnClients, one per
+// UGI. We need to do this because YarnClient is not designed to be reusable across UGIs. Even if the calling UGI
+// changes, the Yarn user still is the original UGI that constructed the YARN client.
 public final class Hadoop21YarnAppClient extends AbstractIdleService implements YarnAppClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(Hadoop21YarnAppClient.class);
-  private final YarnClient yarnClient;
+  private final Configuration configuration;
+
+  // TODO: make thread safe
+  // alternatively, simply construct a new YARNClient when needed. Shouldn't be too expensive
+  private Map<String, YarnClient> yarnClients = new HashMap<>();
 
   public Hadoop21YarnAppClient(Configuration configuration) {
-    this.yarnClient = YarnClient.createYarnClient();
-    yarnClient.init(configuration);
+    this.configuration = configuration;
+  }
+
+  private YarnClient getYarnClient() {
+    try {
+      String userName = UserGroupInformation.getCurrentUser().getShortUserName();
+      if (!yarnClients.containsKey(userName)) {
+        YarnClient yarnClient = YarnClient.createYarnClient();
+        yarnClient.init(configuration);
+        yarnClient.start();
+
+        yarnClients.put(userName, yarnClient);
+      }
+      return yarnClients.get(userName);
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
   }
 
   @Override
   public ProcessLauncher<ApplicationMasterInfo> createLauncher(TwillSpecification twillSpec,
                                                                @Nullable String schedulerQueue) throws Exception {
     // Request for new application
-    YarnClientApplication application = yarnClient.createApplication();
+    YarnClientApplication application = getYarnClient().createApplication();
     final GetNewApplicationResponse response = application.getNewApplicationResponse();
     final ApplicationId appId = response.getApplicationId();
 
@@ -93,6 +120,7 @@ public final class Hadoop21YarnAppClient extends AbstractIdleService implements 
         appSubmissionContext.setMaxAppAttempts(2);
 
         try {
+          YarnClient yarnClient = getYarnClient();
           yarnClient.submitApplication(appSubmissionContext);
           return new ProcessControllerImpl(yarnClient, appId);
         } catch (Exception e) {
@@ -126,22 +154,25 @@ public final class Hadoop21YarnAppClient extends AbstractIdleService implements 
 
   @Override
   public ProcessController<YarnApplicationReport> createProcessController(ApplicationId appId) {
-    return new ProcessControllerImpl(yarnClient, appId);
+    return new ProcessControllerImpl(getYarnClient(), appId);
   }
 
   @Override
   public List<NodeReport> getNodeReports() throws Exception {
-    return this.yarnClient.getNodeReports();
+    return getYarnClient().getNodeReports();
   }
 
   @Override
   protected void startUp() throws Exception {
-    yarnClient.start();
+    // no-op
   }
 
   @Override
   protected void shutDown() throws Exception {
-    yarnClient.stop();
+    for (YarnClient client : yarnClients.values()) {
+      client.stop();
+    }
+    yarnClients.clear();
   }
 
   private static final class ProcessControllerImpl implements ProcessController<YarnApplicationReport> {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceConfig.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceConfig.java
@@ -18,6 +18,8 @@ package co.cask.cdap.proto;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.util.Objects;
+
 /**
  * Represents the configuration of a namespace. This class needs to be GSON serializable.
  */
@@ -61,22 +63,15 @@ public class NamespaceConfig {
 
     NamespaceConfig that = (NamespaceConfig) o;
 
-    if (!schedulerQueueName.equals(that.schedulerQueueName)) {
-      return false;
-    }
-    if (!principal.equals(that.principal)) {
-      return false;
-    }
-    return keytabPath.equals(that.keytabPath);
+    return Objects.equals(schedulerQueueName, that.schedulerQueueName)
+      && Objects.equals(principal, that.principal)
+      && Objects.equals(keytabPath, that.keytabPath);
 
   }
 
   @Override
   public int hashCode() {
-    int result = schedulerQueueName.hashCode();
-    result = 31 * result + principal.hashCode();
-    result = 31 * result + keytabPath.hashCode();
-    return result;
+    return Objects.hash(schedulerQueueName, principal, keytabPath);
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceConfig.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceConfig.java
@@ -18,8 +18,6 @@ package co.cask.cdap.proto;
 
 import com.google.gson.annotations.SerializedName;
 
-import java.util.Objects;
-
 /**
  * Represents the configuration of a namespace. This class needs to be GSON serializable.
  */
@@ -28,12 +26,28 @@ public class NamespaceConfig {
   @SerializedName("scheduler.queue.name")
   private final String schedulerQueueName;
 
-  public NamespaceConfig(String schedulerQueueName) {
+  @SerializedName("principal")
+  private final String principal;
+
+  @SerializedName("keytab.path")
+  private final String keytabPath;
+
+  public NamespaceConfig(String schedulerQueueName, String principal, String keytabPath) {
     this.schedulerQueueName = schedulerQueueName;
+    this.principal = principal;
+    this.keytabPath = keytabPath;
   }
 
   public String getSchedulerQueueName() {
     return schedulerQueueName;
+  }
+
+  public String getPrincipal() {
+    return principal;
+  }
+
+  public String getKeytabPath() {
+    return keytabPath;
   }
 
   @Override
@@ -44,19 +58,33 @@ public class NamespaceConfig {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    NamespaceConfig other = (NamespaceConfig) o;
-    return Objects.equals(schedulerQueueName, other.schedulerQueueName);
+
+    NamespaceConfig that = (NamespaceConfig) o;
+
+    if (!schedulerQueueName.equals(that.schedulerQueueName)) {
+      return false;
+    }
+    if (!principal.equals(that.principal)) {
+      return false;
+    }
+    return keytabPath.equals(that.keytabPath);
+
   }
 
   @Override
   public int hashCode() {
-    return schedulerQueueName.hashCode();
+    int result = schedulerQueueName.hashCode();
+    result = 31 * result + principal.hashCode();
+    result = 31 * result + keytabPath.hashCode();
+    return result;
   }
 
   @Override
   public String toString() {
     return "NamespaceConfig{" +
-      "scheduler.queue.name='" + schedulerQueueName + '\'' +
+      "schedulerQueueName='" + schedulerQueueName + '\'' +
+      ", principal='" + principal + '\'' +
+      ", keytabPath='" + keytabPath + '\'' +
       '}';
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceMeta.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceMeta.java
@@ -58,34 +58,50 @@ public final class NamespaceMeta {
     private String name;
     private String description;
     private String schedulerQueueName;
+    private String principal;
+    private String keytabPath;
 
     public Builder() {
-     // No-Op
+      // No-Op
     }
 
     public Builder(NamespaceMeta meta) {
       this.name = meta.getName();
       this.description = meta.getDescription();
-      this.schedulerQueueName = meta.getConfig().getSchedulerQueueName();
+
+      NamespaceConfig config = meta.getConfig();
+      this.schedulerQueueName = config.getSchedulerQueueName();
+      this.principal = config.getPrincipal();
+      this.keytabPath = config.getKeytabPath();
     }
 
-    public Builder setName(final Id.Namespace id) {
+    public Builder setName(Id.Namespace id) {
       this.name = id.getId();
       return this;
     }
 
-    public Builder setName(final String name) {
+    public Builder setName(String name) {
       this.name = name;
       return this;
     }
 
-    public Builder setDescription(final String description) {
+    public Builder setDescription(String description) {
       this.description = description;
       return this;
     }
 
-    public Builder setSchedulerQueueName(final String schedulerQueueName) {
+    public Builder setSchedulerQueueName(String schedulerQueueName) {
       this.schedulerQueueName = schedulerQueueName;
+      return this;
+    }
+
+    public Builder setPrincipal(String principal) {
+      this.principal = principal;
+      return this;
+    }
+
+    public Builder setKeytabPath(String keytabPath) {
+      this.keytabPath = keytabPath;
       return this;
     }
 
@@ -100,7 +116,15 @@ public final class NamespaceMeta {
       if (schedulerQueueName == null) {
         schedulerQueueName = "";
       }
-      return new NamespaceMeta(name, description, new NamespaceConfig(schedulerQueueName));
+
+      if (principal == null) {
+        principal = "";
+      }
+
+      if (keytabPath == null) {
+        keytabPath = "";
+      }
+      return new NamespaceMeta(name, description, new NamespaceConfig(schedulerQueueName, principal, keytabPath));
     }
   }
 

--- a/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
@@ -113,7 +113,9 @@ public class AuthorizationTest extends TestBase {
       return new String[] {
         Constants.Security.ENABLED, "true",
         Constants.Security.Authorization.ENABLED, "true",
-        Constants.Security.Authorization.EXTENSION_JAR_PATH, authExtensionJar.toURI().getPath()
+        Constants.Security.Authorization.EXTENSION_JAR_PATH, authExtensionJar.toURI().getPath(),
+        // we only want to test authorization, but we don't specify principal/keytab, so disable kerberos
+        Constants.Security.KERBEROS_ENABLED, "false"
       };
     }
   }


### PR DESCRIPTION
Allow users to configure a principal and keytab (on local fs or hdfs), for which to launch cdap programs as.

https://issues.cask.co/browse/CDAP-6131
http://builds.cask.co/browse/CDAP-DUT4304
Integration tests: http://builds.cask.co/browse/CDAP-ITM-9

Note: In order to use this feature, https://github.com/caskdata/cdap/pull/5934 must be merged, or the permissions on the system hbase namespace must be granted to the impersonated principals.
