### PR TITLE
cdap solution template for v2 marketplace

### DIFF
--- a/cdap-distributions/src/hdinsight/cdap-deploy.json
+++ b/cdap-distributions/src/hdinsight/cdap-deploy.json
@@ -1,0 +1,80 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "clusterName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the existing HDInsight cluster"
+            }
+        },
+        "galleryPackageIdentity": {
+            "type": "string",
+            "metadata": {
+                "description" : "Any non-empty value is accepted. After the package is published, this parameter will be used to link the application install to the details about the application in the marketplace."
+            },
+            "defaultValue": "CDAP"
+        },
+        "edgeNodeSize": {
+            "type": "string",
+            "metadata": {
+                "description": "Size of the edge node that hosts the application"
+            },
+            "defaultValue": "Standard_D3",
+            "allowedValues": [
+                "Standard_A3",
+                "Standard_A4",
+                "Standard_D3",
+                "Standard_D4"
+            ]
+        }
+    },
+    "variables": {
+        "clusterApiVersion": "2015-03-01-preview",
+        "applicationName": "cdap"
+    },
+    "resources": [{
+        "name": "[concat(parameters('clusterName'),'/', variables('applicationName'))]",
+        "type": "Microsoft.HDInsight/clusters/applications",
+        "apiVersion": "[variables('clusterApiVersion')]",
+        "properties": {
+            "marketPlaceIdentifier": "[parameters('galleryPackageIdentity')]",
+            "computeProfile": {
+                "roles": [{
+                    "name": "edgenode",
+                    "targetInstanceCount": 1,
+                    "hardwareProfile": {
+                        "vmSize": "[parameters('edgeNodeSize')]"
+                    }
+                }]
+            },
+            "installScriptActions": [{
+                "name": "[concat('cdap-pageblob-configure-v0','-' ,uniquestring(variables('applicationName')))]",
+                "uri": "https://raw.githubusercontent.com/caskdata/cdap/release/3.4/cdap-distributions/src/hdinsight/pageblob-configure.sh",
+                "roles": ["edgenode"]
+            },
+            {
+                "name": "[concat('cdap-install-v0','-' ,uniquestring(variables('applicationName')))]",
+                "uri": "https://raw.githubusercontent.com/caskdata/cdap/release/3.4/cdap-distributions/src/hdinsight/install.sh",
+                "roles": ["edgenode"]
+            }],
+            "uninstallScriptActions": [],
+            "httpsEndpoints": [{
+              "subDomainSuffix": "gui",
+              "destinationPort": 9999,
+              "accessModes": ["webpage"]
+            },
+            {
+              "subDomainSuffix": "api",
+              "destinationPort": 10000
+            }],
+            "applicationType": "CustomApplication"
+        }
+    }],
+    "outputs": {
+        "application": {
+            "type": "object",
+            "value": "[reference(resourceId('Microsoft.HDInsight/clusters/applications/',parameters('clusterName'), variables('applicationName')))]"
+        }
+    }
+}


### PR DESCRIPTION
solution template for deploying CDAP on the Azure HDInsight v2 marketplace platform.  Most of this is boilerplate, with the CDAP-specific bits customized.  This should be merged with https://github.com/caskdata/cdap/pull/5985
- [x] set to use cdap `release/3.4` branch
- [ ] httpsEndpoints for UI doesn't actually work yet... working with them on it.
