### PR TITLE
Fix creation of /cdap/twill and /cdap/queues

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -271,7 +271,7 @@ public class MasterServiceMain extends DaemonMain {
   }
 
   private boolean checkDirectoryExists(FileContext fileContext, org.apache.hadoop.fs.Path path) throws IOException {
-    if ((fileContext.getFileStatus(path)) != null) {
+    if (fileContext.util().exists(path)) {
       // dir exists
       // check permissions
       FsAction action =


### PR DESCRIPTION
FileContext#getFileStatus throws a FileNotFoundException if no such file exists.
We want a simple way to check if it exists, instead.
