### PR TITLE
Add stack trace in the ERROR log when startup check fails.

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/master/startup/MasterStartupTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/startup/MasterStartupTool.java
@@ -100,10 +100,7 @@ public class MasterStartupTool {
     List<CheckRunner.Failure> failures = checkRunner.runChecks();
     if (!failures.isEmpty()) {
       for (CheckRunner.Failure failure : failures) {
-        LOG.error("{} failed: {}", failure.getName(), failure.getException().getMessage());
-        if (failure.getException().getCause() != null) {
-          LOG.error("  Root cause: {}", ExceptionUtils.getRootCauseMessage(failure.getException().getCause()));
-        }
+        LOG.error("{} failed:", failure.getName(), failure.getException());
       }
       LOG.error("Errors detected while starting up master. " +
                   "Please check the logs, address all errors, then try again.");


### PR DESCRIPTION
if there is error in startup checks we only log the message associated with the exception. However that does not give much information 
Sample log

``` java
2016-07-20 21:44:45,433 - ERROR [main:c.c.c.m.s.MasterStartupTool@103] - ConfigurationCheck failed: null
```

Added full stack trace in the message

``` java
2016-07-20 22:46:11,357 - ERROR [main:c.c.c.m.s.MasterStartupTool@103] - ConfigurationCheck failed:
java.lang.NullPointerException: null
        at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:191) ~[com.google.guava.guava-13.0.1.jar:na]
        at co.cask.cdap.common.conf.Configuration.getInt(Configuration.java:661) ~[co.cask.cdap.cdap-common-3.5.0-SNAPSHOT.jar:na]
        at co.cask.cdap.master.startup.ConfigurationCheck.checkPotentialPortConflicts(ConfigurationCheck.java:126) ~[co.cask.cdap.cdap-master-3.5.0-SNAPSHOT.jar:na]
        at co.cask.cdap.master.startup.ConfigurationCheck.run(ConfigurationCheck.java:59) ~[co.cask.cdap.cdap-master-3.5.0-SNAPSHOT.jar:na]
        at co.cask.cdap.common.startup.CheckRunner.runChecks(CheckRunner.java:51) ~[co.cask.cdap.cdap-common-3.5.0-SNAPSHOT.jar:na]
        at co.cask.cdap.master.startup.MasterStartupTool.canStartMaster(MasterStartupTool.java:100) [co.cask.cdap.cdap-master-3.5.0-SNAPSHOT.jar:na]
        at co.cask.cdap.master.startup.MasterStartupTool.main(MasterStartupTool.java:90) [co.cask.cdap.cdap-master-3.5.0-SNAPSHOT.jar:na]
```
