### PR TITLE
CDAP-5029 Changes to show logs on UI on mapreduce failure

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandler.java
@@ -344,9 +344,10 @@ public class LogHandler extends AbstractHttpHandler {
   }
 
   private static TimeRange parseTime(long fromTimeSecsParam, long toTimeSecsParam, HttpResponder responder) {
+    long currentTimeMillis = System.currentTimeMillis();
     long fromMillis = fromTimeSecsParam < 0 ?
-      System.currentTimeMillis() - TimeUnit.HOURS.toMillis(1) : TimeUnit.SECONDS.toMillis(fromTimeSecsParam);
-    long toMillis = toTimeSecsParam < 0 ? System.currentTimeMillis() : TimeUnit.SECONDS.toMillis(toTimeSecsParam);
+      currentTimeMillis - TimeUnit.HOURS.toMillis(1) : TimeUnit.SECONDS.toMillis(fromTimeSecsParam);
+    long toMillis = toTimeSecsParam < 0 ? currentTimeMillis : TimeUnit.SECONDS.toMillis(toTimeSecsParam);
 
     if (toMillis <= fromMillis) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, "Invalid time range. " +

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/AvroFileWriter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/AvroFileWriter.java
@@ -282,6 +282,7 @@ public final class AvroFileWriter implements Closeable, Flushable {
         }
       }
 
+      LOG.trace("Closing file {}", location);
       isOpen = false;
     }
   }


### PR DESCRIPTION
(Cherry-pick from 3.4, and removed FileContextLocation.java
and Locations.java, as they are not required for release 3.3)

Cherry-picked from https://github.com/caskdata/cdap/pull/5468

JIRA - https://issues.cask.co/browse/CDAP-5029
Build - http://builds.cask.co/browse/CDAP-DUT4405-1
