### PR TITLE
CDAP-6234 CDH 5.8 support

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
@@ -38,6 +38,7 @@ public class HBaseVersion {
   private static final String CDH55_CLASSIFIER = "cdh5.5";
   private static final String CDH56_CLASSIFIER = "cdh5.6";
   private static final String CDH57_CLASSIFIER = "cdh5.7";
+  private static final String CDH58_CLASSIFIER = "cdh5.8";
   private static final String CDH_CLASSIFIER = "cdh";
 
   private static final Logger LOG = LoggerFactory.getLogger(HBaseVersion.class);
@@ -96,7 +97,10 @@ public class HBaseVersion {
         currentVersion = Version.HBASE_11;
       } else if (versionString.startsWith(HBASE_12_VERSION)) {
         VersionNumber ver = VersionNumber.create(versionString);
-        if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH57_CLASSIFIER)) {
+        if (ver.getClassifier() != null &&
+          (ver.getClassifier().startsWith(CDH57_CLASSIFIER) ||
+            // CDH 5.7 compat module can be re-used with CDH 5.8
+            ver.getClassifier().startsWith(CDH58_CLASSIFIER))) {
           currentVersion = Version.HBASE_12_CDH57;
         } else {
           currentVersion = Version.UNKNOWN;

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
     <shiro.version>1.2.1</shiro.version>
     <slf4j.version>1.7.5</slf4j.version>
     <tephra.version>0.7.1</tephra.version>
-    <thrift.version>0.9.0</thrift.version>
+    <thrift.version>0.9.3</thrift.version>
     <twill.version>0.7.0-incubating</twill.version>
     <unboundid.version>2.3.6</unboundid.version>
     <zookeeper.version>3.4.5</zookeeper.version>


### PR DESCRIPTION
CDH 5.7 HBase compat modules are binary compatible with CDH 5.8 HBase. We however needed to upgrade thrift to 0.9.3 since Hive uses the newer thrift version.

JIRA - https://issues.cask.co/browse/CDAP-6234
Build - http://builds.cask.co/browse/CDAP-DUT4490-1
ITN on CDH 5.8 cluster - http://builds.cask.co/browse/CDAP-ITCC-214

ITN to check thrift 0.9.3 upgrade - http://builds.cask.co/browse/CDAP-ITM-27  (runs on clusters CDH (5.1, 5.5), HDP (2.0) and Mapr (4.1))
