### PR TITLE
(CDAP-6168) Includes all program options during program execution

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowContext.java
@@ -50,11 +50,6 @@ public interface WorkflowContext extends RuntimeContext, ServiceDiscoverer, Data
   Runnable getProgramRunner(String name);
 
   /**
-   * @return A map of the argument's key and value.
-   */
-  Map<String, String> getRuntimeArguments();
-
-  /**
    * @return a {@link WorkflowToken}
    */
   WorkflowToken getToken();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
@@ -16,6 +16,7 @@
 package co.cask.cdap.app.runtime;
 
 import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.plugin.Plugin;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.program.ProgramDescriptor;
@@ -37,6 +38,7 @@ import co.cask.cdap.internal.app.runtime.artifact.ArtifactRangeCodec;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import co.cask.cdap.internal.app.runtime.artifact.Artifacts;
 import co.cask.cdap.internal.app.runtime.service.SimpleRuntimeInfo;
+import co.cask.cdap.internal.io.SchemaTypeAdapter;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.artifact.ArtifactRange;
@@ -84,6 +86,7 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
 
   private static final Logger LOG = LoggerFactory.getLogger(AbstractProgramRuntimeService.class);
   private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
     .registerTypeAdapter(ArtifactRange.class, new ArtifactRangeCodec())
   .create();
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramOptions.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,15 +17,27 @@
 package co.cask.cdap.app.runtime;
 
 /**
- *
+ * Represents options for a program execution.
  */
 public interface ProgramOptions {
 
+  /**
+   * Returns the name of the program.
+   */
   String getName();
 
+  /**
+   * Returns the system arguments. It is for storing arguments used by the runtime system.
+   */
   Arguments getArguments();
 
+  /**
+   * Returns the user arguments.
+   */
   Arguments getUserArguments();
 
+  /**
+   * Returns {@code true} if executing in debug mode.
+   */
   boolean isDebug();
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/DefaultStreamWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/DefaultStreamWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -25,7 +25,6 @@ import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
 import co.cask.cdap.data2.registry.RuntimeUsageRegistry;
-import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.proto.Id;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
@@ -47,7 +46,6 @@ import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.URL;
 import java.nio.ByteBuffer;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -68,13 +66,13 @@ public class DefaultStreamWriter implements StreamWriter {
   /**
    * The owners of this {@link StreamWriter}.
    */
-  private final List<Id> owners;
+  private final Iterable<? extends Id> owners;
   private final Id.Run run;
   private final LineageWriter lineageWriter;
 
   @Inject
   public DefaultStreamWriter(@Assisted("run") Id.Run run,
-                             @Assisted("owners") List<Id> owners,
+                             @Assisted("owners") Iterable<? extends Id> owners,
                              RuntimeUsageRegistry runtimeUsageRegistry,
                              LineageWriter lineageWriter,
                              DiscoveryServiceClient discoveryServiceClient) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/StreamWriterFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/StreamWriterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -31,6 +31,6 @@ public interface StreamWriterFactory {
    * @param run run information
    * @return a {@link StreamWriter} for the specified namespaceId
    */
-  StreamWriter create(@Assisted("run") Id.Run run, @Assisted("owners") List<Id> owners);
+  StreamWriter create(@Assisted("run") Id.Run run, @Assisted("owners") Iterable<? extends Id> owners);
 }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -22,15 +22,18 @@ import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.common.RuntimeArguments;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.DatasetInstantiationException;
+import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.macro.MacroEvaluator;
 import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.metrics.MetricsContext;
-import co.cask.cdap.api.plugin.Plugin;
+import co.cask.cdap.api.metrics.NoopMetricsContext;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.app.metrics.ProgramUserMetrics;
 import co.cask.cdap.app.program.Program;
-import co.cask.cdap.app.runtime.Arguments;
+import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.services.AbstractServiceDiscoverer;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
@@ -40,11 +43,18 @@ import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
 import co.cask.cdap.data2.dataset2.SingleThreadDatasetCache;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.internal.app.program.ProgramTypeMetricTag;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactMeta;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactRangeCodec;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
+import co.cask.cdap.internal.io.SchemaTypeAdapter;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.ArtifactRange;
+import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.tephra.TransactionSystemClient;
-import com.google.common.collect.ImmutableList;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import org.apache.twill.api.RunId;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
@@ -61,10 +71,19 @@ import javax.annotation.Nullable;
 public abstract class AbstractContext extends AbstractServiceDiscoverer
   implements DatasetContext, RuntimeContext, PluginContext {
 
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(ArtifactRange.class, new ArtifactRangeCodec())
+    .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
+    .create();
+
+  private final ArtifactId artifactId;
+  private final ArtifactMeta artifactMeta;
   private final Program program;
+  private final ProgramOptions programOptions;
   private final RunId runId;
-  private final List<Id> owners;
+  private final Iterable<? extends Id> owners;
   private final Map<String, String> runtimeArguments;
+  private final Metrics userMetrics;
   private final MetricsContext programMetrics;
   private final DiscoveryServiceClient discoveryServiceClient;
   private final PluginInstantiator pluginInstantiator;
@@ -76,30 +95,35 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
   /**
    * Constructs a context without plugin support.
    */
-  protected AbstractContext(Program program, RunId runId, Arguments arguments,
-                            Set<String> datasets, MetricsContext metricsContext,
-                            DatasetFramework dsFramework, TransactionSystemClient txClient,
-                            DiscoveryServiceClient discoveryServiceClient, boolean multiThreaded) {
-    this(program, runId, arguments, datasets, metricsContext,
-         dsFramework, txClient, discoveryServiceClient, multiThreaded, null);
+  protected AbstractContext(Program program, ProgramOptions programOptions,
+                            Set<String> datasets, DatasetFramework dsFramework, TransactionSystemClient txClient,
+                            DiscoveryServiceClient discoveryServiceClient, boolean multiThreaded,
+                            @Nullable MetricsCollectionService metricsService, Map<String, String> metricsTags) {
+    this(program, programOptions, datasets, dsFramework, txClient,
+         discoveryServiceClient, multiThreaded, metricsService, metricsTags, null);
   }
 
   /**
    * Constructs a context. To have plugin support, the {@code pluginInstantiator} must not be null.
    */
-  protected AbstractContext(Program program, RunId runId, Arguments arguments,
-                            Set<String> datasets, MetricsContext metricsContext,
-                            DatasetFramework dsFramework, TransactionSystemClient txClient,
+  protected AbstractContext(Program program, ProgramOptions programOptions,
+                            Set<String> datasets, DatasetFramework dsFramework, TransactionSystemClient txClient,
                             DiscoveryServiceClient discoveryServiceClient, boolean multiThreaded,
+                            @Nullable MetricsCollectionService metricsService, Map<String, String> metricsTags,
                             @Nullable PluginInstantiator pluginInstantiator) {
     super(program.getId().toEntityId());
+
+    this.artifactId = createArtifactId(programOptions);
+    this.artifactMeta = createArtifactMeta(programOptions);
     this.program = program;
-    this.runId = runId;
+    this.programOptions = programOptions;
+    this.runId = ProgramRunners.getRunId(programOptions);
     this.discoveryServiceClient = discoveryServiceClient;
     this.owners = createOwners(program.getId());
-    this.programMetrics = metricsContext;
+    this.programMetrics = createProgramMetrics(program, runId, metricsService, metricsTags);
+    this.userMetrics = new ProgramUserMetrics(programMetrics);
 
-    Map<String, String> runtimeArgs = new HashMap<>(arguments.asMap());
+    Map<String, String> runtimeArgs = new HashMap<>(programOptions.getUserArguments().asMap());
     this.logicalStartTime = ProgramRunners.updateLogicalStartTime(runtimeArgs);
     this.runtimeArguments = Collections.unmodifiableMap(runtimeArgs);
 
@@ -120,17 +144,64 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
     this.admin = new DefaultAdmin(dsFramework, program.getId().getNamespace().toEntityId());
   }
 
-  private List<Id> createOwners(Id.Program programId) {
-    ImmutableList.Builder<Id> result = ImmutableList.builder();
-    result.add(programId);
-    return result.build();
+  /**
+   * Extracts {@link ArtifactId} from the system arguments.
+   */
+  private ArtifactId createArtifactId(ProgramOptions programOptions) {
+    String id = programOptions.getArguments().getOption(ProgramOptionConstants.ARTIFACT_ID);
+    Preconditions.checkArgument(id != null, "Missing " + ProgramOptionConstants.ARTIFACT_ID + " in program options");
+    return GSON.fromJson(id, ArtifactId.class);
   }
 
-  public List<Id> getOwners() {
+  /**
+   * Extracts {@link ArtifactMeta} from the system arguments.
+   */
+  private ArtifactMeta createArtifactMeta(ProgramOptions programOptions) {
+    String meta = programOptions.getArguments().getOption(ProgramOptionConstants.ARTIFACT_META);
+    Preconditions.checkArgument(meta != null,
+                                "Missing " + ProgramOptionConstants.ARTIFACT_META + " in program options");
+    return GSON.fromJson(meta, ArtifactMeta.class);
+  }
+
+  private Iterable<? extends Id> createOwners(Id.Program programId) {
+    return Collections.unmodifiableList(Collections.singletonList(programId));
+  }
+
+  /**
+   * Creates a {@link MetricsContext} for metrics emission of the program represented by this context.
+   *
+   * @param program the {@link Program} context that the metrics should be emitted as
+   * @param runId the {@link RunId} of the current execution
+   * @param metricsService the underlying service for metrics publishing; or {@code null} to suppress metrics publishing
+   * @param metricsTags a set of extra tags to be used for creating the {@link MetricsContext}
+   * @return a {@link MetricsContext} for emitting metrics for the current program context.
+   */
+  private MetricsContext createProgramMetrics(Program program, RunId runId,
+                                              @Nullable MetricsCollectionService metricsService,
+                                              Map<String, String> metricsTags) {
+
+    Map<String, String> tags = Maps.newHashMap(metricsTags);
+    tags.put(Constants.Metrics.Tag.NAMESPACE, program.getNamespaceId());
+    tags.put(Constants.Metrics.Tag.APP, program.getApplicationId());
+    tags.put(ProgramTypeMetricTag.getTagName(program.getType()), program.getName());
+    tags.put(Constants.Metrics.Tag.RUN_ID, runId.getId());
+
+    return metricsService == null ? new NoopMetricsContext(tags) : metricsService.getContext(tags);
+  }
+
+  /**
+   * Returns a list of ID who owns this program context.
+   */
+  public Iterable<? extends Id> getOwners() {
     return owners;
   }
 
-  public abstract Metrics getMetrics();
+  /**
+   * Returns a {@link Metrics} to be used inside user program.
+   */
+  public Metrics getMetrics() {
+    return userMetrics;
+  }
 
   @Override
   public ApplicationSpecification getApplicationSpecification() {
@@ -244,21 +315,31 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
     datasetCache.close();
   }
 
+  /**
+   * Returns the {@link ArtifactId} which contains the program that this context represents.
+   */
+  public ArtifactId getArtifactId() {
+    return artifactId;
+  }
+
+  /**
+   * Returns the {@link ArtifactMeta} which contains the program that this context represents.
+   */
+  public ArtifactMeta getArtifactMeta() {
+    return artifactMeta;
+  }
+
+  /**
+   * Returns the {@link ProgramOptions} for the program execution that this context represents.
+   */
+  public ProgramOptions getProgramOptions() {
+    return programOptions;
+  }
+
   @Override
   public DiscoveryServiceClient getDiscoveryServiceClient() {
     return discoveryServiceClient;
   }
-
-  public static Map<String, String> getMetricsContext(Program program, String runId) {
-    Map<String, String> tags = Maps.newHashMap();
-    tags.put(Constants.Metrics.Tag.NAMESPACE, program.getNamespaceId());
-    tags.put(Constants.Metrics.Tag.APP, program.getApplicationId());
-    tags.put(ProgramTypeMetricTag.getTagName(program.getType()), program.getName());
-    tags.put(Constants.Metrics.Tag.RUN_ID, runId);
-    return tags;
-  }
-
-  public abstract Map<String, Plugin> getPlugins();
 
   @Override
   public PluginProperties getPluginProperties(String pluginId) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramRunners.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramRunners.java
@@ -16,11 +16,15 @@
 
 package co.cask.cdap.internal.app.runtime;
 
+import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
+import co.cask.cdap.common.app.RunIds;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Service;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.twill.api.RunId;
 
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
@@ -81,6 +85,17 @@ public final class ProgramRunners {
         "%s is set to an invalid value %s. Please ensure it is a timestamp in milliseconds.",
         ProgramOptionConstants.LOGICAL_START_TIME, value));
     }
+  }
+
+  /**
+   * Returns the {@link RunId} stored inside the given {@link ProgramOptions#getArguments()}.
+   *
+   * @throws IllegalArgumentException if the given options doesn't contain run id.
+   */
+  public static RunId getRunId(ProgramOptions programOptions) {
+    String id = programOptions.getArguments().getOption(ProgramOptionConstants.RUN_ID);
+    Preconditions.checkArgument(id != null, "Missing " + ProgramOptionConstants.RUN_ID + " in program options");
+    return RunIds.fromString(id);
   }
 
   private ProgramRunners() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
@@ -25,15 +25,11 @@ import co.cask.cdap.api.data.batch.SplitReader;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
 import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
-import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
-import co.cask.cdap.api.metrics.MetricsContext;
-import co.cask.cdap.api.plugin.Plugin;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.app.metrics.MapReduceMetrics;
-import co.cask.cdap.app.metrics.ProgramUserMetrics;
 import co.cask.cdap.app.program.Program;
-import co.cask.cdap.app.runtime.Arguments;
+import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
@@ -53,7 +49,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.hadoop.mapreduce.TaskInputOutputContext;
-import org.apache.twill.api.RunId;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
 import java.io.File;
@@ -77,8 +72,6 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
 
   private final MapReduceSpecification spec;
   private final WorkflowProgramInfo workflowProgramInfo;
-  private final Metrics userMetrics;
-  private final Map<String, Plugin> plugins;
   private final Transaction transaction;
   private final TaskLocalizationContext taskLocalizationContext;
 
@@ -91,27 +84,22 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
   // TODO: (CDAP-3983) The datasets should be managed by the dataset context. That requires TEPHRA-99.
   private final Set<TransactionAware> txAwares = Sets.newIdentityHashSet();
 
-  public BasicMapReduceTaskContext(Program program,
-                                   @Nullable MapReduceMetrics.TaskType type,
-                                   RunId runId, String taskId,
-                                   Arguments runtimeArguments,
-                                   MapReduceSpecification spec,
-                                   @Nullable WorkflowProgramInfo workflowProgramInfo,
-                                   DiscoveryServiceClient discoveryServiceClient,
-                                   MetricsCollectionService metricsCollectionService,
-                                   TransactionSystemClient txClient,
-                                   Transaction transaction,
-                                   DatasetFramework dsFramework,
-                                   @Nullable PluginInstantiator pluginInstantiator,
-                                   Map<String, File> localizedResources) {
-    super(program, runId, runtimeArguments, ImmutableSet.<String>of(),
-          createMetricsContext(program, runId.getId(), metricsCollectionService, taskId, type, workflowProgramInfo),
-          dsFramework, txClient, discoveryServiceClient, false, pluginInstantiator);
+  BasicMapReduceTaskContext(Program program, ProgramOptions programOptions,
+                            @Nullable MapReduceMetrics.TaskType type, String taskId,
+                            MapReduceSpecification spec,
+                            @Nullable WorkflowProgramInfo workflowProgramInfo,
+                            DiscoveryServiceClient discoveryServiceClient,
+                            MetricsCollectionService metricsCollectionService,
+                            TransactionSystemClient txClient,
+                            Transaction transaction,
+                            DatasetFramework dsFramework,
+                            @Nullable PluginInstantiator pluginInstantiator,
+                            Map<String, File> localizedResources) {
+    super(program, programOptions, ImmutableSet.<String>of(), dsFramework, txClient, discoveryServiceClient, false,
+          metricsCollectionService, createMetricsTags(taskId, type, workflowProgramInfo), pluginInstantiator);
     this.workflowProgramInfo = workflowProgramInfo;
     this.transaction = transaction;
-    this.userMetrics = new ProgramUserMetrics(getProgramMetrics());
     this.spec = spec;
-    this.plugins = Maps.newHashMap(program.getApplicationSpecification().getPlugins());
     this.taskLocalizationContext = new DefaultTaskLocalizationContext(localizedResources);
 
     initializeTransactionAwares();
@@ -120,11 +108,6 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
   @Override
   public String toString() {
     return String.format("job=%s,=%s", spec.getName(), super.toString());
-  }
-
-  @Override
-  public Map<String, Plugin> getPlugins() {
-    return plugins;
   }
 
   @Override
@@ -193,29 +176,19 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
     return inputName;
   }
 
-  private static MetricsContext createMetricsContext(Program program, String runId, MetricsCollectionService service,
-                                                     String taskId, @Nullable MapReduceMetrics.TaskType type,
-                                                     @Nullable WorkflowProgramInfo workflowProgramInfo) {
+  private static Map<String, String> createMetricsTags(String taskId, @Nullable MapReduceMetrics.TaskType type,
+                                                       @Nullable WorkflowProgramInfo workflowProgramInfo) {
     Map<String, String> tags = Maps.newHashMap();
-    tags.putAll(getMetricsContext(program, runId));
     if (type != null) {
       tags.put(Constants.Metrics.Tag.MR_TASK_TYPE, type.getId());
       tags.put(Constants.Metrics.Tag.INSTANCE_ID, taskId);
     }
 
     if (workflowProgramInfo != null) {
-      // If running inside Workflow, add the WorkflowMetricsContext as well
-      tags.put(Constants.Metrics.Tag.WORKFLOW, workflowProgramInfo.getName());
-      tags.put(Constants.Metrics.Tag.WORKFLOW_RUN_ID, workflowProgramInfo.getRunId().getId());
-      tags.put(Constants.Metrics.Tag.NODE, workflowProgramInfo.getNodeId());
+      workflowProgramInfo.updateMetricsTags(tags);
     }
 
-    return service.getContext(tags);
-  }
-
-  @Override
-  public Metrics getMetrics() {
-    return userMetrics;
+    return tags;
   }
 
   //---- following are methods to manage transaction lifecycle for the datasets. This needs to
@@ -236,11 +209,6 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
    * the dataset is a new transaction-aware, it starts the transaction and remembers the dataset.
    */
   @Override
-  public <T extends Dataset> T getDataset(String name, Map<String, String> arguments)
-    throws DatasetInstantiationException {
-    return getDataset(name, arguments, AccessType.UNKNOWN);
-  }
-
   protected <T extends Dataset> T getDataset(String name, Map<String, String> arguments, AccessType accessType)
     throws DatasetInstantiationException {
     T dataset = super.getDataset(name, arguments, accessType);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceClassLoader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceClassLoader.java
@@ -28,6 +28,7 @@ import co.cask.cdap.common.lang.jar.BundleJarUtil;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.common.utils.DirUtils;
+import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.batch.distributed.DistributedMapReduceTaskContextProvider;
 import co.cask.cdap.internal.app.runtime.batch.distributed.MapReduceContainerLauncher;
 import co.cask.cdap.internal.app.runtime.plugin.PluginClassLoaders;
@@ -156,7 +157,7 @@ public class MapReduceClassLoader extends CombineClassLoader implements AutoClos
   private LoggingContext createMapReduceLoggingContext() {
     MapReduceContextConfig contextConfig = new MapReduceContextConfig(parameters.getHConf());
     ProgramId programId = contextConfig.getProgramId();
-    RunId runId = contextConfig.getRunId();
+    RunId runId = ProgramRunners.getRunId(contextConfig.getProgramOptions());
     WorkflowProgramInfo workflowProgramInfo = contextConfig.getWorkflowProgramInfo();
     if (workflowProgramInfo == null) {
       return new MapReduceLoggingContext(programId.getNamespace(), programId.getApplication(),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -134,8 +134,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
 
     // Optionally get runId. If the map-reduce started by other program (e.g. Workflow), it inherit the runId.
     Arguments arguments = options.getArguments();
-
-    final RunId runId = RunIds.fromString(arguments.getOption(ProgramOptionConstants.RUN_ID));
+    RunId runId = ProgramRunners.getRunId(options);
 
     WorkflowProgramInfo workflowInfo = WorkflowProgramInfo.create(arguments);
     DatasetFramework programDatasetFramework = workflowInfo == null ?
@@ -165,7 +164,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
       }
 
       final BasicMapReduceContext context =
-        new BasicMapReduceContext(program, runId, options.getUserArguments(), spec,
+        new BasicMapReduceContext(program, options, spec,
                                   workflowInfo, discoveryServiceClient,
                                   metricsCollectionService, txSystemClient, programDatasetFramework, streamAdmin,
                                   getPluginArchive(options), pluginInstantiator);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -193,7 +193,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
       Configuration mapredConf = job.getConfiguration();
 
       classLoader = new MapReduceClassLoader(injector, cConf, mapredConf, context.getProgram().getClassLoader(),
-                                             context.getPlugins(),
+                                             context.getApplicationSpecification().getPlugins(),
                                              context.getPluginInstantiator());
       cleanupTask = createCleanupTask(cleanupTask, classLoader);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -191,7 +191,7 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
                                                              File.createTempFile("appSpec", ".json", tempDir))));
 
       final URI logbackURI = getLogBackURI(program, tempDir);
-      final String programOptions = GSON.toJson(options);
+      final String programOptions = GSON.toJson(options, ProgramOptions.class);
 
       // Obtains and add the HBase delegation token as well (if in non-secure mode, it's a no-op)
       // Twill would also ignore it if it is not running in secure mode.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedFlowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedFlowProgramRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -22,14 +22,13 @@ import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
-import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.common.twill.AbortOnTimeoutEventHandler;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
-import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.security.TokenSecureStoreUpdater;
@@ -99,7 +98,7 @@ public final class DistributedFlowProgramRunner extends AbstractDistributedProgr
       DistributedFlowletInstanceUpdater instanceUpdater =
         new DistributedFlowletInstanceUpdater(program.getId().toEntityId(), controller, queueAdmin,
                                               streamAdmin, flowletQueues, txExecutorFactory);
-      RunId runId = RunIds.fromString(options.getArguments().getOption(ProgramOptionConstants.RUN_ID));
+      RunId runId = ProgramRunners.getRunId(options);
       return new FlowTwillProgramController(program.getId(), controller, instanceUpdater, runId).startListen();
     } catch (Exception e) {
       throw Throwables.propagate(e);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedMapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedMapReduceProgramRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,9 +20,8 @@ import co.cask.cdap.api.mapreduce.MapReduceSpecification;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
-import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.batch.distributed.MapReduceContainerHelper;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.security.TokenSecureStoreUpdater;
@@ -76,7 +75,7 @@ public final class DistributedMapReduceProgramRunner extends AbstractDistributed
       new MapReduceTwillApplication(program, spec, localizeResources, eventHandler),
       extraClassPaths, Collections.singletonList(YarnClientProtocolProvider.class));
 
-    RunId runId = RunIds.fromString(options.getArguments().getOption(ProgramOptionConstants.RUN_ID));
+    RunId runId = ProgramRunners.getRunId(options);
     return new MapReduceTwillProgramController(program.getId(), controller, runId).startListen();
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedServiceProgramRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -21,11 +21,10 @@ import co.cask.cdap.api.service.ServiceSpecification;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
-import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.twill.AbortOnTimeoutEventHandler;
-import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.security.TokenSecureStoreUpdater;
 import com.google.common.base.Preconditions;
@@ -77,7 +76,7 @@ public class DistributedServiceProgramRunner extends AbstractDistributedProgramR
 
     DistributedServiceRunnableInstanceUpdater instanceUpdater =
       new DistributedServiceRunnableInstanceUpdater(controller);
-    RunId runId = RunIds.fromString(options.getArguments().getOption(ProgramOptionConstants.RUN_ID));
+    RunId runId = ProgramRunners.getRunId(options);
     return new ServiceTwillProgramController(program.getId(), controller, instanceUpdater, runId).startListen();
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWebappProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWebappProgramRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,9 +19,8 @@ import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
-import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.security.TokenSecureStoreUpdater;
 import com.google.common.base.Preconditions;
@@ -63,7 +62,7 @@ public final class DistributedWebappProgramRunner extends AbstractDistributedPro
 
     LOG.info("Launching distributed webapp: " + program.getName());
     TwillController controller = launcher.launch(new WebappTwillApplication(program, localizeResources, eventHandler));
-    RunId runId = RunIds.fromString(options.getArguments().getOption(ProgramOptionConstants.RUN_ID));
+    RunId runId = ProgramRunners.getRunId(options);
     return new WebappTwillProgramController(program.getId(), controller, runId).startListen();
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -22,11 +22,11 @@ import co.cask.cdap.api.worker.WorkerSpecification;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
-import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.twill.AbortOnTimeoutEventHandler;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.security.TokenSecureStoreUpdater;
 import com.google.common.base.Preconditions;
@@ -86,7 +86,7 @@ public class DistributedWorkerProgramRunner extends AbstractDistributedProgramRu
 
     TwillController controller = launcher.launch(new WorkerTwillApplication(program, newWorkerSpec,
                                                                             localizeResources, eventHandler));
-    RunId runId = RunIds.fromString(options.getArguments().getOption(ProgramOptionConstants.RUN_ID));
+    RunId runId = ProgramRunners.getRunId(options);
     return new WorkerTwillProgramController(program.getId(), controller, runId).startListen();
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
@@ -31,9 +31,8 @@ import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.app.runtime.ProgramRuntimeProvider;
-import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.ProgramRuntimeProviderLoader;
 import co.cask.cdap.internal.app.runtime.batch.distributed.MapReduceContainerHelper;
 import co.cask.cdap.internal.app.runtime.spark.SparkUtils;
@@ -118,7 +117,7 @@ public final class DistributedWorkflowProgramRunner extends AbstractDistributedP
       new WorkflowTwillApplication(program, workflowSpec, localizeResources, eventHandler, driverMeta.resources),
       extraClassPaths, extraDependencies
     );
-    RunId runId = RunIds.fromString(options.getArguments().getOption(ProgramOptionConstants.RUN_ID));
+    RunId runId = ProgramRunners.getRunId(options);
     return new WorkflowTwillProgramController(program.getId(), controller, runId).startListen();
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/ConsumerSupplier.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/ConsumerSupplier.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.List;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -47,18 +46,18 @@ final class ConsumerSupplier<T> implements Supplier<T>, Closeable {
   private final QueueName queueName;
   private final int numGroups;
   private final RuntimeUsageRegistry runtimeUsageRegistry;
-  private final List<Id> owners;
+  private final Iterable<? extends Id> owners;
   private ConsumerConfig consumerConfig;
   private Closeable consumer;
 
-  static <T> ConsumerSupplier<T> create(List<Id> owners,
+  static <T> ConsumerSupplier<T> create(Iterable<? extends Id> owners,
                                         RuntimeUsageRegistry runtimeUsageRegistry,
                                         DataFabricFacade dataFabricFacade,
                                         QueueName queueName, ConsumerConfig consumerConfig) {
     return create(owners, runtimeUsageRegistry, dataFabricFacade, queueName, consumerConfig, -1);
   }
 
-  static <T> ConsumerSupplier<T> create(List<Id> owners,
+  static <T> ConsumerSupplier<T> create(Iterable<? extends Id> owners,
                                         RuntimeUsageRegistry runtimeUsageRegistry,
                                         DataFabricFacade dataFabricFacade, QueueName queueName,
                                         ConsumerConfig consumerConfig, int numGroups) {
@@ -66,7 +65,7 @@ final class ConsumerSupplier<T> implements Supplier<T>, Closeable {
                                    queueName, consumerConfig, numGroups);
   }
 
-  private ConsumerSupplier(List<Id> owners, RuntimeUsageRegistry runtimeUsageRegistry,
+  private ConsumerSupplier(Iterable<? extends Id> owners, RuntimeUsageRegistry runtimeUsageRegistry,
                            DataFabricFacade dataFabricFacade, QueueName queueName,
                            ConsumerConfig consumerConfig, int numGroups) {
     this.owners = owners;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/WebappProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/webapp/WebappProgramRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,14 +20,13 @@ import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
-import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.ResolvingDiscoverable;
 import co.cask.cdap.common.http.CommonNettyHttpServiceBuilder;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.utils.Networks;
-import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.http.NettyHttpService;
 import com.google.common.base.Preconditions;
@@ -106,7 +105,7 @@ public class WebappProgramRunner implements ProgramRunner {
       httpService.startAndWait();
       final InetSocketAddress address = httpService.getBindAddress();
 
-      RunId runId = RunIds.fromString(options.getArguments().getOption(ProgramOptionConstants.RUN_ID));
+      RunId runId = ProgramRunners.getRunId(options);
 
       // Register service, and the serving host names.
       final List<Cancellable> cancellables = Lists.newArrayList();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/InMemoryWorkerRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/InMemoryWorkerRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -24,10 +24,10 @@ import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
-import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.internal.app.AbstractInMemoryProgramRunner;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.proto.ProgramType;
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
@@ -74,7 +74,7 @@ public class InMemoryWorkerRunner extends AbstractInMemoryProgramRunner {
                                                                 Integer.valueOf(instances));
 
     //RunId for worker
-    RunId runId = RunIds.fromString(options.getArguments().getOption(ProgramOptionConstants.RUN_ID));
+    RunId runId = ProgramRunners.getRunId(options);
     return startAll(program, options, runId, newWorkerSpec.getInstances());
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/BasicWorkflowContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/BasicWorkflowContext.java
@@ -15,29 +15,24 @@
  */
 package co.cask.cdap.internal.app.runtime.workflow;
 
-import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
-import co.cask.cdap.api.metrics.MetricsContext;
-import co.cask.cdap.api.plugin.Plugin;
 import co.cask.cdap.api.workflow.WorkflowActionSpecification;
 import co.cask.cdap.api.workflow.WorkflowContext;
 import co.cask.cdap.api.workflow.WorkflowNodeState;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
 import co.cask.cdap.api.workflow.WorkflowToken;
-import co.cask.cdap.app.metrics.ProgramUserMetrics;
 import co.cask.cdap.app.program.Program;
-import co.cask.cdap.app.runtime.Arguments;
+import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
-import co.cask.cdap.internal.app.program.ProgramTypeMetricTag;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
+import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
-import org.apache.twill.api.RunId;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -50,48 +45,27 @@ final class BasicWorkflowContext extends AbstractContext implements WorkflowCont
   private final WorkflowSpecification workflowSpec;
   private final WorkflowActionSpecification specification;
   private final ProgramWorkflowRunner programWorkflowRunner;
-  private final Map<String, String> runtimeArgs;
   private final WorkflowToken token;
-  private final Metrics userMetrics;
   private final Map<String, WorkflowNodeState> nodeStates;
   private boolean success = false;
 
   BasicWorkflowContext(WorkflowSpecification workflowSpec, @Nullable WorkflowActionSpecification spec,
                        @Nullable ProgramWorkflowRunner programWorkflowRunner,
-                       Arguments arguments, WorkflowToken token, Program program, RunId runId,
+                       WorkflowToken token, Program program, ProgramOptions programOptions,
                        MetricsCollectionService metricsCollectionService,
                        DatasetFramework datasetFramework, TransactionSystemClient txClient,
                        DiscoveryServiceClient discoveryServiceClient, Map<String, WorkflowNodeState> nodeStates,
                        @Nullable PluginInstantiator pluginInstantiator) {
-    super(program, runId, arguments,
-          (spec == null) ? new HashSet<String>() : spec.getDatasets(),
-          getMetricCollector(program, runId.getId(), metricsCollectionService),
-          datasetFramework, txClient, discoveryServiceClient, false, pluginInstantiator);
+    super(program, programOptions, (spec == null) ? new HashSet<String>() : spec.getDatasets(),
+          datasetFramework, txClient, discoveryServiceClient, false,
+          metricsCollectionService, Collections.singletonMap(Constants.Metrics.Tag.WORKFLOW_RUN_ID,
+                                                             ProgramRunners.getRunId(programOptions).getId()),
+          pluginInstantiator);
     this.workflowSpec = workflowSpec;
     this.specification = spec;
     this.programWorkflowRunner = programWorkflowRunner;
-    this.runtimeArgs = ImmutableMap.copyOf(arguments.asMap());
     this.token = token;
-    if (metricsCollectionService != null) {
-      this.userMetrics = new ProgramUserMetrics(getProgramMetrics());
-    } else {
-      this.userMetrics = null;
-    }
     this.nodeStates = nodeStates;
-  }
-
-  @Nullable
-  private static MetricsContext getMetricCollector(Program program, String runId,
-                                                   @Nullable MetricsCollectionService service) {
-    if (service == null) {
-      return null;
-    }
-    Map<String, String> tags = Maps.newHashMap();
-    tags.put(Constants.Metrics.Tag.NAMESPACE, program.getNamespaceId());
-    tags.put(Constants.Metrics.Tag.APP, program.getApplicationId());
-    tags.put(ProgramTypeMetricTag.getTagName(program.getType()), program.getName());
-    tags.put(Constants.Metrics.Tag.WORKFLOW_RUN_ID, runId);
-    return service.getContext(tags);
   }
 
   @Override
@@ -113,21 +87,6 @@ final class BasicWorkflowContext extends AbstractContext implements WorkflowCont
       throw new UnsupportedOperationException("Operation not allowed.");
     }
     return programWorkflowRunner.create(name);
-  }
-
-  @Override
-  public Metrics getMetrics() {
-    return userMetrics;
-  }
-
-  @Override
-  public Map<String, String> getRuntimeArguments() {
-    return runtimeArgs;
-  }
-
-  @Override
-  public Map<String, Plugin> getPlugins() {
-    return null;
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/CustomActionExecutor.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/CustomActionExecutor.java
@@ -110,12 +110,10 @@ class CustomActionExecutor {
     Class<?> clz = Class.forName(context.getSpecification().getClassName(), true, classLoader);
     Preconditions.checkArgument(CustomAction.class.isAssignableFrom(clz), "%s is not a CustomAction.", clz);
     CustomAction action = instantiator.get(TypeToken.of((Class<? extends CustomAction>) clz)).create();
-    Metrics metrics = new ProgramUserMetrics(
-      context.getProgramMetrics().childContext(Constants.Metrics.Tag.NODE, context.getSpecification().getName()));
     Reflections.visit(action, action.getClass(),
                       new PropertyFieldSetter(context.getSpecification().getProperties()),
                       new DataSetFieldSetter(context),
-                      new MetricsFieldSetter(metrics));
+                      new MetricsFieldSetter(context.getMetrics()));
     return action;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramInfo.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramInfo.java
@@ -20,11 +20,13 @@ import co.cask.cdap.api.workflow.Workflow;
 import co.cask.cdap.api.workflow.WorkflowInfo;
 import co.cask.cdap.app.runtime.Arguments;
 import co.cask.cdap.common.app.RunIds;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import com.google.gson.Gson;
 import org.apache.twill.api.RunId;
 
 import java.io.Serializable;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -103,5 +105,15 @@ public final class WorkflowProgramInfo implements WorkflowInfo, Serializable {
    */
   public BasicWorkflowToken getWorkflowToken() {
     return workflowToken;
+  }
+
+  /**
+   * Updates the metrics tags based on the information in this class.
+   */
+  public Map<String, String> updateMetricsTags(Map<String, String> tags) {
+    tags.put(Constants.Metrics.Tag.WORKFLOW, getName());
+    tags.put(Constants.Metrics.Tag.WORKFLOW_RUN_ID, getRunId().getId());
+    tags.put(Constants.Metrics.Tag.NODE, getNodeId());
+    return tags;
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramRunner.java
@@ -26,13 +26,12 @@ import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.app.runtime.ProgramRunnerFactory;
 import co.cask.cdap.app.store.RuntimeStore;
-import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.metadata.writer.ProgramContextAware;
 import co.cask.cdap.internal.app.runtime.AbstractProgramRunnerWithPlugin;
-import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
@@ -92,7 +91,7 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
     WorkflowSpecification workflowSpec = appSpec.getWorkflows().get(program.getName());
     Preconditions.checkNotNull(workflowSpec, "Missing WorkflowSpecification for %s", program.getName());
 
-    RunId runId = RunIds.fromString(options.getArguments().getOption(ProgramOptionConstants.RUN_ID));
+    RunId runId = ProgramRunners.getRunId(options);
 
     // Setup dataset framework context, if required
     if (datasetFramework instanceof ProgramContextAware) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/BasicHttpServiceContextFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/BasicHttpServiceContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,6 +19,8 @@ package co.cask.cdap.internal.app.services;
 import co.cask.cdap.api.service.http.HttpServiceHandlerSpecification;
 import co.cask.cdap.internal.app.runtime.service.http.BasicHttpServiceContext;
 
+import javax.annotation.Nullable;
+
 /**
  * Factory for creating {@link BasicHttpServiceContext}.
  */
@@ -26,6 +28,9 @@ public interface BasicHttpServiceContextFactory {
 
   /**
    * Creates a new instance of {@link BasicHttpServiceContext} with the given spec.
+   *
+   * @param spec the specification of the http handler, or {@code null} if the context created is not
+   *             associated with any handler.
    */
-  BasicHttpServiceContext create(HttpServiceHandlerSpecification spec);
+  BasicHttpServiceContext create(@Nullable HttpServiceHandlerSpecification spec);
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramId.java
@@ -18,6 +18,7 @@ package co.cask.cdap.proto.id;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.element.EntityType;
+import org.apache.twill.api.RunId;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -73,8 +74,18 @@ public class ProgramId extends EntityId implements NamespacedId, ParentedId<Appl
     return new FlowletId(namespace, application, program, flowlet);
   }
 
+  /**
+   * Creates a {@link ProgramRunId} of this program id with the given run id.
+   */
   public ProgramRunId run(String run) {
     return new ProgramRunId(namespace, application, type, program, run);
+  }
+
+  /**
+   * Creates a {@link ProgramRunId} of this program id with the given {@link RunId}.
+   */
+  public ProgramRunId run(RunId runId) {
+    return run(runId.getId());
   }
 
   @Override

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkMetricsReporter.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkMetricsReporter.java
@@ -43,7 +43,7 @@ final class SparkMetricsReporter extends ScheduledReporter {
                        TimeUnit durationUnit,
                        MetricFilter filter) {
     super(registry, "spark-reporter", filter, rateUnit, durationUnit);
-    this.metricsContext = SparkRuntimeContextProvider.get().getMetricsContext();
+    this.metricsContext = SparkRuntimeContextProvider.get().getProgramMetrics();
   }
 
   /**

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRunner.java
@@ -114,7 +114,7 @@ final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
   public ProgramController run(Program program, ProgramOptions options) {
     // Get the RunId first. It is used for the creation of the ClassLoader closing thread.
     Arguments arguments = options.getArguments();
-    RunId runId = RunIds.fromString(arguments.getOption(ProgramOptionConstants.RUN_ID));
+    RunId runId = ProgramRunners.getRunId(options);
 
     Deque<Closeable> closeables = new LinkedList<>();
 
@@ -150,8 +150,7 @@ final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
         closeables.addFirst(pluginInstantiator);
       }
 
-      SparkRuntimeContext runtimeContext = new SparkRuntimeContext(new Configuration(hConf), program, runId,
-                                                                   options.getUserArguments().asMap(),
+      SparkRuntimeContext runtimeContext = new SparkRuntimeContext(new Configuration(hConf), program, options,
                                                                    txClient, programDatasetFramework,
                                                                    discoveryServiceClient,
                                                                    metricsCollectionService, streamAdmin, workflowInfo,

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextConfig.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextConfig.java
@@ -17,20 +17,20 @@
 package co.cask.cdap.app.runtime.spark;
 
 import co.cask.cdap.api.app.ApplicationSpecification;
-import co.cask.cdap.common.app.RunIds;
+import co.cask.cdap.app.runtime.Arguments;
+import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
+import co.cask.cdap.internal.app.runtime.codec.ArgumentsCodec;
+import co.cask.cdap.internal.app.runtime.codec.ProgramOptionsCodec;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
 import co.cask.cdap.proto.id.ProgramId;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.twill.api.RunId;
 
 import java.io.File;
-import java.lang.reflect.Type;
-import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -40,8 +40,10 @@ import javax.annotation.Nullable;
  */
 public class SparkRuntimeContextConfig {
 
-  private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder()).create();
-  private static final Type ARGS_TYPE = new TypeToken<Map<String, String>>() { }.getType();
+  private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder())
+    .registerTypeAdapter(Arguments.class, new ArgumentsCodec())
+    .registerTypeAdapter(ProgramOptions.class, new ProgramOptionsCodec())
+    .create();
 
   /**
    * Configuration key for boolean value to tell whether Spark program is executed on a cluster or not.
@@ -50,8 +52,7 @@ public class SparkRuntimeContextConfig {
 
   private static final String HCONF_ATTR_APP_SPEC = "cdap.spark.app.spec";
   private static final String HCONF_ATTR_PROGRAM_ID = "cdap.spark.program.id";
-  private static final String HCONF_ATTR_RUN_ID = "cdap.spark.run.id";
-  private static final String HCONF_ATTR_ARGS = "cdap.spark.program.args";
+  private static final String HCONF_ATTR_PROGRAM_OPTIONS = "cdap.spark.program.options";
   private static final String HCONF_ATTR_WORKFLOW_INFO = "cdap.spark.program.workflow.info";
   private static final String HCONF_ATTR_LOCAL_RESOURCES = "cdap.spark.local.resources";
 
@@ -92,8 +93,7 @@ public class SparkRuntimeContextConfig {
                                        @Nullable File pluginArchive) {
     setApplicationSpecification(context.getApplicationSpecification());
     setProgramId(context.getProgram().getId().toEntityId());
-    setRunId(context.getRunId().getId());
-    setArguments(context.getRuntimeArguments());
+    setProgramOptions(context.getProgramOptions());
     setWorkflowProgramInfo(context.getWorkflowInfo());
     setLocalizedResourceNames(localizeResourceNames);
     setPluginArchive(pluginArchive);
@@ -116,17 +116,10 @@ public class SparkRuntimeContextConfig {
   }
 
   /**
-   * @return the {@link RunId} stored in the configuration.
+   * @return the {@link ProgramOptions} stored in the configuration.
    */
-  public RunId getRunId() {
-    return RunIds.fromString(hConf.get(HCONF_ATTR_RUN_ID));
-  }
-
-  /**
-   * @return the runtime arguments stored in the configuration.
-   */
-  public Map<String, String> getArguments() {
-    return GSON.fromJson(hConf.get(HCONF_ATTR_ARGS), ARGS_TYPE);
+  public ProgramOptions getProgramOptions() {
+    return GSON.fromJson(hConf.get(HCONF_ATTR_PROGRAM_OPTIONS), ProgramOptions.class);
   }
 
   /**
@@ -138,8 +131,7 @@ public class SparkRuntimeContextConfig {
     if (info == null) {
       return null;
     }
-    WorkflowProgramInfo workflowProgramInfo = GSON.fromJson(info, WorkflowProgramInfo.class);
-    return workflowProgramInfo;
+    return GSON.fromJson(info, WorkflowProgramInfo.class);
   }
 
   /**
@@ -172,17 +164,10 @@ public class SparkRuntimeContextConfig {
   }
 
   /**
-   * Serialize the {@link RunId} to the configuration.
+   * Serialize the {@link ProgramOptions} to the configuration.
    */
-  private void setRunId(String runId) {
-    hConf.set(HCONF_ATTR_RUN_ID, runId);
-  }
-
-  /**
-   * Serialize the runtime arguments to the configuration.
-   */
-  private void setArguments(Map<String, String> runtimeArgs) {
-    hConf.set(HCONF_ATTR_ARGS, GSON.toJson(runtimeArgs, ARGS_TYPE));
+  private void setProgramOptions(ProgramOptions programOptions) {
+    hConf.set(HCONF_ATTR_PROGRAM_OPTIONS, GSON.toJson(programOptions, ProgramOptions.class));
   }
 
   /**

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeUtils.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeUtils.java
@@ -151,15 +151,6 @@ public final class SparkRuntimeUtils {
   };
 
   /**
-   * Creates a program {@link ClassLoader} that have Spark classes visible.
-   */
-  public static ClassLoader createProgramClassLoader(CConfiguration cConf, File dir,
-                                                     ClassLoader unfilteredClassLoader) {
-    ClassLoader parent = new FilterClassLoader(unfilteredClassLoader, SPARK_PROGRAM_CLASS_LOADER_FILTER);
-    return new ProgramClassLoader(cConf, dir, parent);
-  }
-
-  /**
    * Creates a zip file which contains a serialized {@link Properties} with a given zip entry name, together with
    * all files under the given directory. This is called from Client.createConfArchive() as a workaround for the
    * SPARK-13441 bug.

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
@@ -25,11 +25,10 @@ import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.app.runtime.spark.SparkRuntimeContextConfig;
 import co.cask.cdap.app.runtime.spark.SparkRuntimeUtils;
-import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.lang.FilterClassLoader;
 import co.cask.cdap.common.lang.ProgramClassLoaderProvider;
-import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
+import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.distributed.AbstractDistributedProgramRunner;
 import co.cask.cdap.internal.app.runtime.distributed.LocalizeResource;
 import co.cask.cdap.internal.app.runtime.spark.SparkUtils;
@@ -87,7 +86,7 @@ public final class DistributedSparkProgramRunner extends AbstractDistributedProg
     TwillController controller = launcher.launch(
       new SparkTwillApplication(program, spec, localizeResources, eventHandler), sparkAssemblyJarName);
 
-    RunId runId = RunIds.fromString(options.getArguments().getOption(ProgramOptionConstants.RUN_ID));
+    RunId runId = ProgramRunners.getRunId(options);
     return new SparkTwillProgramController(program.getId().toEntityId(), controller, runId).startListen();
   }
 

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/NoopMetricsContext.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/metrics/NoopMetricsContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -32,7 +32,7 @@ public final class NoopMetricsContext implements MetricsContext {
   }
 
   public NoopMetricsContext(Map<String, String> tags) {
-    this.tags = tags;
+    this.tags = ImmutableMap.copyOf(tags);
   }
 
   @Override


### PR DESCRIPTION
This is part 2 of the dataset access control change. It unified the propagation of artifact information so that it can be used for class interception during dataset class loading.
- Preserves all program options
  - Needed so that all artifact information and runtime information
    can easily accessible
  - Serialize the program options for MapReduce and Spark
- Expose the artifact information from AbstractContext
- Refactor the AbstractContext hierarchy
  - Every program context now extends from AbstractContext
- Cleanup AbstractContext sub-classes to remove code duplication and
  proper common implmentation
- Simplify sub-class implementation
- Unify RunId construction from ProgramOptions
