### PR TITLE
API changes and corresponding implementation in the DataPipelineApp for supporting Action plugin.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/customaction/AbstractCustomAction.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/customaction/AbstractCustomAction.java
@@ -35,7 +35,7 @@ public abstract class AbstractCustomAction implements CustomAction {
   }
 
   @Override
-  public void configure(CustomActionConfigurer configurer) {
+  public final void configure(CustomActionConfigurer configurer) {
     this.configurer = configurer;
     setName(name);
     configure();
@@ -58,8 +58,17 @@ public abstract class AbstractCustomAction implements CustomAction {
   }
 
   @Override
-  public void initialize(CustomActionContext context) throws Exception {
+  public final void initialize(CustomActionContext context) throws Exception {
     this.context = context;
+    initialize();
+  }
+
+  /**
+   * Classes derived from {@link AbstractCustomAction} can override this method to initialize the {@link CustomAction}.
+   * @throws Exception if there is any error in initializing the custom action
+   */
+  protected void initialize() throws Exception {
+    // No-op by default
   }
 
   @Override

--- a/cdap-api/src/main/java/co/cask/cdap/api/customaction/CustomActionConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/customaction/CustomActionConfigurer.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.api.customaction;
 
+import co.cask.cdap.api.plugin.PluginConfigurer;
 import co.cask.cdap.api.workflow.Workflow;
 
 import java.util.Map;
@@ -23,7 +24,7 @@ import java.util.Map;
 /**
  * Configurer for configuring the {@link CustomAction} in the {@link Workflow}.
  */
-public interface CustomActionConfigurer {
+public interface CustomActionConfigurer extends PluginConfigurer {
 
   /**
    * Sets the name of the {@link CustomAction}.

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConditionConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowConditionConfigurer.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.api.workflow;
 
 import co.cask.cdap.api.Predicate;
+import co.cask.cdap.api.customaction.CustomAction;
 
 /**
  * Defines an interface for the conditions in the {@link Workflow}.
@@ -41,8 +42,17 @@ public interface WorkflowConditionConfigurer<T> {
    * Adds custom action a a next sequential step to the current branch of the {@link WorkflowConditionNode}.
    * @param action {@link WorkflowAction} to be added
    * @return the configurer for the current condition
+   * @deprecated Deprecated as of 3.5.0. Please use {@link WorkflowConditionConfigurer#addAction(CustomAction)} instead.
    */
+  @Deprecated
   WorkflowConditionConfigurer<T> addAction(WorkflowAction action);
+
+  /**
+   * Adds custom action a a next sequential step to the current branch of the {@link WorkflowConditionNode}.
+   * @param action {@link CustomAction} to be added
+   * @return the configurer for the current condition
+   */
+  WorkflowConditionConfigurer<T> addAction(CustomAction action);
 
   /**
    * Forks the current branch of the {@link WorkflowConditionNode}.

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowForkConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowForkConfigurer.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.api.workflow;
 
 import co.cask.cdap.api.Predicate;
+import co.cask.cdap.api.customaction.CustomAction;
 
 /**
  * Defines an interface for the fork in the {@link Workflow}.
@@ -44,8 +45,17 @@ public interface WorkflowForkConfigurer<T> {
    * Adds custom action a a next sequential step to the current branch of the {@link WorkflowForkNode}
    * @param action {@link WorkflowAction} to be added to the fork
    * @return the configurer for the current fork
+   * @deprecated Deprecated as of 3.5.0. Please use {@link WorkflowForkConfigurer#addAction(CustomAction)} instead.
    */
+  @Deprecated
   WorkflowForkConfigurer<T> addAction(WorkflowAction action);
+
+  /**
+   * Adds custom action a a next sequential step to the current branch of the {@link WorkflowForkNode}
+   * @param action {@link CustomAction} to be added to the fork
+   * @return the configurer for the current fork
+   */
+  WorkflowForkConfigurer<T> addAction(CustomAction action);
 
   /**
    * Adds a nested fork to the current fork

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/customaction/DefaultCustomActionConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/customaction/DefaultCustomActionConfigurer.java
@@ -18,10 +18,14 @@ package co.cask.cdap.internal.app.customaction;
 import co.cask.cdap.api.customaction.CustomAction;
 import co.cask.cdap.api.customaction.CustomActionConfigurer;
 import co.cask.cdap.api.customaction.CustomActionSpecification;
+import co.cask.cdap.internal.app.DefaultPluginConfigurer;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.internal.customaction.DefaultCustomActionSpecification;
 import co.cask.cdap.internal.lang.Reflections;
 import co.cask.cdap.internal.specification.DataSetFieldExtractor;
 import co.cask.cdap.internal.specification.PropertyFieldExtractor;
+import co.cask.cdap.proto.Id;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
@@ -33,7 +37,7 @@ import java.util.Set;
 /**
  * Default implementation of the {@link CustomActionConfigurer}.
  */
-public class DefaultCustomActionConfigurer implements CustomActionConfigurer {
+public final class DefaultCustomActionConfigurer extends DefaultPluginConfigurer implements CustomActionConfigurer {
   private final String className;
   private final Map<String, String> propertyFields;
   private final Set<String> datasetFields;
@@ -42,7 +46,9 @@ public class DefaultCustomActionConfigurer implements CustomActionConfigurer {
   private String description;
   private Map<String, String> properties;
 
-  private DefaultCustomActionConfigurer(CustomAction customAction) {
+  private DefaultCustomActionConfigurer(CustomAction customAction, Id.Namespace deployNamespace, Id.Artifact artifactId,
+                                       ArtifactRepository artifactRepository, PluginInstantiator pluginInstantiator) {
+    super(deployNamespace, artifactId, artifactRepository, pluginInstantiator);
     this.name = customAction.getClass().getSimpleName();
     this.description = "";
     this.className = customAction.getClass().getName();
@@ -80,8 +86,12 @@ public class DefaultCustomActionConfigurer implements CustomActionConfigurer {
     return new DefaultCustomActionSpecification(className, name, description, properties, datasets);
   }
 
-  public static CustomActionSpecification configureAction(CustomAction action) {
-    DefaultCustomActionConfigurer configurer = new DefaultCustomActionConfigurer(action);
+  public static CustomActionSpecification configureAction(CustomAction action, Id.Namespace deployNamespace,
+                                                          Id.Artifact artifactId, ArtifactRepository artifactRepository,
+                                                          PluginInstantiator pluginInstantiator) {
+    DefaultCustomActionConfigurer configurer = new DefaultCustomActionConfigurer(action, deployNamespace, artifactId,
+                                                                                 artifactRepository,
+                                                                                 pluginInstantiator);
     action.configure(configurer);
     return configurer.createSpecification();
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConditionConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConditionConfigurer.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app.workflow;
 
 import co.cask.cdap.api.Predicate;
+import co.cask.cdap.api.customaction.CustomAction;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.workflow.WorkflowAction;
 import co.cask.cdap.api.workflow.WorkflowConditionConfigurer;
@@ -25,6 +26,9 @@ import co.cask.cdap.api.workflow.WorkflowContext;
 import co.cask.cdap.api.workflow.WorkflowForkConfigurer;
 import co.cask.cdap.api.workflow.WorkflowForkNode;
 import co.cask.cdap.api.workflow.WorkflowNode;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
+import co.cask.cdap.proto.Id;
 import com.google.common.collect.Lists;
 
 import java.util.List;
@@ -39,15 +43,27 @@ public class DefaultWorkflowConditionConfigurer<T extends WorkflowConditionAdder
   private final T parentConfigurer;
   private final List<WorkflowNode> ifBranch = Lists.newArrayList();
   private final List<WorkflowNode> elseBranch = Lists.newArrayList();
-  private List<WorkflowNode> currentBranch;
-  private boolean addingToIfBranch = true;
   private final String predicateClassName;
   private final String conditionNodeName;
+  private final Id.Namespace deployNamespace;
+  private final Id.Artifact artifactId;
+  private final ArtifactRepository artifactRepository;
+  private final PluginInstantiator pluginInstantiator;
 
-  public DefaultWorkflowConditionConfigurer(String conditionNodeName, T parentConfigurer, String predicateClassName) {
+  private List<WorkflowNode> currentBranch;
+  private boolean addingToIfBranch = true;
+
+  public DefaultWorkflowConditionConfigurer(String conditionNodeName, T parentConfigurer, String predicateClassName,
+                                            Id.Namespace deployNamespace, Id.Artifact artifactId,
+                                            ArtifactRepository artifactRepository,
+                                            PluginInstantiator pluginInstantiator) {
     this.conditionNodeName = conditionNodeName;
     this.parentConfigurer = parentConfigurer;
     this.predicateClassName = predicateClassName;
+    this.deployNamespace = deployNamespace;
+    this.artifactId = artifactId;
+    this.artifactRepository = artifactRepository;
+    this.pluginInstantiator = pluginInstantiator;
     currentBranch = Lists.newArrayList();
   }
 
@@ -70,8 +86,16 @@ public class DefaultWorkflowConditionConfigurer<T extends WorkflowConditionAdder
   }
 
   @Override
+  public WorkflowConditionConfigurer<T> addAction(CustomAction action) {
+    currentBranch.add(WorkflowNodeCreator.createWorkflowCustomActionNode(action, deployNamespace, artifactId,
+                                                                         artifactRepository, pluginInstantiator));
+    return this;
+  }
+
+  @Override
   public WorkflowForkConfigurer<? extends WorkflowConditionConfigurer<T>> fork() {
-    return new DefaultWorkflowForkConfigurer<>(this);
+    return new DefaultWorkflowForkConfigurer<>(this, deployNamespace, artifactId, artifactRepository,
+                                               pluginInstantiator);
   }
 
   @Override
@@ -79,7 +103,8 @@ public class DefaultWorkflowConditionConfigurer<T extends WorkflowConditionAdder
   public WorkflowConditionConfigurer<? extends WorkflowConditionConfigurer<T>> condition(
     Predicate<WorkflowContext> predicate) {
     return new DefaultWorkflowConditionConfigurer<>(predicate.getClass().getSimpleName(), this,
-                                                    predicate.getClass().getName());
+                                                    predicate.getClass().getName(), deployNamespace, artifactId,
+                                                    artifactRepository, pluginInstantiator);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConfigurer.java
@@ -51,14 +51,18 @@ public class DefaultWorkflowConfigurer extends DefaultPluginConfigurer
   implements WorkflowConfigurer, WorkflowForkJoiner, WorkflowConditionAdder {
 
   private final String className;
+  private final Map<String, DatasetCreationSpec> localDatasetSpecs = new HashMap<>();
+  private final DatasetConfigurer datasetConfigurer;
+  private final Id.Namespace deployNamespace;
+  private final Id.Artifact artifactId;
+  private final ArtifactRepository artifactRepository;
+  private final PluginInstantiator pluginInstantiator;
+  private final List<WorkflowNode> nodes = Lists.newArrayList();
+
+  private int nodeIdentifier = 0;
   private String name;
   private String description;
   private Map<String, String> properties;
-  private final Map<String, DatasetCreationSpec> localDatasetSpecs = new HashMap<>();
-  private int nodeIdentifier = 0;
-  private final DatasetConfigurer datasetConfigurer;
-
-  private final List<WorkflowNode> nodes = Lists.newArrayList();
 
   public DefaultWorkflowConfigurer(Workflow workflow, DatasetConfigurer datasetConfigurer,
                                    Id.Namespace deployNamespace, Id.Artifact artifactId,
@@ -68,6 +72,10 @@ public class DefaultWorkflowConfigurer extends DefaultPluginConfigurer
     this.name = workflow.getClass().getSimpleName();
     this.description = "";
     this.datasetConfigurer = datasetConfigurer;
+    this.deployNamespace = deployNamespace;
+    this.artifactId = artifactId;
+    this.artifactRepository = artifactRepository;
+    this.pluginInstantiator = pluginInstantiator;
   }
 
   @Override
@@ -102,18 +110,21 @@ public class DefaultWorkflowConfigurer extends DefaultPluginConfigurer
 
   @Override
   public void addAction(CustomAction action) {
-    nodes.add(WorkflowNodeCreator.createWorkflowCustomActionNode(action));
+    nodes.add(WorkflowNodeCreator.createWorkflowCustomActionNode(action, deployNamespace, artifactId,
+                                                                 artifactRepository, pluginInstantiator));
   }
 
   @Override
   public WorkflowForkConfigurer<? extends WorkflowConfigurer> fork() {
-    return new DefaultWorkflowForkConfigurer<>(this);
+    return new DefaultWorkflowForkConfigurer<>(this, deployNamespace, artifactId, artifactRepository,
+                                               pluginInstantiator);
   }
 
   @Override
   public WorkflowConditionConfigurer<? extends WorkflowConfigurer> condition(Predicate<WorkflowContext> predicate) {
     return new DefaultWorkflowConditionConfigurer<>(predicate.getClass().getSimpleName(), this,
-                                                    predicate.getClass().getName());
+                                                    predicate.getClass().getName(), deployNamespace, artifactId,
+                                                    artifactRepository, pluginInstantiator);
   }
 
   private void checkArgument(boolean condition, String template, Object...args) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/WorkflowNodeCreator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/WorkflowNodeCreator.java
@@ -25,6 +25,9 @@ import co.cask.cdap.api.workflow.WorkflowActionNode;
 import co.cask.cdap.api.workflow.WorkflowActionSpecification;
 import co.cask.cdap.api.workflow.WorkflowNode;
 import co.cask.cdap.internal.app.customaction.DefaultCustomActionConfigurer;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
+import co.cask.cdap.proto.Id;
 import com.google.common.base.Preconditions;
 
 /**
@@ -61,9 +64,13 @@ final class WorkflowNodeCreator {
     return new WorkflowActionNode(spec.getName(), spec);
   }
 
-  static WorkflowNode createWorkflowCustomActionNode(CustomAction action) {
+  static WorkflowNode createWorkflowCustomActionNode(CustomAction action, Id.Namespace deployNamespace,
+                                                     Id.Artifact artifactId, ArtifactRepository artifactRepository,
+                                                     PluginInstantiator pluginInstantiator) {
     Preconditions.checkArgument(action != null, "CustomAction is null.");
-    CustomActionSpecification spec = DefaultCustomActionConfigurer.configureAction(action);
+    CustomActionSpecification spec = DefaultCustomActionConfigurer.configureAction(action, deployNamespace, artifactId,
+                                                                                   artifactRepository,
+                                                                                   pluginInstantiator);
     return new WorkflowActionNode(spec.getName(), spec);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/BranchProgramAdder.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/BranchProgramAdder.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.datapipeline;
 
+import co.cask.cdap.api.customaction.CustomAction;
 import co.cask.cdap.api.workflow.WorkflowForkConfigurer;
 
 /**
@@ -36,5 +37,10 @@ public class BranchProgramAdder implements WorkflowProgramAdder {
   @Override
   public void addSpark(String name) {
     forkConfigurer.addSpark(name);
+  }
+
+  @Override
+  public void addAction(CustomAction action) {
+    forkConfigurer.addAction(action);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/SmartWorkflow.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/SmartWorkflow.java
@@ -33,6 +33,7 @@ import co.cask.cdap.etl.batch.BatchPhaseSpec;
 import co.cask.cdap.etl.batch.BatchPipelineSpec;
 import co.cask.cdap.etl.batch.WorkflowBackedActionContext;
 import co.cask.cdap.etl.batch.connector.ConnectorSource;
+import co.cask.cdap.etl.batch.customaction.PipelineAction;
 import co.cask.cdap.etl.batch.mapreduce.ETLMapReduce;
 import co.cask.cdap.etl.batch.spark.ETLSpark;
 import co.cask.cdap.etl.common.Constants;
@@ -235,6 +236,14 @@ public class SmartWorkflow extends AbstractWorkflow {
     BatchPhaseSpec batchPhaseSpec = new BatchPhaseSpec(programName, phase, spec.getResources(),
                                                        spec.isStageLoggingEnabled(), phaseConnectorDatasets);
 
+    // Custom action is the only phase in the pipeline which has no associated dag
+    boolean hasCustomAction = batchPhaseSpec.getPhase().getSources().isEmpty()
+      && batchPhaseSpec.getPhase().getSinks().isEmpty();
+    if (hasCustomAction) {
+      // Add custom action to the Workflow
+      programAdder.addAction(new PipelineAction(batchPhaseSpec));
+      return;
+    }
 
     boolean hasSparkCompute = !batchPhaseSpec.getPhase().getStagesOfType(SparkCompute.PLUGIN_TYPE).isEmpty();
     boolean hasSparkSink = !batchPhaseSpec.getPhase().getStagesOfType(SparkSink.PLUGIN_TYPE).isEmpty();

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/TrunkProgramAdder.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/TrunkProgramAdder.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.datapipeline;
 
+import co.cask.cdap.api.customaction.CustomAction;
 import co.cask.cdap.api.workflow.WorkflowConfigurer;
 
 /**
@@ -36,5 +37,10 @@ public class TrunkProgramAdder implements WorkflowProgramAdder {
   @Override
   public void addSpark(String name) {
     configurer.addSpark(name);
+  }
+
+  @Override
+  public void addAction(CustomAction action) {
+    configurer.addAction(action);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/action/Action.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/action/Action.java
@@ -14,21 +14,20 @@
  * the License.
  */
 
-package co.cask.cdap.datapipeline;
+package co.cask.cdap.etl.api.action;
 
-import co.cask.cdap.api.customaction.CustomAction;
-import co.cask.cdap.api.workflow.WorkflowConfigurer;
-import co.cask.cdap.api.workflow.WorkflowForkConfigurer;
+import co.cask.cdap.etl.api.PipelineConfigurable;
 
 /**
- * Adds workflow programs.
- * This is required because {@link WorkflowForkConfigurer} doesn't extend {@link WorkflowConfigurer}.
+ * Represents custom logic to be executed in the pipeline.
  */
-public interface WorkflowProgramAdder {
+public abstract class Action implements PipelineConfigurable {
+  public static final String PLUGIN_TYPE = "action";
 
-  void addMapReduce(String name);
-
-  void addSpark(String name);
-
-  void addAction(CustomAction action);
+  /**
+   * Implement this method to execute the code as a part of action run.
+   * @param context the action context, containing information about the pipeline run
+   * @throws Exception when there is failure in method execution
+   */
+  public abstract void run(ActionContext context) throws Exception;
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/action/ActionContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/action/ActionContext.java
@@ -14,33 +14,27 @@
  * the License.
  */
 
-package co.cask.cdap.api.customaction;
+package co.cask.cdap.etl.api.action;
 
-import co.cask.cdap.api.ProgramState;
-import co.cask.cdap.api.RuntimeContext;
 import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.plugin.PluginContext;
-import co.cask.cdap.api.workflow.WorkflowInfoProvider;
 
 /**
- * Represents runtime context of the {@link CustomAction} in the Workflow.
+ * Represents the context available to the action plugin during runtime.
  */
-public interface CustomActionContext extends RuntimeContext, Transactional, WorkflowInfoProvider, PluginContext {
-
-  /**
-   * Return the specification of the custom action.
-   */
-  CustomActionSpecification getSpecification();
+public interface ActionContext extends Transactional, PluginContext {
 
   /**
    * Returns the logical start time of the batch job which triggers this instance of an action.
-   * Logical start time is the time when the triggering Batch job is supposed to start if it is started
-   * by the scheduler. Otherwise it would be the current time when the action runs.
+   * Logical start time is the time when the triggering Batch job is supposed to start if it is
+   * started by the scheduler. Otherwise it would be the current time when the action runs.
+   *
+   * @return Time in milliseconds since epoch time (00:00:00 January 1, 1970 UTC).
    */
   long getLogicalStartTime();
 
   /**
-   * Return the state of the custom action.
+   * Return the arguments which can be updated.
    */
-  ProgramState getState();
+  SettableArguments getArguments();
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/action/SettableArguments.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/action/SettableArguments.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.etl.api.action;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Provides access to the pipeline arguments which can be updated.
+ */
+public interface SettableArguments extends Iterable<Map.Entry<String, String>> {
+  /**
+   * Returns true if specified argument is provided, otherwise false is returned.
+   */
+  boolean has(String name);
+
+  /**
+   * Returns the value for the given argument name if it exist, otherwise {@code null} is returned.
+   */
+  @Nullable
+  String get(String name);
+
+  /**
+   * Sets the name and value as specified by the input parameters.
+   */
+  void set(String name, String value);
+
+  /**
+   * Returns an map that represents all arguments.
+   */
+  Map<String, String> asMap();
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/customaction/BasicActionContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/customaction/BasicActionContext.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.etl.batch.customaction;
+
+import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.customaction.CustomActionContext;
+import co.cask.cdap.api.macro.InvalidMacroException;
+import co.cask.cdap.api.macro.MacroEvaluator;
+import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.etl.api.action.ActionContext;
+import co.cask.cdap.etl.api.action.SettableArguments;
+import co.cask.tephra.TransactionFailureException;
+
+/**
+ * Default implementation for the {@link ActionContext}.
+ */
+public class BasicActionContext implements ActionContext {
+
+  private final CustomActionContext context;
+
+  public BasicActionContext(CustomActionContext context) {
+    this.context = context;
+  }
+
+  @Override
+  public long getLogicalStartTime() {
+    return context.getLogicalStartTime();
+  }
+
+  @Override
+  public SettableArguments getArguments() {
+    return new BasicSettableArguments(context.getRuntimeArguments());
+  }
+
+  @Override
+  public PluginProperties getPluginProperties(String pluginId) {
+    return context.getPluginProperties(pluginId);
+  }
+
+  @Override
+  public <T> Class<T> loadPluginClass(String pluginId) {
+    return context.loadPluginClass(pluginId);
+  }
+
+  @Override
+  public <T> T newPluginInstance(String pluginId) throws InstantiationException {
+    return context.newPluginInstance(pluginId);
+  }
+
+  @Override
+  public <T> T newPluginInstance(String pluginId, MacroEvaluator evaluator)
+    throws InstantiationException, InvalidMacroException {
+    return context.newPluginInstance(pluginId, evaluator);
+  }
+
+  @Override
+  public void execute(TxRunnable runnable) throws TransactionFailureException {
+    context.execute(runnable);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/customaction/BasicSettableArguments.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/customaction/BasicSettableArguments.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.etl.batch.customaction;
+
+import co.cask.cdap.etl.api.action.SettableArguments;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Default implementation of {@link SettableArguments}.
+ */
+public class BasicSettableArguments implements SettableArguments {
+
+  private final Map<String, String> options;
+
+  public BasicSettableArguments(Map<String, String> arguments) {
+    options = new HashMap<>();
+    for (Map.Entry<String, String> argument : arguments.entrySet()) {
+      options.put(argument.getKey(), argument.getValue());
+    }
+  }
+
+  @Override
+  public boolean has(String name) {
+    return options.containsKey(name);
+  }
+
+  @Override
+  public String get(String name) {
+    return options.get(name);
+  }
+
+  @Override
+  public void set(String name, String value) {
+    options.put(name, value);
+  }
+
+  @Override
+  public Map<String, String> asMap() {
+    return options;
+  }
+
+  @Override
+  public Iterator<Map.Entry<String, String>> iterator() {
+    return options.entrySet().iterator();
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/customaction/PipelineAction.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/customaction/PipelineAction.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.etl.batch.customaction;
+
+import co.cask.cdap.api.customaction.AbstractCustomAction;
+import co.cask.cdap.api.customaction.CustomAction;
+import co.cask.cdap.api.customaction.CustomActionContext;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.workflow.WorkflowToken;
+import co.cask.cdap.etl.api.action.Action;
+import co.cask.cdap.etl.api.action.ActionContext;
+import co.cask.cdap.etl.batch.BatchPhaseSpec;
+import co.cask.cdap.etl.common.Constants;
+import co.cask.cdap.etl.common.PipelinePhase;
+import co.cask.cdap.etl.common.SetMultimapCodec;
+import co.cask.cdap.etl.planner.StageInfo;
+import co.cask.cdap.internal.io.SchemaTypeAdapter;
+import com.google.common.collect.SetMultimap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Implementation of the {@link CustomAction} used in DataPipeline application.
+ */
+public class PipelineAction extends AbstractCustomAction {
+
+  // This is only visible during the configure time, not at runtime.
+  private final BatchPhaseSpec phaseSpec;
+
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
+    .registerTypeAdapter(SetMultimap.class, new SetMultimapCodec<>())
+    .create();
+
+  public PipelineAction(BatchPhaseSpec phaseSpec) {
+    this.phaseSpec = phaseSpec;
+  }
+
+  @Override
+  protected void configure() {
+    setName(phaseSpec.getPhaseName());
+    setDescription("CustomAction phase executor. " + phaseSpec.getPhaseName());
+
+    // add source, sink, transform ids to the properties. These are needed at runtime to instantiate the plugins
+    Map<String, String> properties = new HashMap<>();
+    properties.put(Constants.PIPELINEID, GSON.toJson(phaseSpec));
+    setProperties(properties);
+  }
+
+  @Override
+  public void run() throws Exception {
+    CustomActionContext context = getContext();
+    Map<String, String> properties = context.getSpecification().getProperties();
+    BatchPhaseSpec phaseSpec = GSON.fromJson(properties.get(Constants.PIPELINEID), BatchPhaseSpec.class);
+    PipelinePhase phase = phaseSpec.getPhase();
+    StageInfo stageInfo = phase.iterator().next();
+    Action action = context.newPluginInstance(stageInfo.getName());
+    ActionContext actionContext = new BasicActionContext(context);
+    action.run(actionContext);
+    WorkflowToken token = context.getWorkflowToken();
+    if (token == null) {
+      throw new IllegalStateException("WorkflowToken cannot be null when action is executed through Workflow.");
+    }
+    for (Map.Entry<String, String> entry : actionContext.getArguments()) {
+      token.put(entry.getKey(), entry.getValue());
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/PipelinePhase.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/PipelinePhase.java
@@ -45,7 +45,7 @@ public class PipelinePhase implements Iterable<StageInfo> {
   private final Map<String, Set<StageInfo>> stages;
   private final Dag dag;
 
-  private PipelinePhase(Map<String, Set<StageInfo>> stages, Dag dag) {
+  public PipelinePhase(Map<String, Set<StageInfo>> stages, Dag dag) {
     this.stages = ImmutableMap.copyOf(stages);
     this.dag = dag;
   }
@@ -68,7 +68,7 @@ public class PipelinePhase implements Iterable<StageInfo> {
         stageInfos.addAll(stages.get(pluginType));
       }
     }
-    return Collections.unmodifiableSet(stageInfos == null ? new HashSet<StageInfo>() : stageInfos);
+    return Collections.unmodifiableSet(stageInfos);
   }
 
   public Set<String> getStageOutputs(String stage) {
@@ -81,11 +81,11 @@ public class PipelinePhase implements Iterable<StageInfo> {
   }
 
   public Set<String> getSources() {
-    return dag.getSources();
+    return dag == null ? new HashSet<String>() : dag.getSources();
   }
 
   public Set<String> getSinks() {
-    return dag.getSinks();
+    return dag == null ? new HashSet<String>() : dag.getSinks();
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/action/MockAction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/action/MockAction.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.action;
+
+import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginPropertyField;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.action.Action;
+import co.cask.cdap.etl.api.action.ActionContext;
+import co.cask.cdap.etl.proto.v2.ETLPlugin;
+import co.cask.cdap.test.DataSetManager;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Mock sink that writes records to a Table and has a utility method for getting all records written.
+ */
+@Plugin(type = Action.PLUGIN_TYPE)
+@Name("TableWriterAction")
+public class MockAction extends Action {
+  private final Config config;
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
+
+  /**
+   * Config for the MockAction
+   */
+  public static class Config extends PluginConfig {
+    private String tableName;
+    private String rowKey;
+    private String columnKey;
+    private String value;
+  }
+
+  public MockAction(Config config) {
+    this.config = config;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
+    pipelineConfigurer.createDataset(config.tableName, Table.class);
+  }
+
+  @Override
+  public void run(ActionContext context) throws Exception {
+    context.execute(new TxRunnable() {
+      @Override
+      public void run(DatasetContext context) throws Exception {
+        Table table = context.getDataset(config.tableName);
+        Put put = new Put(config.rowKey);
+        put.add(config.columnKey, config.value);
+        table.put(put);
+      }
+    });
+  }
+
+  public static ETLPlugin getPlugin(String tableName, String rowKey, String columnKey, String value) {
+    Map<String, String> properties = ImmutableMap.of("tableName", tableName, "rowKey", rowKey, "columnKey", columnKey,
+                                                     "value", value);
+    return new ETLPlugin("TableWriterAction", Action.PLUGIN_TYPE, properties, null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("tableName", new PluginPropertyField("tableName", "", "string", true, false));
+    properties.put("rowKey", new PluginPropertyField("rowKey", "", "string", true, false));
+    properties.put("columnKey", new PluginPropertyField("columnKey", "", "string", true, false));
+    properties.put("value", new PluginPropertyField("value", "", "string", true, false));
+    return new PluginClass(Action.PLUGIN_TYPE, "TableWriterAction", "", MockAction.class.getName(),
+                           "config", properties);
+  }
+
+  /**
+   * Read the value for the specified rowKey and columnKey.
+   */
+  public static String readOutput(DataSetManager<Table> tableManager, String rowKey, String columnKey)
+    throws Exception {
+    Table table = tableManager.get();
+    return Bytes.toString(table.get(Bytes.toBytes(rowKey), Bytes.toBytes(columnKey)));
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/test/HydratorTestBase.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/test/HydratorTestBase.java
@@ -18,8 +18,10 @@ package co.cask.cdap.etl.mock.test;
 
 import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.etl.api.PipelineConfigurable;
+import co.cask.cdap.etl.api.action.Action;
 import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.api.realtime.RealtimeSource;
+import co.cask.cdap.etl.mock.action.MockAction;
 import co.cask.cdap.etl.mock.batch.MockExternalSink;
 import co.cask.cdap.etl.mock.batch.MockExternalSource;
 import co.cask.cdap.etl.mock.batch.MockRuntimeDatasetSink;
@@ -59,7 +61,8 @@ public class HydratorTestBase extends TestBase {
     MockRuntimeDatasetSink.PLUGIN_CLASS, MockRuntimeDatasetSource.PLUGIN_CLASS,
     MockExternalSource.PLUGIN_CLASS, MockExternalSink.PLUGIN_CLASS,
     DoubleTransform.PLUGIN_CLASS, ErrorTransform.PLUGIN_CLASS, IdentityTransform.PLUGIN_CLASS,
-    FieldsPrefixTransform.PLUGIN_CLASS, IntValueFilterTransform.PLUGIN_CLASS, StringValueFilterTransform.PLUGIN_CLASS
+    FieldsPrefixTransform.PLUGIN_CLASS, IntValueFilterTransform.PLUGIN_CLASS, StringValueFilterTransform.PLUGIN_CLASS,
+    MockAction.PLUGIN_CLASS
   );
 
   public HydratorTestBase() {
@@ -90,6 +93,7 @@ public class HydratorTestBase extends TestBase {
     // add the app artifact
     addAppArtifact(artifactId, appClass,
                    BatchSource.class.getPackage().getName(),
+                   Action.class.getPackage().getName(),
                    PipelineConfigurable.class.getPackage().getName(),
                    "org.apache.avro.mapred", "org.apache.avro", "org.apache.avro.generic", "org.apache.avro.io");
 


### PR DESCRIPTION
Link to the API design doc - https://wiki.cask.co/display/CE/Custom+actions
Following changes are done as a part of PR:
1. API for the action plugins `Action` and `ActionContext` documented here https://wiki.cask.co/display/CE/Custom+actions
2. Basic implementation of the APIs.
3. DataPipelineApp changes to add the `ETLAction` and ability to configure it.
4. `PipelinePlanner` changes to generate phases and phase connections for the `Action` plugin.
5. Unit test case (will need to add more for the complex pipelines)
