### PR TITLE
Fixes the height of canvas in Hydrator++ Studio view

### DIFF
--- a/cdap-ui/app/features/hydratorplusplus/adapters.less
+++ b/cdap-ui/app/features/hydratorplusplus/adapters.less
@@ -43,12 +43,12 @@ body.theme-cdap {
     my-dag-plus {
       width: 100%;
       // Dag-Height 60% on smaller screen
-      height: 60vh;
+      height: 61.5vh;
       &:not(.canvas-scroll) {
         // Subtract navbar, top panel, collapsed bottom panel and footer from total viewport height
-        height: ~"-moz-calc(100vh - 187px)";
-        height: ~"-webkit-calc(100vh - 187px)";
-        height: ~"calc(100vh - 187px)";
+        height: ~"-moz-calc(100vh - 145px)";
+        height: ~"-webkit-calc(100vh - 145px)";
+        height: ~"calc(100vh - 145px)";
       }
 
       @media (min-height: 800px) {


### PR DESCRIPTION
- When the bottom panel is minimized the canvas height was lesser than it was supposed to be.
- As a result when we drag the entire dag below the canvas there is a distinctive space between the canvas edge and the bottom panel. 
##### Problem:

![problem](https://cloud.githubusercontent.com/assets/1452845/16622286/7517ac0c-434e-11e6-980d-0c16a81c59c0.gif)
##### Fix

![fix](https://cloud.githubusercontent.com/assets/1452845/16622292/7b715bac-434e-11e6-8e7b-723d9211602e.gif)
