### PR TITLE
CDAP-6347 Document setting environment variables for CDAP

### DIFF
--- a/cdap-docs/admin-manual/source/_includes/installation/starting.txt
+++ b/cdap-docs/admin-manual/source/_includes/installation/starting.txt
@@ -16,3 +16,19 @@ accessible through a browser at port ``9999``.
 
 The URL will be ``http://<host>:9999`` where ``<host>`` is the IP address of
 one of the machines where you installed the packages and started the services.
+
+.. _|distribution|-starting-services-java-heapmax:
+
+**Note:** Service-specific Java heap memory settings (that override the default values)
+can be created by setting these environment variables::
+
+  AUTH_JAVA_HEAPMAX
+  KAFKA_JAVA_HEAPMAX
+  MASTER_JAVA_HEAPMAX
+  ROUTER_JAVA_HEAPMAX
+
+.. end_of_list
+
+such as::
+
+  $ export AUTH_JAVA_HEAPMAX="-Xmx1024m"

--- a/cdap-docs/admin-manual/source/installation/ambari.rst
+++ b/cdap-docs/admin-manual/source/installation/ambari.rst
@@ -233,16 +233,23 @@ Customize CDAP
  
       **Ambari Dashboard:** Enabling *CDAP Explore*
 
-   **Additional environment variables** can be set, as required, using Ambari's 
-   "Configs > Advanced > Advanced cdap-env".
-
    **Additional CDAP configuration properties**, not shown in the web interface, can be
    added using Ambari's advanced custom properties at the end of the page. Documentation
    of the available CDAP properties is in the :ref:`appendix-cdap-site.xml`.
 
    For a **complete explanation of these options,** refer to the :ref:`CDAP documentation
-   of cdap-site.xml <appendix-cdap-site.xml>`. When finished with configuration changes,
-   click *Next*.
+   of cdap-site.xml <appendix-cdap-site.xml>`. 
+   
+   **Additional environment variables** can be set, as required, using Ambari's 
+   "Configs > Advanced > Advanced cdap-env".
+
+   .. Environment variables
+   .. ---------------------
+   .. include:: /../target/_includes/ambari-starting.rst
+       :start-after: .. _ambari-starting-services-java-heapmax:
+       :end-before: .. end_of_list
+
+   When finished with configuration changes, click *Next*.
 
 
 Starting CDAP Services

--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -355,13 +355,18 @@ Port* is used by the CDAP UI to connect to the CDAP Router service.
 
    **Add Service Wizard, Page 4:** Reviewing changes and (initial) configuration.
 
-
 **Additional CDAP configuration properties** can be added after using the Cloudera Manager's 
 *Safety Valve* Advanced Configuration Snippets. Documentation of the available CDAP
 properties is in the :ref:`appendix-cdap-site.xml`.
 
 **Additional environment variables** can be set after, as required, using the Cloudera Manager's
 "Cask DAP Service Environment Advanced Configuration Snippet (Safety Valve)".
+
+.. Environment variables
+.. ---------------------
+.. include:: /../target/_includes/cloudera-starting.rst
+    :start-after: .. _cloudera-starting-services-java-heapmax:
+    :end-before: .. end_of_list
 
 At this point, the CDAP installation is configured and is ready to be installed. Review
 your settings before continuing to the next step, which will install and start CDAP.
@@ -415,7 +420,9 @@ needs to contain the location of the Spark libraries, typically as
 ``SPARK_HOME=/opt/cloudera/parcels/CDH/lib/spark``.
 
 **Additional environment variables** are set using the Cloudera Manager's
-"Cask DAP Service Environment Advanced Configuration Snippet (Safety Valve)". 
+"Cask DAP Service Environment Advanced Configuration Snippet (Safety Valve)".
+
+
 
 .. figure:: ../_images/cloudera/cloudera-csd-10.png
    :figwidth: 100%


### PR DESCRIPTION
Add service-specific environment variable settings to all installation instructions.

Passes a [Quick Build](http://builds.cask.co/browse/CDAP-DQB52-1)

Pages of interest:
- [Cloudera](http://builds.cask.co/artifact/CDAP-DQB52/shared/build-1/Docs-HTML/3.5.0-SNAPSHOT/en/admin-manual/installation/cloudera.html#add-service-wizard-reviewing-configuration)
- [Ambari](http://builds.cask.co/artifact/CDAP-DQB52/shared/build-1/Docs-HTML/3.5.0-SNAPSHOT/en/admin-manual/installation/ambari.html#customize-cdap)
- [MapR](http://builds.cask.co/artifact/CDAP-DQB52/shared/build-1/Docs-HTML/3.5.0-SNAPSHOT/en/admin-manual/installation/mapr.html#starting-cdap-services)
- [Packages](http://builds.cask.co/artifact/CDAP-DQB52/shared/build-1/Docs-HTML/3.5.0-SNAPSHOT/en/admin-manual/installation/packages.html#starting-cdap-services)

Fix for https://issues.cask.co/browse/CDAP-6347
