### PR TITLE
CDAP-6587 Impersonate users when launching hive queries.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/scheduler/SchedulerQueueResolver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/scheduler/SchedulerQueueResolver.java
@@ -41,7 +41,7 @@ public class SchedulerQueueResolver {
    * Construct SchedulerQueueResolver with CConfiguration and Store.
    */
   @Inject
-  public SchedulerQueueResolver(CConfiguration cConf, NamespaceQueryAdmin namespaceQueryAdmin) {
+  SchedulerQueueResolver(CConfiguration cConf, NamespaceQueryAdmin namespaceQueryAdmin) {
     this.defaultQueue = cConf.get(Constants.AppFabric.APP_SCHEDULER_QUEUE, "");
     this.namespaceQueryAdmin = namespaceQueryAdmin;
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/ImpersonationUserResolver.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/ImpersonationUserResolver.java
@@ -54,8 +54,8 @@ public class ImpersonationUserResolver {
     try {
       meta = namespaceQueryAdmin.get(new NamespaceId(namespacedId.getNamespace()).toId());
     } catch (Exception e) {
-      throw new RuntimeException(
-        String.format("Failed to retrieve namespace meta for namespace id %s", namespacedId.getNamespace()));
+      throw new RuntimeException(String.format("Failed to retrieve namespace meta for namespace id %s",
+                                               namespacedId.getNamespace()), e);
     }
     NamespaceConfig namespaceConfig = meta.getConfig();
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/RemoteUGIProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/RemoteUGIProvider.java
@@ -87,7 +87,7 @@ public class RemoteUGIProvider implements UGIProvider {
   }
 
   private HttpResponse executeRequest(ImpersonationInfo impersonationInfo) {
-    String resolvedUrl = resolve("/impersonation/credentials");
+    String resolvedUrl = resolve("impersonation/credentials");
     try {
       URL url = new URL(resolvedUrl);
       HttpRequest.Builder builder = HttpRequest.post(url).withBody(GSON.toJson(impersonationInfo));

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorHttpHandler.java
@@ -362,7 +362,7 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
       }
       LOG.error("Exception instantiating dataset {}.", datasetId, e);
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,
-        "Exception instantiating dataset " + datasetId);
+                           "Exception instantiating dataset " + datasetId);
       return;
     }
 

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
@@ -20,6 +20,8 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.runtime.RuntimeModule;
 import co.cask.cdap.data2.datafabric.dataset.RemoteDatasetFramework;
+import co.cask.cdap.data2.security.RemoteUGIProvider;
+import co.cask.cdap.data2.security.UGIProvider;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.explore.executor.ExploreExecutorHttpHandler;
 import co.cask.cdap.explore.executor.ExploreExecutorService;
@@ -249,6 +251,8 @@ public class ExploreRuntimeModule extends RuntimeModule {
         File previewDir = Files.createTempDir();
         LOG.info("Storing preview files in {}", previewDir.getAbsolutePath());
         bind(File.class).annotatedWith(Names.named(Constants.Explore.PREVIEWS_DIR_NAME)).toInstance(previewDir);
+
+        bind(UGIProvider.class).to(RemoteUGIProvider.class).in(Scopes.SINGLETON);
       } catch (Throwable e) {
         throw Throwables.propagate(e);
       }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/ActiveOperationRemovalHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/ActiveOperationRemovalHandler.java
@@ -16,13 +16,17 @@
 
 package co.cask.cdap.explore.service.hive;
 
+import co.cask.cdap.data2.security.Impersonator;
 import co.cask.cdap.proto.QueryHandle;
 import co.cask.cdap.proto.QueryStatus;
+import co.cask.cdap.proto.id.NamespaceId;
+import com.google.common.base.Throwables;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -33,10 +37,13 @@ public class ActiveOperationRemovalHandler implements RemovalListener<QueryHandl
 
   private final BaseHiveExploreService exploreService;
   private final ExecutorService executorService;
+  private final Impersonator impersonator;
 
-  public ActiveOperationRemovalHandler(BaseHiveExploreService exploreService, ExecutorService executorService) {
+  public ActiveOperationRemovalHandler(BaseHiveExploreService exploreService, ExecutorService executorService,
+                                       Impersonator impersonator) {
     this.exploreService = exploreService;
     this.executorService = executorService;
+    this.impersonator = impersonator;
   }
 
   @Override
@@ -57,26 +64,38 @@ public class ActiveOperationRemovalHandler implements RemovalListener<QueryHandl
     @Override
     public void run() {
       try {
-        QueryStatus status = exploreService.fetchStatus(opInfo);
+        impersonator.doAs(new NamespaceId(opInfo.getNamespace()), new Callable<Void>() {
+          @Override
+          public Void call() throws Exception {
+            try {
+              QueryStatus status = exploreService.fetchStatus(opInfo);
 
-        // If operation is still not complete, cancel it.
-        if (status.getStatus() != QueryStatus.OpStatus.FINISHED && status.getStatus() != QueryStatus.OpStatus.CLOSED &&
-          status.getStatus() != QueryStatus.OpStatus.CANCELED && status.getStatus() != QueryStatus.OpStatus.ERROR) {
-          LOG.info("Cancelling handle {} with status {} due to timeout", handle.getHandle(), status.getStatus());
-          // This operation is aysnc, except with Hive CDH 4, in which case cancel throws an unsupported exception
-          exploreService.cancelInternal(handle);
-        }
+              // If operation is still not complete, cancel it.
+              if (status.getStatus() != QueryStatus.OpStatus.FINISHED &&
+                status.getStatus() != QueryStatus.OpStatus.CLOSED &&
+                status.getStatus() != QueryStatus.OpStatus.CANCELED &&
+                status.getStatus() != QueryStatus.OpStatus.ERROR) {
+                LOG.info("Cancelling handle {} with status {} due to timeout", handle.getHandle(), status.getStatus());
+                // This operation is aysnc, except with Hive CDH 4, in which case cancel throws an unsupported exception
+                exploreService.cancelInternal(handle);
+              }
 
-      } catch (Throwable e) {
-        LOG.error("Could not cancel handle {} due to exception", handle.getHandle(), e);
-      } finally {
-        LOG.debug("Timing out handle {}", handle);
-        try {
-          // Finally close the operation
-          exploreService.closeInternal(handle, opInfo);
-        } catch (Throwable e) {
-          LOG.error("Exception while closing handle {}", handle, e);
-        }
+            } catch (Throwable e) {
+              LOG.error("Could not cancel handle {} due to exception", handle.getHandle(), e);
+            } finally {
+              LOG.debug("Timing out handle {}", handle);
+              try {
+                // Finally close the operation
+                exploreService.closeInternal(handle, opInfo);
+              } catch (Throwable e) {
+                LOG.error("Exception while closing handle {}", handle, e);
+              }
+            }
+            return null;
+          }
+        });
+      } catch (Exception e) {
+        Throwables.propagate(e);
       }
     }
   }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12CDH5ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12CDH5ExploreService.java
@@ -16,11 +16,12 @@
 
 package co.cask.cdap.explore.service.hive;
 
+import co.cask.cdap.app.runtime.scheduler.SchedulerQueueResolver;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.security.Impersonator;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.HandleNotFoundException;
@@ -62,11 +63,11 @@ public class Hive12CDH5ExploreService extends BaseHiveExploreService {
   protected Hive12CDH5ExploreService(TransactionSystemClient txClient, DatasetFramework datasetFramework,
                                      CConfiguration cConf, Configuration hConf,
                                      @Named(Constants.Explore.PREVIEWS_DIR_NAME) File previewsDir,
-                                     StreamAdmin streamAdmin, NamespaceQueryAdmin namespaceQueryAdmin,
+                                     StreamAdmin streamAdmin, SchedulerQueueResolver schedulerQueueResolver,
                                      SystemDatasetInstantiatorFactory datasetInstantiatorFactory,
-                                     ExploreTableNaming tableNaming) {
+                                     ExploreTableNaming tableNaming, Impersonator impersonator) {
     super(txClient, datasetFramework, cConf, hConf, previewsDir,
-          streamAdmin, namespaceQueryAdmin, datasetInstantiatorFactory, tableNaming);
+          streamAdmin, schedulerQueueResolver, datasetInstantiatorFactory, tableNaming, impersonator);
   }
 
   @Override

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12ExploreService.java
@@ -16,11 +16,12 @@
 
 package co.cask.cdap.explore.service.hive;
 
+import co.cask.cdap.app.runtime.scheduler.SchedulerQueueResolver;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.security.Impersonator;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.HandleNotFoundException;
@@ -71,11 +72,11 @@ public class Hive12ExploreService extends BaseHiveExploreService {
   public Hive12ExploreService(TransactionSystemClient txClient, DatasetFramework datasetFramework,
                               CConfiguration cConf, Configuration hConf,
                               @Named(Constants.Explore.PREVIEWS_DIR_NAME) File previewsDir,
-                              StreamAdmin streamAdmin, NamespaceQueryAdmin namespaceQueryAdmin,
+                              StreamAdmin streamAdmin, SchedulerQueueResolver schedulerQueueResolver,
                               SystemDatasetInstantiatorFactory datasetInstantiatorFactory,
-                              ExploreTableNaming tableNaming) {
+                              ExploreTableNaming tableNaming, Impersonator impersonator) {
     super(txClient, datasetFramework, cConf, hConf, previewsDir,
-          streamAdmin, namespaceQueryAdmin, datasetInstantiatorFactory, tableNaming);
+          streamAdmin, schedulerQueueResolver, datasetInstantiatorFactory, tableNaming, impersonator);
   }
 
   @Override

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive13ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive13ExploreService.java
@@ -16,11 +16,12 @@
 
 package co.cask.cdap.explore.service.hive;
 
+import co.cask.cdap.app.runtime.scheduler.SchedulerQueueResolver;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.security.Impersonator;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.HandleNotFoundException;
@@ -56,11 +57,11 @@ public class Hive13ExploreService extends BaseHiveExploreService {
   public Hive13ExploreService(TransactionSystemClient txClient, DatasetFramework datasetFramework,
                               CConfiguration cConf, Configuration hConf,
                               @Named(Constants.Explore.PREVIEWS_DIR_NAME) File previewsDir,
-                              StreamAdmin streamAdmin, NamespaceQueryAdmin namespaceQueryAdmin,
+                              StreamAdmin streamAdmin, SchedulerQueueResolver schedulerQueueResolver,
                               SystemDatasetInstantiatorFactory datasetInstantiatorFactory,
-                              ExploreTableNaming tableNaming) {
+                              ExploreTableNaming tableNaming, Impersonator impersonator) {
     super(txClient, datasetFramework, cConf, hConf, previewsDir,
-          streamAdmin, namespaceQueryAdmin, datasetInstantiatorFactory, tableNaming);
+          streamAdmin, schedulerQueueResolver, datasetInstantiatorFactory, tableNaming, impersonator);
     // This config sets the time Hive CLI getOperationStatus method will wait for the status of
     // a running query.
     System.setProperty(HiveConf.ConfVars.HIVE_SERVER2_LONG_POLLING_TIMEOUT.toString(), "50");

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive14ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive14ExploreService.java
@@ -16,11 +16,12 @@
 
 package co.cask.cdap.explore.service.hive;
 
+import co.cask.cdap.app.runtime.scheduler.SchedulerQueueResolver;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.security.Impersonator;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.HandleNotFoundException;
@@ -55,11 +56,11 @@ public class Hive14ExploreService extends BaseHiveExploreService {
   public Hive14ExploreService(TransactionSystemClient txClient, DatasetFramework datasetFramework,
                               CConfiguration cConf, Configuration hConf,
                               @Named(Constants.Explore.PREVIEWS_DIR_NAME) File previewsDir,
-                              StreamAdmin streamAdmin, NamespaceQueryAdmin namespaceQueryAdmin,
+                              StreamAdmin streamAdmin, SchedulerQueueResolver schedulerQueueResolver,
                               SystemDatasetInstantiatorFactory datasetInstantiatorFactory,
-                              ExploreTableNaming tableNaming) {
+                              ExploreTableNaming tableNaming, Impersonator impersonator) {
     super(txClient, datasetFramework, cConf, hConf, previewsDir,
-          streamAdmin, namespaceQueryAdmin, datasetInstantiatorFactory, tableNaming);
+          streamAdmin, schedulerQueueResolver, datasetInstantiatorFactory, tableNaming, impersonator);
     // This config sets the time Hive CLI getOperationStatus method will wait for the status of
     // a running query.
     System.setProperty(HiveConf.ConfVars.HIVE_SERVER2_LONG_POLLING_TIMEOUT.toString(), "50");

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ExploreServiceTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ExploreServiceTwillRunnable.java
@@ -34,8 +34,6 @@ import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.stream.StreamAdminModules;
 import co.cask.cdap.data.view.ViewAdminModules;
 import co.cask.cdap.data2.audit.AuditModule;
-import co.cask.cdap.data2.security.RemoteUGIProvider;
-import co.cask.cdap.data2.security.UGIProvider;
 import co.cask.cdap.explore.executor.ExploreExecutorService;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.explore.guice.ExploreRuntimeModule;
@@ -53,7 +51,6 @@ import com.google.common.util.concurrent.Service;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import com.google.inject.Scopes;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.twill.api.TwillContext;
 import org.apache.twill.kafka.client.KafkaClientService;
@@ -124,6 +121,7 @@ public class ExploreServiceTwillRunnable extends AbstractMasterTwillRunnable {
       new DataFabricModules().getDistributedModules(),
       new DataSetsModules().getDistributedModules(),
       new LoggingModules().getDistributedModules(),
+      new NamespaceClientRuntimeModule().getDistributedModules(),
       new ExploreRuntimeModule().getDistributedModules(),
       new ExploreClientModule(),
       new ViewAdminModules().getDistributedModules(),
@@ -136,7 +134,6 @@ public class ExploreServiceTwillRunnable extends AbstractMasterTwillRunnable {
         protected void configure() {
           bind(Store.class).to(DefaultStore.class);
           bind(NamespaceStore.class).to(DefaultNamespaceStore.class);
-          bind(UGIProvider.class).to(RemoteUGIProvider.class).in(Scopes.SINGLETON);
         }
       });
   }


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-6587
http://builds.cask.co/browse/CDAP-DUT4487-2
Integration tests: http://builds.cask.co/browse/CDAP-ITM-26

Wrap the methods calling CLIService with an Impersonator#doAs.
Some methods aren't possible to be wrapped in a doAs, because they do not operate in a namespace. Example: `BaseHiveExploreService#getInfo(MetaDataInfo.InfoType)`
