### PR TITLE
Avoid getting credentials for a user, if that user is the current user

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/Impersonator.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/Impersonator.java
@@ -66,6 +66,10 @@ public class Impersonator {
     }
 
     ImpersonationInfo impersonationInfo = impersonationUserResolver.getImpersonationInfo(namespaceId);
+    // no need to get a UGI if the current UGI is the one we're requesting; simply return it
+    if (UserGroupInformation.getCurrentUser().getUserName().equals(impersonationInfo.getPrincipal())) {
+      return UserGroupInformation.getCurrentUser();
+    }
     return ugiProvider.getConfiguredUGI(impersonationInfo);
   }
 }

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -46,6 +46,7 @@ import co.cask.cdap.data.stream.StreamAdminModules;
 import co.cask.cdap.data.view.ViewAdminModules;
 import co.cask.cdap.data2.audit.AuditModule;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
+import co.cask.cdap.data2.transaction.queue.QueueConstants;
 import co.cask.cdap.data2.util.hbase.ConfigurationTable;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
@@ -219,9 +220,9 @@ public class MasterServiceMain extends DaemonMain {
   @Override
   public void start() {
     logAppenderInitializer.initialize();
-
     createDirectory("twill");
-    createDirectory("queues");
+    createDirectory(cConf.get(QueueConstants.ConfigKeys.QUEUE_TABLE_COPROCESSOR_DIR,
+                              QueueConstants.DEFAULT_QUEUE_TABLE_COPROCESSOR_DIR));
     createSystemHBaseNamespace();
     updateConfigurationTable();
 


### PR DESCRIPTION
Avoid getting credentials for a user, if that user is already the current user.
Also, use value from cConf, instead of hardcoding it, when creating the directory upon startup of MasterServiceMain.
