### PR TITLE
Adding support for multiple joiner plugin in pipeline

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/KVTransformations.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/KVTransformations.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.batch;
+
+import co.cask.cdap.api.dataset.lib.KeyValue;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.InvalidEntry;
+import co.cask.cdap.etl.api.Transformation;
+import co.cask.cdap.etl.api.batch.BatchAggregator;
+import co.cask.cdap.etl.api.batch.BatchJoiner;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.common.Constants;
+import co.cask.cdap.etl.common.DefaultEmitter;
+
+/**
+ * Key-Value transformation which wraps transformation for each batch plugin to emit stageName along with each record
+ * except for {@link BatchSink}
+ */
+public final class KVTransformations {
+
+  private KVTransformations() {
+  }
+
+  /**
+   * Creates {@link Transformation} which adds stageName to each record being emitted from current stage,
+   * except for {@link BatchSink}. Each stage will strip off stageName, apply original transformation and then again
+   * wrap record with stageName. For {@link co.cask.cdap.etl.api.Joiner} the record is passed with stageName.
+   *
+   * @param stageName      stageName which is emitting the record
+   * @param pluginType     type of the stage
+   * @param isMapPhase     if it is map phase
+   * @param transformation transformation to be wrapped
+   * @return {@link Transformation} to wrap/unwrap stageName
+   */
+  public static Transformation getKVTransformation(String stageName, String pluginType, boolean isMapPhase,
+                                                   Transformation transformation) {
+    if (BatchSink.PLUGIN_TYPE.equalsIgnoreCase(pluginType)) {
+      return new KVSinkTransformation<>(transformation);
+    } else if (BatchSource.PLUGIN_TYPE.equalsIgnoreCase(pluginType)) {
+      return new KVSourceTransformation<>(stageName, transformation);
+    } else if (Constants.CONNECTOR_TYPE.equalsIgnoreCase(pluginType)) {
+      return transformation;
+    } else if (BatchJoiner.PLUGIN_TYPE.equalsIgnoreCase(pluginType)) {
+      if (isMapPhase) {
+        return transformation;
+      } else {
+        return new KVSourceTransformation<>(stageName, transformation);
+      }
+    } else if (BatchAggregator.PLUGIN_TYPE.equalsIgnoreCase(pluginType)) {
+      if (isMapPhase) {
+        return new KVSinkTransformation<>(transformation);
+      } else {
+        return new KVSourceTransformation<>(stageName, transformation);
+      }
+    }
+    return new KVWrappedTransformation(stageName, transformation);
+  }
+
+  /**
+   * Converts input to (stageName, input)
+   *
+   * @param <IN>  type of input
+   * @param <OUT> type of output
+   */
+  public static class KVSourceTransformation<IN, OUT> implements Transformation<IN, KeyValue<String, OUT>> {
+    private final String stageName;
+    private final Transformation<IN, OUT> transformation;
+    private final DefaultEmitter<OUT> singleEmitter;
+
+    public KVSourceTransformation(String stageName, Transformation<IN, OUT> transformation) {
+      this.stageName = stageName;
+      this.transformation = transformation;
+      this.singleEmitter = new DefaultEmitter<>();
+    }
+
+    @Override
+    public void transform(IN input, Emitter<KeyValue<String, OUT>> emitter) throws Exception {
+      singleEmitter.reset();
+      transformation.transform(input, singleEmitter);
+      for (OUT out : singleEmitter.getEntries()) {
+        emitter.emit(new KeyValue<>(stageName, out));
+      }
+      for (InvalidEntry<OUT> error : singleEmitter.getErrors()) {
+        emitter.emitError(new InvalidEntry<>(error.getErrorCode(), error.getErrorMsg(),
+                                             new KeyValue<>(stageName, error.getInvalidRecord())));
+      }
+    }
+  }
+
+  /**
+   * Converts (stageName, input) to input
+   *
+   * @param <IN>  type of input
+   * @param <OUT> type of output
+   */
+  public static class KVSinkTransformation<IN, OUT> implements Transformation<KeyValue<String, IN>, OUT> {
+    private final Transformation<IN, OUT> transformation;
+    private final DefaultEmitter<OUT> singleEmitter;
+
+    public KVSinkTransformation(Transformation<IN, OUT> transformation) {
+      this.transformation = transformation;
+      this.singleEmitter = new DefaultEmitter<>();
+    }
+
+    @Override
+    public void transform(KeyValue<String, IN> input, Emitter<OUT> emitter) throws Exception {
+      singleEmitter.reset();
+      transformation.transform(input.getValue(), singleEmitter);
+      for (OUT out : singleEmitter.getEntries()) {
+        emitter.emit(out);
+      }
+      for (InvalidEntry<OUT> error : singleEmitter.getErrors()) {
+        emitter.emitError(new InvalidEntry<>(error.getErrorCode(), error.getErrorMsg(), error.getInvalidRecord()));
+      }
+    }
+  }
+
+  /**
+   * Unwraps (stageName, input) to input, applies transformation and wraps output to (stageName, output)
+   *
+   * @param <IN>  type of input
+   * @param <OUT> type of output
+   */
+  public static class KVWrappedTransformation<IN, OUT> implements Transformation<KeyValue<String, IN>, KeyValue<String,
+    OUT>> {
+    private final String stageName;
+    private final Transformation<IN, OUT> transformation;
+    private final DefaultEmitter<OUT> singleEmitter;
+
+    public KVWrappedTransformation(String stageName, Transformation<IN, OUT> transformation) {
+      this.stageName = stageName;
+      this.transformation = transformation;
+      this.singleEmitter = new DefaultEmitter<>();
+    }
+
+    @Override
+    public void transform(KeyValue<String, IN> input, Emitter<KeyValue<String, OUT>> emitter) throws Exception {
+      singleEmitter.reset();
+      transformation.transform(input.getValue(), singleEmitter);
+      for (OUT out : singleEmitter.getEntries()) {
+        emitter.emit(new KeyValue<>(stageName, out));
+      }
+      for (InvalidEntry<OUT> error : singleEmitter.getErrors()) {
+        emitter.emitError(new InvalidEntry<>(error.getErrorCode(), error.getErrorMsg(),
+                                             new KeyValue<>(stageName, error.getInvalidRecord())));
+      }
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/PipelinePluginInstantiator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/PipelinePluginInstantiator.java
@@ -59,7 +59,7 @@ public class PipelinePluginInstantiator {
       return (T) new ConnectorSource(datasetName, null);
     } else if (connectorSinks.contains(stageName)) {
       String datasetName = phaseSpec.getConnectorDatasets().get(stageName);
-      return (T) new ConnectorSink(datasetName, phaseSpec.getPhaseName(), true);
+      return (T) new ConnectorSink(datasetName, phaseSpec.getPhaseName());
     }
 
     return pluginContext.newPluginInstance(stageName, macroEvaluator);

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/join/Join.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/join/Join.java
@@ -58,9 +58,7 @@ public class Join<JOIN_KEY, INPUT_RECORD, OUT> {
     JoinConfig joinConfig = joiner.getJoinConfig();
     Set<String> requiredInputs = Sets.newHashSet(joinConfig.getRequiredInputs());
 
-    // As we get intersection of records from all stages present in required inputs, if the number of
-    // stages we got after reduce are less than number of required inputs, then there is nothing to emit.
-    if (perStageJoinElements.size() < requiredInputs.size()) {
+    if (!perStageJoinElements.keySet().containsAll(requiredInputs)) {
       return;
     }
 
@@ -95,6 +93,10 @@ public class Join<JOIN_KEY, INPUT_RECORD, OUT> {
     // check till the end of the list and emit only if records from all the required inputs are present in joinElements
     if (index == list.size() && joinRowInputs.containsAll(requiredInputs)) {
       emitter.emit(joiner.merge(joinKey, joinRow));
+      return;
+    }
+
+    if (index >= list.size()) {
       return;
     }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/TransformRunner.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/TransformRunner.java
@@ -57,7 +57,7 @@ import java.util.Set;
  * do mostly the same thing, except the mapper needs to write to an aggregator or to sinks, whereas the reducer
  * needs to read from an aggregator and write to sinks.
  *
- * @param <KEY> the type of key to send into the transform executor
+ * @param <KEY>   the type of key to send into the transform executor
  * @param <VALUE> the type of value to send into the transform executor
  */
 public class TransformRunner<KEY, VALUE> {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TrackedEmitter.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TrackedEmitter.java
@@ -36,10 +36,6 @@ public class TrackedEmitter<T> implements Emitter<T> {
     this.emitMetricName = emitMetricName;
   }
 
-  public Emitter<T> getEmitter() {
-    return delegate;
-  }
-
   @Override
   public void emit(T value) {
     delegate.emit(value);

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TrackedTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TrackedTransform.java
@@ -34,7 +34,6 @@ public class TrackedTransform<IN, OUT> implements Transformation<IN, OUT>, Destr
   public static final String RECORDS_IN = "records.in";
   public static final String RECORDS_OUT = "records.out";
   private final Transformation<IN, OUT> transform;
-  private String prevStage;
   private final StageMetrics metrics;
   private final String metricInName;
   private final String metricOutName;
@@ -51,16 +50,8 @@ public class TrackedTransform<IN, OUT> implements Transformation<IN, OUT>, Destr
     this.metricOutName = metricOutName;
   }
 
-  public String getPrevStage() {
-    return prevStage;
-  }
-
   @Override
   public void transform(IN input, Emitter<OUT> emitter) throws Exception {
-    if (emitter instanceof TransformDetail) {
-      prevStage = ((TransformDetail) emitter).getPrevStage();
-    }
-
     if (metricInName != null) {
       metrics.count(metricInName, 1);
     }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TransformDetail.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TransformDetail.java
@@ -25,44 +25,34 @@ import java.util.Collection;
 
 /**
  * Encapsulates {@link Transformation} list of next stages, current stage name, and {@link DefaultEmitter}.
- * @param <T> the type of object to emit
  */
-public class TransformDetail<T> implements Emitter<T> {
+public class TransformDetail implements Emitter<Object> {
   private final Transformation transformation;
   private final Collection<String> nextStages;
-  private String prevStage;
-  private final DefaultEmitter<T> defaultEmitter;
+  private final DefaultEmitter<Object> defaultEmitter;
 
   public TransformDetail(Transformation transformation, Collection<String> nextStages) {
     this.transformation = transformation;
     this.nextStages = nextStages;
     this.defaultEmitter = new DefaultEmitter<>();
-    this.prevStage = "";
   }
 
-  public String getPrevStage() {
-    return prevStage;
-  }
-
-  public void setPrevStage(String prevStage) {
-    this.prevStage = prevStage;
-  }
 
   @Override
-  public void emit(T value) {
+  public void emit(Object value) {
     this.defaultEmitter.emit(value);
   }
 
   @Override
-  public void emitError(InvalidEntry<T> invalidEntry) {
+  public void emitError(InvalidEntry<Object> invalidEntry) {
     this.defaultEmitter.emitError(invalidEntry);
   }
 
-  public Collection<T> getEntries() {
+  public Collection<Object> getEntries() {
     return defaultEmitter.getEntries();
   }
 
-  public Collection<InvalidEntry<T>> getErrors() {
+  public Collection<InvalidEntry<Object>> getErrors() {
     return defaultEmitter.getErrors();
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TransformExecutor.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TransformExecutor.java
@@ -47,7 +47,7 @@ public class TransformExecutor<IN> implements Destroyable {
   public TransformResponse runOneIteration(IN input) throws Exception {
     for (String stageName : startingPoints) {
       // no prevStage for starting points
-      executeTransformation("", stageName, ImmutableList.of(input));
+      executeTransformation(stageName, ImmutableList.of(input));
     }
 
     Map<String, Collection<Object>> terminalNodeEntriesMap = new HashMap<>();
@@ -69,14 +69,13 @@ public class TransformExecutor<IN> implements Destroyable {
     return new TransformResponse(terminalNodeEntriesMap, errors);
   }
 
-  private <T> void executeTransformation(final String prevStageName, final String stageName,
+  private <T> void executeTransformation(final String stageName,
                                          Collection<T> input) throws Exception {
     if (input == null) {
       return;
     }
 
     TransformDetail transformDetail = transformDetailMap.get(stageName);
-    transformDetail.setPrevStage(prevStageName);
     Transformation<T, Object> transformation = transformDetail.getTransformation();
 
 
@@ -91,7 +90,7 @@ public class TransformExecutor<IN> implements Destroyable {
 
     Collection<String> nextStages = transformDetail.getNextStages();
     for (String nextStage : nextStages) {
-      executeTransformation(stageName, nextStage, transformDetail.getEntries());
+      executeTransformation(nextStage, transformDetail.getEntries());
     }
 
   }


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/CDAP-6352
Build: http://builds.cask.co/browse/CDAP-DUT4423-11

Summary:
- Adding support for emitting `stageName` along with each record emitted from each stage by using wrapper transformation for each stage.
- Reverting changes related to getting stageName from `TransformDetail` introduced in https://github.com/caskdata/cdap/pull/5914
- Adding testcase`testMultiPhaseJoiner` for having multiple join plugin in pipeline
- Combined spark changes of https://github.com/caskdata/cdap/pull/6065 PR.
