### PR TITLE
CDAP-6157/6158 Enable cross namespace dataset/stream access for spark

### DIFF
--- a/cdap-api-spark/src/main/java/co/cask/cdap/api/spark/JavaSparkExecutionContext.java
+++ b/cdap-api-spark/src/main/java/co/cask/cdap/api/spark/JavaSparkExecutionContext.java
@@ -97,55 +97,114 @@ public abstract class JavaSparkExecutionContext implements RuntimeContext, Trans
   /**
    * Creates a {@link JavaPairRDD} from the given {@link Dataset}.
    *
-   * @param datasetName name of the Dataset
+   * @param datasetName name of the dataset
    * @param <K> key type
    * @param <V> value type
-   * @return A new {@link JavaPairRDD} instance that reads from the given Dataset
-   * @throws DatasetInstantiationException if the Dataset doesn't exist
+   * @return A new {@link JavaPairRDD} instance that reads from the given dataset
+   * @throws DatasetInstantiationException if the dataset doesn't exist
    */
   public <K, V> JavaPairRDD<K, V> fromDataset(String datasetName) {
     return fromDataset(datasetName, Collections.<String, String>emptyMap());
   }
 
   /**
-   * Creates a {@link JavaPairRDD} from the given {@link Dataset} with the given set of Dataset arguments.
+   * Creates a {@link JavaPairRDD} from the given {@link Dataset}.
    *
-   * @param datasetName name of the Dataset
-   * @param arguments arguments for the Dataset
+   * @param namespace namespace in which the dataset exists
+   * @param datasetName name of the dataset
    * @param <K> key type
    * @param <V> value type
-   * @return A new {@link JavaPairRDD} instance that reads from the given Dataset
-   * @throws DatasetInstantiationException if the Dataset doesn't exist
+   * @return A new {@link JavaPairRDD} instance that reads from the given dataset
+   * @throws DatasetInstantiationException if the dataset doesn't exist
+   */
+  public <K, V> JavaPairRDD<K, V> fromDataset(String namespace, String datasetName) {
+    return fromDataset(namespace, datasetName, Collections.<String, String>emptyMap());
+  }
+
+  /**
+   * Creates a {@link JavaPairRDD} from the given {@link Dataset} with the given set of dataset arguments.
+   *
+   * @param datasetName name of the dataset
+   * @param arguments arguments for the dataset
+   * @param <K> key type
+   * @param <V> value type
+   * @return A new {@link JavaPairRDD} instance that reads from the given dataset
+   * @throws DatasetInstantiationException if the dataset doesn't exist
    */
   public <K, V> JavaPairRDD<K, V> fromDataset(String datasetName, Map<String, String> arguments) {
     return fromDataset(datasetName, arguments, null);
   }
 
   /**
-   * Creates a {@link JavaPairRDD} from the given {@link Dataset} with the given set of Dataset arguments
-   * and custom list of {@link Split}s. Each {@link Split} will create a {@link Partition} in the {@link JavaPairRDD}.
+   * Creates a {@link JavaPairRDD} from the given {@link Dataset} with the given set of dataset arguments.
    *
-   * @param datasetName name of the Dataset
-   * @param arguments arguments for the Dataset
-   * @param splits list of {@link Split} or {@code null} to use the default splits provided by the Dataset
+   * @param namespace namespace in which the dataset exists
+   * @param datasetName name of the dataset
+   * @param arguments arguments for the dataset
    * @param <K> key type
    * @param <V> value type
-   * @return A new {@link JavaPairRDD} instance that reads from the given Dataset
-   * @throws DatasetInstantiationException if the Dataset doesn't exist
+   * @return A new {@link JavaPairRDD} instance that reads from the given dataset
+   * @throws DatasetInstantiationException if the dataset doesn't exist
+   */
+  public <K, V> JavaPairRDD<K, V> fromDataset(String namespace, String datasetName, Map<String, String> arguments) {
+    return fromDataset(namespace, datasetName, arguments, null);
+  }
+
+  /**
+   * Creates a {@link JavaPairRDD} from the given {@link Dataset} with the given set of dataset arguments
+   * and custom list of {@link Split}s. Each {@link Split} will create a {@link Partition} in the {@link JavaPairRDD}.
+   *
+   * @param datasetName name of the dataset
+   * @param arguments arguments for the dataset
+   * @param splits list of {@link Split} or {@code null} to use the default splits provided by the dataset
+   * @param <K> key type
+   * @param <V> value type
+   * @return A new {@link JavaPairRDD} instance that reads from the given dataset
+   * @throws DatasetInstantiationException if the dataset doesn't exist
    */
   public abstract <K, V> JavaPairRDD<K, V> fromDataset(String datasetName,
                                                        Map<String, String> arguments,
                                                        @Nullable Iterable<? extends Split> splits);
 
   /**
+   * Creates a {@link JavaPairRDD} from the given {@link Dataset} with the given set of dataset arguments
+   * and custom list of {@link Split}s. Each {@link Split} will create a {@link Partition} in the {@link JavaPairRDD}.
+   *
+   * @param namespace namespace in which the dataset exists
+   * @param datasetName name of the dataset
+   * @param arguments arguments for the dataset
+   * @param splits list of {@link Split} or {@code null} to use the default splits provided by the dataset
+   * @param <K> key type
+   * @param <V> value type
+   * @return A new {@link JavaPairRDD} instance that reads from the given dataset
+   * @throws DatasetInstantiationException if the dataset doesn't exist
+   */
+  public abstract <K, V> JavaPairRDD<K, V> fromDataset(String namespace, String datasetName,
+                                                       Map<String, String> arguments,
+                                                       @Nullable Iterable<? extends Split> splits);
+
+
+  /**
    * Creates a {@link JavaRDD} that represents all events from the given stream.
    *
    * @param streamName name of the stream
    * @return A new {@link JavaRDD} instance that reads from the given stream
-   * @throws DatasetInstantiationException if the Stream doesn't exist
+   * @throws DatasetInstantiationException if the stream doesn't exist
    */
   public JavaRDD<StreamEvent> fromStream(String streamName) {
     return fromStream(streamName, 0, Long.MAX_VALUE);
+  }
+
+  /**
+   * Creates a {@link JavaRDD} that represents all events from the given stream.
+   *
+   * @param namespace namespace in which the stream exists
+   * @param streamName name of the stream
+   * @return A new {@link JavaRDD} instance that reads from the given stream
+   * @throws DatasetInstantiationException if the stream doesn't exist
+   */
+  public JavaRDD<StreamEvent> fromStream(String namespace, String streamName) {
+    return fromStream(namespace, streamName, 0, Long.MAX_VALUE);
   }
 
   /**
@@ -157,9 +216,23 @@ public abstract class JavaSparkExecutionContext implements RuntimeContext, Trans
    * @param endTime the ending time of the streams to be read in milliseconds (exclusive);
    *                passing in {@link Long#MAX_VALUE} means read up to latest event available in the stream.
    * @return A new {@link JavaRDD} instance that reads from the given stream
-   * @throws DatasetInstantiationException if the Stream doesn't exist
+   * @throws DatasetInstantiationException if the stream doesn't exist
    */
   public abstract JavaRDD<StreamEvent> fromStream(String streamName, long startTime, long endTime);
+
+  /**
+   * Creates a {@link JavaRDD} that represents events from the given stream in the given time range.
+   *
+   * @param namespace namespace in which the stream exists
+   * @param streamName name of the stream
+   * @param startTime the starting time of the stream to be read in milliseconds (inclusive);
+   *                  passing in {@code 0} means start reading from the first event available in the stream.
+   * @param endTime the ending time of the streams to be read in milliseconds (exclusive);
+   *                passing in {@link Long#MAX_VALUE} means read up to latest event available in the stream.
+   * @return A new {@link JavaRDD} instance that reads from the given stream
+   * @throws DatasetInstantiationException if the stream doesn't exist
+   */
+  public abstract JavaRDD<StreamEvent> fromStream(String namespace, String streamName, long startTime, long endTime);
 
   /**
    * Creates a {@link JavaPairRDD} that represents all events from the given stream. The key in the
@@ -169,10 +242,25 @@ public abstract class JavaSparkExecutionContext implements RuntimeContext, Trans
    * @param streamName name of the stream
    * @param valueType type of the stream body to decode to
    * @return A new {@link JavaRDD} instance that reads from the given stream
-   * @throws DatasetInstantiationException if the Stream doesn't exist
+   * @throws DatasetInstantiationException if the stream doesn't exist
    */
   public <V> JavaPairRDD<Long, V> fromStream(String streamName, Class<V> valueType) {
     return fromStream(streamName, 0, Long.MAX_VALUE, valueType);
+  }
+
+  /**
+   * Creates a {@link JavaPairRDD} that represents all events from the given stream. The key in the
+   * resulting {@link JavaPairRDD} is the event timestamp. The stream body will
+   * be decoded as the give value type. Currently it supports {@link Text}, {@link String} and {@link ByteWritable}.
+   *
+   * @param namespace namespace in which the stream exists
+   * @param streamName name of the stream
+   * @param valueType type of the stream body to decode to
+   * @return A new {@link JavaRDD} instance that reads from the given stream
+   * @throws DatasetInstantiationException if the stream doesn't exist
+   */
+  public <V> JavaPairRDD<Long, V> fromStream(String namespace, String streamName, Class<V> valueType) {
+    return fromStream(namespace, streamName, 0, Long.MAX_VALUE, valueType);
   }
 
   /**
@@ -188,9 +276,28 @@ public abstract class JavaSparkExecutionContext implements RuntimeContext, Trans
    *                passing in {@link Long#MAX_VALUE} means read up to latest event available in the stream.
    * @param valueType type of the stream body to decode to
    * @return A new {@link JavaRDD} instance that reads from the given stream
-   * @throws DatasetInstantiationException if the Stream doesn't exist
+   * @throws DatasetInstantiationException if the stream doesn't exist
    */
   public abstract <V> JavaPairRDD<Long, V> fromStream(String streamName, long startTime, long endTime,
+                                                      Class<V> valueType);
+
+  /**
+   * Creates a {@link JavaPairRDD} that represents events from the given stream in the given time range.
+   * The key in the resulting {@link JavaPairRDD} is the event timestamp.
+   * The stream body will be decoded as the give value type.
+   * Currently it supports {@link Text}, {@link String} and {@link ByteWritable}.
+   *
+   * @param namespace namespace in which the stream exists
+   * @param streamName name of the stream
+   * @param startTime the starting time of the stream to be read in milliseconds (inclusive);
+   *                  passing in {@code 0} means start reading from the first event available in the stream.
+   * @param endTime the ending time of the streams to be read in milliseconds (exclusive);
+   *                passing in {@link Long#MAX_VALUE} means read up to latest event available in the stream.
+   * @param valueType type of the stream body to decode to
+   * @return A new {@link JavaRDD} instance that reads from the given stream
+   * @throws DatasetInstantiationException if the stream doesn't exist
+   */
+  public abstract <V> JavaPairRDD<Long, V> fromStream(String namespace, String streamName, long startTime, long endTime,
                                                       Class<V> valueType);
 
   /**
@@ -206,9 +313,29 @@ public abstract class JavaSparkExecutionContext implements RuntimeContext, Trans
    * @param keyType the type of the decoded key
    * @param valueType the type of the decoded value
    * @return A new {@link JavaRDD} instance that reads from the given stream
-   * @throws DatasetInstantiationException if the Stream doesn't exist
+   * @throws DatasetInstantiationException if the stream doesn't exist
    */
   public abstract <K, V> JavaPairRDD<K, V> fromStream(String streamName, long startTime, long endTime,
+                                                      Class<? extends StreamEventDecoder<K, V>> decoderClass,
+                                                      Class<K> keyType, Class<V> valueType);
+
+  /**
+   * Creates a {@link JavaPairRDD} that represents events from the given stream in the given time range.
+   * Each steam event will be decoded by an instance of the given {@link StreamEventDecoder} class.
+   *
+   * @param namespace namespace in which the stream exists
+   * @param streamName name of the stream
+   * @param startTime the starting time of the stream to be read in milliseconds (inclusive);
+   *                  passing in {@code 0} means start reading from the first event available in the stream.
+   * @param endTime the ending time of the streams to be read in milliseconds (exclusive);
+   *                passing in {@link Long#MAX_VALUE} means read up to latest event available in the stream.
+   * @param decoderClass the {@link StreamEventDecoder} for decoding {@link StreamEvent}
+   * @param keyType the type of the decoded key
+   * @param valueType the type of the decoded value
+   * @return A new {@link JavaRDD} instance that reads from the given stream
+   * @throws DatasetInstantiationException if the stream doesn't exist
+   */
+  public abstract <K, V> JavaPairRDD<K, V> fromStream(String namespace, String streamName, long startTime, long endTime,
                                                       Class<? extends StreamEventDecoder<K, V>> decoderClass,
                                                       Class<K> keyType, Class<V> valueType);
 
@@ -232,6 +359,26 @@ public abstract class JavaSparkExecutionContext implements RuntimeContext, Trans
   }
 
   /**
+   * Creates a {@link JavaPairRDD} that represents all events from the given stream.
+   * The first entry in the pair is a {@link Long}, representing the
+   * event timestamp, while the second entry is a {@link GenericStreamEventData},
+   * which contains data decoded from the stream event body base on
+   * the given {@link FormatSpecification}.
+   *
+   * @param namespace namespace in which the stream exists
+   * @param streamName name of the stream
+   * @param formatSpec the {@link FormatSpecification} describing the format in the stream
+   * @param <T> value type
+   * @return a new {@link JavaPairRDD} instance that reads from the given stream.
+   * @throws DatasetInstantiationException if the Stream doesn't exist
+   */
+  public <T> JavaPairRDD<Long, GenericStreamEventData<T>> fromStream(String namespace, String streamName,
+                                                                     FormatSpecification formatSpec,
+                                                                     Class<T> dataType) {
+    return fromStream(streamName, formatSpec, 0, Long.MAX_VALUE, dataType);
+  }
+
+  /**
    * Creates a {@link JavaPairRDD} that represents data from the given stream for events in the given
    * time range. The first entry in the pair is a {@link Long}, representing the
    * event timestamp, while the second entry is a {@link GenericStreamEventData},
@@ -249,6 +396,29 @@ public abstract class JavaSparkExecutionContext implements RuntimeContext, Trans
    * @throws DatasetInstantiationException if the Stream doesn't exist
    */
   public abstract <T> JavaPairRDD<Long, GenericStreamEventData<T>> fromStream(String streamName,
+                                                                              FormatSpecification formatSpec,
+                                                                              long startTime, long endTime,
+                                                                              Class<T> dataType);
+
+  /**
+   * Creates a {@link JavaPairRDD} that represents data from the given stream for events in the given
+   * time range. The first entry in the pair is a {@link Long}, representing the
+   * event timestamp, while the second entry is a {@link GenericStreamEventData},
+   * which contains data decoded from the stream event body base on
+   * the given {@link FormatSpecification}.
+   *
+   * @param namespace namespace in which the stream exists
+   * @param streamName name of the stream
+   * @param formatSpec the {@link FormatSpecification} describing the format in the stream
+   * @param startTime the starting time of the stream to be read in milliseconds (inclusive);
+   *                  passing in {@code 0} means start reading from the first event available in the stream.
+   * @param endTime the ending time of the streams to be read in milliseconds (exclusive);
+   *                passing in {@link Long#MAX_VALUE} means read up to latest event available in the stream.
+   * @param <T> value type
+   * @return a new {@link JavaPairRDD} instance that reads from the given stream.
+   * @throws DatasetInstantiationException if the Stream doesn't exist
+   */
+  public abstract <T> JavaPairRDD<Long, GenericStreamEventData<T>> fromStream(String namespace, String streamName,
                                                                               FormatSpecification formatSpec,
                                                                               long startTime, long endTime,
                                                                               Class<T> dataType);

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/BatchReadableRDD.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/BatchReadableRDD.scala
@@ -37,6 +37,7 @@ import scala.reflect.ClassTag
   */
 class BatchReadableRDD[K: ClassTag, V: ClassTag](@transient sc: SparkContext,
                                                  @transient batchReadable: BatchReadable[K, V],
+                                                 namespace: String,
                                                  datasetName: String,
                                                  arguments: Map[String, String],
                                                  @transient splits: Option[Iterable[_ <: Split]],
@@ -53,7 +54,8 @@ class BatchReadableRDD[K: ClassTag, V: ClassTag](@transient sc: SparkContext,
     val sparkTxClient = new SparkTransactionClient(txServiceBaseURI.value)
 
     val datasetCache = SparkRuntimeContextProvider.get().getDatasetCache
-    val dataset: Dataset = datasetCache.getDataset(datasetName, arguments, true, AccessType.READ)
+
+    val dataset: Dataset = datasetCache.getDataset(namespace, datasetName, arguments, true, AccessType.READ)
 
     try {
       // Get the Transaction of the dataset if it is TransactionAware

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DatasetCompute.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DatasetCompute.scala
@@ -29,11 +29,13 @@ private[spark] trait DatasetCompute {
   /**
     * Performs computation on a [[co.cask.cdap.api.dataset.Dataset]] instance.
     *
+    * @param namespace namespace in which the dataset exists
     * @param datasetName name of the dataset
     * @param arguments arguments for the dataset
     * @param computeFunc function to operate on the dataset instance
     * @tparam T type of the result
     * @return result of the computation by the function
     */
-  def apply[T: ClassTag](datasetName: String, arguments: Map[String, String], computeFunc: Dataset => T): T
+  def apply[T: ClassTag](namespace: String, datasetName: String, arguments: Map[String, String],
+                         computeFunc: Dataset => T): T
 }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/app/SparkAppUsingObjectStore.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/app/SparkAppUsingObjectStore.java
@@ -36,6 +36,8 @@ public class SparkAppUsingObjectStore extends AbstractApplication {
 
       addSpark(new CharCountProgram());
       addSpark(new ScalaCharCountProgram());
+      addSpark(new ScalaCrossNSStreamProgram());
+      addSpark(new ScalaCrossNSDatasetProgram());
     } catch (Throwable t) {
       throw Throwables.propagate(t);
     }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/stream/TestSparkCrossNSDatasetApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/stream/TestSparkCrossNSDatasetApp.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spark.stream;
+
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.stream.Stream;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.spark.AbstractSpark;
+import co.cask.cdap.api.spark.JavaSparkExecutionContext;
+import co.cask.cdap.api.spark.JavaSparkMain;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.PairFunction;
+import scala.Tuple2;
+
+/**
+ * A dummy app with spark program which simply read from a dataset from different namespace and write to a dataset in
+ * the current namespace
+ */
+public class TestSparkCrossNSDatasetApp extends AbstractApplication {
+  public static final String SOURCE_DATA_NAMESPACE = "dataSpaceForSpark";
+
+  @Override
+  public void configure() {
+    setName("TestSparkCrossNSDatasetApp");
+    setDescription("App to test Spark with Datasets from other namespace");
+    addStream(new Stream("testStream"));
+    createDataset("result", KeyValueTable.class);
+    addSpark(new SparkStreamProgramSpec());
+  }
+
+  public static class SparkStreamProgramSpec extends AbstractSpark {
+    @Override
+    public void configure() {
+      setName("SparkStreamProgram");
+      setDescription("Test Spark with Datasets from other namespace");
+      setMainClass(SparkStreamProgram.class);
+    }
+  }
+
+  public static class SparkStreamProgram implements JavaSparkMain {
+    @Override
+    public void run(JavaSparkExecutionContext sec) throws Exception {
+      JavaSparkContext jsc = new JavaSparkContext();
+      JavaPairRDD<byte[], byte[]> rdd = sec.fromDataset(SOURCE_DATA_NAMESPACE, "result");
+      sec.saveAsDataset(rdd, "result");
+    }
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/stream/TestSparkCrossNSStreamApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/stream/TestSparkCrossNSStreamApp.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spark.stream;
+
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.stream.Stream;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.spark.AbstractSpark;
+import co.cask.cdap.api.spark.JavaSparkExecutionContext;
+import co.cask.cdap.api.spark.JavaSparkMain;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.PairFunction;
+import scala.Tuple2;
+
+/**
+ * A dummy app with spark program which counts the characters in a string read from a Stream from other namespace
+ */
+public class TestSparkCrossNSStreamApp extends AbstractApplication {
+  public static final String SOURCE_STREAM_NAMESPACE = "streamSpaceForSpark";
+
+  @Override
+  public void configure() {
+    setName("TestSparkCrossNSStreamApp");
+    setDescription("App to test Spark with Streams from other namespace");
+    addStream(new Stream("testStream"));
+    createDataset("result", KeyValueTable.class);
+    addSpark(new SparkStreamProgramSpec());
+  }
+
+  public static class SparkStreamProgramSpec extends AbstractSpark {
+    @Override
+    public void configure() {
+      setName("SparkStreamProgram");
+      setDescription("Test Spark with Streams from other namespace");
+      setMainClass(SparkStreamProgram.class);
+    }
+  }
+
+  public static class SparkStreamProgram implements JavaSparkMain {
+    @Override
+    public void run(JavaSparkExecutionContext sec) throws Exception {
+      JavaSparkContext jsc = new JavaSparkContext();
+      JavaPairRDD<Long, String> rdd = sec.fromStream(SOURCE_STREAM_NAMESPACE, "testStream", String.class);
+      JavaPairRDD<byte[], byte[]> resultRDD = rdd.mapToPair(new PairFunction<Tuple2<Long, String>,
+        byte[], byte[]>() {
+        @Override
+        public Tuple2<byte[], byte[]> call(Tuple2<Long, String> tuple2) throws Exception {
+          return new Tuple2<>(Bytes.toBytes(tuple2._2()), Bytes.toBytes(tuple2._2()));
+        }
+      });
+      sec.saveAsDataset(resultRDD, "result");
+    }
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/base/TestFrameworkTestBase.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/base/TestFrameworkTestBase.java
@@ -65,16 +65,33 @@ public class TestFrameworkTestBase extends TestBase {
   }
 
   /**
+   * Deploys an {@link Application} using the given artifact jar.
+   */
+  protected static ApplicationManager deployWithArtifact(NamespaceId namespaceId,
+                                                         Class<? extends Application> appClass,
+                                                         File artifactJar) throws Exception {
+    return deployWithArtifact(namespaceId, appClass, artifactJar, null);
+  }
+
+  /**
    * Deploys an {@link Application} using the given artifact jar with an optional config object.
    */
   protected static <T> ApplicationManager deployWithArtifact(Class<? extends Application> appClass,
                                                              File artifactJar, @Nullable T config) throws Exception {
-    ArtifactId artifactId = new ArtifactId(NamespaceId.DEFAULT.getNamespace(),
-                                           appClass.getSimpleName(), "1.0-SNAPSHOT");
+    return deployWithArtifact(NamespaceId.DEFAULT, appClass, artifactJar, config);
+  }
+
+  /**
+   * Deploys an {@link Application} using the given artifact jar with an optional config object.
+   */
+  protected static <T> ApplicationManager deployWithArtifact(NamespaceId namespaceId,
+                                                             Class<? extends Application> appClass,
+                                                             File artifactJar, @Nullable T config) throws Exception {
+    ArtifactId artifactId = new ArtifactId(namespaceId.getNamespace(), appClass.getSimpleName(), "1.0-SNAPSHOT");
     addArtifact(artifactId, artifactJar);
     AppRequest<T> appRequest = new AppRequest<>(new ArtifactSummary(artifactId.getArtifact(), artifactId.getVersion()),
                                                 config);
-    return deployApplication(NamespaceId.DEFAULT.app(appClass.getSimpleName()).toId(), appRequest);
+    return deployApplication(namespaceId.app(appClass.getSimpleName()).toId(), appRequest);
   }
 
   protected void reset() {

--- a/cdap-unit-test/src/test/scala/co/cask/cdap/spark/app/ScalaCrossNSDatasetProgram.scala
+++ b/cdap-unit-test/src/test/scala/co/cask/cdap/spark/app/ScalaCrossNSDatasetProgram.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spark.app
+
+import co.cask.cdap.api.common.Bytes
+import co.cask.cdap.api.spark.{AbstractSpark, SparkExecutionContext, SparkMain}
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+
+/**
+  * Change ScalaCharCountProgram to read from another namespace
+  */
+class ScalaCrossNSDatasetProgram extends AbstractSpark with SparkMain {
+
+  override protected def configure() = {
+    setName(classOf[ScalaCrossNSDatasetProgram].getSimpleName)
+    setDescription("Use Objectstore dataset as input job")
+    setMainClass(classOf[ScalaCrossNSDatasetProgram])
+  }
+
+  override def run(implicit sec: SparkExecutionContext) = {
+    val sc = new SparkContext
+
+    // read the dataset
+    val inputData: RDD[(Array[Byte], String)] = sc.fromDataset("datasetSpaceForSpark", "keys")
+
+    // create a new RDD with the same key but the value is the length of the string
+    inputData
+      .map(str => (str._1, Bytes.toBytes(str._2.length)))
+      .saveAsDataset("count")
+  }
+}

--- a/cdap-unit-test/src/test/scala/co/cask/cdap/spark/app/ScalaCrossNSStreamProgram.scala
+++ b/cdap-unit-test/src/test/scala/co/cask/cdap/spark/app/ScalaCrossNSStreamProgram.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spark.app
+
+import co.cask.cdap.api.Resources
+import co.cask.cdap.api.common.Bytes
+import co.cask.cdap.api.spark.{AbstractSpark, SparkExecutionContext, SparkMain}
+import org.apache.spark.SparkContext
+
+/**
+  * A simple Spark program reading stream from another namespace and write to dataset
+  */
+class ScalaCrossNSStreamProgram(name: String) extends AbstractSpark with SparkMain {
+
+  def this() = this(classOf[ScalaCrossNSStreamProgram].getSimpleName)
+
+  override protected def configure(): Unit = {
+    setName(name)
+    setMainClass(classOf[ScalaCrossNSStreamProgram])
+    setDescription("Spaarkprogram reading stream from another namespace");
+  }
+
+  override def run(implicit sec: SparkExecutionContext) {
+    val sparkContext = new SparkContext
+    val trainingData = sparkContext.fromStream[String]("streamSpaceForSpark", "testStream", 0, Long.MaxValue)
+    val num = trainingData.count()
+    trainingData
+      .map(x => (Bytes.toBytes(x), Bytes.toBytes(x)))
+      .saveAsDataset("count")
+  }
+}


### PR DESCRIPTION
Enable cross namespace access for spark.
- Add a namespace field for all `fromdataset()` and `fromstream()` apis for spark program in `JavaSparkExecutionContext` and `SparkExecutionContext`
