### PR TITLE
CDAP-6615 Add UsageDataset to registry using simple name.

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtil.java
@@ -127,7 +127,7 @@ public final class DatasetsUtil {
         props.remove(Table.PROPERTY_SCHEMA_ROW_FIELD);
 
         // LineageDataset and UsageDataset add the conflict level of none
-      } else if (UsageDataset.class.getName().equals(type) ||
+      } else if (UsageDataset.class.getSimpleName().equals(type) ||
         LineageDataset.class.getName().equals(type) || "lineageDataset".equals(type)) {
         props.remove(Table.PROPERTY_CONFLICT_LEVEL);
       }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/DefaultUsageRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/DefaultUsageRegistry.java
@@ -90,7 +90,7 @@ public class DefaultUsageRegistry implements UsageRegistry {
   private UsageDataset getOrCreateUsageDataset() {
     try {
       return DatasetsUtil.getOrCreateDataset(
-        datasetFramework, USAGE_INSTANCE_ID, UsageDataset.class.getName(),
+        datasetFramework, USAGE_INSTANCE_ID, UsageDataset.class.getSimpleName(),
         DatasetProperties.EMPTY, DatasetDefinition.NO_ARGUMENTS, null);
     } catch (Exception e) {
       throw Throwables.propagate(e);
@@ -282,6 +282,6 @@ public class DefaultUsageRegistry implements UsageRegistry {
    * @param datasetFramework framework to add types and datasets to
    */
   public static void setupDatasets(DatasetFramework datasetFramework) throws IOException, DatasetManagementException {
-    datasetFramework.addInstance(UsageDataset.class.getName(), USAGE_INSTANCE_ID, DatasetProperties.EMPTY);
+    datasetFramework.addInstance(UsageDataset.class.getSimpleName(), USAGE_INSTANCE_ID, DatasetProperties.EMPTY);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageDatasetModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageDatasetModule.java
@@ -40,7 +40,7 @@ public class UsageDatasetModule implements DatasetModule {
   @Override
   public void register(DatasetDefinitionRegistry registry) {
     DatasetDefinition<Table, DatasetAdmin> tableDef = registry.get("table");
-    registry.add(new UsageDatasetDefinition(UsageDataset.class.getName(), tableDef));
+    registry.add(new UsageDatasetDefinition(UsageDataset.class.getSimpleName(), tableDef));
   }
 
   /**

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtilTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtilTest.java
@@ -68,7 +68,7 @@ public class DatasetsUtilTest extends DatasetServiceTestBase {
             DatasetProperties.EMPTY);
     testFix(LineageDataset.class.getName(),
             DatasetProperties.builder().add(Table.PROPERTY_TTL, 1000).build());
-    testFix(UsageDataset.class.getName(), DatasetProperties.EMPTY);
+    testFix(UsageDataset.class.getSimpleName(), DatasetProperties.EMPTY);
 
     testFix("table",
             DatasetProperties.builder().add(Table.PROPERTY_COLUMN_FAMILY, "fam").build());

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/registry/UsageDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/registry/UsageDatasetTest.java
@@ -194,6 +194,6 @@ public class UsageDatasetTest {
   protected static UsageDataset getUsageDataset(String instanceId) throws Exception {
     Id.DatasetInstance id = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, instanceId);
     return DatasetsUtil.getOrCreateDataset(dsFrameworkUtil.getFramework(), id,
-                                           UsageDataset.class.getName(), DatasetProperties.EMPTY, null, null);
+                                           UsageDataset.class.getSimpleName(), DatasetProperties.EMPTY, null, null);
   }
 }


### PR DESCRIPTION
Using `UsageDataset` simple name while adding it to the registry and during upgrade process as well. This is different from other datasets where we use name while adding to the registry.
