### PR TITLE
CDAP-6344 Instead of using simple name use the name of the UsageDataset while adding it to registry.

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtil.java
@@ -127,7 +127,7 @@ public final class DatasetsUtil {
         props.remove(Table.PROPERTY_SCHEMA_ROW_FIELD);
 
         // LineageDataset and UsageDataset add the conflict level of none
-      } else if (UsageDataset.class.getSimpleName().equals(type) ||
+      } else if (UsageDataset.class.getName().equals(type) ||
         LineageDataset.class.getName().equals(type) || "lineageDataset".equals(type)) {
         props.remove(Table.PROPERTY_CONFLICT_LEVEL);
       }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/DefaultUsageRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/DefaultUsageRegistry.java
@@ -90,7 +90,7 @@ public class DefaultUsageRegistry implements UsageRegistry {
   private UsageDataset getOrCreateUsageDataset() {
     try {
       return DatasetsUtil.getOrCreateDataset(
-        datasetFramework, USAGE_INSTANCE_ID, UsageDataset.class.getSimpleName(),
+        datasetFramework, USAGE_INSTANCE_ID, UsageDataset.class.getName(),
         DatasetProperties.EMPTY, DatasetDefinition.NO_ARGUMENTS, null);
     } catch (Exception e) {
       throw Throwables.propagate(e);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageDatasetModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageDatasetModule.java
@@ -40,7 +40,7 @@ public class UsageDatasetModule implements DatasetModule {
   @Override
   public void register(DatasetDefinitionRegistry registry) {
     DatasetDefinition<Table, DatasetAdmin> tableDef = registry.get("table");
-    registry.add(new UsageDatasetDefinition(UsageDataset.class.getSimpleName(), tableDef));
+    registry.add(new UsageDatasetDefinition(UsageDataset.class.getName(), tableDef));
   }
 
   /**

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtilTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtilTest.java
@@ -68,8 +68,7 @@ public class DatasetsUtilTest extends DatasetServiceTestBase {
             DatasetProperties.EMPTY);
     testFix(LineageDataset.class.getName(),
             DatasetProperties.builder().add(Table.PROPERTY_TTL, 1000).build());
-    testFix(UsageDataset.class.getSimpleName(),
-            DatasetProperties.EMPTY);
+    testFix(UsageDataset.class.getName(), DatasetProperties.EMPTY);
 
     testFix("table",
             DatasetProperties.builder().add(Table.PROPERTY_COLUMN_FAMILY, "fam").build());

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/registry/UsageDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/registry/UsageDatasetTest.java
@@ -194,6 +194,6 @@ public class UsageDatasetTest {
   protected static UsageDataset getUsageDataset(String instanceId) throws Exception {
     Id.DatasetInstance id = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, instanceId);
     return DatasetsUtil.getOrCreateDataset(dsFrameworkUtil.getFramework(), id,
-                                           UsageDataset.class.getSimpleName(), DatasetProperties.EMPTY, null, null);
+                                           UsageDataset.class.getName(), DatasetProperties.EMPTY, null, null);
   }
 }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetServiceManager.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetServiceManager.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.data.tools;
 
+import co.cask.cdap.app.guice.AuthorizationModule;
+import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.ServiceUnavailableException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.guice.ConfigModule;
@@ -35,8 +37,10 @@ import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutorS
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.security.ImpersonationInfo;
 import co.cask.cdap.data2.security.UGIProvider;
-import co.cask.cdap.data2.security.UnsupportedUGIProvider;
 import co.cask.cdap.explore.guice.ExploreClientModule;
+import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsService;
+import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsServiceModule;
+import co.cask.cdap.internal.app.store.DefaultStore;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.store.guice.NamespaceStoreModule;
@@ -66,6 +70,7 @@ public class DatasetServiceManager extends AbstractIdleService {
   private final ZKClientService zkClientService;
   private final DatasetFramework datasetFramework;
   private final DatasetOpExecutorService datasetOpExecutorService;
+  private final RemoteSystemOperationsService remoteSystemOperationsService;
 
   @Inject
   DatasetServiceManager(CConfiguration cConf, Configuration hConf) {
@@ -74,6 +79,7 @@ public class DatasetServiceManager extends AbstractIdleService {
     this.zkClientService = injector.getInstance(ZKClientService.class);
     this.datasetFramework = injector.getInstance(DatasetFramework.class);
     this.datasetOpExecutorService = injector.getInstance(DatasetOpExecutorService.class);
+    this.remoteSystemOperationsService = injector.getInstance(RemoteSystemOperationsService.class);
   }
 
   public DatasetFramework getDSFramework() {
@@ -86,6 +92,7 @@ public class DatasetServiceManager extends AbstractIdleService {
       zkClientService.startAndWait();
     }
     datasetOpExecutorService.startAndWait();
+    remoteSystemOperationsService.startAndWait();
     datasetService.startAndWait();
 
     // wait 5 minutes for DatasetService to start up
@@ -106,6 +113,7 @@ public class DatasetServiceManager extends AbstractIdleService {
   protected void shutDown() throws Exception {
     try {
       datasetService.stopAndWait();
+      remoteSystemOperationsService.stopAndWait();
       datasetOpExecutorService.startAndWait();
       zkClientService.stopAndWait();
     } catch (Throwable e) {
@@ -128,9 +136,12 @@ public class DatasetServiceManager extends AbstractIdleService {
       new MetricsClientRuntimeModule().getDistributedModules(),
       new ExploreClientModule(),
       new NamespaceStoreModule().getDistributedModules(),
+      new RemoteSystemOperationsServiceModule(),
+      new AuthorizationModule(),
       new AbstractModule() {
         @Override
         protected void configure() {
+          bind(Store.class).to(DefaultStore.class);
           UGIProvider currentUGIProvider = new UGIProvider() {
             @Override
             public UserGroupInformation getConfiguredUGI(ImpersonationInfo impersonationInfo) throws IOException {


### PR DESCRIPTION
Created from https://github.com/caskdata/cdap/pull/6123. Also updated occurrences of `UsageDataset.class.getSimpleName()` by `UsageDataset.class.getName()` from `DatasetsUtil` and `DefaultUsageRegistry` classes.

Build is green here - http://builds.cask.co/browse/CDAP-DUT4463-1
