### PR TITLE
Make LogSaver use NamespacedLocationFactory

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStoreTest.java
@@ -21,7 +21,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
@@ -95,7 +95,7 @@ public class DatasetBasedTimeScheduleStoreTest {
     CConfiguration conf = CConfiguration.create();
     conf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder("data").getAbsolutePath());
     injector = Guice.createInjector(new ConfigModule(conf),
-                                    new LocationUnitTestModule().getModule(),
+                                    new NonCustomLocationUnitTestModule().getModule(),
                                     new DiscoveryRuntimeModule().getInMemoryModules(),
                                     new MetricsClientRuntimeModule().getInMemoryModules(),
                                     new DataFabricModules().getInMemoryModules(),

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
@@ -27,7 +27,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.IOModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.config.guice.ConfigStoreModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
@@ -101,7 +101,7 @@ public final class AppFabricTestModule extends AbstractModule {
       }
     });
     install(new ProgramRunnerRuntimeModule().getInMemoryModules());
-    install(new LocationUnitTestModule().getModule());
+    install(new NonCustomLocationUnitTestModule().getModule());
     install(new LoggingModules().getInMemoryModules());
     install(new LogReaderRuntimeModules().getInMemoryModules());
     install(new MetricsHandlerModule());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/SystemMetadataKafkaPublishTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/SystemMetadataKafkaPublishTest.java
@@ -19,7 +19,7 @@ package co.cask.cdap.metadata;
 import co.cask.cdap.AllProgramsApp;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
@@ -64,7 +64,7 @@ public class SystemMetadataKafkaPublishTest {
           bind(MetadataStore.class).to(DefaultMetadataStore.class);
         }
       }),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new TransactionInMemoryModule(),
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new NamespaceClientRuntimeModule().getInMemoryModules()

--- a/cdap-common/src/test/java/co/cask/cdap/common/guice/NonCustomLocationUnitTestModule.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/guice/NonCustomLocationUnitTestModule.java
@@ -30,7 +30,7 @@ import com.google.inject.util.Modules;
  * {@link DefaultNamespacedLocationFactory} and hence in unit tests the namespace does not need to be created to get
  * namespaces locations.
  */
-public class LocationUnitTestModule {
+public class NonCustomLocationUnitTestModule {
   public Module getModule() {
 
     return Modules.override(new LocationRuntimeModule().getInMemoryModules()).with(

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/InMemoryStreamCoordinatorClientTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/InMemoryStreamCoordinatorClientTest.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data.stream;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
@@ -58,7 +58,7 @@ public class InMemoryStreamCoordinatorClientTest extends StreamCoordinatorTestBa
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new DataSetsModules().getInMemoryModules(),
       new DataFabricModules().getInMemoryModules(),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new NamespaceClientRuntimeModule().getInMemoryModules(),
       new TransactionMetricsModule(),
       new NotificationFeedServiceRuntimeModule().getInMemoryModules(),

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalStreamFileJanitorTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalStreamFileJanitorTest.java
@@ -21,7 +21,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
@@ -72,7 +72,7 @@ public class LocalStreamFileJanitorTest extends StreamFileJanitorTestBase {
 
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new DataSetsModules().getInMemoryModules(),
       new TransactionMetricsModule(),

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/DFSStreamHeartbeatsTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/DFSStreamHeartbeatsTest.java
@@ -21,7 +21,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
@@ -126,7 +126,7 @@ public class DFSStreamHeartbeatsTest {
         new DataFabricModules().getInMemoryModules(),
         new ConfigModule(cConf, new Configuration()),
         new DiscoveryRuntimeModule().getInMemoryModules(),
-        new LocationUnitTestModule().getModule(),
+        new NonCustomLocationUnitTestModule().getModule(),
         new ExploreClientModule(),
         new DataSetServiceModules().getInMemoryModules(),
         new DataSetsModules().getStandaloneModules(),

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
@@ -19,7 +19,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.utils.Networks;
@@ -104,7 +104,7 @@ public class TransactionServiceClientTest extends TransactionSystemTest {
     injector = Guice.createInjector(
       new ConfigModule(cConf, hConf),
       new ZKClientModule(),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getDistributedModules(),
       new TransactionMetricsModule(),
       new DataFabricModules().getDistributedModules(),

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceTest.java
@@ -21,7 +21,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.utils.Networks;
@@ -91,7 +91,7 @@ public class TransactionServiceTest {
       Injector injector = Guice.createInjector(
         new ConfigModule(cConf),
         new ZKClientModule(),
-        new LocationUnitTestModule().getModule(),
+        new NonCustomLocationUnitTestModule().getModule(),
         new DiscoveryRuntimeModule().getDistributedModules(),
         new TransactionMetricsModule(),
         new AbstractModule() {
@@ -208,7 +208,7 @@ public class TransactionServiceTest {
 
     final Injector injector =
       Guice.createInjector(new ConfigModule(cConf, hConf),
-                           new LocationUnitTestModule().getModule(),
+                           new NonCustomLocationUnitTestModule().getModule(),
                            new ZKClientModule(),
                            new DiscoveryRuntimeModule().getDistributedModules(),
                            new TransactionMetricsModule(),

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseConsumerStateTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseConsumerStateTest.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data2.transaction.stream.hbase;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
@@ -90,7 +90,7 @@ public class HBaseConsumerStateTest extends StreamConsumerStateTestBase {
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf, hConf),
       new ZKClientModule(),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getInMemoryModules(),
       new TransactionMetricsModule(),
       new DataFabricDistributedModule(),

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseFileStreamAdminTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseFileStreamAdminTest.java
@@ -19,7 +19,7 @@ package co.cask.cdap.data2.transaction.stream.hbase;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
@@ -96,7 +96,7 @@ public class HBaseFileStreamAdminTest extends StreamAdminTest {
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf, hConf),
       new ZKClientModule(),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getInMemoryModules(),
       new TransactionMetricsModule(),
       new DataSetsModules().getInMemoryModules(),

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerTest.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data2.transaction.stream.hbase;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
@@ -104,7 +104,7 @@ public class HBaseStreamConsumerTest extends StreamConsumerTestBase {
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf, hConf),
       new ZKClientModule(),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getInMemoryModules(),
       new TransactionMetricsModule(),
       new DataSetsModules().getInMemoryModules(),

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBFileStreamAdminTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBFileStreamAdminTest.java
@@ -20,7 +20,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
@@ -72,7 +72,7 @@ public class LevelDBFileStreamAdminTest extends StreamAdminTest {
 
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new DataSetsModules().getInMemoryModules(),
       new DataFabricLevelDBModule(),

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerStateTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerStateTest.java
@@ -19,7 +19,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
@@ -71,7 +71,7 @@ public class LevelDBStreamConsumerStateTest extends StreamConsumerStateTestBase 
 
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new DataSetsModules().getInMemoryModules(),
       new DataFabricLevelDBModule(),

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerTest.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data2.transaction.stream.leveldb;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
@@ -73,7 +73,7 @@ public class LevelDBStreamConsumerTest extends StreamConsumerTestBase {
 
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new DataSetsModules().getInMemoryModules(),
       new DataFabricLevelDBModule(),

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/SystemDatasetDefinitionTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/SystemDatasetDefinitionTest.java
@@ -28,7 +28,7 @@ import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.guice.ConfigModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
 import com.google.inject.Guice;
@@ -58,7 +58,7 @@ public class SystemDatasetDefinitionTest {
   public static void createInjector() {
     injector = Guice.createInjector(
       new ConfigModule(CConfiguration.create()),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new SystemDatasetRuntimeModule().getInMemoryModules());
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -25,7 +25,7 @@ import co.cask.cdap.common.discovery.EndpointStrategy;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
@@ -151,8 +151,8 @@ public abstract class DatasetServiceTestBase {
     // TODO: this whole method is a mess. Streamline it!
     injector = Guice.createInjector(
       new ConfigModule(cConf),
-      new LocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getInMemoryModules(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new NamespaceClientRuntimeModule().getInMemoryModules(),
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new TransactionInMemoryModule(),

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorServiceTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorServiceTest.java
@@ -30,7 +30,7 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.IOModule;
 import co.cask.cdap.common.guice.KafkaClientModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
@@ -118,7 +118,7 @@ public class DatasetOpExecutorServiceTest {
       new ZKClientModule(),
       new KafkaClientModule(),
       new DiscoveryRuntimeModule().getInMemoryModules(),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new DataFabricModules().getInMemoryModules(),
       new DataSetsModules().getStandaloneModules(),
       new DataSetServiceModules().getInMemoryModules(),

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/AbstractDatasetFrameworkTest.java
@@ -34,7 +34,7 @@ import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
@@ -130,7 +130,7 @@ public abstract class AbstractDatasetFrameworkTest {
 
     final Injector injector = Guice.createInjector(
       new ConfigModule(cConf),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new TransactionInMemoryModule(),
       new NamespaceClientRuntimeModule().getInMemoryModules(),
       new AuditModule().getInMemoryModules());

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
@@ -26,8 +26,7 @@ import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data.runtime.TransactionExecutorModule;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
@@ -80,7 +79,7 @@ public final class DatasetFrameworkTestUtil extends ExternalResource {
 
     injector = Guice.createInjector(
       new ConfigModule(cConf),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new TransactionModules().getInMemoryModules(),
       new TransactionExecutorModule(),

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryMetricsTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryMetricsTableTest.java
@@ -20,7 +20,7 @@ import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data.runtime.TransactionMetricsModule;
@@ -49,7 +49,7 @@ public class InMemoryMetricsTableTest extends MetricsTableTest {
   public static void setup() throws Exception {
     Injector injector = Guice.createInjector(
       new ConfigModule(),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getInMemoryModules(),
       new DataFabricModules().getInMemoryModules(),
       new TransactionMetricsModule(),

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBMetricsTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBMetricsTableTest.java
@@ -21,7 +21,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
@@ -53,7 +53,7 @@ public class LevelDBMetricsTableTest extends MetricsTableTest {
     conf.set(Constants.CFG_LOCAL_DATA_DIR, tmpFolder.newFolder().getAbsolutePath());
     Injector injector = Guice.createInjector(
       new ConfigModule(conf),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getStandaloneModules(),
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new DataSetsModules().getInMemoryModules(),

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableServiceTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableServiceTest.java
@@ -21,7 +21,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.TransactionMetricsModule;
@@ -55,7 +55,7 @@ public class LevelDBTableServiceTest {
     conf.set(Constants.CFG_LOCAL_DATA_DIR, tmpFolder.newFolder().getAbsolutePath());
     injector = Guice.createInjector(
       new ConfigModule(conf),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getStandaloneModules(),
       new DataSetsModules().getStandaloneModules(),
       new DataFabricLevelDBModule(),

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableTest.java
@@ -25,7 +25,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.TransactionMetricsModule;
@@ -60,7 +60,7 @@ public class LevelDBTableTest extends BufferingTableTest<LevelDBTable> {
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, tmpFolder.newFolder().getAbsolutePath());
     injector = Guice.createInjector(
       new ConfigModule(cConf),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getStandaloneModules(),
       new DataSetsModules().getStandaloneModules(),
       new DataFabricLevelDBModule(),

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/LocalQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/LocalQueueTest.java
@@ -20,7 +20,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.data.runtime.DataFabricLocalModule;
@@ -75,7 +75,7 @@ public class LocalQueueTest extends QueueTest {
     conf.set(Constants.CFG_LOCAL_DATA_DIR, tmpFolder.newFolder().getAbsolutePath());
     Injector injector = Guice.createInjector(
       new ConfigModule(conf),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getStandaloneModules(),
       new TransactionMetricsModule(),
       new DiscoveryRuntimeModule().getStandaloneModules(),
@@ -96,7 +96,7 @@ public class LocalQueueTest extends QueueTest {
   public void testInjection() throws IOException {
     Injector injector = Guice.createInjector(
       new ConfigModule(conf),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getStandaloneModules(),
       new TransactionMetricsModule(),
       new DataFabricModules().getStandaloneModules(),

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryQueueTest.java
@@ -17,7 +17,7 @@ package co.cask.cdap.data2.transaction.queue.inmemory;
 
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
@@ -52,7 +52,7 @@ public class InMemoryQueueTest extends QueueTest {
 
     injector = Guice.createInjector(
       new ConfigModule(),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getInMemoryModules(),
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new DataSetsModules().getInMemoryModules(),

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/leveldb/LevelDBQueueTest.java
@@ -19,7 +19,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.data.runtime.DataFabricLevelDBModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -59,7 +59,7 @@ public class LevelDBQueueTest extends QueueTest {
     conf.set(Constants.Dataset.TABLE_PREFIX, "test");
     Injector injector = Guice.createInjector(
       new ConfigModule(conf),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getStandaloneModules(),
       new DataSetsModules().getStandaloneModules(),
       new DataFabricLevelDBModule(),

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
@@ -22,7 +22,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.IOModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
@@ -389,7 +389,7 @@ public class BaseHiveExploreServiceTest {
       new ConfigModule(configuration, hConf),
       new IOModule(),
       new DiscoveryRuntimeModule().getInMemoryModules(),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new DataSetsModules().getStandaloneModules(),
       new DataSetServiceModules().getInMemoryModules(),
       new MetricsClientRuntimeModule().getInMemoryModules(),
@@ -449,7 +449,7 @@ public class BaseHiveExploreServiceTest {
       new ConfigModule(cConf, hConf),
       new IOModule(),
       new DiscoveryRuntimeModule().getStandaloneModules(),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new DataFabricModules().getStandaloneModules(),
       new DataSetsModules().getStandaloneModules(),
       new DataSetServiceModules().getStandaloneModules(),

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
@@ -24,7 +24,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.IOModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
@@ -215,7 +215,7 @@ public class ExploreDisabledTest {
         new ConfigModule(configuration, hConf),
         new IOModule(),
         new DiscoveryRuntimeModule().getInMemoryModules(),
-        new LocationUnitTestModule().getModule(),
+        new NonCustomLocationUnitTestModule().getModule(),
         new DataFabricModules().getInMemoryModules(),
         new DataSetsModules().getStandaloneModules(),
         new DataSetServiceModules().getInMemoryModules(),

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/InMemoryExploreServiceTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/InMemoryExploreServiceTest.java
@@ -21,7 +21,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.IOModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
@@ -94,7 +94,7 @@ public class InMemoryExploreServiceTest {
         new ConfigModule(configuration, hConf),
         new IOModule(),
         new DiscoveryRuntimeModule().getInMemoryModules(),
-        new LocationUnitTestModule().getModule(),
+        new NonCustomLocationUnitTestModule().getModule(),
         new DataFabricModules().getInMemoryModules(),
         new DataSetsModules().getStandaloneModules(),
         new DataSetServiceModules().getInMemoryModules(),

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsSuiteTestBase.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/metrics/MetricsSuiteTestBase.java
@@ -25,7 +25,7 @@ import co.cask.cdap.common.discovery.EndpointStrategy;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetServiceModules;
@@ -142,7 +142,7 @@ public abstract class MetricsSuiteTestBase {
   public static Injector startMetricsService(CConfiguration conf) {
     Injector injector = Guice.createInjector(Modules.override(
       new ConfigModule(conf),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new DiscoveryRuntimeModule().getInMemoryModules(),
       new MetricsHandlerModule(),
       new MetricsClientRuntimeModule().getInMemoryModules(),

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DataMigration.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DataMigration.java
@@ -19,7 +19,7 @@ import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.guice.ConfigModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.utils.ProjectInfo;
 import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
@@ -88,7 +88,7 @@ public class DataMigration {
       new ConfigModule(cConf, hConf),
       //  having a namespaced location factory which does not look up  namespace meta here is fine since this data
       // migration tool does not perform namespace specific operations
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-notifications/src/test/java/co/cask/cdap/notifications/NotificationTest.java
+++ b/cdap-notifications/src/test/java/co/cask/cdap/notifications/NotificationTest.java
@@ -23,7 +23,7 @@ import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
 import co.cask.cdap.common.utils.Tasks;
@@ -111,7 +111,7 @@ public abstract class NotificationTest {
       new DiscoveryRuntimeModule().getInMemoryModules(),
       new DataSetsModules().getStandaloneModules(),
       new DataSetServiceModules().getInMemoryModules(),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new MetricsClientRuntimeModule().getInMemoryModules(),
       new ExploreClientModule(),
       new DataFabricModules().getInMemoryModules(),

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogWriterPluginFactory.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogWriterPluginFactory.java
@@ -17,9 +17,10 @@
 package co.cask.cdap.logging.save;
 
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.io.RootLocationFactory;
+import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.logging.write.FileMetaDataManager;
 import com.google.inject.Inject;
-import org.apache.twill.filesystem.LocationFactory;
 
 /**
  * Factory to create {@link KafkaLogWriterPlugin}.
@@ -27,21 +28,25 @@ import org.apache.twill.filesystem.LocationFactory;
 public class KafkaLogWriterPluginFactory implements KafkaLogProcessorFactory {
   private final CConfiguration cConfig;
   private final FileMetaDataManager fileMetaDataManager;
-  private final LocationFactory locationFactory;
+  private final RootLocationFactory rootLocationFactory;
+  private final NamespacedLocationFactory namespacedLocationFactory;
   private final CheckpointManagerFactory checkpointManagerFactory;
 
   @Inject
   public KafkaLogWriterPluginFactory(CConfiguration cConfig, FileMetaDataManager fileMetaDataManager,
-                                     LocationFactory locationFactory,
+                                     RootLocationFactory rootLocationFactory,
+                                     NamespacedLocationFactory namespacedLocationFactory,
                                      CheckpointManagerFactory checkpointManagerFactory) {
     this.cConfig = cConfig;
     this.fileMetaDataManager = fileMetaDataManager;
-    this.locationFactory = locationFactory;
+    this.rootLocationFactory = rootLocationFactory;
+    this.namespacedLocationFactory = namespacedLocationFactory;
     this.checkpointManagerFactory = checkpointManagerFactory;
   }
 
   @Override
   public KafkaLogProcessor create() throws Exception {
-    return new KafkaLogWriterPlugin(cConfig, fileMetaDataManager, locationFactory, checkpointManagerFactory);
+    return new KafkaLogWriterPlugin(cConfig, fileMetaDataManager, checkpointManagerFactory, rootLocationFactory,
+                                    namespacedLocationFactory);
   }
 }

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/KafkaTestBase.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/KafkaTestBase.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.logging;
 
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data.runtime.TransactionExecutorModule;
@@ -59,7 +59,7 @@ public abstract class KafkaTestBase {
       .put(LoggingConfiguration.LOG_SAVER_TOPIC_WAIT_SLEEP_MS, "10")
       .build(),
     ImmutableList.of(
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new TransactionModules().getInMemoryModules(),
       new TransactionExecutorModule(),
       new DataSetsModules().getInMemoryModules(),

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/TestResilientLogging.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/TestResilientLogging.java
@@ -24,7 +24,7 @@ import co.cask.cdap.common.guice.ConfigModule;
 import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.IOModule;
 import co.cask.cdap.common.guice.KafkaClientModule;
-import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
@@ -106,7 +106,7 @@ public class TestResilientLogging {
       new ZKClientModule(),
       new KafkaClientModule(),
       new DiscoveryRuntimeModule().getInMemoryModules(),
-      new LocationRuntimeModule().getInMemoryModules(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new DataFabricModules().getInMemoryModules(),
       new DataSetsModules().getStandaloneModules(),
       new DataSetServiceModules().getInMemoryModules(),

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/file/TestCustomNSLogging.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/file/TestCustomNSLogging.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2014-2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.appender.file;
+
+import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.guice.ConfigModule;
+import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
+import co.cask.cdap.common.namespace.DefaultNamespacedLocationFactory;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.common.namespace.NamespacedLocationFactory;
+import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
+import co.cask.cdap.data.runtime.DataSetsModules;
+import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
+import co.cask.cdap.logging.LoggingConfiguration;
+import co.cask.cdap.logging.appender.LogAppender;
+import co.cask.cdap.logging.appender.LogAppenderInitializer;
+import co.cask.cdap.logging.appender.LoggingTester;
+import co.cask.cdap.logging.context.FlowletLoggingContext;
+import co.cask.cdap.logging.guice.LoggingModules;
+import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.tephra.TransactionManager;
+import co.cask.tephra.runtime.TransactionModules;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+/**
+ * Test for verifying that the log files for custom namespace are being created at the provided custom location
+ * Note: The Guice injector here binds to the actual {@link DefaultNamespacedLocationFactory} unlike other logging
+ * unit tests. This is required to test custom mapped namespaces.
+ */
+public class TestCustomNSLogging {
+
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+  private static CConfiguration cConf;
+  private static TransactionManager txManager;
+  private static NamespaceAdmin namespaceAdmin;
+  private static NamespacedLocationFactory namespacedLocationFactory;
+  private static LogAppender appender;
+
+  @BeforeClass
+  public static void setUpContext() throws Exception {
+    Configuration hConf = HBaseConfiguration.create();
+    cConf = CConfiguration.create();
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, TMP_FOLDER.newFolder().getAbsolutePath());
+    cConf.setInt(LoggingConfiguration.LOG_MAX_FILE_SIZE_BYTES, 20 * 1024);
+    String logBaseDir = cConf.get(LoggingConfiguration.LOG_BASE_DIR) + "/" + TestCustomNSLogging.class.getSimpleName();
+    cConf.set(LoggingConfiguration.LOG_BASE_DIR, logBaseDir);
+
+    Injector injector = Guice.createInjector(
+      new ConfigModule(cConf, hConf),
+      // here bind to the actual LocationRuntimeModule which binds the NamespacesLocationFactory to
+      // DefaultNmaespacedLocationFactory which does look up to resolve namespace location mappinng
+      new LocationRuntimeModule().getInMemoryModules(),
+      new TransactionModules().getInMemoryModules(),
+      new NamespaceClientRuntimeModule().getInMemoryModules(),
+      new LoggingModules().getInMemoryModules(),
+      new DataSetsModules().getInMemoryModules(),
+      new SystemDatasetRuntimeModule().getInMemoryModules(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class);
+        }
+      }
+    );
+
+    namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
+    namespacedLocationFactory = injector.getInstance(NamespacedLocationFactory.class);
+    txManager = injector.getInstance(TransactionManager.class);
+    txManager.startAndWait();
+    appender = injector.getInstance(FileLogAppender.class);
+  }
+
+  @AfterClass
+  public static void cleanUp() throws Exception {
+    txManager.stopAndWait();
+  }
+
+  @Test
+  public void testLogFileLocation() throws Exception {
+    // create a temp folder for custom ns mapping
+    File customNSDir = TMP_FOLDER.newFolder("TFL_NS_1");
+    NamespaceMeta namespaceMeta = new NamespaceMeta.Builder().setName("TFL_NS_1")
+      .setRootDirectory(customNSDir.toString()).build();
+    // create a namespace with the custom directory
+    namespaceAdmin.create(namespaceMeta);
+
+    // publish some logs
+    new LogAppenderInitializer(appender).initialize("TestFileLogging");
+    Logger logger = LoggerFactory.getLogger("TestFileLogging");
+    LoggingTester loggingTester = new LoggingTester();
+    FlowletLoggingContext loggingContext = new FlowletLoggingContext(namespaceMeta.getNamespaceId().getNamespace(),
+                                                                     "APP_1", "FLOW_1", "FLOWLET_1", "RUN1",
+                                                                     "INSTANCE1");
+    loggingTester.generateLogs(logger, loggingContext);
+    appender.stop();
+
+    // verify that the logs directory got created at the custom location and have files in it we don't care what it
+    // is and what is written here
+    String logPathFragment = loggingContext.getLogPathFragment(cConf.get(LoggingConfiguration.LOG_BASE_DIR)).split
+      (namespaceMeta.getName())[1];
+    Assert.assertTrue(new File(customNSDir, logPathFragment).exists());
+    Assert.assertTrue(new File(customNSDir, logPathFragment).list().length > 0);
+
+    // nothing should have been created in the cdap location
+    Assert.assertTrue(namespacedLocationFactory.getBaseLocation().list().isEmpty());
+  }
+}

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/file/TestFileLogging.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/file/TestFileLogging.java
@@ -20,7 +20,7 @@ import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -75,7 +75,7 @@ public class TestFileLogging {
 
     injector = Guice.createInjector(
       new ConfigModule(cConf, hConf),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new TransactionModules().getInMemoryModules(),
       new LoggingModules().getInMemoryModules(),
       new DataSetsModules().getInMemoryModules(),

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/write/LogCleanupTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/write/LogCleanupTest.java
@@ -19,14 +19,17 @@ package co.cask.cdap.logging.write;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
-import co.cask.cdap.common.guice.LocationUnitTestModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.io.RootLocationFactory;
 import co.cask.cdap.common.logging.LoggingContext;
+import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data.runtime.TransactionExecutorModule;
 import co.cask.cdap.logging.LoggingConfiguration;
 import co.cask.cdap.logging.context.FlowletLoggingContext;
+import co.cask.cdap.proto.Id;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.runtime.TransactionModules;
 import com.google.common.base.Function;
@@ -69,6 +72,7 @@ public class LogCleanupTest {
   private static TransactionManager txManager;
   private static String logBaseDir;
   private static String namespacesDir;
+  private static RootLocationFactory rootLocationFactory;
 
   @BeforeClass
   public static void init() throws Exception {
@@ -79,7 +83,7 @@ public class LogCleanupTest {
     namespacesDir = cConf.get(Constants.Namespace.NAMESPACES_DIR);
     injector = Guice.createInjector(
       new ConfigModule(cConf, hConf),
-      new LocationUnitTestModule().getModule(),
+      new NonCustomLocationUnitTestModule().getModule(),
       new TransactionModules().getInMemoryModules(),
       new TransactionExecutorModule(),
       new DataSetsModules().getInMemoryModules(),
@@ -88,6 +92,7 @@ public class LogCleanupTest {
 
     txManager = injector.getInstance(TransactionManager.class);
     txManager.startAndWait();
+    rootLocationFactory = injector.getInstance(RootLocationFactory.class);
   }
 
   @AfterClass
@@ -98,10 +103,7 @@ public class LogCleanupTest {
   @Test
   public void testCleanup() throws Exception {
     FileMetaDataManager fileMetaDataManager = injector.getInstance(FileMetaDataManager.class);
-
-    // Create base dir
-    LocationFactory locationFactory = injector.getInstance(LocationFactory.class);
-    Location baseDir = locationFactory.create(TEMP_FOLDER.newFolder().toURI());
+    NamespacedLocationFactory namespacedLocationFactory = injector.getInstance(NamespacedLocationFactory.class);
 
     // Deletion boundary
     long deletionBoundary = System.currentTimeMillis() - RETENTION_DURATION_MS;
@@ -110,7 +112,7 @@ public class LogCleanupTest {
     // Setup directories
     LoggingContext dummyContext = new FlowletLoggingContext("ns", "app", "flw", "flwt", "run", "instance");
 
-    Location namespacedLogsDir = baseDir.append(namespacesDir).append("ns").append(logBaseDir);
+    Location namespacedLogsDir = namespacedLocationFactory.get(Id.Namespace.from("ns")).append(logBaseDir);
     Location contextDir = namespacedLogsDir.append("app").append("flw");
     List<Location> toDelete = Lists.newArrayList();
     for (int i = 0; i < 5; ++i) {
@@ -152,7 +154,7 @@ public class LogCleanupTest {
     Assert.assertEquals(locationListsToString(toDelete, notDelete),
       toDelete.size() + notDelete.size(), fileMetaDataManager.listFiles(dummyContext).size());
 
-    LogCleanup logCleanup = new LogCleanup(fileMetaDataManager, baseDir, namespacesDir, RETENTION_DURATION_MS);
+    LogCleanup logCleanup = new LogCleanup(fileMetaDataManager, rootLocationFactory, RETENTION_DURATION_MS);
     logCleanup.run();
     logCleanup.run();
 
@@ -173,7 +175,7 @@ public class LogCleanupTest {
   @Test
   public void testDeleteEmptyDir1() throws Exception {
     // Create base dir
-    Location baseDir = injector.getInstance(LocationFactory.class).create(TEMP_FOLDER.newFolder().toURI());
+    Location baseDir = rootLocationFactory.create(TEMP_FOLDER.newFolder().toURI());
     // Create namespaced logs dirs
     Location namespacedLogsDir1 = baseDir.append(namespacesDir).append("ns1").append(logBaseDir);
     Location namespacedLogsDir2 = baseDir.append(namespacesDir).append("ns2").append(logBaseDir);
@@ -212,10 +214,10 @@ public class LogCleanupTest {
       emptyDirs.add(createDir(namespacedLogsDir2.append("def").append("hij").append("dir_" + i)));
     }
 
-    LogCleanup logCleanup = new LogCleanup(null, baseDir, namespacesDir, RETENTION_DURATION_MS);
+    LogCleanup logCleanup = new LogCleanup(null, rootLocationFactory, RETENTION_DURATION_MS);
     for (Location location : Sets.newHashSet(Iterables.concat(nonEmptyDirs, emptyDirs))) {
-      logCleanup.deleteEmptyDir("ns1/" + logBaseDir, location);
-      logCleanup.deleteEmptyDir("ns2/" + logBaseDir, location);
+      logCleanup.deleteEmptyDir(namespacedLogsDir1.toString(), location);
+      logCleanup.deleteEmptyDir(namespacedLogsDir2.toString(), location);
     }
 
     // Assert non-empty dirs (and their files) are still present
@@ -240,7 +242,7 @@ public class LogCleanupTest {
     LocationFactory locationFactory = injector.getInstance(LocationFactory.class);
     Location baseDir = locationFactory.create(TEMP_FOLDER.newFolder().toURI());
 
-    LogCleanup logCleanup = new LogCleanup(null, baseDir, namespacesDir, RETENTION_DURATION_MS);
+    LogCleanup logCleanup = new LogCleanup(null, rootLocationFactory, RETENTION_DURATION_MS);
 
     logCleanup.deleteEmptyDir(namespacesDir + "/ns/" + logBaseDir, baseDir);
     // Assert base dir exists


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/CDAP-6548
Build: http://builds.cask.co/browse/CDAP-DUT4469-1
ITN: http://builds.cask.co/browse/CDAP-ITM-21
- CDAP LogSaver now uses NamespacedLocationFactory
- This change is required because the logs of custom mapped namespaces should go to the custom location. Currently, they went into cdap/namespaces directory since log saver was not using NamespacedLocationFactory
- LogCleanup and FileMetadataManager classes now also need RootLocationFactory because for custom mapped locations the log files can only accessed if we work with  location factory based on root of filesystem
