### PR TITLE
CDAP CLI command help: Remove "beta" from Security command help

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/CommandCategory.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/CommandCategory.java
@@ -30,7 +30,7 @@ public enum CommandCategory {
   METRICS("Metrics"),
   INGEST("Ingest"),
   EGRESS("Egress"),
-  SECURITY("Security (Beta)");
+  SECURITY("Security");
 
   final String name;
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/CommandCategory.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/CommandCategory.java
@@ -21,15 +21,15 @@ package co.cask.cdap.cli;
  */
 public enum CommandCategory {
   GENERAL("General"),
-  NAMESPACE("Namespace"),
-  ARTIFACT("Artifact"),
-  METADATA_AND_LINEAGE("Metadata and Lineage"),
   APPLICATION_LIFECYCLE("Application Lifecycle"),
+  ARTIFACT("Artifact"),
   DATASET("Dataset"),
-  EXPLORE("Explore"),
-  METRICS("Metrics"),
-  INGEST("Ingest"),
   EGRESS("Egress"),
+  EXPLORE("Explore"),
+  INGEST("Ingest"),
+  METADATA_AND_LINEAGE("Metadata and Lineage"),
+  METRICS("Metrics"),
+  NAMESPACE("Namespace"),
   SECURITY("Security");
 
   final String name;

--- a/cdap-docs/tools/docs-cli-commands.py
+++ b/cdap-docs/tools/docs-cli-commands.py
@@ -24,7 +24,7 @@ SECTION_LINE = SPACES + '**'
 COMMAND_LINE = SPACES + LITERAL
 LITERAL_LINE = SPACES + ' | '
 
-SKIP_SECTIONS = ['Security (Beta)']
+SKIP_SECTIONS = []
 
 MISSING_FILE_TEMPLATE = "   **Missing Input File**,\"Missing input file %s\""
 TABLE_HEADER = """.. csv-table::


### PR DESCRIPTION
Remove "beta" tag from security commands, and remove from list of ignore sections.

This will then include the security commands in the command shown in the documentation. (The commands were always visible when the "--help" option was used in the CDAP CLI.)

Running [Quick Build](http://builds.cask.co/browse/CDAP-DQB51-1)
