### PR TITLE
(CDAP-888) Added authorization in Dataset Type Handler.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -238,6 +238,8 @@ public final class DefaultNamespaceAdmin extends DefaultNamespaceQueryAdmin impl
     } catch (Exception e) {
       LOG.warn("Error while deleting namespace {}", namespaceId, e);
       throw new NamespaceCannotBeDeletedException(namespaceId, e);
+    } finally {
+      authorizerInstantiator.get().revoke(namespace);
     }
     LOG.info("All data for namespace '{}' deleted.", namespaceId);
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/DatasetModuleCannotBeDeletedException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/DatasetModuleCannotBeDeletedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,7 @@
 package co.cask.cdap.common;
 
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetModuleId;
 
 /**
  * Thrown when a dataset module cannot be deleted.
@@ -28,6 +29,11 @@ public class DatasetModuleCannotBeDeletedException extends CannotBeDeletedExcept
   public DatasetModuleCannotBeDeletedException(Id.DatasetModule id) {
     super(id);
     this.id = id;
+  }
+
+  public DatasetModuleCannotBeDeletedException(DatasetModuleId datasetModuleId, String reason) {
+    super(datasetModuleId.toId(), reason);
+    this.id = datasetModuleId.toId();
   }
 
   public Id.DatasetModule getId() {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -146,6 +146,7 @@ class DatasetServiceClient {
     return GSON.fromJson(response.getResponseBodyAsString(), MODULE_META_LIST_TYPE);
   }
 
+  @Nullable
   public DatasetTypeMeta getType(String typeName) throws DatasetManagementException {
     HttpResponse response = doGet("types/" + typeName);
     if (HttpResponseStatus.NOT_FOUND.getCode() == response.getResponseCode()) {
@@ -319,6 +320,7 @@ class DatasetServiceClient {
     if (NamespaceId.SYSTEM.equals(namespaceId)) {
       // For getting a system dataset like MDS, use the system principal. It is ok to do so, since DatasetServiceClient
       // is an internal client that is not exposed to users.
+      // TODO: CDAP-6583: This is dangerous. Remove.
       userId = Principal.SYSTEM.getName();
     } else {
       // If the request originated from the router and was forwarded to any service other than dataset service, before
@@ -326,6 +328,7 @@ class DatasetServiceClient {
       // e.g. deploying an app that contains a dataset
       // For user datasets, if a dataset call is happening from a program runtime, then find the userId from
       // UserGroupInformation#getCurrentUser()
+
       userId = authenticationContext.getPrincipal().getName();
     }
     return builder.addHeader(Constants.Security.Headers.USER_ID, userId);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetService.java
@@ -22,8 +22,6 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.ResolvingDiscoverable;
 import co.cask.cdap.common.http.CommonNettyHttpServiceBuilder;
 import co.cask.cdap.common.metrics.MetricsReporterHook;
-import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
-import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.service.UncaughtExceptionIdleService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetTypeManager;
@@ -73,20 +71,18 @@ public class DatasetService extends AbstractExecutionThreadService {
 
   @Inject
   public DatasetService(CConfiguration cConf,
-                        NamespacedLocationFactory namespacedLocationFactory,
                         DiscoveryService discoveryService,
                         DiscoveryServiceClient discoveryServiceClient,
                         DatasetTypeManager typeManager,
                         MetricsCollectionService metricsCollectionService,
                         DatasetOpExecutor opExecutorClient,
                         Set<DatasetMetricsReporter> metricReporters,
+                        DatasetTypeService datasetTypeService,
                         DatasetInstanceService datasetInstanceService,
-                        NamespaceQueryAdmin namespaceQueryAdmin,
                         AuthorizationEnforcementService authorizationEnforcementService) throws Exception {
     this.typeManager = typeManager;
     this.authorizationEnforcementService = authorizationEnforcementService;
-    DatasetTypeHandler datasetTypeHandler = new DatasetTypeHandler(typeManager, cConf, namespacedLocationFactory,
-                                                                   namespaceQueryAdmin);
+    DatasetTypeHandler datasetTypeHandler = new DatasetTypeHandler(datasetTypeService);
     DatasetInstanceHandler datasetInstanceHandler = new DatasetInstanceHandler(datasetInstanceService);
     NettyHttpService.Builder builder = new CommonNettyHttpServiceBuilder(cConf);
     builder.addHttpHandlers(ImmutableList.of(datasetTypeHandler,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeHandler.java
@@ -16,37 +16,18 @@
 
 package co.cask.cdap.data2.datafabric.dataset.service;
 
-import co.cask.cdap.common.NamespaceNotFoundException;
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.http.AbstractBodyConsumer;
-import co.cask.cdap.common.io.Locations;
-import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
-import co.cask.cdap.common.namespace.NamespacedLocationFactory;
-import co.cask.cdap.common.utils.DirUtils;
-import co.cask.cdap.data2.datafabric.dataset.type.DatasetModuleConflictException;
-import co.cask.cdap.data2.datafabric.dataset.type.DatasetTypeManager;
-import co.cask.cdap.proto.DatasetModuleMeta;
-import co.cask.cdap.proto.DatasetTypeMeta;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.BodyConsumer;
 import co.cask.http.HandlerContext;
 import co.cask.http.HttpResponder;
-import com.google.common.collect.Lists;
-import com.google.common.io.Files;
 import com.google.inject.Inject;
-import org.apache.twill.filesystem.Location;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
@@ -65,18 +46,11 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(DatasetTypeHandler.class);
 
-  private final DatasetTypeManager typeManager;
-  private final CConfiguration cConf;
-  private final NamespacedLocationFactory namespacedLocationFactory;
-  private final NamespaceQueryAdmin namespaceQueryAdmin;
+  private final DatasetTypeService typeService;
 
   @Inject
-  DatasetTypeHandler(DatasetTypeManager typeManager, CConfiguration conf,
-                     NamespacedLocationFactory namespacedLocationFactory, NamespaceQueryAdmin namespaceQueryAdmin) {
-    this.typeManager = typeManager;
-    this.cConf = conf;
-    this.namespacedLocationFactory = namespacedLocationFactory;
-    this.namespaceQueryAdmin = namespaceQueryAdmin;
+  DatasetTypeHandler(DatasetTypeService typeService) {
+    this.typeService = typeService;
   }
 
   @Override
@@ -93,38 +67,15 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
   @Path("/data/modules")
   public void listModules(HttpRequest request, HttpResponder responder,
                           @PathParam("namespace-id") String namespaceId) throws Exception {
-    Id.Namespace namespace = Id.Namespace.from(namespaceId);
-    // Throws NamespaceNotFoundException if the namespace does not exist
-    ensureNamespaceExists(namespace);
-    // Sorting by name for convenience
-    List<DatasetModuleMeta> list = Lists.newArrayList(typeManager.getModules(namespace));
-    Collections.sort(list, new Comparator<DatasetModuleMeta>() {
-      @Override
-      public int compare(DatasetModuleMeta o1, DatasetModuleMeta o2) {
-        return o1.getName().compareTo(o2.getName());
-      }
-    });
-    responder.sendJson(HttpResponseStatus.OK, list);
+    responder.sendJson(HttpResponseStatus.OK, typeService.listModules(new NamespaceId(namespaceId)));
   }
 
   @DELETE
   @Path("/data/modules")
   public void deleteModules(HttpRequest request, HttpResponder responder,
                             @PathParam("namespace-id") String namespaceId) throws Exception {
-    Id.Namespace namespace = Id.Namespace.from(namespaceId);
-    if (Id.Namespace.SYSTEM.equals(namespace)) {
-      responder.sendString(HttpResponseStatus.FORBIDDEN,
-                           String.format("Cannot delete modules from '%s' namespace.", namespaceId));
-      return;
-    }
-    // Throws NamespaceNotFoundException if the namespace does not exist
-    ensureNamespaceExists(namespace);
-    try {
-      typeManager.deleteModules(namespace);
-      responder.sendStatus(HttpResponseStatus.OK);
-    } catch (DatasetModuleConflictException e) {
-      responder.sendString(HttpResponseStatus.CONFLICT, e.getMessage());
-    }
+    typeService.deleteAll(new NamespaceId(namespaceId));
+    responder.sendStatus(HttpResponseStatus.OK);
   }
 
   @PUT
@@ -133,92 +84,7 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
                                 @PathParam("namespace-id") String namespaceId, @PathParam("name") final String name,
                                 @QueryParam("force") final boolean forceUpdate,
                                 @HeaderParam(HEADER_CLASS_NAME) final String className) throws Exception {
-    Id.Namespace namespace = Id.Namespace.from(namespaceId);
-    if (Id.Namespace.SYSTEM.equals(namespace)) {
-      responder.sendString(HttpResponseStatus.FORBIDDEN,
-                           String.format("Cannot add module to '%s' namespace.", namespaceId));
-      return null;
-    }
-    // Throws NamespaceNotFoundException if the namespace does not exist
-    ensureNamespaceExists(namespace);
-    // verify namespace directory exists
-    final Location namespaceHomeLocation = namespacedLocationFactory.get(namespace);
-    if (!namespaceHomeLocation.exists()) {
-      String msg = String.format("Home directory %s for namespace %s not found",
-                                 namespaceHomeLocation, namespaceId);
-      LOG.error(msg);
-      responder.sendString(HttpResponseStatus.NOT_FOUND, msg);
-      return null;
-    }
-
-    // Store uploaded content to a local temp file
-    String namespacesDir = cConf.get(Constants.Namespace.NAMESPACES_DIR);
-    File localDataDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR));
-    File namespaceBase = new File(localDataDir, namespacesDir);
-    File tempDir = new File(new File(namespaceBase, namespaceId),
-                            cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
-    if (!DirUtils.mkdirs(tempDir)) {
-      throw new IOException("Could not create temporary directory at: " + tempDir);
-    }
-
-    final Id.DatasetModule datasetModuleId = Id.DatasetModule.from(namespace, name);
-
-    return new AbstractBodyConsumer(File.createTempFile("dataset-", ".jar", tempDir)) {
-      @Override
-      protected void onFinish(HttpResponder responder, File uploadedFile) throws Exception {
-        if (className == null) {
-          // We have to delay until body upload is completed due to the fact that not all client is
-          // requesting with "Expect: 100-continue" header and the client library we have cannot handle
-          // connection close, and yet be able to read response reliably.
-          // In longer term we should fix the client, as well as the netty-http server. However, since
-          // this handler will be gone in near future, it's ok to have this workaround.
-          responder.sendString(HttpResponseStatus.BAD_REQUEST, "Required header 'class-name' is absent.");
-          return;
-        }
-
-        LOG.info("Adding module {}, class name: {}", datasetModuleId, className);
-
-        String dataFabricDir = cConf.get(Constants.Dataset.Manager.OUTPUT_DIR);
-        Location archiveDir = namespaceHomeLocation.append(dataFabricDir).append(name)
-          .append(Constants.ARCHIVE_DIR);
-        String archiveName = name + ".jar";
-        Location archive = archiveDir.append(archiveName);
-
-        // Copy uploaded content to a temporary location
-        Location tmpLocation = archive.getTempFile(".tmp");
-        try {
-          Locations.mkdirsIfNotExists(archiveDir);
-
-          LOG.debug("Copy from {} to {}", uploadedFile, tmpLocation);
-          Files.copy(uploadedFile, Locations.newOutputSupplier(tmpLocation));
-
-          // Finally, move archive to final location
-          LOG.debug("Storing module {} jar at {}", datasetModuleId, archive);
-          if (tmpLocation.renameTo(archive) == null) {
-            throw new IOException(String.format("Could not move archive from location: %s, to location: %s",
-                                                tmpLocation, archive));
-          }
-
-          typeManager.addModule(datasetModuleId, className, archive, forceUpdate);
-          // todo: response with DatasetModuleMeta of just added module (and log this info)
-          LOG.info("Added module {}", datasetModuleId);
-          responder.sendStatus(HttpResponseStatus.OK);
-        } catch (Exception e) {
-          // In case copy to temporary file failed, or rename failed
-          try {
-            tmpLocation.delete();
-          } catch (IOException ex) {
-            LOG.warn("Failed to cleanup temporary location {}", tmpLocation);
-          }
-          if (e instanceof DatasetModuleConflictException) {
-            responder.sendString(HttpResponseStatus.CONFLICT, e.getMessage());
-          } else {
-            LOG.error("Failed to add module {}", name, e);
-            throw e;
-          }
-        }
-      }
-    };
+    return typeService.addModule(new NamespaceId(namespaceId).datasetModule(name), className, forceUpdate);
   }
 
   @DELETE
@@ -226,27 +92,7 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
   public void deleteModule(HttpRequest request, HttpResponder responder,
                            @PathParam("namespace-id") String namespaceId,
                            @PathParam("name") String name) throws Exception {
-    Id.Namespace namespace = Id.Namespace.from(namespaceId);
-    if (Id.Namespace.SYSTEM.equals(namespace)) {
-      responder.sendString(HttpResponseStatus.FORBIDDEN,
-                           String.format("Cannot delete module '%s' from '%s' namespace.", name, namespaceId));
-      return;
-    }
-    // Throws NamespaceNotFoundException if the namespace does not exist
-    ensureNamespaceExists(namespace);
-    boolean deleted;
-    try {
-      deleted = typeManager.deleteModule(Id.DatasetModule.from(namespace, name));
-    } catch (DatasetModuleConflictException e) {
-      responder.sendString(HttpResponseStatus.CONFLICT, e.getMessage());
-      return;
-    }
-
-    if (!deleted) {
-      responder.sendStatus(HttpResponseStatus.NOT_FOUND);
-      return;
-    }
-
+    typeService.delete(new NamespaceId(namespaceId).datasetModule(name));
     responder.sendStatus(HttpResponseStatus.OK);
   }
 
@@ -255,33 +101,14 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
   public void getModuleInfo(HttpRequest request, HttpResponder responder,
                             @PathParam("namespace-id") String namespaceId,
                             @PathParam("name") String name) throws Exception {
-    Id.Namespace namespace = Id.Namespace.from(namespaceId);
-    // Throws NamespaceNotFoundException if the namespace does not exist
-    ensureNamespaceExists(namespace);
-    DatasetModuleMeta moduleMeta = typeManager.getModule(Id.DatasetModule.from(namespace, name));
-    if (moduleMeta == null) {
-      responder.sendStatus(HttpResponseStatus.NOT_FOUND);
-    } else {
-      responder.sendJson(HttpResponseStatus.OK, moduleMeta);
-    }
+    responder.sendJson(HttpResponseStatus.OK, typeService.getModule(new NamespaceId(namespaceId).datasetModule(name)));
   }
 
   @GET
   @Path("/data/types")
   public void listTypes(HttpRequest request, HttpResponder responder,
                         @PathParam("namespace-id") String namespaceId) throws Exception {
-    Id.Namespace namespace = Id.Namespace.from(namespaceId);
-    // Throws NamespaceNotFoundException if the namespace does not exist
-    ensureNamespaceExists(namespace);
-    // Sorting by name for convenience
-    List<DatasetTypeMeta> list = Lists.newArrayList(typeManager.getTypes(namespace));
-    Collections.sort(list, new Comparator<DatasetTypeMeta>() {
-      @Override
-      public int compare(DatasetTypeMeta o1, DatasetTypeMeta o2) {
-        return o1.getName().compareTo(o2.getName());
-      }
-    });
-    responder.sendJson(HttpResponseStatus.OK, list);
+    responder.sendJson(HttpResponseStatus.OK, typeService.listTypes(new NamespaceId(namespaceId)));
   }
 
   @GET
@@ -289,25 +116,6 @@ public class DatasetTypeHandler extends AbstractHttpHandler {
   public void getTypeInfo(HttpRequest request, HttpResponder responder,
                           @PathParam("namespace-id") String namespaceId,
                           @PathParam("name") String name) throws Exception {
-    Id.Namespace namespace = Id.Namespace.from(namespaceId);
-    // Throws NamespaceNotFoundException if the namespace does not exist
-    ensureNamespaceExists(namespace);
-    DatasetTypeMeta typeMeta = typeManager.getTypeInfo(Id.DatasetType.from(namespace, name));
-    if (typeMeta == null) {
-      responder.sendStatus(HttpResponseStatus.NOT_FOUND);
-    } else {
-      responder.sendJson(HttpResponseStatus.OK, typeMeta);
-    }
-  }
-
-  /**
-   * Throws an exception if the specified namespace is not the system namespace and does not exist
-   */
-  private void ensureNamespaceExists(Id.Namespace namespace) throws Exception {
-    if (!Id.Namespace.SYSTEM.equals(namespace)) {
-      if (namespaceQueryAdmin.get(namespace) == null) {
-        throw new NamespaceNotFoundException(namespace);
-      }
-    }
+    responder.sendJson(HttpResponseStatus.OK, typeService.getType(new NamespaceId(namespaceId).datasetType(name)));
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeService.java
@@ -1,0 +1,416 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.datafabric.dataset.service;
+
+import co.cask.cdap.api.Predicate;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.dataset.module.DatasetType;
+import co.cask.cdap.common.ConflictException;
+import co.cask.cdap.common.DatasetModuleCannotBeDeletedException;
+import co.cask.cdap.common.DatasetModuleNotFoundException;
+import co.cask.cdap.common.DatasetTypeNotFoundException;
+import co.cask.cdap.common.NamespaceNotFoundException;
+import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.http.AbstractBodyConsumer;
+import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
+import co.cask.cdap.common.namespace.NamespacedLocationFactory;
+import co.cask.cdap.common.utils.DirUtils;
+import co.cask.cdap.data2.datafabric.dataset.type.DatasetModuleConflictException;
+import co.cask.cdap.data2.datafabric.dataset.type.DatasetTypeManager;
+import co.cask.cdap.proto.DatasetModuleMeta;
+import co.cask.cdap.proto.DatasetTypeMeta;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetModuleId;
+import co.cask.cdap.proto.id.DatasetTypeId;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.security.authorization.AuthorizerInstantiator;
+import co.cask.cdap.security.spi.authentication.AuthenticationContext;
+import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
+import co.cask.cdap.security.spi.authorization.Authorizer;
+import co.cask.cdap.security.spi.authorization.UnauthorizedException;
+import co.cask.http.BodyConsumer;
+import co.cask.http.HttpResponder;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.io.Files;
+import com.google.inject.Inject;
+import org.apache.twill.filesystem.Location;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * Manages lifecycle of dataset {@link DatasetType types} and {@link DatasetModule modules}.
+ */
+public class DatasetTypeService {
+  private static final Logger LOG = LoggerFactory.getLogger(DatasetTypeService.class);
+
+  private final DatasetTypeManager typeManager;
+  private final NamespaceQueryAdmin namespaceQueryAdmin;
+  private final NamespacedLocationFactory namespacedLocationFactory;
+  private final AuthorizationEnforcer authorizationEnforcer;
+  private final Authorizer authorizer;
+  private final AuthenticationContext authenticationContext;
+  private final CConfiguration cConf;
+
+  @Inject
+  @VisibleForTesting
+  public DatasetTypeService(DatasetTypeManager typeManager, NamespaceQueryAdmin namespaceQueryAdmin,
+                            NamespacedLocationFactory namespacedLocationFactory,
+                            AuthorizationEnforcer authorizationEnforcer,
+                            AuthorizerInstantiator authorizerInstantiator, AuthenticationContext authenticationContext,
+                            CConfiguration cConf) {
+    this.typeManager = typeManager;
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
+    this.namespacedLocationFactory = namespacedLocationFactory;
+    this.authorizationEnforcer = authorizationEnforcer;
+    this.authorizer = authorizerInstantiator.get();
+    this.authenticationContext = authenticationContext;
+    this.cConf = cConf;
+  }
+
+  /**
+   * Returns all {@link DatasetModuleMeta dataset modules} in the specified {@link NamespaceId namespace}.
+   */
+  List<DatasetModuleMeta> listModules(final NamespaceId namespaceId) throws Exception {
+    ensureNamespaceExists(namespaceId);
+    // Sorting by name for convenience
+    List<DatasetModuleMeta> allModules = Lists.newArrayList(typeManager.getModules(namespaceId.toId()));
+    Collections.sort(allModules, new Comparator<DatasetModuleMeta>() {
+      @Override
+      public int compare(DatasetModuleMeta o1, DatasetModuleMeta o2) {
+        return o1.getName().compareTo(o2.getName());
+      }
+    });
+
+    Principal principal = authenticationContext.getPrincipal();
+    final Predicate<EntityId> authFilter = authorizationEnforcer.createFilter(principal);
+    Iterable<DatasetModuleMeta> authorizedDatasetModules =
+      Iterables.filter(allModules, new com.google.common.base.Predicate<DatasetModuleMeta>() {
+        @Override
+        public boolean apply(DatasetModuleMeta datasetModuleMeta) {
+          return authFilter.apply(namespaceId.datasetModule(datasetModuleMeta.getName()));
+        }
+      });
+    return Lists.newArrayList(authorizedDatasetModules);
+  }
+
+  /**
+   * Returns the {@link DatasetModuleMeta metadata} of the specified {@link DatasetModuleId}.
+   */
+  DatasetModuleMeta getModule(DatasetModuleId datasetModuleId) throws Exception {
+    ensureNamespaceExists(datasetModuleId.getParent());
+    Id.DatasetModule moduleId = datasetModuleId.toId();
+    DatasetModuleMeta moduleMeta = typeManager.getModule(moduleId);
+    if (moduleMeta == null) {
+      throw new DatasetModuleNotFoundException(moduleId);
+    }
+    Principal principal = authenticationContext.getPrincipal();
+    final Predicate<EntityId> filter = authorizationEnforcer.createFilter(principal);
+    if (!Principal.SYSTEM.equals(principal) && !filter.apply(datasetModuleId)) {
+      throw new UnauthorizedException(principal, datasetModuleId);
+    }
+    return moduleMeta;
+  }
+
+  /**
+   * Adds a new {@link DatasetModule}.
+   *
+   * @param datasetModuleId the {@link DatasetModuleId} for the module to be added
+   * @param className the module class name specified in the HTTP header
+   * @param forceUpdate if true, an update will be allowed even if there are conflicts with other modules, or if
+   *                     removal of a type would break other modules' dependencies
+   * @return a {@link BodyConsumer} to upload the module jar in chunks
+   * @throws NotFoundException if the namespace in which the module is being added is not found
+   * @throws IOException if there are issues while performing I/O like creating temporary directories, moving/unpacking
+   *                      module jar files
+   * @throws DatasetModuleConflictException if #forceUpdate is {@code false}, and there are conflicts with other modules
+   */
+  BodyConsumer addModule(final DatasetModuleId datasetModuleId, final String className,
+                         final boolean forceUpdate) throws Exception {
+    NamespaceId namespaceId = datasetModuleId.getParent();
+    final Principal principal = authenticationContext.getPrincipal();
+    // enforce that the principal has WRITE access on the namespace
+    authorizationEnforcer.enforce(namespaceId, principal, Action.WRITE);
+    if (NamespaceId.SYSTEM.equals(namespaceId)) {
+      throw new UnauthorizedException(String.format("Cannot add module '%s' to '%s' namespace.",
+                                                    datasetModuleId.getModule(), datasetModuleId.getNamespace()));
+    }
+    ensureNamespaceExists(namespaceId);
+
+    // It is now determined that a new dataset module will be deployed. First grant privileges, then deploy the module.
+    // If creation fails, revoke the granted privileges. This ensures that just like delete, there may be orphaned
+    // privileges in rare scenarios, but there can never be orphaned datasets.
+    // If the module previously existed and was deleted, but revoking privileges somehow failed, there may be orphaned
+    // privileges for the module. Revoke them first, so no users unintentionally get privileges on the dataset.
+    revokeAllPrivilegesOnModule(datasetModuleId);
+    grantAllPrivilegesOnModule(datasetModuleId, principal);
+    try {
+      return createModuleConsumer(datasetModuleId, className, forceUpdate, principal);
+    } catch (Exception e) {
+      revokeAllPrivilegesOnModule(datasetModuleId);
+      throw e;
+    }
+  }
+
+  /**
+   * Deletes the specified {@link DatasetModuleId}
+   */
+  void delete(DatasetModuleId datasetModuleId) throws Exception {
+    NamespaceId namespaceId = datasetModuleId.getParent();
+    if (NamespaceId.SYSTEM.equals(namespaceId)) {
+      throw new UnauthorizedException(String.format("Cannot delete module '%s' from '%s' namespace.",
+                                                    datasetModuleId.getModule(), datasetModuleId.getNamespace()));
+    }
+    ensureNamespaceExists(namespaceId);
+
+    Id.DatasetModule module = datasetModuleId.toId();
+    DatasetModuleMeta moduleMeta = typeManager.getModule(module);
+    if (moduleMeta == null) {
+      throw new DatasetModuleNotFoundException(module);
+    }
+
+    Principal principal = authenticationContext.getPrincipal();
+    authorizationEnforcer.enforce(datasetModuleId, principal, Action.ADMIN);
+
+    try {
+      typeManager.deleteModule(module);
+    } catch (DatasetModuleConflictException e) {
+      throw new DatasetModuleCannotBeDeletedException(datasetModuleId, e.getMessage());
+    }
+
+    // revoke all privileges on the module to be deleted
+    revokeAllPrivilegesOnModule(datasetModuleId, moduleMeta);
+  }
+
+  /**
+   * Deletes all {@link DatasetModuleMeta dataset modules} in the specified {@link NamespaceId namespace}.
+   */
+  void deleteAll(NamespaceId namespaceId) throws Exception {
+    Principal principal = authenticationContext.getPrincipal();
+    authorizationEnforcer.enforce(namespaceId, principal, Action.ADMIN);
+
+    if (NamespaceId.SYSTEM.equals(namespaceId)) {
+      throw new UnauthorizedException(String.format("Cannot delete modules from '%s' namespace.", namespaceId));
+    }
+    ensureNamespaceExists(namespaceId);
+
+    // revoke all privileges on all modules
+    Id.Namespace namespace = namespaceId.toId();
+    for (DatasetModuleMeta meta : typeManager.getModules(namespace)) {
+      authorizer.revoke(namespaceId.datasetModule(meta.getName()));
+    }
+    try {
+      typeManager.deleteModules(namespace);
+    } catch (DatasetModuleConflictException e) {
+      throw new ConflictException(e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Lists all {@link DatasetType dataset types} in the specified {@link NamespaceId}.
+   */
+  List<DatasetTypeMeta> listTypes(final NamespaceId namespaceId) throws Exception {
+    ensureNamespaceExists(namespaceId);
+    // Sorting by name for convenience
+    List<DatasetTypeMeta> allTypes = Lists.newArrayList(typeManager.getTypes(namespaceId.toId()));
+    Collections.sort(allTypes, new Comparator<DatasetTypeMeta>() {
+      @Override
+      public int compare(DatasetTypeMeta o1, DatasetTypeMeta o2) {
+        return o1.getName().compareTo(o2.getName());
+      }
+    });
+
+    Principal principal = authenticationContext.getPrincipal();
+    final Predicate<EntityId> authFilter = authorizationEnforcer.createFilter(principal);
+    Iterable<DatasetTypeMeta> authorizedDatasetTypes =
+      Iterables.filter(allTypes, new com.google.common.base.Predicate<DatasetTypeMeta>() {
+        @Override
+        public boolean apply(DatasetTypeMeta datasetTypeMeta) {
+          DatasetTypeId datasetTypeId = namespaceId.datasetType(datasetTypeMeta.getName());
+          return authFilter.apply(datasetTypeId);
+        }
+      });
+    return Lists.newArrayList(authorizedDatasetTypes);
+  }
+
+  /**
+   * Returns details of the specified {@link DatasetTypeId dataset type}.
+   */
+  DatasetTypeMeta getType(DatasetTypeId datasetTypeId) throws Exception {
+    ensureNamespaceExists(datasetTypeId.getParent());
+    Id.DatasetType datasetType = datasetTypeId.toId();
+    DatasetTypeMeta typeMeta = typeManager.getTypeInfo(datasetType);
+    if (typeMeta == null) {
+      throw new DatasetTypeNotFoundException(datasetType);
+    }
+
+    // only return the type if the user has some privileges on it
+    Principal principal = authenticationContext.getPrincipal();
+    Predicate<EntityId> authFilter = authorizationEnforcer.createFilter(principal);
+    if (!Principal.SYSTEM.equals(principal) && !authFilter.apply(datasetTypeId)) {
+      throw new UnauthorizedException(principal, datasetTypeId);
+    }
+    return typeMeta;
+  }
+
+  private AbstractBodyConsumer createModuleConsumer(final DatasetModuleId datasetModuleId,
+                                                    final String className, final boolean forceUpdate,
+                                                    final Principal principal) throws IOException, NotFoundException {
+    NamespaceId namespaceId = datasetModuleId.getParent();
+    // verify namespace directory exists
+    final Location namespaceHomeLocation = namespacedLocationFactory.get(namespaceId.toId());
+    if (!namespaceHomeLocation.exists()) {
+      String msg = String.format("Home directory %s for namespace %s not found", namespaceHomeLocation, namespaceId);
+      LOG.debug(msg);
+      throw new NotFoundException(msg);
+    }
+
+    // Store uploaded content to a local temp file
+    String namespacesDir = cConf.get(Constants.Namespace.NAMESPACES_DIR);
+    File localDataDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR));
+    File namespaceBase = new File(localDataDir, namespacesDir);
+    File tempDir = new File(new File(namespaceBase, datasetModuleId.getNamespace()),
+                            cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
+    if (!DirUtils.mkdirs(tempDir)) {
+      throw new IOException("Could not create temporary directory at: " + tempDir);
+    }
+
+    return new AbstractBodyConsumer(File.createTempFile("dataset-", ".jar", tempDir)) {
+      @Override
+      protected void onFinish(HttpResponder responder, File uploadedFile) throws Exception {
+        if (className == null) {
+          // We have to delay until body upload is completed due to the fact that not all client is
+          // requesting with "Expect: 100-continue" header and the client library we have cannot handle
+          // connection close, and yet be able to read response reliably.
+          // In longer term we should fix the client, as well as the netty-http server. However, since
+          // this handler will be gone in near future, it's ok to have this workaround.
+          responder.sendString(HttpResponseStatus.BAD_REQUEST, "Required header 'class-name' is absent.");
+          return;
+        }
+
+        LOG.debug("Adding module {}, class name: {}", datasetModuleId, className);
+
+        String dataFabricDir = cConf.get(Constants.Dataset.Manager.OUTPUT_DIR);
+        String moduleName = datasetModuleId.getModule();
+        Location archiveDir = namespaceHomeLocation.append(dataFabricDir).append(moduleName)
+          .append(Constants.ARCHIVE_DIR);
+        String archiveName = moduleName + ".jar";
+        Location archive = archiveDir.append(archiveName);
+
+        // Copy uploaded content to a temporary location
+        Location tmpLocation = archive.getTempFile(".tmp");
+        try {
+          Locations.mkdirsIfNotExists(archiveDir);
+
+          LOG.debug("Copy from {} to {}", uploadedFile, tmpLocation);
+          Files.copy(uploadedFile, Locations.newOutputSupplier(tmpLocation));
+
+          // Finally, move archive to final location
+          LOG.debug("Storing module {} jar at {}", datasetModuleId, archive);
+          if (tmpLocation.renameTo(archive) == null) {
+            throw new IOException(String.format("Could not move archive from location: %s, to location: %s",
+                                                tmpLocation, archive));
+          }
+
+          typeManager.addModule(datasetModuleId.toId(), className, archive, forceUpdate);
+          // todo: response with DatasetModuleMeta of just added module (and log this info)
+          // Ideally this should have been done before, but we cannot grant privileges on types until they've been
+          // added to the type MDS. First revoke any orphaned privileges for types left behind by past failed revokes
+          revokeAllPrivilegesOnModule(datasetModuleId);
+          grantAllPrivilegesOnModule(datasetModuleId, principal);
+          LOG.info("Added module {}", datasetModuleId);
+          responder.sendStatus(HttpResponseStatus.OK);
+        } catch (Exception e) {
+          // There was a problem in deploying the dataset module. so revoke the privileges.
+          revokeAllPrivilegesOnModule(datasetModuleId);
+          // In case copy to temporary file failed, or rename failed
+          try {
+            tmpLocation.delete();
+          } catch (IOException ex) {
+            LOG.warn("Failed to cleanup temporary location {}", tmpLocation);
+          }
+          if (e instanceof DatasetModuleConflictException) {
+            responder.sendString(HttpResponseStatus.CONFLICT, e.getMessage());
+          } else {
+            throw e;
+          }
+        }
+      }
+    };
+  }
+
+  private void grantAllPrivilegesOnModule(DatasetModuleId moduleId, Principal principal) throws Exception {
+    Set<Action> allActions = ImmutableSet.of(Action.ALL);
+    authorizer.grant(moduleId, principal, allActions);
+    DatasetModuleMeta moduleMeta = typeManager.getModule(moduleId.toId());
+    if (moduleMeta == null) {
+      LOG.debug("Could not find metadata for module {}. Not granting privileges for its types.", moduleId);
+      return;
+    }
+    for (String type : moduleMeta.getTypes()) {
+      DatasetTypeId datasetTypeId = moduleId.getParent().datasetType(type);
+      authorizer.grant(datasetTypeId, principal, allActions);
+    }
+  }
+
+  private void revokeAllPrivilegesOnModule(DatasetModuleId moduleId) throws Exception {
+    revokeAllPrivilegesOnModule(moduleId, null);
+  }
+
+  private void revokeAllPrivilegesOnModule(DatasetModuleId moduleId,
+                                           @Nullable DatasetModuleMeta moduleMeta) throws Exception {
+    authorizer.revoke(moduleId);
+    moduleMeta = moduleMeta == null ? typeManager.getModule(moduleId.toId()) : moduleMeta;
+    if (moduleMeta == null) {
+      LOG.debug("Could not find metadata for module {}. Will not revoke privileges for its types.", moduleId);
+      return;
+    }
+    for (String type : moduleMeta.getTypes()) {
+      DatasetTypeId datasetTypeId = moduleId.getParent().datasetType(type);
+      authorizer.revoke(datasetTypeId);
+    }
+  }
+
+  /**
+   * Throws an exception if the specified namespace is not the system namespace and does not exist
+   */
+  private void ensureNamespaceExists(NamespaceId namespaceId) throws Exception {
+    if (!NamespaceId.SYSTEM.equals(namespaceId)) {
+      Id.Namespace namespace = namespaceId.toId();
+      if (namespaceQueryAdmin.get(namespace) == null) {
+        throw new NamespaceNotFoundException(namespace);
+      }
+    }
+  }
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeHandlerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeHandlerTest.java
@@ -20,6 +20,7 @@ import co.cask.cdap.proto.DatasetInstanceConfiguration;
 import co.cask.cdap.proto.DatasetModuleMeta;
 import co.cask.cdap.proto.DatasetTypeMeta;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequests;
 import co.cask.common.http.HttpResponse;
@@ -170,7 +171,7 @@ public class DatasetTypeHandlerTest extends DatasetServiceTestBase {
 
     // delete module2, should be removed from usedBy list everywhere and all its types should no longer be available
     Assert.assertEquals(HttpStatus.SC_OK, deleteModule("module2").getResponseCode());
-    Assert.assertEquals(HttpStatus.SC_NOT_FOUND, getType("datasetType2").getResponseCode());
+    Assert.assertEquals(HttpStatus.SC_NOT_FOUND, getMissingType("datasetType2").getResponseCode());
     verifyAll(ONLY_MODULE1, ONLY_1_DEPENDENCIES);
 
     // cannot delete module2 again
@@ -183,7 +184,7 @@ public class DatasetTypeHandlerTest extends DatasetServiceTestBase {
     // drop the instance of type1, now delete of module1 should work
     instanceService.drop(Id.DatasetInstance.from(Id.Namespace.DEFAULT.getId(), "instance1"));
     Assert.assertEquals(HttpStatus.SC_OK, deleteModules().getResponseCode());
-    Assert.assertEquals(HttpStatus.SC_NOT_FOUND, getType("datasetType1").getResponseCode());
+    Assert.assertEquals(HttpStatus.SC_NOT_FOUND, getMissingType("datasetType1").getResponseCode());
     verifyAll(NO_MODULES, NO_DEPENDENCIES);
   }
 
@@ -312,6 +313,10 @@ public class DatasetTypeHandlerTest extends DatasetServiceTestBase {
 
   private ObjectResponse<DatasetTypeMeta> getType(String typeName) throws IOException {
     return getType(Id.DatasetType.from(Id.Namespace.DEFAULT, typeName));
+  }
+
+  private HttpResponse getMissingType(String typeName) throws IOException {
+    return makeTypeInfoRequest(NamespaceId.DEFAULT.datasetType(typeName).toId());
   }
 
   private ObjectResponse<DatasetTypeMeta> getType(Id.DatasetType datasetType) throws IOException {

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
@@ -123,7 +123,7 @@ public class DatasetOpExecutorServerTwillRunnable extends AbstractMasterTwillRun
       new SecureStoreModules().getDistributedModules(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getDistributedModules(),
-      new AuthenticationContextModules().getMasterModule(),
+      new AuthenticationContextModules().getProgramContainerModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/InMemoryAuthorizer.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/InMemoryAuthorizer.java
@@ -78,7 +78,7 @@ public class InMemoryAuthorizer extends AbstractAuthorizer {
       }
     }
     if (!(allowed.contains(Action.ALL) || allowed.containsAll(actions))) {
-      throw new UnauthorizedException(principal, Sets.difference(allowed, actions), entity);
+      throw new UnauthorizedException(principal, Sets.difference(actions, allowed), entity);
     }
   }
 

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -70,7 +70,6 @@ import co.cask.cdap.explore.executor.ExploreExecutorService;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.explore.guice.ExploreRuntimeModule;
 import co.cask.cdap.gateway.handlers.AuthorizationHandler;
-import co.cask.cdap.gateway.handlers.SecureStoreHandler;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
 import co.cask.cdap.logging.guice.LogReaderRuntimeModules;
 import co.cask.cdap.logging.guice.LoggingModules;

--- a/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
@@ -87,7 +87,6 @@ public class AuthorizationTest extends TestBase {
     Constants.Security.Authorization.CACHE_ENABLED, false
   );
 
-  private static String olduser;
   private static final Principal ALICE = new Principal("alice", Principal.PrincipalType.USER);
   private static final Principal BOB = new Principal("bob", Principal.PrincipalType.USER);
   private static final NamespaceId AUTH_NAMESPACE = new NamespaceId("authorization");
@@ -95,6 +94,7 @@ public class AuthorizationTest extends TestBase {
     new NamespaceMeta.Builder().setName(AUTH_NAMESPACE.getNamespace()).build();
 
   private static InstanceId instance;
+  private static String oldUser;
 
   /**
    * An {@link ExternalResource} that wraps a {@link TemporaryFolder} and {@link TestConfiguration} to execute them in
@@ -134,8 +134,8 @@ public class AuthorizationTest extends TestBase {
 
   @BeforeClass
   public static void setup() {
-    olduser = SecurityRequestContext.getUserId();
     instance = new InstanceId(getConfiguration().get(Constants.INSTANCE_NAME));
+    oldUser = SecurityRequestContext.getUserId();
     SecurityRequestContext.setUserId(ALICE.getName());
   }
 
@@ -557,7 +557,7 @@ public class AuthorizationTest extends TestBase {
   public static void cleanup() throws Exception {
     // we want to execute TestBase's @AfterClass after unsetting userid, because the old userid has been granted ADMIN
     // on default namespace in TestBase so it can clean the namespace.
-    SecurityRequestContext.setUserId(olduser);
+    SecurityRequestContext.setUserId(oldUser);
     finish();
   }
 


### PR DESCRIPTION
- Refactored `DatasetTypeHandler` to move most logic to `DatasetTypeService`
- Added authorization enforcement checks in `DatasetTypeService`
- Further refactoring of `DatasetServiceTestBase` to rely more on injector

Jira: [CDAP-888](https://issues.cask.co/browse/CDAP-888)
Build: http://builds.cask.co/browse/CDAP-DUT4481
