### PR TITLE
CDAP-6350 Declare shell constants as readonly

### DIFF
--- a/cdap-common/bin/common-env.sh
+++ b/cdap-common/bin/common-env.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 #
 # Copyright © 2014-2016 Cask Data, Inc.
 #
@@ -15,7 +14,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# Set environment variables here.
+# This file contains defaults for environment variables used in CDAP. Set overrides in CDAP_CONF_DIR/cdap-env.sh instead.
 
 # The java implementation to use.  Java 1.7 required.
 # export JAVA_HOME=/usr/java/jdk1.7.0/
@@ -53,18 +52,10 @@ export LOCAL_DIR=${LOCAL_DIR:-/var/tmp/cdap}
 # The directory serving as the java.io.tmpdir directory for master
 export TEMP_DIR=${TEMP_DIR:-/tmp}
 
-# The options below can be set in the sourced component-specific conf/[component]-env.sh scripts
+# The options below are be set in the sourced component-specific conf/[component]-env.sh scripts
 
 # Main class to be invoked.
 #MAIN_CLASS=
 
 # Arguments for main class.
 #MAIN_CLASS_ARGS=""
-
-# Adds Hadoop and HBase libs to the classpath on startup.
-# If the "hbase" command is on the PATH, this will be done automatically.
-# Or uncomment the line below to point to the HBase installation directly.
-# HBASE_HOME=
-
-# Extra CLASSPATH
-# EXTRA_CLASSPATH=""

--- a/cdap-distributions/src/etc/cdap/conf.dist/cdap-env.sh
+++ b/cdap-distributions/src/etc/cdap/conf.dist/cdap-env.sh
@@ -22,6 +22,14 @@
 # Override detected SPARK_HOME for Spark support
 # export SPARK_HOME="/usr/lib/spark"
 
+# Adds Hadoop and HBase libs to the classpath on startup.
+# If the "hbase" command is on the PATH, this will be done automatically.
+# Or uncomment the line below to point to the HBase installation directly.
+# HBASE_HOME=
+
+# Extra CLASSPATH locations to add to CDAP Java processes
+# EXTRA_CLASSPATH=""
+
 # LOCAL_DIR sets the JVM -Duser.dir property of the CDAP processes, and provides a
 # local working directory for application jars during startup if needed
 LOCAL_DIR="/var/tmp/cdap"

--- a/cdap-gateway/conf/router-env.sh
+++ b/cdap-gateway/conf/router-env.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -16,14 +15,12 @@
 # the License.
 #
 
-# Set environment variables here.
-
 # Main class to be invoked.
-MAIN_CLASS=co.cask.cdap.gateway.router.RouterMain
+declare -r MAIN_CLASS=co.cask.cdap.gateway.router.RouterMain
 
+# Java Heap settings
+declare -r JAVA_HEAP_VAR=ROUTER_JAVA_HEAPMAX
 ROUTER_JAVA_HEAPMAX=${ROUTER_JAVA_HEAPMAX:--Xmx1024m}
-JAVA_HEAP_VAR=ROUTER_JAVA_HEAPMAX
 
 # Arguments for main class.
-#MAIN_CLASS_ARGS=
-
+declare -r MAIN_CLASS_ARGS=

--- a/cdap-kafka/conf/kafka-server-env.sh
+++ b/cdap-kafka/conf/kafka-server-env.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -16,16 +15,12 @@
 # the License.
 #
 
-# Set environment variables here.
-
 # Main class to be invoked.
-MAIN_CLASS=co.cask.cdap.kafka.run.KafkaServerMain
+declare -r MAIN_CLASS=co.cask.cdap.kafka.run.KafkaServerMain
 
 # Arguments for main class.
-MAIN_CLASS_ARGS=
+declare -r MAIN_CLASS_ARGS=
 
-# Add Hadoop HDFS classpath
-EXTRA_CLASSPATH=
-
+# Java Heap settings
+declare -r JAVA_HEAP_VAR=KAFKA_JAVA_HEAPMAX
 KAFKA_JAVA_HEAPMAX=${KAFKA_JAVA_HEAPMAX:--Xmx1024m}
-JAVA_HEAP_VAR=KAFKA_JAVA_HEAPMAX

--- a/cdap-master/conf/master-env.sh
+++ b/cdap-master/conf/master-env.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -16,18 +15,16 @@
 # the License.
 #
 
-# Set environment variables here.
-
 # Main class to be invoked.
-MAIN_CLASS=co.cask.cdap.data.runtime.main.MasterServiceMain
+declare -r MAIN_CLASS=co.cask.cdap.data.runtime.main.MasterServiceMain
 
 # Arguments for main class.
-MAIN_CLASS_ARGS="start"
+declare -r MAIN_CLASS_ARGS="start"
 
 # Add Hadoop HDFS classpath
 # Assuming update-alternatives convention
 EXTRA_CLASSPATH="/etc/hbase/conf/"
 
+# Java Heap settings
+declare -r JAVA_HEAP_VAR=MASTER_JAVA_HEAPMAX
 MASTER_JAVA_HEAPMAX=${MASTER_JAVA_HEAPMAX:--Xmx1024m}
-JAVA_HEAP_VAR=MASTER_JAVA_HEAPMAX
-

--- a/cdap-security/conf/auth-server-env.sh
+++ b/cdap-security/conf/auth-server-env.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -15,16 +14,15 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# Set environment variables here.
-
 # Main class to be invoked.
-MAIN_CLASS=co.cask.cdap.security.runtime.AuthenticationServerMain
+declare -r MAIN_CLASS=co.cask.cdap.security.runtime.AuthenticationServerMain
 
 # Arguments for main class.
-MAIN_CLASS_ARGS=
+declare -r MAIN_CLASS_ARGS=
 
 # Add Hadoop HDFS classpath
 EXTRA_CLASSPATH="$HBASE_HOME/conf/"
 
+# Java Heap settings
+declare -r JAVA_HEAP_VAR=AUTH_JAVA_HEAPMAX
 AUTH_JAVA_HEAPMAX=${AUTH_JAVA_HEAPMAX:--Xmx1024m}
-JAVA_HEAP_VAR=AUTH_JAVA_HEAPMAX

--- a/cdap-ui/conf/ui-env.sh
+++ b/cdap-ui/conf/ui-env.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -16,8 +15,6 @@
 # the License.
 #
 
-
-# Set environment variables here.
 
 # Main cmd is the non-java command to run.
 MAIN_CMD=node
@@ -35,7 +32,8 @@ if test -x ${CDAP_HOME}/ui/bin/node ; then
   fi
 fi
 
+declare -r MAIN_CMD=${MAIN_CMD}
 export NODE_ENV=production
 
 # Arguments for MAIN_CMD
-MAIN_CMD_ARGS="${CDAP_HOME}/ui/server.js"
+declare -r MAIN_CMD_ARGS="${CDAP_HOME}/ui/server.js"


### PR DESCRIPTION
Specifically, we set `MAIN_CLASS`, `MAIN_CLASS_ARGS`, `MAIN_CMD`, and `JAVA_HEAP_VAR` as readonly, since modifications to these will almost surely break the service in question. This prevents a user from overriding these variables in `cdap-env.sh`.
