### PR TITLE
Use --no-install-recommends on apt-get install commands

### DIFF
--- a/cdap-distributions/src/Dockerfile
+++ b/cdap-distributions/src/Dockerfile
@@ -24,7 +24,7 @@ MAINTAINER Cask Data <ops@cask.co>
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.7
 RUN apt-get update && \
-  apt-get install -y \
+  apt-get install -y --no-install-recommends \
     curl \
     git && \
   curl -vL \

--- a/cdap-distributions/src/packer/scripts/lxde.sh
+++ b/cdap-distributions/src/packer/scripts/lxde.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -19,7 +19,7 @@
 #
 
 # Install
-apt-get install -y lxde
+apt-get install -y --no-install-recommends lxde
 
 # Symlink idea
 ln -sf /opt/idea* /opt/idea || (echo "Unable to symlink IDEA" && exit 1)

--- a/cdap-distributions/src/packer/scripts/random-root-password.sh
+++ b/cdap-distributions/src/packer/scripts/random-root-password.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -19,7 +19,7 @@
 #
 
 # Install apg
-apt-get install -y apg
+apt-get install -y --no-install-recommends apg
 
 # Setup cdap for sudo
 usermod -G sudo,adm,cdrom,dip,plugdev,lpadmin,sambashare cdap

--- a/cdap-distributions/src/packer/scripts/sdk-cleanup.sh
+++ b/cdap-distributions/src/packer/scripts/sdk-cleanup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -22,7 +22,7 @@
 /etc/init.d/cdap-sdk stop
 
 # Remove conf, data, and logs directories
-rm -rf /opt/cdap/conf /opt/cdap/sdk/data /opt/cdap/sdk/logs
+rm -rf /opt/cdap/sdk/conf /opt/cdap/sdk/data /opt/cdap/sdk/logs
 
 # Make cdap own /opt/cdap
 chown -R cdap:cdap /opt/cdap

--- a/cdap-distributions/src/packer/scripts/slim.sh
+++ b/cdap-distributions/src/packer/scripts/slim.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -19,7 +19,7 @@
 #
 
 # Install
-apt-get install -y slim
+apt-get install -y --no-install-recommends slim
 
 # Global configuration and auto-login
 echo 'sessiondir /usr/share/xsessions/' >> /etc/slim.conf

--- a/cdap-distributions/src/packer/scripts/xorg.sh
+++ b/cdap-distributions/src/packer/scripts/xorg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -19,7 +19,7 @@
 #
 
 # Install xorg
-apt-get install -y xorg
+apt-get install -y --no-install-recommends xorg
 
 # Remove X11 video drivers
 for i in ati cirrus fbdev intel mach64 mga neomagic nouveau openchrome qxl r128 radeon s3 savage siliconmotion sis sisusb tdfx trident ; do 


### PR DESCRIPTION
This will shrink the size of the Docker and VM images by not installing optional software.
