### PR TITLE
[CDAP-5726] Use generic recursion for dataset properties builders

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/DatasetProperties.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/DatasetProperties.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.api.dataset;
 
+import co.cask.cdap.api.dataset.lib.FileSetProperties;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -39,13 +41,9 @@ public final class DatasetProperties {
   private final String description;
   private final Map<String, String> properties;
 
-  private DatasetProperties(Map<String, String> properties, @Nullable String description) {
+  protected DatasetProperties(Map<String, String> properties, @Nullable String description) {
     this.description = description;
     this.properties = properties;
-  }
-
-  public static Builder builder() {
-    return new Builder();
   }
 
   @Nullable
@@ -67,14 +65,30 @@ public final class DatasetProperties {
       '}';
   }
 
+  public static Builder builder() {
+    return new Builder();
+  }
+
   /**
    * A Builder to construct DatasetProperties instances.
    */
-  public static class Builder {
+  public static class Builder extends AbstractBuilder<Builder> { }
+
+  /**
+   * A abstract builder that is extensible while preserving the builder pattern. Builders that extend
+   * this builder should be defined as
+   * <pre>
+   *   class SubBuilder extends AbstractBuilder&lt;SubBuilder>
+   * </pre>
+   * This has the effect of returning from all the builder methods with type SubBuilder.
+   *
+   * @param <B> the subclass of this builder that is actually used (e.g. {@link FileSetProperties}
+   */
+  public abstract static class AbstractBuilder<B extends AbstractBuilder> {
     private String description;
     private Map<String, String> properties = new HashMap<>();
 
-    protected Builder() {
+    protected AbstractBuilder() {
     }
 
     /**
@@ -83,9 +97,9 @@ public final class DatasetProperties {
      * @param description dataset description
      * @return this builder object to allow chaining
      */
-    public Builder setDescription(String description) {
+    public B setDescription(String description) {
       this.description = description;
-      return this;
+      return thisBuilder();
     }
 
     /**
@@ -94,9 +108,9 @@ public final class DatasetProperties {
      * @param value the value of the property
      * @return this builder object to allow chaining
      */
-    public Builder add(String key, String value) {
+    public B add(String key, String value) {
       this.properties.put(key, value);
-      return this;
+      return thisBuilder();
     }
 
     /**
@@ -105,9 +119,9 @@ public final class DatasetProperties {
      * @param value the value of the property
      * @return this builder object to allow chaining
      */
-    public Builder add(String key, int value) {
+    public B add(String key, int value) {
       this.properties.put(key, String.valueOf(value));
-      return this;
+      return thisBuilder();
     }
 
     /**
@@ -115,9 +129,9 @@ public final class DatasetProperties {
      * @param properties the map of properties to add
      * @return this builder object to allow chaining
      */
-    public Builder addAll(Map<String, String> properties) {
+    public B addAll(Map<String, String> properties) {
       this.properties.putAll(properties);
-      return this;
+      return thisBuilder();
     }
 
     /**
@@ -126,6 +140,17 @@ public final class DatasetProperties {
      */
     public DatasetProperties build() {
       return new DatasetProperties(Collections.unmodifiableMap(this.properties), description);
+    }
+
+    /**
+     * This is a helper to return the current builder as the correct type.
+     * All builders that extend this builder should use this method to
+     * return from a builder method, instead of returning this.
+     * @return this, cast to the type parameter.
+     */
+    @SuppressWarnings("unchecked")
+    protected B thisBuilder() {
+      return (B) this;
     }
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/FileSetProperties.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/FileSetProperties.java
@@ -94,9 +94,7 @@ public class FileSetProperties {
    */
   public static final String PROPERTY_EXPLORE_TABLE_PROPERTY_PREFIX = "explore.table.property.";
 
-  public static Builder builder() {
-    return new Builder();
-  }
+  protected FileSetProperties() { }
 
   /**
    * @return the base path configured in the properties.
@@ -218,133 +216,145 @@ public class FileSetProperties {
     return result;
   }
 
+  public static Builder builder() {
+    return new Builder();
+  }
+
   /**
    * A Builder to construct properties for FileSet datasets.
    */
-  public static class Builder extends DatasetProperties.Builder {
+  public static class Builder extends AbstractBuilder<Builder> { }
+
+  /**
+   * An abstract builder to construct properties for FileSet datasets. See {@link DatasetProperties} for an
+   * explanation of the need for generics.
+   *
+   * @param <B> the subclass of this builder that is actually used (e.g. {@link PartitionedFileSetProperties}
+   */
+  public abstract static class AbstractBuilder<B extends AbstractBuilder> extends DatasetProperties.AbstractBuilder<B> {
 
     private String format = null;
 
     /**
-     * Package visible default constructor, to allow sub-classing by other datasets in this package.
+     * Protected default constructor, to allow sub-classing by other datasets in this package.
      */
-    Builder() { }
+    AbstractBuilder() { }
 
     /**
      * Sets the base path for the file dataset.
      */
-    public Builder setBasePath(String path) {
+    public B setBasePath(String path) {
       add(BASE_PATH, path);
-      return this;
+      return thisBuilder();
     }
 
     /**
      * Configures whether the files (the data) in this fileset are managed externally.
      */
-    public Builder setDataExternal(boolean isExternal) {
+    public B setDataExternal(boolean isExternal) {
       add(DATA_EXTERNAL, Boolean.toString(isExternal));
-      return this;
+      return thisBuilder();
     }
 
     /**
      * Sets the output format of the file dataset.
      */
-    public Builder setOutputFormat(Class<?> outputFormatClass) {
+    public B setOutputFormat(Class<?> outputFormatClass) {
       setOutputFormat(outputFormatClass.getName());
-      return this;
+      return thisBuilder();
     }
 
     /**
      * Sets the output format of the file dataset.
      */
-    public Builder setOutputFormat(String className) {
+    public B setOutputFormat(String className) {
       add(OUTPUT_FORMAT, className);
-      return this;
+      return thisBuilder();
     }
 
     /**
      * Sets the input format of the file dataset.
      */
-    public Builder setInputFormat(Class<?> inputFormatClass) {
+    public B setInputFormat(Class<?> inputFormatClass) {
       setInputFormat(inputFormatClass.getName());
-      return this;
+      return thisBuilder();
     }
 
     /**
      * Sets the input format of the file dataset.
      */
-    public Builder setInputFormat(String className) {
+    public B setInputFormat(String className) {
       add(INPUT_FORMAT, className);
-      return this;
+      return thisBuilder();
     }
 
     /**
      * Sets a property for the input format of the file dataset.
      */
-    public Builder setInputProperty(String name, String value) {
+    public B setInputProperty(String name, String value) {
       add(INPUT_PROPERTIES_PREFIX + name, value);
-      return this;
+      return thisBuilder();
     }
 
     /**
      * Sets a property for the output format of the file dataset.
      */
-    public Builder setOutputProperty(String name, String value) {
+    public B setOutputProperty(String name, String value) {
       add(OUTPUT_PROPERTIES_PREFIX + name, value);
-      return this;
+      return thisBuilder();
     }
 
     /**
      * Enable explore for this dataset.
      */
-    public Builder setEnableExploreOnCreate(boolean enabled) {
+    public B setEnableExploreOnCreate(boolean enabled) {
       add(PROPERTY_ENABLE_EXPLORE_ON_CREATE, Boolean.toString(enabled));
-      return this;
+      return thisBuilder();
     }
 
     /**
      * Set the format for the Hive table.
      * @param format currently, only "text" and "csv" are supported.
      */
-    public Builder setExploreFormat(String format) {
+    public B setExploreFormat(String format) {
       add(PROPERTY_EXPLORE_FORMAT, format);
       this.format = format;
-      return this;
+      return thisBuilder();
     }
 
     /**
      * Set the schema for the Hive table.
      * @param schema a Hive schema string of the form: field type, ...
      */
-    public Builder setExploreSchema(String schema) {
+    public B setExploreSchema(String schema) {
       add(PROPERTY_EXPLORE_SCHEMA, schema);
-      return this;
+      return thisBuilder();
     }
 
     /**
      * Set a property for the table format.
      * This may only be a called after setting the format using {@link #setExploreFormat}.
      */
-    public Builder setExploreFormatProperty(String name, String value) {
+    public B setExploreFormatProperty(String name, String value) {
       if (format == null) {
         throw new IllegalStateException("explore format has not been set");
       }
       add(String.format("%s.%s.%s", PROPERTY_EXPLORE_FORMAT, format, name), value);
-      return this;
+      return thisBuilder();
     }
 
     /**
      * Set the class name of the SerDe used to create the Hive table.
      */
-    public Builder setSerDe(String className) {
+    public B setSerDe(String className) {
       add(PROPERTY_EXPLORE_SERDE, className);
-      return this;
+      return thisBuilder();
     }
 
     /**
      * Set the class name of the SerDe used to create the Hive table.
      */
-    public Builder setSerDe(Class<?> serde) {
+    public B setSerDe(Class<?> serde) {
       return setSerDe(serde.getName());
     }
 
@@ -353,9 +363,9 @@ public class FileSetProperties {
      * Note that this can be different than the input format used
      * for the file set itself.
      */
-    public Builder setExploreInputFormat(String className) {
+    public B setExploreInputFormat(String className) {
       add(PROPERTY_EXPLORE_INPUT_FORMAT, className);
-      return this;
+      return thisBuilder();
     }
 
     /**
@@ -363,7 +373,7 @@ public class FileSetProperties {
      * Note that this can be different than the input format used
      * for the file set itself.
      */
-    public Builder setExploreInputFormat(Class<?> inputFormat) {
+    public B setExploreInputFormat(Class<?> inputFormat) {
       return setExploreInputFormat(inputFormat.getName());
     }
 
@@ -372,9 +382,9 @@ public class FileSetProperties {
      * Note that this can be different than the output format used
      * for the file set itself.
      */
-    public Builder setExploreOutputFormat(String className) {
+    public B setExploreOutputFormat(String className) {
       add(PROPERTY_EXPLORE_OUTPUT_FORMAT, className);
-      return this;
+      return thisBuilder();
     }
 
     /**
@@ -382,23 +392,16 @@ public class FileSetProperties {
      * Note that this can be different than the output format used
      * for the file set itself.
      */
-    public Builder setExploreOutputFormat(Class<?> outputFormat) {
+    public B setExploreOutputFormat(Class<?> outputFormat) {
       return setExploreOutputFormat(outputFormat.getName());
     }
 
     /**
      * Set a table property to be added to the Hive table. Multiple properties can be set.
      */
-    public Builder setTableProperty(String name, String value) {
+    public B setTableProperty(String name, String value) {
       add(PROPERTY_EXPLORE_TABLE_PROPERTY_PREFIX + name, value);
-      return this;
-    }
-
-    /**
-     * Create a DatasetProperties from this builder.
-     */
-    public DatasetProperties build() {
-      return super.build();
+      return thisBuilder();
     }
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/ObjectMappedTableProperties.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/ObjectMappedTableProperties.java
@@ -36,6 +36,8 @@ import java.util.Map;
 public class ObjectMappedTableProperties {
   private static final SchemaGenerator schemaGenerator = new ReflectionSchemaGenerator();
 
+  private ObjectMappedTableProperties() { }
+
   /**
    * The type of object in the table.
    */
@@ -93,7 +95,7 @@ public class ObjectMappedTableProperties {
   /**
    * A Builder to construct properties for {@link ObjectMappedTable} datasets.
    */
-  public static class Builder extends DatasetProperties.Builder {
+  public static class Builder extends DatasetProperties.AbstractBuilder<Builder> {
 
     private final Gson gson = new Gson();
 
@@ -116,7 +118,7 @@ public class ObjectMappedTableProperties {
     public Builder setType(Type type) throws UnsupportedTypeException {
       add(OBJECT_TYPE, gson.toJson(new TypeRepresentation(type)));
       add(OBJECT_SCHEMA, schemaGenerator.generate(type, false).toString());
-      return this;
+      return thisBuilder();
     }
 
     /**
@@ -131,7 +133,7 @@ public class ObjectMappedTableProperties {
      */
     public Builder setRowKeyExploreName(String name) {
       add(ROW_KEY_EXPLORE_NAME, name);
-      return this;
+      return thisBuilder();
     }
 
     /**
@@ -149,14 +151,7 @@ public class ObjectMappedTableProperties {
         throw new IllegalArgumentException("Key type must be bytes or string.");
       }
       add(ROW_KEY_EXPLORE_TYPE, type.name());
-      return this;
-    }
-
-    /**
-     * Create a DatasetProperties from this builder.
-     */
-    public DatasetProperties build() {
-      return super.build();
+      return thisBuilder();
     }
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSetProperties.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSetProperties.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.api.dataset.lib;
 
 import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.dataset.DatasetProperties;
 
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -25,7 +26,7 @@ import javax.annotation.Nullable;
  * Helper to build properties for files datasets.
  */
 @Beta
-public class PartitionedFileSetProperties extends FileSetProperties {
+public class PartitionedFileSetProperties {
 
   /**
    * The property name for the list of partitioning field names.
@@ -78,19 +79,23 @@ public class PartitionedFileSetProperties extends FileSetProperties {
   }
 
   /**
-   * A Builder to construct properties for FileSet datasets.
+   * A Builder to construct properties for PartitionedFileSet datasets.
    */
-  public static class Builder extends FileSetProperties.Builder {
+  public static class Builder extends AbstractBuilder<Builder> { }
 
-    /**
-     * Package visible default constructor, to allow sub-classing by other datasets in this package.
-     */
-    Builder() { }
+  /**
+   * An abstract builder to construct properties for FileSet datasets. See {@link DatasetProperties} for an
+   * explanation of the need for generics.
+   *
+   * @param <B> the subclass of this builder that is actually used (e.g. {@link PartitionedFileSetProperties}
+   */
+  abstract static class AbstractBuilder<B extends AbstractBuilder>
+    extends FileSetProperties.AbstractBuilder<B> {
 
     /**
      * Sets the base path for the file dataset.
      */
-    public Builder setPartitioning(Partitioning partitioning) {
+    public B setPartitioning(Partitioning partitioning) {
       StringBuilder builder = new StringBuilder();
       String sep = "";
       for (String key : partitioning.getFields().keySet()) {
@@ -101,7 +106,7 @@ public class PartitionedFileSetProperties extends FileSetProperties {
       for (Map.Entry<String, Partitioning.FieldType> entry : partitioning.getFields().entrySet()) {
         add(PARTITIONING_FIELD_PREFIX + entry.getKey(), entry.getValue().name());
       }
-      return this;
+      return thisBuilder();
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -487,12 +487,11 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
   }
 
   private DatasetProperties addLocalDatasetProperty(DatasetProperties properties) {
-    String dsDescription = properties.getDescription();
-    DatasetProperties.Builder builder = DatasetProperties.builder();
-    builder.addAll(properties.getProperties());
-    builder.add(Constants.AppFabric.WORKFLOW_LOCAL_DATASET_PROPERTY, "true");
-    builder.setDescription(dsDescription);
-    return builder.build();
+    return DatasetProperties.builder()
+      .setDescription(properties.getDescription())
+      .addAll(properties.getProperties())
+      .add(Constants.AppFabric.WORKFLOW_LOCAL_DATASET_PROPERTY, "true")
+      .build();
   }
 
   private void createLocalDatasets() throws IOException, DatasetManagementException {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/AllProgramsApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/AllProgramsApp.java
@@ -110,8 +110,8 @@ public class AllProgramsApp extends AbstractApplication {
     try {
       createDataset(DS_WITH_SCHEMA_NAME, ObjectMappedTable.class,
                     ObjectMappedTableProperties.builder()
-                      .setType(DsSchema.class)
                       .setDescription("test object mapped table")
+                      .setType(DsSchema.class)
                       .build()
       );
     } catch (UnsupportedTypeException e) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingAvroDynamicPartitioner.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingAvroDynamicPartitioner.java
@@ -73,17 +73,17 @@ public class AppWithMapReduceUsingAvroDynamicPartitioner extends AbstractApplica
     createDataset(INPUT_DATASET, KeyValueTable.class);
 
     createDataset(OUTPUT_DATASET, PartitionedFileSet.class, PartitionedFileSetProperties.builder()
-      // Properties for partitioning
-      .setPartitioning(Partitioning.builder().addLongField("time").addIntField("zip").build())
-        // Properties for file set
+      // Properties for file set
       .setInputFormat(AvroKeyInputFormat.class)
       .setOutputFormat(AvroKeyOutputFormat.class)
-        // Properties for Explore (to create a partitioned Hive table)
+      // Properties for Explore (to create a partitioned Hive table)
       .setEnableExploreOnCreate(true)
       .setSerDe("org.apache.hadoop.hive.serde2.avro.AvroSerDe")
       .setExploreInputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat")
       .setExploreOutputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat")
       .setTableProperty("avro.schema.literal", SCHEMA_STRING)
+      // Properties for partitioning
+      .setPartitioning(Partitioning.builder().addLongField("time").addIntField("zip").build())
       .build());
 
     addMapReduce(new DynamicPartitioningMapReduce());

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetTest.java
@@ -69,8 +69,8 @@ public class TimePartitionedFileSetTest {
 
   @Before
   public void before() throws Exception {
-    dsFrameworkUtil.createInstance("timePartitionedFileSet", TPFS_INSTANCE, FileSetProperties.builder()
-      .setBasePath("testDir").build());
+    dsFrameworkUtil.createInstance("timePartitionedFileSet", TPFS_INSTANCE,
+                                   FileSetProperties.builder().setBasePath("testDir").build());
   }
 
   @After

--- a/cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansing.java
+++ b/cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansing.java
@@ -51,14 +51,15 @@ public class DataCleansing extends AbstractApplication {
     // Create the "rawRecords" partitioned file set for storing the input records, 
     // configure it to work with MapReduce
     createDataset(RAW_RECORDS, PartitionedFileSet.class, PartitionedFileSetProperties.builder()
+      .setDescription("Store input records")
       // Properties for partitioning
       .setPartitioning(Partitioning.builder().addLongField("time").build())
       // Properties for file set
       .setInputFormat(TextInputFormat.class)
-      .setDescription("Store input records")
       .build());
 
     createDataset(CLEAN_RECORDS, PartitionedFileSet.class, PartitionedFileSetProperties.builder()
+      .setDescription("Store clean records")
       // Properties for partitioning
       .setPartitioning(Partitioning.builder().addLongField("time").addIntField("zip").build())
       // Properties for file set
@@ -68,10 +69,10 @@ public class DataCleansing extends AbstractApplication {
       .setExploreFormat("text")
       .setExploreFormatProperty("delimiter", "\n")
       .setExploreSchema("record STRING")
-      .setDescription("Store clean records")
       .build());
 
     createDataset(INVALID_RECORDS, PartitionedFileSet.class, PartitionedFileSetProperties.builder()
+      .setDescription("Store invalid records")
       // Properties for partitioning
       .setPartitioning(Partitioning.builder().addLongField("time").build())
       // Properties for file set
@@ -81,7 +82,6 @@ public class DataCleansing extends AbstractApplication {
       .setExploreFormat("text")
       .setExploreFormatProperty("delimiter", "\n")
       .setExploreSchema("record STRING")
-      .setDescription("Store invalid records")
       .build());
   }
 }

--- a/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetExample.java
+++ b/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetExample.java
@@ -37,16 +37,16 @@ public class FileSetExample extends AbstractApplication {
     setName("FileSetExample");
     setDescription("Application with a MapReduce that uses a FileSet dataset");
     createDataset("lines", FileSet.class, FileSetProperties.builder()
+      .setDescription("Store input lines")
       .setBasePath("example/data/lines")
       .setInputFormat(TextInputFormat.class)
       .setOutputFormat(TextOutputFormat.class)
-      .setDescription("Store input lines")
       .build());
     createDataset("counts", FileSet.class, FileSetProperties.builder()
+      .setDescription("Store word counts")
       .setInputFormat(TextInputFormat.class)
       .setOutputFormat(TextOutputFormat.class)
       .setOutputProperty(TextOutputFormat.SEPERATOR, ":")
-      .setDescription("Store word counts")
       .build());
     addService(new FileSetService());
     addMapReduce(new WordCount());

--- a/cdap-examples/LogAnalysis/src/main/java/co/cask/cdap/examples/loganalysis/LogAnalysisApp.java
+++ b/cdap-examples/LogAnalysis/src/main/java/co/cask/cdap/examples/loganalysis/LogAnalysisApp.java
@@ -93,9 +93,10 @@ public class LogAnalysisApp extends AbstractApplication {
     createDataset(HIT_COUNT_STORE, KeyValueTable.class,
                   DatasetProperties.builder().setDescription("Store hit counts").build());
     createDataset(REQ_COUNT_STORE, TimePartitionedFileSet.class, FileSetProperties.builder()
+      .setDescription("Store request counts")
       .setOutputFormat(TextOutputFormat.class)
       .setOutputProperty(TextOutputFormat.SEPERATOR, ":")
-      .setDescription("Store request counts").build());
+      .build());
   }
 
   /**

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
@@ -85,8 +85,8 @@ public class PurchaseApp extends AbstractApplication {
 
     createDataset("history", PurchaseHistoryStore.class, PurchaseHistoryStore.properties("History dataset"));
     try {
-      createDataset("purchases", ObjectMappedTable.class, ObjectMappedTableProperties.builder().setType(Purchase.class)
-        .setDescription("Store purchases").build());
+      createDataset("purchases", ObjectMappedTable.class, ObjectMappedTableProperties.builder()
+        .setDescription("Store purchases").setType(Purchase.class).build());
     } catch (UnsupportedTypeException e) {
       // This exception is thrown by ObjectMappedTable if its parameter type cannot be
       // (de)serialized (for example, if it is an interface and not a class, then there is

--- a/cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/SportResults.java
+++ b/cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/SportResults.java
@@ -35,7 +35,8 @@ public class SportResults extends AbstractApplication {
 
     // Create the "results" partitioned file set, configure it to work with MapReduce and with Explore
     createDataset("results", PartitionedFileSet.class, PartitionedFileSetProperties.builder()
-      // Properties for partitioning
+      .setDescription("FileSet dataset of game results for a sport league and season")
+        // Properties for partitioning
       .setPartitioning(Partitioning.builder().addStringField("league").addIntField("season").build())
       // Properties for file set
       .setInputFormat(TextInputFormat.class)
@@ -50,7 +51,8 @@ public class SportResults extends AbstractApplication {
 
     // Create the aggregates partitioned file set, configure it to work with MapReduce and with Explore
     createDataset("totals", PartitionedFileSet.class, PartitionedFileSetProperties.builder()
-      // Properties for partitioning
+      .setDescription("FileSet dataset of aggregated results for each sport league")
+        // Properties for partitioning
       .setPartitioning(Partitioning.builder().addStringField("league").build())
       // Properties for file set
       .setInputFormat(TextInputFormat.class)
@@ -60,7 +62,6 @@ public class SportResults extends AbstractApplication {
       .setEnableExploreOnCreate(true)
       .setExploreFormat("csv")
       .setExploreSchema("team STRING, wins INT, ties INT, losses INT, scored INT, conceded INT")
-      .setDescription("FileSet dataset of aggregated results for each sport league")
       .build());
   }
 }

--- a/cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionApp.java
+++ b/cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionApp.java
@@ -48,7 +48,8 @@ public class StreamConversionApp extends AbstractApplication {
 
     // create the time-partitioned file set, configure it to work with MapReduce and with Explore
     createDataset("converted", TimePartitionedFileSet.class, FileSetProperties.builder()
-      // properties for file set
+      .setDescription("Converted stream events dataset")
+        // properties for file set
       .setBasePath("converted")
       .setInputFormat(AvroKeyInputFormat.class)
       .setOutputFormat(AvroKeyOutputFormat.class)
@@ -59,7 +60,6 @@ public class StreamConversionApp extends AbstractApplication {
       .setExploreInputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat")
       .setExploreOutputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat")
       .setTableProperty("avro.schema.literal", SCHEMA_STRING)
-      .setDescription("Converted stream events dataset")
       .build());
   }
 }

--- a/cdap-examples/UserProfiles/src/main/java/co/cask/cdap/examples/profiles/UserProfiles.java
+++ b/cdap-examples/UserProfiles/src/main/java/co/cask/cdap/examples/profiles/UserProfiles.java
@@ -54,12 +54,12 @@ public class UserProfiles extends AbstractApplication {
       Schema.Field.of("active", Schema.nullableOf(Schema.of(Schema.Type.LONG)))
     );
     createDataset("profiles", Table.class.getName(), DatasetProperties.builder()
-      // create the profiles table with column-level conflict detection
+      .setDescription("Profiles table with column-level conflict detection")
+        // create the profiles table with column-level conflict detection
       .add(Table.PROPERTY_CONFLICT_LEVEL, ConflictDetection.COLUMN.name())
       .add(Table.PROPERTY_SCHEMA, profileSchema.toString())
       // to indicate that the id field should come from the row key and not a row column
       .add(Table.PROPERTY_SCHEMA_ROW_FIELD, "id")
-      .setDescription("Profiles table with column-level conflict detection")
       .build());
   }
 }


### PR DESCRIPTION
This makes it possible to mix setXYZ() methods from DatasetProperties.Builder, FileSetProperties.Builder and PartitionedFileSetProperties.Builder. Previously, they had to be in a specific order (PFS first, FileSet next, DatasetProps last), due to the way the builders were defined.  
