### PR TITLE
Support Impersonation for FileSets.

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/Impersonator.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/Impersonator.java
@@ -59,6 +59,7 @@ public class Impersonator {
    * @throws Exception if the callable throws any exception
    */
   public <T> T doAs(NamespaceId namespaceId, final Callable<T> callable) throws Exception {
+    // don't impersonate if kerberos isn't enabled OR if the operation is in the system namespace
     if (!kerberosEnabled || NamespaceId.SYSTEM.equals(namespaceId)) {
       return callable.call();
     }


### PR DESCRIPTION
In order to support FileSet, when impersonating, the DatasetAdmin has to be created with impersonation, not just the actions being done with impersonation.
