### PR TITLE
Feature/add secure store APIs to runtime/admin context

### DIFF
--- a/cdap-api-spark/src/main/java/co/cask/cdap/api/spark/JavaSparkExecutionContext.java
+++ b/cdap-api-spark/src/main/java/co/cask/cdap/api/spark/JavaSparkExecutionContext.java
@@ -28,6 +28,7 @@ import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.stream.GenericStreamEventData;
 import co.cask.cdap.api.stream.StreamEventDecoder;
 import co.cask.cdap.api.workflow.WorkflowInfoProvider;
@@ -46,7 +47,8 @@ import javax.annotation.Nullable;
  * Spark program execution context. User Spark program can interact with CDAP through this context.
  */
 @Beta
-public abstract class JavaSparkExecutionContext implements RuntimeContext, Transactional, WorkflowInfoProvider {
+public abstract class JavaSparkExecutionContext implements RuntimeContext, Transactional,
+                                                           WorkflowInfoProvider, SecureStore {
 
   /**
    * @return The specification used to configure this {@link Spark} job instance.
@@ -85,6 +87,14 @@ public abstract class JavaSparkExecutionContext implements RuntimeContext, Trans
    * @return A {@link Serializable} {@link PluginContext}.
    */
   public abstract PluginContext getPluginContext();
+
+  /**
+   * Returns a {@link Serializable} {@link SecureStore} which can be used to request for plugins instances. The
+   * instance returned can also be used in Spark program's closures.
+   *
+   * @return A {@link Serializable} {@link SecureStore}.
+   */
+  public abstract SecureStore getSecureStore();
 
   /**
    * Returns a {@link Serializable} {@link TaskLocalizationContext} which can be used to retrieve files localized to
@@ -375,7 +385,7 @@ public abstract class JavaSparkExecutionContext implements RuntimeContext, Trans
   public <T> JavaPairRDD<Long, GenericStreamEventData<T>> fromStream(String namespace, String streamName,
                                                                      FormatSpecification formatSpec,
                                                                      Class<T> dataType) {
-    return fromStream(streamName, formatSpec, 0, Long.MAX_VALUE, dataType);
+    return fromStream(namespace, streamName, formatSpec, 0, Long.MAX_VALUE, dataType);
   }
 
   /**

--- a/cdap-api-spark/src/main/scala/co/cask/cdap/api/spark/SparkExecutionContext.scala
+++ b/cdap-api-spark/src/main/scala/co/cask/cdap/api/spark/SparkExecutionContext.scala
@@ -22,6 +22,7 @@ import co.cask.cdap.api.data.format.FormatSpecification
 import co.cask.cdap.api.flow.flowlet.StreamEvent
 import co.cask.cdap.api.metrics.Metrics
 import co.cask.cdap.api.plugin.PluginContext
+import co.cask.cdap.api.security.store.SecureStore
 import co.cask.cdap.api.stream.GenericStreamEventData
 import co.cask.cdap.api.workflow.{WorkflowInfo, WorkflowToken}
 import co.cask.cdap.api.{RuntimeContext, ServiceDiscoverer, TaskLocalizationContext, Transactional}
@@ -73,6 +74,14 @@ trait SparkExecutionContext extends RuntimeContext with Transactional {
     * @return A [[scala.Serializable]] [[co.cask.cdap.api.plugin.PluginContext]]
     */
   def getPluginContext: PluginContext
+
+  /**
+    * Returns a [[scala.Serializable]] [[co.cask.cdap.api.security.store.SecureStore]] which can be used to request
+    * for plugins instances. The instance returned can also be used in Spark program's closures.
+    *
+    * @return A [[scala.Serializable]] [[co.cask.cdap.api.plugin.PluginContext]]
+    */
+  def getSecureStore: SecureStore
 
   /**
     * Returns the [[co.cask.cdap.api.workflow.WorkflowToken]] if the Spark program

--- a/cdap-api/src/main/java/co/cask/cdap/api/Admin.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/Admin.java
@@ -21,12 +21,13 @@ import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.InstanceConflictException;
 import co.cask.cdap.api.dataset.InstanceNotFoundException;
+import co.cask.cdap.api.security.store.SecureStoreManager;
 
 /**
  * This interface provides methods for operational calls from within a CDAP application.
  */
 @Beta
-public interface Admin {
+public interface Admin extends SecureStoreManager {
   /**
    * Check whether a dataset exists in the current namespace.
    * @param name the name of the dataset

--- a/cdap-api/src/main/java/co/cask/cdap/api/customaction/CustomActionContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/customaction/CustomActionContext.java
@@ -20,12 +20,14 @@ import co.cask.cdap.api.ProgramState;
 import co.cask.cdap.api.RuntimeContext;
 import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.workflow.WorkflowInfoProvider;
 
 /**
  * Represents runtime context of the {@link CustomAction} in the Workflow.
  */
-public interface CustomActionContext extends RuntimeContext, Transactional, WorkflowInfoProvider, PluginContext {
+public interface CustomActionContext extends RuntimeContext, Transactional, WorkflowInfoProvider,
+  PluginContext, SecureStore {
 
   /**
    * Return the specification of the custom action.

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/FlowletContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/FlowletContext.java
@@ -19,11 +19,12 @@ package co.cask.cdap.api.flow.flowlet;
 import co.cask.cdap.api.RuntimeContext;
 import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.security.store.SecureStore;
 
 /**
  * This interface represents the Flowlet context.
  */
-public interface FlowletContext extends RuntimeContext, DatasetContext, ServiceDiscoverer {
+public interface FlowletContext extends RuntimeContext, DatasetContext, ServiceDiscoverer, SecureStore {
   /**
    * @return Number of instances of this flowlet.
    */

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
@@ -29,6 +29,7 @@ import co.cask.cdap.api.data.batch.OutputFormatProvider;
 import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.data.stream.StreamBatchReadable;
 import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.workflow.WorkflowInfoProvider;
 
 import java.util.List;
@@ -38,7 +39,7 @@ import java.util.Map;
  * MapReduce job execution context.
  */
 public interface MapReduceContext extends RuntimeContext, DatasetContext, ServiceDiscoverer,
-                                          PluginContext, ClientLocalizationContext, WorkflowInfoProvider {
+                                          PluginContext, ClientLocalizationContext, WorkflowInfoProvider, SecureStore {
 
   /**
    * @return The specification used to configure this {@link MapReduce} job instance.

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceTaskContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceTaskContext.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.TaskLocalizationContext;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.workflow.Workflow;
 import co.cask.cdap.api.workflow.WorkflowInfo;
 import co.cask.cdap.api.workflow.WorkflowToken;
@@ -37,7 +38,7 @@ import javax.annotation.Nullable;
  */
 @Beta
 public interface MapReduceTaskContext<KEYOUT, VALUEOUT> extends RuntimeContext, DatasetContext,
-  ServiceDiscoverer, PluginContext, TaskLocalizationContext {
+  ServiceDiscoverer, PluginContext, TaskLocalizationContext, SecureStore {
 
   /**
    * Write key and value to the named output Dataset. This method must only be used if the MapReduce writes to

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceContext.java
@@ -20,12 +20,14 @@ import co.cask.cdap.api.RuntimeContext;
 import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.api.security.store.SecureStore;
 
 /**
  * The context for a {@link HttpServiceHandler}. Currently contains methods to receive the
  * {@link HttpServiceHandlerSpecification} and the runtime arguments passed by the user.
  */
-public interface HttpServiceContext extends RuntimeContext, DatasetContext, ServiceDiscoverer, PluginContext {
+public interface HttpServiceContext extends RuntimeContext, DatasetContext, ServiceDiscoverer,
+  PluginContext, SecureStore {
 
   /**
    * @return the specification bound to this HttpServiceContext

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkClientContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkClientContext.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.workflow.WorkflowInfoProvider;
 
 /**
@@ -33,7 +34,7 @@ import co.cask.cdap.api.workflow.WorkflowInfoProvider;
  */
 @Beta
 public interface SparkClientContext extends RuntimeContext, DatasetContext, ClientLocalizationContext,
-                                            ServiceDiscoverer, PluginContext, WorkflowInfoProvider {
+                                            ServiceDiscoverer, PluginContext, WorkflowInfoProvider, SecureStore {
   /**
    * @return The specification used to configure this {@link Spark} job instance.
    */

--- a/cdap-api/src/main/java/co/cask/cdap/api/worker/WorkerContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/worker/WorkerContext.java
@@ -24,11 +24,13 @@ import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.stream.StreamWriter;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.api.security.store.SecureStore;
 
 /**
  * Context for {@link Worker}.
  */
-public interface WorkerContext extends RuntimeContext, ServiceDiscoverer, StreamWriter, PluginContext, Transactional {
+public interface WorkerContext extends RuntimeContext, ServiceDiscoverer, StreamWriter,
+  PluginContext, Transactional, SecureStore {
 
   /**
    * Returns the specification used to configure {@link Worker} bounded to this context.

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowContext.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.api.security.store.SecureStore;
 
 import java.util.Map;
 
@@ -28,7 +29,7 @@ import java.util.Map;
  * Represents the runtime context of a {@link Workflow}. This context is also
  * available to {@link WorkflowAction}.
  */
-public interface WorkflowContext extends RuntimeContext, ServiceDiscoverer, DatasetContext, PluginContext {
+public interface WorkflowContext extends RuntimeContext, ServiceDiscoverer, DatasetContext, PluginContext, SecureStore {
 
   WorkflowSpecification getWorkflowSpecification();
 

--- a/cdap-app-fabric/pom.xml
+++ b/cdap-app-fabric/pom.xml
@@ -220,6 +220,17 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-api-spark</artifactId>
+      <version>3.5.0-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_2.10</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AuthorizationModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AuthorizationModule.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DynamicDatasetCache;
@@ -125,15 +126,17 @@ public class AuthorizationModule extends PrivateModule {
   @Singleton
   private static final class AdminProvider implements Provider<Admin> {
     private final DatasetFramework dsFramework;
+    private final SecureStoreManager secureStoreManager;
 
     @Inject
-    private AdminProvider(DatasetFramework dsFramework) {
+    private AdminProvider(DatasetFramework dsFramework, SecureStoreManager secureStoreManager) {
       this.dsFramework = dsFramework;
+      this.secureStoreManager = secureStoreManager;
     }
 
     @Override
     public Admin get() {
-      return new DefaultAdmin(dsFramework, NamespaceId.SYSTEM);
+      return new DefaultAdmin(dsFramework, NamespaceId.SYSTEM, secureStoreManager);
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DefaultAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DefaultAdmin.java
@@ -21,11 +21,13 @@ import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.InstanceNotFoundException;
+import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.NamespaceId;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * Implementation of Admin that delegates dataset operations to a dataset framework.
@@ -34,10 +36,12 @@ public class DefaultAdmin implements Admin {
 
   private final DatasetFramework dsFramework;
   private final NamespaceId namespace;
+  private final SecureStoreManager secureStoreManager;
 
-  public DefaultAdmin(DatasetFramework dsFramework, NamespaceId namespace) {
+  public DefaultAdmin(DatasetFramework dsFramework, NamespaceId namespace, SecureStoreManager secureStoreManager) {
     this.dsFramework = dsFramework;
     this.namespace = namespace;
+    this.secureStoreManager = secureStoreManager;
   }
 
   private Id.DatasetInstance createInstanceId(String name) {
@@ -109,5 +113,16 @@ public class DefaultAdmin implements Admin {
       throw new DatasetManagementException(String.format("Failed to truncate instance %s, details: %s",
                                                          name, ioe.getMessage()), ioe);
     }
+  }
+
+  @Override
+  public void put(String namespace, String name, byte[] data,
+                  String description, Map<String, String> properties) throws IOException {
+    secureStoreManager.put(namespace, name, data, description, properties);
+  }
+
+  @Override
+  public void delete(String namespace, String name) throws IOException {
+    secureStoreManager.delete(namespace, name);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -28,6 +28,8 @@ import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.api.security.store.SecureStore;
+import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.conf.Constants;
@@ -97,9 +99,13 @@ final class BasicMapReduceContext extends AbstractContext implements MapReduceCo
                         DatasetFramework dsFramework,
                         StreamAdmin streamAdmin,
                         @Nullable File pluginArchive,
-                        @Nullable PluginInstantiator pluginInstantiator) {
+                        @Nullable PluginInstantiator pluginInstantiator,
+                        SecureStore secureStore,
+                        SecureStoreManager secureStoreManager) {
     super(program, programOptions, Collections.<String>emptySet(), dsFramework, txClient, discoveryServiceClient, false,
-          metricsCollectionService, createMetricsTags(workflowProgramInfo), pluginInstantiator);
+          metricsCollectionService, createMetricsTags(workflowProgramInfo), secureStore, secureStoreManager,
+          pluginInstantiator);
+
     this.workflowProgramInfo = workflowProgramInfo;
     this.loggingContext = createLoggingContext(program.getId(), getRunId(), workflowProgramInfo);
     this.spec = spec;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
@@ -26,6 +26,8 @@ import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
 import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.api.security.store.SecureStore;
+import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.app.metrics.MapReduceMetrics;
 import co.cask.cdap.app.program.Program;
@@ -94,9 +96,12 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
                             Transaction transaction,
                             DatasetFramework dsFramework,
                             @Nullable PluginInstantiator pluginInstantiator,
-                            Map<String, File> localizedResources) {
+                            Map<String, File> localizedResources,
+                            SecureStore secureStore,
+                            SecureStoreManager secureStoreManager) {
     super(program, programOptions, ImmutableSet.<String>of(), dsFramework, txClient, discoveryServiceClient, false,
-          metricsCollectionService, createMetricsTags(taskId, type, workflowProgramInfo), pluginInstantiator);
+          metricsCollectionService, createMetricsTags(taskId, type, workflowProgramInfo), secureStore,
+          secureStoreManager, pluginInstantiator);
     this.workflowProgramInfo = workflowProgramInfo;
     this.transaction = transaction;
     this.spec = spec;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
@@ -34,6 +34,8 @@ import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
 import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
 import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.api.security.store.SecureStoreData;
+import co.cask.cdap.api.security.store.SecureStoreMetadata;
 import co.cask.cdap.api.workflow.WorkflowInfo;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import org.apache.twill.api.RunId;
@@ -300,5 +302,15 @@ public class MapReduceLifecycleContext<KEY, VALUE> implements MapReduceTaskConte
   @Override
   public Admin getAdmin() {
     return delegate.getAdmin();
+  }
+
+  @Override
+  public List<SecureStoreMetadata> list(String namespace) throws IOException {
+    return delegate.list(namespace);
+  }
+
+  @Override
+  public SecureStoreData get(String namespace, String name) throws IOException {
+    return delegate.get(namespace, name);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -20,6 +20,8 @@ import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.mapreduce.MapReduce;
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.api.security.store.SecureStore;
+import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.Arguments;
 import co.cask.cdap.app.runtime.ProgramController;
@@ -90,6 +92,8 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final RuntimeStore runtimeStore;
   private final TransactionSystemClient txSystemClient;
   private final DiscoveryServiceClient discoveryServiceClient;
+  private final SecureStore secureStore;
+  private final SecureStoreManager secureStoreManager;
 
   @Inject
   public MapReduceProgramRunner(Injector injector, CConfiguration cConf, Configuration hConf,
@@ -98,7 +102,8 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
                                 DatasetFramework datasetFramework,
                                 TransactionSystemClient txSystemClient,
                                 MetricsCollectionService metricsCollectionService,
-                                DiscoveryServiceClient discoveryServiceClient, RuntimeStore runtimeStore) {
+                                DiscoveryServiceClient discoveryServiceClient, RuntimeStore runtimeStore,
+                                SecureStore secureStore, SecureStoreManager secureStoreManager) {
     super(cConf);
     this.injector = injector;
     this.cConf = cConf;
@@ -110,6 +115,8 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.txSystemClient = txSystemClient;
     this.discoveryServiceClient = discoveryServiceClient;
     this.runtimeStore = runtimeStore;
+    this.secureStore = secureStore;
+    this.secureStoreManager = secureStoreManager;
   }
 
   @Inject (optional = true)
@@ -167,7 +174,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
         new BasicMapReduceContext(program, options, spec,
                                   workflowInfo, discoveryServiceClient,
                                   metricsCollectionService, txSystemClient, programDatasetFramework, streamAdmin,
-                                  getPluginArchive(options), pluginInstantiator);
+                                  getPluginArchive(options), pluginInstantiator, secureStore, secureStoreManager);
 
       Reflections.visit(mapReduce, mapReduce.getClass(),
                         new PropertyFieldSetter(context.getSpecification().getProperties()),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
@@ -18,6 +18,8 @@ package co.cask.cdap.internal.app.runtime.batch;
 
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.api.security.store.SecureStore;
+import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.app.metrics.MapReduceMetrics;
 import co.cask.cdap.app.program.DefaultProgram;
 import co.cask.cdap.app.program.Program;
@@ -137,6 +139,8 @@ public class MapReduceTaskContextProvider extends AbstractIdleService {
   private CacheLoader<ContextCacheKey, BasicMapReduceTaskContext> createCacheLoader(final Injector injector) {
     final DiscoveryServiceClient discoveryServiceClient = injector.getInstance(DiscoveryServiceClient.class);
     final DatasetFramework datasetFramework = injector.getInstance(DatasetFramework.class);
+    final SecureStore secureStore = injector.getInstance(SecureStore.class);
+    final SecureStoreManager secureStoreManager = injector.getInstance(SecureStoreManager.class);
     // Multiple instances of BasicMapReduceTaskContext can shares the same program.
     final AtomicReference<Program> programRef = new AtomicReference<>();
 
@@ -181,7 +185,7 @@ public class MapReduceTaskContextProvider extends AbstractIdleService {
           program, contextConfig.getProgramOptions(), taskType, key.getTaskAttemptID().getTaskID().toString(),
           spec, workflowInfo, discoveryServiceClient, metricsCollectionService, txClient,
           contextConfig.getTx(), programDatasetFramework, classLoader.getPluginInstantiator(),
-          contextConfig.getLocalizedResources()
+          contextConfig.getLocalizedResources(), secureStore, secureStoreManager
         );
       }
     };

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/customaction/BasicCustomActionContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/customaction/BasicCustomActionContext.java
@@ -20,6 +20,8 @@ import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.customaction.CustomActionContext;
 import co.cask.cdap.api.customaction.CustomActionSpecification;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.api.security.store.SecureStore;
+import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramOptions;
@@ -54,12 +56,14 @@ public class BasicCustomActionContext extends AbstractContext implements CustomA
                                   MetricsCollectionService metricsCollectionService,
                                   DatasetFramework datasetFramework, TransactionSystemClient txClient,
                                   DiscoveryServiceClient discoveryServiceClient,
-                                  @Nullable PluginInstantiator pluginInstantiator) {
+                                  @Nullable PluginInstantiator pluginInstantiator,
+                                  SecureStore secureStore, SecureStoreManager secureStoreManager) {
 
     super(workflow, programOptions, customActionSpecification.getDatasets(),
           datasetFramework, txClient, discoveryServiceClient, false,
-          metricsCollectionService, workflowProgramInfo.updateMetricsTags(new HashMap<String, String>()),
-          pluginInstantiator);
+          metricsCollectionService, workflowProgramInfo.updateMetricsTags(new HashMap<String, String>()), secureStore,
+          secureStoreManager, pluginInstantiator);
+
     this.customActionSpecification = customActionSpecification;
     this.workflowProgramInfo = workflowProgramInfo;
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/BasicFlowletContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/BasicFlowletContext.java
@@ -20,6 +20,10 @@ import co.cask.cdap.api.flow.flowlet.FlowletContext;
 import co.cask.cdap.api.flow.flowlet.FlowletSpecification;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.metrics.MetricsContext;
+import co.cask.cdap.api.plugin.Plugin;
+import co.cask.cdap.api.security.store.SecureStore;
+import co.cask.cdap.api.security.store.SecureStoreManager;
+import co.cask.cdap.app.metrics.ProgramUserMetrics;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.conf.Constants;
@@ -59,11 +63,15 @@ final class BasicFlowletContext extends AbstractContext implements FlowletContex
                       MetricsCollectionService metricsService,
                       DiscoveryServiceClient discoveryServiceClient,
                       TransactionSystemClient txClient,
-                      DatasetFramework dsFramework) {
+                      DatasetFramework dsFramework,
+                      SecureStore secureStore,
+                      SecureStoreManager secureStoreManager) {
     super(program, programOptions, datasets, dsFramework, txClient, discoveryServiceClient, false, metricsService,
           ImmutableMap.of(Constants.Metrics.Tag.FLOWLET, flowletId,
-                          Constants.Metrics.Tag.INSTANCE_ID, String.valueOf(instanceId))
+                          Constants.Metrics.Tag.INSTANCE_ID, String.valueOf(instanceId)),
+          secureStore, secureStoreManager
     );
+
     this.flowId = program.getName();
     this.flowletId = flowletId;
     this.groupId = FlowUtils.generateConsumerGroupId(program.getId().toEntityId(), flowletId);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
@@ -35,6 +35,8 @@ import co.cask.cdap.api.flow.flowlet.OutputEmitter;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.metrics.MetricsContext;
+import co.cask.cdap.api.security.store.SecureStore;
+import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.api.stream.StreamEventData;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.queue.QueueReader;
@@ -135,6 +137,8 @@ public final class FlowletProgramRunner implements ProgramRunner {
   private final TransactionSystemClient txClient;
   private final DatasetFramework dsFramework;
   private final RuntimeUsageRegistry runtimeUsageRegistry;
+  private final SecureStore secureStore;
+  private final SecureStoreManager secureStoreManager;
 
   @Inject
   public FlowletProgramRunner(SchemaGenerator schemaGenerator,
@@ -146,7 +150,9 @@ public final class FlowletProgramRunner implements ProgramRunner {
                               DiscoveryServiceClient discoveryServiceClient,
                               TransactionSystemClient txClient,
                               DatasetFramework dsFramework,
-                              RuntimeUsageRegistry runtimeUsageRegistry) {
+                              RuntimeUsageRegistry runtimeUsageRegistry,
+                              SecureStore secureStore,
+                              SecureStoreManager secureStoreManager) {
     this.schemaGenerator = schemaGenerator;
     this.datumWriterFactory = datumWriterFactory;
     this.dataFabricFacadeFactory = dataFabricFacadeFactory;
@@ -157,6 +163,8 @@ public final class FlowletProgramRunner implements ProgramRunner {
     this.txClient = txClient;
     this.dsFramework = dsFramework;
     this.runtimeUsageRegistry = runtimeUsageRegistry;
+    this.secureStore = secureStore;
+    this.secureStoreManager = secureStoreManager;
   }
 
   @SuppressWarnings("unused")
@@ -212,7 +220,8 @@ public final class FlowletProgramRunner implements ProgramRunner {
       // Creates flowlet context
       flowletContext = new BasicFlowletContext(program, options, flowletName, instanceId, instanceCount,
                                                flowletDef.getDatasets(), flowletDef.getFlowletSpec(),
-                                               metricsCollectionService, discoveryServiceClient, txClient, dsFramework);
+                                               metricsCollectionService, discoveryServiceClient, txClient,
+                                               dsFramework, secureStore, secureStoreManager);
 
       // Creates tx related objects
       DataFabricFacade dataFabricFacade =

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/ServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/ServiceProgramRunner.java
@@ -18,6 +18,8 @@ package co.cask.cdap.internal.app.runtime.service;
 
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.api.security.store.SecureStore;
+import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.api.service.ServiceSpecification;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramController;
@@ -57,12 +59,15 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final TransactionSystemClient txClient;
   private final ServiceAnnouncer serviceAnnouncer;
   private final DataFabricFacadeFactory dataFabricFacadeFactory;
+  private final SecureStore secureStore;
+  private final SecureStoreManager secureStoreManager;
 
   @Inject
   public ServiceProgramRunner(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
                               DatasetFramework datasetFramework, DiscoveryServiceClient discoveryServiceClient,
                               TransactionSystemClient txClient, ServiceAnnouncer serviceAnnouncer,
-                              DataFabricFacadeFactory dataFabricFacadeFactory) {
+                              DataFabricFacadeFactory dataFabricFacadeFactory,
+                              SecureStore secureStore, SecureStoreManager secureStoreManager) {
     super(cConf);
     this.metricsCollectionService = metricsCollectionService;
     this.datasetFramework = datasetFramework;
@@ -70,6 +75,8 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.txClient = txClient;
     this.serviceAnnouncer = serviceAnnouncer;
     this.dataFabricFacadeFactory = dataFabricFacadeFactory;
+    this.secureStore = secureStore;
+    this.secureStoreManager = secureStoreManager;
   }
 
   @Override
@@ -106,7 +113,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
                                                           instanceId, instanceCount, serviceAnnouncer,
                                                           metricsCollectionService, datasetFramework,
                                                           dataFabricFacadeFactory, txClient, discoveryServiceClient,
-                                                          pluginInstantiator);
+                                                          pluginInstantiator, secureStore, secureStoreManager);
 
       // Add a service listener to make sure the plugin instantiator is closed when the worker driver finished.
       component.addListener(new ServiceListenerAdapter() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/AbstractHttpHandlerDelegator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/AbstractHttpHandlerDelegator.java
@@ -19,6 +19,7 @@ package co.cask.cdap.internal.app.runtime.service.http;
 import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.metrics.MetricsContext;
+import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
 import co.cask.cdap.api.service.http.HttpContentConsumer;
 import co.cask.cdap.api.service.http.HttpContentProducer;
 import co.cask.cdap.api.service.http.HttpServiceContext;
@@ -38,6 +39,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import org.apache.twill.common.Cancellable;
 import org.jboss.netty.handler.codec.http.HttpRequest;
+
+import java.util.Arrays;
 
 /**
  * An abstract base class for all {@link HttpHandler} generated through the {@link HttpHandlerGenerator}.
@@ -80,6 +83,15 @@ public abstract class AbstractHttpHandlerDelegator<T extends HttpServiceHandler>
     Preconditions.checkState(serviceContext instanceof TransactionalHttpServiceContext,
                              "This instance of HttpServiceContext does not support transactions.");
     return ((TransactionalHttpServiceContext) serviceContext).newTransactionContext();
+  }
+
+  /**
+   * Returns a combined class loader of user program class loader and system class loader
+   */
+  @SuppressWarnings("unused")
+  protected final ClassLoader createHandlerContextClassLoader() {
+    return new CombineClassLoader(null, Arrays.asList(getHandler().getClass().getClassLoader(),
+                                                      AbstractHttpServiceHandler.class.getClassLoader()));
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
@@ -17,6 +17,8 @@
 package co.cask.cdap.internal.app.runtime.service.http;
 
 import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.api.security.store.SecureStore;
+import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.api.service.http.HttpServiceHandlerSpecification;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramOptions;
@@ -57,16 +59,19 @@ public class BasicHttpServiceContext extends AbstractContext implements Transact
    * @param discoveryServiceClient discoveryServiceClient used to do service discovery.
    * @param txClient txClient to do transaction operations.
    * @param pluginInstantiator {@link PluginInstantiator}
+   * @param secureStore
    */
   public BasicHttpServiceContext(Program program, ProgramOptions programOptions,
                                  @Nullable HttpServiceHandlerSpecification spec,
                                  int instanceId, AtomicInteger instanceCount,
                                  MetricsCollectionService metricsCollectionService,
                                  DatasetFramework dsFramework, DiscoveryServiceClient discoveryServiceClient,
-                                 TransactionSystemClient txClient, @Nullable PluginInstantiator pluginInstantiator) {
+                                 TransactionSystemClient txClient, @Nullable PluginInstantiator pluginInstantiator,
+                                 SecureStore secureStore, SecureStoreManager secureStoreManager) {
     super(program, programOptions, spec == null ? Collections.<String>emptySet() : spec.getDatasets(),
           dsFramework, txClient, discoveryServiceClient, false,
-          metricsCollectionService, createMetricsTags(spec, instanceId), pluginInstantiator);
+          metricsCollectionService, createMetricsTags(spec, instanceId),
+          secureStore, secureStoreManager, pluginInstantiator);
     this.spec = spec;
     this.instanceId = instanceId;
     this.instanceCount = instanceCount;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGenerator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGenerator.java
@@ -521,7 +521,7 @@ final class HttpHandlerGenerator {
      *     try {
      *       txContext.start();
      *       try {
-     *         ClassLoader classLoader = ClassLoaders.setContextClassLoader(handler.getClass().getClassLoader());
+     *         ClassLoader classLoader = ClassLoaders.setContextClassLoader(createHandlerContextClassLoader());
      *         try {
      *           // Only do assignment if handler method returns HttpContentConsumer
      *           [contentConsumer = ]handler.handle(wrapRequest(request), wrappedResponder, ...);
@@ -756,11 +756,10 @@ final class HttpHandlerGenerator {
 
       int throwable = mg.newLocal(Type.getType(Throwable.class));
 
-      // ClassLoader classLoader = ClassLoaders.setContextClassLoader(handler.getClass().getClassLoader());
+      // ClassLoader classLoader = ClassLoaders.setContextClassLoader(createHandlerContextClassLoader());
       int classLoader = mg.newLocal(classLoaderType);
-      mg.loadLocal(handler, handlerType);
-      mg.invokeVirtual(Type.getType(Object.class), Methods.getMethod(Class.class, "getClass"));
-      mg.invokeVirtual(Type.getType(Class.class), Methods.getMethod(ClassLoader.class, "getClassLoader"));
+      mg.loadThis();
+      mg.invokeVirtual(classType, Methods.getMethod(ClassLoader.class, "createHandlerContextClassLoader"));
       mg.invokeStatic(Type.getType(ClassLoaders.class),
                       Methods.getMethod(ClassLoader.class, "setContextClassLoader", ClassLoader.class));
       mg.storeLocal(classLoader, classLoaderType);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
@@ -20,6 +20,10 @@ import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.data.stream.StreamBatchWriter;
 import co.cask.cdap.api.data.stream.StreamWriter;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.api.metrics.MetricsContext;
+import co.cask.cdap.api.plugin.Plugin;
+import co.cask.cdap.api.security.store.SecureStore;
+import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.api.stream.StreamEventData;
 import co.cask.cdap.api.worker.WorkerContext;
 import co.cask.cdap.api.worker.WorkerSpecification;
@@ -68,11 +72,14 @@ final class BasicWorkerContext extends AbstractContext implements WorkerContext 
                      TransactionSystemClient transactionSystemClient,
                      DiscoveryServiceClient discoveryServiceClient,
                      StreamWriterFactory streamWriterFactory,
-                     @Nullable PluginInstantiator pluginInstantiator) {
+                     @Nullable PluginInstantiator pluginInstantiator,
+                     SecureStore secureStore,
+                     SecureStoreManager secureStoreManager) {
     super(program, programOptions, spec.getDatasets(),
           datasetFramework, transactionSystemClient, discoveryServiceClient, true,
           metricsCollectionService, ImmutableMap.of(Constants.Metrics.Tag.INSTANCE_ID, String.valueOf(instanceId)),
-          pluginInstantiator);
+          secureStore, secureStoreManager, pluginInstantiator);
+
     this.specification = spec;
     this.instanceId = instanceId;
     this.instanceCount = instanceCount;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
@@ -19,6 +19,8 @@ package co.cask.cdap.internal.app.runtime.worker;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.api.security.store.SecureStore;
+import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.api.worker.Worker;
 import co.cask.cdap.api.worker.WorkerSpecification;
 import co.cask.cdap.app.program.Program;
@@ -58,17 +60,22 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final DiscoveryServiceClient discoveryServiceClient;
   private final TransactionSystemClient txClient;
   private final StreamWriterFactory streamWriterFactory;
+  private final SecureStore secureStore;
+  private final SecureStoreManager secureStoreManager;
 
   @Inject
   public WorkerProgramRunner(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
                              DatasetFramework datasetFramework, DiscoveryServiceClient discoveryServiceClient,
-                             TransactionSystemClient txClient, StreamWriterFactory streamWriterFactory) {
+                             TransactionSystemClient txClient, StreamWriterFactory streamWriterFactory,
+                             SecureStore secureStore, SecureStoreManager secureStoreManager) {
     super(cConf);
     this.metricsCollectionService = metricsCollectionService;
     this.datasetFramework = datasetFramework;
     this.discoveryServiceClient = discoveryServiceClient;
     this.txClient = txClient;
     this.streamWriterFactory = streamWriterFactory;
+    this.secureStore = secureStore;
+    this.secureStoreManager = secureStoreManager;
   }
 
   @Override
@@ -112,7 +119,8 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
       BasicWorkerContext context = new BasicWorkerContext(newWorkerSpec, program, options, instanceId, instanceCount,
                                                           metricsCollectionService, datasetFramework, txClient,
                                                           discoveryServiceClient, streamWriterFactory,
-                                                          pluginInstantiator);
+                                                          pluginInstantiator, secureStore, secureStoreManager);
+
       WorkerDriver worker = new WorkerDriver(program, newWorkerSpec, context);
 
       // Add a service listener to make sure the plugin instantiator is closed when the worker driver finished.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/BasicWorkflowContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/BasicWorkflowContext.java
@@ -16,6 +16,10 @@
 package co.cask.cdap.internal.app.runtime.workflow;
 
 import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.api.metrics.MetricsContext;
+import co.cask.cdap.api.plugin.Plugin;
+import co.cask.cdap.api.security.store.SecureStore;
+import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.api.workflow.WorkflowActionSpecification;
 import co.cask.cdap.api.workflow.WorkflowContext;
 import co.cask.cdap.api.workflow.WorkflowNodeState;
@@ -55,12 +59,13 @@ final class BasicWorkflowContext extends AbstractContext implements WorkflowCont
                        MetricsCollectionService metricsCollectionService,
                        DatasetFramework datasetFramework, TransactionSystemClient txClient,
                        DiscoveryServiceClient discoveryServiceClient, Map<String, WorkflowNodeState> nodeStates,
-                       @Nullable PluginInstantiator pluginInstantiator) {
+                       @Nullable PluginInstantiator pluginInstantiator,
+                       SecureStore secureStore, SecureStoreManager secureStoreManager) {
     super(program, programOptions, (spec == null) ? new HashSet<String>() : spec.getDatasets(),
           datasetFramework, txClient, discoveryServiceClient, false,
           metricsCollectionService, Collections.singletonMap(Constants.Metrics.Tag.WORKFLOW_RUN_ID,
                                                              ProgramRunners.getRunId(programOptions).getId()),
-          pluginInstantiator);
+          secureStore, secureStoreManager, pluginInstantiator);
     this.workflowSpec = workflowSpec;
     this.specification = spec;
     this.programWorkflowRunner = programWorkflowRunner;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramRunner.java
@@ -18,6 +18,8 @@ package co.cask.cdap.internal.app.runtime.workflow;
 
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.api.security.store.SecureStore;
+import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.api.workflow.Workflow;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
 import co.cask.cdap.app.program.Program;
@@ -58,6 +60,8 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final DiscoveryServiceClient discoveryServiceClient;
   private final TransactionSystemClient txClient;
   private final RuntimeStore runtimeStore;
+  private final SecureStore secureStore;
+  private final SecureStoreManager secureStoreManager;
   private final CConfiguration cConf;
 
   @Inject
@@ -65,7 +69,8 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
                                @Named(Constants.AppFabric.SERVER_ADDRESS) InetAddress hostname,
                                MetricsCollectionService metricsCollectionService, DatasetFramework datasetFramework,
                                DiscoveryServiceClient discoveryServiceClient, TransactionSystemClient txClient,
-                               RuntimeStore runtimeStore, CConfiguration cConf) {
+                               RuntimeStore runtimeStore, CConfiguration cConf, SecureStore secureStore,
+                               SecureStoreManager secureStoreManager) {
     super(cConf);
     this.programRunnerFactory = programRunnerFactory;
     this.serviceAnnouncer = serviceAnnouncer;
@@ -75,6 +80,8 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.discoveryServiceClient = discoveryServiceClient;
     this.txClient = txClient;
     this.runtimeStore = runtimeStore;
+    this.secureStore = secureStore;
+    this.secureStoreManager = secureStoreManager;
     this.cConf = cConf;
   }
 
@@ -103,8 +110,8 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
     PluginInstantiator pluginInstantiator = createPluginInstantiator(options, program.getClassLoader());
     WorkflowDriver driver = new WorkflowDriver(program, options, hostname, workflowSpec, programRunnerFactory,
                                                metricsCollectionService, datasetFramework, discoveryServiceClient,
-                                               txClient, runtimeStore, cConf,
-                                               pluginInstantiator);
+                                               txClient, runtimeStore, cConf, pluginInstantiator,
+                                               secureStore, secureStoreManager);
     // Controller needs to be created before starting the driver so that the state change of the driver
     // service can be fully captured by the controller.
     ProgramController controller = new WorkflowProgramController(program, driver, serviceAnnouncer, runId);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceHttpServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceHttpServer.java
@@ -18,6 +18,9 @@ package co.cask.cdap.internal.app.services;
 
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.metrics.MetricsContext;
+import co.cask.cdap.api.metrics.NoopMetricsContext;
+import co.cask.cdap.api.security.store.SecureStore;
+import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.api.service.ServiceSpecification;
 import co.cask.cdap.api.service.http.HttpServiceHandler;
 import co.cask.cdap.api.service.http.HttpServiceHandlerSpecification;
@@ -109,7 +112,8 @@ public class ServiceHttpServer extends AbstractIdleService {
                            MetricsCollectionService metricsCollectionService, DatasetFramework datasetFramework,
                            DataFabricFacadeFactory dataFabricFacadeFactory, TransactionSystemClient txClient,
                            DiscoveryServiceClient discoveryServiceClient,
-                           @Nullable PluginInstantiator pluginInstantiator) {
+                           @Nullable PluginInstantiator pluginInstantiator,
+                           SecureStore secureStore, SecureStoreManager secureStoreManager) {
     this.program = program;
     this.instanceCount = new AtomicInteger(instanceCount);
     this.serviceAnnouncer = serviceAnnouncer;
@@ -118,7 +122,8 @@ public class ServiceHttpServer extends AbstractIdleService {
                                                                          instanceId, this.instanceCount,
                                                                          metricsCollectionService,
                                                                          datasetFramework, discoveryServiceClient,
-                                                                         txClient, pluginInstantiator);
+                                                                         txClient, pluginInstantiator, secureStore,
+                                                                         secureStoreManager);
     this.handlerContexts = createHandlerDelegatorContexts(program, spec, contextFactory);
     this.context = contextFactory.create(null);
     this.service = createNettyHttpService(program, host, handlerContexts, context.getProgramMetrics());
@@ -197,13 +202,15 @@ public class ServiceHttpServer extends AbstractIdleService {
                                                               final DatasetFramework datasetFramework,
                                                               final DiscoveryServiceClient discoveryServiceClient,
                                                               final TransactionSystemClient txClient,
-                                                              @Nullable final PluginInstantiator pluginInstantiator) {
+                                                              @Nullable final PluginInstantiator pluginInstantiator,
+                                                              final SecureStore secureStore,
+                                                              final SecureStoreManager secureStoreManager) {
     return new BasicHttpServiceContextFactory() {
       @Override
       public BasicHttpServiceContext create(@Nullable HttpServiceHandlerSpecification spec) {
         return new BasicHttpServiceContext(program, programOptions, spec, instanceId, instanceCount,
-                                           metricsCollectionService,
-                                           datasetFramework, discoveryServiceClient, txClient, pluginInstantiator);
+                                           metricsCollectionService, datasetFramework, discoveryServiceClient,
+                                           txClient, pluginInstantiator, secureStore, secureStoreManager);
       }
     };
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/AppUsingSecureStore.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/AppUsingSecureStore.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap;
+
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.security.store.SecureStore;
+import co.cask.cdap.api.service.AbstractService;
+import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
+import co.cask.cdap.api.service.http.HttpServiceContext;
+import co.cask.cdap.api.service.http.HttpServiceRequest;
+import co.cask.cdap.api.service.http.HttpServiceResponder;
+import co.cask.cdap.api.spark.AbstractSpark;
+import co.cask.cdap.api.spark.JavaSparkExecutionContext;
+import co.cask.cdap.api.spark.JavaSparkMain;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.PairFunction;
+import org.junit.Assert;
+import scala.Tuple2;
+
+import java.io.IOException;
+import java.util.HashMap;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+
+/**
+ * App used to test secure store apis
+ * Includes: A service to access the secure store
+ *           A spark program reading from the stream and writing to a dataset with (data, key)
+ */
+public class AppUsingSecureStore extends AbstractApplication {
+  public static final String SERVICE_NAME = "secureStoreService";
+  public static final String SPARK_NAME = "SparkSecureStoreProgram";
+  public static final String STREAM_NAME = "testStream";
+  public static final String KEY = "key";
+  public static final String VALUE = "value";
+  private static final String NAMESPACE = "namespace";
+
+  @Override
+  public void configure() {
+    setName("TestSecureStoreApis");
+    setDescription("App to test usage of secure store apis");
+    createDataset("result", KeyValueTable.class);
+    addService(new SecureStoreService());
+    addSpark(new SparkSecureStoreProgram());
+  }
+
+  public static class SecureStoreService extends AbstractService {
+    @Override
+    protected void configure() {
+      setName(SERVICE_NAME);
+      addHandler(new SecureStoreHandler());
+    }
+  }
+
+  public static class SecureStoreHandler extends AbstractHttpServiceHandler {
+    private String namespace;
+
+    @Override
+    public void initialize(HttpServiceContext context) throws Exception {
+      super.initialize(context);
+      namespace = context.getNamespace();
+    }
+
+    @Path("/put")
+    @PUT
+    public void put(HttpServiceRequest request, HttpServiceResponder responder) throws IOException {
+      byte[] value = new byte[request.getContent().remaining()];
+      request.getContent().get(value);
+      getContext().getAdmin().put(namespace, KEY, value, "", new HashMap<String, String>());
+      responder.sendStatus(200);
+    }
+
+    @Path("/get")
+    @GET
+    public void get(HttpServiceRequest request, HttpServiceResponder responder) throws IOException {
+      try {
+        byte[] bytes = getContext().get(namespace, KEY).get();
+        responder.sendString(new String(bytes));
+      } catch (IOException e) {
+        responder.sendError(500, e.getMessage());
+      }
+    }
+
+    @Path("/list")
+    @GET
+    public void list(HttpServiceRequest request, HttpServiceResponder responder) throws IOException {
+      String name = getContext().list(namespace).get(0).getName();
+      responder.sendString(name);
+    }
+
+    @Path("/delete")
+    @GET
+    public void delete(HttpServiceRequest request, HttpServiceResponder responder) throws IOException {
+      getContext().getAdmin().delete(namespace, KEY);
+      responder.sendStatus(200);
+    }
+  }
+
+
+  public static class SparkSecureStoreProgram extends AbstractSpark implements JavaSparkMain {
+    @Override
+    public void configure() {
+      setName(SPARK_NAME);
+      setDescription("Test Spark with Streams from other namespace");
+      setMainClass(SparkSecureStoreProgram.class);
+    }
+
+    @Override
+    public void run(JavaSparkExecutionContext sec) throws Exception {
+      final SecureStore secureStore = sec.getSecureStore();
+      // Test secure store apis
+      sec.getAdmin().put(NAMESPACE, KEY, VALUE.getBytes(), "", new HashMap<String, String>());
+      Assert.assertEquals(new String(sec.get(NAMESPACE, KEY).get()), VALUE);
+      Assert.assertEquals(new String(secureStore.get(NAMESPACE, KEY).get()), VALUE);
+      sec.list(NAMESPACE);
+
+      // Test access from a spark closure
+      JavaSparkContext jsc = new JavaSparkContext();
+      JavaPairRDD<Long, String> rdd = sec.fromStream(STREAM_NAME, String.class);
+      JavaPairRDD<byte[], byte[]> resultRDD = rdd.mapToPair(new PairFunction<Tuple2<Long, String>,
+        byte[], byte[]>() {
+        @Override
+        public Tuple2<byte[], byte[]> call(Tuple2<Long, String> tuple2) throws Exception {
+          return new Tuple2<>(Bytes.toBytes(tuple2._2()), secureStore.get(NAMESPACE, KEY).get());
+        }
+      });
+      sec.saveAsDataset(resultRDD, "result");
+
+      // Delete the key
+      sec.getAdmin().delete(NAMESPACE, KEY);
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/AuthorizationHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/AuthorizationHandlerTest.java
@@ -84,7 +84,8 @@ public class AuthorizationHandlerTest {
           //no-op
         }
       };
-      return new DefaultAuthorizationContext(extensionProperties, new NoOpDatasetContext(), new NoOpAdmin(), txnl);
+      return new DefaultAuthorizationContext(extensionProperties, new NoOpDatasetContext(), new NoOpAdmin(),
+                                             txnl, null);
     }
   };
   private final Principal admin = new Principal("admin", Principal.PrincipalType.USER);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
@@ -26,6 +26,8 @@ import co.cask.cdap.api.dataset.InstanceNotFoundException;
 import co.cask.cdap.api.macro.MacroEvaluator;
 import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.api.security.store.SecureStoreData;
+import co.cask.cdap.api.security.store.SecureStoreMetadata;
 import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
 import co.cask.cdap.api.service.http.HttpContentConsumer;
 import co.cask.cdap.api.service.http.HttpContentProducer;
@@ -703,7 +705,28 @@ public class HttpHandlerGeneratorTest {
         public void truncateDataset(String name) {
           // nop-op
         }
+
+        @Override
+        public void put(String namespace, String name, byte[] data, String description, Map<String, String> properties)
+          throws IOException {
+          //no-op
+        }
+
+        @Override
+        public void delete(String namespace, String name) throws IOException {
+          //no-op
+        }
       };
+    }
+
+    @Override
+    public List<SecureStoreMetadata> list(String namespace) throws IOException {
+      return null;
+    }
+
+    @Override
+    public SecureStoreData get(String namespace, String name) throws IOException {
+      return null;
     }
   }
 }

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
@@ -52,6 +52,7 @@ import co.cask.cdap.metadata.MetadataServiceModule;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.security.guice.SecureStoreModules;
 import co.cask.cdap.store.guice.NamespaceStoreModule;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.Service;
@@ -118,6 +119,7 @@ public class DatasetOpExecutorServerTwillRunnable extends AbstractMasterTwillRun
       new NotificationFeedClientModule(),
       new AuditModule().getDistributedModules(),
       new EntityVerifierModule(),
+      new SecureStoreModules().getDistributedModules(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationContext.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationContext.java
@@ -24,12 +24,14 @@ import co.cask.cdap.api.data.DatasetInstantiationException;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.security.spi.authorization.AuthorizationContext;
 import co.cask.tephra.TransactionFailureException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
 
@@ -42,16 +44,18 @@ public class DefaultAuthorizationContext implements AuthorizationContext {
   private final DatasetContext delegateDatasetContext;
   private final Admin delegateAdmin;
   private final Transactional delegateTxnl;
+  private final SecureStoreManager delegateSecureStoreManager;
 
   @Inject
   @VisibleForTesting
   public DefaultAuthorizationContext(@Assisted("extension-properties") Properties extensionProperties,
                                      DatasetContext delegateDatasetContext, Admin delegateAdmin,
-                                     Transactional delegateTxnl) {
+                                     Transactional delegateTxnl, SecureStoreManager delegateSecureStoreManager) {
     this.extensionProperties = extensionProperties;
     this.delegateDatasetContext = delegateDatasetContext;
     this.delegateAdmin = delegateAdmin;
     this.delegateTxnl = delegateTxnl;
+    this.delegateSecureStoreManager = delegateSecureStoreManager;
   }
 
   @Override
@@ -129,5 +133,16 @@ public class DefaultAuthorizationContext implements AuthorizationContext {
   @Override
   public Properties getExtensionProperties() {
     return extensionProperties;
+  }
+
+  @Override
+  public void put(String namespace, String name, byte[] data, String description, Map<String, String> properties)
+    throws IOException {
+    delegateSecureStoreManager.put(namespace, name, data, description, properties);
+  }
+
+  @Override
+  public void delete(String namespace, String name) throws IOException {
+    delegateSecureStoreManager.delete(namespace, name);
   }
 }

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizationTestBase.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizationTestBase.java
@@ -47,7 +47,8 @@ public class AuthorizationTestBase {
           //no-op
         }
       };
-      return new DefaultAuthorizationContext(extensionProperties, new NoOpDatasetContext(), new NoOpAdmin(), txnl);
+      return new DefaultAuthorizationContext(extensionProperties, new NoOpDatasetContext(), new NoOpAdmin(), txnl,
+                                             null);
     }
   };
   protected static LocationFactory locationFactory;

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/NoOpAdmin.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/NoOpAdmin.java
@@ -21,6 +21,9 @@ import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.InstanceNotFoundException;
 
+import java.io.IOException;
+import java.util.Map;
+
 /**
  * A no-op implementation of {@link Admin} for use in tests
  */
@@ -57,6 +60,17 @@ public class NoOpAdmin implements Admin {
 
   @Override
   public void truncateDataset(String name) throws DatasetManagementException {
+    //no-op
+  }
+
+  @Override
+  public void put(String namespace, String name, byte[] data, String description, Map<String, String> properties)
+    throws IOException {
+    //no-op
+  }
+
+  @Override
+  public void delete(String namespace, String name) throws IOException {
     //no-op
   }
 }

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/BasicSparkClientContext.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/BasicSparkClientContext.java
@@ -24,6 +24,8 @@ import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.macro.MacroEvaluator;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.api.security.store.SecureStoreData;
+import co.cask.cdap.api.security.store.SecureStoreMetadata;
 import co.cask.cdap.api.spark.Spark;
 import co.cask.cdap.api.spark.SparkClientContext;
 import co.cask.cdap.api.spark.SparkSpecification;
@@ -36,10 +38,12 @@ import com.google.common.base.Throwables;
 import org.apache.spark.SparkConf;
 import org.apache.twill.api.RunId;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -242,5 +246,15 @@ final class BasicSparkClientContext implements SparkClientContext {
   @Override
   public <T> T newPluginInstance(String pluginId, MacroEvaluator evaluator) throws InstantiationException {
     return sparkRuntimeContext.newPluginInstance(pluginId, evaluator);
+  }
+
+  @Override
+  public List<SecureStoreMetadata> list(String namespace) throws IOException {
+    return sparkRuntimeContext.list(namespace);
+  }
+
+  @Override
+  public SecureStoreData get(String namespace, String name) throws IOException {
+    return sparkRuntimeContext.get(namespace, name);
   }
 }

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRunner.java
@@ -18,6 +18,8 @@ package co.cask.cdap.app.runtime.spark;
 
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.api.security.store.SecureStore;
+import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.api.spark.Spark;
 import co.cask.cdap.api.spark.SparkSpecification;
 import co.cask.cdap.app.program.Program;
@@ -93,12 +95,14 @@ final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
   private final DiscoveryServiceClient discoveryServiceClient;
   private final StreamAdmin streamAdmin;
   private final RuntimeStore runtimeStore;
+  private final SecureStore secureStore;
+  private final SecureStoreManager secureStoreManager;
 
   @Inject
   SparkProgramRunner(CConfiguration cConf, Configuration hConf, TransactionSystemClient txClient,
                      DatasetFramework datasetFramework, MetricsCollectionService metricsCollectionService,
                      DiscoveryServiceClient discoveryServiceClient, StreamAdmin streamAdmin,
-                     RuntimeStore runtimeStore) {
+                     RuntimeStore runtimeStore, SecureStore secureStore, SecureStoreManager secureStoreManager) {
     super(cConf);
     this.cConf = cConf;
     this.hConf = hConf;
@@ -108,6 +112,8 @@ final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
     this.discoveryServiceClient = discoveryServiceClient;
     this.streamAdmin = streamAdmin;
     this.runtimeStore = runtimeStore;
+    this.secureStore = secureStore;
+    this.secureStoreManager = secureStoreManager;
   }
 
   @Override
@@ -154,7 +160,7 @@ final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
                                                                    txClient, programDatasetFramework,
                                                                    discoveryServiceClient,
                                                                    metricsCollectionService, streamAdmin, workflowInfo,
-                                                                   pluginInstantiator);
+                                                                   pluginInstantiator, secureStore, secureStoreManager);
       closeables.addFirst(runtimeContext);
 
       Spark spark;

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContext.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContext.java
@@ -18,6 +18,8 @@ package co.cask.cdap.app.runtime.spark;
 
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.api.security.store.SecureStore;
+import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.api.spark.SparkSpecification;
 import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.runtime.ProgramOptions;
@@ -65,9 +67,12 @@ public final class SparkRuntimeContext extends AbstractContext implements Metric
                       MetricsCollectionService metricsCollectionService,
                       StreamAdmin streamAdmin,
                       @Nullable WorkflowProgramInfo workflowProgramInfo,
-                      @Nullable PluginInstantiator pluginInstantiator) {
+                      @Nullable PluginInstantiator pluginInstantiator,
+                      SecureStore secureStore,
+                      SecureStoreManager secureStoreManager) {
     super(program, programOptions, Collections.<String>emptySet(), datasetFramework, txClient, discoveryServiceClient,
-          true, metricsCollectionService, createMetricsTags(workflowProgramInfo), pluginInstantiator);
+          true, metricsCollectionService, createMetricsTags(workflowProgramInfo), secureStore, secureStoreManager,
+          pluginInstantiator);
 
     this.hConf = hConf;
     this.txClient = txClient;

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
@@ -17,6 +17,8 @@
 package co.cask.cdap.app.runtime.spark;
 
 import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.api.security.store.SecureStore;
+import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.app.guice.DistributedProgramRunnableModule;
 import co.cask.cdap.app.program.DefaultProgram;
 import co.cask.cdap.app.program.Program;
@@ -177,7 +179,9 @@ public final class SparkRuntimeContextProvider {
         metricsCollectionService,
         injector.getInstance(StreamAdmin.class),
         contextConfig.getWorkflowProgramInfo(),
-        pluginInstantiator
+        pluginInstantiator,
+        injector.getInstance(SecureStore.class),
+        injector.getInstance(SecureStoreManager.class)
       );
       return sparkRuntimeContext;
     } catch (Exception e) {

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkSecureStore.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkSecureStore.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark;
+
+import co.cask.cdap.api.security.store.SecureStore;
+import co.cask.cdap.api.security.store.SecureStoreData;
+import co.cask.cdap.api.security.store.SecureStoreMetadata;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.List;
+
+/**
+ * A {@link Externalizable} implementation of {@link SecureStore} used in Spark program execution.
+ * It has no-op for serialize/deserialize operation, with all operations delegated to the {@link SparkRuntimeContext}
+ * of the current execution context.
+ */
+public class SparkSecureStore implements SecureStore, Externalizable {
+
+  private final SecureStore delegate;
+
+  /**
+   * Constructor. It delegates plugin context operations to the current {@link SparkRuntimeContext}.
+   */
+  public SparkSecureStore() {
+    this(SparkRuntimeContextProvider.get());
+  }
+
+  /**
+   * Creates an instance that delegates all plugin context operations to the give {@link SecureStore} delegate.
+   */
+  SparkSecureStore(SecureStore delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public List<SecureStoreMetadata> list(String namespace) throws IOException {
+    return delegate.list(namespace);
+  }
+
+  @Override
+  public SecureStoreData get(String namespace, String name) throws IOException {
+    return delegate.get(namespace, name);
+  }
+
+  @Override
+  public void writeExternal(ObjectOutput out) throws IOException {
+    // np-op
+  }
+
+  @Override
+  public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+    // no-op
+  }
+}

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.app.runtime.spark
 
+import java.io.IOException
 import java.util
 
 import co.cask.cdap.api.app.ApplicationSpecification
@@ -24,6 +25,7 @@ import co.cask.cdap.api.data.format.FormatSpecification
 import co.cask.cdap.api.flow.flowlet.StreamEvent
 import co.cask.cdap.api.metrics.Metrics
 import co.cask.cdap.api.plugin.PluginContext
+import co.cask.cdap.api.security.store.{SecureStore, SecureStoreData, SecureStoreMetadata}
 import co.cask.cdap.api.spark.{JavaSparkExecutionContext, SparkExecutionContext, SparkSpecification}
 import co.cask.cdap.api.stream.{GenericStreamEventData, StreamEventDecoder}
 import co.cask.cdap.api.workflow.{WorkflowInfo, WorkflowToken}
@@ -55,6 +57,8 @@ class DefaultJavaSparkExecutionContext(sec: SparkExecutionContext) extends JavaS
   override def getLogicalStartTime: Long = sec.getLogicalStartTime
 
   override def getPluginContext: PluginContext = sec.getPluginContext
+
+  override def getSecureStore: SecureStore = sec.getSecureStore
 
   override def getWorkflowToken: WorkflowToken = sec.getWorkflowToken.orNull
 
@@ -176,6 +180,16 @@ class DefaultJavaSparkExecutionContext(sec: SparkExecutionContext) extends JavaS
     implicit val kTag: ClassTag[K] = createClassTag
     implicit val vTag: ClassTag[V] = createClassTag
     sec.saveAsDataset(JavaPairRDD.toRDD(rdd), datasetName, arguments.toMap)
+  }
+
+  @throws[IOException]
+  override def list(namespace: String): util.List[SecureStoreMetadata] = {
+    return sec.getSecureStore.list(namespace)
+  }
+
+  @throws[IOException]
+  override def get(namespace: String, name: String): SecureStoreData = {
+    return sec.getSecureStore.get(namespace, name)
   }
 
   /**

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultSparkExecutionContext.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultSparkExecutionContext.scala
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.app.runtime.spark
 
-import java.io.File
+import java.io.{File, IOException}
 import java.net.URI
 import java.util
 import java.util.concurrent.{CountDownLatch, TimeUnit}
@@ -29,6 +29,7 @@ import co.cask.cdap.api.dataset.Dataset
 import co.cask.cdap.api.flow.flowlet.StreamEvent
 import co.cask.cdap.api.metrics.Metrics
 import co.cask.cdap.api.plugin.PluginContext
+import co.cask.cdap.api.security.store.{SecureStore, SecureStoreData, SecureStoreMetadata}
 import co.cask.cdap.api.spark.{SparkExecutionContext, SparkSpecification}
 import co.cask.cdap.api.stream.GenericStreamEventData
 import co.cask.cdap.api.workflow.{WorkflowInfo, WorkflowToken}
@@ -133,6 +134,8 @@ class DefaultSparkExecutionContext(runtimeContext: SparkRuntimeContext,
   override def getServiceDiscoverer: ServiceDiscoverer = new SparkServiceDiscoverer(runtimeContext)
 
   override def getMetrics: Metrics = new SparkUserMetrics(runtimeContext)
+
+  override def getSecureStore: SecureStore = new SparkSecureStore(runtimeContext)
 
   override def getPluginContext: PluginContext = new SparkPluginContext(runtimeContext)
 
@@ -264,6 +267,16 @@ class DefaultSparkExecutionContext(runtimeContext: SparkRuntimeContext,
         }
       }
     }, TransactionType.IMPLICIT)
+  }
+
+  @throws[IOException]
+  def list(namespace: String): util.List[SecureStoreMetadata] = {
+    return runtimeContext.list(namespace)
+  }
+
+  @throws[IOException]
+  def get(namespace: String, name: String): SecureStoreData = {
+    return runtimeContext.get(namespace, name)
   }
 
   private def configureStreamInput(configuration: Configuration, streamId: StreamId, startTime: Long,

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithServices.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithServices.java
@@ -168,8 +168,9 @@ public class AppWithServices extends AbstractApplication {
 
     @Path("verifyClassLoader")
     @GET
-    public void verifyClassLoader(HttpServiceRequest request, HttpServiceResponder responder) {
-      if (Thread.currentThread().getContextClassLoader() != getClass().getClassLoader()) {
+    public void verifyClassLoader(HttpServiceRequest request, HttpServiceResponder responder) throws Exception {
+      Class<?> loadedThisClass = Thread.currentThread().getContextClassLoader().loadClass(getClass().getName());
+      if (loadedThisClass != this.getClass()) {
         responder.sendStatus(500);
       } else {
         responder.sendStatus(200);


### PR DESCRIPTION
Expose secure store apis to programs:
- Make `RuntimeContext` extends `SecureStore` to expose `list` `get`
- Make `Admin` extends `SecureStoreManager` to expose `put`  `delete`

Also, @chtyim made changes here to `HttpHandlerGenerator` using a combined class loader fixing a service bug.
