### PR TITLE
Added AuthorizationEnforcementModule. Moved RemotePrivilegesFetcher t…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramRunnableModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramRunnableModule.java
@@ -39,16 +39,12 @@ import co.cask.cdap.data2.registry.RuntimeUsageRegistry;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.internal.app.queue.QueueReaderFactory;
 import co.cask.cdap.internal.app.store.remote.RemoteLineageWriter;
-import co.cask.cdap.internal.app.store.remote.RemotePrivilegesFetcher;
 import co.cask.cdap.internal.app.store.remote.RemoteRuntimeStore;
 import co.cask.cdap.internal.app.store.remote.RemoteRuntimeUsageRegistry;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
-import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
-import co.cask.cdap.security.authorization.DefaultAuthorizationEnforcementService;
-import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
-import co.cask.cdap.security.spi.authorization.PrivilegesFetcher;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 import com.google.inject.PrivateModule;
@@ -97,6 +93,7 @@ public class DistributedProgramRunnableModule {
       new AuditModule().getDistributedModules(),
       new NamespaceClientRuntimeModule().getDistributedModules(),
       new AuthorizationModule(),
+      new AuthorizationEnforcementModule().getDistributedModules(),
       new AbstractModule() {
         @Override
         protected void configure() {
@@ -110,14 +107,6 @@ public class DistributedProgramRunnableModule {
 
           // For binding StreamWriter
           install(createStreamFactoryModule());
-
-          // also bind AuthorizationEnforcementService as a singleton. This binding is used while starting/stopping
-          // the service itself.
-          bind(AuthorizationEnforcementService.class).to(DefaultAuthorizationEnforcementService.class)
-            .in(Scopes.SINGLETON);
-          // bind AuthorizationEnforcer to AuthorizationEnforcementService
-          bind(AuthorizationEnforcer.class).to(AuthorizationEnforcementService.class).in(Scopes.SINGLETON);
-          bind(PrivilegesFetcher.class).to(RemotePrivilegesFetcher.class);
         }
       }
     );

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/AbstractRemoteSystemOpsHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/AbstractRemoteSystemOpsHandler.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.gateway.handlers.meta;
 
 import co.cask.cdap.common.BadRequestException;
-import co.cask.cdap.internal.app.store.remote.MethodArgument;
+import co.cask.cdap.common.internal.remote.MethodArgument;
 import co.cask.http.AbstractHttpHandler;
 import com.google.common.base.Charsets;
 import com.google.gson.Gson;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteLineageWriterHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteLineageWriterHandler.java
@@ -16,9 +16,9 @@
 
 package co.cask.cdap.gateway.handlers.meta;
 
+import co.cask.cdap.common.internal.remote.MethodArgument;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
-import co.cask.cdap.internal.app.store.remote.MethodArgument;
 import co.cask.cdap.proto.Id;
 import co.cask.http.HttpResponder;
 import com.google.inject.Inject;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemotePrivilegeFetcherHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemotePrivilegeFetcherHandler.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.gateway.handlers.meta;
 
-import co.cask.cdap.internal.app.store.remote.MethodArgument;
+import co.cask.cdap.common.internal.remote.MethodArgument;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteRuntimeStoreHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteRuntimeStoreHandler.java
@@ -18,7 +18,7 @@ package co.cask.cdap.gateway.handlers.meta;
 
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.app.store.Store;
-import co.cask.cdap.internal.app.store.remote.MethodArgument;
+import co.cask.cdap.common.internal.remote.MethodArgument;
 import co.cask.cdap.internal.app.store.remote.RemoteRuntimeStore;
 import co.cask.cdap.proto.BasicThrowable;
 import co.cask.cdap.proto.Id;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteUsageRegistryHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteUsageRegistryHandler.java
@@ -16,8 +16,8 @@
 
 package co.cask.cdap.gateway.handlers.meta;
 
+import co.cask.cdap.common.internal.remote.MethodArgument;
 import co.cask.cdap.data2.registry.UsageRegistry;
-import co.cask.cdap.internal.app.store.remote.MethodArgument;
 import co.cask.cdap.proto.Id;
 import co.cask.http.HttpResponder;
 import com.google.inject.Inject;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteLineageWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteLineageWriter.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app.store.remote;
 
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.internal.remote.RemoteOpsClient;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.data2.metadata.writer.BasicLineageWriter;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeStore.java
@@ -19,6 +19,7 @@ package co.cask.cdap.internal.app.store.remote;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.app.store.RuntimeStore;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.internal.remote.RemoteOpsClient;
 import co.cask.cdap.proto.BasicThrowable;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramRunStatus;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeUsageRegistry.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeUsageRegistry.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app.store.remote;
 
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.internal.remote.RemoteOpsClient;
 import co.cask.cdap.data2.registry.DatasetUsageKey;
 import co.cask.cdap.data2.registry.RuntimeUsageRegistry;
 import co.cask.cdap.proto.Id;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemotePrivilegesFetcherTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemotePrivilegesFetcherTest.java
@@ -32,6 +32,7 @@ import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.authorization.InMemoryAuthorizer;
+import co.cask.cdap.security.authorization.RemotePrivilegesFetcher;
 import co.cask.cdap.security.spi.authorization.PrivilegesFetcher;
 import co.cask.tephra.TransactionManager;
 import com.google.common.collect.ImmutableSet;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
@@ -40,7 +40,6 @@ import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsServiceModule;
 import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerException;
-import co.cask.cdap.internal.app.store.remote.RemotePrivilegesFetcher;
 import co.cask.cdap.logging.guice.LogReaderRuntimeModules;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.metadata.MetadataServiceModule;
@@ -50,8 +49,8 @@ import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModu
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ScheduledRuntime;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.guice.SecureStoreModules;
-import co.cask.cdap.security.spi.authorization.PrivilegesFetcher;
 import co.cask.cdap.store.guice.NamespaceStoreModule;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
@@ -118,13 +117,9 @@ public final class AppFabricTestModule extends AbstractModule {
     install(new MetadataServiceModule());
     install(new RemoteSystemOperationsServiceModule());
     install(new AuthorizationModule());
+    // we want to use RemotePrivilegesFetcher in this module, since app fabric service is started
+    install(new AuthorizationEnforcementModule().getStandaloneModules());
     install(new SecureStoreModules().getInMemoryModules());
-    install(new AbstractModule() {
-      @Override
-      protected void configure() {
-        bind(PrivilegesFetcher.class).to(RemotePrivilegesFetcher.class);
-      }
-    });
   }
 
   private Scheduler createNoopScheduler() {

--- a/cdap-common/src/main/java/co/cask/cdap/common/internal/remote/MethodArgument.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/internal/remote/MethodArgument.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package co.cask.cdap.internal.app.store.remote;
+package co.cask.cdap.common.internal.remote;
 
 import com.google.gson.JsonElement;
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/internal/remote/RemoteOpsClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/internal/remote/RemoteOpsClient.java
@@ -14,7 +14,7 @@
 * the License.
 */
 
-package co.cask.cdap.internal.app.store.remote;
+package co.cask.cdap.common.internal.remote;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
@@ -54,7 +54,7 @@ import javax.annotation.Nullable;
 /**
  * Common HTTP client functionality for remote operations from programs.
  */
-class RemoteOpsClient {
+public class RemoteOpsClient {
 
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(BasicThrowable.class, new BasicThrowableCodec())
@@ -66,7 +66,7 @@ class RemoteOpsClient {
   private final HttpRequestConfig httpRequestConfig;
 
   @Inject
-  RemoteOpsClient(CConfiguration cConf, final DiscoveryServiceClient discoveryClient) {
+  protected RemoteOpsClient(CConfiguration cConf, final DiscoveryServiceClient discoveryClient) {
     this.endpointStrategySupplier = Suppliers.memoize(new Supplier<EndpointStrategy>() {
       @Override
       public EndpointStrategy get() {

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizationEnforcementModule.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizationEnforcementModule.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.common.runtime.RuntimeModule;
+import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
+import co.cask.cdap.security.spi.authorization.PrivilegesFetcher;
+import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+import com.google.inject.Module;
+import com.google.inject.Provider;
+import com.google.inject.Scopes;
+
+/**
+ * A module that contains bindings for {@link AuthorizationEnforcementService} and {@link PrivilegesFetcher}.
+ */
+public class AuthorizationEnforcementModule extends RuntimeModule {
+
+  @Override
+  public Module getInMemoryModules() {
+    return new AbstractModule() {
+      @Override
+      protected void configure() {
+        // bind AuthorizationEnforcementService as a singleton. This binding is used while starting/stopping
+        // the service itself.
+        bind(AuthorizationEnforcementService.class).to(DefaultAuthorizationEnforcementService.class)
+          .in(Scopes.SINGLETON);
+        // bind AuthorizationEnforcer to AuthorizationEnforcementService
+        bind(AuthorizationEnforcer.class).to(AuthorizationEnforcementService.class).in(Scopes.SINGLETON);
+        bind(PrivilegesFetcher.class).toProvider(InMemoryPrivilegesFetcherProvider.class).in(Scopes.SINGLETON);
+      }
+    };
+  }
+
+  @Override
+  public Module getStandaloneModules() {
+    return new AbstractModule() {
+      @Override
+      protected void configure() {
+        // bind AuthorizationEnforcementService as a singleton. This binding is used while starting/stopping
+        // the service itself.
+        bind(AuthorizationEnforcementService.class).to(DefaultAuthorizationEnforcementService.class)
+          .in(Scopes.SINGLETON);
+        // bind AuthorizationEnforcer to AuthorizationEnforcementService
+        bind(AuthorizationEnforcer.class).to(AuthorizationEnforcementService.class).in(Scopes.SINGLETON);
+        bind(PrivilegesFetcher.class).to(RemotePrivilegesFetcher.class);
+      }
+    };
+  }
+
+  @Override
+  public Module getDistributedModules() {
+    return new AbstractModule() {
+      @Override
+      protected void configure() {
+        // bind AuthorizationEnforcementService as a singleton. This binding is used while starting/stopping
+        // the service itself.
+        bind(AuthorizationEnforcementService.class).to(DefaultAuthorizationEnforcementService.class)
+          .in(Scopes.SINGLETON);
+        // bind AuthorizationEnforcer to AuthorizationEnforcementService
+        bind(AuthorizationEnforcer.class).to(AuthorizationEnforcementService.class).in(Scopes.SINGLETON);
+        bind(PrivilegesFetcher.class).to(RemotePrivilegesFetcher.class);
+      }
+    };
+  }
+
+  private static class InMemoryPrivilegesFetcherProvider implements Provider<PrivilegesFetcher> {
+    private final AuthorizerInstantiator authorizerInstantiator;
+
+    @Inject
+    private InMemoryPrivilegesFetcherProvider(AuthorizerInstantiator authorizerInstantiator) {
+      this.authorizerInstantiator = authorizerInstantiator;
+    }
+
+    @Override
+    public PrivilegesFetcher get() {
+      return authorizerInstantiator.get();
+    }
+  }
+}

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/RemotePrivilegesFetcher.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/RemotePrivilegesFetcher.java
@@ -14,10 +14,10 @@
  * the License.
  */
 
-package co.cask.cdap.internal.app.store.remote;
+package co.cask.cdap.security.authorization;
 
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.gateway.handlers.meta.RemotePrivilegeFetcherHandler;
+import co.cask.cdap.common.internal.remote.RemoteOpsClient;
 import co.cask.cdap.internal.guava.reflect.TypeToken;
 import co.cask.cdap.proto.codec.EntityIdTypeAdapter;
 import co.cask.cdap.proto.id.EntityId;
@@ -38,10 +38,9 @@ import java.lang.reflect.Type;
 import java.util.Set;
 
 /**
- * An {@link PrivilegesFetcher} that is used to make an HTTP call to {@link RemotePrivilegeFetcherHandler} to fetch
- * privileges of a given principal. Communication over HTTP is necessary because program containers, which use this
- * class (and run as the user running the program) may not be white-listed to make calls to authorization providers
- * (like Apache Sentry).
+ * An {@link PrivilegesFetcher} that is used to make an HTTP call to to fetch privileges of a given principal.
+ * Communication over HTTP is necessary because program containers, which use this class (and run as the user running
+ * the program) may not be white-listed to make calls to authorization providers (like Apache Sentry).
  */
 public class RemotePrivilegesFetcher extends RemoteOpsClient implements PrivilegesFetcher {
   private static final Logger LOG = LoggerFactory.getLogger(RemotePrivilegesFetcher.class);


### PR DESCRIPTION
…o cdap-security and RemoteOpsClient/MethodArgument to cdap-common so they can be accessed by both cdap-app-fabric and cdap-data-fabric.

This PR has no logic changes. Creating it as a separate PR for the code to be able to be shared between a few upcoming PRs, that enforce authorization in app-fabric and data-fabric.

Since this is only code movement and no logic change, will only rely upon a checkstyle build for this one, so subsequent PRs from @lumig242 and me can be unblocked.
