### PR TITLE
(CDAP-6580) Added an AuthenticationContext that can be injected to de…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -97,6 +97,7 @@ import co.cask.cdap.metrics.runtime.MetricsProcessorStatusServiceManager;
 import co.cask.cdap.metrics.runtime.MetricsServiceManager;
 import co.cask.cdap.pipeline.PipelineFactory;
 import co.cask.cdap.security.DefaultUGIProvider;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.guice.SecureStoreModules;
 import co.cask.http.HttpHandler;
 import com.google.common.base.Supplier;
@@ -143,6 +144,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                            new ConfigStoreModule().getInMemoryModule(),
                            new SecureStoreModules().getInMemoryModules(),
                            new EntityVerifierModule(),
+                           new AuthenticationContextModules().getMasterModule(),
                            new AbstractModule() {
                              @Override
                              protected void configure() {
@@ -178,6 +180,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                            new ConfigStoreModule().getStandaloneModule(),
                            new SecureStoreModules().getStandaloneModules(),
                            new EntityVerifierModule(),
+                           new AuthenticationContextModules().getMasterModule(),
                            new AbstractModule() {
                              @Override
                              protected void configure() {
@@ -235,6 +238,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                            new ConfigStoreModule().getDistributedModule(),
                            new SecureStoreModules().getDistributedModules(),
                            new EntityVerifierModule(),
+                           new AuthenticationContextModules().getMasterModule(),
                            new AbstractModule() {
                              @Override
                              protected void configure() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramRunnableModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramRunnableModule.java
@@ -44,6 +44,7 @@ import co.cask.cdap.internal.app.store.remote.RemoteRuntimeUsageRegistry;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.guice.SecureStoreModules;
 import com.google.inject.AbstractModule;
@@ -95,6 +96,7 @@ public class DistributedProgramRunnableModule {
       new NamespaceClientRuntimeModule().getDistributedModules(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getDistributedModules(),
+      new AuthenticationContextModules().getProgramContainerModule(),
       new SecureStoreModules().getDistributedModules(),
       new AbstractModule() {
         @Override

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/stream/store/MDSStreamMetaStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/stream/store/MDSStreamMetaStoreTest.java
@@ -38,6 +38,7 @@ import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.internal.app.store.DefaultStore;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationTestModule;
 import co.cask.cdap.store.NamespaceStore;
@@ -75,6 +76,7 @@ public class MDSStreamMetaStoreTest extends StreamMetaStoreTestBase {
       new NamespaceStoreModule().getStandaloneModules(),
       new AuthorizationTestModule(),
       new AuthorizationEnforcementModule().getInMemoryModules(),
+      new AuthenticationContextModules().getMasterModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/guice/NamespaceClientRuntimeModule.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/guice/NamespaceClientRuntimeModule.java
@@ -37,9 +37,9 @@ public class NamespaceClientRuntimeModule extends RuntimeModule {
     return new AbstractModule() {
       @Override
       protected void configure() {
-        bind(InMemoryNamespaceClient.class).in(Singleton.class);
-        bind(NamespaceAdmin.class).to(InMemoryNamespaceClient.class);
-        bind(NamespaceQueryAdmin.class).to(InMemoryNamespaceClient.class);
+        InMemoryNamespaceClient namespaceClient = new InMemoryNamespaceClient();
+        bind(NamespaceAdmin.class).toInstance(namespaceClient);
+        bind(NamespaceQueryAdmin.class).toInstance(namespaceClient);
       }
     };
   }

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamFileJanitorTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamFileJanitorTest.java
@@ -44,6 +44,7 @@ import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.store.NamespaceStore;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -124,7 +125,8 @@ public class DFSStreamFileJanitorTest extends StreamFileJanitorTestBase {
           bind(NotificationFeedManager.class).to(NoOpNotificationFeedManager.class);
           bind(NamespaceStore.class).to(InMemoryNamespaceStore.class);
         }
-      }
+      },
+      new AuthenticationContextModules().getMasterModule()
     );
 
     locationFactory = injector.getInstance(LocationFactory.class);

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DistributedStreamCoordinatorClientTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DistributedStreamCoordinatorClientTest.java
@@ -34,6 +34,7 @@ import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.util.hbase.SimpleNamespaceQueryAdmin;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModule;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -101,7 +102,8 @@ public class DistributedStreamCoordinatorClientTest extends StreamCoordinatorTes
           protected void configure() {
             bind(StreamMetaStore.class).to(InMemoryStreamMetaStore.class);
           }
-        })
+        }),
+      new AuthenticationContextModules().getMasterModule()
     );
 
     zkClient = injector.getInstance(ZKClientService.class);

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/DFSStreamHeartbeatsTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/DFSStreamHeartbeatsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -52,6 +52,7 @@ import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModu
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.notifications.service.NotificationService;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationTestModule;
 import co.cask.tephra.TransactionManager;
@@ -135,6 +136,7 @@ public class DFSStreamHeartbeatsTest {
         new ViewAdminModules().getInMemoryModules(),
         new AuthorizationTestModule(),
         new AuthorizationEnforcementModule().getInMemoryModules(),
+        new AuthenticationContextModules().getMasterModule(),
         // We need the distributed modules here to get the distributed stream service, which is the only one
         // that performs heartbeats aggregation
         new StreamServiceRuntimeModule().getDistributedModules(),

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -29,6 +29,7 @@ import co.cask.cdap.data.runtime.TransactionMetricsModule;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.data2.metadata.store.NoOpMetadataStore;
 import co.cask.cdap.data2.util.hbase.SimpleNamespaceQueryAdmin;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionSystemClient;
 import co.cask.tephra.TransactionSystemTest;
@@ -62,7 +63,6 @@ public class TransactionServiceClientTest extends TransactionSystemTest {
   @ClassRule
   public static TemporaryFolder tmpFolder = new TemporaryFolder();
 
-  private static CConfiguration cConf;
   private static InMemoryZKServer zkServer;
   private static TransactionService server;
   private static TransactionStateStorage txStateStorage;
@@ -89,7 +89,7 @@ public class TransactionServiceClientTest extends TransactionSystemTest {
     zkServer = InMemoryZKServer.builder().build();
     zkServer.startAndWait();
 
-    cConf = CConfiguration.create();
+    CConfiguration cConf = CConfiguration.create();
     // tests should use the current user for HDFS
     cConf.set(Constants.CFG_HDFS_USER, System.getProperty("user.name"));
     cConf.set(Constants.Zookeeper.QUORUM, zkServer.getConnectionStr());
@@ -119,7 +119,8 @@ public class TransactionServiceClientTest extends TransactionSystemTest {
         protected void configure() {
           bind(MetadataStore.class).to(NoOpMetadataStore.class);
         }
-      }));
+      }),
+      new AuthenticationContextModules().getMasterModule());
 
     zkClient = injector.getInstance(ZKClientService.class);
     zkClient.startAndWait();
@@ -157,12 +158,9 @@ public class TransactionServiceClientTest extends TransactionSystemTest {
     Transaction tx1 = client.startShort();
     long currentTime = System.currentTimeMillis();
 
-    InputStream in = client.getSnapshotInputStream();
     TransactionSnapshot snapshot;
-    try {
+    try (InputStream in = client.getSnapshotInputStream()) {
       snapshot = codecProvider.decode(in);
-    } finally {
-      in.close();
     }
     Assert.assertTrue(snapshot.getTimestamp() >= currentTime);
     Assert.assertTrue(snapshot.getInProgress().containsKey(tx1.getWritePointer()));

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -34,6 +34,7 @@ import co.cask.cdap.data2.dataset2.lib.table.inmemory.InMemoryTableService;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.data2.metadata.store.NoOpMetadataStore;
 import co.cask.cdap.data2.util.hbase.SimpleNamespaceQueryAdmin;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.tephra.DefaultTransactionExecutor;
 import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TransactionExecutor;
@@ -105,7 +106,8 @@ public class TransactionServiceTest {
           protected void configure() {
             bind(MetadataStore.class).to(NoOpMetadataStore.class);
           }
-        })
+        }),
+        new AuthenticationContextModules().getMasterModule()
       );
 
       ZKClientService zkClient = injector.getInstance(ZKClientService.class);
@@ -159,7 +161,7 @@ public class TransactionServiceTest {
         // releasing resources
         third.stop();
       } finally {
-        dropTable("myTable", cConf);
+        dropTable("myTable");
         zkClient.stopAndWait();
       }
 
@@ -188,7 +190,7 @@ public class TransactionServiceTest {
     return new InMemoryTable(tableName);
   }
 
-  private void dropTable(String tableName, CConfiguration cConf) throws Exception {
+  private void dropTable(String tableName) throws Exception {
     InMemoryTableService.drop(tableName);
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
@@ -40,6 +40,7 @@ import co.cask.cdap.proto.DatasetModuleMeta;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.DatasetTypeMeta;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import com.google.common.base.Objects;
 import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
@@ -80,12 +81,13 @@ public class RemoteDatasetFramework implements DatasetFramework {
 
   @Inject
   public RemoteDatasetFramework(final CConfiguration cConf, final DiscoveryServiceClient discoveryClient,
-                                DatasetDefinitionRegistryFactory registryFactory) {
+                                DatasetDefinitionRegistryFactory registryFactory,
+                                final AuthenticationContext authenticationContext) {
     this.cConf = cConf;
     this.clientCache = CacheBuilder.newBuilder().build(new CacheLoader<Id.Namespace, DatasetServiceClient>() {
       @Override
       public DatasetServiceClient load(Id.Namespace namespace) throws Exception {
-        return new DatasetServiceClient(discoveryClient, namespace, cConf);
+        return new DatasetServiceClient(discoveryClient, namespace.toEntityId(), cConf, authenticationContext);
       }
     });
     this.registryFactory = registryFactory;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
@@ -48,7 +48,7 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;
-import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
+import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
 import co.cask.cdap.security.spi.authorization.Authorizer;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
@@ -85,6 +85,7 @@ public class DatasetInstanceService {
   private final LoadingCache<Id.DatasetInstance, DatasetMeta> metaCache;
   private final AuthorizationEnforcer authorizationEnforcer;
   private final Authorizer authorizer;
+  private final AuthenticationContext authenticationContext;
 
   private AuditPublisher auditPublisher;
 
@@ -93,7 +94,8 @@ public class DatasetInstanceService {
                                 DatasetOpExecutor opExecutorClient, ExploreFacade exploreFacade,
                                 NamespaceQueryAdmin namespaceQueryAdmin,
                                 AuthorizationEnforcer authorizationEnforcer,
-                                AuthorizerInstantiator authorizerInstantiator) {
+                                AuthorizerInstantiator authorizerInstantiator,
+                                AuthenticationContext authenticationContext) {
     this.opExecutorClient = opExecutorClient;
     this.typeManager = typeManager;
     this.instanceManager = instanceManager;
@@ -109,6 +111,7 @@ public class DatasetInstanceService {
     );
     this.authorizationEnforcer = authorizationEnforcer;
     this.authorizer = authorizerInstantiator.get();
+    this.authenticationContext = authenticationContext;
   }
 
   @VisibleForTesting
@@ -128,7 +131,7 @@ public class DatasetInstanceService {
    */
   Collection<DatasetSpecification> list(Id.Namespace namespace) throws Exception {
     final NamespaceId namespaceId = namespace.toEntityId();
-    Principal principal = SecurityRequestContext.toPrincipal();
+    Principal principal = authenticationContext.getPrincipal();
     ensureNamespaceExists(namespace);
     Collection<DatasetSpecification> datasets = instanceManager.getAll(namespace);
     final Predicate<EntityId> filter = authorizationEnforcer.createFilter(principal);
@@ -223,7 +226,7 @@ public class DatasetInstanceService {
    */
   void create(String namespaceId, String name, DatasetInstanceConfiguration props) throws Exception {
     Id.Namespace namespace = ConversionHelpers.toNamespaceId(namespaceId);
-    Principal principal = SecurityRequestContext.toPrincipal();
+    Principal principal = authenticationContext.getPrincipal();
     authorizationEnforcer.enforce(namespace.toEntityId(), principal, Action.WRITE);
 
     ensureNamespaceExists(namespace);
@@ -293,7 +296,7 @@ public class DatasetInstanceService {
     }
 
     LOG.info("Update dataset {}, properties: {}", instance.getId(), ConversionHelpers.toJson(properties));
-    authorizationEnforcer.enforce(instance.toEntityId(), SecurityRequestContext.toPrincipal(), Action.ADMIN);
+    authorizationEnforcer.enforce(instance.toEntityId(), authenticationContext.getPrincipal(), Action.ADMIN);
 
     DatasetTypeMeta typeMeta = getTypeInfo(instance.getNamespace(), existing.getType());
     if (typeMeta == null) {
@@ -334,7 +337,7 @@ public class DatasetInstanceService {
       throw new DatasetNotFoundException(instance);
     }
 
-    authorizationEnforcer.enforce(datasetId, SecurityRequestContext.toPrincipal(), Action.ADMIN);
+    authorizationEnforcer.enforce(datasetId, authenticationContext.getPrincipal(), Action.ADMIN);
     LOG.info("Deleting dataset {}.{}", instance.getNamespaceId(), instance.getId());
     // Drop the dataset first, so that it can never be returned by a subsequent list or get call.
     dropDataset(instance, spec);
@@ -362,14 +365,13 @@ public class DatasetInstanceService {
    *  <ol>
    */
   DatasetAdminOpResponse executeAdmin(Id.DatasetInstance instance, String method) throws Exception {
-    // Throws NamespaceNotFoundException if the namespace does not exist
     ensureNamespaceExists(instance.getNamespace());
 
     Object result = null;
 
     // NOTE: one cannot directly call create and drop, instead this should be called thru
     //       POST/DELETE @ /data/datasets/{instance-id}. Because we must create/drop metadata for these at same time
-    Principal principal = SecurityRequestContext.toPrincipal();
+    Principal principal = authenticationContext.getPrincipal();
     DatasetId datasetId = instance.toEntityId();
     switch (method) {
       case "exists":
@@ -478,6 +480,7 @@ public class DatasetInstanceService {
   private void ensureNamespaceExists(Id.Namespace namespace) throws Exception {
     if (!Id.Namespace.SYSTEM.equals(namespace)) {
       if (namespaceQueryAdmin.get(namespace) == null) {
+        System.out.println("notfound ######## " + namespaceQueryAdmin);
         throw new NamespaceNotFoundException(namespace);
       }
     }
@@ -495,7 +498,7 @@ public class DatasetInstanceService {
    * @throws UnauthorizedException if the logged in user has no {@link Action privileges} on the specified dataset
    */
   private void ensureAccess(DatasetId datasetId) throws Exception {
-    Principal principal = SecurityRequestContext.toPrincipal();
+    Principal principal = authenticationContext.getPrincipal();
     Predicate<EntityId> filter = authorizationEnforcer.createFilter(principal);
     if (!Principal.SYSTEM.equals(principal) && !filter.apply(datasetId)) {
       throw new UnauthorizedException(principal, datasetId);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/view/MDSViewStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/view/MDSViewStoreTest.java
@@ -33,6 +33,7 @@ import co.cask.cdap.data2.security.UGIProvider;
 import co.cask.cdap.data2.security.UnsupportedUGIProvider;
 import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.explore.client.MockExploreClient;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationTestModule;
 import co.cask.tephra.TransactionManager;
@@ -66,6 +67,7 @@ public class MDSViewStoreTest extends ViewStoreTestBase {
       new LocationRuntimeModule().getInMemoryModules(),
       new AuthorizationTestModule(),
       new AuthorizationEnforcementModule().getInMemoryModules(),
+      new AuthenticationContextModules().getMasterModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtilTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtilTest.java
@@ -37,11 +37,17 @@ import co.cask.cdap.data2.metadata.lineage.LineageDataset;
 import co.cask.cdap.data2.registry.UsageDataset;
 import co.cask.cdap.proto.Id;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Map;
 
 public class DatasetsUtilTest extends DatasetServiceTestBase {
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    DatasetServiceTestBase.initialize();
+  }
 
   @Test
   public void testFixProperties() throws DatasetManagementException, UnsupportedTypeException {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandlerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandlerTest.java
@@ -46,6 +46,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -62,6 +63,11 @@ import javax.annotation.Nullable;
 public class DatasetInstanceHandlerTest extends DatasetServiceTestBase {
 
   private static final Gson GSON = new Gson();
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    DatasetServiceTestBase.initialize();
+  }
 
   @Test
   public void testSystemDatasetNotInList() throws Exception {
@@ -84,7 +90,6 @@ public class DatasetInstanceHandlerTest extends DatasetServiceTestBase {
 
   @Test
   public void testBasics() throws Exception {
-
     // nothing has been created, modules and types list is empty
     List<DatasetSpecificationSummary> instances = getInstances().getResponseObject();
 
@@ -181,7 +186,6 @@ public class DatasetInstanceHandlerTest extends DatasetServiceTestBase {
 
   @Test
   public void testUpdateInstance() throws Exception {
-
     // nothing has been created, modules and types list is empty
     List<DatasetSpecificationSummary> instances = getInstances().getResponseObject();
 
@@ -405,8 +409,7 @@ public class DatasetInstanceHandlerTest extends DatasetServiceTestBase {
 
   private ObjectResponse<List<DatasetSpecificationSummary>> getInstances(String namespace) throws IOException {
     return ObjectResponse.fromJsonBody(makeInstancesRequest(namespace),
-                                       new TypeToken<List<DatasetSpecificationSummary>>() {
-                                       }.getType());
+                                       new TypeToken<List<DatasetSpecificationSummary>>() { }.getType());
   }
 
   private HttpResponse makeInstancesRequest(String namespace) throws IOException {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceServiceTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceServiceTest.java
@@ -23,11 +23,17 @@ import co.cask.cdap.proto.Id;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.HashMap;
 
 public class DatasetInstanceServiceTest extends DatasetServiceTestBase {
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    DatasetServiceTestBase.initialize();
+  }
 
   @Test
   public void testInstanceMetaCache() throws Exception {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeHandlerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeHandlerTest.java
@@ -35,6 +35,7 @@ import com.google.gson.reflect.TypeToken;
 import org.apache.http.HttpStatus;
 import org.apache.twill.filesystem.Location;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
@@ -100,6 +101,11 @@ public class DatasetTypeHandlerTest extends DatasetServiceTestBase {
                                           "datasetType1x", ImmutableList.of("module1"),
                                           "datasetType2", ImmutableList.of("module1", "module2"));
 
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    DatasetServiceTestBase.initialize();
+  }
 
   @Test
   public void testBasics() throws Exception {
@@ -283,8 +289,7 @@ public class DatasetTypeHandlerTest extends DatasetServiceTestBase {
 
   private ObjectResponse<List<DatasetTypeMeta>> getTypes(Id.Namespace namespaceId) throws IOException {
     return ObjectResponse.fromJsonBody(makeTypesRequest(namespaceId),
-                                       new TypeToken<List<DatasetTypeMeta>>() {
-                                       }.getType());
+                                       new TypeToken<List<DatasetTypeMeta>>() { }.getType());
   }
 
   private HttpResponse makeTypesRequest(Id.Namespace namespaceId) throws IOException {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorServiceTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorServiceTest.java
@@ -46,6 +46,7 @@ import co.cask.cdap.data2.security.UnsupportedUGIProvider;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationTestModule;
 import co.cask.common.http.HttpRequest;
@@ -124,6 +125,7 @@ public class DatasetOpExecutorServiceTest {
       new TransactionMetricsModule(),
       new ExploreClientModule(),
       new NamespaceClientRuntimeModule().getInMemoryModules(),
+      new AuthenticationContextModules().getMasterModule(),
       new AuthorizationTestModule(),
       new AuthorizationEnforcementModule().getInMemoryModules(),
       new AbstractModule() {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableServiceTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -26,6 +26,7 @@ import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.TransactionMetricsModule;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.junit.Assert;
@@ -58,7 +59,8 @@ public class LevelDBTableServiceTest {
       new DiscoveryRuntimeModule().getStandaloneModules(),
       new DataSetsModules().getStandaloneModules(),
       new DataFabricLevelDBModule(),
-      new TransactionMetricsModule());
+      new TransactionMetricsModule(),
+      new AuthenticationContextModules().getMasterModule());
     service = injector.getInstance(LevelDBTableService.class);
   }
 
@@ -68,8 +70,8 @@ public class LevelDBTableServiceTest {
     String table2 = "cdap_default.table2";
     TableId tableId1 = TableId.from("default", "table1");
     TableId tableId2 = TableId.from("default", "table2");
-    Assert.assertNull(service.getTableStats().get(table1));
-    Assert.assertNull(service.getTableStats().get(table2));
+    Assert.assertNull(service.getTableStats().get(tableId1));
+    Assert.assertNull(service.getTableStats().get(tableId2));
 
     service.ensureTableExists(table1);
     service.ensureTableExists(table2);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableTest.java
@@ -30,6 +30,7 @@ import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.TransactionMetricsModule;
 import co.cask.cdap.data2.dataset2.lib.table.BufferingTableTest;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.junit.Assert;
@@ -63,7 +64,8 @@ public class LevelDBTableTest extends BufferingTableTest<LevelDBTable> {
       new DiscoveryRuntimeModule().getStandaloneModules(),
       new DataSetsModules().getStandaloneModules(),
       new DataFabricLevelDBModule(),
-      new TransactionMetricsModule());
+      new TransactionMetricsModule(),
+      new AuthenticationContextModules().getMasterModule());
     service = injector.getInstance(LevelDBTableService.class);
   }
 
@@ -108,5 +110,4 @@ public class LevelDBTableTest extends BufferingTableTest<LevelDBTable> {
       service.list().contains(tableName);
     }
   }
-
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/LocalQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/LocalQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -37,7 +37,8 @@ import co.cask.cdap.data2.transaction.queue.inmemory.InMemoryQueueProducer;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.tephra.TransactionExecutorFactory;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.TransactionSystemClient;
@@ -76,7 +77,8 @@ public class LocalQueueTest extends QueueTest {
       new TransactionMetricsModule(),
       new DiscoveryRuntimeModule().getStandaloneModules(),
       new DataSetsModules().getStandaloneModules(),
-      new DataFabricLocalModule());
+      new DataFabricLocalModule(),
+      new AuthenticationContextModules().getMasterModule());
     // transaction manager is a "service" and must be started
     transactionManager = injector.getInstance(TransactionManager.class);
     transactionManager.startAndWait();
@@ -98,6 +100,7 @@ public class LocalQueueTest extends QueueTest {
       new DataSetsModules().getStandaloneModules(),
       new ExploreClientModule(),
       new ViewAdminModules().getStandaloneModules(),
+      new AuthenticationContextModules().getMasterModule(),
       Modules.override(new StreamAdminModules().getStandaloneModules())
         .with(new AbstractModule() {
           @Override
@@ -108,8 +111,7 @@ public class LocalQueueTest extends QueueTest {
         }));
     QueueClientFactory factory = injector.getInstance(QueueClientFactory.class);
     QueueProducer producer = factory.createProducer(QueueName.fromFlowlet(
-      Id.Namespace.DEFAULT.getId(), "app", "my", "flowlet", "output"));
+      NamespaceId.DEFAULT.getNamespace(), "app", "my", "flowlet", "output"));
     Assert.assertTrue(producer instanceof InMemoryQueueProducer);
   }
-
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -29,7 +29,8 @@ import co.cask.cdap.data2.queue.QueueClientFactory;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.data2.transaction.queue.QueueEvictor;
 import co.cask.cdap.data2.transaction.queue.QueueTest;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionExecutorFactory;
 import co.cask.tephra.TransactionManager;
@@ -62,7 +63,8 @@ public class LevelDBQueueTest extends QueueTest {
       new DiscoveryRuntimeModule().getStandaloneModules(),
       new DataSetsModules().getStandaloneModules(),
       new DataFabricLevelDBModule(),
-      new TransactionMetricsModule());
+      new TransactionMetricsModule(),
+      new AuthenticationContextModules().getMasterModule());
     // transaction manager is a "service" and must be started
     transactionManager = injector.getInstance(TransactionManager.class);
     transactionManager.startAndWait();
@@ -76,7 +78,7 @@ public class LevelDBQueueTest extends QueueTest {
   // TODO: CDAP-1177 Should move to QueueTest after making getApplicationName() etc instance methods in a base class
   @Test
   public void testQueueTableNameFormat() throws Exception {
-    QueueName queueName = QueueName.fromFlowlet(Id.Namespace.DEFAULT.getId(), "application1", "flow1", "flowlet1",
+    QueueName queueName = QueueName.fromFlowlet(NamespaceId.DEFAULT.getNamespace(), "application1", "flow1", "flowlet1",
                                                 "output1");
     String tableName = ((LevelDBQueueAdmin) queueAdmin).getActualTableName(queueName);
     Assert.assertEquals("default.system.queue.application1.flow1", tableName);

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/context/ContextManager.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/context/ContextManager.java
@@ -45,6 +45,7 @@ import co.cask.cdap.hive.datasets.DatasetSerDe;
 import co.cask.cdap.hive.stream.StreamSerDe;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.inject.AbstractModule;
@@ -131,6 +132,7 @@ public class ContextManager {
       new NotificationFeedClientModule(),
       new KafkaClientModule(),
       new AuditModule().getDistributedModules(),
+      new AuthenticationContextModules().getMasterModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
@@ -64,6 +64,7 @@ import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.proto.QueryStatus;
 import co.cask.cdap.proto.StreamProperties;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationTestModule;
 import co.cask.http.HttpHandler;
@@ -401,6 +402,7 @@ public class BaseHiveExploreServiceTest {
       new NamespaceClientRuntimeModule().getInMemoryModules(),
       new AuthorizationTestModule(),
       new AuthorizationEnforcementModule().getInMemoryModules(),
+      new AuthenticationContextModules().getMasterModule(),
       new AbstractModule() {
         @Override
         protected void configure() {
@@ -464,6 +466,7 @@ public class BaseHiveExploreServiceTest {
       new NamespaceClientRuntimeModule().getInMemoryModules(),
       new AuthorizationTestModule(),
       new AuthorizationEnforcementModule().getInMemoryModules(),
+      new AuthenticationContextModules().getMasterModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
@@ -50,6 +50,7 @@ import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationTestModule;
 import co.cask.tephra.Transaction;
@@ -227,6 +228,7 @@ public class ExploreDisabledTest {
         new NamespaceClientRuntimeModule().getInMemoryModules(),
         new AuthorizationTestModule(),
         new AuthorizationEnforcementModule().getInMemoryModules(),
+        new AuthenticationContextModules().getMasterModule(),
         new AbstractModule() {
           @Override
           protected void configure() {

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/InMemoryExploreServiceTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/InMemoryExploreServiceTest.java
@@ -44,6 +44,7 @@ import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.QueryHandle;
 import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.proto.QueryStatus;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationTestModule;
 import co.cask.cdap.store.guice.NamespaceStoreModule;
@@ -106,6 +107,7 @@ public class InMemoryExploreServiceTest {
         new NamespaceStoreModule().getStandaloneModules(),
         new AuthorizationTestModule(),
         new AuthorizationEnforcementModule().getInMemoryModules(),
+        new AuthenticationContextModules().getMasterModule(),
         new AbstractModule() {
           @Override
           protected void configure() {

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
@@ -52,6 +52,7 @@ import co.cask.cdap.metadata.MetadataServiceModule;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.guice.SecureStoreModules;
 import co.cask.cdap.store.guice.NamespaceStoreModule;
@@ -122,6 +123,7 @@ public class DatasetOpExecutorServerTwillRunnable extends AbstractMasterTwillRun
       new SecureStoreModules().getDistributedModules(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getDistributedModules(),
+      new AuthenticationContextModules().getMasterModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ExploreServiceTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ExploreServiceTwillRunnable.java
@@ -43,8 +43,10 @@ import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.store.DefaultNamespaceStore;
 import co.cask.cdap.store.NamespaceStore;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.Service;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -86,30 +88,7 @@ public class ExploreServiceTwillRunnable extends AbstractMasterTwillRunnable {
 
     // NOTE: twill client will try to load all the classes present here - including hive classes but it
     // will fail since Hive classes are not in master classpath, and ignore those classes silently
-    injector = Guice.createInjector(
-      new ConfigModule(cConf, hConf),
-      new IOModule(), new ZKClientModule(),
-      new KafkaClientModule(),
-      new MetricsClientRuntimeModule().getDistributedModules(),
-      new DiscoveryRuntimeModule().getDistributedModules(),
-      new LocationRuntimeModule().getDistributedModules(),
-      new NamespaceClientRuntimeModule().getDistributedModules(),
-      new DataFabricModules().getDistributedModules(),
-      new DataSetsModules().getDistributedModules(),
-      new LoggingModules().getDistributedModules(),
-      new ExploreRuntimeModule().getDistributedModules(),
-      new ExploreClientModule(),
-      new ViewAdminModules().getDistributedModules(),
-      new StreamAdminModules().getDistributedModules(),
-      new NotificationFeedClientModule(),
-      new AuditModule().getDistributedModules(),
-      new AbstractModule() {
-        @Override
-        protected void configure() {
-          bind(Store.class).to(DefaultStore.class);
-          bind(NamespaceStore.class).to(DefaultNamespaceStore.class);
-        }
-      });
+    injector = createInjector(cConf, hConf);
 
     injector.getInstance(LogAppenderInitializer.class).initialize();
 
@@ -127,5 +106,34 @@ public class ExploreServiceTwillRunnable extends AbstractMasterTwillRunnable {
     services.add(injector.getInstance(ZKClientService.class));
     services.add(injector.getInstance(KafkaClientService.class));
     services.add(injector.getInstance(ExploreExecutorService.class));
+  }
+
+  @VisibleForTesting
+  static Injector createInjector(CConfiguration cConf, Configuration hConf) {
+    return Guice.createInjector(
+      new ConfigModule(cConf, hConf),
+      new IOModule(), new ZKClientModule(),
+      new KafkaClientModule(),
+      new MetricsClientRuntimeModule().getDistributedModules(),
+      new DiscoveryRuntimeModule().getDistributedModules(),
+      new LocationRuntimeModule().getDistributedModules(),
+      new NamespaceClientRuntimeModule().getDistributedModules(),
+      new DataFabricModules().getDistributedModules(),
+      new DataSetsModules().getDistributedModules(),
+      new LoggingModules().getDistributedModules(),
+      new ExploreRuntimeModule().getDistributedModules(),
+      new ExploreClientModule(),
+      new ViewAdminModules().getDistributedModules(),
+      new StreamAdminModules().getDistributedModules(),
+      new NotificationFeedClientModule(),
+      new AuditModule().getDistributedModules(),
+      new AuthenticationContextModules().getMasterModule(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(Store.class).to(DefaultStore.class);
+          bind(NamespaceStore.class).to(DefaultNamespaceStore.class);
+        }
+      });
   }
 }

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/TransactionServiceTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/TransactionServiceTwillRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -37,7 +37,8 @@ import co.cask.cdap.data2.audit.AuditModule;
 import co.cask.cdap.logging.appender.LogAppenderInitializer;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.distributed.TransactionService;
 import co.cask.tephra.persist.TransactionStateStorage;
@@ -81,7 +82,7 @@ public class TransactionServiceTwillRunnable extends AbstractMasterTwillRunnable
 
       Injector injector = createGuiceInjector(getCConfiguration(), getConfiguration());
       injector.getInstance(LogAppenderInitializer.class).initialize();
-      LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Id.Namespace.SYSTEM.getId(),
+      LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(NamespaceId.SYSTEM.getNamespace(),
                                                                          Constants.Logging.COMPONENT_NAME,
                                                                          Constants.Service.TRANSACTION));
 
@@ -128,7 +129,9 @@ public class TransactionServiceTwillRunnable extends AbstractMasterTwillRunnable
       new DiscoveryRuntimeModule().getDistributedModules(),
       new MetricsClientRuntimeModule().getDistributedModules(),
       new LoggingModules().getDistributedModules(),
-      new AuditModule().getDistributedModules()
+      new AuditModule().getDistributedModules(),
+      // needed by RemoteDatasetFramework while making an HTTP call to DatasetService
+      new AuthenticationContextModules().getMasterModule()
     );
   }
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetServiceManager.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetServiceManager.java
@@ -43,6 +43,7 @@ import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsServiceModule;
 import co.cask.cdap.internal.app.store.DefaultStore;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.guice.SecureStoreModules;
 import co.cask.cdap.store.guice.NamespaceStoreModule;
@@ -142,6 +143,7 @@ public class DatasetServiceManager extends AbstractIdleService {
       new SecureStoreModules().getDistributedModules(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getDistributedModules(),
+      new AuthenticationContextModules().getMasterModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -67,6 +67,7 @@ import co.cask.cdap.metrics.store.DefaultMetricStore;
 import co.cask.cdap.metrics.store.MetricDatasetFactory;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.store.NamespaceStore;
 import co.cask.cdap.store.guice.NamespaceStoreModule;
@@ -205,6 +206,7 @@ public class UpgradeTool {
       new NotificationServiceRuntimeModule().getInMemoryModules(),
       new KafkaClientModule(),
       new NamespaceStoreModule().getDistributedModules(),
+      new AuthenticationContextModules().getMasterModule(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getDistributedModules(),
       new AbstractModule() {

--- a/cdap-master/src/test/java/co/cask/cdap/data/runtime/main/TwillRunnableTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/data/runtime/main/TwillRunnableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,19 +19,31 @@ package co.cask.cdap.data.runtime.main;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.conf.CConfiguration;
 import com.google.inject.Injector;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.junit.Assert;
 import org.junit.Test;
 
 /**
- *
+ * Tests for {@link ExploreServiceTwillRunnable}, {@link DatasetOpExecutorServerTwillRunnable},
+ * {@link StreamHandlerRunnable}.
  */
-public class DatasetOpExecutorServerTwillRunnableTest {
+public class TwillRunnableTest {
   @Test
-  public void testInjector() throws Exception {
+  public void testExploreServiceTwillRunnableInjector() {
+    ExploreServiceTwillRunnable.createInjector(CConfiguration.create(), new Configuration());
+  }
+
+  @Test
+  public void testDatasetOpExecutorTwillRunnableInjector() throws Exception {
     Injector injector = DatasetOpExecutorServerTwillRunnable.createInjector(CConfiguration.create(),
                                                                             HBaseConfiguration.create());
     Store store = injector.getInstance(Store.class);
     Assert.assertNotNull(store);
+  }
+
+  @Test
+  public void testStreamHandlerTwillRunnableInjector() {
+    StreamHandlerRunnable.createInjector(CConfiguration.create(), new Configuration());
   }
 }

--- a/cdap-notifications/src/test/java/co/cask/cdap/notifications/NotificationTest.java
+++ b/cdap-notifications/src/test/java/co/cask/cdap/notifications/NotificationTest.java
@@ -45,6 +45,7 @@ import co.cask.cdap.notifications.service.NotificationService;
 import co.cask.cdap.notifications.service.TxRetryPolicy;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationTestModule;
 import co.cask.tephra.TransactionContext;
@@ -117,6 +118,7 @@ public abstract class NotificationTest {
       new NamespaceClientRuntimeModule().getInMemoryModules(),
       new AuthorizationTestModule(),
       new AuthorizationEnforcementModule().getInMemoryModules(),
+      new AuthenticationContextModules().getMasterModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authentication/AuthenticationContext.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authentication/AuthenticationContext.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.spi.authentication;
+
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.security.spi.authorization.AuthorizationContext;
+import co.cask.cdap.security.spi.authorization.Authorizer;
+
+/**
+ * A context that determines authentication details. {@link Authorizer} extensions can obtain authentication details
+ * from the {@link AuthorizationContext} available in their {@link Authorizer#initialize(AuthorizationContext)}
+ * method.
+ */
+public interface AuthenticationContext {
+
+  /**
+   * Determines the {@link Principal} making the authorization request.
+   *
+   * @return the {@link Principal} making the authorization request
+   */
+  Principal getPrincipal();
+}

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/AuthorizationContext.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/AuthorizationContext.java
@@ -19,6 +19,8 @@ package co.cask.cdap.security.spi.authorization;
 import co.cask.cdap.api.Admin;
 import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 
 import java.util.Properties;
 
@@ -31,9 +33,10 @@ import java.util.Properties;
  *   <li>Perform admin operations such as create/update/truncate/drop/exists on a dataset.</li>
  *   <li>Instantiate datasets and obtain objects for them.</li>
  *   <li>Execute operations on datasets inside transactions.</li>
+ *   <li>Determine the authentication details of the {@link Principal} making the authorization request.</li>
  * </ol>
  */
-public interface AuthorizationContext extends DatasetContext, Admin, Transactional {
+public interface AuthorizationContext extends DatasetContext, Admin, Transactional, AuthenticationContext {
   /**
    * Returns the properties for the authorization extension. These properties are composed of all the properties
    * defined in {@code cdap-site.xml} with the prefix {@code security.authorization.extension.config.}.

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/context/AuthenticationContextModules.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/context/AuthenticationContextModules.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.auth.context;
+
+import co.cask.cdap.security.spi.authentication.AuthenticationContext;
+import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
+import com.google.inject.AbstractModule;
+import org.apache.hadoop.security.UserGroupInformation;
+
+/**
+ * Exposes the right {@link AuthenticationContext} via an {@link AbstractModule} based on the context in which
+ * it is being invoked.
+ */
+public class AuthenticationContextModules {
+
+  /**
+   * An {@link AuthenticationContext} for HTTP requests in Master. The authentication details in this context are
+   * derived from {@link SecurityRequestContext}.
+   *
+   * @see SecurityRequestContext
+   */
+  public AbstractModule getMasterModule() {
+    return new AbstractModule() {
+      @Override
+      protected void configure() {
+        bind(AuthenticationContext.class).to(MasterAuthenticationContext.class);
+      }
+    };
+  }
+
+  /**
+   * An {@link AuthenticationContext} for use in program containers. The authentication details in this context are
+   * determined based on the {@link UserGroupInformation} of the user running the program.
+   */
+  public AbstractModule getProgramContainerModule() {
+    return new AbstractModule() {
+      @Override
+      protected void configure() {
+        bind(AuthenticationContext.class).to(ProgramContainerAuthenticationContext.class);
+      }
+    };
+  }
+}

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/context/AuthenticationTestContext.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/context/AuthenticationTestContext.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.auth.context;
+
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.security.spi.authentication.AuthenticationContext;
+
+/**
+ * A dummy {@link AuthenticationContext} to be used in tests.
+ */
+public class AuthenticationTestContext implements AuthenticationContext {
+  @Override
+  public Principal getPrincipal() {
+    return new Principal(System.getProperty("user.name"), Principal.PrincipalType.USER);
+  }
+}

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/context/MasterAuthenticationContext.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/context/MasterAuthenticationContext.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.auth.context;
+
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.security.spi.authentication.AuthenticationContext;
+import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
+
+/**
+ * An {@link AuthenticationContext} for HTTP requests in the Master. The authentication details in this context are
+ * derived from {@link SecurityRequestContext}.
+ *
+ * @see SecurityRequestContext
+ */
+public class MasterAuthenticationContext implements AuthenticationContext {
+
+  @Override
+  public Principal getPrincipal() {
+    return SecurityRequestContext.toPrincipal();
+  }
+}

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/context/ProgramContainerAuthenticationContext.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/context/ProgramContainerAuthenticationContext.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.auth.context;
+
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.security.spi.authentication.AuthenticationContext;
+import com.google.common.base.Throwables;
+import org.apache.hadoop.security.UserGroupInformation;
+
+import java.io.IOException;
+
+/**
+ * An {@link AuthenticationContext} for use in program containers. The authentication details in this context are
+ * determined based on the {@link UserGroupInformation} of the user running the program.
+ */
+public class ProgramContainerAuthenticationContext implements AuthenticationContext {
+
+  @Override
+  public Principal getPrincipal() {
+    try {
+      return new Principal(UserGroupInformation.getCurrentUser().getShortUserName(), Principal.PrincipalType.USER);
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+}

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationContext.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationContext.java
@@ -24,6 +24,8 @@ import co.cask.cdap.api.data.DatasetInstantiationException;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.cdap.security.spi.authorization.AuthorizationContext;
 import co.cask.tephra.TransactionFailureException;
 import com.google.common.annotations.VisibleForTesting;
@@ -43,16 +45,18 @@ public class DefaultAuthorizationContext implements AuthorizationContext {
   private final DatasetContext delegateDatasetContext;
   private final Admin delegateAdmin;
   private final Transactional delegateTxnl;
+  private final AuthenticationContext delegateAuthenticationContext;
 
   @Inject
   @VisibleForTesting
   public DefaultAuthorizationContext(@Assisted("extension-properties") Properties extensionProperties,
                                      DatasetContext delegateDatasetContext, Admin delegateAdmin,
-                                     Transactional delegateTxnl) {
+                                     Transactional delegateTxnl, AuthenticationContext delegateAuthenticationContext) {
     this.extensionProperties = extensionProperties;
     this.delegateDatasetContext = delegateDatasetContext;
     this.delegateAdmin = delegateAdmin;
     this.delegateTxnl = delegateTxnl;
+    this.delegateAuthenticationContext = delegateAuthenticationContext;
   }
 
   @Override
@@ -141,5 +145,9 @@ public class DefaultAuthorizationContext implements AuthorizationContext {
   @Override
   public void delete(String namespace, String name) throws IOException {
     delegateAdmin.delete(namespace, name);
+  }
+
+  public Principal getPrincipal() {
+    return delegateAuthenticationContext.getPrincipal();
   }
 }

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/NoOpAuthorizationContextFactory.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/NoOpAuthorizationContextFactory.java
@@ -25,7 +25,7 @@ import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.InstanceNotFoundException;
-import co.cask.cdap.api.security.store.SecureStoreManager;
+import co.cask.cdap.security.auth.context.AuthenticationTestContext;
 import co.cask.cdap.security.spi.authorization.AuthorizationContext;
 import co.cask.tephra.TransactionFailureException;
 
@@ -40,7 +40,7 @@ public class NoOpAuthorizationContextFactory implements AuthorizationContextFact
   @Override
   public AuthorizationContext create(Properties extensionProperties) {
     return new DefaultAuthorizationContext(extensionProperties, new NoOpDatasetContext(), new NoOpAdmin(),
-                                           new NoOpTransactional());
+                                           new NoOpTransactional(), new AuthenticationTestContext());
   }
 
   private static final class NoOpTransactional implements Transactional {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/LogSaverTwillRunnable.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/LogSaverTwillRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -35,6 +35,8 @@ import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.logging.save.KafkaLogSaverService;
 import co.cask.cdap.logging.service.LogSaverStatusService;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
@@ -179,7 +181,8 @@ public final class LogSaverTwillRunnable extends AbstractTwillRunnable {
     completion.set(null);
   }
 
-  private static Injector createGuiceInjector(CConfiguration cConf, Configuration hConf) {
+  @VisibleForTesting
+  static Injector createGuiceInjector(CConfiguration cConf, Configuration hConf) {
     return Guice.createInjector(
       new ConfigModule(cConf, hConf),
       new IOModule(),
@@ -193,7 +196,8 @@ public final class LogSaverTwillRunnable extends AbstractTwillRunnable {
       new DataSetsModules().getDistributedModules(),
       new LogSaverServiceModule(),
       new LoggingModules().getDistributedModules(),
-      new AuditModule().getDistributedModules()
+      new AuditModule().getDistributedModules(),
+      new AuthenticationContextModules().getMasterModule()
     );
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsTwillRunnable.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsTwillRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -39,7 +39,9 @@ import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.metrics.guice.MetricsHandlerModule;
 import co.cask.cdap.metrics.guice.MetricsStoreModule;
 import co.cask.cdap.metrics.query.MetricsQueryService;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.Service;
 import com.google.inject.Guice;
@@ -77,7 +79,7 @@ public class MetricsTwillRunnable extends AbstractMasterTwillRunnable {
       Injector injector = createGuiceInjector(getCConfiguration(), getConfiguration());
       injector.getInstance(LogAppenderInitializer.class).initialize();
 
-      LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Id.Namespace.SYSTEM.getId(),
+      LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(NamespaceId.SYSTEM.getNamespace(),
                                                                          Constants.Logging.COMPONENT_NAME,
                                                                          Constants.Service.METRICS));
 
@@ -106,7 +108,8 @@ public class MetricsTwillRunnable extends AbstractMasterTwillRunnable {
     services.add(metricsQueryService);
   }
 
-  public static Injector createGuiceInjector(CConfiguration cConf, Configuration hConf) {
+  @VisibleForTesting
+  static Injector createGuiceInjector(CConfiguration cConf, Configuration hConf) {
     return Guice.createInjector(
       new ConfigModule(cConf, hConf),
       new IOModule(),
@@ -122,7 +125,8 @@ public class MetricsTwillRunnable extends AbstractMasterTwillRunnable {
       new MetricsHandlerModule(),
       new MetricsClientRuntimeModule().getDistributedModules(),
       new MetricsStoreModule(),
-      new AuditModule().getDistributedModules()
+      new AuditModule().getDistributedModules(),
+      new AuthenticationContextModules().getMasterModule()
     );
   }
 }

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/TestResilientLogging.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/TestResilientLogging.java
@@ -47,6 +47,7 @@ import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.logging.read.FileLogReader;
 import co.cask.cdap.logging.read.LogEvent;
 import co.cask.cdap.logging.read.ReadRange;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationTestModule;
 import co.cask.tephra.TransactionManager;
@@ -115,6 +116,7 @@ public class TestResilientLogging {
       new NamespaceClientRuntimeModule().getInMemoryModules(),
       new AuthorizationTestModule(),
       new AuthorizationEnforcementModule().getInMemoryModules(),
+      new AuthenticationContextModules().getMasterModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/run/LogSaverTwillRunnableTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/run/LogSaverTwillRunnableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,23 +14,19 @@
  * the License.
  */
 
-package co.cask.cdap.gateway.run;
+package co.cask.cdap.logging.run;
 
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.metrics.runtime.MetricsTwillRunnable;
-import com.google.inject.Injector;
-import org.apache.hadoop.hbase.HBaseConfiguration;
-import org.junit.Assert;
+import org.apache.hadoop.conf.Configuration;
 import org.junit.Test;
 
 /**
- * Test {@link co.cask.cdap.metrics.runtime.MetricsTwillRunnable}.
+ * Tests for {@link LogSaverTwillRunnable}.
  */
-public class MetricsTwillRunnableTest {
+public class LogSaverTwillRunnableTest {
 
   @Test
-  public void testInjection() throws Exception {
-    Injector injector = MetricsTwillRunnable.createGuiceInjector(CConfiguration.create(), HBaseConfiguration.create());
-    Assert.assertNotNull(injector);
+  public void testLogSaverInjector() {
+    LogSaverTwillRunnable.createGuiceInjector(CConfiguration.create(), new Configuration());
   }
 }

--- a/cdap-watchdog/src/test/java/co/cask/cdap/metrics/runtime/MetricsTwillRunnableTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/metrics/runtime/MetricsTwillRunnableTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metrics.runtime;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import com.google.inject.Injector;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test {@link MetricsTwillRunnable} and {@link MetricsProcessorTwillRunnable}.
+ */
+public class MetricsTwillRunnableTest {
+
+  @Test
+  public void testMetricsTwillRunnableInjector() throws Exception {
+    MetricsTwillRunnable.createGuiceInjector(CConfiguration.create(), HBaseConfiguration.create());
+  }
+
+  @Test
+  public void testMetricsProcessorTwillRunnableInjector() {
+    MetricsProcessorTwillRunnable.createGuiceInjector(CConfiguration.create(), new Configuration());
+  }
+}


### PR DESCRIPTION
…ermine the UserId depending on the context.
- `MasterAuthenticationContext` uses `SecurityRequestContext` to determine the UserId
- `ProgramContainerAuthenticationContext` uses `UserGroupInformation.getCurrentUser()` to determine the UserId
- Currently, `AuthenticationContext` is injected into `RemoteDatasetFramework` and `DatasetInstanceService` for `DatasetServiceClient` to use it while making requests to dataset service
- It is also available as `AuthorizationContext` in `Authorizer#initialize`, so that `Authorizer` implementations like `SentryAuthorizer` can get the requesting UserId without CDAP passing it to every method (PR for that will be a follow-up)
- Also added some missing tests for `TwillRunnable` (`StreamHandler`, `Explore`, `Log Saver` and `MetricsProcessor`) injectors, so injection failures can be caught in unit tests

Issue: [CDAP-6580](https://issues.cask.co/browse/CDAP-6580)
Build: http://builds.cask.co/browse/CDAP-DUT4424
