### PR TITLE
highlights Search tab when in usage state

### DIFF
--- a/cdap-ui/app/features/tracker/routes.js
+++ b/cdap-ui/app/features/tracker/routes.js
@@ -281,7 +281,7 @@ angular.module(PKG.name + '.feature.tracker')
             controllerAs: 'UsageController',
             data: {
               authorizedRoles: MYAUTH_ROLE.all,
-              highlightTab: 'usage'
+              highlightTab: 'search'
             }
           })
           .state('tracker.detail.entity.preview', {


### PR DESCRIPTION
-  Search tab now correctly highlighted when in tracker.usage state

![tab](https://cloud.githubusercontent.com/assets/5335210/16890340/51fe8d66-4aa2-11e6-9c42-1778791b62af.gif)
.5
