### PR TITLE
(CDAP-6168) Small improvement the efficiency of Auth cache lookup

### DIFF
--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ApplicationId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ApplicationId.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 public class ApplicationId extends EntityId implements NamespacedId, ParentedId<NamespaceId> {
   private final String namespace;
   private final String application;
+  private transient Integer hashCode;
 
   public ApplicationId(String namespace, String application) {
     super(EntityType.APPLICATION);
@@ -95,7 +96,11 @@ public class ApplicationId extends EntityId implements NamespacedId, ParentedId<
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), namespace, application);
+    Integer hashCode = this.hashCode;
+    if (hashCode == null) {
+      this.hashCode = hashCode = Objects.hash(super.hashCode(), namespace, application);
+    }
+    return hashCode;
   }
 
   @SuppressWarnings("unused")

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ArtifactId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ArtifactId.java
@@ -30,6 +30,7 @@ public class ArtifactId extends EntityId implements NamespacedId, ParentedId<Nam
   private final String namespace;
   private final String artifact;
   private final String version;
+  private transient Integer hashCode;
 
   public ArtifactId(String namespace, String artifact, String version) {
     super(EntityType.ARTIFACT);
@@ -68,7 +69,11 @@ public class ArtifactId extends EntityId implements NamespacedId, ParentedId<Nam
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), namespace, artifact, version);
+    Integer hashCode = this.hashCode;
+    if (hashCode == null) {
+      this.hashCode = hashCode = Objects.hash(super.hashCode(), namespace, artifact, version);
+    }
+    return hashCode;
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetId.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 public class DatasetId extends EntityId implements NamespacedId, ParentedId<NamespaceId> {
   private final String namespace;
   private final String dataset;
+  private transient Integer hashCode;
 
   public DatasetId(String namespace, String dataset) {
     super(EntityType.DATASET);
@@ -72,7 +73,11 @@ public class DatasetId extends EntityId implements NamespacedId, ParentedId<Name
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), namespace, dataset);
+    Integer hashCode = this.hashCode;
+    if (hashCode == null) {
+      this.hashCode = hashCode = Objects.hash(super.hashCode(), namespace, dataset);
+    }
+    return hashCode;
   }
 
   @SuppressWarnings("unused")

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetModuleId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetModuleId.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 public class DatasetModuleId extends EntityId implements NamespacedId, ParentedId<NamespaceId> {
   private final String namespace;
   private final String module;
+  private transient Integer hashCode;
 
   public DatasetModuleId(String namespace, String module) {
     super(EntityType.DATASET_MODULE);
@@ -66,7 +67,11 @@ public class DatasetModuleId extends EntityId implements NamespacedId, ParentedI
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), namespace, module);
+    Integer hashCode = this.hashCode;
+    if (hashCode == null) {
+      this.hashCode = hashCode = Objects.hash(super.hashCode(), namespace, module);
+    }
+    return hashCode;
   }
 
   @SuppressWarnings("unused")

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetTypeId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetTypeId.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 public class DatasetTypeId extends EntityId implements NamespacedId, ParentedId<NamespaceId> {
   private final String namespace;
   private final String type;
+  private transient Integer hashCode;
 
   public DatasetTypeId(String namespace, String type) {
     super(EntityType.DATASET_TYPE);
@@ -61,7 +62,11 @@ public class DatasetTypeId extends EntityId implements NamespacedId, ParentedId<
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), namespace, type);
+    Integer hashCode = this.hashCode;
+    if (hashCode == null) {
+      this.hashCode = hashCode = Objects.hash(super.hashCode(), namespace, type);
+    }
+    return hashCode;
   }
 
   @SuppressWarnings("unused")

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
@@ -63,18 +63,12 @@ public abstract class EntityId implements IdCompatible {
   private static final String IDSTRING_PART_SEPARATOR = ".";
   private static final Pattern IDSTRING_PART_SEPARATOR_PATTERN = Pattern.compile("\\.");
 
-  // Only allow alphanumeric and _ character for namespace
-  private static final Pattern namespacePattern = Pattern.compile("[a-zA-Z0-9_]+");
   // Allow hyphens for other ids.
   private static final Pattern idPattern = Pattern.compile("[a-zA-Z0-9_-]+");
   // Allow '.' and '$' for dataset ids since they can be fully qualified class names
   private static final Pattern datasetIdPattern = Pattern.compile("[$\\.a-zA-Z0-9_-]+");
   // KMS only supports lower case keys.
   private static final Pattern storeKeyNamePattern = Pattern.compile("[a-z0-9_-]+");
-
-  protected static boolean isValidNamespaceId(String name) {
-    return namespacePattern.matcher(name).matches();
-  }
 
   public static boolean isValidId(String name) {
     return idPattern.matcher(name).matches();
@@ -121,9 +115,6 @@ public abstract class EntityId implements IdCompatible {
 
     String typeString = typeAndId[0];
     EntityType type = EntityType.valueOf(typeString.toUpperCase());
-    if (type == null) {
-      throw new IllegalArgumentException("Invalid element type: " + typeString);
-    }
     if (idClass != null && !type.getIdClass().equals(idClass)) {
         throw new IllegalArgumentException(String.format("Expected EntityId of class '%s' but got '%s'",
                                                          idClass.getName(), type.getIdClass().getName()));

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/FlowletId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/FlowletId.java
@@ -32,6 +32,7 @@ public class FlowletId extends EntityId implements NamespacedId, ParentedId<Prog
   private final String application;
   private final String flow;
   private final String flowlet;
+  private transient Integer hashCode;
 
   public FlowletId(String namespace, String application, String flow, String flowlet) {
     super(EntityType.FLOWLET);
@@ -77,7 +78,11 @@ public class FlowletId extends EntityId implements NamespacedId, ParentedId<Prog
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), namespace, application, flow, flowlet);
+    Integer hashCode = this.hashCode;
+    if (hashCode == null) {
+      this.hashCode = hashCode = Objects.hash(super.hashCode(), namespace, application, flow, flowlet);
+    }
+    return hashCode;
   }
 
   public FlowletQueueId queue(String queue) {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/FlowletQueueId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/FlowletQueueId.java
@@ -32,6 +32,7 @@ public class FlowletQueueId extends EntityId implements NamespacedId, ParentedId
   private final String flow;
   private final String flowlet;
   private final String queue;
+  private transient Integer hashCode;
 
   public FlowletQueueId(String namespace, String application, String flow, String flowlet, String queue) {
     super(EntityType.FLOWLET_QUEUE);
@@ -92,7 +93,11 @@ public class FlowletQueueId extends EntityId implements NamespacedId, ParentedId
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), namespace, application, flow, flowlet, queue);
+    Integer hashCode = this.hashCode;
+    if (hashCode == null) {
+      this.hashCode = hashCode = Objects.hash(super.hashCode(), namespace, application, flow, flowlet, queue);
+    }
+    return hashCode;
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/InstanceId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/InstanceId.java
@@ -28,6 +28,7 @@ import java.util.Objects;
  */
 public class InstanceId extends EntityId {
   private final String instance;
+  private transient Integer hashCode;
 
   public InstanceId(String instance) {
     super(EntityType.INSTANCE);
@@ -66,6 +67,10 @@ public class InstanceId extends EntityId {
 
   @Override
   public int hashCode() {
-    return Objects.hash(instance);
+    Integer hashCode = this.hashCode;
+    if (hashCode == null) {
+      this.hashCode = hashCode = Objects.hash(super.hashCode(), instance);
+    }
+    return hashCode;
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/NamespaceId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/NamespaceId.java
@@ -26,10 +26,12 @@ import java.util.Objects;
  * Uniquely identifies a namespace.
  */
 public class NamespaceId extends EntityId {
-  private final String namespace;
 
   public static final NamespaceId DEFAULT = new NamespaceId("default");
   public static final NamespaceId SYSTEM = new NamespaceId("system");
+
+  private final String namespace;
+  private transient Integer hashCode;
 
   public NamespaceId(String namespace) {
     super(EntityType.NAMESPACE);
@@ -80,7 +82,11 @@ public class NamespaceId extends EntityId {
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), namespace);
+    Integer hashCode = this.hashCode;
+    if (hashCode == null) {
+      this.hashCode = hashCode = Objects.hash(super.hashCode(), namespace);
+    }
+    return hashCode;
   }
 
   @SuppressWarnings("unused")

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/NotificationFeedId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/NotificationFeedId.java
@@ -31,6 +31,7 @@ public class NotificationFeedId extends EntityId implements NamespacedId, Parent
   private final String namespace;
   private final String category;
   private final String feed;
+  private transient Integer hashCode;
 
   public NotificationFeedId(String namespace, String category, String feed) {
     super(EntityType.NOTIFICATION_FEED);
@@ -69,7 +70,11 @@ public class NotificationFeedId extends EntityId implements NamespacedId, Parent
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), namespace, category, feed);
+    Integer hashCode = this.hashCode;
+    if (hashCode == null) {
+      this.hashCode = hashCode = Objects.hash(super.hashCode(), namespace, category, feed);
+    }
+    return hashCode;
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramId.java
@@ -33,6 +33,7 @@ public class ProgramId extends EntityId implements NamespacedId, ParentedId<Appl
   private final String application;
   private final ProgramType type;
   private final String program;
+  private transient Integer hashCode;
 
   public ProgramId(String namespace, String application, ProgramType type, String program) {
     super(EntityType.PROGRAM);
@@ -102,7 +103,11 @@ public class ProgramId extends EntityId implements NamespacedId, ParentedId<Appl
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), namespace, application, type, program);
+    Integer hashCode = this.hashCode;
+    if (hashCode == null) {
+      this.hashCode = hashCode = Objects.hash(super.hashCode(), namespace, application, type, program);
+    }
+    return hashCode;
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramRunId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramRunId.java
@@ -33,6 +33,7 @@ public class ProgramRunId extends EntityId implements NamespacedId, ParentedId<P
   private final ProgramType type;
   private final String program;
   private final String run;
+  private transient Integer hashCode;
 
   public ProgramRunId(String namespace, String application, ProgramType type, String program, String run) {
     super(EntityType.PROGRAM_RUN);
@@ -83,7 +84,11 @@ public class ProgramRunId extends EntityId implements NamespacedId, ParentedId<P
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), namespace, application, type, program, run);
+    Integer hashCode = this.hashCode;
+    if (hashCode == null) {
+      this.hashCode = hashCode = Objects.hash(super.hashCode(), namespace, application, type, program, run);
+    }
+    return hashCode;
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/QueryId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/QueryId.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 public class QueryId extends EntityId {
 
   private final String handle;
+  private transient Integer hashCode;
 
   public QueryId(String handle) {
     super(EntityType.QUERY);
@@ -49,7 +50,11 @@ public class QueryId extends EntityId {
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), handle);
+    Integer hashCode = this.hashCode;
+    if (hashCode == null) {
+      this.hashCode = hashCode = Objects.hash(super.hashCode(), handle);
+    }
+    return hashCode;
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ScheduleId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ScheduleId.java
@@ -30,6 +30,7 @@ public class ScheduleId extends EntityId implements NamespacedId, ParentedId<App
   private final String namespace;
   private final String application;
   private final String schedule;
+  private transient Integer hashCode;
 
   public ScheduleId(String namespace, String application, String schedule) {
     super(EntityType.SCHEDULE);
@@ -63,7 +64,11 @@ public class ScheduleId extends EntityId implements NamespacedId, ParentedId<App
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), namespace, application, schedule);
+    Integer hashCode = this.hashCode;
+    if (hashCode == null) {
+      this.hashCode = hashCode = Objects.hash(super.hashCode(), namespace, application, schedule);
+    }
+    return hashCode;
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamId.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 public class StreamId extends EntityId implements NamespacedId, ParentedId<NamespaceId> {
   private final String namespace;
   private final String stream;
+  private transient Integer hashCode;
 
   public StreamId(String namespace, String stream) {
     super(EntityType.STREAM);
@@ -61,7 +62,11 @@ public class StreamId extends EntityId implements NamespacedId, ParentedId<Names
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), namespace, stream);
+    Integer hashCode = this.hashCode;
+    if (hashCode == null) {
+      this.hashCode = hashCode = Objects.hash(super.hashCode(), namespace, stream);
+    }
+    return hashCode;
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamViewId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamViewId.java
@@ -30,6 +30,7 @@ public class StreamViewId extends EntityId implements NamespacedId, ParentedId<S
   private final String namespace;
   private final String stream;
   private final String view;
+  private transient Integer hashCode;
 
   public StreamViewId(String namespace, String stream, String view) {
     super(EntityType.STREAM_VIEW);
@@ -68,7 +69,11 @@ public class StreamViewId extends EntityId implements NamespacedId, ParentedId<S
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), namespace, stream, view);
+    Integer hashCode = this.hashCode;
+    if (hashCode == null) {
+      this.hashCode = hashCode = Objects.hash(super.hashCode(), namespace, stream, view);
+    }
+    return hashCode;
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/SystemServiceId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/SystemServiceId.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 public class SystemServiceId extends EntityId {
 
   private final String service;
+  private transient Integer hashCode;
 
   public SystemServiceId(String service) {
     super(EntityType.SYSTEM_SERVICE);
@@ -49,7 +50,11 @@ public class SystemServiceId extends EntityId {
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), service);
+    Integer hashCode = this.hashCode;
+    if (hashCode == null) {
+      this.hashCode = hashCode = Objects.hash(super.hashCode(), service);
+    }
+    return hashCode;
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/security/Principal.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/security/Principal.java
@@ -38,10 +38,12 @@ public class Principal {
 
   private final String name;
   private final PrincipalType type;
+  private final int hashCode;
 
   public Principal(String name, PrincipalType type) {
     this.name = name;
     this.type = type;
+    this.hashCode = Objects.hash(name, type);
   }
 
   public String getName() {
@@ -69,7 +71,7 @@ public class Principal {
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, type);
+    return hashCode;
   }
 
   @Override


### PR DESCRIPTION
- Use a better cache structure for faster lookup
- Avoid creating new object for lookup
- Cache the hashCode of all EntityId classes
  - Avoid creating intermediate Object[]
