### PR TITLE
CDAP-2963 Mark all CDAP tables (user/system) tables with cdap.version in HTableDescriptor

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
@@ -53,9 +53,6 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
 
   private static final Logger LOG = LoggerFactory.getLogger(AbstractHBaseDataSetAdmin.class);
 
-  // Property key in the coprocessor for storing version of the coprocessor.
-  private static final String CDAP_VERSION = "cdap.version";
-
   // Function to convert Class into class Name
   private static final Function<Class<?>, String> CLASS_TO_NAME = new Function<Class<?>, String>() {
     @Override
@@ -119,7 +116,7 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
     boolean needUpdate = needsUpdate(tableDescriptor) || force;
 
     // Get the cdap version from the table
-    ProjectInfo.Version version = getVersion(tableDescriptor);
+    ProjectInfo.Version version = HBaseTableUtil.getVersion(tableDescriptor);
 
     if (!needUpdate && version.compareTo(ProjectInfo.getVersion()) >= 0) {
       // If neither the table spec nor the cdap version have changed, no need to update
@@ -159,7 +156,7 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
       newDescriptor.removeCoprocessor(remove);
     }
 
-    setVersion(newDescriptor);
+    HBaseTableUtil.setVersion(newDescriptor);
 
     LOG.info("Updating table '{}'...", tableId);
     boolean enableTable = false;
@@ -176,15 +173,6 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
     }
 
     LOG.info("Table '{}' update completed.", tableId);
-  }
-
-  public static void setVersion(HTableDescriptorBuilder tableDescriptor) {
-    tableDescriptor.setValue(CDAP_VERSION, ProjectInfo.getVersion().toString());
-  }
-
-  public static ProjectInfo.Version getVersion(HTableDescriptor tableDescriptor) {
-    String value = tableDescriptor.getValue(CDAP_VERSION);
-    return new ProjectInfo.Version(value);
   }
 
   protected void addCoprocessor(HTableDescriptorBuilder tableDescriptor, Class<? extends Coprocessor> coprocessor,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/kv/HBaseKVTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/kv/HBaseKVTableDefinition.java
@@ -27,7 +27,6 @@ import co.cask.cdap.api.dataset.lib.AbstractDatasetDefinition;
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTableDefinition;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
@@ -93,7 +93,6 @@ public class HBaseTableAdmin extends AbstractHBaseDataSetAdmin implements Updata
     }
 
     final HTableDescriptorBuilder tableDescriptor = tableUtil.buildHTableDescriptor(tableId);
-    setVersion(tableDescriptor);
     tableDescriptor.addFamily(columnDescriptor);
 
     // if the dataset is configured for readless increments, the set the table property to support upgrades

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/MetricHBaseTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/MetricHBaseTableUtil.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.data2.dataset2.lib.table.hbase;
 
 import co.cask.cdap.common.utils.ProjectInfo;
-import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import org.apache.hadoop.hbase.HTableDescriptor;
 
@@ -48,7 +47,7 @@ public class MetricHBaseTableUtil {
     // 2a) If table has no increment handler coprocessor, it is 2.6 or older
     // 2b) If table has increment handler coprocessor, it is 2.7
     
-    ProjectInfo.Version version = AbstractHBaseDataSetAdmin.getVersion(tableDescriptor);
+    ProjectInfo.Version version = HBaseTableUtil.getVersion(tableDescriptor);
     // note: major version is 0 if table doesn't have the cdap version property
     if (version.getMajor() > 0) {
       if (version.getMajor() < 2) {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/AbstractHBaseTableUtilTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/AbstractHBaseTableUtilTest.java
@@ -25,6 +25,7 @@ import co.cask.cdap.data.hbase.HBaseTestFactory;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.proto.Id;
 import com.google.common.base.Predicate;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -200,6 +201,17 @@ public abstract class AbstractHBaseTableUtilTest {
       Assert.assertFalse(tableUtil.hasNamespace(hAdmin, Id.Namespace.from("namespace")));
       Assert.assertFalse(tableUtil.hasNamespace(hAdmin, Id.Namespace.from("namespace2")));
     }
+  }
+
+  @Test
+  public void testCDAPVersion() throws IOException {
+    HBaseTableUtil tableUtil = getTableUtil();
+    TableId tableId = TableId.from("default", "test.dataset");
+    create(tableId);
+    HTableDescriptor tableDescriptor = tableUtil.getHTableDescriptor(hAdmin, tableId);
+    Assert.assertTrue(!Strings.isNullOrEmpty(tableDescriptor.getValue(HBaseTableUtil.CDAP_VERSION)));
+    tableUtil.disableTable(hAdmin, tableId);
+    tableUtil.deleteTable(hAdmin, tableId);
   }
 
   @Test

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/AbstractQueueUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/AbstractQueueUpgrader.java
@@ -20,7 +20,6 @@ import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.utils.ProjectInfo;
-import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
 import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
@@ -85,7 +84,7 @@ public abstract class AbstractQueueUpgrader extends AbstractUpgrader {
         continue;
       }
       HTable hTable = tableUtil.createHTable(conf, tableId);
-      ProjectInfo.Version tableVersion = AbstractHBaseDataSetAdmin.getVersion(hTable.getTableDescriptor());
+      ProjectInfo.Version tableVersion = HBaseTableUtil.getVersion(hTable.getTableDescriptor());
       // Only upgrade if Upgrader's version is greater than table's version.
       if (ProjectInfo.getVersion().compareTo(tableVersion) <= 0) {
         LOG.info("Table {} has already been upgraded. Its version is: {}", tableId, tableVersion);

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
@@ -156,6 +156,6 @@ public class DatasetUpgrader extends AbstractUpgrader {
   // Note: This check can be safely used for user table since we create meta.
   // CDAP-2963 should be fixed so that we can make use of this check generically for all cdap tables
   private boolean isTableCreatedByCDAP(HTableDescriptor desc) {
-    return (desc.getValue("cdap.version") != null);
+    return (desc.getValue(HBaseTableUtil.CDAP_VERSION) != null);
   }
 }


### PR DESCRIPTION
Summary:

With custom namespace mapping, we can't identify CDAP HBase tables solely based on their names (since the HBase namespace can have any value and not necessarily cdap_*). So we will add cdap.version attribute to the HTableDescriptor of all CDAP HBase tables - system and user.

JIRA : https://issues.cask.co/browse/CDAP-2963
Build : http://builds.cask.co/browse/CDAP-DUT4361-9

Note: The check for isCDAPTable still checks the table names as well as the attribute (if one of them is true, we conclude it is a CDAPTable). This check can be modified to simply rely only on the attribute but we need to upgrade all the existing system tables to do so. This will happen in a follow-up PR, after which the check can be simplified. I have opened https://issues.cask.co/browse/CDAP-6450 for the upgrade tool update.
