### PR TITLE
fix indentation and json syntax

### DIFF
--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -70,7 +70,7 @@ ${__packerdir}/cookbook-setup.sh || die "Failed to install cookbooks"
 
 # CDAP cli install, ensures package dependencies are present
 # We must specify the cdap version
-echo "{\"cdap\": \"version\": \"${CDAP_VERSION}\"}}" > ${__tmpdir}/cli-conf.json
+echo "{\"cdap\": {\"version\": \"${CDAP_VERSION}\"}}" > ${__tmpdir}/cli-conf.json
 chef-solo -o 'recipe[cdap::cli]' -j ${__tmpdir}/cli-conf.json
 
 # Read zookeeper quorum from hbase-site.xml, using sourced init script function

--- a/cdap-distributions/src/hdinsight/pageblob-configure.sh
+++ b/cdap-distributions/src/hdinsight/pageblob-configure.sh
@@ -37,125 +37,125 @@ AMBARICREDS="-u ${USERID} -p ${PASSWD}"
 die() { __code=${2:-1}; echo "[ERROR] ${1}"; exit ${__code}; };
 
 checkHostNameAndSetClusterName() {
-    CLUSTERNAME=${CLUSTERNAME:-$(python -c 'import hdinsight_common.ClusterManifestParser as ClusterManifestParser; \
-        print ClusterManifestParser.parse_local_manifest().deployment.cluster_name')}
-    [[ ${CLUSTERNAME} ]] || die "Cannot determine cluster name. Exiting!" 133
+  CLUSTERNAME=${CLUSTERNAME:-$(python -c 'import hdinsight_common.ClusterManifestParser as ClusterManifestParser; \
+    print ClusterManifestParser.parse_local_manifest().deployment.cluster_name')}
+  [[ ${CLUSTERNAME} ]] || die "Cannot determine cluster name. Exiting!" 133
 }
 
 # Try to perform an Ambari API GET
 # Dies if credentials are bad
 validateAmbariConnectivity() {
-    local __coreSiteContent
-    local __ret
-    __coreSiteContent=$(${AMBARICONFIGS_SH} ${AMBARICREDS} get ${ACTIVEAMBARIHOST} ${CLUSTERNAME} core-site)
-    __ret=$?
-    if [[ ${__coreSiteContent} =~ "[ERROR]" && ${__coreSiteContent} =~ "Bad credentials" ]]; then
-        die 'Username and password are invalid. Exiting!' 134
-    elif [ ${__ret} -ne 0 ]; then
-        die "Could not connect to Ambari: ${__coreSiteContent}" 134
-    fi
+  local __coreSiteContent
+  local __ret
+  __coreSiteContent=$(${AMBARICONFIGS_SH} ${AMBARICREDS} get ${ACTIVEAMBARIHOST} ${CLUSTERNAME} core-site)
+  __ret=$?
+  if [[ ${__coreSiteContent} =~ "[ERROR]" && ${__coreSiteContent} =~ "Bad credentials" ]]; then
+    die 'Username and password are invalid. Exiting!' 134
+  elif [ ${__ret} -ne 0 ]; then
+    die "Could not connect to Ambari: ${__coreSiteContent}" 134
+  fi
 }
 
 # Given a config type, name, and value, set the configuration via the Ambari API
 # Dies if unsuccessful
 setAmbariConfig() {
-    local __configtype=${1} # core-site, etc
-    local __name=${2}
-    local __value=${3}
-    local __updateResult
-    __updateResult=$(${AMBARICONFIGS_SH} ${AMBARICREDS} set ${ACTIVEAMBARIHOST} ${CLUSTERNAME} ${__configtype} ${__name} ${__value})
+  local __configtype=${1} # core-site, etc
+  local __name=${2}
+  local __value=${3}
+  local __updateResult
+  __updateResult=$(${AMBARICONFIGS_SH} ${AMBARICREDS} set ${ACTIVEAMBARIHOST} ${CLUSTERNAME} ${__configtype} ${__name} ${__value})
 
-    if [[ ${__updateResult} =~ "[ERROR]" ]] && [[ ! ${__updateResult} =~ "Tag:version" ]]; then
-        die "Failed to update ${__configtype}: ${__updateResult}" 135
-    fi
+  if [[ ${__updateResult} =~ "[ERROR]" ]] && [[ ! ${__updateResult} =~ "Tag:version" ]]; then
+    die "Failed to update ${__configtype}: ${__updateResult}" 135
+  fi
 }
 
 # Fetches value of fs.azure.page.blob.dir, appends '/cdap' to it, updates it via Ambari API, updates the local client configurations, and restarts cluster services
 updateFsAzurePageBlobDirForCDAP() {
-    local __currentValue
-    local __newValue
-    __currentValue=$(${AMBARICONFIGS_SH} ${AMBARICREDS} get ${ACTIVEAMBARIHOST} ${CLUSTERNAME} core-site | grep 'fs.azure.page.blob.dir' | cut -d' ' -f3 | sed -e 's/"\(.*\)"[,]*/\1/')
-    if [ -n ${__currentValue} ]; then
-        if [[ ${__currentValue} =~ "/cdap" ]]; then
-            echo "fs.azure.page.blob.dir already contains /cdap"
-            return 0
-        else
-            __newValue="${__currentValue},/cdap"
-        fi
+  local __currentValue
+  local __newValue
+  __currentValue=$(${AMBARICONFIGS_SH} ${AMBARICREDS} get ${ACTIVEAMBARIHOST} ${CLUSTERNAME} core-site | grep 'fs.azure.page.blob.dir' | cut -d' ' -f3 | sed -e 's/"\(.*\)"[,]*/\1/')
+  if [ -n ${__currentValue} ]; then
+    if [[ ${__currentValue} =~ "/cdap" ]]; then
+      echo "fs.azure.page.blob.dir already contains /cdap"
+      return 0
     else
-        __newValue="/cdap"
+      __newValue="${__currentValue},/cdap"
     fi
-    echo "Updating fs.azure.page.blob.dir to ${__newValue}"
-    setAmbariConfig 'core-site' 'fs.azure.page.blob.dir' ${__newValue} || die "Could not update Ambari config" 1
-    restartCdapDependentClusterServices
+  else
+    __newValue="/cdap"
+  fi
+  echo "Updating fs.azure.page.blob.dir to ${__newValue}"
+  setAmbariConfig 'core-site' 'fs.azure.page.blob.dir' ${__newValue} || die "Could not update Ambari config" 1
+  restartCdapDependentClusterServices
 }
 
 # Stop an Ambari cluster service
 stopServiceViaRest() {
-    local SERVICENAME=${1}
-    [[ ${SERVICENAME} ]] || die "Need service name to stop service" 136
-    echo "Stopping ${SERVICENAME}"
-    cmd="curl -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X PUT -d '{\"RequestInfo\": {\"context\" :\"Configure Azure page blob support for CDAP installation. Stopping ${SERVICENAME}\"}, \"Body\": {\"ServiceInfo\": {\"state\": \"INSTALLED\"}}}' http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${SERVICENAME}"
-    eval $cmd
+  local SERVICENAME=${1}
+  [[ ${SERVICENAME} ]] || die "Need service name to stop service" 136
+  echo "Stopping ${SERVICENAME}"
+  cmd="curl -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X PUT -d '{\"RequestInfo\": {\"context\" :\"Configure Azure page blob support for CDAP installation. Stopping ${SERVICENAME}\"}, \"Body\": {\"ServiceInfo\": {\"state\": \"INSTALLED\"}}}' http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${SERVICENAME}"
+  eval $cmd
 }
 
 # Start an Ambari cluster service
 startServiceViaRest() {
-    local SERVICENAME=${1}
-    local __startResult
-    [[ ${SERVICENAME} ]] || die "Need service name to start service" 136
-    sleep 2
-    echo "Starting ${SERVICENAME}"
-    cmd="curl -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X PUT -d '{\"RequestInfo\": {\"context\" :\"Configure Azure page blob support for CDAP installation. Starting ${SERVICENAME}\"}, \"Body\": {\"ServiceInfo\": {\"state\": \"STARTED\"}}}' http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${SERVICENAME}"
+  local SERVICENAME=${1}
+  local __startResult
+  [[ ${SERVICENAME} ]] || die "Need service name to start service" 136
+  sleep 2
+  echo "Starting ${SERVICENAME}"
+  cmd="curl -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X PUT -d '{\"RequestInfo\": {\"context\" :\"Configure Azure page blob support for CDAP installation. Starting ${SERVICENAME}\"}, \"Body\": {\"ServiceInfo\": {\"state\": \"STARTED\"}}}' http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${SERVICENAME}"
+  __startResult=$(eval $cmd)
+  if [[ ${__startResult} =~ "500 Server Error" || ${__startResult} =~ "internal system exception occurred" ]]; then
+    sleep 60
+    echo "Retry starting ${SERVICENAME}"
     __startResult=$(eval $cmd)
-    if [[ ${__startResult} =~ "500 Server Error" || ${__startResult} =~ "internal system exception occurred" ]]; then
-        sleep 60
-        echo "Retry starting ${SERVICENAME}"
-        __startResult=$(eval $cmd)
-    fi
-    echo ${__startResult}
+  fi
+  echo ${__startResult}
 }
 
 # Given a service and component, wait for "started_count" to equal 0
 waitForComponentStop() {
-    local __svc=${1}
-    local __component=${2}
-    local __currRunning
+  local __svc=${1}
+  local __component=${2}
+  local __currRunning
 
-    for i in {1..60} ; do
-        __currRunning=$(curl -s -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X GET http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${__svc}/components/${__component} | grep \"started_count\" | awk '{ print $3 }' | sed -e 's/,$//')
-        if [ ${__currRunning} -eq 0 ]; then
-            return 0
-        else
-            sleep 5
-        fi
-    done
-    echo "ERROR: giving up waiting for ${__svc}, component ${__component} to have started_count: 0"
-    return 1
+  for i in {1..60} ; do
+    __currRunning=$(curl -s -u ${USERID}:${PASSWD} -i -H 'X-Requested-By: ambari' -X GET http://${ACTIVEAMBARIHOST}:${AMBARIPORT}/api/v1/clusters/${CLUSTERNAME}/services/${__svc}/components/${__component} | grep \"started_count\" | awk '{ print $3 }' | sed -e 's/,$//')
+    if [ ${__currRunning} -eq 0 ]; then
+      return 0
+    else
+      sleep 5
+    fi
+  done
+  echo "ERROR: giving up waiting for ${__svc}, component ${__component} to have started_count: 0"
+  return 1
 }
 
 # Restart Ambari cluster services
 restartCdapDependentClusterServices() {
-    stopServiceViaRest HBASE
-    stopServiceViaRest YARN
-    stopServiceViaRest MAPREDUCE2
-    stopServiceViaRest HDFS
+  stopServiceViaRest HBASE
+  stopServiceViaRest YARN
+  stopServiceViaRest MAPREDUCE2
+  stopServiceViaRest HDFS
 
-    # Ensure all critical components are completely stopped before issuing any starts.  Otherwise, components may be left not running.
-    for __component in HBASE_MASTER HBASE_REGIONSERVER PHOENIX_QUERY_SERVER; do
-        waitForComponentStop HBASE ${__component} || die "Could not stop component ${__component} of service HBASE" 1
-    done
-    for __component in RESOURCEMANAGER NODEMANAGER; do
-        waitForComponentStop YARN ${__component} || die "Could not stop component ${__component} of service YARN" 1
-    done
-    for __component in DATANODE NAMENODE JOURNALNODE ZKFC; do
-        waitForComponentStop HDFS ${__component} || die "Could not stop component ${__component} of service HDFS" 1
-    done
+  # Ensure all critical components are completely stopped before issuing any starts.  Otherwise, components may be left not running.
+  for __component in HBASE_MASTER HBASE_REGIONSERVER PHOENIX_QUERY_SERVER; do
+    waitForComponentStop HBASE ${__component} || die "Could not stop component ${__component} of service HBASE" 1
+  done
+  for __component in RESOURCEMANAGER NODEMANAGER; do
+    waitForComponentStop YARN ${__component} || die "Could not stop component ${__component} of service YARN" 1
+  done
+  for __component in DATANODE NAMENODE JOURNALNODE ZKFC; do
+    waitForComponentStop HDFS ${__component} || die "Could not stop component ${__component} of service HDFS" 1
+  done
 
-    startServiceViaRest HDFS
-    startServiceViaRest MAPREDUCE2
-    startServiceViaRest YARN
-    startServiceViaRest HBASE
+  startServiceViaRest HDFS
+  startServiceViaRest MAPREDUCE2
+  startServiceViaRest YARN
+  startServiceViaRest HBASE
 }
 
 


### PR DESCRIPTION
- [x] `install.sh`: fix missing `{`in generated json
- [x] `pageblob-configure.sh`: convert bash script to CDAP-standard 2-space indentation for consistency.  The only changes are indentation, but github diff is misleading and not properly showing this in a couple cases.
