### PR TITLE
changes initial background color

### DIFF
--- a/cdap-ui/app/features/tracker/directives/jump/jump.less
+++ b/cdap-ui/app/features/tracker/directives/jump/jump.less
@@ -17,8 +17,9 @@
 my-jump-button {
   .btn-jump {
     color: white;
-    background-color: #35c853;
+    background-color: #999999;
     padding: 5px 10px;
+    transition: background-color 0.1s ease-in-out;
     span.fa { margin-left: 10px; }
     &:hover,
     &:focus {


### PR DESCRIPTION
-  Jump button is now gray by default and green on hover/focus/active

![jump](https://cloud.githubusercontent.com/assets/5335210/16890198/2e9bc060-4aa1-11e6-92e7-0c23ff80b043.gif)
