### PR TITLE
Fix broken doc build.

### DIFF
--- a/cdap-docs/vars
+++ b/cdap-docs/vars
@@ -24,7 +24,7 @@ MANUALS="introduction developers-manual cdap-apps admin-manual integrations exam
 # BUILD.rst
 BUILD_RST="BUILD.rst"
 BUILD_RST_HASH_LOCATION="cdap-docs/vars"
-BUILD_RST_HASH="6b6124e34febf8ff1259e923ce29b5f9"
+BUILD_RST_HASH="039fc5b9a1decc5c67f17c332413f5d9"
 
 # This needs to be explicitly set as Git has trouble identifying it.
 GIT_BRANCH_PARENT="develop"


### PR DESCRIPTION
Update the MD5 hash for BUILD.rst.

Passes a [Quick Build](http://builds.cask.co/browse/CDAP-DQB56-1)
