### PR TITLE
Revert "[CDAP-5726] Use generic recursion for dataset properties builders"

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/DatasetProperties.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/DatasetProperties.java
@@ -16,8 +16,6 @@
 
 package co.cask.cdap.api.dataset;
 
-import co.cask.cdap.api.dataset.lib.FileSetProperties;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -41,9 +39,13 @@ public final class DatasetProperties {
   private final String description;
   private final Map<String, String> properties;
 
-  protected DatasetProperties(Map<String, String> properties, @Nullable String description) {
+  private DatasetProperties(Map<String, String> properties, @Nullable String description) {
     this.description = description;
     this.properties = properties;
+  }
+
+  public static Builder builder() {
+    return new Builder();
   }
 
   @Nullable
@@ -65,30 +67,14 @@ public final class DatasetProperties {
       '}';
   }
 
-  public static Builder builder() {
-    return new Builder();
-  }
-
   /**
    * A Builder to construct DatasetProperties instances.
    */
-  public static class Builder extends AbstractBuilder<Builder> { }
-
-  /**
-   * A abstract builder that is extensible while preserving the builder pattern. Builders that extend
-   * this builder should be defined as
-   * <pre>
-   *   class SubBuilder extends AbstractBuilder&lt;SubBuilder>
-   * </pre>
-   * This has the effect of returning from all the builder methods with type SubBuilder.
-   *
-   * @param <B> the subclass of this builder that is actually used (e.g. {@link FileSetProperties}
-   */
-  public abstract static class AbstractBuilder<B extends AbstractBuilder> {
+  public static class Builder {
     private String description;
     private Map<String, String> properties = new HashMap<>();
 
-    protected AbstractBuilder() {
+    protected Builder() {
     }
 
     /**
@@ -97,9 +83,9 @@ public final class DatasetProperties {
      * @param description dataset description
      * @return this builder object to allow chaining
      */
-    public B setDescription(String description) {
+    public Builder setDescription(String description) {
       this.description = description;
-      return thisBuilder();
+      return this;
     }
 
     /**
@@ -108,9 +94,9 @@ public final class DatasetProperties {
      * @param value the value of the property
      * @return this builder object to allow chaining
      */
-    public B add(String key, String value) {
+    public Builder add(String key, String value) {
       this.properties.put(key, value);
-      return thisBuilder();
+      return this;
     }
 
     /**
@@ -119,9 +105,9 @@ public final class DatasetProperties {
      * @param value the value of the property
      * @return this builder object to allow chaining
      */
-    public B add(String key, int value) {
+    public Builder add(String key, int value) {
       this.properties.put(key, String.valueOf(value));
-      return thisBuilder();
+      return this;
     }
 
     /**
@@ -129,9 +115,9 @@ public final class DatasetProperties {
      * @param properties the map of properties to add
      * @return this builder object to allow chaining
      */
-    public B addAll(Map<String, String> properties) {
+    public Builder addAll(Map<String, String> properties) {
       this.properties.putAll(properties);
-      return thisBuilder();
+      return this;
     }
 
     /**
@@ -140,17 +126,6 @@ public final class DatasetProperties {
      */
     public DatasetProperties build() {
       return new DatasetProperties(Collections.unmodifiableMap(this.properties), description);
-    }
-
-    /**
-     * This is a helper to return the current builder as the correct type.
-     * All builders that extend this builder should use this method to
-     * return from a builder method, instead of returning this.
-     * @return this, cast to the type parameter.
-     */
-    @SuppressWarnings("unchecked")
-    protected B thisBuilder() {
-      return (B) this;
     }
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/FileSetProperties.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/FileSetProperties.java
@@ -94,7 +94,9 @@ public class FileSetProperties {
    */
   public static final String PROPERTY_EXPLORE_TABLE_PROPERTY_PREFIX = "explore.table.property.";
 
-  protected FileSetProperties() { }
+  public static Builder builder() {
+    return new Builder();
+  }
 
   /**
    * @return the base path configured in the properties.
@@ -216,145 +218,133 @@ public class FileSetProperties {
     return result;
   }
 
-  public static Builder builder() {
-    return new Builder();
-  }
-
   /**
    * A Builder to construct properties for FileSet datasets.
    */
-  public static class Builder extends AbstractBuilder<Builder> { }
-
-  /**
-   * An abstract builder to construct properties for FileSet datasets. See {@link DatasetProperties} for an
-   * explanation of the need for generics.
-   *
-   * @param <B> the subclass of this builder that is actually used (e.g. {@link PartitionedFileSetProperties}
-   */
-  public abstract static class AbstractBuilder<B extends AbstractBuilder> extends DatasetProperties.AbstractBuilder<B> {
+  public static class Builder extends DatasetProperties.Builder {
 
     private String format = null;
 
     /**
-     * Protected default constructor, to allow sub-classing by other datasets in this package.
+     * Package visible default constructor, to allow sub-classing by other datasets in this package.
      */
-    AbstractBuilder() { }
+    Builder() { }
 
     /**
      * Sets the base path for the file dataset.
      */
-    public B setBasePath(String path) {
+    public Builder setBasePath(String path) {
       add(BASE_PATH, path);
-      return thisBuilder();
+      return this;
     }
 
     /**
      * Configures whether the files (the data) in this fileset are managed externally.
      */
-    public B setDataExternal(boolean isExternal) {
+    public Builder setDataExternal(boolean isExternal) {
       add(DATA_EXTERNAL, Boolean.toString(isExternal));
-      return thisBuilder();
+      return this;
     }
 
     /**
      * Sets the output format of the file dataset.
      */
-    public B setOutputFormat(Class<?> outputFormatClass) {
+    public Builder setOutputFormat(Class<?> outputFormatClass) {
       setOutputFormat(outputFormatClass.getName());
-      return thisBuilder();
+      return this;
     }
 
     /**
      * Sets the output format of the file dataset.
      */
-    public B setOutputFormat(String className) {
+    public Builder setOutputFormat(String className) {
       add(OUTPUT_FORMAT, className);
-      return thisBuilder();
+      return this;
     }
 
     /**
      * Sets the input format of the file dataset.
      */
-    public B setInputFormat(Class<?> inputFormatClass) {
+    public Builder setInputFormat(Class<?> inputFormatClass) {
       setInputFormat(inputFormatClass.getName());
-      return thisBuilder();
+      return this;
     }
 
     /**
      * Sets the input format of the file dataset.
      */
-    public B setInputFormat(String className) {
+    public Builder setInputFormat(String className) {
       add(INPUT_FORMAT, className);
-      return thisBuilder();
+      return this;
     }
 
     /**
      * Sets a property for the input format of the file dataset.
      */
-    public B setInputProperty(String name, String value) {
+    public Builder setInputProperty(String name, String value) {
       add(INPUT_PROPERTIES_PREFIX + name, value);
-      return thisBuilder();
+      return this;
     }
 
     /**
      * Sets a property for the output format of the file dataset.
      */
-    public B setOutputProperty(String name, String value) {
+    public Builder setOutputProperty(String name, String value) {
       add(OUTPUT_PROPERTIES_PREFIX + name, value);
-      return thisBuilder();
+      return this;
     }
 
     /**
      * Enable explore for this dataset.
      */
-    public B setEnableExploreOnCreate(boolean enabled) {
+    public Builder setEnableExploreOnCreate(boolean enabled) {
       add(PROPERTY_ENABLE_EXPLORE_ON_CREATE, Boolean.toString(enabled));
-      return thisBuilder();
+      return this;
     }
 
     /**
      * Set the format for the Hive table.
      * @param format currently, only "text" and "csv" are supported.
      */
-    public B setExploreFormat(String format) {
+    public Builder setExploreFormat(String format) {
       add(PROPERTY_EXPLORE_FORMAT, format);
       this.format = format;
-      return thisBuilder();
+      return this;
     }
 
     /**
      * Set the schema for the Hive table.
      * @param schema a Hive schema string of the form: field type, ...
      */
-    public B setExploreSchema(String schema) {
+    public Builder setExploreSchema(String schema) {
       add(PROPERTY_EXPLORE_SCHEMA, schema);
-      return thisBuilder();
+      return this;
     }
 
     /**
      * Set a property for the table format.
      * This may only be a called after setting the format using {@link #setExploreFormat}.
      */
-    public B setExploreFormatProperty(String name, String value) {
+    public Builder setExploreFormatProperty(String name, String value) {
       if (format == null) {
         throw new IllegalStateException("explore format has not been set");
       }
       add(String.format("%s.%s.%s", PROPERTY_EXPLORE_FORMAT, format, name), value);
-      return thisBuilder();
+      return this;
     }
 
     /**
      * Set the class name of the SerDe used to create the Hive table.
      */
-    public B setSerDe(String className) {
+    public Builder setSerDe(String className) {
       add(PROPERTY_EXPLORE_SERDE, className);
-      return thisBuilder();
+      return this;
     }
 
     /**
      * Set the class name of the SerDe used to create the Hive table.
      */
-    public B setSerDe(Class<?> serde) {
+    public Builder setSerDe(Class<?> serde) {
       return setSerDe(serde.getName());
     }
 
@@ -363,9 +353,9 @@ public class FileSetProperties {
      * Note that this can be different than the input format used
      * for the file set itself.
      */
-    public B setExploreInputFormat(String className) {
+    public Builder setExploreInputFormat(String className) {
       add(PROPERTY_EXPLORE_INPUT_FORMAT, className);
-      return thisBuilder();
+      return this;
     }
 
     /**
@@ -373,7 +363,7 @@ public class FileSetProperties {
      * Note that this can be different than the input format used
      * for the file set itself.
      */
-    public B setExploreInputFormat(Class<?> inputFormat) {
+    public Builder setExploreInputFormat(Class<?> inputFormat) {
       return setExploreInputFormat(inputFormat.getName());
     }
 
@@ -382,9 +372,9 @@ public class FileSetProperties {
      * Note that this can be different than the output format used
      * for the file set itself.
      */
-    public B setExploreOutputFormat(String className) {
+    public Builder setExploreOutputFormat(String className) {
       add(PROPERTY_EXPLORE_OUTPUT_FORMAT, className);
-      return thisBuilder();
+      return this;
     }
 
     /**
@@ -392,16 +382,23 @@ public class FileSetProperties {
      * Note that this can be different than the output format used
      * for the file set itself.
      */
-    public B setExploreOutputFormat(Class<?> outputFormat) {
+    public Builder setExploreOutputFormat(Class<?> outputFormat) {
       return setExploreOutputFormat(outputFormat.getName());
     }
 
     /**
      * Set a table property to be added to the Hive table. Multiple properties can be set.
      */
-    public B setTableProperty(String name, String value) {
+    public Builder setTableProperty(String name, String value) {
       add(PROPERTY_EXPLORE_TABLE_PROPERTY_PREFIX + name, value);
-      return thisBuilder();
+      return this;
+    }
+
+    /**
+     * Create a DatasetProperties from this builder.
+     */
+    public DatasetProperties build() {
+      return super.build();
     }
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/ObjectMappedTableProperties.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/ObjectMappedTableProperties.java
@@ -36,8 +36,6 @@ import java.util.Map;
 public class ObjectMappedTableProperties {
   private static final SchemaGenerator schemaGenerator = new ReflectionSchemaGenerator();
 
-  private ObjectMappedTableProperties() { }
-
   /**
    * The type of object in the table.
    */
@@ -95,7 +93,7 @@ public class ObjectMappedTableProperties {
   /**
    * A Builder to construct properties for {@link ObjectMappedTable} datasets.
    */
-  public static class Builder extends DatasetProperties.AbstractBuilder<Builder> {
+  public static class Builder extends DatasetProperties.Builder {
 
     private final Gson gson = new Gson();
 
@@ -118,7 +116,7 @@ public class ObjectMappedTableProperties {
     public Builder setType(Type type) throws UnsupportedTypeException {
       add(OBJECT_TYPE, gson.toJson(new TypeRepresentation(type)));
       add(OBJECT_SCHEMA, schemaGenerator.generate(type, false).toString());
-      return thisBuilder();
+      return this;
     }
 
     /**
@@ -133,7 +131,7 @@ public class ObjectMappedTableProperties {
      */
     public Builder setRowKeyExploreName(String name) {
       add(ROW_KEY_EXPLORE_NAME, name);
-      return thisBuilder();
+      return this;
     }
 
     /**
@@ -151,7 +149,14 @@ public class ObjectMappedTableProperties {
         throw new IllegalArgumentException("Key type must be bytes or string.");
       }
       add(ROW_KEY_EXPLORE_TYPE, type.name());
-      return thisBuilder();
+      return this;
+    }
+
+    /**
+     * Create a DatasetProperties from this builder.
+     */
+    public DatasetProperties build() {
+      return super.build();
     }
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSetProperties.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSetProperties.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.api.dataset.lib;
 
 import co.cask.cdap.api.annotation.Beta;
-import co.cask.cdap.api.dataset.DatasetProperties;
 
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -26,7 +25,7 @@ import javax.annotation.Nullable;
  * Helper to build properties for files datasets.
  */
 @Beta
-public class PartitionedFileSetProperties {
+public class PartitionedFileSetProperties extends FileSetProperties {
 
   /**
    * The property name for the list of partitioning field names.
@@ -79,23 +78,19 @@ public class PartitionedFileSetProperties {
   }
 
   /**
-   * A Builder to construct properties for PartitionedFileSet datasets.
+   * A Builder to construct properties for FileSet datasets.
    */
-  public static class Builder extends AbstractBuilder<Builder> { }
+  public static class Builder extends FileSetProperties.Builder {
 
-  /**
-   * An abstract builder to construct properties for FileSet datasets. See {@link DatasetProperties} for an
-   * explanation of the need for generics.
-   *
-   * @param <B> the subclass of this builder that is actually used (e.g. {@link PartitionedFileSetProperties}
-   */
-  abstract static class AbstractBuilder<B extends AbstractBuilder>
-    extends FileSetProperties.AbstractBuilder<B> {
+    /**
+     * Package visible default constructor, to allow sub-classing by other datasets in this package.
+     */
+    Builder() { }
 
     /**
      * Sets the base path for the file dataset.
      */
-    public B setPartitioning(Partitioning partitioning) {
+    public Builder setPartitioning(Partitioning partitioning) {
       StringBuilder builder = new StringBuilder();
       String sep = "";
       for (String key : partitioning.getFields().keySet()) {
@@ -106,7 +101,7 @@ public class PartitionedFileSetProperties {
       for (Map.Entry<String, Partitioning.FieldType> entry : partitioning.getFields().entrySet()) {
         add(PARTITIONING_FIELD_PREFIX + entry.getKey(), entry.getValue().name());
       }
-      return thisBuilder();
+      return this;
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -487,11 +487,12 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
   }
 
   private DatasetProperties addLocalDatasetProperty(DatasetProperties properties) {
-    return DatasetProperties.builder()
-      .setDescription(properties.getDescription())
-      .addAll(properties.getProperties())
-      .add(Constants.AppFabric.WORKFLOW_LOCAL_DATASET_PROPERTY, "true")
-      .build();
+    String dsDescription = properties.getDescription();
+    DatasetProperties.Builder builder = DatasetProperties.builder();
+    builder.addAll(properties.getProperties());
+    builder.add(Constants.AppFabric.WORKFLOW_LOCAL_DATASET_PROPERTY, "true");
+    builder.setDescription(dsDescription);
+    return builder.build();
   }
 
   private void createLocalDatasets() throws IOException, DatasetManagementException {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/AllProgramsApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/AllProgramsApp.java
@@ -110,8 +110,8 @@ public class AllProgramsApp extends AbstractApplication {
     try {
       createDataset(DS_WITH_SCHEMA_NAME, ObjectMappedTable.class,
                     ObjectMappedTableProperties.builder()
-                      .setDescription("test object mapped table")
                       .setType(DsSchema.class)
+                      .setDescription("test object mapped table")
                       .build()
       );
     } catch (UnsupportedTypeException e) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingAvroDynamicPartitioner.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AppWithMapReduceUsingAvroDynamicPartitioner.java
@@ -73,17 +73,17 @@ public class AppWithMapReduceUsingAvroDynamicPartitioner extends AbstractApplica
     createDataset(INPUT_DATASET, KeyValueTable.class);
 
     createDataset(OUTPUT_DATASET, PartitionedFileSet.class, PartitionedFileSetProperties.builder()
-      // Properties for file set
+      // Properties for partitioning
+      .setPartitioning(Partitioning.builder().addLongField("time").addIntField("zip").build())
+        // Properties for file set
       .setInputFormat(AvroKeyInputFormat.class)
       .setOutputFormat(AvroKeyOutputFormat.class)
-      // Properties for Explore (to create a partitioned Hive table)
+        // Properties for Explore (to create a partitioned Hive table)
       .setEnableExploreOnCreate(true)
       .setSerDe("org.apache.hadoop.hive.serde2.avro.AvroSerDe")
       .setExploreInputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat")
       .setExploreOutputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat")
       .setTableProperty("avro.schema.literal", SCHEMA_STRING)
-      // Properties for partitioning
-      .setPartitioning(Partitioning.builder().addLongField("time").addIntField("zip").build())
       .build());
 
     addMapReduce(new DynamicPartitioningMapReduce());

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetTest.java
@@ -69,8 +69,8 @@ public class TimePartitionedFileSetTest {
 
   @Before
   public void before() throws Exception {
-    dsFrameworkUtil.createInstance("timePartitionedFileSet", TPFS_INSTANCE,
-                                   FileSetProperties.builder().setBasePath("testDir").build());
+    dsFrameworkUtil.createInstance("timePartitionedFileSet", TPFS_INSTANCE, FileSetProperties.builder()
+      .setBasePath("testDir").build());
   }
 
   @After

--- a/cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansing.java
+++ b/cdap-examples/DataCleansing/src/main/java/co/cask/cdap/examples/datacleansing/DataCleansing.java
@@ -51,15 +51,14 @@ public class DataCleansing extends AbstractApplication {
     // Create the "rawRecords" partitioned file set for storing the input records, 
     // configure it to work with MapReduce
     createDataset(RAW_RECORDS, PartitionedFileSet.class, PartitionedFileSetProperties.builder()
-      .setDescription("Store input records")
       // Properties for partitioning
       .setPartitioning(Partitioning.builder().addLongField("time").build())
       // Properties for file set
       .setInputFormat(TextInputFormat.class)
+      .setDescription("Store input records")
       .build());
 
     createDataset(CLEAN_RECORDS, PartitionedFileSet.class, PartitionedFileSetProperties.builder()
-      .setDescription("Store clean records")
       // Properties for partitioning
       .setPartitioning(Partitioning.builder().addLongField("time").addIntField("zip").build())
       // Properties for file set
@@ -69,10 +68,10 @@ public class DataCleansing extends AbstractApplication {
       .setExploreFormat("text")
       .setExploreFormatProperty("delimiter", "\n")
       .setExploreSchema("record STRING")
+      .setDescription("Store clean records")
       .build());
 
     createDataset(INVALID_RECORDS, PartitionedFileSet.class, PartitionedFileSetProperties.builder()
-      .setDescription("Store invalid records")
       // Properties for partitioning
       .setPartitioning(Partitioning.builder().addLongField("time").build())
       // Properties for file set
@@ -82,6 +81,7 @@ public class DataCleansing extends AbstractApplication {
       .setExploreFormat("text")
       .setExploreFormatProperty("delimiter", "\n")
       .setExploreSchema("record STRING")
+      .setDescription("Store invalid records")
       .build());
   }
 }

--- a/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetExample.java
+++ b/cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetExample.java
@@ -37,16 +37,16 @@ public class FileSetExample extends AbstractApplication {
     setName("FileSetExample");
     setDescription("Application with a MapReduce that uses a FileSet dataset");
     createDataset("lines", FileSet.class, FileSetProperties.builder()
-      .setDescription("Store input lines")
       .setBasePath("example/data/lines")
       .setInputFormat(TextInputFormat.class)
       .setOutputFormat(TextOutputFormat.class)
+      .setDescription("Store input lines")
       .build());
     createDataset("counts", FileSet.class, FileSetProperties.builder()
-      .setDescription("Store word counts")
       .setInputFormat(TextInputFormat.class)
       .setOutputFormat(TextOutputFormat.class)
       .setOutputProperty(TextOutputFormat.SEPERATOR, ":")
+      .setDescription("Store word counts")
       .build());
     addService(new FileSetService());
     addMapReduce(new WordCount());

--- a/cdap-examples/LogAnalysis/src/main/java/co/cask/cdap/examples/loganalysis/LogAnalysisApp.java
+++ b/cdap-examples/LogAnalysis/src/main/java/co/cask/cdap/examples/loganalysis/LogAnalysisApp.java
@@ -93,10 +93,9 @@ public class LogAnalysisApp extends AbstractApplication {
     createDataset(HIT_COUNT_STORE, KeyValueTable.class,
                   DatasetProperties.builder().setDescription("Store hit counts").build());
     createDataset(REQ_COUNT_STORE, TimePartitionedFileSet.class, FileSetProperties.builder()
-      .setDescription("Store request counts")
       .setOutputFormat(TextOutputFormat.class)
       .setOutputProperty(TextOutputFormat.SEPERATOR, ":")
-      .build());
+      .setDescription("Store request counts").build());
   }
 
   /**

--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseApp.java
@@ -85,8 +85,8 @@ public class PurchaseApp extends AbstractApplication {
 
     createDataset("history", PurchaseHistoryStore.class, PurchaseHistoryStore.properties("History dataset"));
     try {
-      createDataset("purchases", ObjectMappedTable.class, ObjectMappedTableProperties.builder()
-        .setDescription("Store purchases").setType(Purchase.class).build());
+      createDataset("purchases", ObjectMappedTable.class, ObjectMappedTableProperties.builder().setType(Purchase.class)
+        .setDescription("Store purchases").build());
     } catch (UnsupportedTypeException e) {
       // This exception is thrown by ObjectMappedTable if its parameter type cannot be
       // (de)serialized (for example, if it is an interface and not a class, then there is

--- a/cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/SportResults.java
+++ b/cdap-examples/SportResults/src/main/java/co/cask/cdap/examples/sportresults/SportResults.java
@@ -35,8 +35,7 @@ public class SportResults extends AbstractApplication {
 
     // Create the "results" partitioned file set, configure it to work with MapReduce and with Explore
     createDataset("results", PartitionedFileSet.class, PartitionedFileSetProperties.builder()
-      .setDescription("FileSet dataset of game results for a sport league and season")
-        // Properties for partitioning
+      // Properties for partitioning
       .setPartitioning(Partitioning.builder().addStringField("league").addIntField("season").build())
       // Properties for file set
       .setInputFormat(TextInputFormat.class)
@@ -51,8 +50,7 @@ public class SportResults extends AbstractApplication {
 
     // Create the aggregates partitioned file set, configure it to work with MapReduce and with Explore
     createDataset("totals", PartitionedFileSet.class, PartitionedFileSetProperties.builder()
-      .setDescription("FileSet dataset of aggregated results for each sport league")
-        // Properties for partitioning
+      // Properties for partitioning
       .setPartitioning(Partitioning.builder().addStringField("league").build())
       // Properties for file set
       .setInputFormat(TextInputFormat.class)
@@ -62,6 +60,7 @@ public class SportResults extends AbstractApplication {
       .setEnableExploreOnCreate(true)
       .setExploreFormat("csv")
       .setExploreSchema("team STRING, wins INT, ties INT, losses INT, scored INT, conceded INT")
+      .setDescription("FileSet dataset of aggregated results for each sport league")
       .build());
   }
 }

--- a/cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionApp.java
+++ b/cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionApp.java
@@ -48,8 +48,7 @@ public class StreamConversionApp extends AbstractApplication {
 
     // create the time-partitioned file set, configure it to work with MapReduce and with Explore
     createDataset("converted", TimePartitionedFileSet.class, FileSetProperties.builder()
-      .setDescription("Converted stream events dataset")
-        // properties for file set
+      // properties for file set
       .setBasePath("converted")
       .setInputFormat(AvroKeyInputFormat.class)
       .setOutputFormat(AvroKeyOutputFormat.class)
@@ -60,6 +59,7 @@ public class StreamConversionApp extends AbstractApplication {
       .setExploreInputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat")
       .setExploreOutputFormat("org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat")
       .setTableProperty("avro.schema.literal", SCHEMA_STRING)
+      .setDescription("Converted stream events dataset")
       .build());
   }
 }

--- a/cdap-examples/UserProfiles/src/main/java/co/cask/cdap/examples/profiles/UserProfiles.java
+++ b/cdap-examples/UserProfiles/src/main/java/co/cask/cdap/examples/profiles/UserProfiles.java
@@ -54,12 +54,12 @@ public class UserProfiles extends AbstractApplication {
       Schema.Field.of("active", Schema.nullableOf(Schema.of(Schema.Type.LONG)))
     );
     createDataset("profiles", Table.class.getName(), DatasetProperties.builder()
-      .setDescription("Profiles table with column-level conflict detection")
-        // create the profiles table with column-level conflict detection
+      // create the profiles table with column-level conflict detection
       .add(Table.PROPERTY_CONFLICT_LEVEL, ConflictDetection.COLUMN.name())
       .add(Table.PROPERTY_SCHEMA, profileSchema.toString())
       // to indicate that the id field should come from the row key and not a row column
       .add(Table.PROPERTY_SCHEMA_ROW_FIELD, "id")
+      .setDescription("Profiles table with column-level conflict detection")
       .build());
   }
 }


### PR DESCRIPTION
This reverts commit c0c7b186279e89acf59da4d74468f0c26ba05207.

This change is not binary compatible (see CDAP-6365) and it breaks hydrator-plugins, too. Rolling back to previous state. 
