### PR TITLE
[Bug Fix] Updated MockRuntimeDatasetSink to allow macros

### DIFF
--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockRuntimeDatasetSink.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockRuntimeDatasetSink.java
@@ -57,7 +57,7 @@ public class MockRuntimeDatasetSink extends MockSink {
 
   private static PluginClass getPluginClass() {
     Map<String, PluginPropertyField> properties = new HashMap<>();
-    properties.put("tableName", new PluginPropertyField("tableName", "", "string", true, false));
+    properties.put("tableName", new PluginPropertyField("tableName", "", "string", true, true));
     return new PluginClass(BatchSink.PLUGIN_TYPE, "MockRuntime", "", MockRuntimeDatasetSink.class.getName(),
                            "config", properties);
   }


### PR DESCRIPTION
Originally unit tests were failing because MockRuntimeDatasetSink which extends MockSink disabled macros. This caused the property field to be slightly different when plugin classes were being added to the test, leading to a different hash code and a duplicate entry for the sink. This was caused by a later PR [CDAP-6357] after [CDAP-6359].

This should fix it.
