### PR TITLE
CDAP-6154 Custom Namespace Mapping for Filesystem

### DIFF
--- a/cdap-app-fabric-tests/pom.xml
+++ b/cdap-app-fabric-tests/pom.xml
@@ -74,6 +74,13 @@ the License.
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-unit-test</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/cdap-app-fabric/pom.xml
+++ b/cdap-app-fabric/pom.xml
@@ -38,6 +38,13 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-proto</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramRunnableModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramRunnableModule.java
@@ -28,6 +28,7 @@ import co.cask.cdap.common.guice.IOModule;
 import co.cask.cdap.common.guice.KafkaClientModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.ZKClientModule;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.stream.StreamAdminModules;
@@ -94,6 +95,7 @@ public class DistributedProgramRunnableModule {
       new StreamAdminModules().getDistributedModules(),
       new NotificationFeedClientModule(),
       new AuditModule().getDistributedModules(),
+      new NamespaceClientRuntimeModule().getDistributedModules(),
       new AuthorizationModule(),
       new AbstractModule() {
         @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/scheduler/SchedulerQueueResolver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/scheduler/SchedulerQueueResolver.java
@@ -16,14 +16,16 @@
 
 package co.cask.cdap.app.runtime.scheduler;
 
+import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceConfig;
 import co.cask.cdap.proto.NamespaceMeta;
-import co.cask.cdap.store.NamespaceStore;
 import com.google.common.base.Strings;
 
+import java.io.IOException;
 import javax.annotation.Nullable;
 
 
@@ -32,14 +34,14 @@ import javax.annotation.Nullable;
  */
 public class SchedulerQueueResolver {
   private final String defaultQueue;
-  private final NamespaceStore store;
+  private final NamespaceQueryAdmin namespaceQueryAdmin;
 
   /**
    * Construct SchedulerQueueResolver with CConfiguration and Store.
    */
-  public SchedulerQueueResolver(CConfiguration cConf, NamespaceStore store) {
+  public SchedulerQueueResolver(CConfiguration cConf, NamespaceQueryAdmin namespaceQueryAdmin) {
     this.defaultQueue = cConf.get(Constants.AppFabric.APP_SCHEDULER_QUEUE, "");
-    this.store = store;
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
   }
 
   /**
@@ -56,8 +58,15 @@ public class SchedulerQueueResolver {
    * @return schedule queue at namespace level or default queue.
    */
   @Nullable
-  public String getQueue(Id.Namespace namespaceId) {
-    NamespaceMeta meta = store.get(namespaceId);
+  public String getQueue(Id.Namespace namespaceId) throws IOException, NamespaceNotFoundException {
+    NamespaceMeta meta;
+    try {
+      meta = namespaceQueryAdmin.get(namespaceId);
+    } catch (NamespaceNotFoundException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
     if (meta != null) {
       NamespaceConfig config = meta.getConfig();
       String namespaceQueue = config.getSchedulerQueueName();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
@@ -23,11 +23,9 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.proto.NamespaceConfig;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.http.HttpHandler;
 import co.cask.http.HttpResponder;
-import com.google.common.base.Strings;
 import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
 import org.jboss.netty.handler.codec.http.HttpRequest;
@@ -104,20 +102,9 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
                                                   namespaceId, namespaceId));
     }
 
-    NamespaceMeta.Builder builder = new NamespaceMeta.Builder().setName(namespace);
-
-    // Handle optional params
-    if (metadata != null) {
-      if (metadata.getDescription() != null) {
-        builder.setDescription(metadata.getDescription());
-      }
-
-      NamespaceConfig config = metadata.getConfig();
-      if (config != null && !Strings.isNullOrEmpty(config.getSchedulerQueueName())) {
-        builder.setSchedulerQueueName(config.getSchedulerQueueName());
-      }
-    }
-
+    NamespaceMeta.Builder builder = metadata == null ? new NamespaceMeta.Builder() :
+      new NamespaceMeta.Builder(metadata);
+    builder.setName(namespace);
     try {
       namespaceAdmin.create(builder.build());
       responder.sendString(HttpResponseStatus.OK,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/AbstractStorageProviderNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/AbstractStorageProviderNamespaceAdmin.java
@@ -18,16 +18,20 @@ package co.cask.cdap.internal.app.namespace;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.id.NamespaceId;
+import com.google.common.base.Strings;
 import org.apache.twill.filesystem.Location;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.sql.SQLException;
 
 /**
@@ -39,12 +43,17 @@ abstract class AbstractStorageProviderNamespaceAdmin implements StorageProviderN
   private final CConfiguration cConf;
   private final NamespacedLocationFactory namespacedLocationFactory;
   private final ExploreFacade exploreFacade;
+  private final NamespaceQueryAdmin namespaceQueryAdmin;
 
-  AbstractStorageProviderNamespaceAdmin(CConfiguration cConf, NamespacedLocationFactory namespacedLocationFactory,
-                                        ExploreFacade exploreFacade) {
+
+  AbstractStorageProviderNamespaceAdmin(CConfiguration cConf,
+                                        NamespacedLocationFactory namespacedLocationFactory,
+                                        ExploreFacade exploreFacade,
+                                        NamespaceQueryAdmin namespaceQueryAdmin) {
     this.cConf = cConf;
     this.namespacedLocationFactory = namespacedLocationFactory;
     this.exploreFacade = exploreFacade;
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
   }
 
   /**
@@ -57,19 +66,8 @@ abstract class AbstractStorageProviderNamespaceAdmin implements StorageProviderN
    */
   @Override
   public void create(NamespaceMeta namespaceMeta) throws IOException, ExploreException, SQLException {
-    Location namespaceHome = namespacedLocationFactory.get(namespaceMeta.getNamespaceId().toId());
-    if (namespaceHome.exists()) {
-      LOG.warn("Home directory '{}' for namespace '{}' already exists. Deleting it.",
-               namespaceHome, namespaceMeta.getName());
-      if (!namespaceHome.delete(true)) {
-        throw new IOException(String.format("Error while deleting home directory '%s' for namespace '%s'",
-                                            namespaceHome, namespaceMeta.getName()));
-      }
-    }
-    if (!namespaceHome.mkdirs()) {
-      throw new IOException(String.format("Error while creating home directory '%s' for namespace '%s'",
-                                          namespaceHome, namespaceMeta.getName()));
-    }
+
+    createLocation(namespaceMeta);
 
     if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED)) {
       exploreFacade.createNamespace(namespaceMeta.getNamespaceId().toId());
@@ -86,21 +84,70 @@ abstract class AbstractStorageProviderNamespaceAdmin implements StorageProviderN
    */
   @Override
   public void delete(NamespaceId namespaceId) throws IOException, ExploreException, SQLException {
-    // TODO: CDAP-1581: Implement soft delete
-    Location namespaceHome = namespacedLocationFactory.get(namespaceId.toId());
-    if (namespaceHome.exists()) {
-      if (!namespaceHome.delete(true)) {
-        throw new IOException(String.format("Error while deleting home directory '%s' for namespace '%s'",
-                                            namespaceHome, namespaceId.getNamespace()));
-      }
-    } else {
-      // warn that namespace home was not found and skip delete step
-      LOG.warn(String.format("Home directory '%s' for namespace '%s' does not exist.",
-                             namespaceHome, namespaceId));
-    }
+
+    deleteLocation(namespaceId);
 
     if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED)) {
       exploreFacade.removeNamespace(namespaceId.toId());
     }
+  }
+
+  private void deleteLocation(NamespaceId namespaceId) throws IOException {
+    // TODO: CDAP-1581: Implement soft delete
+    Location namespaceHome = namespacedLocationFactory.get(namespaceId.toId());
+    try {
+      if (hasCustomLocation(namespaceQueryAdmin.get(namespaceId.toId()))) {
+        LOG.debug("Custom location mapping %s was found while deleting namespace %s. Skipping location delete.",
+                  namespaceHome, namespaceId);
+      } else {
+        // a custom location was not provided for this namespace so cdap is responsible for managing the lifecycle of
+        // the location hence delete it.
+        if (namespaceHome.exists() && !namespaceHome.delete(true)) {
+          throw new IOException(String.format("Error while deleting home directory '%s' for namespace '%s'",
+                                              namespaceHome, namespaceId));
+        }
+      }
+    } catch (Exception e) {
+      throw new IOException(String.format("Error while deleting home directory %s for namespace %s ", namespaceHome,
+                                          namespaceId), e);
+    }
+  }
+
+  private void createLocation(NamespaceMeta namespaceMeta) throws IOException {
+    Location namespaceHome;
+    if (hasCustomLocation(namespaceMeta)) {
+      // a custom location was provided
+      // check that its an absolute path
+      File customLocation = new File(namespaceMeta.getConfig().getRootDirectory());
+      if (!customLocation.isAbsolute()) {
+        throw new IOException(String.format("Cannot create the namespace '%s' with the given custom " +
+                                              "location %s. Custom location must be absolute path.",
+                                            namespaceMeta.getName(), customLocation));
+      }
+      // since this is a custom location we expect it to exists
+      if (!customLocation.exists()) {
+        // TODO: Add username in the below exception message.
+        throw new IOException(String.format(
+          "The provided home directory '%s' for namespace '%s' does not exists. Please create it on filesystem " +
+            "with sufficient privileges for the user and then try creating a namespace.", customLocation.toString(),
+          namespaceMeta.getNamespaceId()));
+      }
+    } else {
+      // no namespace custom location was provided one must be created by cdap
+      namespaceHome = namespacedLocationFactory.get(namespaceMeta.getNamespaceId().toId());
+      if (namespaceHome.exists()) {
+        throw new FileAlreadyExistsException(namespaceHome.toString());
+
+      }
+      // create namespace home dir
+      if (!namespaceHome.mkdirs()) {
+        throw new IOException(String.format("Error while creating home directory '%s' for namespace '%s'",
+                                            namespaceHome, namespaceMeta.getNamespaceId()));
+      }
+    }
+  }
+
+  private boolean hasCustomLocation(NamespaceMeta namespaceMeta) {
+    return !Strings.isNullOrEmpty(namespaceMeta.getConfig().getRootDirectory());
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/AbstractStorageProviderNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/AbstractStorageProviderNamespaceAdmin.java
@@ -126,12 +126,13 @@ abstract class AbstractStorageProviderNamespaceAdmin implements StorageProviderN
       }
       // since this is a custom location we expect it to exists. Get the custom location for the namespace from
       // namespaceLocationFactory since the location needs to be aware of local/distributed fs.
-      if (!namespacedLocationFactory.get(namespaceMeta.getNamespaceId().toId()).exists()) {
+      Location customNamespacedLocation = namespacedLocationFactory.get(namespaceMeta.getNamespaceId().toId());
+      if (!customNamespacedLocation.exists()) {
         // TODO: Add username in the below exception message.
         throw new IOException(String.format(
           "The provided home directory '%s' for namespace '%s' does not exists. Please create it on filesystem " +
-            "with sufficient privileges for the user and then try creating a namespace.", customLocation.toString(),
-          namespaceMeta.getNamespaceId()));
+            "with sufficient privileges for the user and then try creating a namespace.",
+          customNamespacedLocation.toString(), namespaceMeta.getNamespaceId()));
       }
     } else {
       // no namespace custom location was provided one must be created by cdap

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/AbstractStorageProviderNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/AbstractStorageProviderNamespaceAdmin.java
@@ -124,8 +124,9 @@ abstract class AbstractStorageProviderNamespaceAdmin implements StorageProviderN
                                               "location %s. Custom location must be absolute path.",
                                             namespaceMeta.getName(), customLocation));
       }
-      // since this is a custom location we expect it to exists
-      if (!customLocation.exists()) {
+      // since this is a custom location we expect it to exists. Get the custom location for the namespace from
+      // namespaceLocationFactory since the location needs to be aware of local/distributed fs.
+      if (!namespacedLocationFactory.get(namespaceMeta.getNamespaceId().toId()).exists()) {
         // TODO: Add username in the below exception message.
         throw new IOException(String.format(
           "The provided home directory '%s' for namespace '%s' does not exists. Please create it on filesystem " +

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DistributedStorageProviderNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DistributedStorageProviderNamespaceAdmin.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app.namespace;
 
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.explore.client.ExploreFacade;
@@ -43,8 +44,9 @@ public final class DistributedStorageProviderNamespaceAdmin extends AbstractStor
   @Inject
   DistributedStorageProviderNamespaceAdmin(CConfiguration cConf,
                                            NamespacedLocationFactory namespacedLocationFactory,
-                                           ExploreFacade exploreFacade, HBaseTableUtil tableUtil) {
-    super(cConf, namespacedLocationFactory, exploreFacade);
+                                           ExploreFacade exploreFacade, HBaseTableUtil tableUtil,
+                                           NamespaceQueryAdmin namespaceQueryAdmin) {
+    super(cConf, namespacedLocationFactory, exploreFacade, namespaceQueryAdmin);
     this.hConf = HBaseConfiguration.create();
     this.tableUtil = tableUtil;
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/LocalStorageProviderNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/LocalStorageProviderNamespaceAdmin.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app.namespace;
 
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.explore.client.ExploreFacade;
 import com.google.inject.Inject;
@@ -28,7 +29,7 @@ public final class LocalStorageProviderNamespaceAdmin extends AbstractStoragePro
 
   @Inject
   LocalStorageProviderNamespaceAdmin(CConfiguration cConf, NamespacedLocationFactory namespacedLocationFactory,
-                                     ExploreFacade exploreFacade) {
-    super(cConf, namespacedLocationFactory, exploreFacade);
+                                     ExploreFacade exploreFacade, NamespaceQueryAdmin namespaceQueryAdmin) {
+    super(cConf, namespacedLocationFactory, exploreFacade, namespaceQueryAdmin);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
@@ -616,8 +616,8 @@ public class ArtifactStore {
       }
     }
 
-    Location fileDirectory =
-      namespacedLocationFactory.get(artifactId.getNamespace(), ARTIFACTS_PATH).append(artifactId.getName());
+    Location fileDirectory = namespacedLocationFactory.get(artifactId.getNamespace(),
+                                                           ARTIFACTS_PATH).append(artifactId.getName());
     Locations.mkdirsIfNotExists(fileDirectory);
 
     // write the file contents

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/PropertiesResolver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/PropertiesResolver.java
@@ -17,15 +17,17 @@
 package co.cask.cdap.internal.app.services;
 
 import co.cask.cdap.app.runtime.scheduler.SchedulerQueueResolver;
+import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.config.PreferencesStore;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.store.NamespaceStore;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 
+import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -37,9 +39,9 @@ public class PropertiesResolver {
   private final SchedulerQueueResolver queueResolver;
 
   @Inject
-  PropertiesResolver(PreferencesStore prefStore, NamespaceStore store, CConfiguration cConf) {
+  PropertiesResolver(PreferencesStore prefStore, NamespaceQueryAdmin namespaceQueryAdmin, CConfiguration cConf) {
     this.prefStore = prefStore;
-    this.queueResolver = new SchedulerQueueResolver(cConf, store);
+    this.queueResolver = new SchedulerQueueResolver(cConf, namespaceQueryAdmin);
   }
 
   public Map<String, String> getUserProperties(Id.Program id) {
@@ -49,7 +51,7 @@ public class PropertiesResolver {
     return userArgs;
   }
 
-  public Map<String, String> getSystemProperties(Id.Program id) {
+  public Map<String, String> getSystemProperties(Id.Program id) throws IOException, NamespaceNotFoundException {
     Map<String, String> systemArgs = Maps.newHashMap();
     systemArgs.put(Constants.AppFabric.APP_SCHEDULER_QUEUE, queueResolver.getQueue(id.getNamespace()));
     return systemArgs;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/pipeline/ProgramGenerationStageTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/pipeline/ProgramGenerationStageTest.java
@@ -21,8 +21,8 @@ import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.Locations;
-import co.cask.cdap.common.namespace.DefaultNamespacedLocationFactory;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
+import co.cask.cdap.common.namespace.NamespacedLocationFactoryTestClient;
 import co.cask.cdap.internal.DefaultId;
 import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
 import co.cask.cdap.internal.app.deploy.Specifications;
@@ -61,7 +61,7 @@ public class ProgramGenerationStageTest {
     ApplicationSpecification appSpec = Specifications.from(new ToyApp());
     ApplicationSpecificationAdapter adapter = ApplicationSpecificationAdapter.create(new ReflectionSchemaGenerator());
     ApplicationSpecification newSpec = adapter.fromJson(adapter.toJson(appSpec));
-    NamespacedLocationFactory namespacedLocationFactory = new DefaultNamespacedLocationFactory(cConf, lf);
+    NamespacedLocationFactory namespacedLocationFactory = new NamespacedLocationFactoryTestClient(cConf, lf);
     ProgramGenerationStage pgmStage = new ProgramGenerationStage(cConf, namespacedLocationFactory,
                                                                  new NoOpAuthorizer());
     pgmStage.process(new StageContext(Object.class));  // Can do better here - fixed right now to run the test.

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdminTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdminTest.java
@@ -21,19 +21,21 @@ import co.cask.cdap.common.NamespaceAlreadyExistsException;
 import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import org.apache.twill.filesystem.Location;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.io.File;
 
 /**
  * Tests for {@link DefaultNamespaceAdmin}
  */
 public class DefaultNamespaceAdminTest extends AppFabricTestBase {
   private static final NamespaceAdmin namespaceAdmin = getInjector().getInstance(NamespaceAdmin.class);
+  private static final NamespacedLocationFactory namespacedLocationFactory =
+    getInjector().getInstance(NamespacedLocationFactory.class);
 
   @Test
   public void testNamespaces() throws Exception {
@@ -117,10 +119,11 @@ public class DefaultNamespaceAdminTest extends AppFabricTestBase {
     String namespace = "custompaceNamespace";
     Id.Namespace namespaceId = Id.Namespace.from(namespace);
     // check that root directory for a namespace cannot be updated
-    // create the custom directory
-    File customspaceDir = tmpFolder.newFolder("customspace");
+    // create the custom directory since the namespace is being created with custom root directory it needs to exist
+    Location customlocation = namespacedLocationFactory.get(namespaceId);
+    Assert.assertTrue(customlocation.mkdirs());
     NamespaceMeta nsMeta = new NamespaceMeta.Builder().setName(namespaceId)
-      .setRootDirectory(customspaceDir.toString()).build();
+      .setRootDirectory(customlocation.toString()).build();
     namespaceAdmin.create(nsMeta);
     Assert.assertTrue(namespaceAdmin.exists(namespaceId));
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStoreTest.java
@@ -21,7 +21,8 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -32,7 +33,6 @@ import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.internal.TempFolder;
 import co.cask.cdap.internal.app.scheduler.LogPrintingJob;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
-import co.cask.cdap.store.guice.NamespaceStoreModule;
 import co.cask.cdap.test.SlowTests;
 import co.cask.tephra.TransactionExecutorFactory;
 import co.cask.tephra.TransactionManager;
@@ -86,14 +86,14 @@ public class DatasetBasedTimeScheduleStoreTest {
     CConfiguration conf = CConfiguration.create();
     conf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder("data").getAbsolutePath());
     injector = Guice.createInjector(new ConfigModule(conf),
-                                    new LocationRuntimeModule().getInMemoryModules(),
+                                    new LocationUnitTestModule().getModule(),
                                     new DiscoveryRuntimeModule().getInMemoryModules(),
                                     new MetricsClientRuntimeModule().getInMemoryModules(),
                                     new DataFabricModules().getInMemoryModules(),
                                     new DataSetsModules().getStandaloneModules(),
                                     new DataSetServiceModules().getInMemoryModules(),
                                     new ExploreClientModule(),
-                                    new NamespaceStoreModule().getInMemoryModules());
+                                    new NamespaceClientRuntimeModule().getInMemoryModules());
     txService = injector.getInstance(TransactionManager.class);
     txService.startAndWait();
     dsOpsService = injector.getInstance(DatasetOpExecutor.class);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
@@ -80,7 +80,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
@@ -27,7 +27,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.IOModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.config.guice.ConfigStoreModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
@@ -101,7 +101,7 @@ public final class AppFabricTestModule extends AbstractModule {
       }
     });
     install(new ProgramRunnerRuntimeModule().getInMemoryModules());
-    install(new LocationRuntimeModule().getInMemoryModules());
+    install(new LocationUnitTestModule().getModule());
     install(new LoggingModules().getInMemoryModules());
     install(new LogReaderRuntimeModules().getInMemoryModules());
     install(new MetricsHandlerModule());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/SystemMetadataKafkaPublishTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/SystemMetadataKafkaPublishTest.java
@@ -19,7 +19,7 @@ package co.cask.cdap.metadata;
 import co.cask.cdap.AllProgramsApp;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
@@ -64,7 +64,7 @@ public class SystemMetadataKafkaPublishTest {
           bind(MetadataStore.class).to(DefaultMetadataStore.class);
         }
       }),
-      new LocationRuntimeModule().getInMemoryModules(),
+      new LocationUnitTestModule().getModule(),
       new TransactionInMemoryModule(),
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new NamespaceClientRuntimeModule().getInMemoryModules()

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/OpenCloseDataSetTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/OpenCloseDataSetTest.java
@@ -23,6 +23,7 @@ import co.cask.cdap.app.program.ProgramDescriptor;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.common.stream.StreamEventCodec;
@@ -33,6 +34,7 @@ import co.cask.cdap.internal.AppFabricTestHelper;
 import co.cask.cdap.internal.DefaultId;
 import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
 import co.cask.cdap.internal.app.runtime.BasicArguments;
+import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.test.XSlowTests;
 import co.cask.tephra.Transaction;
@@ -89,10 +91,12 @@ public class OpenCloseDataSetTest {
   };
 
   @BeforeClass
-  public static void setup() throws IOException {
+  public static void setup() throws Exception {
     NamespacedLocationFactory namespacedLocationFactory =
       AppFabricTestHelper.getInjector().getInstance(NamespacedLocationFactory.class);
     namespaceHomeLocation = namespacedLocationFactory.get(DefaultId.NAMESPACE);
+    NamespaceAdmin namespaceAdmin = AppFabricTestHelper.getInjector().getInstance(NamespaceAdmin.class);
+    namespaceAdmin.create(new NamespaceMeta.Builder().setName(DefaultId.NAMESPACE).build());
     Locations.mkdirsIfNotExists(namespaceHomeLocation);
   }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/DefaultNamespacedLocationFactory.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/DefaultNamespacedLocationFactory.java
@@ -18,7 +18,9 @@ package co.cask.cdap.common.namespace;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.io.RootLocationFactory;
 import co.cask.cdap.proto.Id;
+import com.google.common.base.Strings;
 import com.google.inject.Inject;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
@@ -31,13 +33,23 @@ import javax.annotation.Nullable;
  */
 public class DefaultNamespacedLocationFactory implements NamespacedLocationFactory {
 
+  // we need the RootLocationFactory because we want to work with the root of filesystem for custom namespace mapping
+  // for example if the custom mapping is /user/someuser/ this requires a locationfactory which works with root of
+  // the filesystem
+  private final RootLocationFactory rootLocationFactory;
   private final LocationFactory locationFactory;
   private final String namespaceDir;
 
+  private final NamespaceQueryAdmin namespaceQueryAdmin;
+
   @Inject
-  public DefaultNamespacedLocationFactory(CConfiguration cConf, LocationFactory locationFactory) {
+  public DefaultNamespacedLocationFactory(CConfiguration cConf, RootLocationFactory rootLocationFactory,
+                                          LocationFactory locationFactory,
+                                          NamespaceQueryAdmin namespaceQueryAdmin) {
     this.namespaceDir = cConf.get(Constants.Namespace.NAMESPACES_DIR);
+    this.rootLocationFactory = rootLocationFactory;
     this.locationFactory = locationFactory;
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
   }
 
   @Override
@@ -47,11 +59,44 @@ public class DefaultNamespacedLocationFactory implements NamespacedLocationFacto
 
   @Override
   public Location get(Id.Namespace namespaceId, @Nullable String subPath) throws IOException {
-    Location namespaceLocation = locationFactory.create(namespaceDir).append(namespaceId.getId());
+    String rootDirectory;
+    Location namespaceLocation;
+    if (Id.Namespace.DEFAULT.equals(namespaceId) || Id.Namespace.SYSTEM.equals(namespaceId) ||
+      Id.Namespace.CDAP.equals(namespaceId)) {
+      // since these are cdap reserved namespace we know there cannot be a custom mapping for this.
+      // for optimization don't query for namespace meta
+      namespaceLocation = getSimpleLocation(namespaceId);
+    } else {
+      // since this is not a cdap reserved namespace we look up meta if there is a custom mapping
+      try {
+        rootDirectory = namespaceQueryAdmin.get(namespaceId).getConfig().getRootDirectory();
+      } catch (Exception e) {
+        throw new IOException(String.format("Failed to get namespace meta for namespace %s", namespaceId), e);
+      }
+      if (Strings.isNullOrEmpty(rootDirectory)) {
+        // if no custom mapping was specified the use the default namespaces location
+        namespaceLocation = getSimpleLocation(namespaceId);
+      } else {
+        // custom mapping are expected to be given from the root of the filesystem.
+        // so here use the rootlocationfactory
+        namespaceLocation = rootLocationFactory.create("/").append(rootDirectory);
+      }
+    }
+
     if (subPath != null) {
       namespaceLocation = namespaceLocation.append(subPath);
     }
     return namespaceLocation;
+  }
+
+  /**
+   * Gives a namespaced location for a namespace which does not have a custom mapping
+   *
+   * @param namespaceId the simple cdap namespace
+   * @return location of the namespace
+   */
+  private Location getSimpleLocation(Id.Namespace namespaceId) throws IOException {
+    return locationFactory.create(namespaceDir).append(namespaceId.getId());
   }
 
   @Override

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/guice/NamespaceClientRuntimeModule.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/guice/NamespaceClientRuntimeModule.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.common.namespace.guice;
 
-import co.cask.cdap.common.namespace.AbstractNamespaceClient;
 import co.cask.cdap.common.namespace.DiscoveryNamespaceClient;
 import co.cask.cdap.common.namespace.InMemoryNamespaceClient;
 import co.cask.cdap.common.namespace.LocalNamespaceClient;
@@ -25,10 +24,12 @@ import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.runtime.RuntimeModule;
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;
-import com.google.inject.Scopes;
+import com.google.inject.Singleton;
 
 /**
- * Module to define Guice bindings for {@link AbstractNamespaceClient}
+ * Module to define Guice bindings for {@link NamespaceAdmin}.
+ * {@link NamespaceAdmin} and {@link NamespaceQueryAdmin} are binded in Singleton to make sure
+ * they use the same instance of the client.
  */
 public class NamespaceClientRuntimeModule extends RuntimeModule {
   @Override
@@ -36,8 +37,9 @@ public class NamespaceClientRuntimeModule extends RuntimeModule {
     return new AbstractModule() {
       @Override
       protected void configure() {
-        bind(NamespaceAdmin.class).to(InMemoryNamespaceClient.class).in(Scopes.SINGLETON);
-        bind(NamespaceQueryAdmin.class).to(InMemoryNamespaceClient.class).in(Scopes.SINGLETON);
+        bind(InMemoryNamespaceClient.class).in(Singleton.class);
+        bind(NamespaceAdmin.class).to(InMemoryNamespaceClient.class);
+        bind(NamespaceQueryAdmin.class).to(InMemoryNamespaceClient.class);
       }
     };
   }
@@ -47,6 +49,7 @@ public class NamespaceClientRuntimeModule extends RuntimeModule {
     return new AbstractModule() {
       @Override
       protected void configure() {
+        bind(LocalNamespaceClient.class).in(Singleton.class);
         bind(NamespaceAdmin.class).to(LocalNamespaceClient.class);
         bind(NamespaceQueryAdmin.class).to(LocalNamespaceClient.class);
       }
@@ -58,6 +61,7 @@ public class NamespaceClientRuntimeModule extends RuntimeModule {
     return new AbstractModule() {
       @Override
       protected void configure() {
+        bind(DiscoveryNamespaceClient.class).in(Singleton.class);
         bind(NamespaceAdmin.class).to(DiscoveryNamespaceClient.class);
         bind(NamespaceQueryAdmin.class).to(DiscoveryNamespaceClient.class);
       }

--- a/cdap-common/src/test/java/co/cask/cdap/common/guice/LocationUnitTestModule.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/guice/LocationUnitTestModule.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.common.guice;
+
+import co.cask.cdap.common.namespace.DefaultNamespacedLocationFactory;
+import co.cask.cdap.common.namespace.NamespacedLocationFactory;
+import co.cask.cdap.common.namespace.NamespacedLocationFactoryTestClient;
+import co.cask.cdap.proto.NamespaceMeta;
+import com.google.inject.AbstractModule;
+import com.google.inject.Module;
+import com.google.inject.util.Modules;
+
+/**
+ * Location Factory guice binding for unit tests. These binding are similar to
+ * {@link LocationRuntimeModule#getInMemoryModules()} but the {@link NamespacedLocationFactory} is binded to a
+ * {@link NamespacedLocationFactoryTestClient} which does not perform {@link NamespaceMeta} lookup like
+ * {@link DefaultNamespacedLocationFactory} and hence in unit tests the namespace does not need to be created to get
+ * namespaces locations.
+ */
+public class LocationUnitTestModule {
+  public Module getModule() {
+
+    return Modules.override(new LocationRuntimeModule().getInMemoryModules()).with(
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(NamespacedLocationFactory.class).to(NamespacedLocationFactoryTestClient.class);
+        }
+      }
+    );
+  }
+}

--- a/cdap-common/src/test/java/co/cask/cdap/common/namespace/DefaultNamespacedLocationFactoryTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/namespace/DefaultNamespacedLocationFactoryTest.java
@@ -17,7 +17,11 @@
 package co.cask.cdap.common.namespace;
 
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.io.RootLocationFactory;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.NamespaceId;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
@@ -26,7 +30,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.IOException;
+import java.io.File;
 
 /**
  * Tests for {@link DefaultNamespacedLocationFactory}.
@@ -37,14 +41,36 @@ public class DefaultNamespacedLocationFactoryTest {
   public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
 
   @Test
-  public void testGet() throws IOException {
-    LocationFactory locationFactory = new LocalLocationFactory(TEMP_FOLDER.newFolder());
+  public void testGet() throws Exception {
+    File rootLocationFactoryPath = TEMP_FOLDER.newFolder();
+    RootLocationFactory rootLocationFactory =
+      new RootLocationFactory(new LocalLocationFactory(rootLocationFactoryPath));
+
+    File locationFactoryPath = TEMP_FOLDER.newFolder();
+    LocationFactory locationFactory = new LocalLocationFactory(locationFactoryPath);
+
+    NamespaceAdmin nsAdmin = new InMemoryNamespaceClient();
+
+    Id.Namespace ns1 = Id.Namespace.from("ns1");
+    NamespaceMeta defaultNSMeta = new NamespaceMeta.Builder().setName(Id.Namespace.DEFAULT).build();
+    NamespaceMeta ns1NSMeta = new NamespaceMeta.Builder().setName(ns1).setRootDirectory("/ns1").build();
+
+    nsAdmin.create(defaultNSMeta);
+    nsAdmin.create(ns1NSMeta);
+
+    CConfiguration cConf = CConfiguration.create();
     NamespacedLocationFactory namespacedLocationFactory =
-      new DefaultNamespacedLocationFactory(CConfiguration.create(), locationFactory);
+      new DefaultNamespacedLocationFactory(cConf, rootLocationFactory, locationFactory, nsAdmin);
 
     Location defaultLoc = namespacedLocationFactory.get(Id.Namespace.DEFAULT);
-    Id.Namespace ns1 = Id.Namespace.from("ns1");
     Location ns1Loc = namespacedLocationFactory.get(ns1);
+
+    // check if location was as expected
+    Location expectedLocation = locationFactory.create(cConf.get(Constants.Namespace.NAMESPACES_DIR))
+      .append(NamespaceId.DEFAULT.getNamespace());
+    Assert.assertEquals(expectedLocation, defaultLoc);
+    expectedLocation = rootLocationFactory.create("/ns1");
+    Assert.assertEquals(expectedLocation, ns1Loc);
 
     // test these are not the same
     Assert.assertNotEquals(defaultLoc, ns1Loc);

--- a/cdap-common/src/test/java/co/cask/cdap/common/namespace/NamespacedLocationFactoryTestClient.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/namespace/NamespacedLocationFactoryTestClient.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.namespace;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.NamespaceMeta;
+import com.google.inject.Inject;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+
+import java.io.IOException;
+import javax.annotation.Nullable;
+
+/**
+ * Implementation of {@link NamespacedLocationFactory} to be only used in unit tests. This implementation does not
+ * perform lookup for {@link NamespaceMeta} like {@link DefaultNamespacedLocationFactory} does and hence allow unit
+ * tests to use it without creating namespace meta for the namespace.
+ */
+public class NamespacedLocationFactoryTestClient implements NamespacedLocationFactory {
+
+  private final LocationFactory locationFactory;
+  private final String namespaceDir;
+
+  @Inject
+  public NamespacedLocationFactoryTestClient(CConfiguration cConf, LocationFactory locationFactory) {
+    this.namespaceDir = cConf.get(Constants.Namespace.NAMESPACES_DIR);
+    this.locationFactory = locationFactory;
+  }
+
+  @Override
+  public Location get(Id.Namespace namespaceId) throws IOException {
+    return get(namespaceId, null);
+  }
+
+  @Override
+  public Location get(Id.Namespace namespaceId, @Nullable String subPath) throws IOException {
+    Location namespaceLocation = locationFactory.create(namespaceDir).append(namespaceId.getId());
+    if (subPath != null) {
+      namespaceLocation = namespaceLocation.append(subPath);
+    }
+    return namespaceLocation;
+  }
+
+  @Override
+  public Location getBaseLocation() throws IOException {
+    return locationFactory.create("/");
+  }
+}

--- a/cdap-data-fabric-tests/pom.xml
+++ b/cdap-data-fabric-tests/pom.xml
@@ -110,6 +110,13 @@
       <artifactId>tephra-core</artifactId>
       <type>test-jar</type>
     </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamFileJanitorTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamFileJanitorTest.java
@@ -21,7 +21,10 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.ZKClientModule;
+import co.cask.cdap.common.io.RootLocationFactory;
 import co.cask.cdap.common.namespace.DefaultNamespacedLocationFactory;
+import co.cask.cdap.common.namespace.InMemoryNamespaceClient;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data.file.FileWriter;
 import co.cask.cdap.data.runtime.DataFabricModules;
@@ -66,6 +69,7 @@ public class DFSStreamFileJanitorTest extends StreamFileJanitorTestBase {
   private static StreamFileWriterFactory fileWriterFactory;
   private static StreamCoordinatorClient streamCoordinatorClient;
   private static NamespaceStore namespaceStore;
+  private static NamespaceAdmin namespaceAdmin;
 
   @BeforeClass
   public static void init() throws IOException {
@@ -74,8 +78,10 @@ public class DFSStreamFileJanitorTest extends StreamFileJanitorTestBase {
     hConf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, tmpFolder.newFolder().getAbsolutePath());
     dfsCluster = new MiniDFSCluster.Builder(hConf).numDataNodes(1).build();
     dfsCluster.waitClusterUp();
+    namespaceAdmin = new InMemoryNamespaceClient();
     final LocationFactory lf = new FileContextLocationFactory(dfsCluster.getFileSystem().getConf());
-    final NamespacedLocationFactory nlf = new DefaultNamespacedLocationFactory(cConf, lf);
+    final NamespacedLocationFactory nlf = new DefaultNamespacedLocationFactory(cConf, new RootLocationFactory(lf), lf,
+                                                                               namespaceAdmin);
 
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf, hConf),
@@ -85,6 +91,7 @@ public class DFSStreamFileJanitorTest extends StreamFileJanitorTestBase {
         protected void configure() {
           bind(LocationFactory.class).toInstance(lf);
           bind(NamespacedLocationFactory.class).toInstance(nlf);
+          bind(NamespaceAdmin.class).toInstance(namespaceAdmin);
         }
       },
       new TransactionMetricsModule(),
@@ -150,6 +157,11 @@ public class DFSStreamFileJanitorTest extends StreamFileJanitorTestBase {
   @Override
   protected NamespaceStore getNamespaceStore() {
     return namespaceStore;
+  }
+
+  @Override
+  protected NamespaceAdmin getNamespaceAdmin() {
+    return namespaceAdmin;
   }
 
   @Override

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DistributedStreamCoordinatorClientTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DistributedStreamCoordinatorClientTest.java
@@ -19,8 +19,8 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.ZKClientModule;
-import co.cask.cdap.common.namespace.DefaultNamespacedLocationFactory;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
+import co.cask.cdap.common.namespace.NamespacedLocationFactoryTestClient;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.TransactionMetricsModule;
@@ -45,8 +45,6 @@ import org.apache.twill.zookeeper.ZKClientService;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
-import java.io.IOException;
-
 /**
  * Tests for {@link DistributedStreamCoordinatorClient}
  */
@@ -59,7 +57,7 @@ public class DistributedStreamCoordinatorClientTest extends StreamCoordinatorTes
   private static StreamCoordinatorClient coordinatorClient;
 
   @BeforeClass
-  public static void init() throws IOException {
+  public static void init() throws Exception {
     zkServer = InMemoryZKServer.builder().setDataDir(tmpFolder.newFolder()).build();
     zkServer.startAndWait();
 
@@ -68,7 +66,7 @@ public class DistributedStreamCoordinatorClientTest extends StreamCoordinatorTes
     dfsCluster = new MiniDFSCluster.Builder(hConf).numDataNodes(1).build();
     dfsCluster.waitClusterUp();
     final LocationFactory lf = new FileContextLocationFactory(dfsCluster.getFileSystem().getConf());
-    final NamespacedLocationFactory nlf = new DefaultNamespacedLocationFactory(cConf, lf);
+    final NamespacedLocationFactory nlf = new NamespacedLocationFactoryTestClient(cConf, lf);
 
     cConf.set(Constants.Zookeeper.QUORUM, zkServer.getConnectionStr());
 

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/InMemoryStreamCoordinatorClientTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/InMemoryStreamCoordinatorClientTest.java
@@ -18,8 +18,9 @@ package co.cask.cdap.data.stream;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
@@ -37,8 +38,6 @@ import com.google.inject.util.Modules;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
-import java.io.IOException;
-
 /**
  *
  */
@@ -48,7 +47,7 @@ public class InMemoryStreamCoordinatorClientTest extends StreamCoordinatorTestBa
   private static StreamCoordinatorClient coordinatorClient;
 
   @BeforeClass
-  public static void init() throws IOException {
+  public static void init() throws Exception {
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, tmpFolder.newFolder().getAbsolutePath());
 
     Injector injector = Guice.createInjector(
@@ -57,7 +56,8 @@ public class InMemoryStreamCoordinatorClientTest extends StreamCoordinatorTestBa
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new DataSetsModules().getInMemoryModules(),
       new DataFabricModules().getInMemoryModules(),
-      new LocationRuntimeModule().getInMemoryModules(),
+      new LocationUnitTestModule().getModule(),
+      new NamespaceClientRuntimeModule().getInMemoryModules(),
       new TransactionMetricsModule(),
       new NotificationFeedServiceRuntimeModule().getInMemoryModules(),
       new ExploreClientModule(),

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalStreamFileJanitorTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalStreamFileJanitorTest.java
@@ -21,8 +21,10 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.file.FileWriter;
 import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -60,6 +62,7 @@ public class LocalStreamFileJanitorTest extends StreamFileJanitorTestBase {
   private static StreamFileWriterFactory fileWriterFactory;
   private static StreamCoordinatorClient streamCoordinatorClient;
   private static NamespaceStore namespaceStore;
+  private static NamespaceAdmin namespaceAdmin;
 
   @BeforeClass
   public static void init() throws IOException {
@@ -67,12 +70,13 @@ public class LocalStreamFileJanitorTest extends StreamFileJanitorTestBase {
 
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf),
-      new LocationRuntimeModule().getInMemoryModules(),
+      new LocationUnitTestModule().getModule(),
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new DataSetsModules().getInMemoryModules(),
       new TransactionMetricsModule(),
       new DataFabricLevelDBModule(),
       new DiscoveryRuntimeModule().getInMemoryModules(),
+      new NamespaceClientRuntimeModule().getInMemoryModules(),
       new ExploreClientModule(),
       new ViewAdminModules().getInMemoryModules(),
       Modules.override(new StreamAdminModules().getStandaloneModules()).with(new AbstractModule() {
@@ -92,6 +96,7 @@ public class LocalStreamFileJanitorTest extends StreamFileJanitorTestBase {
     );
 
     locationFactory = injector.getInstance(LocationFactory.class);
+    namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
     namespacedLocationFactory = injector.getInstance(NamespacedLocationFactory.class);
     namespaceStore = injector.getInstance(NamespaceStore.class);
     streamAdmin = injector.getInstance(StreamAdmin.class);
@@ -123,6 +128,11 @@ public class LocalStreamFileJanitorTest extends StreamFileJanitorTestBase {
   @Override
   protected NamespaceStore getNamespaceStore() {
     return namespaceStore;
+  }
+
+  @Override
+  protected NamespaceAdmin getNamespaceAdmin() {
+    return namespaceAdmin;
   }
 
   @Override

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamFileJanitorTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamFileJanitorTestBase.java
@@ -19,6 +19,7 @@ package co.cask.cdap.data.stream;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data.file.FileWriter;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
@@ -55,6 +56,8 @@ public abstract class StreamFileJanitorTestBase {
 
   protected abstract NamespaceStore getNamespaceStore();
 
+  protected abstract NamespaceAdmin getNamespaceAdmin();
+
   protected abstract CConfiguration getCConfiguration();
 
   protected abstract FileWriter<StreamEvent> createWriter(Id.Stream streamId) throws IOException;
@@ -63,7 +66,7 @@ public abstract class StreamFileJanitorTestBase {
   public void setup() throws Exception {
     // FileStreamAdmin expects namespace directory to exist.
     // Simulate namespace create, since its an inmemory-namespace admin
-    getNamespaceStore().create(NamespaceMeta.DEFAULT);
+    getNamespaceAdmin().create(NamespaceMeta.DEFAULT);
     getNamespacedLocationFactory().get(Id.Namespace.DEFAULT).mkdirs();
   }
 
@@ -77,7 +80,7 @@ public abstract class StreamFileJanitorTestBase {
     streamAdmin.create(streamId);
     StreamConfig streamConfig = streamAdmin.getConfig(streamId);
     StreamFileJanitor janitor = new StreamFileJanitor(getCConfiguration(), getStreamAdmin(),
-                                                      getNamespacedLocationFactory(), getNamespaceStore());
+                                                      getNamespacedLocationFactory(), getNamespaceAdmin());
 
     for (int i = 0; i < 5; i++) {
       FileWriter<StreamEvent> writer = createWriter(streamId);
@@ -112,7 +115,7 @@ public abstract class StreamFileJanitorTestBase {
 
     StreamAdmin streamAdmin = getStreamAdmin();
     StreamFileJanitor janitor = new StreamFileJanitor(getCConfiguration(), getStreamAdmin(),
-                                                      getNamespacedLocationFactory(), getNamespaceStore());
+                                                      getNamespacedLocationFactory(), getNamespaceAdmin());
 
     Properties properties = new Properties();
     properties.setProperty(Constants.Stream.PARTITION_DURATION, "2000");
@@ -152,7 +155,7 @@ public abstract class StreamFileJanitorTestBase {
     Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, "cleanupDelete");
     StreamAdmin streamAdmin = getStreamAdmin();
     StreamFileJanitor janitor = new StreamFileJanitor(getCConfiguration(), streamAdmin, getNamespacedLocationFactory(),
-                                                      getNamespaceStore());
+                                                      getNamespaceAdmin());
     streamAdmin.create(streamId);
 
     // Write some data

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/DFSConcurrentStreamWriterTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/DFSConcurrentStreamWriterTest.java
@@ -17,8 +17,8 @@
 package co.cask.cdap.data.stream.service;
 
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.namespace.DefaultNamespacedLocationFactory;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
+import co.cask.cdap.common.namespace.NamespacedLocationFactoryTestClient;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.twill.filesystem.FileContextLocationFactory;
@@ -44,7 +44,7 @@ public class DFSConcurrentStreamWriterTest extends ConcurrentStreamWriterTestBas
     dfsCluster = new MiniDFSCluster.Builder(hConf).numDataNodes(1).build();
     dfsCluster.waitClusterUp();
     LocationFactory locationFactory = new FileContextLocationFactory(dfsCluster.getFileSystem().getConf());
-    namespacedLocationFactory = new DefaultNamespacedLocationFactory(CConfiguration.create(), locationFactory);
+    namespacedLocationFactory = new NamespacedLocationFactoryTestClient(CConfiguration.create(), locationFactory);
 
   }
 

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/DFSStreamHeartbeatsTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/DFSStreamHeartbeatsTest.java
@@ -21,7 +21,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
@@ -121,7 +121,7 @@ public class DFSStreamHeartbeatsTest {
         new DataFabricModules().getInMemoryModules(),
         new ConfigModule(cConf, new Configuration()),
         new DiscoveryRuntimeModule().getInMemoryModules(),
-        new LocationRuntimeModule().getInMemoryModules(),
+        new LocationUnitTestModule().getModule(),
         new ExploreClientModule(),
         new DataSetServiceModules().getInMemoryModules(),
         new DataSetsModules().getStandaloneModules(),

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/LocalConcurrentStreamWriterTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/LocalConcurrentStreamWriterTest.java
@@ -17,8 +17,8 @@
 package co.cask.cdap.data.stream.service;
 
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.namespace.DefaultNamespacedLocationFactory;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
+import co.cask.cdap.common.namespace.NamespacedLocationFactoryTestClient;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.LocationFactory;
 import org.junit.BeforeClass;
@@ -35,7 +35,7 @@ public class LocalConcurrentStreamWriterTest extends ConcurrentStreamWriterTestB
   @BeforeClass
   public static void init() throws IOException {
     LocationFactory locationFactory = new LocalLocationFactory(TMP_FOLDER.newFolder());
-    namespacedLocationFactory = new DefaultNamespacedLocationFactory(CConfiguration.create(), locationFactory);
+    namespacedLocationFactory = new NamespacedLocationFactoryTestClient(CConfiguration.create(), locationFactory);
   }
 
   @Override

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/StreamFileSizeFetcherTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/StreamFileSizeFetcherTest.java
@@ -18,8 +18,8 @@ package co.cask.cdap.data.stream.service;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.io.Locations;
-import co.cask.cdap.common.namespace.DefaultNamespacedLocationFactory;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
+import co.cask.cdap.common.namespace.NamespacedLocationFactoryTestClient;
 import co.cask.cdap.data.stream.NoopStreamAdmin;
 import co.cask.cdap.data.stream.StreamDataFileWriter;
 import co.cask.cdap.data.stream.StreamFileTestUtils;
@@ -52,7 +52,7 @@ public class StreamFileSizeFetcherTest {
   @BeforeClass
   public static void init() throws IOException {
     LocationFactory locationFactory = new LocalLocationFactory(TMP_FOLDER.newFolder());
-    namespacedLocationFactory = new DefaultNamespacedLocationFactory(cConf, locationFactory);
+    namespacedLocationFactory = new NamespacedLocationFactoryTestClient(cConf, locationFactory);
   }
 
   @Test

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableTest.java
@@ -25,6 +25,7 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.ZKClientModule;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.hbase.HBaseTestBase;
 import co.cask.cdap.data.hbase.HBaseTestFactory;
 import co.cask.cdap.data.runtime.DataFabricDistributedModule;
@@ -76,6 +77,7 @@ public class HBaseMetricsTableTest extends MetricsTableTest {
                                              new DiscoveryRuntimeModule().getDistributedModules(),
                                              new TransactionMetricsModule(),
                                              new LocationRuntimeModule().getDistributedModules(),
+                                             new NamespaceClientRuntimeModule().getInMemoryModules(),
                                              new SystemDatasetRuntimeModule().getDistributedModules(),
                                              new DataSetsModules().getInMemoryModules());
 

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
@@ -19,7 +19,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.data.runtime.DataFabricModules;
@@ -102,7 +102,7 @@ public class TransactionServiceClientTest extends TransactionSystemTest {
     injector = Guice.createInjector(
       new ConfigModule(cConf, hConf),
       new ZKClientModule(),
-      new LocationRuntimeModule().getInMemoryModules(),
+      new LocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getDistributedModules(),
       new TransactionMetricsModule(),
       new DataFabricModules().getDistributedModules(),

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceTest.java
@@ -21,7 +21,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.data.runtime.DataFabricModules;
@@ -88,7 +88,7 @@ public class TransactionServiceTest {
       Injector injector = Guice.createInjector(
         new ConfigModule(cConf),
         new ZKClientModule(),
-        new LocationRuntimeModule().getInMemoryModules(),
+        new LocationUnitTestModule().getModule(),
         new DiscoveryRuntimeModule().getDistributedModules(),
         new TransactionMetricsModule(),
         new DataFabricModules().getDistributedModules(),
@@ -198,7 +198,7 @@ public class TransactionServiceTest {
 
     final Injector injector =
       Guice.createInjector(new ConfigModule(cConf, hConf),
-                           new LocationRuntimeModule().getInMemoryModules(),  // Use local location factory
+                           new LocationUnitTestModule().getModule(),
                            new ZKClientModule(),
                            new DiscoveryRuntimeModule().getDistributedModules(),
                            new TransactionMetricsModule(),

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseConsumerStateTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseConsumerStateTest.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data2.transaction.stream.hbase;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data.hbase.HBaseTestBase;
@@ -86,7 +86,7 @@ public class HBaseConsumerStateTest extends StreamConsumerStateTestBase {
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf, hConf),
       new ZKClientModule(),
-      new LocationRuntimeModule().getInMemoryModules(),
+      new LocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getInMemoryModules(),
       new TransactionMetricsModule(),
       new DataFabricDistributedModule(),

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseFileStreamAdminTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseFileStreamAdminTest.java
@@ -19,7 +19,7 @@ package co.cask.cdap.data2.transaction.stream.hbase;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data.hbase.HBaseTestBase;
@@ -92,7 +92,7 @@ public class HBaseFileStreamAdminTest extends StreamAdminTest {
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf, hConf),
       new ZKClientModule(),
-      new LocationRuntimeModule().getInMemoryModules(),
+      new LocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getInMemoryModules(),
       new TransactionMetricsModule(),
       new DataSetsModules().getInMemoryModules(),

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerTest.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data2.transaction.stream.hbase;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data.hbase.HBaseTestBase;
@@ -99,7 +99,7 @@ public class HBaseStreamConsumerTest extends StreamConsumerTestBase {
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf, hConf),
       new ZKClientModule(),
-      new LocationRuntimeModule().getInMemoryModules(),
+      new LocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getInMemoryModules(),
       new TransactionMetricsModule(),
       new DataSetsModules().getInMemoryModules(),

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBFileStreamAdminTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBFileStreamAdminTest.java
@@ -20,7 +20,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -69,7 +69,7 @@ public class LevelDBFileStreamAdminTest extends StreamAdminTest {
 
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf),
-      new LocationRuntimeModule().getInMemoryModules(),
+      new LocationUnitTestModule().getModule(),
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new DataSetsModules().getInMemoryModules(),
       new DataFabricLevelDBModule(),

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerStateTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerStateTest.java
@@ -19,7 +19,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -68,7 +68,7 @@ public class LevelDBStreamConsumerStateTest extends StreamConsumerStateTestBase 
 
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf),
-      new LocationRuntimeModule().getInMemoryModules(),
+      new LocationUnitTestModule().getModule(),
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new DataSetsModules().getInMemoryModules(),
       new DataFabricLevelDBModule(),

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerTest.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data2.transaction.stream.leveldb;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -70,7 +70,7 @@ public class LevelDBStreamConsumerTest extends StreamConsumerTestBase {
 
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf),
-      new LocationRuntimeModule().getInMemoryModules(),
+      new LocationUnitTestModule().getModule(),
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new DataSetsModules().getInMemoryModules(),
       new DataFabricLevelDBModule(),

--- a/cdap-data-fabric/pom.xml
+++ b/cdap-data-fabric/pom.xml
@@ -38,6 +38,13 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-formats</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamFileJanitor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamFileJanitor.java
@@ -19,12 +19,12 @@ package co.cask.cdap.data.stream;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
-import co.cask.cdap.store.NamespaceStore;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import org.apache.twill.filesystem.Location;
@@ -44,23 +44,23 @@ public final class StreamFileJanitor {
   private final StreamAdmin streamAdmin;
   private final NamespacedLocationFactory namespacedLocationFactory;
   private final String streamBaseDirPath;
-  private final NamespaceStore namespaceStore;
+  private final NamespaceQueryAdmin namespaceQueryAdmin;
 
   @Inject
   public StreamFileJanitor(CConfiguration cConf, StreamAdmin streamAdmin,
                            NamespacedLocationFactory namespacedLocationFactory,
-                           NamespaceStore namespaceStore) {
+                           NamespaceQueryAdmin namespaceQueryAdmin) {
     this.streamAdmin = streamAdmin;
     this.streamBaseDirPath = cConf.get(Constants.Stream.BASE_DIR);
     this.namespacedLocationFactory = namespacedLocationFactory;
-    this.namespaceStore = namespaceStore;
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
   }
 
   /**
    * Performs file cleanup for all streams.
    */
   public void cleanAll() throws Exception {
-    List<NamespaceMeta> namespaces = namespaceStore.list();
+    List<NamespaceMeta> namespaces = namespaceQueryAdmin.list();
 
     for (NamespaceMeta namespace : namespaces) {
       Location streamBaseLocation =

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
@@ -27,6 +27,7 @@ import co.cask.cdap.common.HandlerException;
 import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.data2.audit.AuditPublisher;
 import co.cask.cdap.data2.audit.AuditPublishers;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
@@ -41,7 +42,6 @@ import co.cask.cdap.proto.DatasetTypeMeta;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.audit.AuditPayload;
 import co.cask.cdap.proto.audit.AuditType;
-import co.cask.cdap.store.NamespaceStore;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -67,7 +67,7 @@ public class DatasetInstanceService {
   private final DatasetInstanceManager instanceManager;
   private final DatasetOpExecutor opExecutorClient;
   private final ExploreFacade exploreFacade;
-  private final NamespaceStore nsStore;
+  private final NamespaceQueryAdmin namespaceQueryAdmin;
 
   private AuditPublisher auditPublisher;
 
@@ -77,12 +77,12 @@ public class DatasetInstanceService {
   @Inject
   public DatasetInstanceService(DatasetTypeManager typeManager, DatasetInstanceManager instanceManager,
                                 DatasetOpExecutor opExecutorClient, ExploreFacade exploreFacade, CConfiguration conf,
-                                NamespaceStore nsStore) {
+                                NamespaceQueryAdmin namespaceQueryAdmin) {
     this.opExecutorClient = opExecutorClient;
     this.typeManager = typeManager;
     this.instanceManager = instanceManager;
     this.exploreFacade = exploreFacade;
-    this.nsStore = nsStore;
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
     this.metaCache = CacheBuilder.newBuilder().build(
       new CacheLoader<Id.DatasetInstance, DatasetMeta>() {
         @Override
@@ -388,7 +388,7 @@ public class DatasetInstanceService {
    */
   private void ensureNamespaceExists(Id.Namespace namespace) throws Exception {
     if (!Id.Namespace.SYSTEM.equals(namespace)) {
-      if (nsStore.get(namespace) == null) {
+      if (namespaceQueryAdmin.get(namespace) == null) {
         throw new NamespaceNotFoundException(namespace);
       }
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetService.java
@@ -22,12 +22,12 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.ResolvingDiscoverable;
 import co.cask.cdap.common.http.CommonNettyHttpServiceBuilder;
 import co.cask.cdap.common.metrics.MetricsReporterHook;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.service.UncaughtExceptionIdleService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetTypeManager;
 import co.cask.cdap.data2.metrics.DatasetMetricsReporter;
-import co.cask.cdap.store.NamespaceStore;
 import co.cask.http.NettyHttpService;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
@@ -79,11 +79,11 @@ public class DatasetService extends AbstractExecutionThreadService {
                         DatasetOpExecutor opExecutorClient,
                         Set<DatasetMetricsReporter> metricReporters,
                         DatasetInstanceService datasetInstanceService,
-                        NamespaceStore namespaceStore) throws Exception {
+                        NamespaceQueryAdmin namespaceQueryAdmin) throws Exception {
 
     this.typeManager = typeManager;
     DatasetTypeHandler datasetTypeHandler = new DatasetTypeHandler(typeManager, cConf, namespacedLocationFactory,
-                                                                   namespaceStore);
+                                                                   namespaceQueryAdmin);
     DatasetInstanceHandler datasetInstanceHandler = new DatasetInstanceHandler(datasetInstanceService);
     NettyHttpService.Builder builder = new CommonNettyHttpServiceBuilder(cConf);
     builder.addHttpHandlers(ImmutableList.of(datasetTypeHandler,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeHandler.java
@@ -21,6 +21,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.http.AbstractBodyConsumer;
 import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetModuleConflictException;
@@ -28,7 +29,6 @@ import co.cask.cdap.data2.datafabric.dataset.type.DatasetTypeManager;
 import co.cask.cdap.proto.DatasetModuleMeta;
 import co.cask.cdap.proto.DatasetTypeMeta;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.store.NamespaceStore;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.BodyConsumer;
 import co.cask.http.HandlerContext;
@@ -68,15 +68,15 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
   private final DatasetTypeManager typeManager;
   private final CConfiguration cConf;
   private final NamespacedLocationFactory namespacedLocationFactory;
-  private final NamespaceStore namespaceStore;
+  private final NamespaceQueryAdmin namespaceQueryAdmin;
 
   @Inject
   DatasetTypeHandler(DatasetTypeManager typeManager, CConfiguration conf,
-                     NamespacedLocationFactory namespacedLocationFactory, NamespaceStore namespaceStore) {
+                     NamespacedLocationFactory namespacedLocationFactory, NamespaceQueryAdmin namespaceQueryAdmin) {
     this.typeManager = typeManager;
     this.cConf = conf;
     this.namespacedLocationFactory = namespacedLocationFactory;
-    this.namespaceStore = namespaceStore;
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
   }
 
   @Override
@@ -305,7 +305,7 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
    */
   private void ensureNamespaceExists(Id.Namespace namespace) throws Exception {
     if (!Id.Namespace.SYSTEM.equals(namespace)) {
-      if (namespaceStore.get(namespace) == null) {
+      if (namespaceQueryAdmin.get(namespace) == null) {
         throw new NamespaceNotFoundException(namespace);
       }
     }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/SystemDatasetDefinitionTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/SystemDatasetDefinitionTest.java
@@ -28,7 +28,7 @@ import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.guice.ConfigModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
 import com.google.inject.Guice;
@@ -58,7 +58,7 @@ public class SystemDatasetDefinitionTest {
   public static void createInjector() {
     injector = Guice.createInjector(
       new ConfigModule(CConfiguration.create()),
-      new LocationRuntimeModule().getInMemoryModules(),
+      new LocationUnitTestModule().getModule(),
       new SystemDatasetRuntimeModule().getInMemoryModules());
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/view/MDSViewStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/view/MDSViewStoreTest.java
@@ -24,13 +24,13 @@ import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
 import co.cask.cdap.common.namespace.AbstractNamespaceClient;
 import co.cask.cdap.common.namespace.InMemoryNamespaceClient;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.explore.client.MockExploreClient;
-import co.cask.cdap.store.guice.NamespaceStoreModule;
 import co.cask.tephra.TransactionManager;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -58,7 +58,7 @@ public class MDSViewStoreTest extends ViewStoreTestBase {
       new DataSetsModules().getStandaloneModules(),
       new DataFabricModules().getInMemoryModules(),
       new DiscoveryRuntimeModule().getInMemoryModules(),
-      new NamespaceStoreModule().getInMemoryModules(),
+      new NamespaceClientRuntimeModule().getInMemoryModules(),
       new LocationRuntimeModule().getInMemoryModules(),
       new AbstractModule() {
         @Override

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -48,7 +48,7 @@ import co.cask.cdap.data2.transaction.TransactionSystemClientService;
 import co.cask.cdap.explore.client.DiscoveryExploreClient;
 import co.cask.cdap.explore.client.ExploreFacade;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.http.HttpHandler;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.inmemory.InMemoryTxSystemClient;
@@ -67,7 +67,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.HashSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -126,7 +125,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
       new LocalDatasetOpExecutor(cConf, discoveryService, opExecutorService),
       exploreFacade,
       cConf,
-      NAMESPACE_STORE);
+      namespaceQueryAdmin);
     instanceService.setAuditPublisher(inMemoryAuditPublisher);
 
     service = new DatasetService(cConf,
@@ -138,8 +137,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
                                  metricsCollectionService,
                                  new InMemoryDatasetOpExecutor(framework),
                                  new HashSet<DatasetMetricsReporter>(),
-                                 instanceService,
-                                 NAMESPACE_STORE
+                                 instanceService, namespaceQueryAdmin
     );
     // Start dataset service, wait for it to be discoverable
     service.start();
@@ -155,8 +153,8 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
 
     startLatch.await(5, TimeUnit.SECONDS);
 
-    namespacedLocationFactory.get(Id.Namespace.SYSTEM).mkdirs();
-    namespacedLocationFactory.get(NAMESPACE_ID).mkdirs();
+    createNamespace(Id.Namespace.SYSTEM);
+    createNamespace(NAMESPACE_ID);
   }
 
   // Note: Cannot have these system namespace restrictions in system namespace since we use it internally in
@@ -187,10 +185,25 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
     }
   }
 
+  private void createNamespace (Id.Namespace namespaceId) throws Exception {
+    // since the namespace admin here is an in memory one we need to create the location explicitly
+    namespacedLocationFactory.get(namespaceId).mkdirs();
+    // the framework.delete looks up namespace config through namespaceadmin add the meta there too.
+    namespaceAdmin.create(new NamespaceMeta.Builder().setName(namespaceId).build());
+  }
+
+  private void deleteNamespace (Id.Namespace namespaceId) throws Exception {
+    // since the namespace admin here is an in memory one we need to delete the location explicitly
+    namespacedLocationFactory.get(namespaceId).delete(true);
+    namespaceAdmin.delete(namespaceId);
+  }
+
   @After
-  public void after() throws IOException {
-    namespacedLocationFactory.get(NAMESPACE_ID).delete(true);
-    namespacedLocationFactory.get(NamespaceId.SYSTEM.toId()).delete(true);
+  public void after() throws Exception {
+    // since we stored namespace meta through admin so that framework.delete can lookup namespaceconfig clean the
+    // meta from there too
+    deleteNamespace(NAMESPACE_ID);
+    deleteNamespace(Id.Namespace.SYSTEM);
     Futures.getUnchecked(Services.chainStop(service, opExecutorService, txManager));
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -22,10 +22,12 @@ import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data.runtime.DynamicTransactionExecutorFactory;
@@ -41,7 +43,6 @@ import co.cask.cdap.data2.datafabric.dataset.type.DatasetTypeManager;
 import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
-import co.cask.cdap.data2.dataset2.InMemoryNamespaceStore;
 import co.cask.cdap.data2.metadata.store.NoOpMetadataStore;
 import co.cask.cdap.data2.metrics.DatasetMetricsReporter;
 import co.cask.cdap.data2.transaction.DelegatingTransactionSystemClientService;
@@ -53,7 +54,6 @@ import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.proto.DatasetModuleMeta;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
-import co.cask.cdap.store.NamespaceStore;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequests;
 import co.cask.common.http.HttpResponse;
@@ -105,8 +105,8 @@ public abstract class DatasetServiceTestBase {
   private InMemoryDiscoveryService discoveryService;
   private DatasetOpExecutorService opExecutorService;
   private DatasetService service;
-  private LocationFactory locationFactory;
-  private NamespaceStore namespaceStore;
+  protected LocationFactory locationFactory;
+  protected NamespaceAdmin namespaceAdmin;
   protected TransactionManager txManager;
   protected RemoteDatasetFramework dsFramework;
   protected InMemoryDatasetFramework inMemoryDatasetFramework;
@@ -140,7 +140,8 @@ public abstract class DatasetServiceTestBase {
 
     injector = Guice.createInjector(
       new ConfigModule(cConf),
-      new LocationRuntimeModule().getInMemoryModules(),
+      new LocationUnitTestModule().getModule(),
+      new NamespaceClientRuntimeModule().getInMemoryModules(),
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new TransactionInMemoryModule());
 
@@ -186,8 +187,8 @@ public abstract class DatasetServiceTestBase {
     inMemoryDatasetFramework = new InMemoryDatasetFramework(registryFactory, modules);
 
     ExploreFacade exploreFacade = new ExploreFacade(new DiscoveryExploreClient(cConf, discoveryService), cConf);
-    namespaceStore = new InMemoryNamespaceStore();
-    namespaceStore.create(NamespaceMeta.DEFAULT);
+    namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
+    namespaceAdmin.create(NamespaceMeta.DEFAULT);
     TransactionExecutorFactory txExecutorFactory = new DynamicTransactionExecutorFactory(txSystemClient);
     DatasetTypeManager typeManager = new DatasetTypeManager(cConf, locationFactory, txSystemClientService,
                                                             txExecutorFactory,
@@ -198,7 +199,7 @@ public abstract class DatasetServiceTestBase {
       new InMemoryDatasetOpExecutor(dsFramework),
       exploreFacade,
       cConf,
-      namespaceStore);
+      namespaceAdmin);
 
     service = new DatasetService(cConf,
                                  namespacedLocationFactory,
@@ -209,7 +210,7 @@ public abstract class DatasetServiceTestBase {
                                  new InMemoryDatasetOpExecutor(dsFramework),
                                  new HashSet<DatasetMetricsReporter>(),
                                  instanceService,
-                                 namespaceStore);
+                                 namespaceAdmin);
 
     // Start dataset service, wait for it to be discoverable
     service.start();
@@ -231,7 +232,7 @@ public abstract class DatasetServiceTestBase {
   @After
   public void after() throws Exception {
     Services.chainStop(service, opExecutorService, txManager);
-    namespaceStore.delete(Id.Namespace.DEFAULT);
+    namespaceAdmin.delete(Id.Namespace.DEFAULT);
     Locations.deleteQuietly(locationFactory.create(Id.Namespace.DEFAULT.getId()));
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
@@ -27,6 +27,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data.runtime.TransactionExecutorModule;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
@@ -79,7 +80,7 @@ public final class DatasetFrameworkTestUtil extends ExternalResource {
 
     injector = Guice.createInjector(
       new ConfigModule(cConf),
-      new LocationRuntimeModule().getInMemoryModules(),
+      new LocationUnitTestModule().getModule(),
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new TransactionModules().getInMemoryModules(),
       new TransactionExecutorModule(),

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryMetricsTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryMetricsTableTest.java
@@ -20,7 +20,7 @@ import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data.runtime.TransactionMetricsModule;
@@ -49,7 +49,7 @@ public class InMemoryMetricsTableTest extends MetricsTableTest {
   public static void setup() throws Exception {
     Injector injector = Guice.createInjector(
       new ConfigModule(),
-      new LocationRuntimeModule().getInMemoryModules(),
+      new LocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getInMemoryModules(),
       new DataFabricModules().getInMemoryModules(),
       new TransactionMetricsModule(),

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBMetricsTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBMetricsTableTest.java
@@ -21,7 +21,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
@@ -53,7 +53,7 @@ public class LevelDBMetricsTableTest extends MetricsTableTest {
     conf.set(Constants.CFG_LOCAL_DATA_DIR, tmpFolder.newFolder().getAbsolutePath());
     Injector injector = Guice.createInjector(
       new ConfigModule(conf),
-      new LocationRuntimeModule().getStandaloneModules(),
+      new LocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getStandaloneModules(),
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new DataSetsModules().getInMemoryModules(),

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableServiceTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableServiceTest.java
@@ -21,7 +21,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.TransactionMetricsModule;
@@ -54,7 +54,7 @@ public class LevelDBTableServiceTest {
     conf.set(Constants.CFG_LOCAL_DATA_DIR, tmpFolder.newFolder().getAbsolutePath());
     injector = Guice.createInjector(
       new ConfigModule(conf),
-      new LocationRuntimeModule().getStandaloneModules(),
+      new LocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getStandaloneModules(),
       new DataSetsModules().getStandaloneModules(),
       new DataFabricLevelDBModule(),

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableTest.java
@@ -25,7 +25,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.TransactionMetricsModule;
@@ -59,7 +59,7 @@ public class LevelDBTableTest extends BufferingTableTest<LevelDBTable> {
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, tmpFolder.newFolder().getAbsolutePath());
     injector = Guice.createInjector(
       new ConfigModule(cConf),
-      new LocationRuntimeModule().getStandaloneModules(),
+      new LocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getStandaloneModules(),
       new DataSetsModules().getStandaloneModules(),
       new DataFabricLevelDBModule(),

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/LocalQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/LocalQueueTest.java
@@ -20,7 +20,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.data.runtime.DataFabricLocalModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
@@ -71,7 +71,7 @@ public class LocalQueueTest extends QueueTest {
     conf.set(Constants.CFG_LOCAL_DATA_DIR, tmpFolder.newFolder().getAbsolutePath());
     Injector injector = Guice.createInjector(
       new ConfigModule(conf),
-      new LocationRuntimeModule().getStandaloneModules(),
+      new LocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getStandaloneModules(),
       new TransactionMetricsModule(),
       new DiscoveryRuntimeModule().getStandaloneModules(),
@@ -91,7 +91,7 @@ public class LocalQueueTest extends QueueTest {
   public void testInjection() throws IOException {
     Injector injector = Guice.createInjector(
       new ConfigModule(conf),
-      new LocationRuntimeModule().getStandaloneModules(),
+      new LocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getStandaloneModules(),
       new TransactionMetricsModule(),
       new DataFabricModules().getStandaloneModules(),

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueTest.java
@@ -22,6 +22,7 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.ZKClientModule;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.data.hbase.HBaseTestBase;
@@ -148,6 +149,7 @@ public abstract class HBaseQueueTest extends QueueTest {
       new ConfigModule(cConf, hConf),
       new ZKClientModule(),
       new LocationRuntimeModule().getDistributedModules(),
+      new NamespaceClientRuntimeModule().getInMemoryModules(),
       new DiscoveryRuntimeModule().getDistributedModules(),
       new TransactionMetricsModule(),
       new DataSetsModules().getInMemoryModules(),

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryQueueTest.java
@@ -17,7 +17,7 @@ package co.cask.cdap.data2.transaction.queue.inmemory;
 
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
@@ -52,7 +52,7 @@ public class InMemoryQueueTest extends QueueTest {
 
     injector = Guice.createInjector(
       new ConfigModule(),
-      new LocationRuntimeModule().getInMemoryModules(),
+      new LocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getInMemoryModules(),
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new DataSetsModules().getInMemoryModules(),

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBQueueTest.java
@@ -19,7 +19,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -58,7 +58,7 @@ public class LevelDBQueueTest extends QueueTest {
     conf.set(Constants.Dataset.TABLE_PREFIX, "test");
     Injector injector = Guice.createInjector(
       new ConfigModule(conf),
-      new LocationRuntimeModule().getStandaloneModules(),
+      new LocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getStandaloneModules(),
       new DataSetsModules().getStandaloneModules(),
       new DataFabricLevelDBModule(),

--- a/cdap-explore/pom.xml
+++ b/cdap-explore/pom.xml
@@ -49,6 +49,13 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-data-fabric</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -21,9 +21,11 @@ import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.lib.PartitionDetail;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.app.runtime.scheduler.SchedulerQueueResolver;
+import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.ConfigurationUtil;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
@@ -53,7 +55,6 @@ import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.proto.QueryStatus;
 import co.cask.cdap.proto.TableInfo;
 import co.cask.cdap.proto.TableNameInfo;
-import co.cask.cdap.store.NamespaceStore;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.base.Charsets;
@@ -180,12 +181,12 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
 
   protected BaseHiveExploreService(TransactionSystemClient txClient, DatasetFramework datasetFramework,
                                    CConfiguration cConf, Configuration hConf,
-                                   File previewsDir, StreamAdmin streamAdmin, NamespaceStore store,
+                                   File previewsDir, StreamAdmin streamAdmin, NamespaceQueryAdmin namespaceQueryAdmin,
                                    SystemDatasetInstantiatorFactory datasetInstantiatorFactory,
                                    ExploreTableNaming tableNaming) {
     this.cConf = cConf;
     this.hConf = hConf;
-    this.schedulerQueueResolver = new SchedulerQueueResolver(cConf, store);
+    this.schedulerQueueResolver = new SchedulerQueueResolver(cConf, namespaceQueryAdmin);
     this.previewsDir = previewsDir;
     this.metastoreClientLocal = new ThreadLocal<>();
     this.metastoreClientReferences = Maps.newConcurrentMap();
@@ -1294,11 +1295,12 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
    * @throws IOException
    * @throws ExploreException
    */
-  protected Map<String, String> startSession() throws IOException, ExploreException {
+  protected Map<String, String> startSession() throws IOException, ExploreException, NamespaceNotFoundException {
     return startSession(null);
   }
 
-  protected Map<String, String> startSession(Id.Namespace namespace) throws IOException, ExploreException {
+  protected Map<String, String> startSession(Id.Namespace namespace)
+    throws IOException, ExploreException, NamespaceNotFoundException {
     Map<String, String> sessionConf = Maps.newHashMap();
 
     QueryHandle queryHandle = QueryHandle.generate();

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12CDH5ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12CDH5ExploreService.java
@@ -18,6 +18,7 @@ package co.cask.cdap.explore.service.hive;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
@@ -26,7 +27,6 @@ import co.cask.cdap.explore.service.HandleNotFoundException;
 import co.cask.cdap.explore.utils.ExploreTableNaming;
 import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.proto.QueryStatus;
-import co.cask.cdap.store.NamespaceStore;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -62,11 +62,11 @@ public class Hive12CDH5ExploreService extends BaseHiveExploreService {
   protected Hive12CDH5ExploreService(TransactionSystemClient txClient, DatasetFramework datasetFramework,
                                      CConfiguration cConf, Configuration hConf,
                                      @Named(Constants.Explore.PREVIEWS_DIR_NAME) File previewsDir,
-                                     StreamAdmin streamAdmin, NamespaceStore store,
+                                     StreamAdmin streamAdmin, NamespaceQueryAdmin namespaceQueryAdmin,
                                      SystemDatasetInstantiatorFactory datasetInstantiatorFactory,
                                      ExploreTableNaming tableNaming) {
     super(txClient, datasetFramework, cConf, hConf, previewsDir,
-          streamAdmin, store, datasetInstantiatorFactory, tableNaming);
+          streamAdmin, namespaceQueryAdmin, datasetInstantiatorFactory, tableNaming);
   }
 
   @Override

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12ExploreService.java
@@ -18,6 +18,7 @@ package co.cask.cdap.explore.service.hive;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
@@ -26,7 +27,6 @@ import co.cask.cdap.explore.service.HandleNotFoundException;
 import co.cask.cdap.explore.utils.ExploreTableNaming;
 import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.proto.QueryStatus;
-import co.cask.cdap.store.NamespaceStore;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
@@ -71,11 +71,11 @@ public class Hive12ExploreService extends BaseHiveExploreService {
   public Hive12ExploreService(TransactionSystemClient txClient, DatasetFramework datasetFramework,
                               CConfiguration cConf, Configuration hConf,
                               @Named(Constants.Explore.PREVIEWS_DIR_NAME) File previewsDir,
-                              StreamAdmin streamAdmin, NamespaceStore store,
+                              StreamAdmin streamAdmin, NamespaceQueryAdmin namespaceQueryAdmin,
                               SystemDatasetInstantiatorFactory datasetInstantiatorFactory,
                               ExploreTableNaming tableNaming) {
     super(txClient, datasetFramework, cConf, hConf, previewsDir,
-          streamAdmin, store, datasetInstantiatorFactory, tableNaming);
+          streamAdmin, namespaceQueryAdmin, datasetInstantiatorFactory, tableNaming);
   }
 
   @Override

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive13ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive13ExploreService.java
@@ -18,6 +18,7 @@ package co.cask.cdap.explore.service.hive;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
@@ -26,7 +27,6 @@ import co.cask.cdap.explore.service.HandleNotFoundException;
 import co.cask.cdap.explore.utils.ExploreTableNaming;
 import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.proto.QueryStatus;
-import co.cask.cdap.store.NamespaceStore;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -56,11 +56,11 @@ public class Hive13ExploreService extends BaseHiveExploreService {
   public Hive13ExploreService(TransactionSystemClient txClient, DatasetFramework datasetFramework,
                               CConfiguration cConf, Configuration hConf,
                               @Named(Constants.Explore.PREVIEWS_DIR_NAME) File previewsDir,
-                              StreamAdmin streamAdmin, NamespaceStore store,
+                              StreamAdmin streamAdmin, NamespaceQueryAdmin namespaceQueryAdmin,
                               SystemDatasetInstantiatorFactory datasetInstantiatorFactory,
                               ExploreTableNaming tableNaming) {
     super(txClient, datasetFramework, cConf, hConf, previewsDir,
-          streamAdmin, store, datasetInstantiatorFactory, tableNaming);
+          streamAdmin, namespaceQueryAdmin, datasetInstantiatorFactory, tableNaming);
     // This config sets the time Hive CLI getOperationStatus method will wait for the status of
     // a running query.
     System.setProperty(HiveConf.ConfVars.HIVE_SERVER2_LONG_POLLING_TIMEOUT.toString(), "50");

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive14ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive14ExploreService.java
@@ -18,6 +18,7 @@ package co.cask.cdap.explore.service.hive;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
@@ -26,7 +27,6 @@ import co.cask.cdap.explore.service.HandleNotFoundException;
 import co.cask.cdap.explore.utils.ExploreTableNaming;
 import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.proto.QueryStatus;
-import co.cask.cdap.store.NamespaceStore;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -55,11 +55,11 @@ public class Hive14ExploreService extends BaseHiveExploreService {
   public Hive14ExploreService(TransactionSystemClient txClient, DatasetFramework datasetFramework,
                               CConfiguration cConf, Configuration hConf,
                               @Named(Constants.Explore.PREVIEWS_DIR_NAME) File previewsDir,
-                              StreamAdmin streamAdmin, NamespaceStore store,
+                              StreamAdmin streamAdmin, NamespaceQueryAdmin namespaceQueryAdmin,
                               SystemDatasetInstantiatorFactory datasetInstantiatorFactory,
                               ExploreTableNaming tableNaming) {
     super(txClient, datasetFramework, cConf, hConf, previewsDir,
-          streamAdmin, store, datasetInstantiatorFactory, tableNaming);
+          streamAdmin, namespaceQueryAdmin, datasetInstantiatorFactory, tableNaming);
     // This config sets the time Hive CLI getOperationStatus method will wait for the status of
     // a running query.
     System.setProperty(HiveConf.ConfVars.HIVE_SERVER2_LONG_POLLING_TIMEOUT.toString(), "50");

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
@@ -24,8 +24,10 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.IOModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -46,8 +48,6 @@ import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
-import co.cask.cdap.store.NamespaceStore;
-import co.cask.cdap.store.guice.NamespaceStoreModule;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionManager;
 import com.google.common.collect.ImmutableList;
@@ -76,8 +76,8 @@ public class ExploreDisabledTest {
   private static DatasetOpExecutor dsOpExecutor;
   private static DatasetService datasetService;
   private static ExploreClient exploreClient;
-  private static NamespaceStore namespaceStore;
   private static NamespacedLocationFactory namespacedLocationFactory;
+  private static NamespaceAdmin namespaceAdmin;
 
   @BeforeClass
   public static void start() throws Exception {
@@ -96,12 +96,12 @@ public class ExploreDisabledTest {
 
     datasetFramework = injector.getInstance(DatasetFramework.class);
 
-    namespaceStore = injector.getInstance(NamespaceStore.class);
+    namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
     namespacedLocationFactory = injector.getInstance(NamespacedLocationFactory.class);
 
+    namespaceAdmin.create(new NamespaceMeta.Builder().setName(namespaceId).build());
     // This happens when you create a namespace via REST APIs. However, since we do not start AppFabricServer in
     // Explore tests, simulating that scenario by explicitly calling DatasetFramework APIs.
-    namespaceStore.create(new NamespaceMeta.Builder().setName(namespaceId).build());
     namespacedLocationFactory.get(namespaceId).mkdirs();
     exploreClient.addNamespace(namespaceId);
 
@@ -110,7 +110,7 @@ public class ExploreDisabledTest {
   @AfterClass
   public static void stop() throws Exception {
     exploreClient.removeNamespace(namespaceId);
-    namespaceStore.delete(namespaceId);
+    namespaceAdmin.delete(namespaceId);
     exploreClient.close();
     datasetService.stopAndWait();
     dsOpExecutor.stopAndWait();
@@ -212,7 +212,7 @@ public class ExploreDisabledTest {
         new ConfigModule(configuration, hConf),
         new IOModule(),
         new DiscoveryRuntimeModule().getInMemoryModules(),
-        new LocationRuntimeModule().getInMemoryModules(),
+        new LocationUnitTestModule().getModule(),
         new DataFabricModules().getInMemoryModules(),
         new DataSetsModules().getStandaloneModules(),
         new DataSetServiceModules().getInMemoryModules(),
@@ -222,7 +222,7 @@ public class ExploreDisabledTest {
         new ViewAdminModules().getInMemoryModules(),
         new StreamAdminModules().getInMemoryModules(),
         new NotificationServiceRuntimeModule().getInMemoryModules(),
-        new NamespaceStoreModule().getInMemoryModules(),
+        new NamespaceClientRuntimeModule().getInMemoryModules(),
         new AbstractModule() {
           @Override
           protected void configure() {

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTestRun.java
@@ -28,6 +28,7 @@ import co.cask.cdap.hive.datasets.DatasetSerDe;
 import co.cask.cdap.hive.datasets.DatasetStorageHandler;
 import co.cask.cdap.proto.ColumnDesc;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.QueryHandle;
 import co.cask.cdap.proto.QueryInfo;
 import co.cask.cdap.proto.QueryResult;
@@ -271,6 +272,7 @@ public class HiveExploreServiceTestRun extends BaseHiveExploreServiceTest {
   @Test
   public void testQueriesCount() throws Exception {
     Id.Namespace testNamespace1 = Id.Namespace.from("testQueriesCount");
+    namespaceAdmin.create(new NamespaceMeta.Builder().setName(testNamespace1).build());
     exploreClient.addNamespace(testNamespace1).get();
 
     try {
@@ -303,6 +305,8 @@ public class HiveExploreServiceTestRun extends BaseHiveExploreServiceTest {
     Id.Namespace testNamespace1 = Id.Namespace.from("test1");
     Id.Namespace testNamespace2 = Id.Namespace.from("test2");
 
+    namespaceAdmin.create(new NamespaceMeta.Builder().setName(testNamespace1).build());
+    namespaceAdmin.create(new NamespaceMeta.Builder().setName(testNamespace2).build());
     exploreClient.addNamespace(testNamespace1).get();
     exploreClient.addNamespace(testNamespace2).get();
 

--- a/cdap-gateway/pom.xml
+++ b/cdap-gateway/pom.xml
@@ -47,6 +47,13 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-data-fabric</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterMain.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterMain.java
@@ -25,6 +25,7 @@ import co.cask.cdap.common.guice.IOModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.kerberos.SecurityUtil;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.common.runtime.DaemonMain;
 import co.cask.cdap.security.guice.SecurityModules;
 import com.google.common.base.Throwables;
@@ -114,6 +115,7 @@ public class RouterMain extends DaemonMain {
       new ConfigModule(cConf),
       new ZKClientModule(),
       new LocationRuntimeModule().getDistributedModules(),
+      new NamespaceClientRuntimeModule().getDistributedModules(),
       new DiscoveryRuntimeModule().getDistributedModules(),
       new RouterModules().getDistributedModules(),
       new SecurityModules().getDistributedModules(),

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsSuiteTestBase.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsSuiteTestBase.java
@@ -25,7 +25,8 @@ import co.cask.cdap.common.discovery.EndpointStrategy;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -38,7 +39,6 @@ import co.cask.cdap.logging.read.LogReader;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.metrics.guice.MetricsHandlerModule;
 import co.cask.cdap.metrics.query.MetricsQueryService;
-import co.cask.cdap.store.guice.NamespaceStoreModule;
 import co.cask.tephra.TransactionManager;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ObjectArrays;
@@ -137,7 +137,7 @@ public abstract class MetricsSuiteTestBase {
   public static Injector startMetricsService(CConfiguration conf) {
     Injector injector = Guice.createInjector(Modules.override(
       new ConfigModule(conf),
-      new LocationRuntimeModule().getInMemoryModules(),
+      new LocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getInMemoryModules(),
       new MetricsHandlerModule(),
       new MetricsClientRuntimeModule().getInMemoryModules(),
@@ -145,7 +145,7 @@ public abstract class MetricsSuiteTestBase {
       new DataSetsModules().getStandaloneModules(),
       new DataSetServiceModules().getInMemoryModules(),
       new ExploreClientModule(),
-      new NamespaceStoreModule().getInMemoryModules()
+      new NamespaceClientRuntimeModule().getInMemoryModules()
     ).with(new AbstractModule() {
       @Override
       protected void configure() {

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -58,6 +58,12 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-data-fabric</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
@@ -103,6 +103,7 @@ public class DatasetOpExecutorServerTwillRunnable extends AbstractMasterTwillRun
       new MetricsClientRuntimeModule().getDistributedModules(),
       new DiscoveryRuntimeModule().getDistributedModules(),
       new LocationRuntimeModule().getDistributedModules(),
+      new NamespaceClientRuntimeModule().getDistributedModules(),
       new DataFabricModules().getDistributedModules(),
       new DataSetsModules().getDistributedModules(),
       new DataSetServiceModules().getDistributedModules(),

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ExploreServiceTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ExploreServiceTwillRunnable.java
@@ -27,6 +27,7 @@ import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.common.logging.ServiceLoggingContext;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.common.twill.AbstractMasterTwillRunnable;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -92,6 +93,7 @@ public class ExploreServiceTwillRunnable extends AbstractMasterTwillRunnable {
       new MetricsClientRuntimeModule().getDistributedModules(),
       new DiscoveryRuntimeModule().getDistributedModules(),
       new LocationRuntimeModule().getDistributedModules(),
+      new NamespaceClientRuntimeModule().getDistributedModules(),
       new DataFabricModules().getDistributedModules(),
       new DataSetsModules().getDistributedModules(),
       new LoggingModules().getDistributedModules(),

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/StreamHandlerRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/StreamHandlerRunnable.java
@@ -86,6 +86,7 @@ public class StreamHandlerRunnable extends AbstractMasterTwillRunnable {
         new KafkaClientModule(),
         new DiscoveryRuntimeModule().getDistributedModules(),
         new LocationRuntimeModule().getDistributedModules(),
+        new NamespaceClientRuntimeModule().getDistributedModules(),
         new MetricsClientRuntimeModule().getDistributedModules(),
         new MetricsStoreModule(),
         new DataFabricModules().getDistributedModules(),

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/TransactionServiceTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/TransactionServiceTwillRunnable.java
@@ -27,6 +27,7 @@ import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.common.logging.ServiceLoggingContext;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.common.twill.AbstractMasterTwillRunnable;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -123,6 +124,7 @@ public class TransactionServiceTwillRunnable extends AbstractMasterTwillRunnable
       createDataFabricModule(),
       new DataSetsModules().getDistributedModules(),
       new LocationRuntimeModule().getDistributedModules(),
+      new NamespaceClientRuntimeModule().getDistributedModules(),
       new DiscoveryRuntimeModule().getDistributedModules(),
       new MetricsClientRuntimeModule().getDistributedModules(),
       new LoggingModules().getDistributedModules(),

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DataMigration.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DataMigration.java
@@ -19,7 +19,7 @@ import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.guice.ConfigModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.common.utils.ProjectInfo;
 import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
@@ -85,7 +85,9 @@ public class DataMigration {
 
     return Guice.createInjector(
       new ConfigModule(cConf, hConf),
-      new LocationRuntimeModule().getDistributedModules(),
+      //  having a namespaced location factory which does not look up  namespace meta here is fine since this data
+      // migration tool does not perform namespace specific operations
+      new LocationUnitTestModule().getModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetServiceManager.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetServiceManager.java
@@ -24,6 +24,7 @@ import co.cask.cdap.common.guice.IOModule;
 import co.cask.cdap.common.guice.KafkaClientModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.ZKClientModule;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
@@ -114,6 +115,7 @@ public class DatasetServiceManager extends AbstractIdleService {
       new IOModule(),
       new KafkaClientModule(),
       new DiscoveryRuntimeModule().getDistributedModules(),
+      new NamespaceClientRuntimeModule().getDistributedModules(),
       new DataSetServiceModules().getDistributedModules(),
       new DataFabricModules().getDistributedModules(),
       new DataSetsModules().getDistributedModules(),

--- a/cdap-notifications/pom.xml
+++ b/cdap-notifications/pom.xml
@@ -72,6 +72,13 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/cdap-notifications/src/test/java/co/cask/cdap/notifications/NotificationTest.java
+++ b/cdap-notifications/src/test/java/co/cask/cdap/notifications/NotificationTest.java
@@ -23,7 +23,9 @@ import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
@@ -41,8 +43,6 @@ import co.cask.cdap.notifications.service.NotificationService;
 import co.cask.cdap.notifications.service.TxRetryPolicy;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
-import co.cask.cdap.store.NamespaceStore;
-import co.cask.cdap.store.guice.NamespaceStoreModule;
 import co.cask.tephra.TransactionContext;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.TransactionSystemClient;
@@ -87,7 +87,7 @@ public abstract class NotificationTest {
   private static TransactionManager txManager;
   private static DatasetOpExecutor dsOpService;
   private static DatasetService datasetService;
-  private static NamespaceStore namespaceStore;
+  private static NamespaceAdmin namespaceAdmin;
   private static NotificationService notificationService;
 
   private static final Id.Namespace namespace = Id.Namespace.from("namespace");
@@ -105,11 +105,11 @@ public abstract class NotificationTest {
       new DiscoveryRuntimeModule().getInMemoryModules(),
       new DataSetsModules().getStandaloneModules(),
       new DataSetServiceModules().getInMemoryModules(),
-      new LocationRuntimeModule().getInMemoryModules(),
+      new LocationUnitTestModule().getModule(),
       new MetricsClientRuntimeModule().getInMemoryModules(),
       new ExploreClientModule(),
       new DataFabricModules().getInMemoryModules(),
-      new NamespaceStoreModule().getInMemoryModules()
+      new NamespaceClientRuntimeModule().getInMemoryModules()
     );
   }
 
@@ -128,7 +128,7 @@ public abstract class NotificationTest {
     datasetService.startAndWait();
 
     txClient = injector.getInstance(TransactionSystemClient.class);
-    namespaceStore = injector.getInstance(NamespaceStore.class);
+    namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
   }
 
   public static void stopServices() throws Exception {
@@ -172,7 +172,7 @@ public abstract class NotificationTest {
     // clear the feeds
     feedManager.deleteFeed(FEED1);
     feedManager.deleteFeed(FEED2);
-    namespaceStore.delete(namespace);
+    namespaceAdmin.delete(namespace);
     Assert.assertEquals(0, feedManager.listFeeds(namespace).size());
   }
 
@@ -190,7 +190,7 @@ public abstract class NotificationTest {
   public void useTransactionTest() throws Exception {
     // Performing admin operations to create dataset instance
     // keyValueTable is a system dataset module
-    namespaceStore.create(new NamespaceMeta.Builder().setName(namespace).build());
+    namespaceAdmin.create(new NamespaceMeta.Builder().setName(namespace).build());
     Id.DatasetInstance myTableInstance = Id.DatasetInstance.from(namespace, "myTable");
     dsFramework.addInstance("keyValueTable", myTableInstance, DatasetProperties.EMPTY);
 
@@ -249,7 +249,7 @@ public abstract class NotificationTest {
     } finally {
       dsFramework.deleteInstance(myTableInstance);
       feedManager.deleteFeed(FEED1);
-      namespaceStore.delete(namespace);
+      namespaceAdmin.delete(namespace);
     }
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceConfig.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceConfig.java
@@ -19,21 +19,57 @@ package co.cask.cdap.proto;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
  * Represents the configuration of a namespace. This class needs to be GSON serializable.
  */
 public class NamespaceConfig {
 
-  @SerializedName("scheduler.queue.name")
+
+  public static final String SCHEDULER_QUEUE_NAME = "scheduler.queue.name";
+  public static final String ROOT_DIRECTORY = "root.directory";
+  public static final String HBASE_NAMESPACE = "hbase.namespace";
+  public static final String HIVE_DATABASE = "hive.database";
+
+  @SerializedName(SCHEDULER_QUEUE_NAME)
   private final String schedulerQueueName;
 
-  public NamespaceConfig(String schedulerQueueName) {
+  @SerializedName(ROOT_DIRECTORY)
+  private final String rootDirectory;
+
+  @SerializedName(HBASE_NAMESPACE)
+  private final String hbaseNamespace;
+
+  @SerializedName(HIVE_DATABASE)
+  private final String hiveDatabase;
+
+  // scheduler queue name is kept non nullable unlike others like root directory, hbase namespace etc for backward
+  // compatibility
+  public NamespaceConfig(String schedulerQueueName, @Nullable String rootDirectory,
+                         @Nullable String hbaseNamespace, @Nullable String hiveDatabase) {
     this.schedulerQueueName = schedulerQueueName;
+    this.rootDirectory = rootDirectory;
+    this.hbaseNamespace = hbaseNamespace;
+    this.hiveDatabase = hiveDatabase;
   }
 
   public String getSchedulerQueueName() {
     return schedulerQueueName;
+  }
+
+  public String getRootDirectory() {
+    return rootDirectory;
+  }
+
+  @Nullable
+  public String getHbaseNamespace() {
+    return hbaseNamespace;
+  }
+
+  @Nullable
+  public String getHiveDatabase() {
+    return hiveDatabase;
   }
 
   @Override
@@ -45,18 +81,23 @@ public class NamespaceConfig {
       return false;
     }
     NamespaceConfig other = (NamespaceConfig) o;
-    return Objects.equals(schedulerQueueName, other.schedulerQueueName);
+    return Objects.equals(schedulerQueueName, other.schedulerQueueName) &&
+      Objects.equals(rootDirectory, other.rootDirectory) && Objects.equals(hbaseNamespace, other.hbaseNamespace) &&
+      Objects.equals(hiveDatabase, other.hiveDatabase);
   }
 
   @Override
   public int hashCode() {
-    return schedulerQueueName.hashCode();
+    return Objects.hash(schedulerQueueName, rootDirectory, hbaseNamespace, hiveDatabase);
   }
 
   @Override
   public String toString() {
     return "NamespaceConfig{" +
-      "scheduler.queue.name='" + schedulerQueueName + '\'' +
+      "schedulerQueueName='" + schedulerQueueName + '\'' +
+      ", rootDirectory='" + rootDirectory + '\'' +
+      ", hbaseNamespace='" + hbaseNamespace + '\'' +
+      ", hiveDatabase='" + hiveDatabase + '\'' +
       '}';
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceMeta.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceMeta.java
@@ -58,6 +58,9 @@ public final class NamespaceMeta {
     private String name;
     private String description;
     private String schedulerQueueName;
+    private String rootDirectory;
+    private String hbaseNamespace;
+    private String hiveDatabase;
 
     public Builder() {
      // No-Op
@@ -66,7 +69,12 @@ public final class NamespaceMeta {
     public Builder(NamespaceMeta meta) {
       this.name = meta.getName();
       this.description = meta.getDescription();
-      this.schedulerQueueName = meta.getConfig().getSchedulerQueueName();
+      if (meta.getConfig() != null) {
+        this.schedulerQueueName = meta.getConfig().getSchedulerQueueName();
+        this.rootDirectory = meta.getConfig().getRootDirectory();
+        this.hbaseNamespace = meta.getConfig().getHbaseNamespace();
+        this.hiveDatabase = meta.getConfig().getHiveDatabase();
+      }
     }
 
     public Builder setName(final Id.Namespace id) {
@@ -89,6 +97,21 @@ public final class NamespaceMeta {
       return this;
     }
 
+    public Builder setRootDirectory(final String hdfsDirectory) {
+      this.rootDirectory = hdfsDirectory;
+      return this;
+    }
+
+    public Builder setHbaseNamespace(final String hbaseNamespace) {
+      this.hbaseNamespace = hbaseNamespace;
+      return this;
+    }
+
+    public Builder setHiveDatabase(final String hiveDatabase) {
+      this.hiveDatabase = hiveDatabase;
+      return this;
+    }
+
     public NamespaceMeta build() {
       if (name == null) {
         throw new IllegalArgumentException("Namespace id cannot be null.");
@@ -97,10 +120,14 @@ public final class NamespaceMeta {
         description = "";
       }
 
+      // scheduler queue name is kept non nullable unlike others like root directory, hbase namespace etc for backward
+      // compatibility
       if (schedulerQueueName == null) {
         schedulerQueueName = "";
       }
-      return new NamespaceMeta(name, description, new NamespaceConfig(schedulerQueueName));
+
+      return new NamespaceMeta(name, description, new NamespaceConfig(schedulerQueueName, rootDirectory,
+                                                                      hbaseNamespace, hiveDatabase));
     }
   }
 

--- a/cdap-watchdog/pom.xml
+++ b/cdap-watchdog/pom.xml
@@ -39,6 +39,13 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-watchdog-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/LogSaverTwillRunnable.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/LogSaverTwillRunnable.java
@@ -25,6 +25,7 @@ import co.cask.cdap.common.guice.IOModule;
 import co.cask.cdap.common.guice.KafkaClientModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.ZKClientModule;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data2.audit.AuditModule;
@@ -187,6 +188,7 @@ public final class LogSaverTwillRunnable extends AbstractTwillRunnable {
       new MetricsClientRuntimeModule().getDistributedModules(),
       new DiscoveryRuntimeModule().getDistributedModules(),
       new LocationRuntimeModule().getDistributedModules(),
+      new NamespaceClientRuntimeModule().getDistributedModules(),
       new DataFabricModules().getDistributedModules(),
       new DataSetsModules().getDistributedModules(),
       new LogSaverServiceModule(),

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsProcessorTwillRunnable.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsProcessorTwillRunnable.java
@@ -28,6 +28,7 @@ import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.common.logging.ServiceLoggingContext;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.common.twill.AbstractMasterTwillRunnable;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -133,6 +134,7 @@ public final class MetricsProcessorTwillRunnable extends AbstractMasterTwillRunn
       new DiscoveryRuntimeModule().getDistributedModules(),
       new LoggingModules().getDistributedModules(),
       new LocationRuntimeModule().getDistributedModules(),
+      new NamespaceClientRuntimeModule().getDistributedModules(),
       new DataFabricModules().getDistributedModules(),
       new DataSetsModules().getDistributedModules(),
       new KafkaMetricsProcessorModule(),

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsTwillRunnable.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsTwillRunnable.java
@@ -27,6 +27,7 @@ import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.common.logging.ServiceLoggingContext;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.common.twill.AbstractMasterTwillRunnable;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -114,6 +115,7 @@ public class MetricsTwillRunnable extends AbstractMasterTwillRunnable {
       new DataFabricModules().getDistributedModules(),
       new DataSetsModules().getDistributedModules(),
       new LocationRuntimeModule().getDistributedModules(),
+      new NamespaceClientRuntimeModule().getDistributedModules(),
       new DiscoveryRuntimeModule().getDistributedModules(),
       new LoggingModules().getDistributedModules(),
       new LogReaderRuntimeModules().getDistributedModules(),

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/KafkaTestBase.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/KafkaTestBase.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.logging;
 
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data.runtime.TransactionExecutorModule;
@@ -55,7 +55,7 @@ public abstract class KafkaTestBase {
       .put(LoggingConfiguration.LOG_SAVER_TOPIC_WAIT_SLEEP_MS, "10")
       .build(),
     ImmutableList.of(
-      new LocationRuntimeModule().getInMemoryModules(),
+      new LocationUnitTestModule().getModule(),
       new TransactionModules().getInMemoryModules(),
       new TransactionExecutorModule(),
       new DataSetsModules().getInMemoryModules(),

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/TestResilientLogging.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/TestResilientLogging.java
@@ -28,6 +28,7 @@ import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
@@ -44,7 +45,6 @@ import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.logging.read.FileLogReader;
 import co.cask.cdap.logging.read.LogEvent;
 import co.cask.cdap.logging.read.ReadRange;
-import co.cask.cdap.store.guice.NamespaceStoreModule;
 import co.cask.tephra.TransactionManager;
 import com.google.common.collect.Iterables;
 import com.google.inject.Guice;
@@ -106,7 +106,7 @@ public class TestResilientLogging {
       new TransactionMetricsModule(),
       new ExploreClientModule(),
       new LoggingModules().getInMemoryModules(),
-      new NamespaceStoreModule().getInMemoryModules());
+      new NamespaceClientRuntimeModule().getInMemoryModules());
 
     TransactionManager txManager = injector.getInstance(TransactionManager.class);
     txManager.startAndWait();

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/file/TestFileLogging.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/file/TestFileLogging.java
@@ -20,7 +20,7 @@ import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -75,7 +75,7 @@ public class TestFileLogging {
 
     injector = Guice.createInjector(
       new ConfigModule(cConf, hConf),
-      new LocationRuntimeModule().getInMemoryModules(),
+      new LocationUnitTestModule().getModule(),
       new TransactionModules().getInMemoryModules(),
       new LoggingModules().getInMemoryModules(),
       new DataSetsModules().getInMemoryModules(),

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/write/LogCleanupTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/write/LogCleanupTest.java
@@ -19,7 +19,7 @@ package co.cask.cdap.logging.write;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.LocationUnitTestModule;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -78,7 +78,7 @@ public class LogCleanupTest {
     namespacesDir = cConf.get(Constants.Namespace.NAMESPACES_DIR);
     injector = Guice.createInjector(
       new ConfigModule(cConf, hConf),
-      new LocationRuntimeModule().getInMemoryModules(),
+      new LocationUnitTestModule().getModule(),
       new TransactionModules().getInMemoryModules(),
       new TransactionExecutorModule(),
       new DataSetsModules().getInMemoryModules(),


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/CDAP-6154
Build: http://builds.cask.co/browse/CDAP-DUT4347-1
ITN: http://builds.cask.co/browse/CDAP-ITM-5
## Summary
- Allow user to specify custom location to use for cdap namespace.
- Custom locations are expected to be absolute path. A check is performed to ensure this before creating namespace.
- If a custom location is provided we check for it to exists while creating namespace
- If a custom location was provided we don't delete it while deleting namespace.
- This works on standalone too. (Tested on unix system. It has not been tested on windows system)
- Currently there is no CachingNamespaceQueryAdmin for performance improvement. It will be added in a separate PR. 
- The NamespacedLocationFactory now has a NamespaceQueryAdmin which it uses to look up namespace meta to give the correct location which is namespaced.
- NamespacedLocationFactory now takes in RootLocationFactory rather than LocationFactory (whose basepath is cdap dir) since the custom mapping can be any absolute path and to work with these we need to work with root of the filesystem.
- Added NamespacedLocationFactoryTestClient which is same as earlier NamespacedLocationFactory this is helpful in unit tests as it does not perform a namespace meta lookup and hence the unit tests does not need to  create namespace to get namespaced locations. 
- Added a LocationUnitTestModule which gives the same Module as LocationRuntimeModule.getInMemory ones but binds the NamespacedLocationFactory to the above mentioned NamespacedLocationFactoryTestClient to be used in tests. 
- DatasetService, DatasetInstanceService and DatasetTypeHandler now uses NamespaceQueryAdmin rather than NamespaceStore which it was doing earlier to avoid circular dependency in Guice injection. 

TODO:
- [ ] Run integration tests on this branch
- [ ] Test more rigorously on a cluster for edge cases
- [ ] After Hbase Mapping is done fix the todo to clean the if statements. 
