### PR TITLE
Scaling RemoteSystemOperation handlers using DatasetOpExecutorTwillRunnable

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -36,6 +36,7 @@ import co.cask.cdap.data.stream.service.StreamFetchHandler;
 import co.cask.cdap.data.stream.service.StreamHandler;
 import co.cask.cdap.data2.datafabric.dataset.DatasetExecutorServiceManager;
 import co.cask.cdap.data2.datafabric.dataset.MetadataServiceManager;
+import co.cask.cdap.data2.datafabric.dataset.RemoteSystemOperationServiceManager;
 import co.cask.cdap.explore.service.ExploreServiceManager;
 import co.cask.cdap.gateway.handlers.AppFabricDataHttpHandler;
 import co.cask.cdap.gateway.handlers.AppLifecycleHttpHandler;
@@ -56,10 +57,6 @@ import co.cask.cdap.gateway.handlers.UsageHandler;
 import co.cask.cdap.gateway.handlers.VersionHandler;
 import co.cask.cdap.gateway.handlers.WorkflowHttpHandler;
 import co.cask.cdap.gateway.handlers.WorkflowStatsSLAHttpHandler;
-import co.cask.cdap.gateway.handlers.meta.RemoteLineageWriterHandler;
-import co.cask.cdap.gateway.handlers.meta.RemotePrivilegeFetcherHandler;
-import co.cask.cdap.gateway.handlers.meta.RemoteRuntimeStoreHandler;
-import co.cask.cdap.gateway.handlers.meta.RemoteUsageRegistryHandler;
 import co.cask.cdap.internal.app.deploy.LocalApplicationManager;
 import co.cask.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
 import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
@@ -258,6 +255,8 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                         .to(DatasetExecutorServiceManager.class);
                                mapBinder.addBinding(Constants.Service.METADATA_SERVICE)
                                         .to(MetadataServiceManager.class);
+                               mapBinder.addBinding(Constants.Service.REMOTE_SYSTEM_OPERATION)
+                                        .to(RemoteSystemOperationServiceManager.class);
                                mapBinder.addBinding(Constants.Service.EXPLORE_HTTP_USER_SERVICE)
                                         .to(ExploreServiceManager.class);
 
@@ -329,11 +328,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       handlerBinder.addBinding().to(ArtifactHttpHandler.class);
       handlerBinder.addBinding().to(WorkflowStatsSLAHttpHandler.class);
       handlerBinder.addBinding().to(AuthorizationHandler.class);
-      handlerBinder.addBinding().to(RemoteRuntimeStoreHandler.class);
       handlerBinder.addBinding().to(SecureStoreHandler.class);
-      handlerBinder.addBinding().to(RemoteLineageWriterHandler.class);
-      handlerBinder.addBinding().to(RemoteUsageRegistryHandler.class);
-      handlerBinder.addBinding().to(RemotePrivilegeFetcherHandler.class);
 
       for (Class<? extends HttpHandler> handlerClass : handlerClasses) {
         handlerBinder.addBinding().to(handlerClass);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteSystemOperationsService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteSystemOperationsService.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.handlers.meta;
+
+import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.discovery.ResolvingDiscoverable;
+import co.cask.cdap.common.http.CommonNettyHttpServiceBuilder;
+import co.cask.cdap.common.logging.LoggingContextAccessor;
+import co.cask.cdap.common.logging.ServiceLoggingContext;
+import co.cask.cdap.common.metrics.MetricsReporterHook;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.http.HttpHandler;
+import co.cask.http.NettyHttpService;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import org.apache.twill.common.Cancellable;
+import org.apache.twill.discovery.Discoverable;
+import org.apache.twill.discovery.DiscoveryService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.util.Set;
+
+/**
+ * Provides REST endpoints to execute System Operations such as writing to Store, Lineage etc remotely.
+ */
+public class RemoteSystemOperationsService extends AbstractIdleService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RemoteSystemOperationsService.class);
+
+  private final DiscoveryService discoveryService;
+  private final NettyHttpService httpService;
+  private Cancellable cancellable;
+
+  @Inject
+  RemoteSystemOperationsService(CConfiguration cConf, DiscoveryService discoveryService,
+                                       MetricsCollectionService metricsCollectionService,
+                                       @Named(Constants.RemoteSystemOpService.HANDLERS_NAME)
+                                       Set<HttpHandler> handlers) {
+    this.discoveryService = discoveryService;
+
+    int workerThreads = cConf.getInt(Constants.RemoteSystemOpService.WORKER_THREADS);
+    int execThreads = cConf.getInt(Constants.RemoteSystemOpService.EXEC_THREADS);
+
+    this.httpService = new CommonNettyHttpServiceBuilder(cConf)
+      .addHttpHandlers(handlers)
+      .setHost(cConf.get(Constants.RemoteSystemOpService.SERVICE_BIND_ADDRESS))
+      .setHandlerHooks(ImmutableList.of(
+        new MetricsReporterHook(metricsCollectionService, Constants.Service.REMOTE_SYSTEM_OPERATION)))
+      .setWorkerThreadPoolSize(workerThreads)
+      .setExecThreadPoolSize(execThreads)
+      .setConnectionBacklog(20000)
+      .build();
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(NamespaceId.SYSTEM.getNamespace(),
+                                                                       Constants.Logging.COMPONENT_NAME,
+                                                                       Constants.Service.REMOTE_SYSTEM_OPERATION));
+    LOG.info("Starting RemoteSystemOperationService...");
+
+    httpService.startAndWait();
+    cancellable = discoveryService.register(ResolvingDiscoverable.of(new Discoverable() {
+      @Override
+      public String getName() {
+        return Constants.Service.REMOTE_SYSTEM_OPERATION;
+      }
+
+      @Override
+      public InetSocketAddress getSocketAddress() {
+        return httpService.getBindAddress();
+      }
+    }));
+
+    LOG.info("RemoteSystemOperationService started successfully on {}", httpService.getBindAddress());
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    LOG.info("Stopping RemoteSystemOperationService...");
+
+    try {
+      if (cancellable != null) {
+        cancellable.cancel();
+      }
+    } finally {
+      httpService.stopAndWait();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+      .add("bindAddress", httpService.getBindAddress())
+      .toString();
+  }
+
+  public NettyHttpService getHttpService() {
+    return httpService;
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteSystemOperationsServiceModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteSystemOperationsServiceModule.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.handlers.meta;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.gateway.handlers.CommonHandlers;
+import co.cask.http.HttpHandler;
+import com.google.inject.Key;
+import com.google.inject.PrivateModule;
+import com.google.inject.TypeLiteral;
+import com.google.inject.multibindings.Multibinder;
+import com.google.inject.name.Names;
+
+import java.util.Set;
+
+/**
+ * Guice module for {@link RemoteSystemOperationsService}
+ */
+public class RemoteSystemOperationsServiceModule extends PrivateModule {
+
+  @Override
+  protected void configure() {
+    Multibinder<HttpHandler> handlerBinder = Multibinder.newSetBinder(
+      binder(), HttpHandler.class, Names.named(Constants.RemoteSystemOpService.HANDLERS_NAME));
+
+    CommonHandlers.add(handlerBinder);
+    handlerBinder.addBinding().to(RemoteLineageWriterHandler.class);
+    handlerBinder.addBinding().to(RemotePrivilegeFetcherHandler.class);
+    handlerBinder.addBinding().to(RemoteRuntimeStoreHandler.class);
+    handlerBinder.addBinding().to(RemoteUsageRegistryHandler.class);
+    expose(Key.get(new TypeLiteral<Set<HttpHandler>>() { },
+                   Names.named(Constants.RemoteSystemOpService.HANDLERS_NAME)));
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteOpsClient.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteOpsClient.java
@@ -70,7 +70,7 @@ class RemoteOpsClient {
     this.endpointStrategySupplier = Suppliers.memoize(new Supplier<EndpointStrategy>() {
       @Override
       public EndpointStrategy get() {
-        return new RandomEndpointStrategy(discoveryClient.discover(Constants.Service.APP_FABRIC_HTTP));
+        return new RandomEndpointStrategy(discoveryClient.discover(Constants.Service.REMOTE_SYSTEM_OPERATION));
       }
     });
 
@@ -87,7 +87,7 @@ class RemoteOpsClient {
     Discoverable discoverable = endpointStrategySupplier.get().pick(3L, TimeUnit.SECONDS);
     if (discoverable == null) {
       throw new RuntimeException(
-        String.format("Cannot discover service %s", Constants.Service.APP_FABRIC_HTTP));
+        String.format("Cannot discover service %s", Constants.Service.REMOTE_SYSTEM_OPERATION));
     }
     InetSocketAddress addr = discoverable.getSocketAddress();
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -36,6 +36,7 @@ import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.data.stream.service.StreamService;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
+import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsService;
 import co.cask.cdap.internal.app.services.AppFabricServer;
 import co.cask.cdap.internal.guice.AppFabricTestModule;
 import co.cask.cdap.internal.test.AppJarHelper;
@@ -143,6 +144,7 @@ public abstract class AppFabricTestBase {
   private static MetricsQueryService metricsService;
   private static MetricsCollectionService metricsCollectionService;
   private static DatasetOpExecutor dsOpService;
+  private static RemoteSystemOperationsService remoteSysOpService;
   private static DatasetService datasetService;
   private static TransactionSystemClient txClient;
   private static StreamService streamService;
@@ -172,6 +174,8 @@ public abstract class AppFabricTestBase {
     txManager.startAndWait();
     dsOpService = injector.getInstance(DatasetOpExecutor.class);
     dsOpService.startAndWait();
+    remoteSysOpService = injector.getInstance(RemoteSystemOperationsService.class);
+    remoteSysOpService.startAndWait();
     datasetService = injector.getInstance(DatasetService.class);
     datasetService.startAndWait();
     appFabricServer = injector.getInstance(AppFabricServer.class);
@@ -206,6 +210,7 @@ public abstract class AppFabricTestBase {
     metricsCollectionService.stopAndWait();
     metricsService.stopAndWait();
     datasetService.stopAndWait();
+    remoteSysOpService.stopAndWait();
     dsOpService.stopAndWait();
     txManager.stopAndWait();
     serviceStore.stopAndWait();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemoteLineageWriterTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemoteLineageWriterTest.java
@@ -14,14 +14,13 @@
  * the License.
  */
 
-package co.cask.cdap.internal.app.store;
+package co.cask.cdap.internal.app.store.remote;
 
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.data2.metadata.lineage.LineageStore;
 import co.cask.cdap.data2.metadata.lineage.Relation;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
-import co.cask.cdap.internal.app.store.remote.RemoteLineageWriter;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemotePrivilegesFetcherTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemotePrivilegesFetcherTest.java
@@ -14,13 +14,13 @@
  * the License.
  */
 
-package co.cask.cdap.internal.app.store;
+package co.cask.cdap.internal.app.store.remote;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
+import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsService;
 import co.cask.cdap.internal.app.services.AppFabricServer;
-import co.cask.cdap.internal.app.store.remote.RemotePrivilegesFetcher;
 import co.cask.cdap.internal.guice.AppFabricTestModule;
 import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.proto.ProgramType;
@@ -62,6 +62,7 @@ public class RemotePrivilegesFetcherTest {
   private static PrivilegesFetcher privilegesFetcher;
   private static TransactionManager txManager;
   private static DatasetService datasetService;
+  private static RemoteSystemOperationsService remoteSysOpService;
   private static AppFabricServer appFabricServer;
 
   @BeforeClass
@@ -79,6 +80,8 @@ public class RemotePrivilegesFetcherTest {
     txManager.startAndWait();
     datasetService = injector.getInstance(DatasetService.class);
     datasetService.startAndWait();
+    remoteSysOpService = injector.getInstance(RemoteSystemOperationsService.class);
+    remoteSysOpService.startAndWait();
     appFabricServer = injector.getInstance(AppFabricServer.class);
     appFabricServer.startAndWait();
     authorizerInstantiator = injector.getInstance(AuthorizerInstantiator.class);
@@ -106,6 +109,7 @@ public class RemotePrivilegesFetcherTest {
   @AfterClass
   public static void tearDown() {
     appFabricServer.stopAndWait();
+    remoteSysOpService.stopAndWait();
     datasetService.stopAndWait();
     txManager.stopAndWait();
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeStoreTest.java
@@ -14,13 +14,14 @@
  * the License.
  */
 
-package co.cask.cdap.internal.app.store;
+package co.cask.cdap.internal.app.store.remote;
 
 import co.cask.cdap.api.workflow.NodeStatus;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
-import co.cask.cdap.internal.app.store.remote.RemoteRuntimeStore;
+import co.cask.cdap.internal.app.store.DefaultStore;
+import co.cask.cdap.internal.app.store.RunRecordMeta;
 import co.cask.cdap.proto.BasicThrowable;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeUsageRegistryTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeUsageRegistryTest.java
@@ -14,22 +14,17 @@
  * the License.
  */
 
-package co.cask.cdap.internal.app.store;
+package co.cask.cdap.internal.app.store.remote;
 
 import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
-import co.cask.cdap.internal.app.store.remote.RemoteRuntimeStore;
-import co.cask.cdap.internal.app.store.remote.RemoteRuntimeUsageRegistry;
 import co.cask.cdap.proto.Id;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.inject.Injector;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.util.Set;
 
 /**
  * Tests implementation of {@link RemoteRuntimeUsageRegistry}, by using it to perform writes/updates, and then using a

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
@@ -37,6 +37,7 @@ import co.cask.cdap.data.stream.StreamAdminModules;
 import co.cask.cdap.data.stream.service.StreamServiceRuntimeModule;
 import co.cask.cdap.data.view.ViewAdminModules;
 import co.cask.cdap.explore.guice.ExploreClientModule;
+import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsServiceModule;
 import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerException;
 import co.cask.cdap.internal.app.store.remote.RemotePrivilegesFetcher;
@@ -115,6 +116,7 @@ public final class AppFabricTestModule extends AbstractModule {
     install(new StreamServiceRuntimeModule().getInMemoryModules());
     install(new NamespaceStoreModule().getStandaloneModules());
     install(new MetadataServiceModule());
+    install(new RemoteSystemOperationsServiceModule());
     install(new AuthorizationModule());
     install(new SecureStoreModules().getInMemoryModules());
     install(new AbstractModule() {

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -76,6 +76,7 @@ public final class Constants {
     public static final String METRICS_PROCESSOR = "metrics.processor";
     public static final String DATASET_MANAGER = "dataset.service";
     public static final String DATASET_EXECUTOR = "dataset.executor";
+    public static final String REMOTE_SYSTEM_OPERATION = "remote.system.operation";
     public static final String EXTERNAL_AUTHENTICATION = "external.authentication";
     public static final String EXPLORE_HTTP_USER_SERVICE = "explore.service";
     public static final String SERVICE_INSTANCE_TABLE_NAME = "cdap.services.instances";
@@ -963,6 +964,17 @@ public final class Constants {
     public static final String UPDATES_PUBLISH_ENABLED = "metadata.updates.publish.enabled";
     public static final String UPDATES_KAFKA_BROKER_LIST = "metadata.updates.kafka.broker.list";
     public static final String MAX_CHARS_ALLOWED = "metadata.max.allowed.chars";
+  }
+
+  /**
+   * Constants for Remote System Operation Service.
+   */
+  public static final class RemoteSystemOpService {
+    public static final String EXEC_THREADS = "remote.system.op.exec.threads";
+    public static final String WORKER_THREADS = "remote.system.op.worker.threads";
+    public static final String SERVICE_DESCRIPTION = "Service to perform system operations through HTTP requests.";
+    public static final String SERVICE_BIND_ADDRESS = "remote.system.op.service.bind.address";
+    public static final String HANDLERS_NAME = "remote.system.op.handlers";
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1084,6 +1084,32 @@
     </description>
   </property>
 
+  <!-- Remote System Operation Service Configuration -->
+
+  <property>
+    <name>remote.system.op.exec.threads</name>
+    <value>${http.service.exec.threads}</value>
+    <description>
+      Number of Netty service executor threads for Remote System Operation HTTP service
+    </description>
+  </property>
+
+  <property>
+    <name>remote.system.op.service.bind.address</name>
+    <value>0.0.0.0</value>
+    <description>
+      Remote System Operation HTTP service bind address
+    </description>
+  </property>
+
+  <property>
+    <name>remote.system.op.worker.threads</name>
+    <value>${http.service.worker.threads}</value>
+    <description>
+      Number of Netty service IO worker threads for Remote System Operation HTTP service
+    </description>
+  </property>
+
 
   <!-- Metadata Configuration -->
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteSystemOperationServiceManager.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteSystemOperationServiceManager.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.datafabric.dataset;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import com.google.inject.Inject;
+import org.apache.twill.api.TwillRunnerService;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+
+/**
+ * CDAP Remote Sytem Operations Management in distributed mode.
+ */
+public class RemoteSystemOperationServiceManager extends DatasetExecutorServiceManager {
+
+  @Inject
+  RemoteSystemOperationServiceManager(CConfiguration cConf, TwillRunnerService twillRunnerService,
+                                             DiscoveryServiceClient discoveryServiceClient) {
+    super(cConf, twillRunnerService, discoveryServiceClient);
+  }
+
+  @Override
+  public String getDescription() {
+    return Constants.RemoteSystemOpService.SERVICE_DESCRIPTION;
+  }
+
+  @Override
+  public String getDiscoverableName() {
+    return Constants.Service.REMOTE_SYSTEM_OPERATION;
+  }
+}

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data.runtime.main;
 
 import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.app.guice.AuthorizationModule;
 import co.cask.cdap.app.guice.EntityVerifierModule;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.conf.CConfiguration;
@@ -39,6 +40,8 @@ import co.cask.cdap.data.view.ViewAdminModules;
 import co.cask.cdap.data2.audit.AuditModule;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutorService;
 import co.cask.cdap.explore.guice.ExploreClientModule;
+import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsService;
+import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsServiceModule;
 import co.cask.cdap.internal.app.store.DefaultStore;
 import co.cask.cdap.logging.appender.LogAppenderInitializer;
 import co.cask.cdap.logging.guice.LoggingModules;
@@ -111,6 +114,8 @@ public class DatasetOpExecutorServerTwillRunnable extends AbstractMasterTwillRun
       new NamespaceClientRuntimeModule().getDistributedModules(),
       new NamespaceStoreModule().getDistributedModules(),
       new MetadataServiceModule(),
+      new AuthorizationModule(),
+      new RemoteSystemOperationsServiceModule(),
       new ViewAdminModules().getDistributedModules(),
       new StreamAdminModules().getDistributedModules(),
       new NotificationFeedClientModule(),
@@ -131,5 +136,6 @@ public class DatasetOpExecutorServerTwillRunnable extends AbstractMasterTwillRun
     services.add(injector.getInstance(MetricsCollectionService.class));
     services.add(injector.getInstance(DatasetOpExecutorService.class));
     services.add(injector.getInstance(MetadataService.class));
+    services.add(injector.getInstance(RemoteSystemOperationsService.class));
   }
 }

--- a/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/StandaloneMain.java
@@ -49,6 +49,7 @@ import co.cask.cdap.explore.executor.ExploreExecutorService;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.explore.guice.ExploreRuntimeModule;
 import co.cask.cdap.explore.service.ExploreServiceUtils;
+import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsServiceModule;
 import co.cask.cdap.gateway.router.NettyRouter;
 import co.cask.cdap.gateway.router.RouterModules;
 import co.cask.cdap.internal.app.services.AppFabricServer;
@@ -504,6 +505,7 @@ public class StandaloneMain {
       new StreamAdminModules().getStandaloneModules(),
       new NamespaceStoreModule().getStandaloneModules(),
       new MetadataServiceModule(),
+      new RemoteSystemOperationsServiceModule(),
       new AuditModule().getStandaloneModules(),
       new AuthorizationModule()
     );


### PR DESCRIPTION
Created a Guava service that starts a NettyHttpService with the RemoteSystemOp handlers in DatasetOpExecutorTwillRunnable. Since the system twill runnable's instances can be scaled, we get the required scalability for remote system operation handlers as well.

Build : http://builds.cask.co/browse/CDAP-DUT4418

Tested in distributed mode.
