### PR TITLE
[CDAP-6386] Alter the Hive table instead of drop and create when updating a file set dataset

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
@@ -265,7 +265,7 @@ public class DatasetInstanceService {
       publishAudit(newInstance, AuditType.CREATE);
 
       // Enable explore
-      enableExplore(newInstance, props);
+      enableExplore(newInstance, spec, props);
     } catch (Exception e) {
       // there was a problem in creating the dataset instance. so revoke the privileges.
       authorizer.revoke(datasetId);
@@ -302,8 +302,6 @@ public class DatasetInstanceService {
         ConversionHelpers.toDatasetTypeId(instance.getNamespace(), existing.getType()));
     }
 
-    disableExplore(instance);
-
     // Note how we execute configure() via opExecutorClient (outside of ds service) to isolate running user code
     DatasetSpecification spec = opExecutorClient.update(instance, typeMeta, DatasetProperties.of(properties), existing);
     instanceManager.add(instance.getNamespace(), spec);
@@ -312,7 +310,7 @@ public class DatasetInstanceService {
     DatasetInstanceConfiguration creationProperties =
       new DatasetInstanceConfiguration(existing.getType(), properties, null);
 
-    enableExplore(instance, creationProperties);
+    updateExplore(instance, creationProperties, existing, spec);
     publishAudit(instance, AuditType.UPDATE);
   }
 
@@ -457,11 +455,28 @@ public class DatasetInstanceService {
     }
   }
 
-  private void enableExplore(Id.DatasetInstance datasetInstance, DatasetInstanceConfiguration creationProperties) {
+  private void enableExplore(Id.DatasetInstance datasetInstance, DatasetSpecification spec,
+                             DatasetInstanceConfiguration creationProperties) {
     // Enable ad-hoc exploration of dataset
     // Note: today explore enable is not transactional with dataset create - CDAP-8
     try {
-      exploreFacade.enableExploreDataset(datasetInstance);
+      exploreFacade.enableExploreDataset(datasetInstance, spec);
+    } catch (Exception e) {
+      String msg = String.format("Cannot enable exploration of dataset instance %s of type %s: %s",
+                                 datasetInstance, creationProperties.getProperties(), e.getMessage());
+      LOG.error(msg, e);
+      // TODO: at this time we want to still allow using dataset even if it cannot be used for exploration
+      //responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, msg);
+      //return;
+    }
+  }
+
+  private void updateExplore(Id.DatasetInstance datasetInstance, DatasetInstanceConfiguration creationProperties,
+                             DatasetSpecification oldSpec, DatasetSpecification newSpec) {
+    // Enable ad-hoc exploration of dataset
+    // Note: today explore enable is not transactional with dataset create - CDAP-8
+    try {
+      exploreFacade.updateExploreDataset(datasetInstance, oldSpec, newSpec);
     } catch (Exception e) {
       String msg = String.format("Cannot enable exploration of dataset instance %s of type %s: %s",
                                  datasetInstance, creationProperties.getProperties(), e.getMessage());

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/AbstractExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/AbstractExploreClient.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.explore.client;
 
 import co.cask.cdap.api.data.format.FormatSpecification;
+import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.explore.service.Explore;
 import co.cask.cdap.explore.service.ExploreException;
@@ -94,11 +95,40 @@ public abstract class AbstractExploreClient extends ExploreHttpClient implements
   }
 
   @Override
+  public ListenableFuture<Void> updateExploreDataset(final Id.DatasetInstance datasetInstance,
+                                                     final DatasetSpecification oldSpec,
+                                                     final DatasetSpecification newSpec) {
+    ListenableFuture<ExploreExecutionResult> futureResults = getResultsFuture(new HandleProducer() {
+      @Override
+      public QueryHandle getHandle() throws ExploreException, SQLException {
+        return doUpdateExploreDataset(datasetInstance, oldSpec, newSpec);
+      }
+    });
+
+    // Exceptions will be thrown in case of an error in the futureHandle
+    return Futures.transform(futureResults, Functions.<Void>constant(null));
+  }
+
+  @Override
   public ListenableFuture<Void> enableExploreDataset(final Id.DatasetInstance datasetInstance) {
     ListenableFuture<ExploreExecutionResult> futureResults = getResultsFuture(new HandleProducer() {
       @Override
       public QueryHandle getHandle() throws ExploreException, SQLException {
-        return doEnableExploreDataset(datasetInstance);
+        return doEnableExploreDataset(datasetInstance, null);
+      }
+    });
+
+    // Exceptions will be thrown in case of an error in the futureHandle
+    return Futures.transform(futureResults, Functions.<Void>constant(null));
+  }
+
+  @Override
+  public ListenableFuture<Void> enableExploreDataset(final Id.DatasetInstance datasetInstance,
+                                                     final DatasetSpecification spec) {
+    ListenableFuture<ExploreExecutionResult> futureResults = getResultsFuture(new HandleProducer() {
+      @Override
+      public QueryHandle getHandle() throws ExploreException, SQLException {
+        return doEnableExploreDataset(datasetInstance, spec);
       }
     });
 

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/EnableExploreParameters.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/EnableExploreParameters.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.explore.client;
+
+import co.cask.cdap.api.dataset.DatasetSpecification;
+
+/**
+ * This class represents the body of an HTTP request to enable a dataset for Explore.
+ */
+public class EnableExploreParameters {
+
+  private final DatasetSpecification spec;
+
+  public EnableExploreParameters(DatasetSpecification newSpec) {
+    this.spec = newSpec;
+  }
+
+  public DatasetSpecification getSpec() {
+    return spec;
+  }
+}

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreClient.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.explore.client;
 
 import co.cask.cdap.api.data.format.FormatSpecification;
+import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.explore.service.MetaDataInfo;
 import co.cask.cdap.proto.Id;
@@ -39,16 +40,40 @@ public interface ExploreClient extends Closeable {
   /**
    * Enables ad-hoc exploration of the given {@link co.cask.cdap.api.data.batch.RecordScannable}.
    *
-   * @param datasetInstance dataset instance id.
+   * @param datasetInstance dataset instance id
    * @return a {@code Future} object that can either successfully complete, or enter a failed state depending on
    *         the success of the enable operation.
    */
   ListenableFuture<Void> enableExploreDataset(Id.DatasetInstance datasetInstance);
 
   /**
+   * Enables ad-hoc exploration of the given {@link co.cask.cdap.api.data.batch.RecordScannable}.
+   *
+   * @param datasetInstance dataset instance id
+   * @param spec the dataset specification of the dataset
+   *
+   * @return a {@code Future} object that can either successfully complete, or enter a failed state depending on
+   *         the success of the enable operation.
+   */
+  ListenableFuture<Void> enableExploreDataset(Id.DatasetInstance datasetInstance, DatasetSpecification spec);
+
+  /**
+   * Updates ad-hoc exploration of the given {@link co.cask.cdap.api.data.batch.RecordScannable}.
+   *
+   * @param datasetInstance dataset instance id
+   * @param oldSpec the dataset specification from before the update
+   * @param newSpec the dataset specification after the update
+   * @return a {@code Future} object that can either successfully complete, or enter a failed state depending on
+   *         the success of the update operation.
+   */
+  ListenableFuture<Void> updateExploreDataset(Id.DatasetInstance datasetInstance,
+                                              DatasetSpecification oldSpec,
+                                              DatasetSpecification newSpec);
+
+  /**
    * Disable ad-hoc exploration of the given {@link co.cask.cdap.api.data.batch.RecordScannable}.
    *
-   * @param datasetInstance dataset instance id.
+   * @param datasetInstance dataset instance id
    * @return a {@code Future} object that can either successfully complete, or enter a failed state depending on
    *         the success of the disable operation.
    */

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreFacade.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreFacade.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.explore.client;
 
 import co.cask.cdap.api.data.format.FormatSpecification;
+import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
@@ -95,6 +96,36 @@ public class ExploreFacade {
 
     ListenableFuture<Void> futureSuccess = exploreClient.enableExploreDataset(datasetInstance);
     handleExploreFuture(futureSuccess, "enable", "dataset", datasetInstance.getId());
+  }
+
+  /**
+   * Enables ad-hoc exploration of the given {@link co.cask.cdap.api.data.batch.RecordScannable}.
+   * @param datasetInstance dataset instance id.
+   */
+  public void enableExploreDataset(Id.DatasetInstance datasetInstance,
+                                   DatasetSpecification spec) throws ExploreException, SQLException {
+    if (!(exploreEnabled && isDatasetExplorable(datasetInstance))) {
+      return;
+    }
+
+    ListenableFuture<Void> futureSuccess = exploreClient.enableExploreDataset(datasetInstance, spec);
+    handleExploreFuture(futureSuccess, "enable", "dataset", datasetInstance.getId());
+  }
+
+  /**
+   * Enables ad-hoc exploration of the given {@link co.cask.cdap.api.data.batch.RecordScannable}.
+   * @param datasetInstance dataset instance id.
+   * @param oldSpec the previous dataset spec
+   */
+  public void updateExploreDataset(Id.DatasetInstance datasetInstance,
+                                   DatasetSpecification oldSpec,
+                                   DatasetSpecification newSpec) throws ExploreException, SQLException {
+    if (!(exploreEnabled && isDatasetExplorable(datasetInstance))) {
+      return;
+    }
+
+    ListenableFuture<Void> futureSuccess = exploreClient.updateExploreDataset(datasetInstance, oldSpec, newSpec);
+    handleExploreFuture(futureSuccess, "update", "dataset", datasetInstance.getId());
   }
 
   /**

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/MockExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/MockExploreClient.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.explore.client;
 
 import co.cask.cdap.api.data.format.FormatSpecification;
+import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.MetaDataInfo;
@@ -61,7 +62,18 @@ public class MockExploreClient extends AbstractIdleService implements ExploreCli
   }
 
   @Override
+  public ListenableFuture<Void> updateExploreDataset(Id.DatasetInstance datasetInstance,
+                                                     DatasetSpecification oldSpec, DatasetSpecification newSpec) {
+    return null;
+  }
+
+  @Override
   public ListenableFuture<Void> enableExploreDataset(Id.DatasetInstance datasetInstance) {
+    return null;
+  }
+
+  @Override
+  public ListenableFuture<Void> enableExploreDataset(Id.DatasetInstance datasetInstance, DatasetSpecification spec) {
     return null;
   }
 

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/UpdateExploreParameters.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/UpdateExploreParameters.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.explore.client;
+
+import co.cask.cdap.api.dataset.DatasetSpecification;
+
+/**
+ * This class represents the body of an HTTP request to update a dataset in Explore.
+ */
+public class UpdateExploreParameters {
+
+  private final DatasetSpecification oldSpec;
+  private final DatasetSpecification newSpec;
+
+  public UpdateExploreParameters(DatasetSpecification oldSpec, DatasetSpecification newSpec) {
+    this.oldSpec = oldSpec;
+    this.newSpec = newSpec;
+  }
+
+  public DatasetSpecification getOldSpec() {
+    return oldSpec;
+  }
+
+  public DatasetSpecification getNewSpec() {
+    return newSpec;
+  }
+}

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/utils/ExploreTableNaming.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/utils/ExploreTableNaming.java
@@ -17,6 +17,8 @@
 package co.cask.cdap.explore.utils;
 
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.StreamId;
 
 /**
  * Specifies how to name tables for Explore.
@@ -25,6 +27,14 @@ public final class ExploreTableNaming {
 
   public String getTableName(Id.Stream streamId) {
     return String.format("stream_%s", cleanTableName(streamId.getId()));
+  }
+
+  public String getTableName(StreamId streamId) {
+    return String.format("stream_%s", cleanTableName(streamId.getStream()));
+  }
+
+  public String getTableName(DatasetId datasetID) {
+    return String.format("dataset_%s", cleanTableName(datasetID.getDataset()));
   }
 
   public String getTableName(Id.DatasetInstance datasetID) {

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreService.java
@@ -16,10 +16,28 @@
 
 package co.cask.cdap.explore.service;
 
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.QueryHandle;
 import com.google.common.util.concurrent.Service;
+
+import java.sql.SQLException;
 
 /**
  * Interface for service exploring datasets.
  */
 public interface ExploreService extends Service, Explore {
+
+  /**
+   * Execute a sequence of Hive SQL statements. All but the last statement are executed synchronously, and
+   * the last statement is run asynchronously. The returned {@link QueryHandle} can be used to get the
+   * status/result of the operation.
+   *
+   * @param namespace namespace to run the query in.
+   * @param statements SQL statement.
+   * @return {@link QueryHandle} representing the operation.
+   * @throws ExploreException on any error executing statement.
+   * @throws SQLException if there are errors in the SQL statement.
+   */
+  QueryHandle execute(Id.Namespace namespace, String[] statements) throws ExploreException, SQLException;
+
 }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12CDH5ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12CDH5ExploreService.java
@@ -114,7 +114,13 @@ public class Hive12CDH5ExploreService extends BaseHiveExploreService {
   }
 
   @Override
-  protected OperationHandle doExecute(SessionHandle sessionHandle, String statement)
+  protected OperationHandle executeSync(SessionHandle sessionHandle, String statement)
+    throws HiveSQLException, ExploreException {
+    return getCliService().executeStatement(sessionHandle, statement, ImmutableMap.<String, String>of());
+  }
+
+  @Override
+  protected OperationHandle executeAsync(SessionHandle sessionHandle, String statement)
     throws HiveSQLException, ExploreException {
     return getCliService().executeStatementAsync(sessionHandle, statement, ImmutableMap.<String, String>of());
   }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12ExploreService.java
@@ -128,7 +128,13 @@ public class Hive12ExploreService extends BaseHiveExploreService {
   }
 
   @Override
-  protected OperationHandle doExecute(SessionHandle sessionHandle, String statement)
+  protected OperationHandle executeSync(SessionHandle sessionHandle, String statement)
+    throws HiveSQLException, ExploreException {
+    return getCliService().executeStatement(sessionHandle, statement, ImmutableMap.<String, String>of());
+  }
+
+  @Override
+  protected OperationHandle executeAsync(SessionHandle sessionHandle, String statement)
     throws HiveSQLException, ExploreException {
     return getCliService().executeStatementAsync(sessionHandle, statement, ImmutableMap.<String, String>of());
   }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive13ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive13ExploreService.java
@@ -106,8 +106,15 @@ public class Hive13ExploreService extends BaseHiveExploreService {
   }
 
   @Override
-  protected OperationHandle doExecute(SessionHandle sessionHandle, String statement)
+  protected OperationHandle executeSync(SessionHandle sessionHandle, String statement)
+    throws HiveSQLException, ExploreException {
+    return getCliService().executeStatement(sessionHandle, statement, ImmutableMap.<String, String>of());
+  }
+
+  @Override
+  protected OperationHandle executeAsync(SessionHandle sessionHandle, String statement)
     throws HiveSQLException, ExploreException {
     return getCliService().executeStatementAsync(sessionHandle, statement, ImmutableMap.<String, String>of());
   }
+
 }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive14ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive14ExploreService.java
@@ -91,7 +91,13 @@ public class Hive14ExploreService extends BaseHiveExploreService {
   }
 
   @Override
-  protected OperationHandle doExecute(SessionHandle sessionHandle, String statement)
+  protected OperationHandle executeSync(SessionHandle sessionHandle, String statement)
+    throws HiveSQLException, ExploreException {
+    return getCliService().executeStatement(sessionHandle, statement, new HashMap<String, String>());
+  }
+
+  @Override
+  protected OperationHandle executeAsync(SessionHandle sessionHandle, String statement)
     throws HiveSQLException, ExploreException {
     return getCliService().executeStatementAsync(sessionHandle, statement, new HashMap<String, String>());
   }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/table/AlterStatementBuilder.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/table/AlterStatementBuilder.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.explore.table;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.data.schema.UnsupportedTypeException;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.utils.ProjectInfo;
+import com.google.common.collect.ImmutableMap;
+import org.apache.twill.filesystem.Location;
+
+import java.util.Map;
+
+/**
+ * Builds alter table statements for Hive. Table DDL we support is of the form:
+ *
+ * ALTER TABLE table_name SET TBLPROPERTIES (property_name=property_value, ...);
+ * ALTER TABLE table_name SET LOCATION hdfs_path;
+ * ALTER TABLE table_name REPLACE COLUMNS (col_name data_type, ...)
+ * ALTER TABLE table_name SET SERDEPROPERTIES ('field.delim' = '|')
+ * ALTER TABLE table_name SET SERDE classname WITH SERDEPROPERTIES (...)
+ * ALTER TABLE table_name SET FILEFORMAT INPUTFORMAT 'classname' OUTPUTFORMAT 'classname'
+ *
+ * We only support a subset of what Hive can do. For example, there is no support for SKEWED BY or CLUSTERED BY.
+ */
+public class AlterStatementBuilder {
+  private final String name;
+  private final String hiveTableName;
+  private boolean escapeColumns;
+
+  public AlterStatementBuilder(String name, String hiveTableName, boolean escapeColumns) {
+    this.name = name;
+    this.hiveTableName = hiveTableName;
+    this.escapeColumns = escapeColumns;
+  }
+
+  /**
+   * Set the location of the Hive table.
+   * For example:
+   * ALTER TABLE mytable SET LOCATION '/my/path';
+   */
+  public String buildWithLocation(Location location) {
+    return startBuild()
+      .append("SET LOCATION '")
+      .append(location.toURI().toString())
+      .append("'")
+      .toString();
+  }
+
+  /**
+   * Set table properties. CDAP name and version must not be in the given properties, as they are added by the builder.
+   */
+  public String buildWithTableProperties(Map<String, String> tableProperties) {
+    StringBuilder builder = startBuild()
+      .append("SET TBLPROPERTIES ");
+    appendMap(builder, addRequiredTableProperties(tableProperties));
+    return builder.toString();
+  }
+
+  /**
+   * Set the hive schema for the table. Should be of the form "column_name column_type, ...".
+   */
+  public String buildWithSchema(Schema schema) throws UnsupportedTypeException {
+    return buildWithSchemaInternal(new SchemaConverter(escapeColumns).toHiveSchema(schema));
+  }
+
+  /**
+   * Set the hive schema for the table. Should be of the form "column_name column_type, ...".
+   * For example:
+   * ALTER TABLE mytable REPLACE COLUMNS (a int, b float);
+   */
+  public String buildWithSchema(String hiveSchema) {
+    return buildWithSchemaInternal("(" + hiveSchema + ")");
+  }
+
+  private String buildWithSchemaInternal(String hiveSchemaWithParentheses) {
+    return startBuild()
+      .append("REPLACE COLUMNS ")
+      .append(hiveSchemaWithParentheses)
+      .toString();
+
+  }
+
+  /**
+   * Sets a native Hive file format for the table.
+   * For example:
+   * ALTER TABLE mytable SET FILEFORMAT avro;
+   */
+  public String buildWithFileFormat(String fileFormat) {
+    return startBuild()
+      .append("SET FILEFORMAT ")
+      .append(fileFormat)
+      .toString();
+  }
+
+  /**
+   * Changes the delimiter for the row format. Note that there is no way to directly
+   * change the row format in the ALTER TABLE syntax. Instead we have to set the
+   * Serde property that controls the field delimiter.
+   * See http://osdir.com/ml/hive-user-hadoop-apache/2009-12/msg00109.html.
+   * For Example:
+   * ALTER TABLE mytable SET SERDEPROPERTIES ('mapkey.delim' = '|');
+   */
+  public String buildWithDelimiter(String delimiter) {
+    StringBuilder builder = startBuild()
+      .append("SET SERDEPROPERTIES ");
+    appendMap(builder, ImmutableMap.of("field.delim", delimiter == null ? "\\001" : delimiter));
+    return builder.toString();
+  }
+
+  public String buildWithFormats(String inputFormat, String outputFormat, String serde) {
+    return startBuild()
+      .append("SET FILEFORMAT INPUTFORMAT '")
+      .append(inputFormat)
+      .append("' OUTPUTFORMAT '")
+      .append(outputFormat)
+      .append("' SERDE '")
+      .append(serde)
+      .append("'")
+      .toString();
+  }
+
+  // required properties for every CDAP Hive table
+  private Map<String, String> addRequiredTableProperties(Map<String, String> map) {
+    return ImmutableMap.<String, String>builder().putAll(map)
+      .put(Constants.Explore.CDAP_NAME, name)
+      .put(Constants.Explore.CDAP_VERSION, ProjectInfo.getVersion().toString())
+      .build();
+  }
+
+  /**
+   * Start the create statement: ALTER TABLE tableName ...
+   */
+  private StringBuilder startBuild() {
+    return new StringBuilder()
+      .append("ALTER TABLE ")
+      .append(hiveTableName)
+      .append(' ');
+  }
+
+  // appends the contents of the map as ('key'='val', ...). Also escapes any single quotes in the map.
+  private void appendMap(StringBuilder strBuilder, Map<String, String> map) {
+    boolean first = true;
+    for (Map.Entry<String, String> entry : map.entrySet()) {
+      strBuilder.append(first ? "('" : ", '")
+        .append(entry.getKey().replaceAll("'", "\\\\'"))
+        .append("'='")
+        .append(entry.getValue().replaceAll("'", "\\\\'"))
+        .append("'");
+      first = false;
+    }
+    strBuilder.append(")");
+  }
+
+}

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/table/CreateStatementBuilder.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/table/CreateStatementBuilder.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import org.apache.twill.filesystem.Location;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -86,6 +87,14 @@ public class CreateStatementBuilder {
    */
   public CreateStatementBuilder setSchema(Schema schema) throws UnsupportedTypeException {
     this.hiveSchema = schemaConverter.toHiveSchema(schema);
+    return this;
+  }
+
+  /**
+   * Set the schema for the table. Throws an exception if it is not valid for Hive.
+   */
+  public CreateStatementBuilder setSchema(Type type) throws UnsupportedTypeException {
+    this.hiveSchema = schemaConverter.toHiveSchema(type);
     return this;
   }
 

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreExtensiveSchemaTableTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreExtensiveSchemaTableTestRun.java
@@ -77,7 +77,7 @@ public class ExploreExtensiveSchemaTableTestRun extends BaseHiveExploreServiceTe
         new ExtensiveSchemaTableDefinition.Value[] {
           new ExtensiveSchemaTableDefinition.Value("bar", 3), new ExtensiveSchemaTableDefinition.Value("foobar", 4)
         }, ImmutableList.of(new ExtensiveSchemaTableDefinition.Value("foobar2", 3)),
-        ImmutableMap.of("key", new ExtensiveSchemaTableDefinition.Value("foobar3", 9)));
+        ImmutableMap.of("key", new ExtensiveSchemaTableDefinition.Value("foobar3", 9)), 42L);
     value1.setExt(value1);
     table.put("1", value1);
 
@@ -153,8 +153,9 @@ public class ExploreExtensiveSchemaTableTestRun extends BaseHiveExploreServiceTe
                  new QueryResult(Lists.<Object>newArrayList("vlist", "array<struct<s:string,i:int>>",
                                                             "from deserializer")),
                  new QueryResult(Lists.<Object>newArrayList("stovmap", "map<string,struct<s:string,i:int>>",
-                                                       "from deserializer"))
-               )
+                                                       "from deserializer")),
+                 new QueryResult(Lists.<Object>newArrayList("date", "bigint", "from deserializer"))
+                 )
     );
 
     runCommand(NAMESPACE_ID, "select * from " + MY_TABLE_NAME,
@@ -198,7 +199,8 @@ public class ExploreExtensiveSchemaTableTestRun extends BaseHiveExploreServiceTe
                                   new ColumnDesc(MY_TABLE_NAME + ".vlist", "array<struct<s:string,i:int>>",
                                                  31, null),
                                   new ColumnDesc(MY_TABLE_NAME + ".stovmap",
-                                                 "map<string,struct<s:string,i:int>>", 32, null)
+                                                 "map<string,struct<s:string,i:int>>", 32, null),
+                                  new ColumnDesc(MY_TABLE_NAME + ".date", "BIGINT", 33, null)
                ),
                Lists.newArrayList(
                  new QueryResult(Lists.<Object>newArrayList(
@@ -225,7 +227,8 @@ public class ExploreExtensiveSchemaTableTestRun extends BaseHiveExploreServiceTe
                    // maps
                    "{\"foo3\":51}", "{3.55:51.98}", "{890:45}",
                    "{true:27}", "{\"s\":\"foo\",\"i\":2}", "[{\"s\":\"bar\",\"i\":3},{\"s\":\"foobar\",\"i\":4}]",
-                   "[{\"s\":\"foobar2\",\"i\":3}]", "{\"key\":{\"s\":\"foobar3\",\"i\":9}}"
+                   "[{\"s\":\"foobar2\",\"i\":3}]", "{\"key\":{\"s\":\"foobar3\",\"i\":9}}",
+                   42L
                  )))
     );
 
@@ -265,8 +268,10 @@ public class ExploreExtensiveSchemaTableTestRun extends BaseHiveExploreServiceTe
                                          new TableInfo.ColumnInfo("v", "struct<s:string,i:int>", null),
                                          new TableInfo.ColumnInfo("varr", "array<struct<s:string,i:int>>", null),
                                          new TableInfo.ColumnInfo("vlist", "array<struct<s:string,i:int>>", null),
-                                         new TableInfo.ColumnInfo("stovmap", "map<string,struct<s:string,i:int>>", null)
-                        ),
+                                         new TableInfo.ColumnInfo("stovmap", "map<string,struct<s:string,i:int>>",
+                                                                  null),
+                                         new TableInfo.ColumnInfo("date", "bigint", null)
+                                         ),
                         exploreService.getTableInfo(NAMESPACE_ID.getId(), MY_TABLE_NAME).getSchema());
   }
 }

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/FileWriterHelper.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/FileWriterHelper.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.explore.service;
 
 import co.cask.cdap.api.common.Bytes;
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Closeables;
 import org.apache.avro.Schema;
@@ -70,6 +71,23 @@ public class FileWriterHelper {
     try {
       for (int i = start; i < end; i++) {
         String line = String.format("%s%d%s%d\n", prefix, i, delim, i);
+        out.write(Bytes.toBytes(line));
+      }
+    } finally {
+      Closeables.closeQuietly(out);
+    }
+  }
+
+  /**
+   * Generate a text file where each line has the form i(delim0)x(delim1)x...x(delimK)i
+   * for start <= i < end, using the given delimiters. The file is written using the passed-in output stream.
+   */
+  public static void generateMultiDelimitersFile(OutputStream out, Iterable<String> delims, int start, int end)
+    throws IOException {
+    String delim = Joiner.on("x").join(delims);
+    try {
+      for (int i = start; i < end; i++) {
+        String line = String.format("%d%s%d\n", i, delim, i);
         out.write(Bytes.toBytes(line));
       }
     } finally {

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreObjectMappedTableTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreObjectMappedTableTestRun.java
@@ -90,6 +90,10 @@ public class HiveExploreObjectMappedTableTestRun extends BaseHiveExploreServiceT
 
   @Test
   public void testSchema() throws Exception {
+    testSchema("row_key");
+  }
+
+  private void testSchema(String rowKey) throws Exception {
     runCommand(NAMESPACE_ID, "describe " + MY_TABLE_NAME,
                true,
                Lists.newArrayList(
@@ -98,7 +102,7 @@ public class HiveExploreObjectMappedTableTestRun extends BaseHiveExploreServiceT
                  new ColumnDesc("comment", "STRING", 3, "from deserializer")
                ),
                Lists.newArrayList(
-                 new QueryResult(Lists.<Object>newArrayList("row_key", "string", "from deserializer")),
+                 new QueryResult(Lists.<Object>newArrayList(rowKey, "string", "from deserializer")),
                  new QueryResult(Lists.<Object>newArrayList("bytearrayfield", "binary", "from deserializer")),
                  new QueryResult(Lists.<Object>newArrayList("doublefield", "double", "from deserializer")),
                  new QueryResult(Lists.<Object>newArrayList("floatfield", "float", "from deserializer")),
@@ -107,6 +111,24 @@ public class HiveExploreObjectMappedTableTestRun extends BaseHiveExploreServiceT
                  new QueryResult(Lists.<Object>newArrayList("stringfield", "string", "from deserializer"))
                )
     );
+  }
+
+  @Test
+  public void testUpdate() throws Exception {
+    datasetFramework.updateInstance(MY_TABLE, ObjectMappedTableProperties.builder()
+      .setType(Record.class)
+      .setRowKeyExploreName("new_key")
+      .setRowKeyExploreType(Schema.Type.STRING)
+      .build());
+    testSchema("new_key");
+
+    // update back to previous schema as other tests depend on it
+    datasetFramework.updateInstance(MY_TABLE, ObjectMappedTableProperties.builder()
+      .setType(Record.class)
+      .setRowKeyExploreName("row_key")
+      .setRowKeyExploreType(Schema.Type.STRING)
+      .build());
+    testSchema();
   }
 
   @Test

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreStructuredRecordTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreStructuredRecordTestRun.java
@@ -28,6 +28,7 @@ import co.cask.cdap.proto.ColumnDesc;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.proto.QueryStatus;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.test.SlowTests;
 import co.cask.tephra.Transaction;
 import com.google.common.collect.Lists;
@@ -86,26 +87,26 @@ public class HiveExploreStructuredRecordTestRun extends BaseHiveExploreServiceTe
 
   @Test(expected = IllegalArgumentException.class)
   public void testMissingSchemaFails() throws Exception {
-    Id.DatasetInstance instanceId = Id.DatasetInstance.from(NAMESPACE_ID, "badtable");
-    datasetFramework.addInstance("TableWrapper", instanceId, DatasetProperties.EMPTY);
+    DatasetId instanceId = new DatasetId(NAMESPACE_ID.getId(), "badtable");
+    datasetFramework.addInstance("TableWrapper", instanceId.toId(), DatasetProperties.EMPTY);
 
-    DatasetSpecification spec = datasetFramework.getDatasetSpec(instanceId);
+    DatasetSpecification spec = datasetFramework.getDatasetSpec(instanceId.toId());
     try {
       exploreTableManager.enableDataset(instanceId, spec);
     } finally {
-      datasetFramework.deleteInstance(instanceId);
+      datasetFramework.deleteInstance(instanceId.toId());
     }
   }
 
   @Test
   public void testRecordScannableAndWritableIsOK() throws Exception {
-    Id.DatasetInstance instanceId = Id.DatasetInstance.from(NAMESPACE_ID, "tabul");
-    datasetFramework.addInstance("TableWrapper", instanceId, DatasetProperties.builder()
+    DatasetId instanceId = new DatasetId(NAMESPACE_ID.getId(), "tabul");
+    datasetFramework.addInstance("TableWrapper", instanceId.toId(), DatasetProperties.builder()
       .add(DatasetProperties.SCHEMA,
            Schema.recordOf("intRecord", Schema.Field.of("x", Schema.of(Schema.Type.STRING))).toString())
       .build());
 
-    DatasetSpecification spec = datasetFramework.getDatasetSpec(instanceId);
+    DatasetSpecification spec = datasetFramework.getDatasetSpec(instanceId.toId());
     try {
       exploreTableManager.enableDataset(instanceId, spec);
       runCommand(NAMESPACE_ID, "describe dataset_tabul",
@@ -120,7 +121,7 @@ public class HiveExploreStructuredRecordTestRun extends BaseHiveExploreServiceTe
         )
       );
     } finally {
-      datasetFramework.deleteInstance(instanceId);
+      datasetFramework.deleteInstance(instanceId.toId());
     }
   }
 

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/ExtensiveSchemaTableDefinition.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/datasets/ExtensiveSchemaTableDefinition.java
@@ -173,6 +173,9 @@ public class ExtensiveSchemaTableDefinition
     private final List<Value> vList;
     private final Map<String, Value> stovMap;
 
+    // field that is a reserved word in Hive
+    private final long date;
+
     // Transient and static fields - they shouldn't be included in the schema
     private transient int t = 0;
     private static int st = 80;
@@ -181,13 +184,13 @@ public class ExtensiveSchemaTableDefinition
     // TODO fix infinite loop
 //    private ExtensiveSchema ext;
 
-    public ExtensiveSchema(String s, int i, float f, double d, long l, byte b, boolean bo, short sh, int[] iArr,
-                           float[] fArr, double[] dArr, long[] lArr, byte[] bArr, boolean[] boArr, short[] shArr,
-                           String[] sArr, List<Integer> iList, List<Float> fList, List<Double> dList, List<Long> lList,
-                           List<Byte> bList, List<Boolean> boList, List<Short> shList, List<String> sList,
-                           Map<String, Integer> stoiMap, Map<Float, Double> ftodMap, Map<Long, Byte> ltobMap,
-                           Map<Boolean, Short> botoshMap, Value v, Value[] vArr, List<Value> vList,
-                           Map<String, Value> stovMap) {
+    public ExtensiveSchema(String s, int i, float f, double d, long l, byte b, boolean bo, short sh,
+                           int[] iArr, float[] fArr, double[] dArr, long[] lArr, byte[] bArr, boolean[] boArr,
+                           short[] shArr, String[] sArr, List<Integer> iList, List<Float> fList, List<Double> dList,
+                           List<Long> lList, List<Byte> bList, List<Boolean> boList, List<Short> shList,
+                           List<String> sList, Map<String, Integer> stoiMap, Map<Float, Double> ftodMap,
+                           Map<Long, Byte> ltobMap, Map<Boolean, Short> botoshMap, Value v, Value[] vArr,
+                           List<Value> vList, Map<String, Value> stovMap, long date) {
       this.s = s;
       this.i = i;
       this.f = f;
@@ -220,6 +223,7 @@ public class ExtensiveSchemaTableDefinition
       this.vArr = vArr;
       this.vList = vList;
       this.stovMap = stovMap;
+      this.date = date;
     }
 
     public void setExt(ExtensiveSchema ext) {

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/table/AlterStatementBuilderTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/table/AlterStatementBuilderTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.explore.table;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.common.utils.ProjectInfo;
+import com.google.common.collect.ImmutableMap;
+import org.apache.twill.filesystem.LocalLocationFactory;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class AlterStatementBuilderTest {
+
+  LocationFactory locationFactory = new LocalLocationFactory();
+
+  @Test
+  public void testWithLocation() throws Exception {
+    Location location = locationFactory.create("/some/path");
+    String expected = "ALTER TABLE dataset_xyz " +
+      "SET LOCATION '" + location.toURI().toString() + "'";
+
+    String actual = new AlterStatementBuilder("xyz", "dataset_xyz", true)
+      .buildWithLocation(location);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testWithTableProperties() throws Exception {
+    String expected = "ALTER TABLE dataset_xyz " +
+      "SET TBLPROPERTIES ('somekey'='someval', 'cdap.name'='xyz', " +
+      "'cdap.version'='" + ProjectInfo.getVersion().toString() + "')";
+
+    String actual = new AlterStatementBuilder("xyz", "dataset_xyz", true)
+      .buildWithTableProperties(ImmutableMap.of("somekey", "someval"));
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testWithSchema() throws Exception {
+    Schema schema = Schema.recordOf(
+      "stuff",
+      Schema.Field.of("f1", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("f2", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("f3", Schema.of(Schema.Type.DOUBLE)),
+      Schema.Field.of("f4", Schema.of(Schema.Type.BOOLEAN)),
+      Schema.Field.of("f5", Schema.of(Schema.Type.FLOAT)),
+      Schema.Field.of("f6", Schema.of(Schema.Type.BYTES)));
+
+    // escape = false
+    String expected = "ALTER TABLE dataset_xyz " +
+      "REPLACE COLUMNS (f1 string, f2 int, f3 double, f4 boolean, f5 float, f6 binary)";
+    String actual = new AlterStatementBuilder("xyz", "dataset_xyz", false)
+      .buildWithSchema(schema);
+    Assert.assertEquals(expected, actual);
+
+    // escape true
+    expected = "ALTER TABLE dataset_xyz " +
+      "REPLACE COLUMNS (`f1` string, `f2` int, `f3` double, `f4` boolean, `f5` float, `f6` binary)";
+    actual = new AlterStatementBuilder("xyz", "dataset_xyz", true)
+      .buildWithSchema(schema);
+    Assert.assertEquals(expected, actual);
+
+    // escape true, schema given as string
+    expected = "ALTER TABLE dataset_xyz " +
+      "REPLACE COLUMNS (f1 string, f2 int, f3 double)";
+    actual = new AlterStatementBuilder("xyz", "dataset_xyz", true)
+      .buildWithSchema("f1 string, f2 int, f3 double");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testWithFileFormat() throws Exception {
+    String expected = "ALTER TABLE dataset_xyz SET FILEFORMAT TEXTFILE";
+    String actual = new AlterStatementBuilder("xyz", "dataset_xyz", true)
+      .buildWithFileFormat("TEXTFILE");
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testWithDelimiter() throws Exception {
+    String expected = "ALTER TABLE dataset_xyz SET SERDEPROPERTIES ('field.delim'='|')";
+    String actual = new AlterStatementBuilder("xyz", "dataset_xyz", true)
+      .buildWithDelimiter("|");
+    Assert.assertEquals(expected, actual);
+
+    expected = "ALTER TABLE dataset_xyz SET SERDEPROPERTIES ('field.delim'='\\001')";
+    actual = new AlterStatementBuilder("xyz", "dataset_xyz", true)
+      .buildWithDelimiter(null);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testWithFormats() throws Exception {
+    String expected = "ALTER TABLE dataset_xyz SET FILEFORMAT " +
+      "INPUTFORMAT 'org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat' " +
+      "OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat' " +
+      "SERDE 'org.apache.hadoop.hive.serde2.avro.AvroSerDe'";
+    String actual = new AlterStatementBuilder("xyz", "dataset_xyz", true)
+      .buildWithFormats("org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat",
+                        "org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat",
+                        "org.apache.hadoop.hive.serde2.avro.AvroSerDe");
+    Assert.assertEquals(expected, actual);
+  }
+
+
+
+}


### PR DESCRIPTION
This changes the way we update explore when dataset properties are updated. 
- previously, this would disable and then enable explore again. But that loses all existing partitions in Hive
- now we attempt to generate a sequence of ALTER TABLE statements instead. That will preserve the partitions. However, sometimes it is not possible, because Hive limits what can be altered.
- for example, a Hive table with a custom serde cannot be altered. Therefore we still drop/create the Hive table for RecordScannables. 
- but for (partitioned) file sets, we attempt to alter, and if that fails, we leave the Hive table in the state that it is in. 

It is arguable whether we should fail the dataset update if the updateExplore fails. But because we also ignore failures from explore when creating or dropping datasets, this is consistent behavior. 

In follow-up PRs, I am planning to improve this such that:
- we make the Hive table unusable if ALTER fails. That ensures that the user notices the problem
- we provide a tool bring Explore into consistency with the actual dataset by recreating the Hive table and then recreating all partitions. 
