### PR TITLE
Fix generation of CDAP CLI documentation

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Configuration.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Configuration.java
@@ -1735,7 +1735,9 @@ public class Configuration implements Iterable<Map.Entry<String, String>> {
           if (deprecatedKeyMap.containsKey(attr)) {
             DeprecatedKeyInfo keyInfo = deprecatedKeyMap.get(attr);
             keyInfo.accessed = false;
-            warnOnceIfDeprecated(attr);
+            if (!quiet) {
+              warnOnceIfDeprecated(attr);
+            }
             for (String key : keyInfo.newKeys) {
               // update new keys with deprecated key's value
               loadProperty(properties, name, key, value, finalParameter);


### PR DESCRIPTION
Display deprecation warnings only if not in quiet mode.

This issue showed up once some recent properties were deprecated in `cdap-default.xml`.

See [CLI Commands](http://builds.cask.co/artifact/CDAP-DRBDE/JOB1/build-340/Docs-HTML/3.5.0-SNAPSHOT/en/reference-manual/cli-api.html#available-commands) for an example:

![screen shot 2016-07-19 at 8 43 01 am](https://cloud.githubusercontent.com/assets/6394794/16956331/d9b24b2a-4d8c-11e6-96fd-978cee0338e3.png)

This change shows the deprecation warning only if not in quiet mode, and fixes the problem for the CLI documentation.

Though this fixes the problem in the CDAP CLI documentation, I am not certain that are not any side-effects to this change. I don't know if there are any cases where these deprecation warnings would normally be expected to appear, as the default mode for these configuration files is "quiet".

Ran a [docs release build](http://builds.cask.co/browse/CDAP-DDB41-1).
The build fails (because the develop branch doc build was broken, see https://github.com/caskdata/cdap/pull/6097), but the CDAP CLI commands are [now fine](http://builds.cask.co/artifact/CDAP-DDB41/shared/build-1/Docs-HTML/3.5.0-SNAPSHOT/en/reference-manual/cli-api.html#available-commands).
