### PR TITLE
CDAP-6545 Remove wait time in log saver when reading old log events

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogWriterPlugin.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogWriterPlugin.java
@@ -63,6 +63,7 @@ public class KafkaLogWriterPlugin extends AbstractKafkaLogProcessor {
 
   private final String logBaseDir;
   private final LogFileWriter<KafkaLogEvent> logFileWriter;
+  // Table structure - <event time bucket, log context, event arrival time bucket, log event>
   private final RowSortedTable<Long, String, Map.Entry<Long, List<KafkaLogEvent>>> messageTable;
   private final long eventBucketIntervalMs;
   private final int logCleanupIntervalMins;
@@ -162,10 +163,10 @@ public class KafkaLogWriterPlugin extends AbstractKafkaLogProcessor {
         Threads.createDaemonThreadFactory("log-saver-log-processor-" + partition)));
     }
 
-    LogWriter logWriter = new LogWriter(logFileWriter, messageTable,
-                                        eventBucketIntervalMs, maxNumberOfBucketsInTable);
-    scheduledExecutor.scheduleWithFixedDelay(logWriter, 100, 200, TimeUnit.MILLISECONDS);
     countDownLatch = new CountDownLatch(1);
+    LogWriter logWriter = new LogWriter(logFileWriter, messageTable,
+                                        eventBucketIntervalMs, maxNumberOfBucketsInTable, countDownLatch);
+    scheduledExecutor.execute(logWriter);
   }
 
   @Override
@@ -182,13 +183,21 @@ public class KafkaLogWriterPlugin extends AbstractKafkaLogProcessor {
       while (true) {
         // Get the oldest bucket in the table
         long oldestBucketKey;
+        int numBuckets;
         synchronized (messageTable) {
           SortedSet<Long> rowKeySet = messageTable.rowKeySet();
-          oldestBucketKey = rowKeySet.isEmpty() ? System.currentTimeMillis() : rowKeySet.first();
+          numBuckets = rowKeySet.size();
+          oldestBucketKey = numBuckets == 0 ? System.currentTimeMillis() : rowKeySet.first();
+          long latestBucketKey = numBuckets == 0 ? oldestBucketKey : rowKeySet.last();
 
-          // If the current event falls in the bucket number which is in window [oldestBucketKey, oldestBucketKey+8]
+          // If the number of buckets in memory are less than maxBuckets or
+          // if the current event falls in the bucket number which is in
+          // the window [oldestBucketKey, oldestBucketKey+maxBuckets]
           // then we can add the event to message table
-          if (firstKey <= (oldestBucketKey + maxNumberOfBucketsInTable)) {
+          // We try to limit in-memory buckets to prevent OOM.
+          // Note that we can still have more than maxBuckets in memory if buckets are not consecutive, or
+          // we get an event older than oldest bucket
+          if (numBuckets < maxNumberOfBucketsInTable || firstKey <= latestBucketKey) {
             while (peekingIterator.hasNext()) {
               KafkaLogEvent event = peekingIterator.next();
               LoggingContext loggingContext = event.getLoggingContext();
@@ -215,8 +224,8 @@ public class KafkaLogWriterPlugin extends AbstractKafkaLogProcessor {
         // Cannot insert event into message table
         // since there are still maxNumberOfBucketsInTable buckets that need to be processed
         // sleep for the time duration till event falls in the window
-        LOG.trace("key={}, oldestBucketKey={}, maxNumberOfBucketsInTable={}. Sleeping for {} ms.",
-                  firstKey, oldestBucketKey, maxNumberOfBucketsInTable, SLEEP_TIME_MS);
+        LOG.trace("key={}, oldestBucketKey={}, maxNumberOfBucketsInTable={}, buckets={}. Sleeping for {} ms.",
+                  firstKey, oldestBucketKey, maxNumberOfBucketsInTable, numBuckets, SLEEP_TIME_MS);
 
         if (countDownLatch.await(SLEEP_TIME_MS, TimeUnit.MILLISECONDS)) {
           // if count down occurred return

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogSaver.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogSaver.java
@@ -171,7 +171,7 @@ public final class LogSaver extends AbstractIdleService {
       kafkaCancelCallbackLatchMap.put(part, new CountDownLatch(1));
 
       kafkaCancelMap.put(part, preparer.consume(
-        new KafkaMessageCallback(kafkaCancelCallbackLatchMap.get(part), kafkaLogProcessors, metricsContext)));
+        new KafkaMessageCallback(part, kafkaCancelCallbackLatchMap.get(part), kafkaLogProcessors, metricsContext)));
     }
 
     LOG.info("Consumer created for topic {}, partitions {}", topic, partitionOffset);

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogWriter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogWriter.java
@@ -31,70 +31,96 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.SortedSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Persists bucketized logs stored by {@link KafkaMessageCallback}.
  */
 public class LogWriter implements Runnable {
   private static final Logger LOG = LoggerFactory.getLogger(LogWriter.class);
+  private static final long SLEEP_TIME_NS = TimeUnit.MILLISECONDS.toNanos(100);
+
   private final LogFileWriter<KafkaLogEvent> logFileWriter;
   private final RowSortedTable<Long, String, Entry<Long, List<KafkaLogEvent>>> messageTable;
   private final long eventBucketIntervalMs;
   private final long maxNumberOfBucketsInTable;
+  private final CountDownLatch stopLatch;
 
   private final ListMultimap<String, KafkaLogEvent> writeListMap = ArrayListMultimap.create();
 
   public LogWriter(LogFileWriter<KafkaLogEvent> logFileWriter,
                    RowSortedTable<Long, String, Entry<Long, List<KafkaLogEvent>>> messageTable,
-                   long eventBucketIntervalMs, long maxNumberOfBucketsInTable) {
+                   long eventBucketIntervalMs, long maxNumberOfBucketsInTable, CountDownLatch stopLatch) {
     this.logFileWriter = logFileWriter;
     this.messageTable = messageTable;
     this.eventBucketIntervalMs = eventBucketIntervalMs;
     this.maxNumberOfBucketsInTable = maxNumberOfBucketsInTable;
+    this.stopLatch = stopLatch;
   }
 
   @Override
   public void run() {
-    try {
-      // Read new messages only if previous write was successful.
-      if (writeListMap.isEmpty()) {
-        int messages = 0;
+    while (true) {
+      try {
+        // Read new messages only if previous write was successful.
+        if (writeListMap.isEmpty()) {
+          int messages = 0;
 
-        long limitKey = System.currentTimeMillis() / eventBucketIntervalMs;
-        synchronized (messageTable) {
-          SortedSet<Long> rowKeySet = messageTable.rowKeySet();
-          if (!rowKeySet.isEmpty()) {
-            // Get the oldest bucket in the table
-            long oldestBucketKey = rowKeySet.first();
+          // The newest event that we can write to disk
+          // We try to buffer events up to (eventBucketIntervalMs * maxNumberOfBucketsInTable) time
+          // so that we collect almost all events for a time bucket before we sort it.
+          long limitKey = (System.currentTimeMillis() / eventBucketIntervalMs) - maxNumberOfBucketsInTable;
+          synchronized (messageTable) {
+            SortedSet<Long> rowKeySet = messageTable.rowKeySet();
+            if (!rowKeySet.isEmpty()) {
+              int numBuckets = rowKeySet.size();
+              long oldestBucketKey = rowKeySet.first();
 
-            Map<String, Entry<Long, List<KafkaLogEvent>>> row = messageTable.row(oldestBucketKey);
-            for (Iterator<Map.Entry<String, Entry<Long, List<KafkaLogEvent>>>> it = row.entrySet().iterator();
-                 it.hasNext(); ) {
-              Map.Entry<String, Entry<Long, List<KafkaLogEvent>>> mapEntry = it.next();
-              if (limitKey < (mapEntry.getValue().getKey() + maxNumberOfBucketsInTable)) {
-                break;
+              Map<String, Entry<Long, List<KafkaLogEvent>>> row = messageTable.row(oldestBucketKey);
+              for (Iterator<Map.Entry<String, Entry<Long, List<KafkaLogEvent>>>> it = row.entrySet().iterator();
+                   it.hasNext(); ) {
+                Map.Entry<String, Entry<Long, List<KafkaLogEvent>>> mapEntry = it.next();
+                // Stop if event arrival time is more than the limit (this is for events being generated now)
+                // However, if we have reached maxNumberOfBucketsInTable then it means we are reading old
+                // events and we can write as soon as we fill up maxNumberOfBucketsInTable
+                if (numBuckets < maxNumberOfBucketsInTable &&
+                  limitKey < mapEntry.getValue().getKey()) {
+                  break;
+                }
+                writeListMap.putAll(mapEntry.getKey(), mapEntry.getValue().getValue());
+                messages += mapEntry.getValue().getValue().size();
+                it.remove();
               }
-              writeListMap.putAll(mapEntry.getKey(), mapEntry.getValue().getValue());
-              messages += mapEntry.getValue().getValue().size();
-              it.remove();
             }
           }
+
+          LOG.trace("Got {} log messages to save", messages);
         }
 
-        LOG.trace("Got {} log messages to save", messages);
-      }
+        long sleepTimeNanos = writeListMap.isEmpty() ? SLEEP_TIME_NS : 1;
 
-      for (Iterator<Map.Entry<String, Collection<KafkaLogEvent>>> it = writeListMap.asMap().entrySet().iterator();
-           it.hasNext(); ) {
-        Map.Entry<String, Collection<KafkaLogEvent>> mapEntry = it.next();
-        List<KafkaLogEvent> list = (List<KafkaLogEvent>) mapEntry.getValue();
-        Collections.sort(list);
-        logFileWriter.append(list);
-        // Remove successfully written message
-        it.remove();
+        // Wait for more data to arrive if writeListMap is empty, otherwise check if stopped
+        if (stopLatch.await(sleepTimeNanos, TimeUnit.NANOSECONDS)) {
+          // if count down occurred return
+          LOG.debug("Returning since stop latch is cancelled");
+          return;
+        } else {
+          LOG.trace("Waiting for events, sleeping for {} ns", sleepTimeNanos);
+        }
+
+        for (Iterator<Entry<String, Collection<KafkaLogEvent>>> it = writeListMap.asMap().entrySet().iterator();
+             it.hasNext(); ) {
+          Entry<String, Collection<KafkaLogEvent>> mapEntry = it.next();
+          List<KafkaLogEvent> list = (List<KafkaLogEvent>) mapEntry.getValue();
+          Collections.sort(list);
+          logFileWriter.append(list);
+          // Remove successfully written message
+          it.remove();
+        }
+      } catch (Throwable e) {
+        LOG.error("Caught exception during save, will try again.", e);
       }
-    } catch (Throwable e) {
-      LOG.error("Caught exception during save, will try again.", e);
     }
   }
 }


### PR DESCRIPTION
When processing events from Kafka, Log Saver waits to collect all events for a given time bucket based on event arrival time. This is to make sure that we don't write live events as soon as we receive them. We don't need this check when processing old events.

JIRA - https://issues.cask.co/browse/CDAP-6545
Build - http://builds.cask.co/browse/CDAP-DUT4460-2
