### PR TITLE
CDAP-6545 Fix to make log saver work when Kafka partitions are highly skewed

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -606,7 +606,7 @@ public final class Constants {
     public static final String ADDRESS = "log.saver.status.bind.address";
 
     public static final String SERVICE_DESCRIPTION = "Service to collect and store logs.";
-    public static final String MESSAGE_PROCESSORS =  "log.saver.message.processors";
+    public static final String MESSAGE_PROCESSOR_FACTORIES =  "log.saver.message.processor.factories";
   }
 
   /**

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/standalone/StandaloneLogAppender.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/appender/standalone/StandaloneLogAppender.java
@@ -21,6 +21,7 @@ import co.cask.cdap.logging.appender.LogAppender;
 import co.cask.cdap.logging.appender.LogMessage;
 import co.cask.cdap.logging.kafka.KafkaLogEvent;
 import co.cask.cdap.logging.save.KafkaLogProcessor;
+import com.google.common.collect.Iterators;
 
 import java.util.Set;
 
@@ -42,7 +43,7 @@ public class StandaloneLogAppender extends LogAppender {
   protected void append(LogMessage logMessage) {
     appender.append(logMessage);
     for (KafkaLogProcessor plugin : plugins) {
-      plugin.process(getKafkaLogEvent(logMessage));
+      plugin.process(Iterators.singletonIterator(getKafkaLogEvent(logMessage)));
     }
   }
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/AbstractKafkaLogProcessor.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/AbstractKafkaLogProcessor.java
@@ -17,32 +17,17 @@
 package co.cask.cdap.logging.save;
 
 import co.cask.cdap.logging.kafka.KafkaLogEvent;
-import com.google.common.base.Throwables;
-import com.google.common.collect.Maps;
 
-import java.util.Map;
-import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Abstract Log Processor that stores offsets for paritions and checks if a given event is already processed.
  */
 public abstract class AbstractKafkaLogProcessor implements KafkaLogProcessor {
+  private Checkpoint checkpoint;
 
-  private final Map<Integer, Checkpoint> partitonCheckpoints;
-  public AbstractKafkaLogProcessor() {
-    this.partitonCheckpoints = Maps.newHashMap();
-  }
-
-  public void init(Set<Integer> partitions, CheckpointManager checkpointManager) {
-    partitonCheckpoints.clear();
-    try {
-      Map<Integer, Checkpoint> partitionMap = checkpointManager.getCheckpoint(partitions);
-      for (Map.Entry<Integer, Checkpoint> partition : partitionMap.entrySet()) {
-        partitonCheckpoints.put(partition.getKey(), partition.getValue());
-      }
-    } catch (Exception e) {
-      throw Throwables.propagate(e);
-    }
+  public void init(@Nullable Checkpoint checkpoint) {
+    this.checkpoint = checkpoint;
   }
 
   public void process(KafkaLogEvent event) {
@@ -61,7 +46,6 @@ public abstract class AbstractKafkaLogProcessor implements KafkaLogProcessor {
   public boolean alreadyProcessed(KafkaLogEvent event) {
     // If no checkpoint is found, then the event needs to be processed.
     // if the event offset is less than or equal to what is already checkpointed then the event is already processed
-    Checkpoint checkpoint = partitonCheckpoints.get(event.getPartition());
     return checkpoint != null && event.getNextOffset() <= checkpoint.getNextOffset();
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogProcessor.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogProcessor.java
@@ -18,6 +18,8 @@ package co.cask.cdap.logging.save;
 
 import co.cask.cdap.logging.kafka.KafkaLogEvent;
 
+import java.util.Iterator;
+
 /**
  * Process {@link KafkaLogEvent} with KafkaLogProcessor. init and stop are lifecycle methods that can be called
  * multiple times when kafka leader partitions change.
@@ -33,9 +35,9 @@ public interface KafkaLogProcessor {
   /**
    * Process method will be called for each event received from Kafka from the topics published for log saver.
    *
-   * @param event instance of {@link KafkaLogEvent}
+   * @param events list of {@link KafkaLogEvent}
    */
-  void process(KafkaLogEvent event);
+  void process(Iterator<KafkaLogEvent> events);
 
   /**
    * Called to stop processing for the current set of kafka partitions. Stop can be called before init.

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogProcessor.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogProcessor.java
@@ -18,8 +18,6 @@ package co.cask.cdap.logging.save;
 
 import co.cask.cdap.logging.kafka.KafkaLogEvent;
 
-import java.util.Set;
-
 /**
  * Process {@link KafkaLogEvent} with KafkaLogProcessor. init and stop are lifecycle methods that can be called
  * multiple times when kafka leader partitions change.
@@ -28,9 +26,9 @@ public interface KafkaLogProcessor {
 
   /**
    * Called when the leader partitions change.
-   * @param partitions new leader partitions.
+   * @param partition new leader partition.
    */
-  void init(Set<Integer> partitions);
+  void init(int partition) throws Exception;
 
   /**
    * Process method will be called for each event received from Kafka from the topics published for log saver.
@@ -46,12 +44,12 @@ public interface KafkaLogProcessor {
 
 
   /**
-   * Get the checkpoint offset for a given partition. This will be used to figure out the lowest offset to read
+   * Get the checkpoint offset for a given partition processed by this plugin.
+   * This will be used to figure out the lowest offset to read
    * from for any given partition across multiple plugins. If the plugin doesn't care about check pointing offset
    * the implementations can just return -1;
    *
-   * @param partition partition number in kafka
    * @return checkpoint offset
    */
- Checkpoint getCheckpoint(int partition);
+  Checkpoint getCheckpoint();
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogProcessorFactory.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogProcessorFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.save;
+
+/**
+ * Factory to create {@link KafkaLogProcessor} instances
+ */
+public interface KafkaLogProcessorFactory {
+  KafkaLogProcessor create() throws Exception;
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogWriterPlugin.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogWriterPlugin.java
@@ -36,7 +36,6 @@ import com.google.common.collect.RowSortedTable;
 import com.google.common.collect.TreeBasedTable;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.inject.Inject;
 import org.apache.twill.common.Threads;
 import org.apache.twill.filesystem.LocationFactory;
 import org.slf4j.Logger;
@@ -45,7 +44,6 @@ import org.slf4j.LoggerFactory;
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.SortedSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -73,8 +71,8 @@ public class KafkaLogWriterPlugin extends AbstractKafkaLogProcessor {
 
   private ListeningScheduledExecutorService scheduledExecutor;
   private CountDownLatch countDownLatch;
+  private int partition;
 
-  @Inject
   public KafkaLogWriterPlugin(CConfiguration cConfig, FileMetaDataManager fileMetaDataManager,
                               LocationFactory locationFactory, CheckpointManagerFactory checkpointManagerFactory)
     throws Exception {
@@ -146,21 +144,26 @@ public class KafkaLogWriterPlugin extends AbstractKafkaLogProcessor {
   }
 
   @Override
-  public void init(Set<Integer> partitions) {
-    super.init(partitions, checkpointManager);
+  public void init(int partition) throws Exception {
+    this.partition = partition;
+    Checkpoint checkpoint = checkpointManager.getCheckpoint(partition);
+    super.init(checkpoint);
 
-    scheduledExecutor = MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor(
-      Threads.createDaemonThreadFactory("log-saver-log-processor")));
+    // We schedule clean up task if partition is zero, so that only one cleanup task gets scheduled
+    if (partition == 0) {
+      scheduledExecutor = MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(2,
+        Threads.createDaemonThreadFactory("log-saver-log-processor-" + partition)));
+      LOG.info("Scheduling cleanup task");
+      scheduledExecutor.scheduleAtFixedRate(logCleanup, 10, logCleanupIntervalMins, TimeUnit.MINUTES);
+    } else {
+      scheduledExecutor = MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor(
+        Threads.createDaemonThreadFactory("log-saver-log-processor-" + partition)));
+    }
 
     LogWriter logWriter = new LogWriter(logFileWriter, messageTable,
                                         eventBucketIntervalMs, maxNumberOfBucketsInTable);
     scheduledExecutor.scheduleWithFixedDelay(logWriter, 100, 200, TimeUnit.MILLISECONDS);
     countDownLatch = new CountDownLatch(1);
-
-    if (partitions.contains(0)) {
-      LOG.info("Scheduling cleanup task");
-      scheduledExecutor.scheduleAtFixedRate(logCleanup, 10, logCleanupIntervalMins, TimeUnit.MINUTES);
-    }
   }
 
   @Override
@@ -231,7 +234,9 @@ public class KafkaLogWriterPlugin extends AbstractKafkaLogProcessor {
 
       if (scheduledExecutor != null) {
         scheduledExecutor.shutdown();
-        scheduledExecutor.awaitTermination(5, TimeUnit.MINUTES);
+        if (!scheduledExecutor.awaitTermination(5, TimeUnit.MINUTES)) {
+          scheduledExecutor.shutdownNow();
+        }
       }
 
       logFileWriter.flush();
@@ -244,7 +249,7 @@ public class KafkaLogWriterPlugin extends AbstractKafkaLogProcessor {
   }
 
   @Override
-  public Checkpoint getCheckpoint(int partition) {
+  public Checkpoint getCheckpoint() {
     try {
       return checkpointManager.getCheckpoint(partition);
     } catch (Exception e) {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogWriterPluginFactory.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogWriterPluginFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.save;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.logging.write.FileMetaDataManager;
+import com.google.inject.Inject;
+import org.apache.twill.filesystem.LocationFactory;
+
+/**
+ * Factory to create {@link KafkaLogWriterPlugin}.
+ */
+public class KafkaLogWriterPluginFactory implements KafkaLogProcessorFactory {
+  private final CConfiguration cConfig;
+  private final FileMetaDataManager fileMetaDataManager;
+  private final LocationFactory locationFactory;
+  private final CheckpointManagerFactory checkpointManagerFactory;
+
+  @Inject
+  public KafkaLogWriterPluginFactory(CConfiguration cConfig, FileMetaDataManager fileMetaDataManager,
+                                     LocationFactory locationFactory,
+                                     CheckpointManagerFactory checkpointManagerFactory) {
+    this.cConfig = cConfig;
+    this.fileMetaDataManager = fileMetaDataManager;
+    this.locationFactory = locationFactory;
+    this.checkpointManagerFactory = checkpointManagerFactory;
+  }
+
+  @Override
+  public KafkaLogProcessor create() throws Exception {
+    return new KafkaLogWriterPlugin(cConfig, fileMetaDataManager, locationFactory, checkpointManagerFactory);
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogMetricsPlugin.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogMetricsPlugin.java
@@ -18,24 +18,25 @@ package co.cask.cdap.logging.save;
 
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.metrics.MetricsContext;
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LoggingContext;
+import co.cask.cdap.logging.LoggingConfiguration;
 import co.cask.cdap.logging.appender.kafka.KafkaTopic;
 import co.cask.cdap.logging.context.LoggingContextHelper;
 import co.cask.cdap.logging.kafka.KafkaLogEvent;
 import co.cask.cdap.proto.Id;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.inject.Inject;
 import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
@@ -51,38 +52,40 @@ public class LogMetricsPlugin extends AbstractKafkaLogProcessor {
 
   private final CheckpointManager checkpointManager;
   private final MetricsCollectionService metricsCollectionService;
+  private final CConfiguration cConfig;
 
   private final Map<Integer, Checkpoint> partitionCheckpoints = Maps.newConcurrentMap();
   private ListeningScheduledExecutorService scheduledExecutor;
   private CheckPointWriter checkPointWriter;
+  private int partition;
 
-  @Inject
   public LogMetricsPlugin (MetricsCollectionService metricsCollectionService,
-                           CheckpointManagerFactory checkpointManagerFactory) {
+                           CheckpointManagerFactory checkpointManagerFactory, CConfiguration cConfig) {
     this.metricsCollectionService = metricsCollectionService;
+    this.cConfig = cConfig;
     this.checkpointManager = checkpointManagerFactory.create(KafkaTopic.getTopic(), ROW_KEY_PREFIX);
   }
 
   @Override
-  public void init(Set<Integer> partitions) {
-    super.init(partitions, checkpointManager);
+  public void init(int partition) throws Exception {
+    long checkpointIntervalMs = cConfig.getLong(LoggingConfiguration.LOG_SAVER_CHECKPOINT_INTERVAL_MS,
+                                                LoggingConfiguration.DEFAULT_LOG_SAVER_CHECKPOINT_INTERVAL_MS);
+    Preconditions.checkArgument(checkpointIntervalMs > 0,
+                                "Checkpoint interval is invalid: %s", checkpointIntervalMs);
+
+    Checkpoint checkpoint = checkpointManager.getCheckpoint(partition);
+    super.init(checkpoint);
+    this.partition = partition;
 
     scheduledExecutor = MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor(
       Threads.createDaemonThreadFactory("log-saver-metrics-plugin")));
 
     partitionCheckpoints.clear();
-    try {
-      Map<Integer, Checkpoint> partitionMap = checkpointManager.getCheckpoint(partitions);
-      for (Map.Entry<Integer, Checkpoint> partition : partitionMap.entrySet()) {
-        partitionCheckpoints.put(partition.getKey(), partition.getValue());
-      }
-    } catch (Exception e) {
-      LOG.error("Caught exception while reading checkpoint", e);
-      throw Throwables.propagate(e);
-    }
+    partitionCheckpoints.put(partition, checkpoint);
 
     checkPointWriter = new CheckPointWriter(checkpointManager, partitionCheckpoints);
-    scheduledExecutor.scheduleWithFixedDelay(checkPointWriter, 100, 500, TimeUnit.MILLISECONDS);
+    scheduledExecutor.scheduleWithFixedDelay(checkPointWriter, checkpointIntervalMs, checkpointIntervalMs,
+                                             TimeUnit.MILLISECONDS);
   }
 
   @Override
@@ -127,7 +130,7 @@ public class LogMetricsPlugin extends AbstractKafkaLogProcessor {
   }
 
   @Override
-  public Checkpoint getCheckpoint(int partition) {
+  public Checkpoint getCheckpoint() {
     try {
       return checkpointManager.getCheckpoint(partition);
     } catch (Exception e) {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogMetricsPlugin.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogMetricsPlugin.java
@@ -36,6 +36,7 @@ import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -89,23 +90,25 @@ public class LogMetricsPlugin extends AbstractKafkaLogProcessor {
   }
 
   @Override
-  public void doProcess(KafkaLogEvent event) {
+  public void doProcess(Iterator<KafkaLogEvent> events) {
 
-    LoggingContext context = event.getLoggingContext();
-    Map<String, String> tags = LoggingContextHelper.getMetricsTags(context);
-    MetricsContext collector = metricsCollectionService.getContext(tags);
+    while (events.hasNext()) {
+      KafkaLogEvent event = events.next();
+      LoggingContext context = event.getLoggingContext();
+      Map<String, String> tags = LoggingContextHelper.getMetricsTags(context);
+      MetricsContext collector = metricsCollectionService.getContext(tags);
 
-    String metricName = getMetricName(tags.get(Constants.Metrics.Tag.NAMESPACE),
-                                      event.getLogEvent().getLevel().toString().toLowerCase());
+      String metricName = getMetricName(tags.get(Constants.Metrics.Tag.NAMESPACE),
+                                        event.getLogEvent().getLevel().toString().toLowerCase());
 
-    if  (!(tags.containsKey(Constants.Metrics.Tag.COMPONENT) &&
-           tags.get(Constants.Metrics.Tag.COMPONENT).equals(Constants.Service.METRICS_PROCESSOR))) {
-      collector.increment(metricName, 1);
+      if  (!(tags.containsKey(Constants.Metrics.Tag.COMPONENT) &&
+             tags.get(Constants.Metrics.Tag.COMPONENT).equals(Constants.Service.METRICS_PROCESSOR))) {
+        collector.increment(metricName, 1);
+      }
+
+      partitionCheckpoints.put(event.getPartition(),
+                               new Checkpoint(event.getNextOffset(), event.getLogEvent().getTimeStamp()));
     }
-
-    partitionCheckpoints.put(event.getPartition(),
-                             new Checkpoint(event.getNextOffset(), event.getLogEvent().getTimeStamp()));
-
   }
 
   private String getMetricName(String namespace, String logLevel) {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogMetricsPluginFactory.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogMetricsPluginFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.save;
+
+import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.common.conf.CConfiguration;
+import com.google.inject.Inject;
+
+/**
+ * Factory to create {@link LogMetricsPlugin}.
+ */
+public class LogMetricsPluginFactory implements KafkaLogProcessorFactory {
+  private final MetricsCollectionService metricsCollectionService;
+  private final CheckpointManagerFactory checkpointManagerFactory;
+  private final CConfiguration cConfig;
+
+  @Inject
+  public LogMetricsPluginFactory(MetricsCollectionService metricsCollectionService,
+                                 CheckpointManagerFactory checkpointManagerFactory, CConfiguration cConfig) {
+    this.metricsCollectionService = metricsCollectionService;
+    this.checkpointManagerFactory = checkpointManagerFactory;
+    this.cConfig = cConfig;
+  }
+
+  @Override
+  public KafkaLogProcessor create() throws Exception {
+    return new LogMetricsPlugin(metricsCollectionService, checkpointManagerFactory, cConfig);
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogSaver.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogSaver.java
@@ -22,8 +22,10 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.logging.appender.kafka.KafkaTopic;
 import co.cask.cdap.proto.Id;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.google.common.collect.SetMultimap;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
@@ -35,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -52,15 +55,17 @@ public final class LogSaver extends AbstractIdleService {
   private final KafkaClientService kafkaClient;
   private final Set<Integer> partitions;
 
-  private Map<Integer, Cancellable> kafkaCancelMap;
-  private Map<Integer, CountDownLatch> kafkaCancelCallbackLatchMap;
-  private Set<KafkaLogProcessor> messageProcessors;
+  private final Map<Integer, Cancellable> kafkaCancelMap;
+  private final Map<Integer, CountDownLatch> kafkaCancelCallbackLatchMap;
+  private final Set<KafkaLogProcessorFactory> messageProcessorFactories;
+  private final SetMultimap<Integer, KafkaLogProcessor> partitionProcessorsMap;
 
   private final MetricsContext metricsContext;
 
   @Inject
   public LogSaver(KafkaClientService kafkaClient,
-                  @Named(Constants.LogSaver.MESSAGE_PROCESSORS) Set<KafkaLogProcessor> messageProcessors,
+                  @Named(Constants.LogSaver.MESSAGE_PROCESSOR_FACTORIES)
+                  Set<KafkaLogProcessorFactory> messageProcessorFactories,
                   @Assisted Set<Integer> partitions,
                   MetricsCollectionService metricsCollectionService)
                   throws Exception {
@@ -73,7 +78,8 @@ public final class LogSaver extends AbstractIdleService {
     this.kafkaClient = kafkaClient;
     this.kafkaCancelMap = new HashMap<>();
     this.kafkaCancelCallbackLatchMap = new HashMap<>();
-    this.messageProcessors = messageProcessors;
+    this.messageProcessorFactories = messageProcessorFactories;
+    this.partitionProcessorsMap = HashMultimap.create();
 
     // TODO: add instance id of the log saver as a tag, when CDAP-3265 is fixed
     this.metricsContext = metricsCollectionService.getContext(
@@ -84,6 +90,7 @@ public final class LogSaver extends AbstractIdleService {
   @Override
   protected void startUp() throws Exception {
     LOG.info("Starting LogSaver...");
+    createProcessors(partitions);
     waitForDatasetAvailability();
     scheduleTasks(partitions);
     LOG.info("Started LogSaver.");
@@ -105,7 +112,7 @@ public final class LogSaver extends AbstractIdleService {
   void unscheduleTasks() {
     cancelLogCollectorCallbacks();
 
-    for (KafkaLogProcessor processor : messageProcessors) {
+    for (KafkaLogProcessor processor : partitionProcessorsMap.values()) {
       try {
         // Catching the exception to let all the plugins a chance to stop cleanly.
         processor.stop();
@@ -113,6 +120,18 @@ public final class LogSaver extends AbstractIdleService {
         LOG.error("Error stopping processor {}",
                   processor.getClass().getSimpleName());
       }
+    }
+    partitionProcessorsMap.clear();
+  }
+
+  private void createProcessors(Set<Integer> partitions) throws Exception {
+    for (int partition : partitions) {
+      Set<KafkaLogProcessor> processors = new HashSet<>();
+      for (KafkaLogProcessorFactory factory : messageProcessorFactories) {
+        KafkaLogProcessor logProcessor = factory.create();
+        processors.add(logProcessor);
+      }
+      partitionProcessorsMap.putAll(partition, processors);
     }
   }
 
@@ -132,12 +151,13 @@ public final class LogSaver extends AbstractIdleService {
   private void subscribe(Set<Integer> partitions) throws Exception {
     LOG.info("Prepare to subscribe for partitions: {}", partitions);
 
-    for (KafkaLogProcessor processor : messageProcessors) {
-      processor.init(partitions);
-    }
-
     Map<Integer, Long> partitionOffset = Maps.newHashMap();
     for (int part : partitions) {
+      Set<KafkaLogProcessor> kafkaLogProcessors = partitionProcessorsMap.get(part);
+      for (KafkaLogProcessor kafkaLogProcessor : kafkaLogProcessors) {
+        kafkaLogProcessor.init(part);
+      }
+
       KafkaConsumer.Preparer preparer = kafkaClient.getConsumer().prepare();
       long offset = getLowestCheckpointOffset(part);
       partitionOffset.put(part, offset);
@@ -149,8 +169,9 @@ public final class LogSaver extends AbstractIdleService {
       }
 
       kafkaCancelCallbackLatchMap.put(part, new CountDownLatch(1));
+
       kafkaCancelMap.put(part, preparer.consume(
-        new KafkaMessageCallback(kafkaCancelCallbackLatchMap.get(part), messageProcessors, metricsContext)));
+        new KafkaMessageCallback(kafkaCancelCallbackLatchMap.get(part), kafkaLogProcessors, metricsContext)));
     }
 
     LOG.info("Consumer created for topic {}, partitions {}", topic, partitionOffset);
@@ -159,8 +180,10 @@ public final class LogSaver extends AbstractIdleService {
   private long getLowestCheckpointOffset(int partition) {
     long lowestCheckpoint = -1L;
 
-    for (KafkaLogProcessor processor : messageProcessors) {
-      Checkpoint checkpoint = processor.getCheckpoint(partition);
+    for (KafkaLogProcessor processor : partitionProcessorsMap.get(partition)) {
+      Checkpoint checkpoint = processor.getCheckpoint();
+      LOG.trace("Got checkpoint {} for partition {} and processor {}",
+                checkpoint, partition, processor.getClass().getName());
       // If checkpoint offset is -1; then ignore the checkpoint offset
       if (checkpoint.getNextOffset() != -1) {
         lowestCheckpoint =  (lowestCheckpoint == -1 || checkpoint.getNextOffset() < lowestCheckpoint) ?
@@ -168,6 +191,7 @@ public final class LogSaver extends AbstractIdleService {
                              lowestCheckpoint;
       }
     }
+    LOG.debug("Lowest checkpoint for partition {} is {}", partition, lowestCheckpoint);
     return lowestCheckpoint;
   }
 
@@ -176,8 +200,8 @@ public final class LogSaver extends AbstractIdleService {
     boolean isDatasetAvailable = false;
     while (!isDatasetAvailable) {
       try {
-         for (KafkaLogProcessor processor : messageProcessors) {
-           processor.getCheckpoint(0);
+         for (KafkaLogProcessor processor : partitionProcessorsMap.values()) {
+           processor.getCheckpoint();
          }
         isDatasetAvailable = true;
       } catch (Exception e) {

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/LogSaverTableUtilOverride.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/LogSaverTableUtilOverride.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.logging.save.LogSaverTableUtil;
+import com.google.inject.Inject;
+
+/**
+ * Test utility used to change log meta table.
+ */
+public class LogSaverTableUtilOverride extends LogSaverTableUtil {
+  private static String logMetaTableName = "log.meta";
+
+  @Inject
+  public LogSaverTableUtilOverride(DatasetFramework framework, CConfiguration conf) {
+    super(framework, conf);
+  }
+
+  @Override
+  public String getMetaTableName() {
+    return logMetaTableName;
+  }
+
+  public static void setLogMetaTableName(String tableName) {
+    logMetaTableName = tableName;
+  }
+}

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/save/LogSaverPluginTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/save/LogSaverPluginTest.java
@@ -28,6 +28,7 @@ import co.cask.cdap.common.logging.NamespaceLoggingContext;
 import co.cask.cdap.common.logging.ServiceLoggingContext;
 import co.cask.cdap.common.logging.SystemLoggingContext;
 import co.cask.cdap.logging.KafkaTestBase;
+import co.cask.cdap.logging.LogSaverTableUtilOverride;
 import co.cask.cdap.logging.LoggingConfiguration;
 import co.cask.cdap.logging.appender.LogAppenderInitializer;
 import co.cask.cdap.logging.appender.kafka.KafkaLogAppender;
@@ -43,7 +44,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
@@ -86,16 +86,15 @@ public class LogSaverPluginTest extends KafkaTestBase {
 
   private static Injector injector;
   private static TransactionManager txManager;
-  private static String logBaseDir;
   private static LogSaver logSaver;
   private static String namespaceDir;
   private static KafkaLogAppender appender;
   private static CountingLogAppender countingLogAppender;
+  private static CConfiguration cConf;
 
   @BeforeClass
   public static void initialize() throws IOException {
-    CConfiguration cConf = KAFKA_TESTER.getCConf();
-    logBaseDir = cConf.get(LoggingConfiguration.LOG_BASE_DIR);
+    cConf = KAFKA_TESTER.getCConf();
     namespaceDir = cConf.get(Constants.Namespace.NAMESPACES_DIR);
 
     injector = KAFKA_TESTER.getInjector();
@@ -130,50 +129,66 @@ public class LogSaverPluginTest extends KafkaTestBase {
     publishLogs();
 
     LocationFactory locationFactory = injector.getInstance(LocationFactory.class);
+    String logBaseDir = cConf.get(LoggingConfiguration.LOG_BASE_DIR);
     Location ns1LogBaseDir = locationFactory.create(namespaceDir).append("NS_1").append(logBaseDir);
     waitTillLogSaverDone(ns1LogBaseDir, "APP_1/flow-FLOW_1/%s", "Test log message 59 arg1 arg2");
 
-    testLogRead(new FlowletLoggingContext("NS_1", "APP_1", "FLOW_1", "", "RUN1", "INSTANCE"));
+    testLogRead(new FlowletLoggingContext("NS_1", "APP_1", "FLOW_1", "", "RUN1", "INSTANCE"), logBaseDir);
 
     LogCallback logCallback = new LogCallback();
-    FileLogReader distributedLogReader = injector.getInstance(FileLogReader.class);
-    distributedLogReader.getLog(new FlowletLoggingContext("NS_1", "APP_1", "FLOW_1", "", null, "INSTANCE"),
+    FileLogReader fileLogReader = injector.getInstance(FileLogReader.class);
+    fileLogReader.getLog(new FlowletLoggingContext("NS_1", "APP_1", "FLOW_1", "", null, "INSTANCE"),
                                 0, Long.MAX_VALUE, Filter.EMPTY_FILTER, logCallback);
     Assert.assertEquals(60, logCallback.getEvents().size());
 
+    stopLogSaver();
+
+    // Checkpoint should read 60 for both processor
+    verifyCheckpoint();
+
+    // Now reset the logsaver to start reading from reset offset
+    // Change the log meta table so that checkpoints are new, and old log files are not read during read later
+    LogSaverTableUtilOverride.setLogMetaTableName("log.meta1");
+
     // Reset checkpoint for log saver plugin
-    resetLogSaverPluginCheckpoint();
+    resetLogSaverPluginCheckpoint(10);
 
-    // reset the logsaver to start reading from reset offset
-    Set<Integer> partitions = Sets.newHashSet(0, 1);
-    logSaver.unscheduleTasks();
-    logSaver.scheduleTasks(partitions);
+    // Change base dir so that new files get written and read from a different location (makes it easy for asserting)
+    String logBaseDir1 = logBaseDir + "1";
+    cConf.set(LoggingConfiguration.LOG_BASE_DIR, logBaseDir1);
+    Location ns1LogBaseDir1 = locationFactory.create(namespaceDir).append("NS_1").append(logBaseDir1);
 
-    waitTillLogSaverDone(ns1LogBaseDir, "APP_1/flow-FLOW_1/%s", "Test log message 59 arg1 arg2");
+    // Start log saver again
+    startLogSaver();
+    // Reset the log base dir back to original value
+    cConf.set(LoggingConfiguration.LOG_BASE_DIR, logBaseDir);
+
+    waitTillLogSaverDone(ns1LogBaseDir1, "APP_1/flow-FLOW_1/%s", "Test log message 59 arg1 arg2");
     stopLogSaver();
 
     LogCallback callbackAfterReset = new LogCallback();
 
     //Verify that more records are processed by LogWriter plugin
-    distributedLogReader.getLog(new FlowletLoggingContext("NS_1", "APP_1", "FLOW_1", "", null, "INSTANCE"),
+    fileLogReader = injector.getInstance(FileLogReader.class);
+    fileLogReader.getLog(new FlowletLoggingContext("NS_1", "APP_1", "FLOW_1", "", null, "INSTANCE"),
                                 0, Long.MAX_VALUE, Filter.EMPTY_FILTER, callbackAfterReset);
-    Assert.assertEquals(60, logCallback.getEvents().size());
+    // Since we started from offset 10, we should have only saved 50 messages this time
+    Assert.assertEquals(50, callbackAfterReset.getEvents().size());
     // Checkpoint should read 60 for both processor
     verifyCheckpoint();
   }
 
-  private void resetLogSaverPluginCheckpoint() throws Exception {
-    TypeLiteral<Set<KafkaLogProcessor>> type = new TypeLiteral<Set<KafkaLogProcessor>>() { };
-    Set<KafkaLogProcessor> processors =
-      injector.getInstance(Key.get(type, Names.named(Constants.LogSaver.MESSAGE_PROCESSORS)));
+  private void resetLogSaverPluginCheckpoint(long offset) throws Exception {
+    TypeLiteral<Set<KafkaLogProcessorFactory>> type = new TypeLiteral<Set<KafkaLogProcessorFactory>>() { };
+    Set<KafkaLogProcessorFactory> processorFactories =
+      injector.getInstance(Key.get(type, Names.named(Constants.LogSaver.MESSAGE_PROCESSOR_FACTORIES)));
 
-    for (KafkaLogProcessor processor : processors) {
+    for (KafkaLogProcessorFactory processorFactory : processorFactories) {
+      KafkaLogProcessor processor = processorFactory.create();
       if (processor instanceof  KafkaLogWriterPlugin) {
         KafkaLogWriterPlugin plugin = (KafkaLogWriterPlugin) processor;
         CheckpointManager manager = plugin.getCheckPointManager();
-        manager.saveCheckpoint(ImmutableMap.of(0, new Checkpoint(10, -1)));
-        Set<Integer> partitions = Sets.newHashSet(0, 1);
-        plugin.init(partitions);
+        manager.saveCheckpoint(ImmutableMap.of(0, new Checkpoint(offset, -1)));
       }
     }
   }
@@ -185,13 +200,15 @@ public class LogSaverPluginTest extends KafkaTestBase {
   }
 
   public void verifyCheckpoint() throws Exception {
-    TypeLiteral<Set<KafkaLogProcessor>> type = new TypeLiteral<Set<KafkaLogProcessor>>() { };
-    Set<KafkaLogProcessor> processors =
-      injector.getInstance(Key.get(type, Names.named(Constants.LogSaver.MESSAGE_PROCESSORS)));
+    TypeLiteral<Set<KafkaLogProcessorFactory>> type = new TypeLiteral<Set<KafkaLogProcessorFactory>>() { };
+    Set<KafkaLogProcessorFactory> processorFactories =
+      injector.getInstance(Key.get(type, Names.named(Constants.LogSaver.MESSAGE_PROCESSOR_FACTORIES)));
 
-    for (KafkaLogProcessor processor : processors) {
+    for (KafkaLogProcessorFactory processorFactory : processorFactories) {
+      KafkaLogProcessor processor = processorFactory.create();
       CheckpointManager checkpointManager = getCheckPointManager(processor);
-      Assert.assertEquals(60, checkpointManager.getCheckpoint(0).getNextOffset());
+      Assert.assertEquals("Checkpoint mismatch for " + processor.getClass().getName(),
+                          60, checkpointManager.getCheckpoint(0).getNextOffset());
     }
   }
 
@@ -206,7 +223,7 @@ public class LogSaverPluginTest extends KafkaTestBase {
     throw new IllegalArgumentException("Invalid processor");
   }
 
-  private void testLogRead(LoggingContext loggingContext) throws Exception {
+  private void testLogRead(LoggingContext loggingContext, String logBaseDir) throws Exception {
     LOG.info("Verifying logging context {}", loggingContext.getLogPathFragment(logBaseDir));
     FileLogReader distributedLogReader = injector.getInstance(FileLogReader.class);
 
@@ -386,7 +403,6 @@ public class LogSaverPluginTest extends KafkaTestBase {
         List<LogEvent> events = logCallback.getEvents();
         if (events.size() > 0) {
           LogEvent event = events.get(events.size() - 1);
-          System.out.println(event.getLoggingEvent().getFormattedMessage());
           if (event.getLoggingEvent().getFormattedMessage().equals(logLine)) {
             break;
           }

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/save/LogSaverTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/save/LogSaverTest.java
@@ -131,11 +131,12 @@ public class LogSaverTest extends KafkaTestBase {
 
   @Test
   public void testCheckpoint() throws Exception {
-    TypeLiteral<Set<KafkaLogProcessor>> type = new TypeLiteral<Set<KafkaLogProcessor>>() { };
-    Set<KafkaLogProcessor> processors =
-      injector.getInstance(Key.get(type, Names.named(Constants.LogSaver.MESSAGE_PROCESSORS)));
+    TypeLiteral<Set<KafkaLogProcessorFactory>> type = new TypeLiteral<Set<KafkaLogProcessorFactory>>() { };
+    Set<KafkaLogProcessorFactory> processorFactories =
+      injector.getInstance(Key.get(type, Names.named(Constants.LogSaver.MESSAGE_PROCESSOR_FACTORIES)));
 
-    for (KafkaLogProcessor processor : processors) {
+    for (KafkaLogProcessorFactory processorFactory : processorFactories) {
+      KafkaLogProcessor processor = processorFactory.create();
       CheckpointManager checkpointManager = getCheckPointManager(processor);
 
       // Verify checkpoint offset


### PR DESCRIPTION
JIRA - https://issues.cask.co/browse/CDAP-6545
Build - http://builds.cask.co/browse/CDAP-DUT4446-5

The two major changes for this are -
1. Process each Kafka partition concurrently, so that one skewed partition does not slow the others (commit https://github.com/caskdata/cdap/commit/ab802fbbbe213381e01232fde176b7d418fa0068)
2. Process a batch of events fetched from Kafka in one process method call (commit https://github.com/caskdata/cdap/commit/cb0e81df6f99781d52733b46a4dd22d5dc1776c6)
