### PR TITLE
[CDAP-6358] Implementation of PluginInstantiator and MacroParser

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginConfig.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginConfig.java
@@ -42,7 +42,8 @@ public abstract class PluginConfig extends Config implements Serializable {
   }
 
   /**
-   * Returns true if property value contains a macro; false otherwise.
+   * Returns true if property value contains a macro; false otherwise. At runtime, properties that are macro-enabled
+   * and contained macro syntax will still return "true" to indicate that a macro was present at configuration time.
    * @param fieldName name of the field
    * @return whether the field contains a macro or not
    */

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DefaultPluginContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DefaultPluginContext.java
@@ -66,10 +66,10 @@ public class DefaultPluginContext implements PluginContext {
   @Override
   public <T> Class<T> loadPluginClass(String pluginId) {
     try {
-      Plugin plugin = getPlugin(pluginId);
       if (pluginInstantiator == null) {
         throw new UnsupportedOperationException("Plugin is not supported");
       }
+      Plugin plugin = getPlugin(pluginId);
       return pluginInstantiator.loadClass(plugin);
     } catch (ClassNotFoundException e) {
       // Shouldn't happen, unless there is bug in file localization
@@ -82,12 +82,17 @@ public class DefaultPluginContext implements PluginContext {
 
   @Override
   public <T> T newPluginInstance(String pluginId) throws InstantiationException {
+    return newPluginInstance(pluginId, null);
+  }
+
+  @Override
+  public <T> T newPluginInstance(String pluginId, @Nullable MacroEvaluator evaluator) throws InstantiationException {
     try {
       Plugin plugin = getPlugin(pluginId);
       if (pluginInstantiator == null) {
         throw new UnsupportedOperationException("Plugin is not supported");
       }
-      return pluginInstantiator.newInstance(plugin);
+      return pluginInstantiator.newInstance(plugin, evaluator);
     } catch (ClassNotFoundException e) {
       // Shouldn't happen, unless there is bug in file localization
       throw new IllegalArgumentException("Plugin class not found", e);
@@ -95,12 +100,6 @@ public class DefaultPluginContext implements PluginContext {
       // This is fatal, since jar cannot be expanded.
       throw Throwables.propagate(e);
     }
-  }
-
-  @Override
-  public <T> T newPluginInstance(String pluginId, MacroEvaluator evaluator) throws InstantiationException {
-    // todo : use pluginInstantiator#newPluginInstance(String pluginId, MacroEvaluator evaluator)
-    return newPluginInstance(pluginId);
   }
 
   private Plugin getPlugin(String pluginId) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/MacroParser.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/MacroParser.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.plugin;
+
+import co.cask.cdap.api.macro.InvalidMacroException;
+import co.cask.cdap.api.macro.MacroEvaluator;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
+
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+
+/**
+ * Provides a parser to validate the syntax of and evaluate macros.
+ */
+public class MacroParser {
+  private static final String[] ESCAPED_TOKENS = {"\\${", "\\}", "\\(", "\\)"};
+  private static final Pattern ARGUMENT_DELIMITER = Pattern.compile(",");
+  private static final int MAX_SUBSTITUTION_DEPTH = 10;
+
+  private final MacroEvaluator macroEvaluator;
+
+  public MacroParser(MacroEvaluator macroEvaluator) {
+    this.macroEvaluator = macroEvaluator;
+  }
+
+  /**
+   * Substitutes the provided string with a given macro evaluator. Expands macros from right-to-left recursively.
+   * @param str the raw string containing macro syntax
+   * @return the original string with all macros expanded and substituted
+   * @throws InvalidMacroException
+   */
+  public String parse(String str) throws InvalidMacroException {
+    // final string should have escapes that are not directly embedded in macro syntax replaced
+    return replaceEscapedSyntax(parse(str, 0));
+  }
+
+  /**
+   * Recursive helper method for macro parsing. Expands macros from right-to-left up to a maximum depth.
+   * @param str the raw string containing macro syntax
+   * @param depth the current depth of expansion
+   * @return the parsed string
+   * @throws InvalidMacroException
+   */
+  private String parse(String str, int depth) throws InvalidMacroException {
+    if (depth > MAX_SUBSTITUTION_DEPTH) {
+      throw new InvalidMacroException(String.format("Failed substituting maco '%s', expansion exceeded %d levels.",
+                                                    str, MAX_SUBSTITUTION_DEPTH));
+    }
+
+    MacroMetadata macroPosition = findRightmostMacro(str);
+    while (macroPosition != null) {
+      str = str.substring(0, macroPosition.startIndex) +
+            parse(macroPosition.substitution, depth + 1) +
+            str.substring(macroPosition.endIndex + 1);
+      macroPosition = findRightmostMacro(str);
+    }
+    return str;
+  }
+
+  /**
+   * Find the rightmost macro in the specified string. If no macro is found, returns null.
+   * @param str the string to find a macro in
+   * @return the rightmost macro and its position in the string
+   * @throws InvalidMacroException if invalid macro syntax was found.
+   */
+  @Nullable
+  private MacroMetadata findRightmostMacro(String str)
+    throws InvalidMacroException {
+    // find opening "${" skipping escaped syntax "\${" TODO: and allowing doubly-escaping "\\${"
+    int startIndex = getStartIndex(str);
+    if (startIndex < 0) {
+      return null;
+    }
+
+    // found "${", now look for enclosing "}" and allow escaping "\}" TODO: and doubly-escaping "\\}"
+    int endIndex = getEndIndex(str, startIndex);
+    if (endIndex < 0) {
+      throw new InvalidMacroException(String.format("Could not find enclosing '}' for macro '%s'.",
+                                                    str.substring(startIndex)));
+    }
+
+    // macroStr = 'macroFunction(macroArguments)' or just 'property' for ${property}
+    String macroStr = str.substring(startIndex + 2, endIndex).trim();
+
+    // look for "(", which indicates there are arguments and allow escaping "\(" TODO: and doubly-escaping "\\("
+    int argsStartIndex = getArgsStartIndex(str, macroStr);
+
+    // determine whether to use a macro function or a property lookup
+    if (argsStartIndex >= 0) {
+      return getMacroFunctionMetadata(startIndex, endIndex, macroStr, argsStartIndex);
+    } else {
+      macroStr = replaceEscapedSyntax(macroStr);
+      return new MacroMetadata(macroEvaluator.lookup(macroStr), startIndex, endIndex);
+    }
+  }
+
+  private MacroMetadata getMacroFunctionMetadata(int startIndex, int endIndex, String macroStr, int argsStartIndex) {
+    // check for closing ")" and allow escaping "\)" TODO: and doubly-escaping "\\)"
+    int closingParenIndex = getClosingParenIndex(macroStr);
+    if (closingParenIndex < 0 || !macroStr.endsWith(")")) {
+      throw new InvalidMacroException(String.format("Could not find enclosing ')' for macro arguments in '%s'.",
+                                                    macroStr));
+    }
+
+    // arguments and macroFunction are expected to have escapes replaced when being evaluated
+    String arguments = replaceEscapedSyntax(macroStr.substring(argsStartIndex + 1, macroStr.length() - 1));
+    String macroFunction = replaceEscapedSyntax(macroStr.substring(0, argsStartIndex));
+
+    String[] args = Iterables.toArray(Splitter.on(ARGUMENT_DELIMITER).split(arguments), String.class);
+    return new MacroMetadata(macroEvaluator.evaluate(macroFunction, args), startIndex, endIndex);
+  }
+
+  private int getStartIndex(String str) {
+    int startIndex = str.lastIndexOf("${");
+    while (escaped(startIndex, str)) {
+      // TODO: Break if doubly-escaped syntax
+      startIndex = str.substring(0, startIndex - 1).lastIndexOf("${");
+    }
+    return startIndex;
+  }
+
+  private int getEndIndex(String str, int startIndex) {
+    int endIndex = str.indexOf('}', startIndex);
+    while (escaped(endIndex, str)) {
+      // TODO: Break if doubly-escaped syntax
+      endIndex = str.indexOf('}', endIndex + 1);
+    }
+    return endIndex;
+  }
+
+  private int getArgsStartIndex(String str, String macroStr) {
+    int argsStartIndex = macroStr.indexOf('(');
+    while (escaped(argsStartIndex, str)) {
+      // TODO: Break if doubly-escaped syntax
+      argsStartIndex = macroStr.indexOf('(', argsStartIndex);
+    }
+    return argsStartIndex;
+  }
+
+  private int getClosingParenIndex(String macroStr) {
+    int closingParenIndex = macroStr.lastIndexOf(')');
+    while (escaped(closingParenIndex, macroStr)) {
+      // TODO: Break if doubly-escaped syntax
+      closingParenIndex = macroStr.substring(0, closingParenIndex).lastIndexOf(')');
+    }
+    return closingParenIndex;
+  }
+
+  private boolean escaped(int index, String str) {
+    return (index > 0 && str.charAt(index - 1) == '\\');
+  }
+
+  private boolean doublyEscaped(int index, String str) {
+    return (index > 1 && str.charAt(index - 2) == '\\');
+  }
+
+  /**
+   * Removes all escaped syntax for all macro syntax symbols: ${, }, (, )
+   * TODO: Handle doubly-escaped syntax (e.g. \\${macro} should still be evaluated)
+   * @param str the string to replace escaped syntax in
+   * @return the string with no escaped syntax
+   */
+  private String replaceEscapedSyntax(String str) {
+    for (String token : ESCAPED_TOKENS) {
+      str = str.replace(token, token.substring(1));
+    }
+    return str;
+  }
+
+  private static final class MacroMetadata {
+    private final String substitution;
+    private final int startIndex;
+    private final int endIndex;
+
+    private MacroMetadata(String substitution, int startIndex, int endIndex) {
+      this.substitution = substitution;
+      this.startIndex = startIndex;
+      this.endIndex = endIndex;
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/TrackingMacroEvaluator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/TrackingMacroEvaluator.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.plugin;
+
+import co.cask.cdap.api.macro.MacroEvaluator;
+
+/**
+ * A macro evaluator used strictly for checking if strings contains valid macros.
+ *
+ * The evaluator is passed as an argument to a {@link MacroParser} and internally keeps
+ * track of whether or not a macro was found when the parser
+ */
+public class TrackingMacroEvaluator implements MacroEvaluator {
+
+  private boolean foundMacro;
+
+  public TrackingMacroEvaluator() {
+    this.foundMacro = false;
+  }
+
+  public String lookup(String property) {
+    foundMacro = true;
+    return "";
+  }
+
+  public String evaluate(String macroFunction, String... arguments) {
+    foundMacro = true;
+    return "";
+  }
+
+  /**
+   * Returns whether or not the last String parsed by the evaluator's associated
+   * {@link MacroParser} contained a macro.
+   * @return if the evaluator found a macro in the last String parsed.
+   */
+  public boolean hasMacro() {
+    return foundMacro;
+  }
+
+  /**
+   * Resets whether the evaluator found a macro in the last String parsed to false.
+   */
+  public void reset() {
+    foundMacro = false;
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/plugins/test/TestPlugin.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/plugins/test/TestPlugin.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.internal.app.plugins.test;
 
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.plugin.PluginConfig;
@@ -35,15 +36,15 @@ public class TestPlugin implements Callable<String> {
   @Override
   public String call() throws Exception {
     if (config.timeout % 2 == 0) {
-      return Class.forName(config.className).getName();
+      return config.name;
     }
     return null;
   }
 
   public static final class Config extends PluginConfig {
 
-    @Name("class.name")
-    private String className;
+    @Macro
+    private String name;
 
     @Nullable
     private Long timeout;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/plugin/MacroParserTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/plugin/MacroParserTest.java
@@ -1,0 +1,440 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.plugin;
+
+
+import co.cask.cdap.api.macro.InvalidMacroException;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MacroParserTest {
+
+  // Test containsMacro Parsing
+
+  @Test
+  public void testContainsUndefinedMacro() throws InvalidMacroException {
+    assertContainsMacroParsing("${undefined}", true);
+  }
+
+  @Test
+  public void testContainsExcessivelyEscapedMacro() throws InvalidMacroException {
+    assertContainsMacroParsing("\\${${macro}}\\${${{\\}}}\\escaped\\${one}${fun${\\${escapedMacroLiteral\\}}}\\no-op",
+                               true);
+  }
+
+  @Test
+  public void testContainsSimpleEscapedMacro() throws InvalidMacroException {
+    assertContainsMacroParsing("$${{\\}}", true);
+  }
+
+  @Test
+  public void testContainsConsecutiveMacros() throws InvalidMacroException {
+    assertContainsMacroParsing("${simpleHostname}/${simplePath}:${simplePort}", true);
+  }
+
+  @Test
+  public void testContainsManyMacros() throws InvalidMacroException {
+    assertContainsMacroParsing("${l}${o}${c}${a}${l}${hostSuffix}", true);
+  }
+
+  @Test
+  public void testContainsNestedMacros() throws InvalidMacroException {
+    assertContainsMacroParsing("${nested${macros${are${ok}}}}", true);
+  }
+
+  @Test(expected = InvalidMacroException.class)
+  public void testContainsBadlyFormattedNestedMacros() {
+    assertContainsMacroParsing("${nested${macros${are${ok}}}", true);
+  }
+
+  @Test(expected = InvalidMacroException.class)
+  public void containsBadlyFormattedMacro() throws InvalidMacroException {
+    assertContainsMacroParsing("${badFormatting", false);
+  }
+
+  @Test
+  public void containsEmptyMacro() throws InvalidMacroException {
+    assertContainsMacroParsing("${}", true);
+  }
+
+  @Test
+  public void containsNoMacro() throws InvalidMacroException {
+    assertContainsMacroParsing("hostname/path:port", false);
+  }
+
+  @Test
+  public void containsNoEscapedMacro() {
+    assertContainsMacroParsing("\\{definitely\\{not\\{test(aMacro)}}}", false);
+  }
+
+
+  // Test Macro Substitution
+
+  @Test(expected = InvalidMacroException.class)
+  public void testUndefinedMacro() throws InvalidMacroException {
+    assertSubstitution("${undefined}", "", new HashMap<String, String>(), new HashMap<String, String>());
+  }
+
+  /**
+   * Tests if the empty string can be passed macro-substituted.
+   * Expands the following macro tree of depth 1:
+   *
+   *             ${}
+   *              |
+   *           emptyMacro
+   */
+  @Test
+  public void testEmptyMacro() throws InvalidMacroException {
+    Map<String, String> properties = ImmutableMap.<String, String>builder()
+      .put("", "emptyMacro")
+      .build();
+    assertSubstitution("${}", "emptyMacro", properties, new HashMap<String, String>());
+  }
+
+  /**
+   * Tests if empty string can be passed as arguments to a macro function.
+   * Expands the following macro tree of depth 1:
+   *
+   *          ${test()}
+   *              |
+   *          emptyMacro
+   */
+  @Test
+  public void testEmptyArguments() throws InvalidMacroException {
+    Map<String, String> macroFunctionSubstitutions = ImmutableMap.<String, String>builder()
+      .put("", "emptyMacro")
+      .build();
+    assertSubstitution("${test()}", "emptyMacro", new HashMap<String, String>(), macroFunctionSubstitutions);
+  }
+
+  /**
+   * Tests if escape indicator '\' is not replaced when not followed by a macro syntax token.
+   * Expands the following macro tree of depth 2:
+   *
+   *     ------ \test\${${macro}}\${${}}\escaped\${one}${fun${\${escapedMacroLiteral\}}}\no-op ------
+   *     |                                        |                                                 |
+   * \test${42}                       ${brackets}\escaped${one}                             ${funTimes}\no-op
+   *                                                                                                |
+   *                                                                                            ahead\no-op
+   */
+  @Test
+  public void testNoUnnecessaryReplacement() {
+    Map<String, String> properties = ImmutableMap.<String, String>builder()
+      .put("{}", "brackets")
+      .put("macro", "42")
+      .put("${escapedMacroLiteral}", "Times")
+      .put("escapedMacroLiteral", "SHOULD NOT EVALUATE")
+      .put("funTimes", "ahead")
+      .build();
+    assertSubstitution("\\\\test\\${${macro}}\\${${{\\}}}\\escaped\\${one}${fun${\\${escapedMacroLiteral\\}}}\\no-op",
+                       "\\\\test${42}${brackets}\\escaped${one}ahead\\no-op", properties,
+                       new HashMap<String, String>());
+  }
+
+  /**
+   * Tests simple escaping of property macros.
+   * Expands the following macro tree of depth 1:
+   *
+   *              $${{\}}
+   *                 |
+   *             $brackets
+   */
+  @Test
+  public void propertyBracketEscapingTest() throws InvalidMacroException {
+    Map<String, String> properties = ImmutableMap.<String, String>builder()
+      .put("{}", "brackets")
+      .build();
+    assertSubstitution("$${{\\}}", "$brackets", properties, new HashMap<String, String>());
+  }
+
+  @Test
+  public void testRidiculousSyntaxEscaping() throws InvalidMacroException {
+    Map<String, String> properties = ImmutableMap.<String, String>builder()
+      .put("{}", "brackets")
+      .put("macro", "42")
+      .put("${escapedMacroLiteral}", "Times")
+      .put("escapedMacroLiteral", "SHOULD NOT EVALUATE")
+      .put("funTimes", "ahead")
+      .build();
+    assertSubstitution("\\${${macro}}\\${${{\\}}}\\${one}${fun${\\${escapedMacroLiteral\\}}}",
+                       "${42}${brackets}${one}ahead", properties, new HashMap<String, String>());
+  }
+
+  // TODO: Implement doubly-escaping
+  @Ignore
+  public void testEscapingOfEscaping() throws InvalidMacroException {
+    Map<String, String> properties = ImmutableMap.<String, String>builder()
+      .put("filePathMacro", "executable.exe")
+      .build();
+    assertSubstitution("\\file\\path\\name\\\\${filePathMacro}", "\\file\\path\\name\\executable.exe", properties,
+                       new HashMap<String, String>());
+  }
+
+  /**
+   * Tests if an exception is thrown on a nonexistent/unspecified macro.
+   */
+  @Test(expected = InvalidMacroException.class)
+  public void testNonexistentMacro() throws InvalidMacroException {
+    assertSubstitution("${test(invalid)}", "", new HashMap<String, String>(), new HashMap<String, String>());
+  }
+
+  /**
+   * Tests if an exception is thrown if substitution depth exceeds a maximum with a circular key.
+   * Expands the following macro tree of depth infinity:
+   *
+   *                      ${key} ---
+   *                        |      |
+   *                      ${key} ---
+   */
+  @Test(expected = InvalidMacroException.class)
+  public void testCircularMacro() throws InvalidMacroException {
+    Map<String, String> macroFunctionSubstitutions = ImmutableMap.<String, String>builder()
+      .put("key", "${test(key)}")
+      .build();
+    assertSubstitution("${test(key)}", "", new HashMap<String, String>(), macroFunctionSubstitutions);
+  }
+
+  /**
+   * Tests simple macro syntax escaping.
+   */
+  @Test
+  public void testSimpleMacroSyntaxEscaping() throws InvalidMacroException {
+    Map<String, String> macroFunctionSubstitutions = ImmutableMap.<String, String>builder()
+      .put("simpleEscape", "\\${test(\\${test(expansiveHostnameTree)})}")
+      .build();
+    assertSubstitution("${test(simpleEscape)}", "${test(${test(expansiveHostnameTree)})}",
+                       new HashMap<String, String>(), macroFunctionSubstitutions);
+  }
+
+  /**
+   * Tests advanced macro syntax escaping
+   * Expands the following macro tree of depth 2:
+   *
+   *                                ${test(advancedEscape)}
+   *                                          |
+   *                               ${test(lotsOfEscaping)}
+   *                                          |
+   *      ${test(simpleHostnameTree)${test(first)}${test(filename${test(fileTypeMacro))}
+   */
+  @Test
+  public void testAdvancedMacroSyntaxEscaping() throws InvalidMacroException {
+    Map<String, String> macroFunctionSubstiutions = ImmutableMap.<String, String>builder()
+      .put("advancedEscape", "${test(lotsOfEscaping)}")
+      .put("lotsOfEscaping", "\\${test(simpleHostnameTree)\\${test(first)}\\${test(filename\\${test(fileTypeMacro))}")
+      .build();
+    assertSubstitution("${test(advancedEscape)}",
+                       "${test(simpleHostnameTree)${test(first)}${test(filename${test(fileTypeMacro))}",
+                       new HashMap<String, String>(), macroFunctionSubstiutions);
+  }
+
+
+  /**
+   * Tests expansive use of macro syntax escaping.
+   * Expands the following macro tree of depth 3:
+   *
+   *      ${test(${test(\${test(macroLiteral)\})\})}\${test(nothing)}${test(simplePath} -----------------
+   *                                               |                                                    |
+   *                                         ${test(match)})}                               ${test(nothing)}index.html
+   *                                               |
+   *           --- {test(dontEvaluate):${test(firstPortDigit)}0\${test-\${test(null)}\${\${\${nil ---
+   *           |                                      |                                             |
+   *   {test(dontEvaluate):                           8                                0${test-${test(null)}${${${nil
+   *
+   */
+  @Test
+  public void testExpansiveSyntaxEscaping() throws InvalidMacroException {
+    Map<String, String> macroFunctionSubstiutions = ImmutableMap.<String, String>builder()
+      .put("expansiveEscape", "${test(${test(\\${test(macroLiteral\\)\\})})}\\${test(nothing)${test(simplePath)}")
+      .put("${test(macroLiteral)}", "match")
+      .put("match", "{test(dontEvaluate):${test(firstPortDigit)}0\\${test-\\${test(null)}\\${\\${\\${nil")
+      .put("simplePath", "index.html")
+      .put("firstPortDigit", "8")
+      .put("secondPortDigit", "0")
+      .build();
+    assertSubstitution("${test(expansiveEscape)}",
+                       "{test(dontEvaluate):80${test-${test(null)}${${${nil${test(nothing)index.html",
+                       new HashMap<String, String>(), macroFunctionSubstiutions);
+  }
+
+  /**
+   * Tests a simple property tree expansion.
+   * Expands the following macro tree of depth 2:
+   *
+   *                                ${simpleHostnameTree}
+   *                                          |
+   *           -------- ${simpleHostname}/${simplePath}:${simplePort} --------
+   *           |                              |                              |
+   *        localhost                     index.html                        80
+   */
+  @Test
+  public void testSimplePropertyTree() {
+    Map<String, String> properties = ImmutableMap.<String, String>builder()
+      .put("simpleHostnameTree", "${simpleHostname}/${simplePath}:${simplePort}")
+      .put("simpleHostname", "localhost")
+      .put("simplePath", "index.html")
+      .put("simplePort", "80")
+      .build();
+    assertSubstitution("${simpleHostnameTree}", "localhost/index.html:80", properties, new HashMap<String, String>());
+  }
+
+  /**
+   * Tests an advanced property tree expansion.
+   * Expands the following macro tree of depth 4:
+   *
+   *                      ${advancedHostnameTree}
+   *                                |
+   *              --------- ${first}/${second} ---------------------
+   *              |                                                |
+   *          localhost                             ------ ${third}:${sixth} -----------
+   *                                                |                                   |
+   *                                ------- ${fourth}${fifth} -------                  80
+   *                                |                               |
+   *                              index                           .html
+   */
+  @Test
+  public void testAdvancedPropertyTree() throws InvalidMacroException {
+    Map<String, String> properties = ImmutableMap.<String, String>builder()
+      .put("advancedHostnameTree", "${first}/${second}")
+      .put("first", "localhost")
+      .put("second", "${third}:${sixth}")
+      .put("third", "${fourth}${fifth}")
+      .put("fourth", "index")
+      .put("fifth", ".html")
+      .put("sixth", "80")
+      .build();
+    assertSubstitution("${advancedHostnameTree}", "localhost/index.html:80", properties, new HashMap<String, String>());
+  }
+
+  /**
+   * Tests an expansive property tree expansion.
+   * Expands the following macro tree of depth 6:
+   *
+   *                              ${expansiveHostnameTree}
+   *                                        |
+   *                  ---------- ${hostname}/${path}:${port} -------------------
+   *                 |                      |                                  |
+   *               ${one}                 ${two}                        --- ${three} -------
+   *                 |                      |                           |                  |
+   *        ${host${hostScopeMacro}} ${filename${fileTypeMacro}} ${firstPortDigit} ${secondPortDigit}
+   *                 |                      |                           |                  |
+   *           ${host-local}          ${filename-html}                  8                  0
+   *                 |                      |
+   *  ${l}${o}${c}${a}${l}${hostSuffix}  index.html
+   *                 |
+   *              localhost
+   *
+   */
+  @Test
+  public void testExpansivePropertyTree() throws InvalidMacroException {
+    Map<String, String> properties = ImmutableMap.<String, String>builder()
+      .put("expansiveHostnameTree", "${hostname}/${path}:${port}")
+      .put("hostname", "${one}")
+      .put("path", "${two}")
+      .put("port", "${three}")
+      .put("one", "${host${hostScopeMacro}}")
+      .put("hostScopeMacro", "-local")
+      .put("host-local", "${l}${o}${c}${a}${l}${hostSuffix}")
+      .put("l", "l")
+      .put("o", "o")
+      .put("c", "c")
+      .put("a", "a")
+      .put("hostSuffix", "host")
+      .put("two", "${filename${fileTypeMacro}}")
+      .put("three", "${firstPortDigit}${secondPortDigit}")
+      .put("filename", "index")
+      .put("fileTypeMacro", "-html")
+      .put("filename-html", "index.html")
+      .put("filename-php", "index.php")
+      .put("firstPortDigit", "8")
+      .put("secondPortDigit", "0")
+      .build();
+    assertSubstitution("${expansiveHostnameTree}", "localhost/index.html:80", properties,
+                       new HashMap<String, String>());
+  }
+
+  /**
+   * See simple, advanced, and expansive tree tests for details.
+   */
+  @Test
+  public void stressTestPropertyTree() throws InvalidMacroException {
+    Map<String, String> properties = ImmutableMap.<String, String>builder()
+      // simple hostname tree
+      .put("simpleHostnameTree", "${simpleHostname}/${simplePath}:${simplePort}")
+      .put("simpleHostname", "localhost")
+      .put("simplePath", "index.html")
+      .put("simplePort", "80")
+      // advanced hostname tree
+      .put("advancedHostnameTree", "${first}/${second}")
+      .put("first", "localhost")
+      .put("second", "${third}:${sixth}")
+      .put("third", "${fourth}${fifth}")
+      .put("fourth", "index")
+      .put("fifth", ".html")
+      .put("sixth", "80")
+      // expansive hostname tree
+      .put("expansiveHostnameTree", "${hostname}/${path}:${port}")
+      .put("hostname", "${one}")
+      .put("path", "${two}")
+      .put("port", "${three}")
+      .put("one", "${host${hostScopeMacro}}")
+      .put("hostScopeMacro", "-local")
+      .put("host-local", "${l}${o}${c}${a}${l}${hostSuffix}")
+      .put("l", "l")
+      .put("o", "o")
+      .put("c", "c")
+      .put("a", "a")
+      .put("hostSuffix", "host")
+      .put("two", "${filename${fileTypeMacro}}")
+      .put("three", "${firstPortDigit}${secondPortDigit}")
+      .put("filename", "index")
+      .put("fileTypeMacro", "-html")
+      .put("filename-html", "index.html")
+      .put("filename-php", "index.php")
+      .put("firstPortDigit", "8")
+      .put("secondPortDigit", "0")
+      .build();
+    assertSubstitution("${simpleHostnameTree}${simpleHostnameTree}${simpleHostnameTree}" +
+                          "${advancedHostnameTree}${advancedHostnameTree}${advancedHostnameTree}" +
+                          "${expansiveHostnameTree}${expansiveHostnameTree}${expansiveHostnameTree}" +
+                          "${simpleHostnameTree}${advancedHostnameTree}${expansiveHostnameTree}",
+                        "localhost/index.html:80localhost/index.html:80localhost/index.html:80localhost/index.html:80" +
+                        "localhost/index.html:80localhost/index.html:80localhost/index.html:80localhost/index.html:80" +
+                        "localhost/index.html:80localhost/index.html:80localhost/index.html:80localhost/index.html:80",
+                       properties, new HashMap<String, String>());
+  }
+
+
+  // Testing util methods
+
+  private static void assertContainsMacroParsing(String macro, boolean expected) {
+    TrackingMacroEvaluator trackingMacroEvaluator = new TrackingMacroEvaluator();
+    new MacroParser(trackingMacroEvaluator).parse(macro);
+    Assert.assertEquals(trackingMacroEvaluator.hasMacro(), expected);
+  }
+
+  private static void assertSubstitution(String macro, String expected, Map<String, String> propertySubstitutions,
+                                  Map<String, String> macroFunctionSubstitutions) {
+    MacroParser macroParser = new MacroParser(new TestMacroEvaluator(propertySubstitutions,
+                                                                     macroFunctionSubstitutions));
+    Assert.assertEquals(expected, macroParser.parse(macro));
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/plugin/TestMacroEvaluator.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/plugin/TestMacroEvaluator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.plugin;
+
+import co.cask.cdap.api.macro.InvalidMacroException;
+import co.cask.cdap.api.macro.MacroEvaluator;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+public class TestMacroEvaluator implements MacroEvaluator {
+
+  private final Map<String, String> propertySubstitutions;
+  private final Map<String, String> macroFunctionSubstitutions;
+
+  public TestMacroEvaluator(Map<String, String> propertySubstitutions, Map<String, String> macroFunctionSubstitutions) {
+    this.propertySubstitutions = propertySubstitutions;
+    this.macroFunctionSubstitutions = macroFunctionSubstitutions;
+  }
+
+  @Override
+  public String lookup(String value)  {
+    if (value == null) {
+      value = "";
+    }
+    String substitution = propertySubstitutions.get(value);
+    if (substitution == null) {
+      throw new InvalidMacroException(String.format("Macro '%s' not specified.", value));
+    }
+    return substitution;
+  }
+
+  @Override
+  public String evaluate(String macroFunction, String... arguments) {
+    if (!macroFunction.equals("test")) {
+      throw new InvalidMacroException(String.format("Macro function '%s' not defined.", macroFunction));
+    } else if (arguments.length > 1) {
+      throw new InvalidMacroException("Test macro function only takes 1 argument.");
+    } else {
+      String value = arguments[0];
+      if (value == null) {
+        value = "";
+      }
+      String substitution = macroFunctionSubstitutions.get(value);
+      if (substitution == null) {
+        throw new InvalidMacroException(String.format("Macro '%s' not specified.", value));
+      }
+      return substitution;
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockRuntimeDatasetSink.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockRuntimeDatasetSink.java
@@ -16,48 +16,126 @@
 
 package co.cask.cdap.etl.mock.batch;
 
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.dataset.table.Scanner;
+import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.plugin.PluginPropertyField;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSinkContext;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
+import co.cask.cdap.format.StructuredRecordStringConverter;
+import co.cask.cdap.test.DataSetManager;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Mock sink that tests creation of datasets during runtime based on if dataset exists or not.
  */
 @Plugin(type = BatchSink.PLUGIN_TYPE)
 @Name("MockRuntime")
-public class MockRuntimeDatasetSink extends MockSink {
+public class MockRuntimeDatasetSink extends BatchSink<StructuredRecord, byte[], Put> {
   public static final PluginClass PLUGIN_CLASS = getPluginClass();
+  private static final byte[] SCHEMA_COL = Bytes.toBytes("s");
+  private static final byte[] RECORD_COL = Bytes.toBytes("r");
+  private final Config config;
 
   public MockRuntimeDatasetSink(Config config) {
-    super(config);
+    this.config = config;
+  }
+
+  /**
+   * Config for the sink.
+   */
+  public static class Config extends PluginConfig {
+    @Macro
+    private String tableName;
+
+    @Macro
+    private String runtimeDatasetName;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    super.configurePipeline(pipelineConfigurer);
+    pipelineConfigurer.createDataset(config.tableName, Table.class);
+    if (!config.containsMacro("runtimeDatasetName")) {
+      pipelineConfigurer.createDataset(config.runtimeDatasetName, KeyValueTable.class.getName(),
+                                       DatasetProperties.EMPTY);
+    }
   }
 
   @Override
   public void prepareRun(BatchSinkContext context) throws Exception {
-    super.prepareRun(context);
-    if (!context.datasetExists("mockRuntimeSinkDataset")) {
-      context.createDataset("mockRuntimeSinkDataset", KeyValueTable.class.getName(), DatasetProperties.EMPTY);
+    context.addOutput(config.tableName);
+    if (!context.datasetExists(config.runtimeDatasetName)) {
+      context.createDataset(config.runtimeDatasetName, KeyValueTable.class.getName(), DatasetProperties.EMPTY);
     }
   }
 
-  public static ETLPlugin getPlugin(String tableName) {
+  @Override
+  public void initialize(BatchRuntimeContext context) throws Exception {
+    super.initialize(context);
+  }
+
+  public static ETLPlugin getPlugin(String tableName, String runtimeDatasetName) {
     Map<String, String> properties = new HashMap<>();
     properties.put("tableName", tableName);
+    properties.put("runtimeDatasetName", runtimeDatasetName);
     return new ETLPlugin("MockRuntime", BatchSink.PLUGIN_TYPE, properties, null);
+  }
+
+  @Override
+  public void transform(StructuredRecord input, Emitter<KeyValue<byte[], Put>> emitter) throws Exception {
+    byte[] rowkey = Bytes.toBytes(UUID.randomUUID());
+    Put put = new Put(rowkey);
+    put.add(SCHEMA_COL, input.getSchema().toString());
+    put.add(RECORD_COL, StructuredRecordStringConverter.toJsonString(input));
+    emitter.emit(new KeyValue<>(rowkey, put));
+  }
+
+  /**
+   * Used to read the records written by this sink.
+   *
+   * @param tableManager dataset manager used to get the sink dataset to read from
+   */
+  public static List<StructuredRecord> readOutput(DataSetManager<Table> tableManager) throws Exception {
+    Table table = tableManager.get();
+
+    try (Scanner scanner = table.scan(null, null)) {
+      List<StructuredRecord> records = new ArrayList<>();
+      Row row;
+      while ((row = scanner.next()) != null) {
+        Schema schema = Schema.parseJson(row.getString(SCHEMA_COL));
+        String recordStr = row.getString(RECORD_COL);
+        records.add(StructuredRecordStringConverter.fromJsonString(recordStr, schema));
+      }
+      return records;
+    }
   }
 
   private static PluginClass getPluginClass() {
     Map<String, PluginPropertyField> properties = new HashMap<>();
     properties.put("tableName", new PluginPropertyField("tableName", "", "string", true, true));
+    properties.put("runtimeDatasetName", new PluginPropertyField("runtimeDatasetName", "", "string", true, true));
     return new PluginClass(BatchSink.PLUGIN_TYPE, "MockRuntime", "", MockRuntimeDatasetSink.class.getName(),
                            "config", properties);
   }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockRuntimeDatasetSource.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockRuntimeDatasetSource.java
@@ -16,48 +16,120 @@
 
 package co.cask.cdap.etl.mock.batch;
 
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.batch.Input;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.plugin.PluginPropertyField;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
 import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.api.batch.BatchSourceContext;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
+import co.cask.cdap.format.StructuredRecordStringConverter;
+import co.cask.cdap.test.DataSetManager;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Mock source that tests creation of datasets during runtime based on if dataset exists or not.
  */
 @Plugin(type = BatchSource.PLUGIN_TYPE)
 @Name("MockRuntime")
-public class MockRuntimeDatasetSource extends MockSource {
+public class MockRuntimeDatasetSource extends BatchSource<byte[], Row, StructuredRecord> {
   public static final PluginClass PLUGIN_CLASS = getPluginClass();
+  private static final byte[] SCHEMA_COL = Bytes.toBytes("s");
+  private static final byte[] RECORD_COL = Bytes.toBytes("r");
+  private final Config config;
 
   public MockRuntimeDatasetSource(Config config) {
-    super(config);
+    this.config = config;
+  }
+
+  /**
+   * Config for the source.
+   */
+  public static class Config extends PluginConfig {
+    private String tableName;
+
+    @Macro
+    private String runtimeDatasetName;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    super.configurePipeline(pipelineConfigurer);
+    pipelineConfigurer.createDataset(config.tableName, Table.class);
+    if (!config.containsMacro("runtimeDatasetName")) {
+      pipelineConfigurer.createDataset(config.runtimeDatasetName, KeyValueTable.class.getName(),
+                                       DatasetProperties.EMPTY);
+    }
+  }
+
+  @Override
+  public void initialize(BatchRuntimeContext context) throws Exception {
+    super.initialize(context);
   }
 
   @Override
   public void prepareRun(BatchSourceContext context) throws Exception {
-    super.prepareRun(context);
-    if (!context.datasetExists("mockRuntimeSourceDataset")) {
-      context.createDataset("mockRuntimeSourceDataset", KeyValueTable.class.getName(), DatasetProperties.EMPTY);
+    context.setInput(Input.ofDataset(config.tableName));
+    if (!context.datasetExists(config.runtimeDatasetName)) {
+      context.createDataset(config.runtimeDatasetName, KeyValueTable.class.getName(), DatasetProperties.EMPTY);
     }
   }
 
-  public static ETLPlugin getPlugin(String tableName) {
+  @Override
+  public void transform(KeyValue<byte[], Row> input, Emitter<StructuredRecord> emitter) throws Exception {
+    Schema schema = Schema.parseJson(input.getValue().getString(SCHEMA_COL));
+    String recordStr = input.getValue().getString(RECORD_COL);
+    emitter.emit(StructuredRecordStringConverter.fromJsonString(recordStr, schema));
+  }
+
+  public static ETLPlugin getPlugin(String tableName, String runtimeDatasetName) {
     Map<String, String> properties = new HashMap<>();
     properties.put("tableName", tableName);
+    properties.put("runtimeDatasetName", runtimeDatasetName);
     return new ETLPlugin("MockRuntime", BatchSource.PLUGIN_TYPE, properties, null);
+  }
+
+  /**
+   * Used to write the input records for the pipeline run. Should be called after the pipeline has been created.
+   *
+   * @param tableManager dataset manager used to write to the source dataset
+   * @param records records that should be the input for the pipeline
+   */
+  public static void writeInput(DataSetManager<Table> tableManager,
+                                Iterable<StructuredRecord> records) throws Exception {
+    tableManager.flush();
+    Table table = tableManager.get();
+    // write each record as a separate row, with the serialized record as one column and schema as another
+    // each rowkey will be a UUID.
+    for (StructuredRecord record : records) {
+      byte[] row = Bytes.toBytes(UUID.randomUUID());
+      table.put(row, SCHEMA_COL, Bytes.toBytes(record.getSchema().toString()));
+      table.put(row, RECORD_COL, Bytes.toBytes(StructuredRecordStringConverter.toJsonString(record)));
+    }
+    tableManager.flush();
   }
 
   private static PluginClass getPluginClass() {
     Map<String, PluginPropertyField> properties = new HashMap<>();
     properties.put("tableName", new PluginPropertyField("tableName", "", "string", true, false));
+    properties.put("runtimeDatasetName", new PluginPropertyField("runtimeDatasetName", "", "string", true, true));
     return new PluginClass(BatchSource.PLUGIN_TYPE, "MockRuntime", "", MockRuntimeDatasetSource.class.getName(),
                            "config", properties);
   }


### PR DESCRIPTION
Initial implementation of PluginInstantiator and MacroParser to support macros.

TODO: allow doubly-escaping of macro syntax (e.g. \${macro} still evaluators ${macro}) and add test for macro-enabled newPlugin method. Will ask @albertshau when I get in for a bit of help with that...

Surfacing all macros in a given string for the REST APIs will come in a different PR.
