### PR TITLE
[CDAP-6359] Added createDataset and datasetExists to BatchContext

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/batch/BatchContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/batch/BatchContext.java
@@ -18,6 +18,9 @@ package co.cask.cdap.etl.api.batch;
 
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetManagementException;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.InstanceConflictException;
 import co.cask.cdap.etl.api.TransformContext;
 
 import java.util.Map;
@@ -27,6 +30,26 @@ import java.util.Map;
  */
 @Beta
 public interface BatchContext extends DatasetContext, TransformContext {
+
+  /**
+   * Create a new dataset instance.
+   * @param datasetName the name of the new dataset
+   * @param typeName the type of the dataset to create
+   * @param properties the properties for the new dataset
+   * @throws InstanceConflictException if the dataset already exists
+   * @throws DatasetManagementException for any issues encountered in the dataset system,
+   *         or if the dataset type's create method fails.
+   */
+  void createDataset(String datasetName, String typeName, DatasetProperties properties)
+    throws DatasetManagementException;
+
+  /**
+   * Check whether a dataset exists in the current namespace.
+   * @param datasetName the name of the dataset
+   * @return whether a dataset of that name exists
+   * @throws DatasetManagementException for any issues encountered in the dataset system
+   */
+  boolean datasetExists(String datasetName) throws DatasetManagementException;
 
   /**
    * Returns the logical start time of the Batch Job.  Logical start time is the time when this Batch

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/WorkflowBackedActionContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/WorkflowBackedActionContext.java
@@ -37,7 +37,8 @@ public class WorkflowBackedActionContext extends AbstractBatchContext implements
                                      String stageName,
                                      long logicalStartTime,
                                      Map<String, String> runtimeArgs) {
-    super(workflowContext, workflowContext, metrics, lookup, stageName, logicalStartTime, runtimeArgs);
+    super(workflowContext, workflowContext, metrics, lookup, stageName, logicalStartTime, runtimeArgs,
+          workflowContext.getAdmin());
     this.workflowContext = workflowContext;
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/AbstractSparkBatchContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/AbstractSparkBatchContext.java
@@ -30,7 +30,7 @@ public abstract class AbstractSparkBatchContext extends AbstractBatchContext imp
 
   public AbstractSparkBatchContext(SparkClientContext sparkContext, LookupProvider lookupProvider, String stageId) {
     super(sparkContext, sparkContext, sparkContext.getMetrics(), lookupProvider, stageId,
-          sparkContext.getLogicalStartTime(), sparkContext.getRuntimeArguments());
+          sparkContext.getLogicalStartTime(), sparkContext.getRuntimeArguments(), sparkContext.getAdmin());
     this.sparkContext = sparkContext;
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/BasicSparkPluginContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/BasicSparkPluginContext.java
@@ -31,7 +31,7 @@ public class BasicSparkPluginContext extends AbstractBatchContext implements Spa
 
   public BasicSparkPluginContext(SparkClientContext sparkContext, LookupProvider lookupProvider, String stageId) {
     super(sparkContext, sparkContext, sparkContext.getMetrics(), lookupProvider, stageId,
-          sparkContext.getLogicalStartTime(), sparkContext.getRuntimeArguments());
+          sparkContext.getLogicalStartTime(), sparkContext.getRuntimeArguments(), sparkContext.getAdmin());
     this.sparkContext = sparkContext;
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkAggregatorContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/spark/SparkAggregatorContext.java
@@ -27,7 +27,7 @@ public class SparkAggregatorContext extends AbstractAggregatorContext {
 
   public SparkAggregatorContext(SparkClientContext context, LookupProvider lookup, String stageName) {
     super(context, context, context.getMetrics(),
-          lookup, stageName, context.getLogicalStartTime(), context.getRuntimeArguments());
+          lookup, stageName, context.getLogicalStartTime(), context.getRuntimeArguments(), context.getAdmin());
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/batch/ETLBatchRuntimeDatasetTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/batch/ETLBatchRuntimeDatasetTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch;
+
+import co.cask.cdap.etl.batch.mapreduce.ETLMapReduce;
+import co.cask.cdap.etl.batch.spark.ETLSpark;
+import co.cask.cdap.etl.batch.spark.ETLSparkProgram;
+import co.cask.cdap.etl.mock.batch.MockRuntimeDatasetSink;
+import co.cask.cdap.etl.mock.batch.MockRuntimeDatasetSource;
+import co.cask.cdap.etl.proto.Engine;
+import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
+import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.MapReduceManager;
+import co.cask.cdap.test.SparkManager;
+import co.cask.cdap.test.WorkflowManager;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests for runtime dataset creation of batch plugins.
+ */
+public class ETLBatchRuntimeDatasetTest extends ETLBatchTestBase {
+
+  @Test
+  public void testDatasetCreationInMapReducePipelinePrepareRun() throws Exception {
+    /*
+     * Trivial MapReduce pipeline from batch source to batch sink.
+     *
+     * source --------- sink
+     */
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+      .addStage(new ETLStage("source", MockRuntimeDatasetSource.getPlugin("mrinput")))
+      .addStage(new ETLStage("sink", MockRuntimeDatasetSink.getPlugin("mroutput")))
+      .addConnection("source", "sink")
+      .build();
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig);
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "MRApp");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    MapReduceManager mrManager = appManager.getMapReduceManager(ETLMapReduce.NAME);
+    mrManager.start();
+    mrManager.waitForFinish(5, TimeUnit.MINUTES);
+
+    Assert.assertNotNull(getDataset("mockRuntimeSourceDataset").get());
+    Assert.assertNotNull(getDataset("mockRuntimeSinkDataset").get());
+  }
+
+  @Test
+  public void testDatasetCreationInSparkPipelinePrepareRun() throws Exception {
+    /*
+     * Trivial Spark pipeline from batch source to batch sink.
+     *
+     * source --------- sink
+     */
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+      .setEngine(Engine.SPARK)
+      .addStage(new ETLStage("source", MockRuntimeDatasetSource.getPlugin("sparkinput")))
+      .addStage(new ETLStage("sink", MockRuntimeDatasetSink.getPlugin("sparkoutput")))
+      .addConnection("source", "sink")
+      .build();
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig);
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "SparkApp");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    WorkflowManager workflowManager = appManager.getWorkflowManager(ETLWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForFinish(5, TimeUnit.MINUTES);
+
+    Assert.assertNotNull(getDataset("mockRuntimeSourceDataset").get());
+    Assert.assertNotNull(getDataset("mockRuntimeSinkDataset").get());
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/AbstractAggregatorContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/AbstractAggregatorContext.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.etl.batch;
 
+import co.cask.cdap.api.Admin;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginContext;
@@ -38,8 +39,9 @@ public abstract class AbstractAggregatorContext extends AbstractBatchContext imp
                                       LookupProvider lookup,
                                       String stageName,
                                       long logicalStartTime,
-                                      Map<String, String> runtimeArgs) {
-    super(pluginContext, datasetContext, metrics, lookup, stageName, logicalStartTime, runtimeArgs);
+                                      Map<String, String> runtimeArgs,
+                                      Admin admin) {
+    super(pluginContext, datasetContext, metrics, lookup, stageName, logicalStartTime, runtimeArgs, admin);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/AbstractBatchContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/AbstractBatchContext.java
@@ -16,9 +16,12 @@
 
 package co.cask.cdap.etl.batch;
 
+import co.cask.cdap.api.Admin;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.DatasetInstantiationException;
 import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetManagementException;
+import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.etl.api.LookupProvider;
@@ -37,6 +40,7 @@ public abstract class AbstractBatchContext extends AbstractTransformContext impl
   private final DatasetContext datasetContext;
   private final long logicalStartTime;
   private final Map<String, String> runtimeArgs;
+  private final Admin admin;
 
   protected AbstractBatchContext(PluginContext pluginContext,
                                  DatasetContext datasetContext,
@@ -44,11 +48,13 @@ public abstract class AbstractBatchContext extends AbstractTransformContext impl
                                  LookupProvider lookup,
                                  String stageName,
                                  long logicalStartTime,
-                                 Map<String, String> runtimeArgs) {
+                                 Map<String, String> runtimeArgs,
+                                 Admin admin) {
     super(pluginContext, metrics, lookup, stageName);
     this.datasetContext = datasetContext;
     this.logicalStartTime = logicalStartTime;
     this.runtimeArgs = runtimeArgs;
+    this.admin = admin;
   }
 
   protected <T extends PluginContext & DatasetContext> AbstractBatchContext(T context,
@@ -56,13 +62,23 @@ public abstract class AbstractBatchContext extends AbstractTransformContext impl
                                                                             LookupProvider lookup,
                                                                             String stageName,
                                                                             long logicalStartTime,
-                                                                            Map<String, String> runtimeArgs) {
+                                                                            Map<String, String> runtimeArgs,
+                                                                            Admin admin) {
     super(context, metrics, lookup, stageName);
     this.datasetContext = context;
     this.logicalStartTime = logicalStartTime;
     this.runtimeArgs = runtimeArgs;
+    this.admin = admin;
   }
 
+  public void createDataset(String datasetName, String typeName, DatasetProperties properties)
+    throws DatasetManagementException {
+    admin.createDataset(datasetName, typeName, properties);
+  }
+
+  public boolean datasetExists(String datasetName) throws DatasetManagementException {
+    return admin.datasetExists(datasetName);
+  }
 
   @Override
   public long getLogicalStartTime() {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/AbstractJoinerContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/AbstractJoinerContext.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.etl.batch;
 
+import co.cask.cdap.api.Admin;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginContext;
@@ -38,8 +39,9 @@ public abstract class AbstractJoinerContext extends AbstractBatchContext impleme
                                   LookupProvider lookup,
                                   String stageName,
                                   long logicalStartTime,
-                                  Map<String, String> runtimeArgs) {
-    super(pluginContext, datasetContext, metrics, lookup, stageName, logicalStartTime, runtimeArgs);
+                                  Map<String, String> runtimeArgs,
+                                  Admin admin) {
+    super(pluginContext, datasetContext, metrics, lookup, stageName, logicalStartTime, runtimeArgs, admin);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceAggregatorContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceAggregatorContext.java
@@ -32,7 +32,7 @@ public class MapReduceAggregatorContext extends AbstractAggregatorContext {
   public MapReduceAggregatorContext(MapReduceContext context, Metrics metrics, LookupProvider lookup,
                                     String stageName,
                                     Map<String, String> runtimeArgs) {
-    super(context, context, metrics, lookup, stageName, context.getLogicalStartTime(), runtimeArgs);
+    super(context, context, metrics, lookup, stageName, context.getLogicalStartTime(), runtimeArgs, context.getAdmin());
     this.mrContext = context;
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceBatchContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceBatchContext.java
@@ -34,7 +34,7 @@ public class MapReduceBatchContext extends AbstractBatchContext {
 
   public MapReduceBatchContext(MapReduceContext context, Metrics metrics,
                                LookupProvider lookup, String stageName, Map<String, String> runtimeArguments) {
-    super(context, metrics, lookup, stageName, context.getLogicalStartTime(), runtimeArguments);
+    super(context, metrics, lookup, stageName, context.getLogicalStartTime(), runtimeArguments, context.getAdmin());
     this.mrContext = context;
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceJoinerContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceJoinerContext.java
@@ -32,7 +32,7 @@ public class MapReduceJoinerContext extends AbstractJoinerContext {
   public MapReduceJoinerContext(MapReduceContext context, Metrics metrics, LookupProvider lookup,
                                     String stageName,
                                     Map<String, String> runtimeArgs) {
-    super(context, context, metrics, lookup, stageName, context.getLogicalStartTime(), runtimeArgs);
+    super(context, context, metrics, lookup, stageName, context.getLogicalStartTime(), runtimeArgs, context.getAdmin());
     this.mrContext = context;
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockRuntimeDatasetSink.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockRuntimeDatasetSink.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.batch;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginPropertyField;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.cdap.etl.api.batch.BatchSinkContext;
+import co.cask.cdap.etl.proto.v2.ETLPlugin;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Mock sink that tests creation of datasets during runtime based on if dataset exists or not.
+ */
+@Plugin(type = BatchSink.PLUGIN_TYPE)
+@Name("MockRuntime")
+public class MockRuntimeDatasetSink extends MockSink {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
+
+  public MockRuntimeDatasetSink(Config config) {
+    super(config);
+  }
+
+  @Override
+  public void prepareRun(BatchSinkContext context) throws Exception {
+    super.prepareRun(context);
+    if (!context.datasetExists("mockRuntimeSinkDataset")) {
+      context.createDataset("mockRuntimeSinkDataset", KeyValueTable.class.getName(), DatasetProperties.EMPTY);
+    }
+  }
+
+  public static ETLPlugin getPlugin(String tableName) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("tableName", tableName);
+    return new ETLPlugin("MockRuntime", BatchSink.PLUGIN_TYPE, properties, null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("tableName", new PluginPropertyField("tableName", "", "string", true, false));
+    return new PluginClass(BatchSink.PLUGIN_TYPE, "MockRuntime", "", MockRuntimeDatasetSink.class.getName(),
+                           "config", properties);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockRuntimeDatasetSource.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockRuntimeDatasetSource.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.batch;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginPropertyField;
+import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.api.batch.BatchSourceContext;
+import co.cask.cdap.etl.proto.v2.ETLPlugin;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Mock source that tests creation of datasets during runtime based on if dataset exists or not.
+ */
+@Plugin(type = BatchSource.PLUGIN_TYPE)
+@Name("MockRuntime")
+public class MockRuntimeDatasetSource extends MockSource {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
+
+  public MockRuntimeDatasetSource(Config config) {
+    super(config);
+  }
+
+  @Override
+  public void prepareRun(BatchSourceContext context) throws Exception {
+    super.prepareRun(context);
+    if (!context.datasetExists("mockRuntimeSourceDataset")) {
+      context.createDataset("mockRuntimeSourceDataset", KeyValueTable.class.getName(), DatasetProperties.EMPTY);
+    }
+  }
+
+  public static ETLPlugin getPlugin(String tableName) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("tableName", tableName);
+    return new ETLPlugin("MockRuntime", BatchSource.PLUGIN_TYPE, properties, null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("tableName", new PluginPropertyField("tableName", "", "string", true, false));
+    return new PluginClass(BatchSource.PLUGIN_TYPE, "MockRuntime", "", MockRuntimeDatasetSource.class.getName(),
+                           "config", properties);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/test/HydratorTestBase.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/test/HydratorTestBase.java
@@ -22,6 +22,8 @@ import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.api.realtime.RealtimeSource;
 import co.cask.cdap.etl.mock.batch.MockExternalSink;
 import co.cask.cdap.etl.mock.batch.MockExternalSource;
+import co.cask.cdap.etl.mock.batch.MockRuntimeDatasetSink;
+import co.cask.cdap.etl.mock.batch.MockRuntimeDatasetSource;
 import co.cask.cdap.etl.mock.batch.NodeStatesAction;
 import co.cask.cdap.etl.mock.batch.aggregator.FieldCountAggregator;
 import co.cask.cdap.etl.mock.batch.aggregator.IdentityAggregator;
@@ -54,6 +56,7 @@ public class HydratorTestBase extends TestBase {
   private static final Set<PluginClass> BATCH_MOCK_PLUGINS = ImmutableSet.of(
     FieldCountAggregator.PLUGIN_CLASS, IdentityAggregator.PLUGIN_CLASS, Join.PLUGIN_CLASS,
     co.cask.cdap.etl.mock.batch.MockSink.PLUGIN_CLASS, co.cask.cdap.etl.mock.batch.MockSource.PLUGIN_CLASS,
+    MockRuntimeDatasetSink.PLUGIN_CLASS, MockRuntimeDatasetSource.PLUGIN_CLASS,
     MockExternalSource.PLUGIN_CLASS, MockExternalSink.PLUGIN_CLASS,
     DoubleTransform.PLUGIN_CLASS, ErrorTransform.PLUGIN_CLASS, IdentityTransform.PLUGIN_CLASS,
     FieldsPrefixTransform.PLUGIN_CLASS, IntValueFilterTransform.PLUGIN_CLASS, StringValueFilterTransform.PLUGIN_CLASS


### PR DESCRIPTION
Closed the other pull request on account of a horrible rebase gone wrong... Lesson learned.

Part of macro implementation. Adding createDataset and datasetExists to BathContext allows plugins to check the existence of and create datasets at runtime if necessary (in the case where dataset names are macro-enabled).

Bamboo build: http://builds.cask.co/browse/CDAP-DUT4357-1
