### PR TITLE
CDAP-6105 (Remove "client" usage) and fix broken build

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -445,7 +445,7 @@
     <name>data.tx.num.cores</name>
     <value>${master.service.num.cores}</value>
     <description>
-      Maximum number of transaction service cores
+      Number of cores for the transaction service
     </description>
   </property>
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -429,7 +429,7 @@
     <name>data.tx.max.instances</name>
     <value>${master.service.max.instances}</value>
     <description>
-      Maximum number of transaction client instances
+      Maximum number of transaction service instances
     </description>
   </property>
 
@@ -437,7 +437,7 @@
     <name>data.tx.memory.mb</name>
     <value>${master.service.memory.mb}</value>
     <description>
-      Memory in megabytes of the transaction clients
+      Memory in megabytes of the transaction service
     </description>
   </property>
 
@@ -445,7 +445,7 @@
     <name>data.tx.num.cores</name>
     <value>${master.service.num.cores}</value>
     <description>
-      Maximum number of transaction client cores
+      Maximum number of transaction service cores
     </description>
   </property>
 
@@ -453,7 +453,7 @@
     <name>data.tx.num.instances</name>
     <value>1</value>
     <description>
-      Requested number of transaction client instances
+      Requested number of transaction service instances
     </description>
   </property>
 
@@ -1084,33 +1084,6 @@
     </description>
   </property>
 
-  <!-- Remote System Operation Service Configuration -->
-
-  <property>
-    <name>remote.system.op.exec.threads</name>
-    <value>${http.service.exec.threads}</value>
-    <description>
-      Number of Netty service executor threads for Remote System Operation HTTP service
-    </description>
-  </property>
-
-  <property>
-    <name>remote.system.op.service.bind.address</name>
-    <value>0.0.0.0</value>
-    <description>
-      Remote System Operation HTTP service bind address
-    </description>
-  </property>
-
-  <property>
-    <name>remote.system.op.worker.threads</name>
-    <value>${http.service.worker.threads}</value>
-    <description>
-      Number of Netty service IO worker threads for Remote System Operation HTTP service
-    </description>
-  </property>
-
-
   <!-- Metadata Configuration -->
 
   <property>
@@ -1425,6 +1398,33 @@
     <value>16</value>
     <description>
       Number of splits in the queue table
+    </description>
+  </property>
+
+
+  <!-- Remote System Operation Configuration -->
+
+  <property>
+    <name>remote.system.op.exec.threads</name>
+    <value>${http.service.exec.threads}</value>
+    <description>
+      Number of Netty service executor threads for the remote system operation HTTP service
+    </description>
+  </property>
+
+  <property>
+    <name>remote.system.op.service.bind.address</name>
+    <value>0.0.0.0</value>
+    <description>
+      Remote system operation HTTP service bind address
+    </description>
+  </property>
+
+  <property>
+    <name>remote.system.op.worker.threads</name>
+    <value>${http.service.worker.threads}</value>
+    <description>
+      Number of Netty service IO worker threads for the remote system operation HTTP service
     </description>
   </property>
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="53378f5794e2692c9b54bb880ba05a37"
+DEFAULT_XML_MD5_HASH="c3223f49bd5cbc2201509da9565dd50d"
 
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="baad1c30daf742bfa9e7344ee4407962"
+DEFAULT_XML_MD5_HASH="53378f5794e2692c9b54bb880ba05a37"
 
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"


### PR DESCRIPTION
Passes [Quick Build](http://builds.cask.co/browse/CDAP-DQB46-1)

Addresses https://issues.cask.co/browse/CDAP-6105 as it was in the same file.

Moves the "Remote System Operation Service Configuration" to the correct location in the file and edits the name to match others.
