### PR TITLE
(CDAP-6516) Added a filter method to AuthorizationEnforcer, that can …

### DIFF
--- a/cdap-client/src/main/java/co/cask/cdap/client/AuthorizationClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/AuthorizationClient.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Collections;
 import java.util.Set;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -80,8 +81,18 @@ public class AuthorizationClient extends AbstractAuthorizer {
 
   @Override
   public void enforce(EntityId entity, Principal principal, Action action) throws Exception {
+    enforce(entity, principal, Collections.singleton(action));
+  }
+
+  @Override
+  public void enforce(EntityId entity, Principal principal, Set<Action> actions) throws Exception {
     throw new UnsupportedOperationException("Enforcement is not supported via Java Client. Please instead use the " +
                                               "listPrivileges method to view the privileges for a principal.");
+  }
+
+  @Override
+  public <T extends EntityId> Set<T> filter(Set<T> unfiltered, Principal principal) throws Exception {
+    throw new UnsupportedOperationException("Filtering is not supported via Java Client.");
   }
 
   @Override

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/AuthorizationEnforcer.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/AuthorizationEnforcer.java
@@ -21,6 +21,8 @@ import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 
+import java.util.Set;
+
 /**
  * Enforces authorization for a {@link Principal} to perform an {@link Action} on an {@link EntityId}.
  */
@@ -32,10 +34,31 @@ public interface AuthorizationEnforcer {
    * {@link EntityId}.
    *
    * @param entity the {@link EntityId} on which authorization is to be enforced
-   * @param principal the {@link Principal} that performs the actions
+   * @param principal the {@link Principal} that performs the action
    * @param action the {@link Action} being performed
-   * @throws UnauthorizedException if the principal is not authorized to perform action on the entity
+   * @throws UnauthorizedException if the principal is not authorized to perform the specified action on the entity
    * @throws Exception if any other errors occurred while performing the authorization enforcement check
    */
   void enforce(EntityId entity, Principal principal, Action action) throws Exception;
+
+  /**
+   * Enforces authorization for the specified {@link Principal} for the specified {@link Action actions} on the
+   * specified {@link EntityId}.
+   *
+   * @param entity the {@link EntityId} on which authorization is to be enforced
+   * @param principal the {@link Principal} that performs the actions
+   * @param actions the {@link Action actions} being performed
+   * @throws UnauthorizedException if the principal is not authorized to perform the specified actions on the entity
+   * @throws Exception if any other errors occurred while performing the authorization enforcement check
+   */
+  void enforce(EntityId entity, Principal principal, Set<Action> actions) throws Exception;
+
+  /**
+   * Filters the specified set of entities to only return the ones that the user has access (READ/WRITE/ADMIN/ALL).
+   *
+   * @param unfiltered the set of {@link EntityId entities} to filter
+   * @param principal the {@link Principal} for which to filter
+   * @return a set of {@link EntityId entities} that the specified user has access to
+   */
+  <T extends EntityId> Set<T> filter(Set<T> unfiltered, Principal principal) throws Exception;
 }

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/NoOpAuthorizer.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/NoOpAuthorizer.java
@@ -31,8 +31,18 @@ import java.util.Set;
 public class NoOpAuthorizer extends AbstractAuthorizer {
 
   @Override
-  public void enforce(EntityId entity, Principal principal, Action action) throws UnauthorizedException {
+  public void enforce(EntityId entity, Principal principal, Action action) throws Exception {
     // no-op
+  }
+
+  @Override
+  public void enforce(EntityId entity, Principal principal, Set<Action> actions) throws Exception {
+    // no-op
+  }
+
+  @Override
+  public <T extends EntityId> Set<T> filter(Set<T> unfiltered, Principal principal) throws Exception {
+    return unfiltered;
   }
 
   @Override

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/UnauthorizedException.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/UnauthorizedException.java
@@ -22,6 +22,7 @@ import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 
 import java.net.HttpURLConnection;
+import java.util.Set;
 
 /**
  * Exception thrown when Authentication is successful, but a {@link Principal} is not authorized to perform an
@@ -32,6 +33,11 @@ public class UnauthorizedException extends Exception implements HttpErrorStatusP
   public UnauthorizedException(Principal principal, Action action, EntityId entityId) {
     super(String.format("Principal '%s' is not authorized to perform action '%s' on entity '%s'",
                         principal, action, entityId));
+  }
+
+  public UnauthorizedException(Principal principal, Set<Action> actions, EntityId entityId) {
+    super(String.format("Principal '%s' is not authorized to perform actions '%s' on entity '%s'",
+                        principal, actions, entityId));
   }
 
   public UnauthorizedException(String message) {

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizerInstantiatorTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizerInstantiatorTest.java
@@ -31,7 +31,6 @@ import co.cask.cdap.security.spi.authorization.Authorizer;
 import co.cask.cdap.security.spi.authorization.NoOpAuthorizer;
 import co.cask.cdap.security.spi.authorization.RoleAlreadyExistsException;
 import co.cask.cdap.security.spi.authorization.RoleNotFoundException;
-import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
@@ -294,8 +293,18 @@ public class AuthorizerInstantiatorTest extends AuthorizationTestBase {
     }
 
     @Override
-    public void enforce(EntityId entity, Principal principal, Action action) throws UnauthorizedException {
+    public void enforce(EntityId entity, Principal principal, Action action) throws Exception {
       // no-op
+    }
+
+    @Override
+    public void enforce(EntityId entity, Principal principal, Set<Action> actions) throws Exception {
+      // no-op
+    }
+
+    @Override
+    public <T extends EntityId> Set<T> filter(Set<T> unfiltered, Principal principal) throws Exception {
+      return unfiltered;
     }
   }
 


### PR DESCRIPTION
…be used in any list/get API. This method filters the input set of entities to only return the ones that the user has access to. Also added a method to enforce multiple actions on the same entity.

Jira: [CDAP-6516](https://issues.cask.co/browse/CDAP-6516)
Build: http://builds.cask.co/browse/CDAP-DUT4416
