### PR TITLE
CDAP-6344 Instead of using simple name use the name of the UsageDataset while adding it to registry.

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageDatasetModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageDatasetModule.java
@@ -40,7 +40,7 @@ public class UsageDatasetModule implements DatasetModule {
   @Override
   public void register(DatasetDefinitionRegistry registry) {
     DatasetDefinition<Table, DatasetAdmin> tableDef = registry.get("table");
-    registry.add(new UsageDatasetDefinition(UsageDataset.class.getSimpleName(), tableDef));
+    registry.add(new UsageDatasetDefinition(UsageDataset.class.getName(), tableDef));
   }
 
   /**

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetServiceManager.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetServiceManager.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.data.tools;
 
+import co.cask.cdap.app.guice.AuthorizationModule;
+import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.ServiceUnavailableException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.guice.ConfigModule;
@@ -35,8 +37,10 @@ import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutorS
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.security.ImpersonationInfo;
 import co.cask.cdap.data2.security.UGIProvider;
-import co.cask.cdap.data2.security.UnsupportedUGIProvider;
 import co.cask.cdap.explore.guice.ExploreClientModule;
+import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsService;
+import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsServiceModule;
+import co.cask.cdap.internal.app.store.DefaultStore;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.store.guice.NamespaceStoreModule;
@@ -66,6 +70,7 @@ public class DatasetServiceManager extends AbstractIdleService {
   private final ZKClientService zkClientService;
   private final DatasetFramework datasetFramework;
   private final DatasetOpExecutorService datasetOpExecutorService;
+  private final RemoteSystemOperationsService remoteSystemOperationsService;
 
   @Inject
   DatasetServiceManager(CConfiguration cConf, Configuration hConf) {
@@ -74,6 +79,7 @@ public class DatasetServiceManager extends AbstractIdleService {
     this.zkClientService = injector.getInstance(ZKClientService.class);
     this.datasetFramework = injector.getInstance(DatasetFramework.class);
     this.datasetOpExecutorService = injector.getInstance(DatasetOpExecutorService.class);
+    this.remoteSystemOperationsService = injector.getInstance(RemoteSystemOperationsService.class);
   }
 
   public DatasetFramework getDSFramework() {
@@ -86,6 +92,7 @@ public class DatasetServiceManager extends AbstractIdleService {
       zkClientService.startAndWait();
     }
     datasetOpExecutorService.startAndWait();
+    remoteSystemOperationsService.startAndWait();
     datasetService.startAndWait();
 
     // wait 5 minutes for DatasetService to start up
@@ -106,6 +113,7 @@ public class DatasetServiceManager extends AbstractIdleService {
   protected void shutDown() throws Exception {
     try {
       datasetService.stopAndWait();
+      remoteSystemOperationsService.stopAndWait();
       datasetOpExecutorService.startAndWait();
       zkClientService.stopAndWait();
     } catch (Throwable e) {
@@ -128,9 +136,12 @@ public class DatasetServiceManager extends AbstractIdleService {
       new MetricsClientRuntimeModule().getDistributedModules(),
       new ExploreClientModule(),
       new NamespaceStoreModule().getDistributedModules(),
+      new RemoteSystemOperationsServiceModule(),
+      new AuthorizationModule(),
       new AbstractModule() {
         @Override
         protected void configure() {
+          bind(Store.class).to(DefaultStore.class);
           UGIProvider currentUGIProvider = new UGIProvider() {
             @Override
             public UserGroupInformation getConfiguredUGI(ImpersonationInfo impersonationInfo) throws IOException {


### PR DESCRIPTION
While registering the `UsageDataset` we were using the simple name, however while addingInstance we were using name which was causing following exception

``` java
Failed to perform action 'UPGRADE'. Reason: 'Dataset type 'co.cask.cdap.data2.registry.UsageDataset' is neither registered in the 'system' namespace nor in the system namespace'.
2016-07-04 19:44:15,229 - ERROR [main:c.c.c.d.t.UpgradeTool@413] - Failed to upgrade ...
co.cask.cdap.api.dataset.DatasetManagementException: Dataset type 'co.cask.cdap.data2.registry.UsageDataset' is neither registered in the 'system' namespace nor in the system namespace
        at co.cask.cdap.data2.dataset2.InMemoryDatasetFramework.addInstance(InMemoryDatasetFramework.java:235) ~[co.cask.cdap.cdap-data-fabric-3.5.0-SNAPSHOT.jar:na]
        at co.cask.cdap.data2.registry.DefaultUsageRegistry.setupDatasets(DefaultUsageRegistry.java:287) ~[co.cask.cdap.cdap-data-fabric-3.5.0-SNAPSHOT.jar:na]
        at co.cask.cdap.data.tools.UpgradeTool.initializeDSFramework(UpgradeTool.java:444) ~[co.cask.cdap.cdap-master-3.5.0-SNAPSHOT.jar:na]
        at co.cask.cdap.data.tools.UpgradeTool.startUp(UpgradeTool.java:249) ~[co.cask.cdap.cdap-master-3.5.0-SNAPSHOT.jar:na]
        at co.cask.cdap.data.tools.UpgradeTool.doMain(UpgradeTool.java:296) ~[co.cask.cdap.cdap-master-3.5.0-SNAPSHOT.jar:na]
        at co.cask.cdap.data.tools.UpgradeTool.main(UpgradeTool.java:410) ~[co.cask.cdap.cdap-master-3.5.0-SNAPSHOT.jar:na]
```
