### PR TITLE
[CDAP-6317] Changes to CDAP Kafka properties not deprecated correctly

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -737,6 +737,38 @@
   <!-- Kafka Server Configuration -->
 
   <property>
+    <name>kafka.bind.address</name>
+    <value>${kafka.server.host.name}</value>
+    <description>
+      CDAP Kafka service bind port (deprecated: replaced with kafka.server.host.name)
+    </description>
+  </property>
+
+  <property>
+    <name>kafka.bind.port</name>
+    <value>${kafka.server.port}</value>
+    <description>
+      CDAP Kafka service bind port (deprecated: replaced with kafka.server.port)
+    </description>
+  </property>
+
+  <property>
+    <name>kafka.default.replication.factor</name>
+    <value>${kafka.server.default.replication.factor}</value>
+    <description>
+      CDAP Kafka service replication factor (deprecated: replaced with kafka.server.default.replication.factor)
+    </description>
+  </property>
+
+  <property>
+    <name>kafka.log.dir</name>
+    <value>${kafka.server.log.dirs}</value>
+    <description>
+      CDAP Kafka service log storage directory (deprecated: replaced with kafka.server.log.dirs)
+    </description>
+  </property>
+
+  <property>
     <name>kafka.log.retention.hours</name>
     <value>${kafka.server.log.retention.hours}</value>
     <description>
@@ -788,7 +820,7 @@
     <name>kafka.server.log.dirs</name>
     <value>/tmp/kafka-logs</value>
     <description>
-      CDAP Kafka service log storage directory
+      Comma-separated list of CDAP Kafka service log storage directories
     </description>
   </property>
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="6882f19593d099a1634c4a15d0ce80b2"
+DEFAULT_XML_MD5_HASH="895ddc151e0bb3a2abc24de7990f2182"
 
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"


### PR DESCRIPTION
Re-included all deprecated kafka configs so they don't break doc builds.

http://builds.cask.co/browse/CDAP-DQB43-2
