### PR TITLE
CDAP-6192 Adding scheduler.queue settings to cdap-defaults.xml

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -303,6 +303,12 @@
   </property>
 
   <property>
+    <name>apps.scheduler.queue</name>
+    <value></value>
+    <description>Scheduler queue for CDAP programs and CDAP Explore queries</description>
+  </property>
+
+  <property>
     <name>scheduler.max.thread.pool.size</name>
     <value>100</value>
     <description>
@@ -1049,7 +1055,7 @@
     <name>master.service.max.instances</name>
     <value>5</value>
     <description>
-      Maximum number of Master Service instances
+      Maximum number of master service instances
     </description>
   </property>
 
@@ -1057,7 +1063,7 @@
     <name>master.service.memory.mb</name>
     <value>512</value>
     <description>
-      Size of memory in megabytes for Master Service instance
+      Size of memory in megabytes for master service instance
     </description>
   </property>
 
@@ -1065,7 +1071,7 @@
     <name>master.service.num.cores</name>
     <value>2</value>
     <description>
-      Number of cores for Master Service instance
+      Number of cores for master service instance
     </description>
   </property>
 
@@ -1083,6 +1089,13 @@
       themselves.
     </description>
   </property>
+
+  <property>
+    <name>master.services.scheduler.queue</name>
+    <value></value>
+    <description>Scheduler queue for CDAP Master Services</description>
+  </property>
+
 
   <!-- Metadata Configuration -->
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="c3223f49bd5cbc2201509da9565dd50d"
+DEFAULT_XML_MD5_HASH="f7a825d42551f16dba208602c52017a4"
 
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"

--- a/cdap-docs/admin-manual/source/operations/resource-guarantees.rst
+++ b/cdap-docs/admin-manual/source/operations/resource-guarantees.rst
@@ -11,10 +11,10 @@ Resource Guarantees for CDAP Programs in YARN
 =============================================
 
 CDAP :term:`Master Services <master services>` |---| Transaction, Twill, CDAP programs (flows, MapReduce, 
-services, workers) and Explore Queries |---| run in YARN on default YARN queues. 
+services, workers) and CDAP Explore queries |---| run in YARN on default YARN queues. 
 
 YARN provides capabilites for resource guarantees via Capacity Schedulers and Fair
-Schedulers. CDAP provides capabilities to submit CDAP programs and Explore Queries to
+Schedulers. CDAP provides capabilities to submit CDAP programs and CDAP Explore queries to
 non-default YARN queues.
 
 Configurations for submitting to non-default YARN queues can be specified in two levels.
@@ -22,19 +22,19 @@ Configurations for submitting to non-default YARN queues can be specified in two
 1. Using the CDAP site configuration ``cdap-site.xml``:
 
    The configuration parameter of the queue name for Master Services, CDAP programs and
-   Explore Queries can be specified at the CDAP instance level. This is then applied for
-   all programs and Hive queries::
+   CDAP Explore queries can be specified at the CDAP instance level. This is then applied
+   for all programs and Hive queries. For example::
 
     <property>
       <name>master.services.scheduler.queue</name>
       <value>sys</value>
-      <description>Scheduler queue for CDAP master services</description>
+      <description>Scheduler queue for CDAP Master Services</description>
     </property>
 
     <property>
       <name>apps.scheduler.queue</name>
       <value>app</value>
-      <description>Scheduler queue for CDAP programs and Explore Queries</description>
+      <description>Scheduler queue for CDAP programs and CDAP Explore queries</description>
     </property>
 
 2. Using a namespace-level property: 
@@ -61,6 +61,6 @@ Configurations for submitting to non-default YARN queues can be specified in two
    Master Services are not tied to a namespace level.
 
    **Note:** If the configuration is not specified at either the namespace or
-   ``cdap-site`` levels, then all the Master Services, CDAP programs and Explore queries
-   will be submitted to default YARN queues.
+   ``cdap-site`` levels, then all the Master Services, CDAP programs and CDAP Explore
+   queries will be submitted to default YARN queues.
 


### PR DESCRIPTION
Add resource guarantees to the cdap-default.xml file.
Fix some capitalization inconsistencies.

Fix for https://issues.cask.co/browse/CDAP-6192

Running a [Quick Build](http://builds.cask.co/browse/CDAP-DQB50-1)
