### PR TITLE
Feature/hdinsight v2 scripts 34

### DIFF
--- a/cdap-distributions/src/hdinsight/cdap-conf.json
+++ b/cdap-distributions/src/hdinsight/cdap-conf.json
@@ -5,6 +5,10 @@
       "kafka.log.dir": "/var/cdap/kafka-logs",
       "explore.enabled": "{{EXPLORE_ENABLED}}"
     },
+    "cdap_env": {
+      "tez_home": "/usr/hdp/{{HDP_VERSION}}/tez",
+      "tez_conf_dir": "/etc/tez/conf"
+    },
     "fs_superuser": "root",
     "skip_prerequisites": "true",
     "version": "{{CDAP_VERSION}}"

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -69,7 +69,9 @@ ${__packerdir}/cookbook-dir.sh || die "Failed to setup cookbook dir"
 ${__packerdir}/cookbook-setup.sh || die "Failed to install cookbooks"
 
 # CDAP cli install, ensures package dependencies are present
-chef-solo -o 'recipe[cdap::cli]'
+# We must specify the cdap version
+echo "{\"cdap\": \"version\": \"${CDAP_VERSION}\"}}" > ${__tmpdir}/cli-conf.json
+chef-solo -o 'recipe[cdap::cli]' -j ${__tmpdir}/cli-conf.json
 
 # Read zookeeper quorum from hbase-site.xml, using sourced init script function
 source ${__gitdir}/cdap-common/bin/common.sh || die "Cannot source CDAP common script"

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -15,20 +15,8 @@
 # the License.
 
 #
-# Install CDAP for Azure HDInsight cluster
+# Install CDAP for Azure HDInsight v2 marketplace
 #
-
-# Arguments supplied by https://raw.githubusercontent.com/hdinsight/Edge-Node-Scripts/release-12-1-2015/edgeNodeSetup.sh
-CLUSTERNAME=${1}
-USERID=${2}
-PASSWD=${3}
-CUSTOMPARAMETER=${4} # Not used
-SSHUSER=${5}
-
-# Ambari constants
-AMBARICONFIGS_SH=/var/lib/ambari-server/resources/scripts/configs.sh
-AMBARIPORT=8080
-
 
 # CDAP config
 # The git branch to clone
@@ -36,9 +24,9 @@ CDAP_BRANCH='release/3.4'
 # Optional tag to checkout - All released versions of this script should set this
 CDAP_TAG=''
 # The CDAP package version passed to Chef
-CDAP_VERSION='3.4.0-1'
+CDAP_VERSION='3.4.3-1'
 # The version of Chef to install
-CHEF_VERSION='12.7.2'
+CHEF_VERSION='12.10.24'
 # cdap-site.xml configuration parameters
 EXPLORE_ENABLED='true'
 
@@ -55,148 +43,6 @@ die() { echo "ERROR: ${*}"; exit 1; };
 
 __cleanup_tmpdir() { test -d ${__tmpdir} && rm -rf ${__tmpdir}; };
 __create_tmpdir() { mkdir -p ${__tmpdir}; };
-
-
-# HDInsight cluster maintains an /etc/hosts entry 'headnodehost' to designate active master.
-# Here on the edgenode we only have 'headnode0' and 'headnode1', so we can only guess and check
-# Sets ${ACTIVEAMBARIHOST} if successful
-setHeadNodeOrDie() {
-  __validateAmbariConnectivity 'headnode0' || __validateAmbariConnectivity 'headnode1' || die 'Could not determine active headnode'
-}
-
-# Given a candidate Ambari host, try to perform an API GET
-# Dies if credentials are bad
-__validateAmbariConnectivity() {
-    ACTIVEAMBARIHOST=${1}
-    coreSiteContent=$(bash ${AMBARICONFIGS_SH} -u ${USERID} -p ${PASSWD} get ${ACTIVEAMBARIHOST} ${CLUSTERNAME} core-site)
-    local __ret=$?
-    if [[ ${coreSiteContent} == *"[ERROR]"* && ${coreSiteContent} == *"Bad credentials"* ]]; then
-        die '[ERROR] Username and password are invalid. Exiting!'
-    fi
-    return ${__ret}
-}
-
-# Given a config type, name, and value, set the configuration via the Ambari API
-# Dies if unsuccessful
-setAmbariConfig() {
-    local __configtype=${1} # core-site, etc
-    local __name=${2}
-    local __value=${3}
-    updateResult=$(bash ${AMBARICONFIGS_SH} -u ${USERID} -p ${PASSWD} set ${ACTIVEAMBARIHOST} ${CLUSTERNAME} ${__configtype} ${__name} ${__value})
-
-    if [[ ${updateResult} != *"Tag:version"* ]] && [[ ${updateResult} == *"[ERROR]"* ]]; then
-        die "[ERROR] Failed to update ${__configtype}: ${updateResult}"
-    fi
-}
-
-# DANGEROUS! unless you know your input is unique
-# Runs sed -i to update local Hadoop/HBase client configuration
-substituteLocalConfigValue() {
-    local __oldVal=${1}
-    local __newVal=${2}
-
-    for f in $(ls -1 /etc/hadoop/conf/*.xml /etc/hbase/conf/*.xml) ; do
-      sed -i.old -e "s#${__oldVal}#${__newVal}#g" ${f}
-    done
-}
-
-# Fetches value of fs.azure.page.blob.dir, appends '/cdap' to it, updates it via Ambari API, updates the local client configurations, and restarts cluster services
-updateFsAzurePageBlobDirForCDAP() {
-    currentValue=$(bash ${AMBARICONFIGS_SH} -u ${USERID} -p ${PASSWD} get ${ACTIVEAMBARIHOST} ${CLUSTERNAME} core-site | grep 'fs.azure.page.blob.dir' | cut -d' ' -f3 | sed -e 's/"\(.*\)"[,]*/\1/')
-    if [ -n ${currentValue} ]; then
-      if echo ${currentValue} | grep -q '/cdap'; then
-        echo "fs.azure.page.blob.dir already contains /cdap"
-        return 0
-      else
-        newValue="${currentValue},/cdap"
-      fi
-    else
-      newValue="/cdap"
-    fi
-    echo "Updating fs.azure.page.blob.dir to ${newValue}"
-    setAmbariConfig 'core-site' 'fs.azure.page.blob.dir' ${newValue} || die "Could not update Ambari config"
-    substituteLocalConfigValue ${currentValue} ${newValue} || die "Could not update Local Hadoop Client config"
-    restartCdapDependentClusterServices
-}
-
-__waitForServiceState() {
-    local __svc=${1}
-    local __state=${2}
-
-    for i in {1..60} ; do
-      __currState=$(curl -s -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X GET http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${__svc} | grep \"state\" | awk '{ print $3}' | sed -e 's/"\(.*\)"[,]*/\1/')
-      if [ "${__state}" == "${__currState}" ]; then
-        return 0
-      else
-        sleep 5
-      fi
-    done
-    echo "ERROR: giving up waiting for ${__svc} state to become ${__state}. Current state: ${__currState}"
-    return 1
-}
-
-# Stop an Ambari cluster service
-stopServiceViaRest() {
-    if [ -z "${1}" ]; then
-        echo "Need service name to stop service"
-        exit 136
-    fi
-    SERVICENAME=${1}
-    echo "Stopping ${SERVICENAME}"
-    curl -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X PUT -d '{"RequestInfo": {"context" :"Stop Service for CDAP installation"}, "Body": {"ServiceInfo": {"state": "INSTALLED"}}}' http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${SERVICENAME}
-}
-
-# Start an Ambari cluster service
-startServiceViaRest() {
-    if [ -z "${1}" ]; then
-        echo "Need service name to start service"
-        exit 136
-    fi
-    sleep 2
-    SERVICENAME=${1}
-    echo "Starting ${SERVICENAME}"
-    startResult=$(curl -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X PUT -d '{"RequestInfo": {"context" :"Start Service for CDAP installation"}, "Body": {"ServiceInfo": {"state": "STARTED"}}}' http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${SERVICENAME})
-    if [[ ${startResult} == *"500 Server Error"* || ${startResult} == *"internal system exception occurred"* ]]; then
-        sleep 60
-        echo "Retry starting ${SERVICENAME}"
-        startResult=$(curl -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X PUT -d '{"RequestInfo": {"context" :"Start Service for CDAP installation"}, "Body": {"ServiceInfo": {"state": "STARTED"}}}' http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${SERVICENAME})
-    fi
-    echo ${startResult}
-}
-
-# Restart Ambari cluster services
-# Ambari API is asynchronous, so this implements polling to make it somewhat synchronous
-restartCdapDependentClusterServices() {
-    stopServiceViaRest HBASE
-    stopServiceViaRest YARN
-    stopServiceViaRest MAPREDUCE2
-    stopServiceViaRest HDFS
-
-    __waitForServiceState HBASE INSTALLED || die "Could not stop service HBASE"
-    __waitForServiceState YARN INSTALLED || die "Could not stop service YARN"
-    __waitForServiceState MAPREDUCE2 INSTALLED || die "Could not stop service MAPREDUCE2"
-    __waitForServiceState HDFS INSTALLED || die "Could not stop service HDFS"
-
-    startServiceViaRest HDFS
-    startServiceViaRest MAPREDUCE2
-    startServiceViaRest YARN
-    startServiceViaRest HBASE
-
-    __waitForServiceState HDFS STARTED || die "Could not start service HDFS"
-    __waitForServiceState MAPREDUCE2 STARTED || die "Could not start service MAPREDUCE2"
-    __waitForServiceState YARN STARTED || die "Could not start service YARN"
-    __waitForServiceState HBASE STARTED || die "Could not start service HBASE"
-}
-
-
-# Begin Ambari Cluster Prep
-
-# Find/Validate Ambari connectivity
-setHeadNodeOrDie && echo "Found active Ambari host: ${ACTIVEAMBARIHOST}"
-
-# Update necessary hadoop configuration
-updateFsAzurePageBlobDirForCDAP
-
 
 # Begin CDAP Prep/Install
 

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -88,8 +88,8 @@ sed \
   -e "s/{{EXPLORE_ENABLED}}/${EXPLORE_ENABLED}/" \
   ${__cdap_site_template} > ${__tmpdir}/generated-conf.json
 
-# Install/Configure ntp, CDAP
-chef-solo -o 'recipe[ntp::default],recipe[ulimit::default],recipe[cdap::fullstack],recipe[cdap::init]' -j ${__tmpdir}/generated-conf.json
+# Install/Configure CDAP
+chef-solo -o 'recipe[ulimit::default],recipe[cdap::fullstack],recipe[cdap::init]' -j ${__tmpdir}/generated-conf.json
 
 # Temporary Hack to workaround CDAP-4089
 rm -f /opt/cdap/kafka/lib/log4j.log4j-1.2.14.jar

--- a/cdap-distributions/src/hdinsight/pageblob-configure.sh
+++ b/cdap-distributions/src/hdinsight/pageblob-configure.sh
@@ -44,7 +44,7 @@ checkHostNameAndSetClusterName() {
 
 # Try to perform an Ambari API GET
 # Dies if credentials are bad
-__validateAmbariConnectivity() {
+validateAmbariConnectivity() {
     local __coreSiteContent
     local __ret
     __coreSiteContent=$(${AMBARICONFIGS_SH} ${AMBARICREDS} get ${ACTIVEAMBARIHOST} ${CLUSTERNAME} core-site)
@@ -133,7 +133,7 @@ restartCdapDependentClusterServices() {
 
 checkHostNameAndSetClusterName
 
-__validateAmbariConnectivity
+validateAmbariConnectivity
 
 # Update necessary hadoop configuration
 updateFsAzurePageBlobDirForCDAP

--- a/cdap-distributions/src/hdinsight/pageblob-configure.sh
+++ b/cdap-distributions/src/hdinsight/pageblob-configure.sh
@@ -95,7 +95,8 @@ stopServiceViaRest() {
     local SERVICENAME=${1}
     [[ ${SERVICENAME} ]] || die "Need service name to stop service" 136
     echo "Stopping ${SERVICENAME}"
-    curl -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X PUT -d '{"RequestInfo": {"context" :"Configure Azure page blob support for CDAP installation"}, "Body": {"ServiceInfo": {"state": "INSTALLED"}}}' http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${SERVICENAME}
+    cmd="curl -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X PUT -d '{\"RequestInfo\": {\"context\" :\"Configure Azure page blob support for CDAP installation. Stopping ${SERVICENAME}\"}, \"Body\": {\"ServiceInfo\": {\"state\": \"INSTALLED\"}}}' http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${SERVICENAME}"
+    eval $cmd
 }
 
 # Start an Ambari cluster service
@@ -105,7 +106,7 @@ startServiceViaRest() {
     [[ ${SERVICENAME} ]] || die "Need service name to start service" 136
     sleep 2
     echo "Starting ${SERVICENAME}"
-    cmd="curl -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X PUT -d '{\"RequestInfo\": {\"context\" :\"Configure Azure page blob support for CDAP installation\"}, \"Body\": {\"ServiceInfo\": {\"state\": \"STARTED\"}}}' http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${SERVICENAME}"
+    cmd="curl -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X PUT -d '{\"RequestInfo\": {\"context\" :\"Configure Azure page blob support for CDAP installation. Starting ${SERVICENAME}\"}, \"Body\": {\"ServiceInfo\": {\"state\": \"STARTED\"}}}' http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${SERVICENAME}"
     __startResult=$(eval $cmd)
     if [[ ${__startResult} =~ "500 Server Error" || ${__startResult} =~ "internal system exception occurred" ]]; then
         sleep 60

--- a/cdap-distributions/src/hdinsight/pageblob-configure.sh
+++ b/cdap-distributions/src/hdinsight/pageblob-configure.sh
@@ -76,14 +76,14 @@ updateFsAzurePageBlobDirForCDAP() {
     local __newValue
     __currentValue=$(${AMBARICONFIGS_SH} ${AMBARICREDS} get ${ACTIVEAMBARIHOST} ${CLUSTERNAME} core-site | grep 'fs.azure.page.blob.dir' | cut -d' ' -f3 | sed -e 's/"\(.*\)"[,]*/\1/')
     if [ -n ${__currentValue} ]; then
-      if [[ ${__currentValue} =~ "/cdap" ]]; then
-        echo "fs.azure.page.blob.dir already contains /cdap"
-        return 0
-      else
-        __newValue="${__currentValue},/cdap"
-      fi
+        if [[ ${__currentValue} =~ "/cdap" ]]; then
+            echo "fs.azure.page.blob.dir already contains /cdap"
+            return 0
+        else
+            __newValue="${__currentValue},/cdap"
+        fi
     else
-      __newValue="/cdap"
+        __newValue="/cdap"
     fi
     echo "Updating fs.azure.page.blob.dir to ${__newValue}"
     setAmbariConfig 'core-site' 'fs.azure.page.blob.dir' ${__newValue} || die "Could not update Ambari config" 1

--- a/cdap-distributions/src/hdinsight/pageblob-configure.sh
+++ b/cdap-distributions/src/hdinsight/pageblob-configure.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+#
+# Copyright © 2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+#
+# Configure HDFS Pageblob support for CDAP HDInsight cluster
+#
+
+# Ambari constants
+AMBARICONFIGS_SH=/var/lib/ambari-server/resources/scripts/configs.sh
+AMBARIPORT=8080
+ACTIVEAMBARIHOST=headnodehost
+
+# Function definitions
+
+die() { echo "ERROR: ${*}"; exit 1; };
+
+checkHostNameAndSetClusterName() {
+    fullHostName=$(hostname -f)
+    echo "fullHostName=$fullHostName"
+    CLUSTERNAME=$(sed -n -e 's/.*\.\(.*\)-ssh.*/\1/p' <<< $fullHostName)
+    if [ -z "$CLUSTERNAME" ]; then
+        CLUSTERNAME=$(echo -e "import hdinsight_common.ClusterManifestParser as ClusterManifestParser\nprint ClusterManifestParser.parse_local_manifest().deployment.cluster_name" | python)
+        if [ $? -ne 0 ]; then
+            echo "[ERROR] Cannot determine cluster name. Exiting!"
+            exit 133
+        fi
+    fi
+    echo "Cluster Name=$CLUSTERNAME"
+}
+
+# Try to perform an Ambari API GET
+# Dies if credentials are bad
+__validateAmbariConnectivity() {
+    coreSiteContent=$(bash ${AMBARICONFIGS_SH} -u ${USERID} -p ${PASSWD} get ${ACTIVEAMBARIHOST} ${CLUSTERNAME} core-site)
+    if [[ ${coreSiteContent} == *"[ERROR]"* && ${coreSiteContent} == *"Bad credentials"* ]]; then
+        echo '[ERROR] Username and password are invalid. Exiting!'
+        exit 134
+    fi
+}
+
+# Given a config type, name, and value, set the configuration via the Ambari API
+# Dies if unsuccessful
+setAmbariConfig() {
+    local __configtype=${1} # core-site, etc
+    local __name=${2}
+    local __value=${3}
+    updateResult=$(bash ${AMBARICONFIGS_SH} -u ${USERID} -p ${PASSWD} set ${ACTIVEAMBARIHOST} ${CLUSTERNAME} ${__configtype} ${__name} ${__value})
+
+    if [[ ${updateResult} != *"Tag:version"* ]] && [[ ${updateResult} == *"[ERROR]"* ]]; then
+        die "[ERROR] Failed to update ${__configtype}: ${updateResult}"
+    fi
+}
+
+# Fetches value of fs.azure.page.blob.dir, appends '/cdap' to it, updates it via Ambari API, updates the local client configurations, and restarts cluster services
+updateFsAzurePageBlobDirForCDAP() {
+    currentValue=$(bash ${AMBARICONFIGS_SH} -u ${USERID} -p ${PASSWD} get ${ACTIVEAMBARIHOST} ${CLUSTERNAME} core-site | grep 'fs.azure.page.blob.dir' | cut -d' ' -f3 | sed -e 's/"\(.*\)"[,]*/\1/')
+    if [ -n ${currentValue} ]; then
+      if echo ${currentValue} | grep -q '/cdap'; then
+        echo "fs.azure.page.blob.dir already contains /cdap"
+        return 0
+      else
+        newValue="${currentValue},/cdap"
+      fi
+    else
+      newValue="/cdap"
+    fi
+    echo "Updating fs.azure.page.blob.dir to ${newValue}"
+    setAmbariConfig 'core-site' 'fs.azure.page.blob.dir' ${newValue} || die "Could not update Ambari config"
+    restartCdapDependentClusterServices
+}
+
+# Stop an Ambari cluster service
+stopServiceViaRest() {
+    if [ -z "${1}" ]; then
+        echo "Need service name to stop service"
+        exit 136
+    fi
+    SERVICENAME=${1}
+    echo "Stopping ${SERVICENAME}"
+    curl -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X PUT -d '{"RequestInfo": {"context" :"Configure Azure page blob support for CDAP installation"}, "Body": {"ServiceInfo": {"state": "INSTALLED"}}}' http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${SERVICENAME}
+}
+
+# Start an Ambari cluster service
+startServiceViaRest() {
+    if [ -z "${1}" ]; then
+        echo "Need service name to start service"
+        exit 136
+    fi
+    sleep 2
+    SERVICENAME=${1}
+    echo "Starting ${SERVICENAME}"
+    startResult=$(curl -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X PUT -d '{"RequestInfo": {"context" :"Configure Azure page blob support for CDAP installation"}, "Body": {"ServiceInfo": {"state": "STARTED"}}}' http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${SERVICENAME})
+    if [[ ${startResult} == *"500 Server Error"* || ${startResult} == *"internal system exception occurred"* ]]; then
+        sleep 60
+        echo "Retry starting ${SERVICENAME}"
+        startResult=$(curl -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X PUT -d '{"RequestInfo": {"context" :"Configure Azure page blob support for CDAP installation"}, "Body": {"ServiceInfo": {"state": "STARTED"}}}' http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${SERVICENAME})
+    fi
+    echo ${startResult}
+}
+
+# Restart Ambari cluster services
+restartCdapDependentClusterServices() {
+    stopServiceViaRest HBASE
+    stopServiceViaRest YARN
+    stopServiceViaRest MAPREDUCE2
+    stopServiceViaRest HDFS
+
+    startServiceViaRest HDFS
+    startServiceViaRest MAPREDUCE2
+    startServiceViaRest YARN
+    startServiceViaRest HBASE
+}
+
+
+# Begin Ambari Cluster Prep
+
+USERID=$(echo -e "import hdinsight_common.Constants as Constants\nprint Constants.AMBARI_WATCHDOG_USERNAME" | python)
+echo "USERID=$USERID"
+
+PASSWD=$(echo -e "import hdinsight_common.ClusterManifestParser as ClusterManifestParser\nimport hdinsight_common.Constants as Constants\nimport base64\nbase64pwd = ClusterManifestParser.parse_local_manifest().ambari_users.usersmap[Constants.AMBARI_WATCHDOG_USERNAME].password\nprint base64.b64decode(base64pwd)" | python)
+
+checkHostNameAndSetClusterName
+
+__validateAmbariConnectivity
+
+# Update necessary hadoop configuration
+updateFsAzurePageBlobDirForCDAP
+
+exit 0


### PR DESCRIPTION
Updates for HDInsight V2.  This is against the release/3.4 branch as we hope to get an initial release out soon.
- [x] splits the install script into two... `pageblob-configure.sh` to make the HDFS configuration changes to Ambari and restart dependent services, and `install.sh` to actually install CDAP.  This is because these scripts are run on the client by Ambari itself, and Ambari empirically will not start services while the script is still running.
- [x] Ambari credentials are no longer passed to the script, but instead obtained per their guide
- [x] Ambari functions are copied from their examples, else otherwise equivalent
- [x] bugfix to set version of cli installed
- [x] no longer mess with ntp
- [x] configure Tez in `cdap-env.sh`
- [ ] next PR will contain the template that runs these scripts
