### PR TITLE
CDAP 6492: endpoint to getting plugin detail

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/macro/MacroFunction.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/macro/MacroFunction.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.macro;
+
+import java.util.List;
+
+/**
+ * Class representing a macro function
+ */
+public class MacroFunction {
+  private final String functionName;
+  private final List<String> arguments;
+
+  public MacroFunction(String functionName, List<String> arguments) {
+    this.functionName = functionName;
+    this.arguments = arguments;
+  }
+
+  /**
+   * return the function name
+   * @return funtion name
+   */
+  public String getFunctionName() {
+    return functionName;
+  }
+
+  /**
+   * return the list of arguments to the funcion
+   * @return the list of arguments
+   */
+  public List<String> getArguments() {
+    return arguments;
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/macro/Macros.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/macro/Macros.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.macro;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Class encapsulating lookup property macros and macro functions
+ */
+public class Macros implements Serializable {
+  private static final long serialVersionUID = 1606313949471664886L;
+  private final Set<String> lookupProperties;
+  private final Set<MacroFunction> macroFunctions;
+
+  public Macros(Set<String> lookupProperties, Set<MacroFunction> macroFunctions) {
+    this.lookupProperties = lookupProperties;
+    this.macroFunctions = macroFunctions;
+  }
+
+  public Macros() {
+    this.lookupProperties = new HashSet<>();
+    this.macroFunctions = new HashSet<>();
+  }
+
+  public Set<String> getLookups() {
+    return lookupProperties;
+  }
+
+  public Set<MacroFunction> getMacroFunctions() {
+    return macroFunctions;
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginProperties.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginProperties.java
@@ -17,11 +17,13 @@
 package co.cask.cdap.api.plugin;
 
 import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.macro.Macros;
 
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Plugin instance properties.
@@ -33,17 +35,38 @@ public class PluginProperties implements Serializable {
 
   // Currently only support String->String map.
   private final Map<String, String> properties;
+  private final Macros macros;
+
+  private PluginProperties(Map<String, String> properties, @Nullable Macros macros) {
+    this.properties = properties;
+    this.macros = macros;
+  }
 
   public static Builder builder() {
     return new Builder();
   }
 
   private PluginProperties(Map<String, String> properties) {
-    this.properties = properties;
+    this(properties, new Macros());
   }
 
   public Map<String, String> getProperties() {
     return properties;
+  }
+
+  public Macros getMacros() {
+    return  (macros == null) ? new Macros() : macros;
+  }
+
+  /**
+   * Creates and returns a new instance of Plugin properties with current properties and the passed macros parameter.
+   * Note this is used internally by the CDAP Platform and it is advisable
+   * that plugin developers not use this method.
+   * @param macros set of macros used by this plugin.
+   * @return new instance of plugin properties with macros set.
+   */
+  public PluginProperties setMacros(Macros macros) {
+    return new PluginProperties(getProperties(), macros);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -198,6 +198,20 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   }
 
   /**
+   * Returns the plugins in the application.
+   */
+  @GET
+  @Path("/apps/{app-id}/plugins")
+  public void getPluginsInfo(HttpRequest request, HttpResponder responder,
+                         @PathParam("namespace-id") String namespaceId,
+                         @PathParam("app-id") final String appId)
+    throws NamespaceNotFoundException, BadRequestException, ApplicationNotFoundException {
+
+    Id.Application applicationId = validateApplicationId(namespaceId, appId);
+    responder.sendJson(HttpResponseStatus.OK, applicationLifecycleService.getPlugins(applicationId.toEntityId()));
+  }
+
+  /**
    * Delete an application specified by appId.
    */
   @DELETE

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/CollectMacroEvaluator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/CollectMacroEvaluator.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.plugin;
+
+import co.cask.cdap.api.macro.MacroEvaluator;
+import co.cask.cdap.api.macro.MacroFunction;
+import co.cask.cdap.api.macro.Macros;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A macro evaluator used strictly for collecting macro properties and functions.
+ *
+ * The evaluator is passed as an argument to a {@link MacroParser} and internally keeps
+ * track of macro properties and macro functions
+ * TODO: CDAP-6628 this currently works only for simple properties lookup and simple functions,
+ * nested macros wouldn't work and needs change in macroparser logic
+ * TODO: consolidate this with TrackingMacroEvaluator
+ */
+public class CollectMacroEvaluator implements MacroEvaluator {
+  private final Set<String> lookupProperties;
+  private final Set<MacroFunction> macroFunctions;
+
+  public CollectMacroEvaluator() {
+    this.lookupProperties = new HashSet<>();
+    this.macroFunctions = new HashSet<>();
+  }
+
+  public String lookup(String property) {
+    lookupProperties.add(property);
+    return "";
+  }
+
+  public String evaluate(String macroFunction, String... arguments) {
+    List<String> argumentsList = new ArrayList<>();
+    for (String arg : arguments) {
+      argumentsList.add(arg);
+    }
+    macroFunctions.add(new MacroFunction(macroFunction, argumentsList));
+    return "";
+  }
+
+  public Macros getMacros() {
+    return new Macros(lookupProperties, macroFunctions);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/FindPluginHelper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/FindPluginHelper.java
@@ -69,6 +69,8 @@ public final class FindPluginHelper {
     } catch (IOException e) {
       throw Throwables.propagate(e);
     }
+    CollectMacroEvaluator collectMacroEvaluator = new CollectMacroEvaluator();
+    MacroParser parser = new MacroParser(collectMacroEvaluator);
 
     // Just verify if all required properties are provided.
     // No type checking is done for now.
@@ -76,6 +78,9 @@ public final class FindPluginHelper {
       Preconditions.checkArgument(!field.isRequired() || (properties.getProperties().containsKey(field.getName())),
                                   "Required property '%s' missing for plugin of type %s, name %s.",
                                   field.getName(), pluginType, pluginName);
+      if (field.isMacroSupported()) {
+        parser.parse(properties.getProperties().get(field.getName()));
+      }
     }
 
     ArtifactId artifact = pluginEntry.getKey().getArtifactId();
@@ -84,7 +89,8 @@ public final class FindPluginHelper {
     } catch (IOException e) {
       Throwables.propagate(e);
     }
-    return new Plugin(artifact, pluginEntry.getValue(), properties);
+    return new Plugin(artifact, pluginEntry.getValue(),
+                      properties.setMacros(collectMacroEvaluator.getMacros()));
   }
 
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.flow.FlowSpecification;
 import co.cask.cdap.api.flow.FlowletConnection;
 import co.cask.cdap.api.metrics.MetricDeleteQuery;
 import co.cask.cdap.api.metrics.MetricStore;
+import co.cask.cdap.api.plugin.Plugin;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
 import co.cask.cdap.app.deploy.Manager;
@@ -56,6 +57,7 @@ import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
 import co.cask.cdap.proto.ApplicationDetail;
 import co.cask.cdap.proto.ApplicationRecord;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.PluginInstanceDetail;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.ProgramTypes;
 import co.cask.cdap.proto.artifact.AppRequest;
@@ -427,6 +429,26 @@ public class ApplicationLifecycleService extends AbstractIdleService {
       throw new NotFoundException(appId);
     }
     deleteApp(appId, spec);
+  }
+
+  /**
+   * Get detail about the plugin in the specified application
+   *
+   * @param appId the id of the application
+   * @return list of plugins in the application
+   * @throws ApplicationNotFoundException if the specified application does not exist
+   */
+  public List<PluginInstanceDetail> getPlugins(ApplicationId appId)
+    throws ApplicationNotFoundException {
+    ApplicationSpecification appSpec = store.getApplication(appId.toId());
+    if (appSpec == null) {
+      throw new ApplicationNotFoundException(appId.toId());
+    }
+    List<PluginInstanceDetail> pluginInstanceDetails = new ArrayList<>();
+    for (Map.Entry<String, Plugin> entry : appSpec.getPlugins().entrySet()) {
+      pluginInstanceDetails.add(new PluginInstanceDetail(entry.getKey(), entry.getValue()));
+    }
+    return pluginInstanceDetails;
   }
 
   private Iterable<ProgramSpecification> getProgramSpecs(Id.Application appId) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
@@ -217,7 +217,6 @@ public class ProgramLifecycleService extends AbstractIdleService {
     return programSpec;
   }
 
-
   /**
    * Starts a Program with the specified argument overrides.
    *

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
@@ -36,6 +36,7 @@ import co.cask.cdap.proto.ApplicationDetail;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.Instances;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.PluginInstanceDetail;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
@@ -490,5 +491,18 @@ public class AppFabricClient {
                                                        programId.getApplication(),
                                                        programId.getType().getCategoryName(), programId.getProgram());
     verifyResponse(HttpResponseStatus.OK, mockResponder.getStatus(), "Saving runtime arguments failed");
+  }
+
+  public List<PluginInstanceDetail> getPlugins(ApplicationId application) throws Exception {
+    DefaultHttpRequest request = new DefaultHttpRequest(
+      HttpVersion.HTTP_1_1, HttpMethod.GET,
+      String.format("%s/apps/%s", getNamespacePath(application.getNamespace()), application.getApplication())
+    );
+    request.setHeader(Constants.Gateway.API_KEY, "api-key-example");
+    MockResponder mockResponder = new MockResponder();
+    appLifecycleHttpHandler.getPluginsInfo(request, mockResponder, application.getNamespace(),
+                                           application.getApplication());
+    verifyResponse(HttpResponseStatus.OK, mockResponder.getStatus(), "Getting app info failed");
+    return mockResponder.decodeResponseContent(new TypeToken<List<PluginInstanceDetail>>() { }.getType(), GSON);
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/plugin/CollectMacroEvaluatorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/plugin/CollectMacroEvaluatorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.plugin;
+
+import co.cask.cdap.api.macro.MacroFunction;
+import com.google.common.collect.ImmutableList;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ *
+ */
+public class CollectMacroEvaluatorTest {
+
+  @Test
+  public void testMacrosCollected() throws Exception {
+    CollectMacroEvaluator collectMacroEvaluator = new CollectMacroEvaluator();
+    MacroParser parser = new MacroParser(collectMacroEvaluator);
+    List<String> macros = new ArrayList<>();
+    macros.add("${hello}${world}");
+    macros.add("${secure2(password)}");
+    macros.add("${hello}");
+    for (String macro : macros) {
+      parser.parse(macro);
+    }
+
+    Set<String> expectedLookups = new HashSet<>();
+    expectedLookups.add("hello");
+    expectedLookups.add("world");
+
+    Assert.assertEquals(expectedLookups, collectMacroEvaluator.getMacros().getLookups());
+
+
+    Map<String, List<String>> functionNameToArguments = new HashMap<>();
+    functionNameToArguments.put("secure2", ImmutableList.of("password"));
+
+    for (MacroFunction macroFunction : collectMacroEvaluator.getMacros().getMacroFunctions()) {
+      Assert.assertTrue(functionNameToArguments.containsKey(macroFunction.getFunctionName()));
+      Assert.assertEquals(functionNameToArguments.get(macroFunction.getFunctionName()),
+                          macroFunction.getArguments());
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/batch/ETLWorkflowTestRun.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/batch/ETLWorkflowTestRun.java
@@ -36,6 +36,7 @@ import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
 import co.cask.cdap.etl.proto.v2.ETLStage;
 import co.cask.cdap.format.StructuredRecordStringConverter;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.PluginInstanceDetail;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.artifact.AppRequest;
@@ -215,6 +216,36 @@ public class ETLWorkflowTestRun extends ETLBatchTestBase {
   @Test
   public void testBackwardsCompatibleExternalDatasetTrackingSpark() throws Exception {
     testExternalDatasetTracking(Engine.SPARK, true);
+  }
+
+  // todo : move this test to AppLifecycleHTTPHandlerTest, here currently due to availability of app with plugins.
+  @Test
+  public void testGetPlugins() throws Exception {
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+      .addStage(new ETLStage("source", MockSource.getPlugin("daginput")))
+      .addStage(new ETLStage("sink1", MockSink.getPlugin("dagoutput1")))
+      .addStage(new ETLStage("sink2", MockSink.getPlugin("dagoutput2")))
+      .addStage(new ETLStage("filter", StringValueFilterTransform.getPlugin("name", "samuel")))
+      .addConnection("source", "filter")
+      .addConnection("source", "sink1")
+      .addConnection("filter", "sink2")
+      .build();
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig);
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "DagApp");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+    Set<String> expectedPluginIds = new HashSet<String>();
+    expectedPluginIds.add("source");
+    expectedPluginIds.add("sink1");
+    expectedPluginIds.add("sink2");
+    expectedPluginIds.add("filter");
+
+    Assert.assertEquals(expectedPluginIds.size(), appManager.getPlugins().size());
+    for (PluginInstanceDetail pluginInstanceDetail : appManager.getPlugins()) {
+      Assert.assertTrue(expectedPluginIds.contains(pluginInstanceDetail.getId()));
+      expectedPluginIds.remove(pluginInstanceDetail.getId());
+    }
+    Assert.assertTrue(expectedPluginIds.isEmpty());
   }
 
   private void testExternalDatasetTracking(Engine engine, boolean backwardsCompatible) throws Exception {

--- a/cdap-client/src/main/java/co/cask/cdap/client/ApplicationClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ApplicationClient.java
@@ -28,9 +28,11 @@ import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.proto.ApplicationDetail;
 import co.cask.cdap.proto.ApplicationRecord;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.PluginInstanceDetail;
 import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpResponse;
@@ -172,6 +174,30 @@ public class ApplicationClient {
       throw new ApplicationNotFoundException(appId);
     }
     return ObjectResponse.fromJsonBody(response, ApplicationDetail.class).getResponseObject();
+  }
+
+  /**
+   * Get plugins in the specified application.
+   *
+   * @param appId the id of the application to get
+   * @return list of plugins in the application
+   * @throws ApplicationNotFoundException if the application with the given ID was not found
+   * @throws IOException if a network error occurred
+   * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
+   */
+  public List<PluginInstanceDetail> getPlugins(ApplicationId appId)
+    throws ApplicationNotFoundException, IOException, UnauthenticatedException {
+
+    HttpResponse response = restClient.execute(HttpMethod.GET,
+                                               config.resolveNamespacedURLV3(
+                                                 appId.getParent().toId(),
+                                                 "apps/" + appId.getApplication() + "/plugins"),
+                                               config.getAccessToken(),
+                                               HttpURLConnection.HTTP_NOT_FOUND);
+    if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+      throw new ApplicationNotFoundException(appId.toId());
+    }
+    return ObjectResponse.fromJsonBody(response, new TypeToken<List<PluginInstanceDetail>>() { }).getResponseObject();
   }
 
   /**

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteApplicationManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteApplicationManager.java
@@ -22,6 +22,7 @@ import co.cask.cdap.client.config.ClientConfig;
 import co.cask.cdap.client.util.RESTClient;
 import co.cask.cdap.proto.ApplicationDetail;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.PluginInstanceDetail;
 import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
@@ -95,6 +96,15 @@ public class RemoteApplicationManager extends AbstractApplicationManager {
   public WorkerManager getWorkerManager(String workerName) {
     Id.Worker programId = Id.Worker.from(application, workerName);
     return new RemoteWorkerManager(programId, clientConfig, restClient, this);
+  }
+
+  @Override
+  public List<PluginInstanceDetail> getPlugins() {
+    try {
+      return applicationClient.getPlugins(application.toEntityId());
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/PluginDetail.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/PluginDetail.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.proto;
+
+/**
+ * Represents a plugin id and name in an HTTP response.
+ */
+public class PluginDetail {
+  private final String id;
+  private final String name;
+  private final String type;
+
+  public PluginDetail(String id, String name, String type) {
+    this.id = id;
+    this.name = name;
+    this.type = type;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getType() {
+    return type;
+  }
+}
+

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/PluginInstanceDetail.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/PluginInstanceDetail.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.proto;
+
+import co.cask.cdap.api.plugin.Plugin;
+
+/**
+ * Represents a plugin instance in an HTTP Response
+ */
+public class PluginInstanceDetail extends PluginDetail {
+  private final Plugin spec;
+
+  public PluginInstanceDetail(String pluginId, Plugin spec) {
+    super(pluginId, spec.getPluginClass().getName(), spec.getPluginClass().getType());
+    this.spec = spec;
+  }
+
+  public Plugin getSpec() {
+    return spec;
+  }
+}

--- a/cdap-test/src/main/java/co/cask/cdap/test/ApplicationManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/ApplicationManager.java
@@ -18,6 +18,7 @@ package co.cask.cdap.test;
 
 import co.cask.cdap.proto.ApplicationDetail;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.PluginInstanceDetail;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.artifact.AppRequest;
@@ -72,6 +73,12 @@ public interface ApplicationManager {
    * @return A {@link WorkerManager} for controlling the worker
    */
   WorkerManager getWorkerManager(String workerName);
+
+  /**
+   * Returns the list of plugins used in the application.
+   * @return list of plugins
+   */
+  List<PluginInstanceDetail> getPlugins();
 
   /**
    * Stops all processors managed by this manager and clear all associated runtime metrics.

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
@@ -19,6 +19,7 @@ package co.cask.cdap.test.internal;
 import co.cask.cdap.internal.AppFabricClient;
 import co.cask.cdap.proto.ApplicationDetail;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.PluginInstanceDetail;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.RunRecord;
@@ -102,6 +103,15 @@ public class DefaultApplicationManager extends AbstractApplicationManager {
   public WorkerManager getWorkerManager(String workerName) {
     Id.Program programId = Id.Program.from(application, ProgramType.WORKER, workerName);
     return new DefaultWorkerManager(programId, appFabricClient, this);
+  }
+
+  @Override
+  public List<PluginInstanceDetail> getPlugins() {
+    try {
+      return appFabricClient.getPlugins(application.toEntityId());
+    } catch (Exception e) {
+     throw Throwables.propagate(e);
+    }
   }
 
   @Override


### PR DESCRIPTION
PluginProperties to include set of macros that are used in the plugin. 
REST endpoint to get the plugins in an application 
Added getPlugins method in ApplicationManager in TestBase and corresponding implementation in Unit and Remote test base.
JIRA : http://builds.cask.co/browse/CDAP-DUT4437-1
