### PR TITLE
CDAP-6507 fix hydrator phase splitting bug

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/ConnectorDag.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/ConnectorDag.java
@@ -221,17 +221,25 @@ public class ConnectorDag extends Dag {
   }
 
   /**
-   * Split this dag into multiple dags. Each connector is used as a split point where it is a sink of one dag and the
-   * source of another dag.
+   * Split this dag into multiple dags. Each subdag will contain at most a single reduce node.
    *
-   * @return list of dags split on connectors.
+   * @return list of subdags.
    */
-  public List<Dag> splitOnConnectors() {
+  public List<Dag> split() {
     List<Dag> dags = new ArrayList<>();
-    dags.add(subsetFrom(sources, connectors));
-    for (String connector : connectors) {
-      dags.add(subsetFrom(connector, connectors));
+
+    Set<String> remainingNodes = new HashSet<>();
+    remainingNodes.addAll(nodes);
+    Set<String> possibleNewSources = Sets.union(sources, connectors);
+    Set<String> possibleNewSinks = Sets.union(sinks, connectors);
+    for (String reduceNode : reduceNodes) {
+      Dag subdag = subsetAround(reduceNode, possibleNewSources, possibleNewSinks);
+      remainingNodes.removeAll(subdag.getNodes());
+      dags.add(subdag);
     }
+
+    Set<String> remainingSources = Sets.intersection(remainingNodes, possibleNewSources);
+    dags.add(subsetFrom(remainingSources, possibleNewSinks));
     return dags;
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/ConnectorDag.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/ConnectorDag.java
@@ -239,7 +239,9 @@ public class ConnectorDag extends Dag {
     }
 
     Set<String> remainingSources = Sets.intersection(remainingNodes, possibleNewSources);
-    dags.add(subsetFrom(remainingSources, possibleNewSinks));
+    if (!remainingSources.isEmpty()) {
+      dags.add(subsetFrom(remainingSources, possibleNewSinks));
+    }
     return dags;
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/PipelinePlanner.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/PipelinePlanner.java
@@ -132,7 +132,7 @@ public class PipelinePlanner {
     // now split the logical pipeline into pipeline phases, using the connectors as split points
     Map<String, Dag> subdags = new HashMap<>();
     // assign some name to each subdag
-    for (Dag subdag : cdag.splitOnConnectors()) {
+    for (Dag subdag : cdag.split()) {
       String name = getPhaseName(subdag.getSources(), subdag.getSinks());
       subdags.put(name, subdag);
     }


### PR DESCRIPTION
Fixed bugs with phase splitting introduced when we added support
for multiple inputs. After that change, the previous algorithm
of splitting the dag on connector nodes could result in subdags
that contained multiple reduce nodes.

Changed the algorithm to ensure that each subdag contains at most
a single reduce node.
