### PR TITLE
CDAP-5199 Update documentation for "Apache Tephra"

### DIFF
--- a/cdap-docs/_common/_themes/cdap/casksites.html
+++ b/cdap-docs/_common/_themes/cdap/casksites.html
@@ -1,7 +1,7 @@
 {#
     casksites.html
     ~~~~~~~~~~~~~~~~~~~~~
-    Sphinx sidebar template: "CDAP Data Sites" links.
+    Sphinx sidebar template: "CDAP Cask Data Sites" links.
     
 #}
 <div role="note" aria-label="other links">
@@ -9,7 +9,6 @@
     <ul class="this-page-menu">
         <li><a href="http://docs.cask.co/cdap/index.html" target="_blank">CDAP</a></li>
         <li><a href="http://docs.cask.co/coopr/index.html" target="_blank">Coopr</a></li>
-        <li><a href="http://docs.cask.co/tephra/index.html" target="_blank">Tephra</em></a></li>
         <li><a href="http://docs.cask.co/tigon/index.html" target="_blank">Tigon</a></li>
     </ul>
 </div>

--- a/cdap-docs/developers-manual/source/building-blocks/transaction-system.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/transaction-system.rst
@@ -34,8 +34,8 @@ object can be reattempted. This ensures "exactly-once" processing of each object
 OCC: Optimistic Concurrency Control
 -----------------------------------
 
-The Cask Data Application Platform uses `Cask's Tephra™ <http://tephra.io>`__, which uses
-*Optimistic Concurrency Control* (OCC) to implement transactions. Unlike most relational
+The Cask Data Application Platform uses `Apache Tephra™ <http://tephra.incubator.apache.org>`__, 
+which uses *Optimistic Concurrency Control* (OCC) to implement transactions. Unlike most relational
 databases that use locks to prevent conflicting operations between transactions, under OCC
 we allow these conflicting writes to happen. When the transaction is committed, we can
 detect whether it has any conflicts: namely, if during the lifetime of the transaction,

--- a/cdap-docs/developers-manual/source/overview/abstractions.rst
+++ b/cdap-docs/developers-manual/source/overview/abstractions.rst
@@ -30,8 +30,8 @@ In CDAP applications, you interact with data through *datasets*. Datasets provid
 - Abstraction of the actual representation of data in storage. You can write your code or queries without
   having to know where and how your data is stored—be it in HBase, LevelDB or a relational database.
 - Encapsulation of data access patterns and business logic as reusable, managed Java code.
-- Consistency of your data under highly concurrent access using Cask's 
-  `Tephra™ transaction system <https://github.com/caskdata/tephra/>`__.
+- Consistency of your data under highly concurrent access using the 
+  `Apache Tephra™ transaction system <http://tephra.incubator.apache.org>`__.
 - Injection of datasets into different programming paradigms and runtimes. As soon as your data is in a
   dataset, you can immediately use it: in real-time programs; in batch processing applications such as MapReduce
   and Spark; in ad-hoc SQL queries.

--- a/cdap-docs/reference-manual/source/licenses/index.rst
+++ b/cdap-docs/reference-manual/source/licenses/index.rst
@@ -28,8 +28,6 @@ Cask Data, Inc.:
      - Common descriptive name for the goods or services
    * - Cask
      - Computer software and related services
-   * - Tephra
-     - Computer software and related services
    * - Tigon
      - Computer software and related services
 
@@ -52,6 +50,7 @@ the addition of appropriate symbols has been made.
 
 Apache®, `Apache Hadoop <https://hadoop.apache.org>`__, `Hadoop®
 <https://hadoop.apache.org>`__, Avro, `Apache Avro <http://avro.apache.org/>`__,
+`Apache Tephra <http://tephra.incubator.apache.org>`__,
 and `Apache ZooKeeper <https://zookeeper.apache.org/>`__, 
 are either registered trademarks or trademarks of the
 `Apache Software Foundation <https://www.apache.org>`__ in the United States and/or other


### PR DESCRIPTION
Removes "Tephra" from the list of sites in lower-left panel of all documentation pages.
Removes Tephra and replace with "Apache Tephra™" as appropriate.

Passes [Quick Build](http://builds.cask.co/browse/CDAP-DQB53-1)

[Main Page](http://builds.cask.co/artifact/CDAP-DQB53/shared/build-1/Docs-HTML/3.5.0-SNAPSHOT/en/index.html)
