### PR TITLE
CDAP-6382 Refactor NamespaceAdmin to have a NamespaceDefinitionAdmin

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -25,7 +25,7 @@ import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
-import co.cask.cdap.common.namespace.NamespaceDefinitionAdmin;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.runtime.RuntimeModule;
 import co.cask.cdap.common.twill.MasterServiceManager;
 import co.cask.cdap.common.utils.Networks;
@@ -60,7 +60,7 @@ import co.cask.cdap.internal.app.deploy.LocalApplicationManager;
 import co.cask.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
 import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
 import co.cask.cdap.internal.app.namespace.DefaultNamespaceAdmin;
-import co.cask.cdap.internal.app.namespace.DefaultNamespaceDefinitionAdmin;
+import co.cask.cdap.internal.app.namespace.DefaultNamespaceQueryAdmin;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactStore;
 import co.cask.cdap.internal.app.runtime.batch.InMemoryTransactionServiceManager;
 import co.cask.cdap.internal.app.runtime.distributed.AppFabricServiceManager;
@@ -291,7 +291,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       bind(ArtifactStore.class).in(Scopes.SINGLETON);
       bind(ProgramLifecycleService.class).in(Scopes.SINGLETON);
       bind(NamespaceAdmin.class).to(DefaultNamespaceAdmin.class).in(Scopes.SINGLETON);
-      bind(NamespaceDefinitionAdmin.class).to(DefaultNamespaceDefinitionAdmin.class).in(Scopes.SINGLETON);
+      bind(NamespaceQueryAdmin.class).to(DefaultNamespaceQueryAdmin.class).in(Scopes.SINGLETON);
 
       Multibinder<HttpHandler> handlerBinder = Multibinder.newSetBinder(
         binder(), HttpHandler.class, Names.named(Constants.AppFabric.HANDLERS_BINDING));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -25,6 +25,7 @@ import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.common.namespace.NamespaceDefinitionAdmin;
 import co.cask.cdap.common.runtime.RuntimeModule;
 import co.cask.cdap.common.twill.MasterServiceManager;
 import co.cask.cdap.common.utils.Networks;
@@ -59,6 +60,7 @@ import co.cask.cdap.internal.app.deploy.LocalApplicationManager;
 import co.cask.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
 import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
 import co.cask.cdap.internal.app.namespace.DefaultNamespaceAdmin;
+import co.cask.cdap.internal.app.namespace.DefaultNamespaceDefinitionAdmin;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactStore;
 import co.cask.cdap.internal.app.runtime.batch.InMemoryTransactionServiceManager;
 import co.cask.cdap.internal.app.runtime.distributed.AppFabricServiceManager;
@@ -73,7 +75,6 @@ import co.cask.cdap.internal.app.services.AppFabricServer;
 import co.cask.cdap.internal.app.services.ProgramLifecycleService;
 import co.cask.cdap.internal.app.services.StandaloneAppFabricServer;
 import co.cask.cdap.internal.app.store.DefaultStore;
-import co.cask.cdap.internal.app.store.remote.RemoteRuntimeStore;
 import co.cask.cdap.internal.pipeline.SynchronousPipelineFactory;
 import co.cask.cdap.logging.run.InMemoryAppFabricServiceManager;
 import co.cask.cdap.logging.run.InMemoryDatasetExecutorServiceManager;
@@ -290,6 +291,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       bind(ArtifactStore.class).in(Scopes.SINGLETON);
       bind(ProgramLifecycleService.class).in(Scopes.SINGLETON);
       bind(NamespaceAdmin.class).to(DefaultNamespaceAdmin.class).in(Scopes.SINGLETON);
+      bind(NamespaceDefinitionAdmin.class).to(DefaultNamespaceDefinitionAdmin.class).in(Scopes.SINGLETON);
 
       Multibinder<HttpHandler> handlerBinder = Multibinder.newSetBinder(
         binder(), HttpHandler.class, Names.named(Constants.AppFabric.HANDLERS_BINDING));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -31,7 +31,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.http.AbstractBodyConsumer;
 import co.cask.cdap.common.io.CaseInsensitiveEnumTypeAdapterFactory;
-import co.cask.cdap.common.namespace.NamespaceDefinitionAdmin;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
@@ -98,7 +98,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
 
   private final CConfiguration configuration;
   private final Scheduler scheduler;
-  private final NamespaceDefinitionAdmin namespaceDefinitionAdmin;
+  private final NamespaceQueryAdmin namespaceQueryAdmin;
   private final NamespacedLocationFactory namespacedLocationFactory;
   private final ApplicationLifecycleService applicationLifecycleService;
   private final File tmpDir;
@@ -106,11 +106,11 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @Inject
   AppLifecycleHttpHandler(CConfiguration configuration,
                           Scheduler scheduler, ProgramRuntimeService runtimeService,
-                          NamespaceDefinitionAdmin namespaceDefinitionAdmin,
+                          NamespaceQueryAdmin namespaceQueryAdmin,
                           NamespacedLocationFactory namespacedLocationFactory,
                           ApplicationLifecycleService applicationLifecycleService) {
     this.configuration = configuration;
-    this.namespaceDefinitionAdmin = namespaceDefinitionAdmin;
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
     this.scheduler = scheduler;
     this.runtimeService = runtimeService;
     this.namespacedLocationFactory = namespacedLocationFactory;
@@ -416,7 +416,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     }
 
     try {
-      namespaceDefinitionAdmin.get(namespace);
+      namespaceQueryAdmin.get(namespace);
     } catch (NamespaceNotFoundException e) {
       throw e;
     } catch (Exception e) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -31,7 +31,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.http.AbstractBodyConsumer;
 import co.cask.cdap.common.io.CaseInsensitiveEnumTypeAdapterFactory;
-import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.common.namespace.NamespaceDefinitionAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
@@ -98,7 +98,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
 
   private final CConfiguration configuration;
   private final Scheduler scheduler;
-  private final NamespaceAdmin namespaceAdmin;
+  private final NamespaceDefinitionAdmin namespaceDefinitionAdmin;
   private final NamespacedLocationFactory namespacedLocationFactory;
   private final ApplicationLifecycleService applicationLifecycleService;
   private final File tmpDir;
@@ -106,10 +106,11 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @Inject
   AppLifecycleHttpHandler(CConfiguration configuration,
                           Scheduler scheduler, ProgramRuntimeService runtimeService,
-                          NamespaceAdmin namespaceAdmin, NamespacedLocationFactory namespacedLocationFactory,
+                          NamespaceDefinitionAdmin namespaceDefinitionAdmin,
+                          NamespacedLocationFactory namespacedLocationFactory,
                           ApplicationLifecycleService applicationLifecycleService) {
     this.configuration = configuration;
-    this.namespaceAdmin = namespaceAdmin;
+    this.namespaceDefinitionAdmin = namespaceDefinitionAdmin;
     this.scheduler = scheduler;
     this.runtimeService = runtimeService;
     this.namespacedLocationFactory = namespacedLocationFactory;
@@ -415,7 +416,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     }
 
     try {
-      namespaceAdmin.get(namespace);
+      namespaceDefinitionAdmin.get(namespace);
     } catch (NamespaceNotFoundException e) {
       throw e;
     } catch (Exception e) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
@@ -31,7 +31,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.conf.PluginClassDeserializer;
 import co.cask.cdap.common.http.AbstractBodyConsumer;
-import co.cask.cdap.common.namespace.NamespaceDefinitionAdmin;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactDescriptor;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactDetail;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
@@ -120,14 +120,14 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   private static final Type PLUGINS_TYPE = new TypeToken<Set<PluginClass>>() { }.getType();
 
   private final ArtifactRepository artifactRepository;
-  private final NamespaceDefinitionAdmin namespaceDefinitionAdmin;
+  private final NamespaceQueryAdmin namespaceQueryAdmin;
   private final File tmpDir;
   private final PluginService pluginService;
 
   @Inject
   ArtifactHttpHandler(CConfiguration cConf, ArtifactRepository artifactRepository,
-                      NamespaceDefinitionAdmin namespaceDefinitionAdmin, PluginService pluginService) {
-    this.namespaceDefinitionAdmin = namespaceDefinitionAdmin;
+                      NamespaceQueryAdmin namespaceQueryAdmin, PluginService pluginService) {
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
     this.artifactRepository = artifactRepository;
     this.tmpDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
                            cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
@@ -721,7 +721,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
     throws NamespaceNotFoundException {
 
     try {
-      namespaceDefinitionAdmin.get(namespace.toId());
+      namespaceQueryAdmin.get(namespace.toId());
     } catch (NamespaceNotFoundException e) {
       throw e;
     } catch (Exception e) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
@@ -31,7 +31,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.conf.PluginClassDeserializer;
 import co.cask.cdap.common.http.AbstractBodyConsumer;
-import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.common.namespace.NamespaceDefinitionAdmin;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactDescriptor;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactDetail;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
@@ -120,14 +120,14 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   private static final Type PLUGINS_TYPE = new TypeToken<Set<PluginClass>>() { }.getType();
 
   private final ArtifactRepository artifactRepository;
-  private final NamespaceAdmin namespaceAdmin;
+  private final NamespaceDefinitionAdmin namespaceDefinitionAdmin;
   private final File tmpDir;
   private final PluginService pluginService;
 
   @Inject
-  ArtifactHttpHandler(CConfiguration cConf, ArtifactRepository artifactRepository, NamespaceAdmin namespaceAdmin,
-                      PluginService pluginService) {
-    this.namespaceAdmin = namespaceAdmin;
+  ArtifactHttpHandler(CConfiguration cConf, ArtifactRepository artifactRepository,
+                      NamespaceDefinitionAdmin namespaceDefinitionAdmin, PluginService pluginService) {
+    this.namespaceDefinitionAdmin = namespaceDefinitionAdmin;
     this.artifactRepository = artifactRepository;
     this.tmpDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
                            cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
@@ -721,7 +721,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
     throws NamespaceNotFoundException {
 
     try {
-      namespaceAdmin.get(namespace.toId());
+      namespaceDefinitionAdmin.get(namespace.toId());
     } catch (NamespaceNotFoundException e) {
       throw e;
     } catch (Exception e) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -64,7 +64,7 @@ import java.util.regex.Pattern;
 /**
  * Admin for managing namespaces.
  */
-public final class DefaultNamespaceAdmin extends DefaultNamespaceDefinitionAdmin implements NamespaceAdmin {
+public final class DefaultNamespaceAdmin extends DefaultNamespaceQueryAdmin implements NamespaceAdmin {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultNamespaceAdmin.class);
 
   private final Store store;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -25,7 +25,6 @@ import co.cask.cdap.common.NamespaceAlreadyExistsException;
 import co.cask.cdap.common.NamespaceCannotBeCreatedException;
 import co.cask.cdap.common.NamespaceCannotBeDeletedException;
 import co.cask.cdap.common.NamespaceNotFoundException;
-import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
@@ -59,18 +58,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
 /**
  * Admin for managing namespaces.
  */
-public final class DefaultNamespaceAdmin implements NamespaceAdmin {
+public final class DefaultNamespaceAdmin extends DefaultNamespaceDefinitionAdmin implements NamespaceAdmin {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultNamespaceAdmin.class);
 
   private final Store store;
-  private final NamespaceStore nsStore;
   private final PreferencesStore preferencesStore;
   private final DashboardStore dashboardStore;
   private final DatasetFramework dsFramework;
@@ -94,10 +91,10 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
                         ArtifactRepository artifactRepository,
                         AuthorizerInstantiator authorizerInstantiator,
                         CConfiguration cConf) {
+    super(nsStore);
     this.queueAdmin = queueAdmin;
     this.streamAdmin = streamAdmin;
     this.store = store;
-    this.nsStore = nsStore;
     this.preferencesStore = preferencesStore;
     this.dashboardStore = dashboardStore;
     this.dsFramework = dsFramework;
@@ -108,48 +105,6 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
     this.artifactRepository = artifactRepository;
     this.authorizerInstantiator = authorizerInstantiator;
     this.instanceId = createInstanceId(cConf);
-  }
-
-  /**
-   * Lists all namespaces
-   *
-   * @return a list of {@link NamespaceMeta} for all namespaces
-   */
-  @Override
-  public List<NamespaceMeta> list() throws Exception {
-    return nsStore.list();
-  }
-
-  /**
-   * Gets details of a namespace
-   *
-   * @param namespaceId the {@link Id.Namespace} of the requested namespace
-   * @return the {@link NamespaceMeta} of the requested namespace
-   * @throws NamespaceNotFoundException if the requested namespace is not found
-   */
-  @Override
-  public NamespaceMeta get(Id.Namespace namespaceId) throws Exception {
-    NamespaceMeta ns = nsStore.get(namespaceId);
-    if (ns == null) {
-      throw new NamespaceNotFoundException(namespaceId);
-    }
-    return ns;
-  }
-
-  /**
-   * Checks if the specified namespace exists
-   *
-   * @param namespaceId the {@link Id.Namespace} to check for existence
-   * @return true, if the specifed namespace exists, false otherwise
-   */
-  @Override
-  public boolean exists(Id.Namespace namespaceId) throws Exception {
-    try {
-      get(namespaceId);
-    } catch (NotFoundException e) {
-      return false;
-    }
-    return true;
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceDefinitionAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceDefinitionAdmin.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.namespace;
+
+import co.cask.cdap.common.NamespaceNotFoundException;
+import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.common.namespace.NamespaceDefinitionAdmin;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.store.NamespaceStore;
+import com.google.inject.Inject;
+
+import java.util.List;
+
+/**
+ * Default implementation of {@link NamespaceDefinitionAdmin} to query namespace details.
+ */
+public class DefaultNamespaceDefinitionAdmin implements NamespaceDefinitionAdmin {
+
+  protected final NamespaceStore nsStore;
+
+  @Inject
+  public DefaultNamespaceDefinitionAdmin(NamespaceStore nsStore) {
+    this.nsStore = nsStore;
+  }
+
+  /**
+   * Lists all namespaces
+   *
+   * @return a list of {@link NamespaceMeta} for all namespaces
+   */
+  @Override
+  public List<NamespaceMeta> list() throws Exception {
+    return nsStore.list();
+  }
+
+  /**
+   * Gets details of a namespace
+   *
+   * @param namespaceId the {@link Id.Namespace} of the requested namespace
+   * @return the {@link NamespaceMeta} of the requested namespace
+   * @throws NamespaceNotFoundException if the requested namespace is not found
+   */
+  @Override
+  public NamespaceMeta get(Id.Namespace namespaceId) throws Exception {
+    NamespaceMeta ns = nsStore.get(namespaceId);
+    if (ns == null) {
+      throw new NamespaceNotFoundException(namespaceId);
+    }
+    return ns;
+  }
+
+  /**
+   * Checks if the specified namespace exists
+   *
+   * @param namespaceId the {@link Id.Namespace} to check for existence
+   * @return true, if the specifed namespace exists, false otherwise
+   */
+  @Override
+  public boolean exists(Id.Namespace namespaceId) throws Exception {
+    try {
+      get(namespaceId);
+    } catch (NotFoundException e) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceQueryAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceQueryAdmin.java
@@ -18,7 +18,7 @@ package co.cask.cdap.internal.app.namespace;
 
 import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.common.namespace.NamespaceDefinitionAdmin;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.store.NamespaceStore;
@@ -27,14 +27,14 @@ import com.google.inject.Inject;
 import java.util.List;
 
 /**
- * Default implementation of {@link NamespaceDefinitionAdmin} to query namespace details.
+ * Default implementation of {@link NamespaceQueryAdmin} to query namespace details.
  */
-public class DefaultNamespaceDefinitionAdmin implements NamespaceDefinitionAdmin {
+public class DefaultNamespaceQueryAdmin implements NamespaceQueryAdmin {
 
   protected final NamespaceStore nsStore;
 
   @Inject
-  public DefaultNamespaceDefinitionAdmin(NamespaceStore nsStore) {
+  public DefaultNamespaceQueryAdmin(NamespaceStore nsStore) {
     this.nsStore = nsStore;
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
@@ -23,7 +23,7 @@ import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.NotImplementedException;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.common.namespace.NamespaceDefinitionAdmin;
 import co.cask.cdap.gateway.handlers.AppLifecycleHttpHandler;
 import co.cask.cdap.gateway.handlers.NamespaceHttpHandler;
 import co.cask.cdap.gateway.handlers.ProgramLifecycleHttpHandler;
@@ -94,20 +94,20 @@ public class AppFabricClient {
   private final ProgramLifecycleHttpHandler programLifecycleHttpHandler;
   private final WorkflowHttpHandler workflowHttpHandler;
   private final NamespaceHttpHandler namespaceHttpHandler;
-  private final NamespaceAdmin namespaceAdmin;
+  private final NamespaceDefinitionAdmin namespaceDefinitionAdmin;
 
   @Inject
   public AppFabricClient(LocationFactory locationFactory,
                          AppLifecycleHttpHandler appLifecycleHttpHandler,
                          ProgramLifecycleHttpHandler programLifecycleHttpHandler,
                          NamespaceHttpHandler namespaceHttpHandler,
-                         NamespaceAdmin namespaceAdmin,
+                         NamespaceDefinitionAdmin namespaceDefinitionAdmin,
                          WorkflowHttpHandler workflowHttpHandler) {
     this.locationFactory = locationFactory;
     this.appLifecycleHttpHandler = appLifecycleHttpHandler;
     this.programLifecycleHttpHandler = programLifecycleHttpHandler;
     this.namespaceHttpHandler = namespaceHttpHandler;
-    this.namespaceAdmin = namespaceAdmin;
+    this.namespaceDefinitionAdmin = namespaceDefinitionAdmin;
     this.workflowHttpHandler = workflowHttpHandler;
   }
 
@@ -120,7 +120,7 @@ public class AppFabricClient {
     HttpRequest request;
 
     // delete all namespaces
-    for (NamespaceMeta namespaceMeta : namespaceAdmin.list()) {
+    for (NamespaceMeta namespaceMeta : namespaceDefinitionAdmin.list()) {
       Id.Namespace namespace = Id.Namespace.from(namespaceMeta.getName());
 
       responder = new MockResponder();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
@@ -23,7 +23,7 @@ import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.NotImplementedException;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.namespace.NamespaceDefinitionAdmin;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.gateway.handlers.AppLifecycleHttpHandler;
 import co.cask.cdap.gateway.handlers.NamespaceHttpHandler;
 import co.cask.cdap.gateway.handlers.ProgramLifecycleHttpHandler;
@@ -94,20 +94,20 @@ public class AppFabricClient {
   private final ProgramLifecycleHttpHandler programLifecycleHttpHandler;
   private final WorkflowHttpHandler workflowHttpHandler;
   private final NamespaceHttpHandler namespaceHttpHandler;
-  private final NamespaceDefinitionAdmin namespaceDefinitionAdmin;
+  private final NamespaceQueryAdmin namespaceQueryAdmin;
 
   @Inject
   public AppFabricClient(LocationFactory locationFactory,
                          AppLifecycleHttpHandler appLifecycleHttpHandler,
                          ProgramLifecycleHttpHandler programLifecycleHttpHandler,
                          NamespaceHttpHandler namespaceHttpHandler,
-                         NamespaceDefinitionAdmin namespaceDefinitionAdmin,
+                         NamespaceQueryAdmin namespaceQueryAdmin,
                          WorkflowHttpHandler workflowHttpHandler) {
     this.locationFactory = locationFactory;
     this.appLifecycleHttpHandler = appLifecycleHttpHandler;
     this.programLifecycleHttpHandler = programLifecycleHttpHandler;
     this.namespaceHttpHandler = namespaceHttpHandler;
-    this.namespaceDefinitionAdmin = namespaceDefinitionAdmin;
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
     this.workflowHttpHandler = workflowHttpHandler;
   }
 
@@ -120,7 +120,7 @@ public class AppFabricClient {
     HttpRequest request;
 
     // delete all namespaces
-    for (NamespaceMeta namespaceMeta : namespaceDefinitionAdmin.list()) {
+    for (NamespaceMeta namespaceMeta : namespaceQueryAdmin.list()) {
       Id.Namespace namespace = Id.Namespace.from(namespaceMeta.getName());
 
       responder = new MockResponder();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
@@ -23,7 +23,7 @@ import co.cask.cdap.AppWithStreamSizeSchedule;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.namespace.AbstractNamespaceClient;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
@@ -328,7 +328,7 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
   @Test
   public void testNamespaceClient() throws Exception {
     // tests the NamespaceClient's ability to interact with Namespace service/handlers.
-    AbstractNamespaceClient namespaceClient = getInjector().getInstance(AbstractNamespaceClient.class);
+    NamespaceAdmin namespaceClient = getInjector().getInstance(NamespaceAdmin.class);
     // test setup creates two namespaces in @BeforeClass, apart from the default namespace which always exists.
     List<NamespaceMeta> namespaces = namespaceClient.list();
     Assert.assertEquals(3, namespaces.size());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
@@ -28,7 +28,6 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.IOModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
-import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.config.guice.ConfigStoreModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
@@ -111,7 +110,6 @@ public final class AppFabricTestModule extends AbstractModule {
     install(new ViewAdminModules().getInMemoryModules());
     install(new StreamAdminModules().getInMemoryModules());
     install(new StreamServiceRuntimeModule().getInMemoryModules());
-    install(new NamespaceClientRuntimeModule().getStandaloneModules());
     install(new NamespaceStoreModule().getStandaloneModules());
     install(new MetadataServiceModule());
     install(new AuthorizationModule());

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/NamespaceAdmin.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/NamespaceAdmin.java
@@ -27,7 +27,7 @@ import co.cask.cdap.proto.NamespaceMeta;
 /**
  * Admin class for managing a namespace's lifecycle
  */
-public interface NamespaceAdmin extends NamespaceDefinitionAdmin {
+public interface NamespaceAdmin extends NamespaceQueryAdmin {
 
   /**
    * Creates a new namespace.

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/NamespaceAdmin.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/NamespaceAdmin.java
@@ -24,36 +24,10 @@ import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 
-import java.util.List;
-
 /**
  * Admin class for managing a namespace's lifecycle
  */
-public interface NamespaceAdmin {
-
-  /**
-   * Lists all namespaces.
-   *
-   * @return a list of {@link NamespaceMeta} for all namespaces
-   */
-  List<NamespaceMeta> list() throws Exception;
-
-  /**
-   * Gets details of a namespace.
-   *
-   * @param namespaceId the {@link Id.Namespace} of the requested namespace
-   * @return the {@link NamespaceMeta} of the requested namespace
-   * @throws NamespaceNotFoundException if the requested namespace is not found
-   */
-  NamespaceMeta get(Id.Namespace namespaceId) throws Exception;
-
-  /**
-   * Checks if the specified namespace exists.
-   *
-   * @param namespaceId the {@link Id.Namespace} to check for existence
-   * @return true, if the specifed namespace exists, false otherwise
-   */
-  boolean exists(Id.Namespace namespaceId) throws Exception;
+public interface NamespaceAdmin extends NamespaceDefinitionAdmin {
 
   /**
    * Creates a new namespace.

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/NamespaceDefinitionAdmin.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/NamespaceDefinitionAdmin.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.namespace;
+
+import co.cask.cdap.common.NamespaceNotFoundException;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.NamespaceMeta;
+
+import java.util.List;
+
+/**
+ * Admin for querying namespace. For namespace manipulation operation see {@link NamespaceAdmin}
+ */
+public interface NamespaceDefinitionAdmin {
+  /**
+   * Lists all namespaces.
+   *
+   * @return a list of {@link NamespaceMeta} for all namespaces
+   */
+  List<NamespaceMeta> list() throws Exception;
+
+  /**
+   * Gets details of a namespace.
+   *
+   * @param namespaceId the {@link Id.Namespace} of the requested namespace
+   * @return the {@link NamespaceMeta} of the requested namespace
+   * @throws NamespaceNotFoundException if the requested namespace is not found
+   */
+  NamespaceMeta get(Id.Namespace namespaceId) throws Exception;
+
+  /**
+   * Checks if the specified namespace exists.
+   *
+   * @param namespaceId the {@link Id.Namespace} to check for existence
+   * @return true, if the specifed namespace exists, false otherwise
+   */
+  boolean exists(Id.Namespace namespaceId) throws Exception;
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/NamespaceQueryAdmin.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/NamespaceQueryAdmin.java
@@ -25,7 +25,7 @@ import java.util.List;
 /**
  * Admin for querying namespace. For namespace manipulation operation see {@link NamespaceAdmin}
  */
-public interface NamespaceDefinitionAdmin {
+public interface NamespaceQueryAdmin {
   /**
    * Lists all namespaces.
    *

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/guice/NamespaceClientRuntimeModule.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/guice/NamespaceClientRuntimeModule.java
@@ -21,6 +21,7 @@ import co.cask.cdap.common.namespace.DiscoveryNamespaceClient;
 import co.cask.cdap.common.namespace.InMemoryNamespaceClient;
 import co.cask.cdap.common.namespace.LocalNamespaceClient;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.runtime.RuntimeModule;
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;
@@ -36,6 +37,7 @@ public class NamespaceClientRuntimeModule extends RuntimeModule {
       @Override
       protected void configure() {
         bind(NamespaceAdmin.class).to(InMemoryNamespaceClient.class).in(Scopes.SINGLETON);
+        bind(NamespaceQueryAdmin.class).to(InMemoryNamespaceClient.class).in(Scopes.SINGLETON);
       }
     };
   }
@@ -46,6 +48,7 @@ public class NamespaceClientRuntimeModule extends RuntimeModule {
       @Override
       protected void configure() {
         bind(NamespaceAdmin.class).to(LocalNamespaceClient.class);
+        bind(NamespaceQueryAdmin.class).to(LocalNamespaceClient.class);
       }
     };
   }
@@ -56,6 +59,7 @@ public class NamespaceClientRuntimeModule extends RuntimeModule {
       @Override
       protected void configure() {
         bind(NamespaceAdmin.class).to(DiscoveryNamespaceClient.class);
+        bind(NamespaceQueryAdmin.class).to(DiscoveryNamespaceClient.class);
       }
     };
   }

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/guice/NamespaceClientRuntimeModule.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/guice/NamespaceClientRuntimeModule.java
@@ -20,6 +20,7 @@ import co.cask.cdap.common.namespace.AbstractNamespaceClient;
 import co.cask.cdap.common.namespace.DiscoveryNamespaceClient;
 import co.cask.cdap.common.namespace.InMemoryNamespaceClient;
 import co.cask.cdap.common.namespace.LocalNamespaceClient;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.runtime.RuntimeModule;
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;
@@ -34,7 +35,7 @@ public class NamespaceClientRuntimeModule extends RuntimeModule {
     return new AbstractModule() {
       @Override
       protected void configure() {
-        bind(AbstractNamespaceClient.class).to(InMemoryNamespaceClient.class).in(Scopes.SINGLETON);
+        bind(NamespaceAdmin.class).to(InMemoryNamespaceClient.class).in(Scopes.SINGLETON);
       }
     };
   }
@@ -44,7 +45,7 @@ public class NamespaceClientRuntimeModule extends RuntimeModule {
     return new AbstractModule() {
       @Override
       protected void configure() {
-        bind(AbstractNamespaceClient.class).to(LocalNamespaceClient.class);
+        bind(NamespaceAdmin.class).to(LocalNamespaceClient.class);
       }
     };
   }
@@ -54,7 +55,7 @@ public class NamespaceClientRuntimeModule extends RuntimeModule {
     return new AbstractModule() {
       @Override
       protected void configure() {
-        bind(AbstractNamespaceClient.class).to(DiscoveryNamespaceClient.class);
+        bind(NamespaceAdmin.class).to(DiscoveryNamespaceClient.class);
       }
     };
   }

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/DFSStreamHeartbeatsTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/DFSStreamHeartbeatsTest.java
@@ -25,9 +25,8 @@ import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
-import co.cask.cdap.common.namespace.AbstractNamespaceClient;
-import co.cask.cdap.common.namespace.InMemoryNamespaceClient;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
@@ -138,8 +137,7 @@ public class DFSStreamHeartbeatsTest {
         @Override
         protected void configure() {
           bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class);
-          bind(AbstractNamespaceClient.class).to(InMemoryNamespaceClient.class);
-
+          install(new NamespaceClientRuntimeModule().getInMemoryModules());
           bind(StreamConsumerStateStoreFactory.class).to(LevelDBStreamConsumerStateStoreFactory.class)
             .in(Singleton.class);
           bind(StreamAdmin.class).to(FileStreamAdmin.class).in(Singleton.class);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
@@ -25,7 +25,7 @@ import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.namespace.NamespaceDefinitionAdmin;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.data.stream.StreamCoordinatorClient;
 import co.cask.cdap.data.stream.StreamFileWriterFactory;
 import co.cask.cdap.data.stream.service.upload.ContentWriterFactory;
@@ -106,7 +106,7 @@ public final class StreamHandler extends AbstractHttpHandler {
   private final ConcurrentStreamWriter streamWriter;
   private final long batchBufferThreshold;
   private final StreamBodyConsumerFactory streamBodyConsumerFactory;
-  private final NamespaceDefinitionAdmin namespaceDefinitionAdmin;
+  private final NamespaceQueryAdmin namespaceQueryAdmin;
 
   // Executor for serving async enqueue requests
   private ExecutorService asyncExecutor;
@@ -118,7 +118,7 @@ public final class StreamHandler extends AbstractHttpHandler {
                        StreamFileWriterFactory writerFactory,
                        final MetricsCollectionService metricsCollectionService,
                        StreamWriterSizeCollector sizeCollector,
-                       NamespaceDefinitionAdmin namespaceDefinitionAdmin) {
+                       NamespaceQueryAdmin namespaceQueryAdmin) {
     this.cConf = cConf;
     this.streamAdmin = streamAdmin;
     this.sizeCollector = sizeCollector;
@@ -136,7 +136,7 @@ public final class StreamHandler extends AbstractHttpHandler {
     this.streamWriter = new ConcurrentStreamWriter(streamCoordinatorClient, streamAdmin, writerFactory,
                                                    cConf.getInt(Constants.Stream.WORKER_THREADS),
                                                    metricsCollectorFactory);
-    this.namespaceDefinitionAdmin = namespaceDefinitionAdmin;
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
   }
 
   @Override
@@ -182,7 +182,7 @@ public final class StreamHandler extends AbstractHttpHandler {
                      @PathParam("namespace-id") String namespaceId,
                      @PathParam("stream") String stream) throws Exception {
     // Check for namespace existence. Throws NotFoundException if namespace doesn't exist
-    namespaceDefinitionAdmin.get(Id.Namespace.from(namespaceId));
+    namespaceQueryAdmin.get(Id.Namespace.from(namespaceId));
 
     Id.Stream streamId;
     try {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
@@ -25,7 +25,7 @@ import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.namespace.AbstractNamespaceClient;
+import co.cask.cdap.common.namespace.NamespaceDefinitionAdmin;
 import co.cask.cdap.data.stream.StreamCoordinatorClient;
 import co.cask.cdap.data.stream.StreamFileWriterFactory;
 import co.cask.cdap.data.stream.service.upload.ContentWriterFactory;
@@ -106,7 +106,7 @@ public final class StreamHandler extends AbstractHttpHandler {
   private final ConcurrentStreamWriter streamWriter;
   private final long batchBufferThreshold;
   private final StreamBodyConsumerFactory streamBodyConsumerFactory;
-  private final AbstractNamespaceClient namespaceClient;
+  private final NamespaceDefinitionAdmin namespaceDefinitionAdmin;
 
   // Executor for serving async enqueue requests
   private ExecutorService asyncExecutor;
@@ -118,7 +118,7 @@ public final class StreamHandler extends AbstractHttpHandler {
                        StreamFileWriterFactory writerFactory,
                        final MetricsCollectionService metricsCollectionService,
                        StreamWriterSizeCollector sizeCollector,
-                       AbstractNamespaceClient namespaceClient) {
+                       NamespaceDefinitionAdmin namespaceDefinitionAdmin) {
     this.cConf = cConf;
     this.streamAdmin = streamAdmin;
     this.sizeCollector = sizeCollector;
@@ -136,7 +136,7 @@ public final class StreamHandler extends AbstractHttpHandler {
     this.streamWriter = new ConcurrentStreamWriter(streamCoordinatorClient, streamAdmin, writerFactory,
                                                    cConf.getInt(Constants.Stream.WORKER_THREADS),
                                                    metricsCollectorFactory);
-    this.namespaceClient = namespaceClient;
+    this.namespaceDefinitionAdmin = namespaceDefinitionAdmin;
   }
 
   @Override
@@ -182,7 +182,7 @@ public final class StreamHandler extends AbstractHttpHandler {
                      @PathParam("namespace-id") String namespaceId,
                      @PathParam("stream") String stream) throws Exception {
     // Check for namespace existence. Throws NotFoundException if namespace doesn't exist
-    namespaceClient.get(Id.Namespace.from(namespaceId));
+    namespaceDefinitionAdmin.get(Id.Namespace.from(namespaceId));
 
     Id.Stream streamId;
     try {

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/GatewayTestBase.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/GatewayTestBase.java
@@ -164,7 +164,6 @@ public abstract class GatewayTestBase {
         @Override
         protected void configure() {
           install(new StreamServiceRuntimeModule().getStandaloneModules());
-          install(new NamespaceClientRuntimeModule().getStandaloneModules());
 
           // It's a bit hacky to add it here. Need to refactor these
           // bindings out as it overlaps with

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -33,7 +33,6 @@ import co.cask.cdap.common.guice.TwillModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.io.URLConnections;
 import co.cask.cdap.common.kerberos.SecurityUtil;
-import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.common.runtime.DaemonMain;
 import co.cask.cdap.common.service.RetryOnStartFailureService;
 import co.cask.cdap.common.service.RetryStrategies;
@@ -464,7 +463,6 @@ public class MasterServiceMain extends DaemonMain {
       new NotificationServiceRuntimeModule().getDistributedModules(),
       new ViewAdminModules().getDistributedModules(),
       new StreamAdminModules().getDistributedModules(),
-      new NamespaceClientRuntimeModule().getDistributedModules(),
       new NamespaceStoreModule().getDistributedModules(),
       new AuditModule().getDistributedModules(),
       new AuthorizationModule(),

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/AbstractQueueUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/AbstractQueueUpgrader.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.data.tools;
 
 import co.cask.cdap.api.common.Bytes;
-import co.cask.cdap.common.namespace.NamespaceDefinitionAdmin;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.utils.ProjectInfo;
 import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
@@ -50,16 +50,16 @@ public abstract class AbstractQueueUpgrader extends AbstractUpgrader {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractQueueUpgrader.class);
   protected final HBaseTableUtil tableUtil;
   protected final Configuration conf;
-  protected final NamespaceDefinitionAdmin namespaceDefinitionAdmin;
+  protected final NamespaceQueryAdmin namespaceQueryAdmin;
 
   protected AbstractQueueUpgrader(LocationFactory locationFactory,
                                   NamespacedLocationFactory namespacedLocationFactory,
                                   HBaseTableUtil tableUtil, Configuration conf,
-                                  NamespaceDefinitionAdmin namespaceDefinitionAdmin) {
+                                  NamespaceQueryAdmin namespaceQueryAdmin) {
     super(locationFactory, namespacedLocationFactory);
     this.tableUtil = tableUtil;
     this.conf = conf;
-    this.namespaceDefinitionAdmin = namespaceDefinitionAdmin;
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
   }
 
   /**

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/AbstractQueueUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/AbstractQueueUpgrader.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.data.tools;
 
 import co.cask.cdap.api.common.Bytes;
-import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.common.namespace.NamespaceDefinitionAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.utils.ProjectInfo;
 import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
@@ -50,16 +50,16 @@ public abstract class AbstractQueueUpgrader extends AbstractUpgrader {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractQueueUpgrader.class);
   protected final HBaseTableUtil tableUtil;
   protected final Configuration conf;
-  protected final NamespaceAdmin namespaceAdmin;
+  protected final NamespaceDefinitionAdmin namespaceDefinitionAdmin;
 
   protected AbstractQueueUpgrader(LocationFactory locationFactory,
                                   NamespacedLocationFactory namespacedLocationFactory,
                                   HBaseTableUtil tableUtil, Configuration conf,
-                                  NamespaceAdmin namespaceAdmin) {
+                                  NamespaceDefinitionAdmin namespaceDefinitionAdmin) {
     super(locationFactory, namespacedLocationFactory);
     this.tableUtil = tableUtil;
     this.conf = conf;
-    this.namespaceAdmin = namespaceAdmin;
+    this.namespaceDefinitionAdmin = namespaceDefinitionAdmin;
   }
 
   /**

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseQueueDebugger.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseQueueDebugger.java
@@ -36,7 +36,7 @@ import co.cask.cdap.common.guice.KafkaClientModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.TwillModule;
 import co.cask.cdap.common.guice.ZKClientModule;
-import co.cask.cdap.common.namespace.NamespaceDefinitionAdmin;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.common.utils.ImmutablePair;
 import co.cask.cdap.data.runtime.DataFabricDistributedModule;
@@ -123,7 +123,7 @@ public class HBaseQueueDebugger extends AbstractIdleService {
   private final ZKClientService zkClientService;
   private final HBaseQueueClientFactory queueClientFactory;
   private final TransactionExecutorFactory txExecutorFactory;
-  private final NamespaceDefinitionAdmin namespaceDefinitionAdmin;
+  private final NamespaceQueryAdmin namespaceQueryAdmin;
   private final Store store;
 
   @Inject
@@ -131,14 +131,14 @@ public class HBaseQueueDebugger extends AbstractIdleService {
                             HBaseQueueClientFactory queueClientFactory,
                             ZKClientService zkClientService,
                             TransactionExecutorFactory txExecutorFactory,
-                            NamespaceDefinitionAdmin namespaceDefinitionAdmin,
+                            NamespaceQueryAdmin namespaceQueryAdmin,
                             Store store) {
     this.tableUtil = tableUtil;
     this.queueAdmin = queueAdmin;
     this.queueClientFactory = queueClientFactory;
     this.zkClientService = zkClientService;
     this.txExecutorFactory = txExecutorFactory;
-    this.namespaceDefinitionAdmin = namespaceDefinitionAdmin;
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
     this.store = store;
   }
 
@@ -155,7 +155,7 @@ public class HBaseQueueDebugger extends AbstractIdleService {
   public void scanAllQueues() throws Exception {
     QueueStatistics totalStats = new QueueStatistics();
 
-    List<NamespaceMeta> namespaceMetas = namespaceDefinitionAdmin.list();
+    List<NamespaceMeta> namespaceMetas = namespaceQueryAdmin.list();
     for (NamespaceMeta namespaceMeta : namespaceMetas) {
       Id.Namespace namespaceId = Id.Namespace.from(namespaceMeta.getName());
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseQueueDebugger.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseQueueDebugger.java
@@ -36,7 +36,7 @@ import co.cask.cdap.common.guice.KafkaClientModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.TwillModule;
 import co.cask.cdap.common.guice.ZKClientModule;
-import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.common.namespace.NamespaceDefinitionAdmin;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.common.utils.ImmutablePair;
 import co.cask.cdap.data.runtime.DataFabricDistributedModule;
@@ -123,7 +123,7 @@ public class HBaseQueueDebugger extends AbstractIdleService {
   private final ZKClientService zkClientService;
   private final HBaseQueueClientFactory queueClientFactory;
   private final TransactionExecutorFactory txExecutorFactory;
-  private final NamespaceAdmin namespaceAdmin;
+  private final NamespaceDefinitionAdmin namespaceDefinitionAdmin;
   private final Store store;
 
   @Inject
@@ -131,14 +131,14 @@ public class HBaseQueueDebugger extends AbstractIdleService {
                             HBaseQueueClientFactory queueClientFactory,
                             ZKClientService zkClientService,
                             TransactionExecutorFactory txExecutorFactory,
-                            NamespaceAdmin namespaceAdmin,
+                            NamespaceDefinitionAdmin namespaceDefinitionAdmin,
                             Store store) {
     this.tableUtil = tableUtil;
     this.queueAdmin = queueAdmin;
     this.queueClientFactory = queueClientFactory;
     this.zkClientService = zkClientService;
     this.txExecutorFactory = txExecutorFactory;
-    this.namespaceAdmin = namespaceAdmin;
+    this.namespaceDefinitionAdmin = namespaceDefinitionAdmin;
     this.store = store;
   }
 
@@ -155,7 +155,7 @@ public class HBaseQueueDebugger extends AbstractIdleService {
   public void scanAllQueues() throws Exception {
     QueueStatistics totalStats = new QueueStatistics();
 
-    List<NamespaceMeta> namespaceMetas = namespaceAdmin.list();
+    List<NamespaceMeta> namespaceMetas = namespaceDefinitionAdmin.list();
     for (NamespaceMeta namespaceMeta : namespaceMetas) {
       Id.Namespace namespaceId = Id.Namespace.from(namespaceMeta.getName());
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/StreamStateStoreUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/StreamStateStoreUpgrader.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.data.tools;
 
 import co.cask.cdap.api.common.Bytes;
-import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.common.namespace.NamespaceDefinitionAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data.stream.StreamUtils;
 import co.cask.cdap.data2.util.TableId;
@@ -45,13 +45,13 @@ public class StreamStateStoreUpgrader extends AbstractQueueUpgrader {
   @Inject
   public StreamStateStoreUpgrader(LocationFactory locationFactory, HBaseTableUtil tableUtil,
                                   NamespacedLocationFactory namespacedLocationFactory, Configuration conf,
-                                  NamespaceAdmin namespaceAdmin) {
-    super(locationFactory, namespacedLocationFactory, tableUtil, conf, namespaceAdmin);
+                                  NamespaceDefinitionAdmin namespaceDefinitionAdmin) {
+    super(locationFactory, namespacedLocationFactory, tableUtil, conf, namespaceDefinitionAdmin);
   }
 
   @Override
   protected Iterable<TableId> getTableIds() throws Exception {
-    return Lists.transform(namespaceAdmin.list(), new Function<NamespaceMeta, TableId>() {
+    return Lists.transform(namespaceDefinitionAdmin.list(), new Function<NamespaceMeta, TableId>() {
       @Override
       public TableId apply(NamespaceMeta input) {
         return StreamUtils.getStateStoreTableId(Id.Namespace.from(input.getName()));

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/StreamStateStoreUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/StreamStateStoreUpgrader.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.data.tools;
 
 import co.cask.cdap.api.common.Bytes;
-import co.cask.cdap.common.namespace.NamespaceDefinitionAdmin;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data.stream.StreamUtils;
 import co.cask.cdap.data2.util.TableId;
@@ -45,13 +45,13 @@ public class StreamStateStoreUpgrader extends AbstractQueueUpgrader {
   @Inject
   public StreamStateStoreUpgrader(LocationFactory locationFactory, HBaseTableUtil tableUtil,
                                   NamespacedLocationFactory namespacedLocationFactory, Configuration conf,
-                                  NamespaceDefinitionAdmin namespaceDefinitionAdmin) {
-    super(locationFactory, namespacedLocationFactory, tableUtil, conf, namespaceDefinitionAdmin);
+                                  NamespaceQueryAdmin namespaceQueryAdmin) {
+    super(locationFactory, namespacedLocationFactory, tableUtil, conf, namespaceQueryAdmin);
   }
 
   @Override
   protected Iterable<TableId> getTableIds() throws Exception {
-    return Lists.transform(namespaceDefinitionAdmin.list(), new Function<NamespaceMeta, TableId>() {
+    return Lists.transform(namespaceQueryAdmin.list(), new Function<NamespaceMeta, TableId>() {
       @Override
       public TableId apply(NamespaceMeta input) {
         return StreamUtils.getStateStoreTableId(Id.Namespace.from(input.getName()));

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/flow/FlowQueuePendingCorrector.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/flow/FlowQueuePendingCorrector.java
@@ -43,7 +43,7 @@ import co.cask.cdap.common.guice.KafkaClientModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.TwillModule;
 import co.cask.cdap.common.guice.ZKClientModule;
-import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.common.namespace.NamespaceDefinitionAdmin;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.data.runtime.DataFabricDistributedModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -118,14 +118,15 @@ public class FlowQueuePendingCorrector extends AbstractIdleService {
   private final Store store;
   private final ProgramRuntimeService programRuntimeService;
   private final TwillRunnerService twillRunnerService;
-  private final NamespaceAdmin namespaceAdmin;
+  private final NamespaceDefinitionAdmin namespaceDefinitionAdmin;
 
   @Inject
   public FlowQueuePendingCorrector(HBaseQueueDebugger queueDebugger, ZKClientService zkClientService,
                                    MetricsCollectionService metricsCollectionService, MetricStore metricStore,
                                    KafkaClientService kafkaClientService, Store store,
                                    ProgramRuntimeService programRuntimeService,
-                                   TwillRunnerService twillRunnerService, NamespaceAdmin namespaceAdmin) {
+                                   TwillRunnerService twillRunnerService,
+                                   NamespaceDefinitionAdmin namespaceDefinitionAdmin) {
     this.queueDebugger = queueDebugger;
     this.zkClientService = zkClientService;
     this.metricsCollectionService = metricsCollectionService;
@@ -134,7 +135,7 @@ public class FlowQueuePendingCorrector extends AbstractIdleService {
     this.store = store;
     this.programRuntimeService = programRuntimeService;
     this.twillRunnerService = twillRunnerService;
-    this.namespaceAdmin = namespaceAdmin;
+    this.namespaceDefinitionAdmin = namespaceDefinitionAdmin;
   }
 
   /**
@@ -142,7 +143,7 @@ public class FlowQueuePendingCorrector extends AbstractIdleService {
    */
   public void run() throws Exception {
     System.out.println("Running queue.pending correction");
-    List<NamespaceMeta> namespaceMetas = namespaceAdmin.list();
+    List<NamespaceMeta> namespaceMetas = namespaceDefinitionAdmin.list();
     for (NamespaceMeta namespaceMeta : namespaceMetas) {
       run(Id.Namespace.from(namespaceMeta.getName()));
     }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/flow/FlowQueuePendingCorrector.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/flow/FlowQueuePendingCorrector.java
@@ -43,7 +43,7 @@ import co.cask.cdap.common.guice.KafkaClientModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.TwillModule;
 import co.cask.cdap.common.guice.ZKClientModule;
-import co.cask.cdap.common.namespace.NamespaceDefinitionAdmin;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.data.runtime.DataFabricDistributedModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -118,7 +118,7 @@ public class FlowQueuePendingCorrector extends AbstractIdleService {
   private final Store store;
   private final ProgramRuntimeService programRuntimeService;
   private final TwillRunnerService twillRunnerService;
-  private final NamespaceDefinitionAdmin namespaceDefinitionAdmin;
+  private final NamespaceQueryAdmin namespaceQueryAdmin;
 
   @Inject
   public FlowQueuePendingCorrector(HBaseQueueDebugger queueDebugger, ZKClientService zkClientService,
@@ -126,7 +126,7 @@ public class FlowQueuePendingCorrector extends AbstractIdleService {
                                    KafkaClientService kafkaClientService, Store store,
                                    ProgramRuntimeService programRuntimeService,
                                    TwillRunnerService twillRunnerService,
-                                   NamespaceDefinitionAdmin namespaceDefinitionAdmin) {
+                                   NamespaceQueryAdmin namespaceQueryAdmin) {
     this.queueDebugger = queueDebugger;
     this.zkClientService = zkClientService;
     this.metricsCollectionService = metricsCollectionService;
@@ -135,7 +135,7 @@ public class FlowQueuePendingCorrector extends AbstractIdleService {
     this.store = store;
     this.programRuntimeService = programRuntimeService;
     this.twillRunnerService = twillRunnerService;
-    this.namespaceDefinitionAdmin = namespaceDefinitionAdmin;
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
   }
 
   /**
@@ -143,7 +143,7 @@ public class FlowQueuePendingCorrector extends AbstractIdleService {
    */
   public void run() throws Exception {
     System.out.println("Running queue.pending correction");
-    List<NamespaceMeta> namespaceMetas = namespaceDefinitionAdmin.list();
+    List<NamespaceMeta> namespaceMetas = namespaceQueryAdmin.list();
     for (NamespaceMeta namespaceMeta : namespaceMetas) {
       run(Id.Namespace.from(namespaceMeta.getName()));
     }

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -32,7 +32,6 @@ import co.cask.cdap.common.guice.KafkaClientModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.io.URLConnections;
-import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.common.startup.ConfigurationLogger;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.common.utils.OSDetector;
@@ -501,7 +500,6 @@ public class StandaloneMain {
       new NotificationServiceRuntimeModule().getStandaloneModules(),
       new ViewAdminModules().getStandaloneModules(),
       new StreamAdminModules().getStandaloneModules(),
-      new NamespaceClientRuntimeModule().getStandaloneModules(),
       new NamespaceStoreModule().getStandaloneModules(),
       new MetadataServiceModule(),
       new AuditModule().getStandaloneModules(),

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -236,7 +236,6 @@ public class TestBase {
       new ExploreClientModule(),
       new NotificationFeedServiceRuntimeModule().getInMemoryModules(),
       new NotificationServiceRuntimeModule().getInMemoryModules(),
-      new NamespaceClientRuntimeModule().getStandaloneModules(),
       new NamespaceStoreModule().getStandaloneModules(),
       new AuthorizationModule(),
       new AbstractModule() {


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/CDAP-6382
Build: http://builds.cask.co/browse/CDAP-DUT4331-2
- NamespaceDefinitionAdmin can be used by the classes which need to look up NamespaceMeta. For example DefaultNamespacedLocationFactory can use NamespaceDefinitionAdmin rather than NamespaceAdmin which needs a lot of guice injection leading to issues of circular dependency. 
- NamespaceAdmin extends NamespaceDefinitionAdmin so that someone using NamespaceAdmin can do all ns operation and also to reuse the existing code. 
- This NamespaceDefinitionAdmin will also be used by hbase, hive classes to look up NamespaceMeta. 
- Tested this to work with DefaultNamespacedLocationFactory 
