### PR TITLE
CDAP-6599 Added binding for the NamespaceQueryAdmin in ContextManager used for hive queries.

### DIFF
--- a/cdap-explore/pom.xml
+++ b/cdap-explore/pom.xml
@@ -135,6 +135,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-client</artifactId>
+      <version>${hbase98.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-minicluster</artifactId>
     </dependency>

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/context/ContextManager.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/context/ContextManager.java
@@ -29,6 +29,7 @@ import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.lang.FilterClassLoader;
 import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data.runtime.DataFabricModules;
@@ -44,6 +45,7 @@ import co.cask.cdap.hive.datasets.DatasetSerDe;
 import co.cask.cdap.hive.stream.StreamSerDe;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.proto.Id;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -113,18 +115,13 @@ public class ContextManager {
     return savedContext;
   }
 
-  // this method is called by the mappers/reducers of jobs launched by Hive.
-  private static Context createContext(Configuration conf) throws IOException {
-    // Create context needs to happen only when running in as a MapReduce job.
-    // In other cases, ContextManager will be initialized using saveContext method.
-
-    CConfiguration cConf = ConfigurationUtil.get(conf, Constants.Explore.CCONF_KEY, CConfCodec.INSTANCE);
-    Configuration hConf = ConfigurationUtil.get(conf, Constants.Explore.HCONF_KEY, HConfCodec.INSTANCE);
-
-    Injector injector = Guice.createInjector(
+  @VisibleForTesting
+  static Injector createInjector(CConfiguration cConf, Configuration hConf) {
+    return Guice.createInjector(
       new ConfigModule(cConf, hConf),
       new ZKClientModule(),
       new LocationRuntimeModule().getDistributedModules(),
+      new NamespaceClientRuntimeModule().getDistributedModules(),
       new DiscoveryRuntimeModule().getDistributedModules(),
       new DataFabricModules().getDistributedModules(),
       new DataSetsModules().getDistributedModules(),
@@ -141,6 +138,17 @@ public class ContextManager {
         }
       }
     );
+  }
+
+  // this method is called by the mappers/reducers of jobs launched by Hive.
+  private static Context createContext(Configuration conf) throws IOException {
+    // Create context needs to happen only when running in as a MapReduce job.
+    // In other cases, ContextManager will be initialized using saveContext method.
+
+    CConfiguration cConf = ConfigurationUtil.get(conf, Constants.Explore.CCONF_KEY, CConfCodec.INSTANCE);
+    Configuration hConf = ConfigurationUtil.get(conf, Constants.Explore.HCONF_KEY, HConfCodec.INSTANCE);
+
+    Injector injector = createInjector(cConf, hConf);
 
     ZKClientService zkClientService = injector.getInstance(ZKClientService.class);
     zkClientService.startAndWait();

--- a/cdap-explore/src/test/java/co/cask/cdap/hive/context/ContextManagerTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/hive/context/ContextManagerTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.hive.context;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+
+/**
+ * Tests for {@link ContextManager}.
+ */
+public class ContextManagerTest {
+
+  @Test
+  public void testInjector() throws Exception {
+    ContextManager.createInjector(CConfiguration.create(), new Configuration());
+  }
+}


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-6599
