### PR TITLE
Fix DistributedProgramRunnableModule.java to have all necessary bindings

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramRunnableModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramRunnableModule.java
@@ -45,6 +45,7 @@ import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
+import co.cask.cdap.security.guice.SecureStoreModules;
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 import com.google.inject.PrivateModule;
@@ -94,6 +95,7 @@ public class DistributedProgramRunnableModule {
       new NamespaceClientRuntimeModule().getDistributedModules(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getDistributedModules(),
+      new SecureStoreModules().getDistributedModules(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/app/guice/DistributedProgramRunnableModuleTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/app/guice/DistributedProgramRunnableModuleTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.guice;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import com.google.inject.Guice;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+
+/**
+ * Test case that simple creates a Guice injector from the {@link DistributedProgramRunnableModule}, to ensure
+ * that all bindings are proper.
+ */
+public class DistributedProgramRunnableModuleTest {
+  @Test
+  public void createModule() throws Exception {
+    DistributedProgramRunnableModule distributedProgramRunnableModule =
+      new DistributedProgramRunnableModule(CConfiguration.create(), new Configuration());
+    Guice.createInjector(distributedProgramRunnableModule.createModule());
+  }
+}


### PR DESCRIPTION
Fix DistributedProgramRunnableModule.java to have all necessary bindings. Add test case for the module's bindings (which fails without this new binding).

Integration tests were failing without this change: https://builds.cask.co/browse/CDAP-ITN-386

In master logs of failing cluster:
![image](https://cloud.githubusercontent.com/assets/2440977/17053269/18ba308c-4fb6-11e6-86ec-debfbda0efba.png)
