### PR TITLE
initial createUiDef, restricting it to the latest HBase cluster version

### DIFF
--- a/cdap-distributions/src/hdinsight/createUiDef.json
+++ b/cdap-distributions/src/hdinsight/createUiDef.json
@@ -2,12 +2,8 @@
     "handler": "Microsoft.HDInsight",
     "version": "0.0.1-preview",
     "clusterFilters": {
-        "types": [
-            "HBase"
-        ],
-        "tiers": [
-            "Standard"
-        ],
+        "types": [ "HBase" ],
+        "tiers": [ "Standard" ],
         "versions": [ "3.4" ]
     }
 }

--- a/cdap-distributions/src/hdinsight/createUiDef.json
+++ b/cdap-distributions/src/hdinsight/createUiDef.json
@@ -1,0 +1,13 @@
+{
+    "handler": "Microsoft.HDInsight",
+    "version": "0.0.1-preview",
+    "clusterFilters": {
+        "types": [
+            "HBase"
+        ],
+        "tiers": [
+            "Standard"
+        ],
+        "versions": [ "3.4" ]
+    }
+}


### PR DESCRIPTION
- [x] adding the required `createUiDef.json`, which restricts which HDInsight cluster types/versions our application is compatible with:
  - [x] HBase is the only compatible type
  - [x] premium tier not available for HBase clusters
  - [x] 3.4 is the latest HDInsight version
