### PR TITLE
[CDAP-6358] Added support for non-string property macros

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginContext.java
@@ -53,6 +53,17 @@ public interface PluginContext {
    * {@link PluginConfigurer#usePlugin(String, String, String, PluginProperties)} was called during the
    * program configuration time.
    *
+   * All plugin properties that are macro-enabled and were configured with macro syntax present will be substituted
+   * with Java's default values based on the property's type at configuration time. The default values are:
+   *  - boolean: false
+   *  - byte: 0
+   *  - double: 0.0d
+   *  - float: 0.0f
+   *  - int: 0
+   *  - long: 0L
+   *  - short: 0
+   *  - String: null
+   *
    * @param pluginId the unique identifier provide when declaring plugin usage in the program.
    * @param <T> the class type of the plugin
    * @return A new instance of the plugin being specified by the arguments

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/MacroParser.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/MacroParser.java
@@ -40,11 +40,16 @@ public class MacroParser {
 
   /**
    * Substitutes the provided string with a given macro evaluator. Expands macros from right-to-left recursively.
+   * If the string passed to parse is null, then null will be returned.
    * @param str the raw string containing macro syntax
    * @return the original string with all macros expanded and substituted
    * @throws InvalidMacroException
    */
-  public String parse(String str) throws InvalidMacroException {
+  @Nullable
+  public String parse(@Nullable String str) throws InvalidMacroException {
+    if (str == null) {
+      return null;
+    }
     // final string should have escapes that are not directly embedded in macro syntax replaced
     return replaceEscapedSyntax(parse(str, 0));
   }
@@ -64,6 +69,10 @@ public class MacroParser {
 
     MacroMetadata macroPosition = findRightmostMacro(str);
     while (macroPosition != null) {
+      // in the case that the MacroEvaluator does not internally handle unspecified macros
+      if (macroPosition.substitution == null) {
+        throw new InvalidMacroException(String.format("Unable to substitute macro in string %s.", str));
+      }
       str = str.substring(0, macroPosition.startIndex) +
             parse(macroPosition.substitution, depth + 1) +
             str.substring(macroPosition.endIndex + 1);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/TrackingMacroEvaluator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/TrackingMacroEvaluator.java
@@ -25,7 +25,6 @@ import co.cask.cdap.api.macro.MacroEvaluator;
  * track of whether or not a macro was found when the parser
  */
 public class TrackingMacroEvaluator implements MacroEvaluator {
-
   private boolean foundMacro;
 
   public TrackingMacroEvaluator() {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/plugins/test/TestPlugin.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/plugins/test/TestPlugin.java
@@ -20,12 +20,13 @@ import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.plugin.PluginConfig;
+import com.google.common.base.Joiner;
 
 import java.util.concurrent.Callable;
 import javax.annotation.Nullable;
 
 /**
- * Plugin class for testing instantiation with field injection.
+ * Plugin class for testing instantiation with field injection and macro substitution of primitive types and strings.
  */
 @Plugin
 @Name("TestPlugin")
@@ -35,8 +36,9 @@ public class TestPlugin implements Callable<String> {
 
   @Override
   public String call() throws Exception {
-    if (config.timeout % 2 == 0) {
-      return config.name;
+    if (config.nullableLongFlag != null && config.nullableLongFlag % 2 == 0) {
+        return config.host + "," + Joiner.on(',').join(config.aBoolean, config.aByte, config.aDouble, config.aFloat,
+                                   config.anInt, config.aLong, config.aShort);
     }
     return null;
   }
@@ -44,9 +46,31 @@ public class TestPlugin implements Callable<String> {
   public static final class Config extends PluginConfig {
 
     @Macro
-    private String name;
+    private String host;
 
     @Nullable
-    private Long timeout;
+    private Long nullableLongFlag;
+
+    @Macro
+    private boolean aBoolean;
+
+    @Macro
+    private byte aByte;
+
+    @Macro
+    private double aDouble;
+
+    @Macro
+    private float aFloat;
+
+    @Macro
+    @Nullable
+    private int anInt;
+
+    @Macro
+    private long aLong;
+
+    @Macro
+    private short aShort;
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
@@ -297,11 +297,18 @@ public class ArtifactRepositoryTest {
         for (PluginClass pluginClass : entry.getValue()) {
           Plugin pluginInfo = new Plugin(entry.getKey().getArtifactId(), pluginClass,
                                          PluginProperties.builder().add("class.name", TEST_EMPTY_CLASS)
-                                           .add("timeout", "10")
-                                           .add("name", "${macro}")
+                                           .add("nullableLongFlag", "10")
+                                           .add("host", "${expansiveHostname}")
+                                           .add("aBoolean", "${aBoolean}")
+                                           .add("aByte", "${aByte}")
+                                           .add("aDouble", "${aDouble}")
+                                           .add("anInt", "${anInt}")
+                                           .add("aFloat", "${aFloat}")
+                                           .add("aLong", "${aLong}")
+                                           .add("aShort", "${aShort}")
                                            .build());
           Callable<String> plugin = instantiator.newInstance(pluginInfo);
-          Assert.assertEquals("${macro}", plugin.call());
+          Assert.assertEquals("null,false,0,0.0,0.0,0,0,0", plugin.call());
         }
       }
     }
@@ -315,7 +322,33 @@ public class ArtifactRepositoryTest {
 
     // set up test macro evaluator's substitutions
     Map<String, String> propertySubstitutions = ImmutableMap.<String, String>builder()
-      .put("macro", "expandedProperty")
+      .put("expansiveHostname", "${hostname}/${path}:${port}")
+      .put("hostname", "${one}")
+      .put("path", "${two}")
+      .put("port", "${three}")
+      .put("one", "${host${hostScopeMacro}}")
+      .put("hostScopeMacro", "-local")
+      .put("host-local", "${l}${o}${c}${a}${l}${hostSuffix}")
+      .put("l", "l")
+      .put("o", "o")
+      .put("c", "c")
+      .put("a", "a")
+      .put("hostSuffix", "host")
+      .put("two", "${filename${fileTypeMacro}}")
+      .put("three", "${firstPortDigit}${secondPortDigit}")
+      .put("filename", "index")
+      .put("fileTypeMacro", "-html")
+      .put("filename-html", "index.html")
+      .put("filename-php", "index.php")
+      .put("firstPortDigit", "8")
+      .put("secondPortDigit", "0")
+      .put("aBoolean", "true")
+      .put("aByte", "101")
+      .put("aDouble", "64.0")
+      .put("aFloat", "52.0")
+      .put("anInt", "42")
+      .put("aLong", "32")
+      .put("aShort", "81")
       .build();
 
     // Instantiate the plugins and execute them
@@ -324,14 +357,21 @@ public class ArtifactRepositoryTest {
         for (PluginClass pluginClass : entry.getValue()) {
           Plugin pluginInfo = new Plugin(entry.getKey().getArtifactId(), pluginClass,
                                          PluginProperties.builder().add("class.name", TEST_EMPTY_CLASS)
-                                           .add("timeout", "10")
-                                           .add("name", "${macro}")
+                                           .add("nullableLongFlag", "10")
+                                           .add("host", "${expansiveHostname}")
+                                           .add("aBoolean", "${aBoolean}")
+                                           .add("aByte", "${aByte}")
+                                           .add("aDouble", "${aDouble}")
+                                           .add("anInt", "${anInt}")
+                                           .add("aFloat", "${aFloat}")
+                                           .add("aLong", "${aLong}")
+                                           .add("aShort", "${aShort}")
                                            .build());
 
           TestMacroEvaluator testMacroEvaluator = new TestMacroEvaluator(propertySubstitutions,
                                                                          new HashMap<String, String>());
           Callable<String> plugin = instantiator.newInstance(pluginInfo, testMacroEvaluator);
-          Assert.assertEquals("expandedProperty", plugin.call());
+          Assert.assertEquals("localhost/index.html:80,true,101,64.0,52.0,42,32,81", plugin.call());
         }
       }
     }


### PR DESCRIPTION
Adding support to allow non-string properties to be macro enabled. Currently, the "char" type was omitted on account of this issue: https://issues.cask.co/browse/CDAP-6524
