### PR TITLE
Impersonation in dataset op executor and storage provider namespace admin

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.app.guice;
 
 import co.cask.cdap.app.deploy.Manager;
@@ -37,6 +38,8 @@ import co.cask.cdap.data.stream.service.StreamHandler;
 import co.cask.cdap.data2.datafabric.dataset.DatasetExecutorServiceManager;
 import co.cask.cdap.data2.datafabric.dataset.MetadataServiceManager;
 import co.cask.cdap.data2.datafabric.dataset.RemoteSystemOperationServiceManager;
+import co.cask.cdap.data2.security.UGIProvider;
+import co.cask.cdap.data2.security.UnsupportedUGIProvider;
 import co.cask.cdap.explore.service.ExploreServiceManager;
 import co.cask.cdap.gateway.handlers.AppFabricDataHttpHandler;
 import co.cask.cdap.gateway.handlers.AppLifecycleHttpHandler;
@@ -46,6 +49,7 @@ import co.cask.cdap.gateway.handlers.CommonHandlers;
 import co.cask.cdap.gateway.handlers.ConfigHandler;
 import co.cask.cdap.gateway.handlers.ConsoleSettingsHttpHandler;
 import co.cask.cdap.gateway.handlers.DashboardHttpHandler;
+import co.cask.cdap.gateway.handlers.ImpersonationHandler;
 import co.cask.cdap.gateway.handlers.MonitorHandler;
 import co.cask.cdap.gateway.handlers.NamespaceHttpHandler;
 import co.cask.cdap.gateway.handlers.NotificationFeedHttpHandler;
@@ -92,6 +96,7 @@ import co.cask.cdap.logging.run.LogSaverStatusServiceManager;
 import co.cask.cdap.metrics.runtime.MetricsProcessorStatusServiceManager;
 import co.cask.cdap.metrics.runtime.MetricsServiceManager;
 import co.cask.cdap.pipeline.PipelineFactory;
+import co.cask.cdap.security.DefaultUGIProvider;
 import co.cask.cdap.security.guice.SecureStoreModules;
 import co.cask.http.HttpHandler;
 import com.google.common.base.Supplier;
@@ -145,6 +150,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                bind(Scheduler.class).to(SchedulerService.class);
                                bind(MRJobInfoFetcher.class).to(LocalMRJobInfoFetcher.class);
                                bind(StorageProviderNamespaceAdmin.class).to(LocalStorageProviderNamespaceAdmin.class);
+                               bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
 
                                addInMemoryBindings(binder());
 
@@ -180,6 +186,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                bind(Scheduler.class).to(SchedulerService.class);
                                bind(MRJobInfoFetcher.class).to(LocalMRJobInfoFetcher.class);
                                bind(StorageProviderNamespaceAdmin.class).to(LocalStorageProviderNamespaceAdmin.class);
+                               bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
 
                                addInMemoryBindings(binder());
 
@@ -224,7 +231,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
   @Override
   public Module getDistributedModules() {
 
-    return Modules.combine(new AppFabricServiceModule(),
+    return Modules.combine(new AppFabricServiceModule(ImpersonationHandler.class),
                            new ConfigStoreModule().getDistributedModule(),
                            new SecureStoreModules().getDistributedModules(),
                            new EntityVerifierModule(),
@@ -236,6 +243,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                bind(MRJobInfoFetcher.class).to(DistributedMRJobInfoFetcher.class);
                                bind(StorageProviderNamespaceAdmin.class)
                                  .to(DistributedStorageProviderNamespaceAdmin.class);
+                               bind(UGIProvider.class).to(DefaultUGIProvider.class);
 
                                MapBinder<String, MasterServiceManager> mapBinder = MapBinder.newMapBinder(
                                  binder(), String.class, MasterServiceManager.class);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
@@ -137,7 +137,7 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
       return runtimeInfo;
     } catch (Exception e) {
       cleanUpTask.run();
-      LOG.error("Exception while trying to createPluginSnapshot", e);
+      LOG.error("Exception while trying to run program", e);
       throw Throwables.propagate(e);
     }
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/scheduler/SchedulerQueueResolver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/scheduler/SchedulerQueueResolver.java
@@ -24,6 +24,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceConfig;
 import co.cask.cdap.proto.NamespaceMeta;
 import com.google.common.base.Strings;
+import com.google.inject.Inject;
 
 import java.io.IOException;
 import javax.annotation.Nullable;
@@ -39,6 +40,7 @@ public class SchedulerQueueResolver {
   /**
    * Construct SchedulerQueueResolver with CConfiguration and Store.
    */
+  @Inject
   public SchedulerQueueResolver(CConfiguration cConf, NamespaceQueryAdmin namespaceQueryAdmin) {
     this.defaultQueue = cConf.get(Constants.AppFabric.APP_SCHEDULER_QUEUE, "");
     this.namespaceQueryAdmin = namespaceQueryAdmin;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ImpersonationHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ImpersonationHandler.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.handlers;
+
+import co.cask.cdap.common.BadRequestException;
+import co.cask.cdap.data2.security.ImpersonationInfo;
+import co.cask.cdap.data2.security.ImpersonationUtils;
+import co.cask.cdap.data2.security.UGIProvider;
+import co.cask.cdap.security.DefaultUGIProvider;
+import co.cask.cdap.security.TokenSecureStoreUpdater;
+import co.cask.http.AbstractHttpHandler;
+import co.cask.http.HttpResponder;
+import com.google.common.base.Charsets;
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.twill.api.SecureStore;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedOutputStream;
+import java.io.DataOutputStream;
+import java.util.concurrent.Callable;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+/**
+ * Resolves the UGI for a given namespace, acquires the delegation tokens for that UGI,
+ * using {@link TokenSecureStoreUpdater}, and serializes these Credentials to a location.
+ *
+ * Response with the location to which the credentials were serialized to, as well as the UGI's short username
+ */
+// we don't share the same version as other handlers, so we can upgrade/iterate faster
+@Path("/v1/impersonation")
+public class ImpersonationHandler extends AbstractHttpHandler {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ImpersonationHandler.class);
+  private static final Gson GSON = new Gson();
+
+  private final UGIProvider ugiProvider;
+  private final TokenSecureStoreUpdater tokenSecureStoreUpdater;
+  private final LocationFactory locationFactory;
+
+  @Inject
+  ImpersonationHandler(UGIProvider ugiProvider, TokenSecureStoreUpdater tokenSecureStoreUpdater,
+                       LocationFactory locationFactory) {
+    this.ugiProvider = ugiProvider;
+    this.tokenSecureStoreUpdater = tokenSecureStoreUpdater;
+    this.locationFactory = locationFactory;
+  }
+
+  @POST
+  @Path("/credentials")
+  public void getCredentials(HttpRequest request, HttpResponder responder) throws Exception {
+    String requestContent = request.getContent().toString(Charsets.UTF_8);
+    if (requestContent == null) {
+      throw new BadRequestException("Request body is empty.");
+    }
+    ImpersonationInfo impersonationInfo = GSON.fromJson(requestContent, ImpersonationInfo.class);
+
+    UserGroupInformation ugi = ugiProvider.getConfiguredUGI(impersonationInfo);
+    Credentials credentials = ImpersonationUtils.doAs(ugi, new Callable<Credentials>() {
+      @Override
+      public Credentials call() throws Exception {
+        SecureStore update = tokenSecureStoreUpdater.update(null, null);
+        return update.getStore();
+      }
+    });
+
+    // example: hdfs:///cdap/credentials
+    Location credentialsDir = locationFactory.create("credentials");
+    Preconditions.checkState(credentialsDir.mkdirs());
+
+    // the getTempFile() doesn't create the file within the directory that you call it on. It simply appends the path
+    // without a separator, which is why we manually append the "tmp"
+    // example: hdfs:///cdap/credentials/tmp.5960fe60-6fd8-4f3e-8e92-3fb6d4726006.credentials
+    Location credentialsFile = credentialsDir.append("tmp").getTempFile(".credentials");
+    // 600 is owner-only READ_WRITE
+    try (DataOutputStream os = new DataOutputStream(new BufferedOutputStream(credentialsFile.getOutputStream("600")))) {
+      credentials.writeTokenStorageToStream(os);
+    }
+    LOG.debug("Wrote credentials for user {} to {}", ugi.getUserName(), credentialsFile);
+    responder.sendString(HttpResponseStatus.OK, credentialsFile.toURI().toString());
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
@@ -81,8 +81,8 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
 
   @PUT
   @Path("/namespaces/{namespace-id}")
-  public void create(HttpRequest request, HttpResponder responder, @PathParam("namespace-id") String namespaceId)
-    throws Exception {
+  public void create(HttpRequest request, HttpResponder responder,
+                     @PathParam("namespace-id") String namespaceId) throws Exception {
     Id.Namespace namespace;
     try {
       namespace = Id.Namespace.from(namespaceId);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -81,4 +81,12 @@ public final class ProgramOptionConstants {
    * Option to a json encoded {@link ArtifactMeta} of the artifact containing the program.
    */
   public static final String ARTIFACT_META = "artifactMeta";
+
+  /**
+   * Options for impersonation
+   */
+  public static final String PRINCIPAL = "principal";
+
+  public static final String KEYTAB_URI = "keytabURI";
+
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedFlowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedFlowProgramRunner.java
@@ -26,6 +26,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.common.twill.AbortOnTimeoutEventHandler;
+import co.cask.cdap.data2.security.Impersonator;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
@@ -42,6 +43,7 @@ import org.apache.twill.api.EventHandler;
 import org.apache.twill.api.RunId;
 import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillRunner;
+import org.apache.twill.filesystem.LocationFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,8 +65,9 @@ public final class DistributedFlowProgramRunner extends AbstractDistributedProgr
   DistributedFlowProgramRunner(TwillRunner twillRunner, YarnConfiguration hConf,
                                CConfiguration cConfig, QueueAdmin queueAdmin, StreamAdmin streamAdmin,
                                TransactionExecutorFactory txExecutorFactory,
-                               TokenSecureStoreUpdater tokenSecureStoreUpdater) {
-    super(twillRunner,  hConf, cConfig, tokenSecureStoreUpdater);
+                               TokenSecureStoreUpdater tokenSecureStoreUpdater,
+                               Impersonator impersonator) {
+    super(twillRunner,  hConf, cConfig, tokenSecureStoreUpdater, impersonator);
     this.queueAdmin = queueAdmin;
     this.streamAdmin = streamAdmin;
     this.txExecutorFactory = txExecutorFactory;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedMapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedMapReduceProgramRunner.java
@@ -21,6 +21,7 @@ import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.data2.security.Impersonator;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.batch.distributed.MapReduceContainerHelper;
 import co.cask.cdap.proto.ProgramType;
@@ -32,6 +33,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.twill.api.RunId;
 import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillRunner;
+import org.apache.twill.filesystem.LocationFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,9 +50,10 @@ public final class DistributedMapReduceProgramRunner extends AbstractDistributed
   private static final Logger LOG = LoggerFactory.getLogger(DistributedMapReduceProgramRunner.class);
 
   @Inject
-  public DistributedMapReduceProgramRunner(TwillRunner twillRunner, YarnConfiguration hConf, CConfiguration cConf,
-                                           TokenSecureStoreUpdater tokenSecureStoreUpdater) {
-    super(twillRunner, hConf, cConf, tokenSecureStoreUpdater);
+  DistributedMapReduceProgramRunner(TwillRunner twillRunner, YarnConfiguration hConf, CConfiguration cConf,
+                                    TokenSecureStoreUpdater tokenSecureStoreUpdater,
+                                    Impersonator impersonator) {
+    super(twillRunner, hConf, cConf, tokenSecureStoreUpdater, impersonator);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedServiceProgramRunner.java
@@ -24,6 +24,7 @@ import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.twill.AbortOnTimeoutEventHandler;
+import co.cask.cdap.data2.security.Impersonator;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.security.TokenSecureStoreUpdater;
@@ -34,6 +35,7 @@ import org.apache.twill.api.EventHandler;
 import org.apache.twill.api.RunId;
 import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillRunner;
+import org.apache.twill.filesystem.LocationFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,8 +51,9 @@ public class DistributedServiceProgramRunner extends AbstractDistributedProgramR
 
   @Inject
   DistributedServiceProgramRunner(TwillRunner twillRunner, YarnConfiguration hConf, CConfiguration cConf,
-                                  TokenSecureStoreUpdater tokenSecureStoreUpdater) {
-    super(twillRunner, hConf, cConf, tokenSecureStoreUpdater);
+                                  TokenSecureStoreUpdater tokenSecureStoreUpdater,
+                                  Impersonator impersonator) {
+    super(twillRunner, hConf, cConf, tokenSecureStoreUpdater, impersonator);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWebappProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWebappProgramRunner.java
@@ -20,6 +20,7 @@ import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.data2.security.Impersonator;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.security.TokenSecureStoreUpdater;
@@ -29,6 +30,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.twill.api.RunId;
 import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillRunner;
+import org.apache.twill.filesystem.LocationFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,9 +45,10 @@ public final class DistributedWebappProgramRunner extends AbstractDistributedPro
   private static final Logger LOG = LoggerFactory.getLogger(DistributedWebappProgramRunner.class);
 
   @Inject
-  public DistributedWebappProgramRunner(TwillRunner twillRunner, YarnConfiguration hConf, CConfiguration cConf,
-                                        TokenSecureStoreUpdater tokenSecureStoreUpdater) {
-    super(twillRunner, hConf, cConf, tokenSecureStoreUpdater);
+  DistributedWebappProgramRunner(TwillRunner twillRunner, YarnConfiguration hConf, CConfiguration cConf,
+                                 TokenSecureStoreUpdater tokenSecureStoreUpdater,
+                                 Impersonator impersonator) {
+    super(twillRunner, hConf, cConf, tokenSecureStoreUpdater, impersonator);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
@@ -25,6 +25,7 @@ import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.twill.AbortOnTimeoutEventHandler;
+import co.cask.cdap.data2.security.Impersonator;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.proto.ProgramType;
@@ -37,6 +38,7 @@ import org.apache.twill.api.EventHandler;
 import org.apache.twill.api.RunId;
 import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillRunner;
+import org.apache.twill.filesystem.LocationFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,8 +55,9 @@ public class DistributedWorkerProgramRunner extends AbstractDistributedProgramRu
 
   @Inject
   DistributedWorkerProgramRunner(TwillRunner twillRunner, YarnConfiguration hConf, CConfiguration cConf,
-                                 TokenSecureStoreUpdater tokenSecureStoreUpdater) {
-    super(twillRunner, hConf, cConf, tokenSecureStoreUpdater);
+                                 TokenSecureStoreUpdater tokenSecureStoreUpdater,
+                                 Impersonator impersonator) {
+    super(twillRunner, hConf, cConf, tokenSecureStoreUpdater, impersonator);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
@@ -32,6 +32,7 @@ import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.app.runtime.ProgramRuntimeProvider;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.data2.security.Impersonator;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.ProgramRuntimeProviderLoader;
 import co.cask.cdap.internal.app.runtime.batch.distributed.MapReduceContainerHelper;
@@ -45,6 +46,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.twill.api.RunId;
 import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillRunner;
+import org.apache.twill.filesystem.LocationFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,10 +67,11 @@ public final class DistributedWorkflowProgramRunner extends AbstractDistributedP
   private final ProgramRuntimeProviderLoader runtimeProviderLoader;
 
   @Inject
-  public DistributedWorkflowProgramRunner(TwillRunner twillRunner, YarnConfiguration hConf, CConfiguration cConf,
-                                          TokenSecureStoreUpdater tokenSecureStoreUpdater,
-                                          ProgramRuntimeProviderLoader runtimeProviderLoader) {
-    super(twillRunner, createConfiguration(hConf), cConf, tokenSecureStoreUpdater);
+  DistributedWorkflowProgramRunner(TwillRunner twillRunner, YarnConfiguration hConf, CConfiguration cConf,
+                                   TokenSecureStoreUpdater tokenSecureStoreUpdater,
+                                   ProgramRuntimeProviderLoader runtimeProviderLoader,
+                                   Impersonator impersonator) {
+    super(twillRunner, createConfiguration(hConf), cConf, tokenSecureStoreUpdater, impersonator);
     this.runtimeProviderLoader = runtimeProviderLoader;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
@@ -56,6 +56,7 @@ import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.cdap.store.NamespaceStore;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Collections2;
@@ -101,22 +102,18 @@ public class ProgramLifecycleService extends AbstractIdleService {
   private final CConfiguration cConf;
   private final NamespaceStore nsStore;
   private final PropertiesResolver propertiesResolver;
-  private final NamespacedLocationFactory namespacedLocationFactory;
-  private final String appFabricDir;
   private final PreferencesStore preferencesStore;
   private final AuthorizerInstantiator authorizerInstantiator;
 
   @Inject
   ProgramLifecycleService(Store store, NamespaceStore nsStore, ProgramRuntimeService runtimeService,
                           CConfiguration cConf, PropertiesResolver propertiesResolver,
-                          NamespacedLocationFactory namespacedLocationFactory, PreferencesStore preferencesStore,
+                          PreferencesStore preferencesStore,
                           AuthorizerInstantiator authorizerInstantiator) {
     this.store = store;
     this.nsStore = nsStore;
     this.runtimeService = runtimeService;
     this.propertiesResolver = propertiesResolver;
-    this.namespacedLocationFactory = namespacedLocationFactory;
-    this.appFabricDir = cConf.get(Constants.AppFabric.OUTPUT_DIR);
     this.scheduledExecutorService = Executors.newScheduledThreadPool(1);
     this.cConf = cConf;
     this.preferencesStore = preferencesStore;
@@ -235,14 +232,14 @@ public class ProgramLifecycleService extends AbstractIdleService {
    * @throws Exception if there were other exceptions checking if the current user is authorized to start the program
    */
   public synchronized void start(ProgramId programId, Map<String, String> overrides, boolean debug) throws Exception {
+    if (isRunning(programId) && !isConcurrentRunsAllowed(programId.getType())) {
+      throw new ConflictException(String.format("Program %s is already running", programId));
+    }
+
     Map<String, String> sysArgs = propertiesResolver.getSystemProperties(programId.toId());
     Map<String, String> userArgs = propertiesResolver.getUserProperties(programId.toId());
     if (overrides != null) {
       userArgs.putAll(overrides);
-    }
-
-    if (isRunning(programId) && !isConcurrentRunsAllowed(programId.getType())) {
-      throw new ConflictException(String.format("Program %s is already running", programId));
     }
 
     ProgramRuntimeService.RuntimeInfo runtimeInfo = start(programId, sysArgs, userArgs, debug);
@@ -576,6 +573,7 @@ public class ProgramLifecycleService extends AbstractIdleService {
    * @param programType The type of program the run records need to validate and update.
    * @param processedInvalidRunRecordIds the {@link Set} of processed invalid run record ids.
    */
+  @VisibleForTesting
   void validateAndCorrectRunningRunRecords(final ProgramType programType,
                                            final Set<String> processedInvalidRunRecordIds) {
     final Map<RunId, RuntimeInfo> runIdToRuntimeInfo = runtimeService.list(programType);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/security/DefaultUGIProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/security/DefaultUGIProvider.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.kerberos.SecurityUtil;
+import co.cask.cdap.common.utils.DirUtils;
+import co.cask.cdap.data2.security.ImpersonationInfo;
+import co.cask.cdap.data2.security.ImpersonationUtils;
+import co.cask.cdap.data2.security.UGIProvider;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Files;
+import com.google.inject.Inject;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+
+/**
+ * Provides a UGI by logging in with a keytab file for that user.
+ */
+public class DefaultUGIProvider implements UGIProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultUGIProvider.class);
+
+  private final CConfiguration cConf;
+  private final LocationFactory locationFactory;
+
+  @Inject
+  DefaultUGIProvider(CConfiguration cConf, LocationFactory locationFactory) {
+    this.cConf = cConf;
+    this.locationFactory = locationFactory;
+  }
+
+  /**
+   * Resolves the {@link UserGroupInformation} for a given user, performing any keytab localization, if necessary.
+   *
+   * @return a {@link UserGroupInformation}, based upon the information configured for a particular user
+   * @throws IOException if there was any IOException during localization of the keytab
+   */
+  @Override
+  public UserGroupInformation getConfiguredUGI(ImpersonationInfo impersonationInfo) throws IOException {
+    LOG.debug("Configured impersonation info: {}", impersonationInfo);
+
+    // by default, don't delete any file
+    File cleanupFile = null;
+
+    try {
+      URI keytabURI = URI.create(impersonationInfo.getKeytabURI());
+
+      File localKeytabFile;
+      if (keytabURI.getScheme() == null || "file".equals(keytabURI.getScheme())) {
+        localKeytabFile = new File(keytabURI.getPath());
+      } else {
+        localKeytabFile = localizeKeytab(locationFactory.create(keytabURI));
+        // since we localized the keytab file, remove it after we're done with it
+        cleanupFile = localKeytabFile;
+      }
+
+      String expandedPrincipal = SecurityUtil.expandPrincipal(impersonationInfo.getPrincipal());
+      LOG.debug("Logging in as: principal={}, keytab={}", expandedPrincipal, localKeytabFile);
+
+      return UserGroupInformation.loginUserFromKeytabAndReturnUGI(expandedPrincipal, localKeytabFile.getAbsolutePath());
+    } finally {
+      if (cleanupFile != null) {
+        if (!cleanupFile.delete()) {
+          LOG.warn("Failed to delete file: {}", cleanupFile);
+        }
+      }
+    }
+  }
+
+  /**
+   * Returns the path to a keytab file, after copying it to the local file system, if necessary
+   *
+   * @param keytabLocation the keytabLocation of the keytab file
+   * @return local keytab file
+   */
+  private File localizeKeytab(Location keytabLocation) throws IOException {
+    // if scheme is not specified, assume its local file
+    URI keytabURI = keytabLocation.toURI();
+    if (keytabURI.getScheme() == null || "file".equals(keytabURI.getScheme())) {
+      return new File(keytabURI.getPath());
+    }
+
+    // ensure temp dir exists
+    File tempDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
+                            cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
+    if (!DirUtils.mkdirs(tempDir)) {
+      throw new IOException(String.format(
+        "Could not create temporary directory at %s, while localizing keytab", tempDir));
+    }
+
+    // create a local file with restricted permissions
+    // only allow the owner to read/write, since it contains credentials
+    FileAttribute<Set<PosixFilePermission>> ownerOnlyAttrs =
+      PosixFilePermissions.asFileAttribute(ImmutableSet.of(PosixFilePermission.OWNER_WRITE,
+                                                           PosixFilePermission.OWNER_READ));
+    Path localKeytabFile = java.nio.file.Files.createTempFile(tempDir.toPath(), null, "keytab.localized",
+                                                              ownerOnlyAttrs);
+
+    // copy to this local file
+    LOG.debug("Copying keytab file from {} to {}", keytabLocation, localKeytabFile);
+
+    Files.copy(Locations.newInputSupplier(keytabLocation), localKeytabFile.toFile());
+    return localKeytabFile.toFile();
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemoteNamespaceQueryTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemoteNamespaceQueryTest.java
@@ -105,7 +105,8 @@ public class RemoteNamespaceQueryTest {
     String hiveDb = "myHive";
     String schedulerQueue = "schQ";
     String description = "Namespace with custom HBase mapping";
-    NamespaceConfig namespaceConfig = new NamespaceConfig(schedulerQueue, rootDirectory, hbaseNamespace, hiveDb);
+    NamespaceConfig namespaceConfig = new NamespaceConfig(schedulerQueue, rootDirectory, hbaseNamespace, hiveDb,
+                                                          null, null);
     namespaceStore.create(new NamespaceMeta.Builder()
                             .setName(cdapNamespace)
                             .setDescription(description)

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/stream/store/MDSStreamMetaStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/stream/store/MDSStreamMetaStoreTest.java
@@ -32,6 +32,8 @@ import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.stream.service.MDSStreamMetaStore;
 import co.cask.cdap.data.stream.service.StreamMetaStore;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
+import co.cask.cdap.data2.security.UGIProvider;
+import co.cask.cdap.data2.security.UnsupportedUGIProvider;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.internal.app.store.DefaultStore;
 import co.cask.cdap.proto.Id;
@@ -75,6 +77,7 @@ public class MDSStreamMetaStoreTest extends StreamMetaStoreTestBase {
           bind(StreamMetaStore.class).to(MDSStreamMetaStore.class).in(Scopes.SINGLETON);
           bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Scopes.SINGLETON);
           bind(Store.class).to(DefaultStore.class);
+          bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
         }
       }
     );

--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/AuthorizationCLITest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/AuthorizationCLITest.java
@@ -88,7 +88,9 @@ public class AuthorizationCLITest extends CLITestBase {
         Constants.Security.Authorization.EXTENSION_JAR_PATH, authExtensionJar.toURI().getPath(),
         // Bypass authorization enforcement for grant/revoke operations in this test. Authorization enforcement for
         // grant/revoke is tested in AuthorizationHandlerTest
-        Constants.Security.Authorization.EXTENSION_CONFIG_PREFIX + "superusers", "*"
+        Constants.Security.Authorization.EXTENSION_CONFIG_PREFIX + "superusers", "*",
+        // we only want to test authorization, but we don't specify principal/keytab, so disable kerberos
+        Constants.Security.KERBEROS_ENABLED, "false"
       };
     }
   }

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -771,9 +771,9 @@ public final class Constants {
       public static final String DEFAULT_SSL_KEYSTORE_TYPE = "JKS";
     }
 
-    /** Path to the Kerberos keytab file used by CDAP */
+    /** Path to the Kerberos keytab file used by CDAP master */
     public static final String CFG_CDAP_MASTER_KRB_KEYTAB_PATH = "cdap.master.kerberos.keytab";
-    /** Kerberos principal used by CDAP */
+    /** Kerberos principal used by CDAP master */
     public static final String CFG_CDAP_MASTER_KRB_PRINCIPAL = "cdap.master.kerberos.principal";
   }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/internal/remote/RemoteOpsClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/internal/remote/RemoteOpsClient.java
@@ -125,9 +125,7 @@ public class RemoteOpsClient {
                                                createErrorMessage(resolvedUrl, requestMethod, headers, body),
                                                response));
     } catch (IOException e) {
-      // throw diff type of Exception?
-      throw new RuntimeException(createErrorMessage(resolvedUrl, requestMethod, headers, body),
-                                 e);
+      throw new RuntimeException(createErrorMessage(resolvedUrl, requestMethod, headers, body), e);
     }
   }
 

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/DFSStreamHeartbeatsTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/DFSStreamHeartbeatsTest.java
@@ -38,6 +38,8 @@ import co.cask.cdap.data.stream.service.heartbeat.HeartbeatPublisher;
 import co.cask.cdap.data.stream.service.heartbeat.StreamWriterHeartbeat;
 import co.cask.cdap.data.view.ViewAdminModules;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
+import co.cask.cdap.data2.security.UGIProvider;
+import co.cask.cdap.data2.security.UnsupportedUGIProvider;
 import co.cask.cdap.data2.transaction.stream.FileStreamAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerFactory;
@@ -147,6 +149,8 @@ public class DFSStreamHeartbeatsTest {
 
           bind(StreamMetaStore.class).to(InMemoryStreamMetaStore.class).in(Scopes.SINGLETON);
           bind(HeartbeatPublisher.class).to(MockHeartbeatPublisher.class).in(Scopes.SINGLETON);
+
+          bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
         }
       }));
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetAdminOpHTTPHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetAdminOpHTTPHandler.java
@@ -43,6 +43,7 @@ import javax.ws.rs.PathParam;
 
 /**
  * Provides REST endpoints for {@link DatasetAdmin} operations.
+ * The corresponding client is {@link RemoteDatasetOpExecutor}.
  */
 @Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
 public class DatasetAdminOpHTTPHandler extends AbstractHttpHandler {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/ImpersonatingDatasetAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/ImpersonatingDatasetAdmin.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.datafabric.dataset.service.executor;
+
+import co.cask.cdap.api.dataset.DatasetAdmin;
+import co.cask.cdap.data2.security.ImpersonationUtils;
+import co.cask.cdap.data2.security.Impersonator;
+import co.cask.cdap.proto.id.NamespaceId;
+import com.google.common.base.Throwables;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.security.PrivilegedExceptionAction;
+import java.util.concurrent.Callable;
+
+/**
+ * A {link DatasetAdmin} that executes operations, while impersonating.
+ */
+class ImpersonatingDatasetAdmin implements DatasetAdmin {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ImpersonatingDatasetAdmin.class);
+
+  private final DatasetAdmin delegate;
+  private final Impersonator impersonator;
+  private final NamespaceId namespaceId;
+
+  ImpersonatingDatasetAdmin(DatasetAdmin delegate, Impersonator impersonator, NamespaceId namespaceId) {
+    this.delegate = delegate;
+    this.impersonator = impersonator;
+    this.namespaceId = namespaceId;
+  }
+
+  @Override
+  public boolean exists() throws IOException {
+    return execute(new Callable<Boolean>() {
+      @Override
+      public Boolean call() throws Exception {
+        return delegate.exists();
+      }
+    });
+  }
+
+  @Override
+  public void create() throws IOException {
+    execute(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        delegate.create();
+        return null;
+      }
+    });
+  }
+
+  @Override
+  public void drop() throws IOException {
+    execute(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        delegate.drop();
+        return null;
+      }
+    });
+  }
+
+  @Override
+  public void truncate() throws IOException {
+    execute(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        delegate.truncate();
+        return null;
+      }
+    });
+  }
+
+  @Override
+  public void upgrade() throws IOException {
+    execute(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        delegate.upgrade();
+        return null;
+      }
+    });
+  }
+
+  @Override
+  public void close() throws IOException {
+    execute(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        delegate.close();
+        return null;
+      }
+    });
+  }
+
+  // helper method to execute a callable, while declaring only IOException as being thrown
+  private <T> T execute(final Callable<T> callable) throws IOException {
+    try {
+      return impersonator.doAs(namespaceId, callable);
+    } catch (IOException ioe) {
+      throw ioe;
+    } catch (Exception t) {
+      Throwables.propagateIfPossible(t);
+
+      // since the callables we execute only throw IOException (besides unchecked exceptions),
+      // this should never happen
+      LOG.warn("Unexpected exception while executing dataset admin operation in namespace {}.", namespaceId,  t);
+      // the only checked exception that the Callables in this class is IOException, and we handle that in the previous
+      // catch statement. So, no checked exceptions should be wrapped by the following statement. However, we need it
+      // because ImpersonationUtils#doAs declares 'throws Exception', because it can throw other checked exceptions
+      // in the general case
+      throw Throwables.propagate(t);
+    }
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/InMemoryDatasetOpExecutor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/InMemoryDatasetOpExecutor.java
@@ -62,7 +62,6 @@ public class InMemoryDatasetOpExecutor extends AbstractIdleService implements Da
       throw new IllegalArgumentException("Dataset type cannot be instantiated for provided type meta: " + typeMeta);
     }
 
-    // TODO: Note - for now, just sending the name. However, type likely needs to be namesapce-aware too.
     DatasetSpecification spec = type.configure(datasetInstanceId.getId(), props);
     DatasetAdmin admin = type.getAdmin(DatasetContext.from(datasetInstanceId.getNamespaceId()), spec);
     admin.create();
@@ -73,7 +72,6 @@ public class InMemoryDatasetOpExecutor extends AbstractIdleService implements Da
   @Override
   public DatasetSpecification update(Id.DatasetInstance datasetInstanceId, DatasetTypeMeta typeMeta,
                                      DatasetProperties props, DatasetSpecification existing) throws Exception {
-    // TODO: Note - for now, just sending the name. However, type likely needs to be namesapce-aware too.
     DatasetType type = client.getDatasetType(typeMeta, null, new ConstantClassLoaderProvider());
     if (type == null) {
       throw new IllegalArgumentException("Dataset type cannot be instantiated for provided type meta: " + typeMeta);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/ImpersonationInfo.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/ImpersonationInfo.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.security;
+
+/**
+ * Encapsulates information necessary to impersonate a user - principal and keytab path.
+ */
+public final class ImpersonationInfo {
+  private final String principal;
+  private final String keytabURI;
+
+  public ImpersonationInfo(String principal, String keytabURI) {
+    this.principal = principal;
+    this.keytabURI = keytabURI;
+  }
+
+  public String getPrincipal() {
+    return principal;
+  }
+
+  public String getKeytabURI() {
+    return keytabURI;
+  }
+
+  @Override
+  public String toString() {
+    return "ImpersonationInfo{" +
+      "principal='" + principal + '\'' +
+      ", keytabURI='" + keytabURI + '\'' +
+      '}';
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/ImpersonationUserResolver.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/ImpersonationUserResolver.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.security;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
+import co.cask.cdap.proto.NamespaceConfig;
+import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.NamespacedId;
+import com.google.common.base.Objects;
+import com.google.inject.Inject;
+
+/**
+ * Helper class to resolve the principal which CDAP will launch programs as.
+ * This class should only be used if Kerberos security is enabled and it is for a user namespace.
+ */
+public class ImpersonationUserResolver {
+
+  private final NamespaceQueryAdmin namespaceQueryAdmin;
+  private final String defaultPrincipal;
+  private final String defaultKeytabPath;
+
+  @Inject
+  ImpersonationUserResolver(NamespaceQueryAdmin namespaceQueryAdmin, CConfiguration cConf) {
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
+    this.defaultPrincipal = cConf.get(Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL);
+    this.defaultKeytabPath = cConf.get(Constants.Security.CFG_CDAP_MASTER_KRB_KEYTAB_PATH);
+  }
+
+  /**
+   * Get impersonation info for a given namespace. If the info configured at the namespace level is empty,
+   * returns the info configured at the cdap level.
+   *
+   * @return configured {@link ImpersonationInfo}.
+   */
+  public ImpersonationInfo getImpersonationInfo(NamespacedId namespacedId) {
+    NamespaceMeta meta;
+    try {
+      meta = namespaceQueryAdmin.get(new NamespaceId(namespacedId.getNamespace()).toId());
+    } catch (Exception e) {
+      throw new RuntimeException(
+        String.format("Failed to retrieve namespace meta for namespace id %s", namespacedId.getNamespace()));
+    }
+    NamespaceConfig namespaceConfig = meta.getConfig();
+
+    String principal = Objects.firstNonNull(namespaceConfig.getPrincipal(), defaultPrincipal);
+    String keytabURI = Objects.firstNonNull(namespaceConfig.getKeytabURI(), defaultKeytabPath);
+    return new ImpersonationInfo(principal, keytabURI);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/ImpersonationUtils.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/ImpersonationUtils.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.security;
+
+import com.google.common.base.Throwables;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.UndeclaredThrowableException;
+import java.security.PrivilegedExceptionAction;
+import java.util.concurrent.Callable;
+
+/**
+ * Utility functions for impersonation.
+ */
+public final class ImpersonationUtils {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ImpersonationUtils.class);
+
+  private ImpersonationUtils() { }
+
+  /**
+   * Helper function, to unwrap any exceptions that were wrapped
+   * by {@link UserGroupInformation#doAs(PrivilegedExceptionAction)}
+   */
+  public static <T> T doAs(UserGroupInformation ugi, final Callable<T> callable) throws Exception {
+    try {
+      return ugi.doAs(new PrivilegedExceptionAction<T>() {
+        @Override
+        public T run() throws Exception {
+          return callable.call();
+        }
+      });
+    } catch (UndeclaredThrowableException e) {
+      // UserGroupInformation#doAs will wrap any checked exceptions, so unwrap and rethrow here
+      Throwable wrappedException = e.getUndeclaredThrowable();
+      Throwables.propagateIfPossible(wrappedException);
+
+      if (wrappedException instanceof Exception) {
+        throw (Exception) wrappedException;
+      }
+      // since PrivilegedExceptionAction#run can only throw Exception (besides runtime exception),
+      // this should never happen
+      LOG.warn("Unexpected exception while executing callable as {}.",
+               ugi.getUserName(), wrappedException);
+      throw Throwables.propagate(wrappedException);
+    }
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/Impersonator.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/Impersonator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.security;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.kerberos.SecurityUtil;
+import co.cask.cdap.proto.id.NamespaceId;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import org.apache.hadoop.security.UserGroupInformation;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Responsible for executing code for a user, configurable at the namespace level.
+ */
+public class Impersonator {
+
+  private final boolean kerberosEnabled;
+  private final UGIProvider ugiProvider;
+  private final ImpersonationUserResolver impersonationUserResolver;
+
+  @Inject
+  @VisibleForTesting
+  public Impersonator(CConfiguration cConf, UGIProvider ugiProvider,
+                      ImpersonationUserResolver impersonationUserResolver) {
+    this.kerberosEnabled = SecurityUtil.isKerberosEnabled(cConf);
+    this.ugiProvider = ugiProvider;
+    this.impersonationUserResolver = impersonationUserResolver;
+  }
+
+  /**
+   * Executes a callable as the user, configurable at a namespace level
+   *
+   * @param namespaceId the namespace to use to lookup the user
+   * @param callable the callable to execute
+   * @param <T> return type of the callable
+   *
+   * @return the return value of the callable
+   * @throws Exception if the callable throws any exception
+   */
+  public <T> T doAs(NamespaceId namespaceId, final Callable<T> callable) throws Exception {
+    if (!kerberosEnabled) {
+      return callable.call();
+    }
+    ImpersonationInfo impersonationInfo = impersonationUserResolver.getImpersonationInfo(namespaceId);
+    UserGroupInformation ugi = ugiProvider.getConfiguredUGI(impersonationInfo);
+    return ImpersonationUtils.doAs(ugi, callable);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/RemoteUGIProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/RemoteUGIProvider.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.security;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.discovery.EndpointStrategy;
+import co.cask.cdap.common.discovery.RandomEndpointStrategy;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.common.http.HttpRequest;
+import co.cask.common.http.HttpRequestConfig;
+import co.cask.common.http.HttpRequests;
+import co.cask.common.http.HttpResponse;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.twill.discovery.Discoverable;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Makes requests to ImpersonationHandler to request credentials.
+ */
+public class RemoteUGIProvider implements UGIProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RemoteUGIProvider.class);
+  private static final Gson GSON = new Gson();
+
+  private final Supplier<EndpointStrategy> endpointStrategySupplier;
+  private final LocationFactory locationFactory;
+  private final HttpRequestConfig httpRequestConfig;
+
+  @Inject
+  RemoteUGIProvider(CConfiguration cConf, final DiscoveryServiceClient discoveryClient,
+                    LocationFactory locationFactory) {
+    this.endpointStrategySupplier = Suppliers.memoize(new Supplier<EndpointStrategy>() {
+      @Override
+      public EndpointStrategy get() {
+        return new RandomEndpointStrategy(discoveryClient.discover(Constants.Service.APP_FABRIC_HTTP));
+      }
+    });
+    this.locationFactory = locationFactory;
+
+    int httpClientTimeoutMs = cConf.getInt(Constants.HTTP_CLIENT_TIMEOUT_MS);
+    this.httpRequestConfig = new HttpRequestConfig(httpClientTimeoutMs, httpClientTimeoutMs);
+  }
+
+  private String resolve(String resource) {
+    Discoverable discoverable = endpointStrategySupplier.get().pick(3L, TimeUnit.SECONDS);
+    if (discoverable == null) {
+      throw new RuntimeException(
+        String.format("Cannot discover service %s", Constants.Service.APP_FABRIC_HTTP));
+    }
+    InetSocketAddress addr = discoverable.getSocketAddress();
+
+    return String.format("http://%s:%s%s/%s",
+                         addr.getHostName(), addr.getPort(), "/v1", resource);
+  }
+
+  private HttpResponse executeRequest(ImpersonationInfo impersonationInfo) {
+    String resolvedUrl = resolve("/impersonation/credentials");
+    try {
+      URL url = new URL(resolvedUrl);
+      HttpRequest.Builder builder = HttpRequest.post(url).withBody(GSON.toJson(impersonationInfo));
+      HttpResponse response = HttpRequests.execute(builder.build(), httpRequestConfig);
+      if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
+        return response;
+      }
+      throw new RuntimeException(String.format("%s Response: %s.",
+                                               createErrorMessage(resolvedUrl), response));
+    } catch (IOException e) {
+      throw new RuntimeException(createErrorMessage(resolvedUrl), e);
+    }
+  }
+
+  // creates error message, encoding details about the request
+  private static String createErrorMessage(String resolvedUrl) {
+    return String.format("Error making request to AppFabric Service at %s.", resolvedUrl);
+  }
+
+  @Override
+  public UserGroupInformation getConfiguredUGI(ImpersonationInfo impersonationInfo) throws IOException {
+    String credentialsURI = executeRequest(impersonationInfo).getResponseBodyAsString();
+    LOG.debug("Received response: {}", credentialsURI);
+
+    UserGroupInformation impersonatedUGI = UserGroupInformation.createRemoteUser(impersonationInfo.getPrincipal());
+
+    Location location = locationFactory.create(URI.create(credentialsURI));
+    Credentials credentials = readCredentials(location);
+    impersonatedUGI.addCredentials(credentials);
+    return impersonatedUGI;
+  }
+
+  private static Credentials readCredentials(Location location) throws IOException {
+    Credentials credentials = new Credentials();
+    try (DataInputStream input = new DataInputStream(new BufferedInputStream(location.getInputStream()))) {
+      credentials.readTokenStorageStream(input);
+    }
+    LOG.debug("Read credentials from {}", location);
+    return credentials;
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/UGIProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/UGIProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.security;
+
+import org.apache.hadoop.security.UserGroupInformation;
+
+import java.io.IOException;
+
+/**
+ * Facilitates getting UserGroupInformation configured for a given user.
+ */
+public interface UGIProvider {
+
+  /**
+   * Looks up the Kerberos principal to be impersonated for a given user and returns a {@link UserGroupInformation}
+   * for that principal.
+   *
+   * @param impersonationInfo information specifying how to create the UGI
+   * @return the {@link UserGroupInformation} for the configured user
+   */
+  UserGroupInformation getConfiguredUGI(ImpersonationInfo impersonationInfo) throws IOException;
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/UnsupportedUGIProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/UnsupportedUGIProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.security;
+
+import org.apache.hadoop.security.UserGroupInformation;
+
+import java.io.IOException;
+
+/**
+ * An implementation of {@link UGIProvider} that is used when Kerberos is never enabled, and so should never be called.
+ */
+public class UnsupportedUGIProvider implements UGIProvider {
+  @Override
+  public UserGroupInformation getConfiguredUGI(ImpersonationInfo impersonationInfo) throws IOException {
+    // If this implementation's method is called, then some guice binding is done improperly.
+    // For instance, we don't call this method if Kerberos is not enabled, and we only bind this implementation
+    // in-memory and for Standalone, where Kerberos is not enabled.
+    throw new UnsupportedOperationException(".");
+  }
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/view/MDSViewStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/view/MDSViewStoreTest.java
@@ -29,6 +29,8 @@ import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
+import co.cask.cdap.data2.security.UGIProvider;
+import co.cask.cdap.data2.security.UnsupportedUGIProvider;
 import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.explore.client.MockExploreClient;
 import co.cask.tephra.TransactionManager;
@@ -67,6 +69,7 @@ public class MDSViewStoreTest extends ViewStoreTestBase {
           bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Singleton.class);
           bind(ExploreClient.class).to(MockExploreClient.class);
           bind(ViewStore.class).to(MDSViewStore.class).in(Scopes.SINGLETON);
+          bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
         }
       }
     );

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -42,6 +42,7 @@ import co.cask.cdap.data2.dataset2.lib.table.CoreDatasetsModule;
 import co.cask.cdap.data2.dataset2.module.lib.inmemory.InMemoryTableModule;
 import co.cask.cdap.data2.metadata.store.NoOpMetadataStore;
 import co.cask.cdap.data2.metrics.DatasetMetricsReporter;
+import co.cask.cdap.data2.security.Impersonator;
 import co.cask.cdap.data2.transaction.DelegatingTransactionSystemClientService;
 import co.cask.cdap.data2.transaction.TransactionExecutorFactory;
 import co.cask.cdap.data2.transaction.TransactionSystemClientService;
@@ -101,8 +102,12 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
     SystemDatasetInstantiatorFactory datasetInstantiatorFactory =
       new SystemDatasetInstantiatorFactory(locationFactory, framework, cConf);
 
+    // ok to pass null, since the impersonator won't actually be called, if kerberos security is not enabled
+    Impersonator impersonator = new Impersonator(cConf, null, null);
+
     DatasetAdminService datasetAdminService =
-      new DatasetAdminService(framework, cConf, locationFactory, datasetInstantiatorFactory, new NoOpMetadataStore());
+      new DatasetAdminService(framework, cConf, locationFactory, datasetInstantiatorFactory, new NoOpMetadataStore(),
+                              impersonator);
     ImmutableSet<HttpHandler> handlers =
       ImmutableSet.<HttpHandler>of(new DatasetAdminOpHTTPHandler(datasetAdminService));
     opExecutorService = new DatasetOpExecutorService(cConf, discoveryService, metricsCollectionService, handlers);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -45,6 +45,7 @@ import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
 import co.cask.cdap.data2.metadata.store.NoOpMetadataStore;
 import co.cask.cdap.data2.metrics.DatasetMetricsReporter;
+import co.cask.cdap.data2.security.Impersonator;
 import co.cask.cdap.data2.transaction.DelegatingTransactionSystemClientService;
 import co.cask.cdap.data2.transaction.TransactionExecutorFactory;
 import co.cask.cdap.data2.transaction.TransactionSystemClientService;
@@ -167,8 +168,11 @@ public abstract class DatasetServiceTestBase {
     SystemDatasetInstantiatorFactory datasetInstantiatorFactory =
       new SystemDatasetInstantiatorFactory(locationFactory, dsFramework, cConf);
 
+    // ok to pass null, since the impersonator won't actually be called, if kerberos security is not enabled
+    Impersonator impersonator = new Impersonator(cConf, null, null);
     DatasetAdminService datasetAdminService =
-      new DatasetAdminService(dsFramework, cConf, locationFactory, datasetInstantiatorFactory, new NoOpMetadataStore());
+      new DatasetAdminService(dsFramework, cConf, locationFactory, datasetInstantiatorFactory, new NoOpMetadataStore(),
+                              impersonator);
     ImmutableSet<HttpHandler> handlers =
       ImmutableSet.<HttpHandler>of(new DatasetAdminOpHTTPHandler(datasetAdminService));
     opExecutorService = new DatasetOpExecutorService(cConf, discoveryService, metricsCollectionService, handlers);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorServiceTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorServiceTest.java
@@ -41,6 +41,8 @@ import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.TransactionMetricsModule;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.security.UGIProvider;
+import co.cask.cdap.data2.security.UnsupportedUGIProvider;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
@@ -55,6 +57,7 @@ import co.cask.tephra.inmemory.InMemoryTxSystemClient;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
+import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.apache.hadoop.conf.Configuration;
@@ -118,7 +121,13 @@ public class DatasetOpExecutorServiceTest {
       new DataSetServiceModules().getInMemoryModules(),
       new TransactionMetricsModule(),
       new ExploreClientModule(),
-      new NamespaceClientRuntimeModule().getInMemoryModules());
+      new NamespaceClientRuntimeModule().getInMemoryModules(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
+        }
+      });
 
     txManager = injector.getInstance(TransactionManager.class);
     txManager.startAndWait();

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
@@ -41,6 +41,8 @@ import co.cask.cdap.data.view.ViewAdminModules;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.security.UGIProvider;
+import co.cask.cdap.data2.security.UnsupportedUGIProvider;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.explore.client.ExploreExecutionResult;
@@ -399,6 +401,7 @@ public class BaseHiveExploreServiceTest {
         @Override
         protected void configure() {
           bind(NotificationFeedManager.class).to(NoOpNotificationFeedManager.class);
+          bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
 
           Multibinder<HttpHandler> handlerBinder =
             Multibinder.newSetBinder(binder(), HttpHandler.class, Names.named(Constants.Stream.STREAM_HANDLER));
@@ -459,6 +462,7 @@ public class BaseHiveExploreServiceTest {
         @Override
         protected void configure() {
           bind(NotificationFeedManager.class).to(NoOpNotificationFeedManager.class);
+          bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
 
           Multibinder<HttpHandler> handlerBinder =
             Multibinder.newSetBinder(binder(), HttpHandler.class, Names.named(Constants.Stream.STREAM_HANDLER));

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
@@ -36,6 +36,8 @@ import co.cask.cdap.data.view.ViewAdminModules;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.security.UGIProvider;
+import co.cask.cdap.data2.security.UnsupportedUGIProvider;
 import co.cask.cdap.explore.client.DiscoveryExploreClient;
 import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.explore.guice.ExploreClientModule;
@@ -76,7 +78,6 @@ public class ExploreDisabledTest {
   private static DatasetOpExecutor dsOpExecutor;
   private static DatasetService datasetService;
   private static ExploreClient exploreClient;
-  private static NamespacedLocationFactory namespacedLocationFactory;
   private static NamespaceAdmin namespaceAdmin;
 
   @BeforeClass
@@ -97,14 +98,13 @@ public class ExploreDisabledTest {
     datasetFramework = injector.getInstance(DatasetFramework.class);
 
     namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
-    namespacedLocationFactory = injector.getInstance(NamespacedLocationFactory.class);
+    NamespacedLocationFactory namespacedLocationFactory = injector.getInstance(NamespacedLocationFactory.class);
 
     namespaceAdmin.create(new NamespaceMeta.Builder().setName(namespaceId).build());
     // This happens when you create a namespace via REST APIs. However, since we do not start AppFabricServer in
     // Explore tests, simulating that scenario by explicitly calling DatasetFramework APIs.
     namespacedLocationFactory.get(namespaceId).mkdirs();
     exploreClient.addNamespace(namespaceId);
-
   }
 
   @AfterClass
@@ -227,6 +227,7 @@ public class ExploreDisabledTest {
           @Override
           protected void configure() {
             bind(NotificationFeedManager.class).to(NoOpNotificationFeedManager.class);
+            bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
           }
         }
     );

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/InMemoryExploreServiceTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/InMemoryExploreServiceTest.java
@@ -31,6 +31,8 @@ import co.cask.cdap.data.stream.StreamAdminModules;
 import co.cask.cdap.data.view.ViewAdminModules;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
+import co.cask.cdap.data2.security.UGIProvider;
+import co.cask.cdap.data2.security.UnsupportedUGIProvider;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.explore.guice.ExploreRuntimeModule;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
@@ -104,6 +106,7 @@ public class InMemoryExploreServiceTest {
           @Override
           protected void configure() {
             bind(NotificationFeedManager.class).to(NoOpNotificationFeedManager.class);
+            bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
           }
         });
     transactionManager = injector.getInstance(TransactionManager.class);

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsSuiteTestBase.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsSuiteTestBase.java
@@ -32,6 +32,8 @@ import co.cask.cdap.data.runtime.DataSetServiceModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
+import co.cask.cdap.data2.security.UGIProvider;
+import co.cask.cdap.data2.security.UnsupportedUGIProvider;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.gateway.handlers.log.MockLogReader;
 import co.cask.cdap.internal.app.store.DefaultStore;
@@ -151,6 +153,7 @@ public abstract class MetricsSuiteTestBase {
       protected void configure() {
         bind(LogReader.class).to(MockLogReader.class).in(Scopes.SINGLETON);
         bind(Store.class).to(DefaultStore.class);
+        bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
       }
     }));
 

--- a/cdap-notifications/src/test/java/co/cask/cdap/notifications/NotificationTest.java
+++ b/cdap-notifications/src/test/java/co/cask/cdap/notifications/NotificationTest.java
@@ -33,6 +33,8 @@ import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.security.UGIProvider;
+import co.cask.cdap.data2.security.UnsupportedUGIProvider;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
@@ -55,6 +57,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Sets;
+import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import org.apache.twill.common.Cancellable;
@@ -109,7 +112,13 @@ public abstract class NotificationTest {
       new MetricsClientRuntimeModule().getInMemoryModules(),
       new ExploreClientModule(),
       new DataFabricModules().getInMemoryModules(),
-      new NamespaceClientRuntimeModule().getInMemoryModules()
+      new NamespaceClientRuntimeModule().getInMemoryModules(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
+        }
+      }
     );
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceConfig.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceConfig.java
@@ -27,7 +27,6 @@ import javax.ws.rs.HEAD;
  */
 public class NamespaceConfig {
 
-
   public static final String SCHEDULER_QUEUE_NAME = "scheduler.queue.name";
   public static final String ROOT_DIRECTORY = "root.directory";
   public static final String HBASE_NAMESPACE = "hbase.namespace";
@@ -45,14 +44,20 @@ public class NamespaceConfig {
   @SerializedName(HIVE_DATABASE)
   private final String hiveDatabase;
 
+  private final String principal;
+  private final String keytabURI;
+
   // scheduler queue name is kept non nullable unlike others like root directory, hbase namespace etc for backward
   // compatibility
   public NamespaceConfig(String schedulerQueueName, @Nullable String rootDirectory,
-                         @Nullable String hbaseNamespace, @Nullable String hiveDatabase) {
+                         @Nullable String hbaseNamespace, @Nullable String hiveDatabase,
+                         @Nullable String principal, @Nullable String keytabURI) {
     this.schedulerQueueName = schedulerQueueName;
     this.rootDirectory = rootDirectory;
     this.hbaseNamespace = hbaseNamespace;
     this.hiveDatabase = hiveDatabase;
+    this.principal = principal;
+    this.keytabURI = keytabURI;
   }
 
   public String getSchedulerQueueName() {
@@ -73,6 +78,16 @@ public class NamespaceConfig {
     return hiveDatabase;
   }
 
+  @Nullable
+  public String getPrincipal() {
+    return principal;
+  }
+
+  @Nullable
+  public String getKeytabURI() {
+    return keytabURI;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -83,13 +98,16 @@ public class NamespaceConfig {
     }
     NamespaceConfig other = (NamespaceConfig) o;
     return Objects.equals(schedulerQueueName, other.schedulerQueueName) &&
-      Objects.equals(rootDirectory, other.rootDirectory) && Objects.equals(hbaseNamespace, other.hbaseNamespace) &&
-      Objects.equals(hiveDatabase, other.hiveDatabase);
+      Objects.equals(rootDirectory, other.rootDirectory) &&
+      Objects.equals(hbaseNamespace, other.hbaseNamespace) &&
+      Objects.equals(hiveDatabase, other.hiveDatabase) &&
+      Objects.equals(principal, other.principal) &&
+      Objects.equals(keytabURI, other.keytabURI);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(schedulerQueueName, rootDirectory, hbaseNamespace, hiveDatabase);
+    return Objects.hash(schedulerQueueName, rootDirectory, hbaseNamespace, hiveDatabase, principal, keytabURI);
   }
 
   @Override
@@ -99,6 +117,8 @@ public class NamespaceConfig {
       ", rootDirectory='" + rootDirectory + '\'' +
       ", hbaseNamespace='" + hbaseNamespace + '\'' +
       ", hiveDatabase='" + hiveDatabase + '\'' +
+      ", principal='" + principal + '\'' +
+      ", keytabURI='" + keytabURI + '\'' +
       '}';
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceMeta.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceMeta.java
@@ -50,7 +50,6 @@ public final class NamespaceMeta {
     return config;
   }
 
-
   /**
    * Builder used to build {@link NamespaceMeta}
    */
@@ -61,37 +60,43 @@ public final class NamespaceMeta {
     private String rootDirectory;
     private String hbaseNamespace;
     private String hiveDatabase;
+    private String principal;
+    private String keytabURI;
+
     public Builder() {
-     // No-Op
+      // No-Op
     }
 
     public Builder(NamespaceMeta meta) {
       this.name = meta.getName();
       this.description = meta.getDescription();
-      if (meta.getConfig() != null) {
-        this.schedulerQueueName = meta.getConfig().getSchedulerQueueName();
-        this.rootDirectory = meta.getConfig().getRootDirectory();
-        this.hbaseNamespace = meta.getConfig().getHbaseNamespace();
-        this.hiveDatabase = meta.getConfig().getHiveDatabase();
+      NamespaceConfig config = meta.getConfig();
+      if (config != null) {
+        this.schedulerQueueName = config.getSchedulerQueueName();
+        this.rootDirectory = config.getRootDirectory();
+        this.hbaseNamespace = config.getHbaseNamespace();
+        this.hiveDatabase = config.getHiveDatabase();
+        this.principal = config.getPrincipal();
+        this.keytabURI = config.getKeytabURI();
       }
     }
 
-    public Builder setName(final Id.Namespace id) {
+    public Builder setName(Id.Namespace id) {
       this.name = id.getId();
       return this;
     }
 
-    public Builder setName(final String name) {
+    public Builder setName(String name) {
       this.name = name;
       return this;
     }
 
-    public Builder setDescription(final String description) {
+    public Builder setDescription(String description) {
       this.description = description;
       return this;
     }
 
-    public Builder setSchedulerQueueName(final String schedulerQueueName) {
+    public Builder setSchedulerQueueName(String schedulerQueueName) {
       this.schedulerQueueName = schedulerQueueName;
       return this;
     }
@@ -111,6 +116,16 @@ public final class NamespaceMeta {
       return this;
     }
 
+    public Builder setPrincipal(String principal) {
+      this.principal = principal;
+      return this;
+    }
+
+    public Builder setKeytabURI(String keytabURI) {
+      this.keytabURI = keytabURI;
+      return this;
+    }
+
     public NamespaceMeta build() {
       if (name == null) {
         throw new IllegalArgumentException("Namespace id cannot be null.");
@@ -126,7 +141,8 @@ public final class NamespaceMeta {
       }
 
       return new NamespaceMeta(name, description, new NamespaceConfig(schedulerQueueName, rootDirectory,
-                                                                      hbaseNamespace, hiveDatabase));
+                                                                      hbaseNamespace, hiveDatabase,
+                                                                      principal, keytabURI));
     }
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/NamespaceId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/NamespaceId.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.proto.id;
 
 import co.cask.cdap.proto.Id;
@@ -25,7 +26,7 @@ import java.util.Objects;
 /**
  * Uniquely identifies a namespace.
  */
-public class NamespaceId extends EntityId {
+public class NamespaceId extends EntityId implements NamespacedId {
 
   public static final NamespaceId DEFAULT = new NamespaceId("default");
   public static final NamespaceId SYSTEM = new NamespaceId("system");

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
@@ -28,6 +28,7 @@ import co.cask.cdap.app.runtime.spark.SparkRuntimeUtils;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.lang.FilterClassLoader;
 import co.cask.cdap.common.lang.ProgramClassLoaderProvider;
+import co.cask.cdap.data2.security.Impersonator;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.distributed.AbstractDistributedProgramRunner;
 import co.cask.cdap.internal.app.runtime.distributed.LocalizeResource;
@@ -40,6 +41,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.twill.api.RunId;
 import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillRunner;
+import org.apache.twill.filesystem.LocationFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,8 +60,9 @@ public final class DistributedSparkProgramRunner extends AbstractDistributedProg
 
   @Inject
   DistributedSparkProgramRunner(TwillRunner twillRunner, YarnConfiguration hConf, CConfiguration cConf,
-                                TokenSecureStoreUpdater tokenSecureStoreUpdater) {
-    super(twillRunner, createConfiguration(hConf), cConf, tokenSecureStoreUpdater);
+                                TokenSecureStoreUpdater tokenSecureStoreUpdater,
+                                Impersonator impersonator) {
+    super(twillRunner, createConfiguration(hConf), cConf, tokenSecureStoreUpdater, impersonator);
   }
 
   @Override

--- a/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
@@ -113,7 +113,9 @@ public class AuthorizationTest extends TestBase {
       return new String[] {
         Constants.Security.ENABLED, "true",
         Constants.Security.Authorization.ENABLED, "true",
-        Constants.Security.Authorization.EXTENSION_JAR_PATH, authExtensionJar.toURI().getPath()
+        Constants.Security.Authorization.EXTENSION_JAR_PATH, authExtensionJar.toURI().getPath(),
+        // we only want to test authorization, but we don't specify principal/keytab, so disable kerberos
+        Constants.Security.KERBEROS_ENABLED, "false"
       };
     }
   }

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/TestResilientLogging.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/TestResilientLogging.java
@@ -36,6 +36,8 @@ import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.TransactionMetricsModule;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutorService;
+import co.cask.cdap.data2.security.UGIProvider;
+import co.cask.cdap.data2.security.UnsupportedUGIProvider;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.logging.LoggingConfiguration;
 import co.cask.cdap.logging.appender.file.FileLogAppender;
@@ -47,6 +49,7 @@ import co.cask.cdap.logging.read.LogEvent;
 import co.cask.cdap.logging.read.ReadRange;
 import co.cask.tephra.TransactionManager;
 import com.google.common.collect.Iterables;
+import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.apache.hadoop.conf.Configuration;
@@ -106,7 +109,13 @@ public class TestResilientLogging {
       new TransactionMetricsModule(),
       new ExploreClientModule(),
       new LoggingModules().getInMemoryModules(),
-      new NamespaceClientRuntimeModule().getInMemoryModules());
+      new NamespaceClientRuntimeModule().getInMemoryModules(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
+        }
+      });
 
     TransactionManager txManager = injector.getInstance(TransactionManager.class);
     txManager.startAndWait();


### PR DESCRIPTION
Allow users to configure a principal and keytab (on local fs or hdfs), for which to launch cdap programs as. Another goal of this PR is to impersonate user when creating/deleting datasets (hbase table or hdfs directory, in the case of file sets). This is done by impersonating for all DatasetAdmin operations.
Impersonation is also done in the StorageProviderNamespaceHandler so that when creating underlying namespaces (hbase namespace or hdfs directory for a namespace), they are created as a particular user.

https://issues.cask.co/browse/CDAP-6131
https://issues.cask.co/browse/CDAP-6433
https://issues.cask.co/browse/CDAP-6434
http://builds.cask.co/browse/CDAP-DUT4365
