### PR TITLE
adds conditional truth meter info icon

### DIFF
--- a/cdap-ui/app/features/tracker/directives/truth-meter/truth-meter.html
+++ b/cdap-ui/app/features/tracker/directives/truth-meter/truth-meter.html
@@ -20,4 +20,10 @@
       ng-style="{'left': ((TruthMeter.width * -1) + (TruthMeter.score * (TruthMeter.width / 100))) + 'px'}">
     <span ng-bind="TruthMeter.score"></span>
   </div>
+  <span ng-if="TruthMeter.showInfoIcon === true"
+        class="fa fa-info-circle"
+        uib-tooltip="This score indicates how active a dataset is in this namespace. It is calculated based on the relative number and frequency of dataset accesses."
+        tooltip-placement="right"
+        tooltip-append-to-body="true"
+        tooltip-class="tracker-tooltip"></span>
 </div>

--- a/cdap-ui/app/features/tracker/directives/truth-meter/truth-meter.js
+++ b/cdap-ui/app/features/tracker/directives/truth-meter/truth-meter.js
@@ -21,11 +21,13 @@ angular.module(PKG.name + '.feature.tracker')
       restrict: 'E',
       scope: {
         score: '=',
-        width: '@'
+        width: '@',
+        showInfoIcon: '='
       },
       templateUrl: '/assets/features/tracker/directives/truth-meter/truth-meter.html',
       controller: function() {
         this.score = this.score || 0;
+        this.showInfoIcon = this.showInfoIcon || false;
       },
       bindToController: true,
       controllerAs: 'TruthMeter'

--- a/cdap-ui/app/features/tracker/directives/truth-meter/truth-meter.less
+++ b/cdap-ui/app/features/tracker/directives/truth-meter/truth-meter.less
@@ -39,13 +39,19 @@ my-truth-meter {
       display: block;
       position: absolute;
     }
+    span {
+      display: block;
+      font-weight: 600;
+      position: absolute;
+      left: -5px;
+      text-align: center;
+    }
   }
-  span {
-    display: block;
-    font-weight: 600;
-    position: absolute;
-    left: -5px;
-    text-align: center;
+  span.fa-info-circle {
+    color: #999999;
+    font-size: 14px;
+    margin-left: 8px;
+    vertical-align: top;
   }
 }
 
@@ -68,11 +74,11 @@ body.state-tracker-detail-result {
         height: 7px;
         width: 7px;
       }
-    }
-    span {
-      font-size: 12px;
-      bottom: -15px;
-      width: 25px;
+      span {
+        font-size: 12px;
+        bottom: -15px;
+        width: 25px;
+      }
     }
   }
 }
@@ -96,11 +102,11 @@ body.state-tracker-detail-entity {
         height: 4px;
         width: 4px;
       }
-    }
-    span {
-      font-size: 11px;
-      bottom: -12px;
-      width: 20px;
+      span {
+        font-size: 11px;
+        bottom: -12px;
+        width: 20px;
+      }
     }
   }
 }

--- a/cdap-ui/app/features/tracker/directives/truth-meter/truth-meter.less
+++ b/cdap-ui/app/features/tracker/directives/truth-meter/truth-meter.less
@@ -51,7 +51,6 @@ my-truth-meter {
     color: #999999;
     font-size: 14px;
     margin-left: 8px;
-    vertical-align: top;
   }
 }
 

--- a/cdap-ui/app/features/tracker/templates/entity.html
+++ b/cdap-ui/app/features/tracker/templates/entity.html
@@ -39,6 +39,7 @@
 
   <div class="truth-meter-container">
     <my-truth-meter score="EntityController.truthMeterMap[$state.params.entityType][$state.params.entityId]"
+                    show-info-icon="true"
                     width="125"></my-truth-meter>
   </div>
 

--- a/cdap-ui/app/features/tracker/tracker.less
+++ b/cdap-ui/app/features/tracker/tracker.less
@@ -68,6 +68,9 @@ body[class*='state-tracker'] {
       &.top {
         .tooltip-arrow { border-top-color: black; }
       }
+      &.right {
+        .tooltip-arrow { border-right-color: black; }
+      }
     }
   }
 
@@ -501,7 +504,7 @@ body.state-tracker-detail-entity {
     border-left: 1px solid @table-border-color;
     display: table-cell;
     height: 100%;
-    width: 150px;
+    width: 165px;
     padding-left: 10px;
     vertical-align: middle;
   }


### PR DESCRIPTION
-  Adds conditional display of Tracker Meter info icon (currently used only in the Tracker entity detail views)

![info](https://cloud.githubusercontent.com/assets/5335210/16897360/ac0f8848-4b63-11e6-8f8a-96868a1e94e4.gif)
