### PR TITLE
(CDAP-6168) Includes dataset classes information in artifact meta

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
@@ -32,11 +32,14 @@ import co.cask.cdap.internal.app.runtime.BasicArguments;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactDetail;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactMeta;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactRangeCodec;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import co.cask.cdap.internal.app.runtime.artifact.Artifacts;
 import co.cask.cdap.internal.app.runtime.service.SimpleRuntimeInfo;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.ProgramId;
 import com.google.common.base.Preconditions;
@@ -51,6 +54,8 @@ import com.google.common.collect.Table;
 import com.google.common.io.Closeables;
 import com.google.common.io.Files;
 import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import org.apache.twill.api.RunId;
 import org.apache.twill.common.Threads;
 import org.apache.twill.filesystem.Location;
@@ -78,6 +83,10 @@ import javax.annotation.Nullable;
 public abstract class AbstractProgramRuntimeService extends AbstractIdleService implements ProgramRuntimeService {
 
   private static final Logger LOG = LoggerFactory.getLogger(AbstractProgramRuntimeService.class);
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(ArtifactRange.class, new ArtifactRangeCodec())
+  .create();
+
   private static final EnumSet<ProgramController.State> COMPLETED_STATES = EnumSet.of(ProgramController.State.COMPLETED,
                                                                                       ProgramController.State.KILLED,
                                                                                       ProgramController.State.ERROR);
@@ -102,16 +111,23 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
 
     ProgramRunner runner = programRunnerFactory.create(programId.getType());
     Preconditions.checkNotNull(runner, "Fail to get ProgramRunner for type " + programId.getType());
+
     RunId runId = RunIds.generate();
-    ProgramOptions optionsWithRunId = updateProgramOptions(options, runId);
     File tempDir = createTempDirectory(programId, runId);
     Runnable cleanUpTask = createCleanupTask(tempDir, runner);
     try {
-      ProgramOptions optionsWithPlugins = createPluginSnapshot(optionsWithRunId, programId, tempDir,
+      // Get the artifact details and save it into the program options.
+      ArtifactId artifactId = programDescriptor.getArtifactId();
+      ArtifactDetail artifactDetail = getArtifactDetail(artifactId);
+      ProgramOptions runtimeProgramOptions = updateProgramOptions(options, runId, artifactId, artifactDetail.getMeta());
+
+      // Take a snapshot of all the plugin artifacts used by the program
+      ProgramOptions optionsWithPlugins = createPluginSnapshot(runtimeProgramOptions, programId, tempDir,
                                                                programDescriptor.getApplicationSpecification());
-      // The Jar Location will be null for some unit-test. It won't be for production.
-      Location jarLocation = getArtifactLocation(programDescriptor);
-      Program executableProgram = createProgram(cConf, runner, programDescriptor, jarLocation, tempDir);
+
+      // Create and run the program
+      Program executableProgram = createProgram(cConf, runner, programDescriptor,
+                                                artifactDetail.getDescriptor().getLocation(), tempDir);
       cleanUpTask = createCleanupTask(cleanUpTask, executableProgram);
       RuntimeInfo runtimeInfo = createRuntimeInfo(runner.run(executableProgram, optionsWithPlugins), programId);
       monitorProgram(runtimeInfo, cleanUpTask);
@@ -123,8 +139,8 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
     }
   }
 
-  protected Location getArtifactLocation(ProgramDescriptor descriptor) throws IOException, ArtifactNotFoundException {
-    return artifactRepository.getArtifact(descriptor.getArtifactId().toId()).getDescriptor().getLocation();
+  protected ArtifactDetail getArtifactDetail(ArtifactId artifactId) throws IOException, ArtifactNotFoundException {
+    return artifactRepository.getArtifact(artifactId.toId());
   }
 
   /**
@@ -241,13 +257,18 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
    *
    * @param options The {@link ProgramOptions} in which the RunId to be included
    * @param runId   The RunId to be included
+   * @param artifactId The {@link ArtifactId} of the artifact that contains the program to be executed
+   * @param artifactMeta The {@link ArtifactMeta} of the artifact that contains the program to be executed
    * @return the copy of the program options with RunId included in them
    */
-  private ProgramOptions updateProgramOptions(ProgramOptions options, RunId runId) {
+  private ProgramOptions updateProgramOptions(ProgramOptions options, RunId runId,
+                                              ArtifactId artifactId, ArtifactMeta artifactMeta) {
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
     builder.putAll(options.getArguments().asMap());
     builder.putAll(getExtraProgramOptions());
     builder.put(ProgramOptionConstants.RUN_ID, runId.getId());
+    builder.put(ProgramOptionConstants.ARTIFACT_ID, GSON.toJson(artifactId));
+    builder.put(ProgramOptionConstants.ARTIFACT_META, GSON.toJson(artifactMeta));
 
     return new SimpleProgramOptions(options.getName(), new BasicArguments(builder.build()), options.getUserArguments(),
                                     options.isDebug());

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,6 +15,9 @@
  */
 
 package co.cask.cdap.internal.app.runtime;
+
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactMeta;
+import co.cask.cdap.proto.id.ArtifactId;
 
 /**
  * Defines constants used across different modules.
@@ -68,4 +71,14 @@ public final class ProgramOptionConstants {
    * Option to a local file path of a JAR file containing plugins artifacts.
    */
   public static final String PLUGIN_ARCHIVE = "pluginArchive";
+
+  /**
+   * Option to a json encoded {@link ArtifactId} of the artifact containing the program.
+   */
+  public static final String ARTIFACT_ID = "artifactId";
+
+  /**
+   * Option to a json encoded {@link ArtifactMeta} of the artifact containing the program.
+   */
+  public static final String ARTIFACT_META = "artifactMeta";
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspector.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -22,11 +22,10 @@ import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.app.Application;
-import co.cask.cdap.api.artifact.ApplicationClass;
-import co.cask.cdap.api.artifact.ArtifactClasses;
 import co.cask.cdap.api.artifact.ArtifactId;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.data.schema.UnsupportedTypeException;
+import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.plugin.EndpointPluginContext;
 import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginConfig;
@@ -41,7 +40,11 @@ import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.internal.io.ReflectionSchemaGenerator;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.ApplicationClass;
+import co.cask.cdap.proto.artifact.ArtifactClasses;
+import co.cask.cdap.proto.artifact.DatasetClass;
 import com.google.common.base.Function;
+import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractIterator;
@@ -67,19 +70,27 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.URL;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
 import java.util.zip.ZipException;
 import javax.annotation.Nullable;
-import javax.ws.rs.Path;
 
 /**
  * Inspects a jar file to determine metadata about the artifact.
@@ -111,29 +122,75 @@ final class ArtifactInspector {
    */
   ArtifactClasses inspectArtifact(Id.Artifact artifactId, File artifactFile,
                                   ClassLoader parentClassLoader) throws IOException, InvalidArtifactException {
+    Path tmpDir = Paths.get(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
+                            cConf.get(Constants.AppFabric.TEMP_DIR)).toAbsolutePath();
+    Files.createDirectories(tmpDir);
+    Location artifactLocation = Locations.toLocation(artifactFile);
 
-    ArtifactClasses.Builder builder = inspectApplications(artifactId, ArtifactClasses.builder(),
-                                                          Locations.toLocation(artifactFile));
-    File tmpDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
-                           cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
-    File stageDir = DirUtils.createTempDir(tmpDir);
-    try (PluginInstantiator pluginInstantiator = new PluginInstantiator(cConf, parentClassLoader, stageDir)) {
-      pluginInstantiator.addArtifact(Locations.toLocation(artifactFile), artifactId.toArtifactId());
-      inspectPlugins(builder, artifactFile, artifactId.toArtifactId(), pluginInstantiator);
+    Path stageDir = Files.createTempDirectory(tmpDir, artifactFile.getName());
+    try {
+      File unpackedDir = BundleJarUtil.unJar(artifactLocation,
+                                             Files.createTempDirectory(stageDir, "unpacked-").toFile());
+
+      ArtifactClasses.Builder builder = inspectApplications(artifactId, ArtifactClasses.builder(),
+                                                            artifactLocation, unpackedDir);
+
+      try (PluginInstantiator pluginInstantiator =
+             new PluginInstantiator(cConf, parentClassLoader,
+                                    Files.createTempDirectory(stageDir, "plugins-").toFile())) {
+        pluginInstantiator.addArtifact(artifactLocation, artifactId.toArtifactId());
+        inspectPlugins(builder, artifactFile, artifactId.toArtifactId(), pluginInstantiator);
+      }
+      return builder.build();
     } finally {
       try {
-        DirUtils.deleteDirectoryContents(stageDir);
+        DirUtils.deleteDirectoryContents(stageDir.toFile());
       } catch (IOException e) {
         LOG.warn("Exception raised while deleting directory {}", stageDir, e);
       }
     }
-    return builder.build();
+  }
+
+  /**
+   * Extracts all dataset classes defined under the given artifact directory. It will scan every .class files under
+   * the artifact directory as well as .class files inside .jar files in the artifact directory.
+   * This method uses bytecode inspection, hence the actual class is not loaded. This is because loading every single
+   * class is a very slow and memory consumption process.
+   *
+   * @param unpackedArtifactDir directory that the artifact jar was expanded to
+   * @param artifactClassLoader an artifact {@link ClassLoader} defined based on the unpacked directory
+   * @param builder for adding dataset classes information
+   * @return the given {@link ArtifactClasses.Builder}.
+   * @throws IOException if failed to extract dataset classes information due to failure in reading the .class files.
+   */
+  private ArtifactClasses.Builder extractDatasets(File unpackedArtifactDir,
+                                                  final ClassLoader artifactClassLoader,
+                                                  ArtifactClasses.Builder builder) throws IOException {
+    final Set<String> classes = scanClasses(unpackedArtifactDir.toPath(), new HashSet<String>());
+    Function<String, URL> resourceProvider = new Function<String, URL>() {
+      @Nullable
+      @Override
+      public URL apply(String className) {
+        String resourceName = className.replace('.', '/') + ".class";
+        URL resource = artifactClassLoader.getResource(resourceName);
+        return resource != null ? resource : getClass().getClassLoader().getResource(resourceName);
+      }
+    };
+
+    Map<String, Boolean> cache = new HashMap<>();
+    for (String className : classes) {
+      if (isSubTypeOf(className, Dataset.class.getName(), resourceProvider, cache)) {
+        builder.addDataset(new DatasetClass(className));
+      }
+    }
+
+    return builder;
   }
 
   private ArtifactClasses.Builder inspectApplications(Id.Artifact artifactId,
                                                       ArtifactClasses.Builder builder,
-                                                      Location artifactLocation) throws IOException,
-    InvalidArtifactException {
+                                                      Location artifactLocation,
+                                                      File unpackedDir) throws IOException, InvalidArtifactException {
 
     // right now we force users to include the application main class as an attribute in their manifest,
     // which forces them to have a single application class.
@@ -155,44 +212,94 @@ final class ArtifactInspector {
         "Couldn't unzip artifact %s, please check it is a valid jar file.", artifactId), e);
     }
 
-    if (mainClassName != null) {
-      try (CloseableClassLoader artifactClassLoader = artifactClassLoaderFactory.createClassLoader(artifactLocation)) {
-        Object appMain = artifactClassLoader.loadClass(mainClassName).newInstance();
-        if (!(appMain instanceof Application)) {
-          // we don't want to error here, just don't record an application class.
-          // possible for 3rd party plugin artifacts to have the main class set
-          return builder;
-        }
+    if (mainClassName == null) {
+      return builder;
+    }
 
-        Application app = (Application) appMain;
+    try (CloseableClassLoader artifactClassLoader = artifactClassLoaderFactory.createClassLoader(unpackedDir)) {
+      extractDatasets(unpackedDir, artifactClassLoader, builder);
 
-        java.lang.reflect.Type configType;
-        // if the user parameterized their application, like 'xyz extends Application<T>',
-        // we can deserialize the config into that object. Otherwise it'll just be a Config
-        try {
-          configType = Artifacts.getConfigType(app.getClass());
-        } catch (Exception e) {
-          throw new InvalidArtifactException(String.format(
-            "Could not resolve config type for Application class %s in artifact %s. " +
-              "The type must extend Config and cannot be parameterized.", mainClassName, artifactId));
-        }
-
-        Schema configSchema = configType == Config.class ? null : schemaGenerator.generate(configType);
-        builder.addApp(new ApplicationClass(mainClassName, "", configSchema));
-      } catch (ClassNotFoundException e) {
-        throw new InvalidArtifactException(String.format(
-          "Could not find Application main class %s in artifact %s.", mainClassName, artifactId));
-      } catch (UnsupportedTypeException e) {
-        throw new InvalidArtifactException(String.format(
-          "Config for Application %s in artifact %s has an unsupported schema. " +
-            "The type must extend Config and cannot be parameterized.", mainClassName, artifactId));
-      } catch (InstantiationException | IllegalAccessException e) {
-        throw new InvalidArtifactException(String.format(
-          "Could not instantiate Application class %s in artifact %s.", mainClassName, artifactId), e);
+      Object appMain = artifactClassLoader.loadClass(mainClassName).newInstance();
+      if (!(appMain instanceof Application)) {
+        // we don't want to error here, just don't record an application class.
+        // possible for 3rd party plugin artifacts to have the main class set
+        return builder;
       }
+
+      Application app = (Application) appMain;
+
+      java.lang.reflect.Type configType;
+      // if the user parameterized their application, like 'xyz extends Application<T>',
+      // we can deserialize the config into that object. Otherwise it'll just be a Config
+      try {
+        configType = Artifacts.getConfigType(app.getClass());
+      } catch (Exception e) {
+        throw new InvalidArtifactException(String.format(
+          "Could not resolve config type for Application class %s in artifact %s. " +
+            "The type must extend Config and cannot be parameterized.", mainClassName, artifactId));
+      }
+
+      Schema configSchema = configType == Config.class ? null : schemaGenerator.generate(configType);
+      builder.addApp(new ApplicationClass(mainClassName, "", configSchema));
+    } catch (ClassNotFoundException e) {
+      throw new InvalidArtifactException(String.format(
+        "Could not find Application main class %s in artifact %s.", mainClassName, artifactId));
+    } catch (UnsupportedTypeException e) {
+      throw new InvalidArtifactException(String.format(
+        "Config for Application %s in artifact %s has an unsupported schema. " +
+          "The type must extend Config and cannot be parameterized.", mainClassName, artifactId));
+    } catch (InstantiationException | IllegalAccessException e) {
+      throw new InvalidArtifactException(String.format(
+        "Could not instantiate Application class %s in artifact %s.", mainClassName, artifactId), e);
     }
 
     return builder;
+  }
+
+  /**
+   * Scans the given artifact directory for all classes. It scans classes inside .jar file as well.
+   */
+  private Set<String> scanClasses(final Path unpackedDir, final Set<String> result) throws IOException {
+    Files.walkFileTree(unpackedDir, new SimpleFileVisitor<Path>() {
+      @Override
+      public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+        Path relativePath = unpackedDir.relativize(file);
+        String pathString = relativePath.toString();
+        if (pathString.endsWith(".jar")) {
+          // Only index top level jars and jars inside the "lib/" directory.
+          int nameCount = relativePath.getNameCount();
+          if (nameCount == 1 || nameCount == 2 && relativePath.getName(0).equals(Paths.get("lib"))) {
+            scanJarClasses(file, result);
+          }
+        } else if (pathString.endsWith(".class")) {
+          String className = Joiner.on('.').join(relativePath);
+          className = className.substring(0, className.length() - ".class".length());
+          result.add(className);
+        }
+        return FileVisitResult.CONTINUE;
+      }
+    });
+
+    return result;
+  }
+
+  /**
+   * Scans the given jar file and for classes.
+   */
+  private Set<String> scanJarClasses(final Path jarFilePath, Set<String> result) throws IOException {
+    try (JarInputStream jarInput = new JarInputStream(Files.newInputStream(jarFilePath))) {
+      JarEntry jarEntry;
+      while ((jarEntry = jarInput.getNextJarEntry()) != null) {
+        // Only index the .class files inside the jar
+        String entryName = jarEntry.getName();
+        if (entryName.endsWith(".class")) {
+          String className = entryName.replace('/', '.');
+          className = className.substring(0, className.length() - ".class".length());
+          result.add(className);
+        }
+      }
+    }
+    return result;
   }
 
   /**
@@ -337,7 +444,7 @@ final class ArtifactInspector {
     Set<String> endpoints = new HashSet<>();
     Method[] methods = cls.getMethods();
     for (Method method : methods) {
-      Path pathAnnotation = method.getAnnotation(Path.class);
+      javax.ws.rs.Path pathAnnotation = method.getAnnotation(javax.ws.rs.Path.class);
       // method should have path annotation else continue
       if (pathAnnotation != null) {
         if (!endpoints.add(pathAnnotation.value())) {
@@ -500,5 +607,70 @@ final class ArtifactInspector {
       LOG.warn("Failed to open class file for {}", className, e);
       return false;
     }
+  }
+
+  /**
+   * Checks if the given class extends or implements a super type.
+   *
+   * @param className name of the class to check
+   * @param superTypeName name of the super type
+   * @param resourceProvider a {@link Function} to provide {@link URL} of a class from the class name
+   * @param cache a cache for memorizing previous decision for classes of the same super type
+   * @return true if the given class name is a sub-class of the given super type
+   * @throws IOException if failed to read class information
+   */
+  private boolean isSubTypeOf(String className, final String superTypeName,
+                              final Function<String, URL> resourceProvider,
+                              final Map<String, Boolean> cache) throws IOException {
+    // Base case
+    if (superTypeName.equals(className)) {
+      cache.put(className, true);
+      return true;
+    }
+
+    // Check the cache first
+    Boolean cachedResult = cache.get(className);
+    if (cachedResult != null) {
+      return cachedResult;
+    }
+
+    // Try to get the URL resource of the given class
+    URL url = resourceProvider.apply(className);
+    if (url == null) {
+      // Ignore it if cannot find the class file for the given class.
+      // Normally this shouldn't happen, however it is to guard against mis-packaged artifact jar that included
+      // invalid/incomplete jars. Anyway, if this happen, the class won't be loadable in runtime.
+      return false;
+    }
+
+    // Inspect the bytecode and check the super class/interfaces recursively
+    boolean result = false;
+    try (InputStream input = url.openStream()) {
+      ClassReader cr = new ClassReader(input);
+      String superName = cr.getSuperName();
+      if (superName != null) {
+        result = isSubTypeOf(Type.getObjectType(superName).getClassName(), superTypeName, resourceProvider, cache);
+      }
+
+      if (!result) {
+        String[] interfaces = cr.getInterfaces();
+        if (interfaces != null) {
+          for (String intf : interfaces) {
+            if (isSubTypeOf(Type.getObjectType(intf).getClassName(), superTypeName, resourceProvider, cache)) {
+              result = true;
+              break;
+            }
+          }
+        }
+      }
+    } catch (Exception e) {
+      if (e.getCause() != null) {
+        Throwables.propagateIfInstanceOf(e.getCause(), IOException.class);
+      }
+      throw e;
+    }
+
+    cache.put(className, result);
+    return result;
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactMeta.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.internal.app.runtime.artifact;
 
-import co.cask.cdap.api.artifact.ArtifactClasses;
+import co.cask.cdap.proto.artifact.ArtifactClasses;
 import co.cask.cdap.proto.artifact.ArtifactRange;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRangeCodec.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRangeCodec.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.artifact;
+
+import co.cask.cdap.proto.artifact.ArtifactRange;
+import co.cask.cdap.proto.artifact.InvalidArtifactRangeException;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+
+/**
+ * Gson serialize and deserialize {@link ArtifactRange}.
+ */
+public class ArtifactRangeCodec implements JsonDeserializer<ArtifactRange>, JsonSerializer<ArtifactRange> {
+
+  @Override
+  public ArtifactRange deserialize(JsonElement json, Type typeOfT,
+                                   JsonDeserializationContext context) throws JsonParseException {
+    try {
+      return ArtifactRange.parse(json.getAsString());
+    } catch (InvalidArtifactRangeException e) {
+      throw new JsonParseException(e);
+    }
+  }
+
+  @Override
+  public JsonElement serialize(ArtifactRange src, Type typeOfSrc, JsonSerializationContext context) {
+    return new JsonPrimitive(src.toString());
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,8 +16,6 @@
 
 package co.cask.cdap.internal.app.runtime.artifact;
 
-import co.cask.cdap.api.artifact.ApplicationClass;
-import co.cask.cdap.api.artifact.ArtifactClasses;
 import co.cask.cdap.api.artifact.ArtifactVersion;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.schema.Schema;
@@ -42,8 +40,9 @@ import co.cask.cdap.data2.dataset2.tx.Transactional;
 import co.cask.cdap.internal.app.runtime.plugin.PluginNotExistsException;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.ApplicationClass;
+import co.cask.cdap.proto.artifact.ArtifactClasses;
 import co.cask.cdap.proto.artifact.ArtifactRange;
-import co.cask.cdap.proto.artifact.InvalidArtifactRangeException;
 import co.cask.cdap.proto.id.Ids;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.tephra.TransactionConflictException;
@@ -66,13 +65,6 @@ import com.google.common.io.ByteStreams;
 import com.google.common.io.InputSupplier;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
 import com.google.inject.Inject;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
@@ -80,7 +72,6 @@ import org.apache.twill.filesystem.LocationFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -1071,25 +1062,6 @@ public class ArtifactStore {
     public AppData(ApplicationClass appClass, Location artifactLocation) {
       this.appClass = appClass;
       this.artifactLocationURI = artifactLocation.toURI();
-    }
-  }
-
-  // serialize and deserialize artifact range
-  private static class ArtifactRangeCodec implements JsonDeserializer<ArtifactRange>, JsonSerializer<ArtifactRange> {
-
-    @Override
-    public ArtifactRange deserialize(JsonElement json, Type typeOfT,
-                                     JsonDeserializationContext context) throws JsonParseException {
-      try {
-        return ArtifactRange.parse(json.getAsString());
-      } catch (InvalidArtifactRangeException e) {
-        throw new JsonParseException(e);
-      }
-    }
-
-    @Override
-    public JsonElement serialize(ArtifactRange src, Type typeOfSrc, JsonSerializationContext context) {
-      return new JsonPrimitive(src.toString());
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -18,7 +18,6 @@ package co.cask.cdap.internal.app.services;
 
 import co.cask.cdap.api.ProgramSpecification;
 import co.cask.cdap.api.app.ApplicationSpecification;
-import co.cask.cdap.api.artifact.ApplicationClass;
 import co.cask.cdap.api.artifact.ArtifactId;
 import co.cask.cdap.api.artifact.ArtifactVersion;
 import co.cask.cdap.api.flow.FlowSpecification;
@@ -60,6 +59,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.ProgramTypes;
 import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.artifact.ApplicationClass;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.Ids;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/app/customds/CustomDatasetApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/app/customds/CustomDatasetApp.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.customds;
+
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.dataset.module.EmbeddedDataset;
+import co.cask.cdap.api.dataset.table.Table;
+
+import java.io.IOException;
+
+/**
+ *
+ */
+public class CustomDatasetApp extends AbstractApplication {
+
+  @Override
+  public void configure() {
+    addDatasetType(InnerStaticInheritDataset.class);
+    addDatasetType(InnerDataset.class);
+    addDatasetType(TopLevelDataset.class);
+    addDatasetType(TopLevelDirectDataset.class);
+    addDatasetType(DefaultTopLevelExtendsDataset.class);
+  }
+
+  /**
+   *
+   */
+  public static final class InnerStaticInheritDataset extends TopLevelDataset {
+
+    public InnerStaticInheritDataset(DatasetSpecification spec, @EmbeddedDataset("table") Table table,
+                                     @EmbeddedDataset("kv") KeyValueTable kvTable) {
+      super(spec, table, kvTable);
+    }
+  }
+
+  /**
+   *
+   */
+  public final class InnerDataset implements TopLevelExtendsDataset {
+
+    @Override
+    public DatasetSpecification getSpecification() {
+      return null;
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/app/customds/DefaultTopLevelExtendsDataset.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/app/customds/DefaultTopLevelExtendsDataset.java
@@ -14,18 +14,24 @@
  * the License.
  */
 
-package co.cask.cdap.common.lang;
+package co.cask.cdap.app.customds;
+
+import co.cask.cdap.api.dataset.DatasetSpecification;
+
+import java.io.IOException;
 
 /**
- * A provider for for program classloading creation.
+ *
  */
-public interface ProgramClassLoaderProvider {
+public class DefaultTopLevelExtendsDataset implements TopLevelExtendsDataset {
 
-  /**
-   * Creates a {@link ClassLoader} that will be used as the parent {@link ClassLoader} of
-   * {@link ProgramClassLoader}.
-   *
-   * @return an instance of {@link ClassLoader}
-   */
-  ClassLoader createProgramClassLoaderParent();
+  @Override
+  public DatasetSpecification getSpecification() {
+    return null;
+  }
+
+  @Override
+  public void close() throws IOException {
+
+  }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/app/customds/TopLevelDataset.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/app/customds/TopLevelDataset.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.customds;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.lib.AbstractDataset;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.dataset.module.EmbeddedDataset;
+import co.cask.cdap.api.dataset.table.Get;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.dataset.table.Table;
+
+/**
+ * A top level dataset class.
+ */
+public class TopLevelDataset extends AbstractDataset {
+
+  private final Table table;
+  private final KeyValueTable kvTable;
+
+  public TopLevelDataset(DatasetSpecification spec, @EmbeddedDataset("table") Table table,
+                         @EmbeddedDataset("kv")KeyValueTable kvTable) {
+    super(spec.getName(), table);
+    this.table = table;
+    this.kvTable = kvTable;
+  }
+
+  public void put(String row, String column, String value) {
+    table.put(new Put(row, column, value));
+    kvTable.write(row, value);
+  }
+
+  public String get(String row, String column) {
+    return table.get(new Get(row, column)).getString(column) + " " + Bytes.toString(kvTable.read(row));
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/app/customds/TopLevelDirectDataset.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/app/customds/TopLevelDirectDataset.java
@@ -14,18 +14,19 @@
  * the License.
  */
 
-package co.cask.cdap.common.lang;
+package co.cask.cdap.app.customds;
+
+import co.cask.cdap.api.dataset.Dataset;
+
+import java.io.IOException;
 
 /**
- * A provider for for program classloading creation.
+ *
  */
-public interface ProgramClassLoaderProvider {
+public class TopLevelDirectDataset implements Dataset {
 
-  /**
-   * Creates a {@link ClassLoader} that will be used as the parent {@link ClassLoader} of
-   * {@link ProgramClassLoader}.
-   *
-   * @return an instance of {@link ClassLoader}
-   */
-  ClassLoader createProgramClassLoaderParent();
+  @Override
+  public void close() throws IOException {
+    // no-op
+  }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/app/customds/TopLevelExtendsDataset.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/app/customds/TopLevelExtendsDataset.java
@@ -14,18 +14,15 @@
  * the License.
  */
 
-package co.cask.cdap.common.lang;
+package co.cask.cdap.app.customds;
+
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetSpecification;
 
 /**
- * A provider for for program classloading creation.
+ *
  */
-public interface ProgramClassLoaderProvider {
+public interface TopLevelExtendsDataset extends Dataset {
 
-  /**
-   * Creates a {@link ClassLoader} that will be used as the parent {@link ClassLoader} of
-   * {@link ProgramClassLoader}.
-   *
-   * @return an instance of {@link ClassLoader}
-   */
-  ClassLoader createProgramClassLoaderParent();
+  DatasetSpecification getSpecification();
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeServiceTest.java
@@ -17,6 +17,8 @@
 package co.cask.cdap.app.runtime;
 
 import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.api.artifact.ArtifactScope;
+import co.cask.cdap.api.artifact.ArtifactVersion;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.program.ProgramDescriptor;
 import co.cask.cdap.common.ArtifactNotFoundException;
@@ -26,10 +28,15 @@ import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.internal.app.runtime.ProgramControllerServiceAdapter;
 import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactDescriptor;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactDetail;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactMeta;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramLiveInfo;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.artifact.ArtifactClasses;
+import co.cask.cdap.proto.id.ArtifactId;
 import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.common.util.concurrent.Service;
@@ -72,17 +79,18 @@ public class AbstractProgramRuntimeServiceTest {
       }
 
       @Override
-      protected Location getArtifactLocation(ProgramDescriptor descriptor) throws IOException,
-                                                                                  ArtifactNotFoundException {
-        // Just return some dummy location. It is not used by the test.
-        return Locations.toLocation(TEMP_FOLDER.newFile());
-      }
-
-      @Override
       protected Program createProgram(CConfiguration cConf, ProgramRunner programRunner,
                                       ProgramDescriptor programDescriptor,
                                       Location programJarLocation, File tempDir) throws IOException {
         return program;
+      }
+
+      @Override
+      protected ArtifactDetail getArtifactDetail(ArtifactId artifactId) throws IOException, ArtifactNotFoundException {
+        co.cask.cdap.api.artifact.ArtifactId id = new co.cask.cdap.api.artifact.ArtifactId(
+          "dummy", new ArtifactVersion("1.0"), ArtifactScope.USER);
+        return new ArtifactDetail(new ArtifactDescriptor(id, Locations.toLocation(TEMP_FOLDER.newFile())),
+                                  new ArtifactMeta(ArtifactClasses.builder().build()));
       }
     };
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
@@ -16,8 +16,6 @@
 
 package co.cask.cdap.internal.app.runtime.artifact;
 
-import co.cask.cdap.api.artifact.ApplicationClass;
-import co.cask.cdap.api.artifact.ArtifactClasses;
 import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.app.program.ManifestFields;
@@ -32,6 +30,8 @@ import co.cask.cdap.internal.app.runtime.artifact.app.inspection.InspectionApp;
 import co.cask.cdap.internal.io.ReflectionSchemaGenerator;
 import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.ApplicationClass;
+import co.cask.cdap.proto.artifact.ArtifactClasses;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Files;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStoreTest.java
@@ -17,8 +17,6 @@
 package co.cask.cdap.internal.app.runtime.artifact;
 
 import co.cask.cdap.WordCountApp;
-import co.cask.cdap.api.artifact.ApplicationClass;
-import co.cask.cdap.api.artifact.ArtifactClasses;
 import co.cask.cdap.api.artifact.ArtifactScope;
 import co.cask.cdap.api.artifact.ArtifactVersion;
 import co.cask.cdap.api.common.Bytes;
@@ -31,6 +29,8 @@ import co.cask.cdap.internal.app.runtime.artifact.app.inspection.InspectionApp;
 import co.cask.cdap.internal.app.runtime.plugin.PluginNotExistsException;
 import co.cask.cdap.internal.io.ReflectionSchemaGenerator;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.ApplicationClass;
+import co.cask.cdap.proto.artifact.ArtifactClasses;
 import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.id.Ids;
 import co.cask.cdap.proto.id.NamespaceId;

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/ArtifactClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/ArtifactClientTestRun.java
@@ -16,8 +16,6 @@
 
 package co.cask.cdap.client;
 
-import co.cask.cdap.api.artifact.ApplicationClass;
-import co.cask.cdap.api.artifact.ArtifactClasses;
 import co.cask.cdap.api.artifact.ArtifactScope;
 import co.cask.cdap.api.artifact.ArtifactVersion;
 import co.cask.cdap.api.data.schema.Schema;
@@ -35,8 +33,10 @@ import co.cask.cdap.internal.io.ReflectionSchemaGenerator;
 import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.internal.test.PluginJarHelper;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.ApplicationClass;
 import co.cask.cdap.proto.artifact.ApplicationClassInfo;
 import co.cask.cdap.proto.artifact.ApplicationClassSummary;
+import co.cask.cdap.proto.artifact.ArtifactClasses;
 import co.cask.cdap.proto.artifact.ArtifactInfo;
 import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.artifact.ArtifactSummary;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ArtifactSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ArtifactSystemMetadataWriter.java
@@ -16,10 +16,10 @@
 
 package co.cask.cdap.data2.metadata.system;
 
-import co.cask.cdap.api.artifact.ArtifactClasses;
 import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.ArtifactClasses;
 import co.cask.cdap.proto.artifact.ArtifactInfo;
 import com.google.common.collect.ImmutableMap;
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ApplicationClass.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ApplicationClass.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.cdap.api.artifact;
+package co.cask.cdap.proto.artifact;
 
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.schema.Schema;

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ArtifactClasses.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ArtifactClasses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.cdap.api.artifact;
+package co.cask.cdap.proto.artifact;
 
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.plugin.PluginClass;
@@ -30,15 +30,21 @@ import java.util.Set;
 @Beta
 public final class ArtifactClasses {
   private final Set<ApplicationClass> apps;
+  private final Set<DatasetClass> datasets;
   private final Set<PluginClass> plugins;
 
-  private ArtifactClasses(Set<ApplicationClass> apps, Set<PluginClass> plugins) {
+  private ArtifactClasses(Set<ApplicationClass> apps, Set<DatasetClass> datasets, Set<PluginClass> plugins) {
     this.apps = apps;
+    this.datasets = datasets;
     this.plugins = plugins;
   }
 
   public Set<ApplicationClass> getApps() {
     return apps;
+  }
+
+  public Set<DatasetClass> getDatasets() {
+    return datasets;
   }
 
   public Set<PluginClass> getPlugins() {
@@ -55,19 +61,21 @@ public final class ArtifactClasses {
     }
 
     ArtifactClasses that = (ArtifactClasses) o;
-
-    return Objects.equals(apps, that.apps) && Objects.equals(plugins, that.plugins);
+    return Objects.equals(apps, that.apps) &&
+      Objects.equals(datasets, that.datasets) &&
+      Objects.equals(plugins, that.plugins);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(apps, plugins);
+    return Objects.hash(apps, datasets, plugins);
   }
 
   @Override
   public String toString() {
     return "ArtifactClasses{" +
       "apps=" + apps +
+      ", datasets=" + datasets +
       ", plugins=" + plugins +
       '}';
   }
@@ -82,6 +90,7 @@ public final class ArtifactClasses {
   public static class Builder {
 
     private final Set<ApplicationClass> apps = new HashSet<>();
+    private final Set<DatasetClass> datasets = new HashSet<>();
     private final Set<PluginClass> plugins = new HashSet<>();
 
     public Builder addApps(ApplicationClass... apps) {
@@ -98,6 +107,18 @@ public final class ArtifactClasses {
 
     public Builder addApp(ApplicationClass app) {
       apps.add(app);
+      return this;
+    }
+
+    public Builder addDatasets(Iterable<DatasetClass> datasets) {
+      for (DatasetClass dataset : datasets) {
+        this.datasets.add(dataset);
+      }
+      return this;
+    }
+
+    public Builder addDataset(DatasetClass dataset) {
+      datasets.add(dataset);
       return this;
     }
 
@@ -119,7 +140,9 @@ public final class ArtifactClasses {
     }
 
     public ArtifactClasses build() {
-      return new ArtifactClasses(Collections.unmodifiableSet(apps), Collections.unmodifiableSet(plugins));
+      return new ArtifactClasses(Collections.unmodifiableSet(apps),
+                                 Collections.unmodifiableSet(datasets),
+                                 Collections.unmodifiableSet(plugins));
     }
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ArtifactInfo.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/ArtifactInfo.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.proto.artifact;
 
 import co.cask.cdap.api.annotation.Beta;
-import co.cask.cdap.api.artifact.ArtifactClasses;
 import co.cask.cdap.api.artifact.ArtifactId;
 import co.cask.cdap.api.artifact.ArtifactScope;
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/DatasetClass.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/artifact/DatasetClass.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto.artifact;
+
+import java.util.Objects;
+
+/**
+ * Contains information about a Dataset class.
+ */
+public class DatasetClass {
+
+  private final String className;
+
+  public DatasetClass(String className) {
+    this.className = className;
+  }
+
+  public String getClassName() {
+    return className;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DatasetClass that = (DatasetClass) o;
+    return Objects.equals(className, that.className);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(className);
+  }
+
+  @Override
+  public String toString() {
+    return "DatasetClass{" +
+      "className='" + className + '\'' +
+      '}';
+  }
+}

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRunner.java
@@ -32,8 +32,8 @@ import co.cask.cdap.app.store.RuntimeStore;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.lang.FilterClassLoader;
 import co.cask.cdap.common.lang.InstantiatorFactory;
-import co.cask.cdap.common.lang.ProgramClassLoader;
 import co.cask.cdap.common.lang.ProgramClassLoaderProvider;
 import co.cask.cdap.common.lang.PropertyFieldSetter;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
@@ -200,8 +200,8 @@ final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
   }
 
   @Override
-  public ProgramClassLoader createProgramClassLoader(CConfiguration cConf, File dir) {
-    return SparkRuntimeUtils.createProgramClassLoader(cConf, dir, getClass().getClassLoader());
+  public ClassLoader createProgramClassLoaderParent() {
+    return new FilterClassLoader(getClass().getClassLoader(), SparkRuntimeUtils.SPARK_PROGRAM_CLASS_LOADER_FILTER);
   }
 
   /**

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
@@ -213,7 +213,7 @@ public final class SparkRuntimeContextProvider {
                                        SparkRuntimeContextConfig contextConfig) throws IOException {
     File programJar = new File(PROGRAM_JAR_NAME);
     File programDir = new File(PROGRAM_JAR_EXPANDED_NAME);
-    ProgramClassLoader classLoader = SparkRuntimeUtils.createProgramClassLoader(
+    ClassLoader classLoader = SparkRuntimeUtils.createProgramClassLoader(
       cConf, programDir, SparkRuntimeContextProvider.class.getClassLoader());
     return new DefaultProgram(new ProgramDescriptor(contextConfig.getProgramId(),
                                                     contextConfig.getApplicationSpecification()),

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeUtils.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeUtils.java
@@ -151,10 +151,10 @@ public final class SparkRuntimeUtils {
   };
 
   /**
-   * Creates a {@link ProgramClassLoader} that have Spark classes visible.
+   * Creates a program {@link ClassLoader} that have Spark classes visible.
    */
-  public static ProgramClassLoader createProgramClassLoader(CConfiguration cConf, File dir,
-                                                            ClassLoader unfilteredClassLoader) {
+  public static ClassLoader createProgramClassLoader(CConfiguration cConf, File dir,
+                                                     ClassLoader unfilteredClassLoader) {
     ClassLoader parent = new FilterClassLoader(unfilteredClassLoader, SPARK_PROGRAM_CLASS_LOADER_FILTER);
     return new ProgramClassLoader(cConf, dir, parent);
   }

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
@@ -27,7 +27,7 @@ import co.cask.cdap.app.runtime.spark.SparkRuntimeContextConfig;
 import co.cask.cdap.app.runtime.spark.SparkRuntimeUtils;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.lang.ProgramClassLoader;
+import co.cask.cdap.common.lang.FilterClassLoader;
 import co.cask.cdap.common.lang.ProgramClassLoaderProvider;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.distributed.AbstractDistributedProgramRunner;
@@ -98,7 +98,7 @@ public final class DistributedSparkProgramRunner extends AbstractDistributedProg
   }
 
   @Override
-  public ProgramClassLoader createProgramClassLoader(CConfiguration cConf, File dir) {
-    return SparkRuntimeUtils.createProgramClassLoader(cConf, dir, getClass().getClassLoader());
+  public ClassLoader createProgramClassLoaderParent() {
+    return new FilterClassLoader(getClass().getClassLoader(), SparkRuntimeUtils.SPARK_PROGRAM_CLASS_LOADER_FILTER);
   }
 }


### PR DESCRIPTION
- Move ArtifactClasses and ApplicationClass from cdap-api to cdap-proto
- Added scanning of dataset classes during artifact deployment.
- Cleanup ProgramClassLoader usage as field or return type.
  - This is to prepare for Class rewriting of Dataset classes through ClassLoader.
