### PR TITLE
CDAP-6372 add spark streaming app

### DIFF
--- a/cdap-api-common/src/main/java/co/cask/cdap/api/common/Bytes.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/common/Bytes.java
@@ -17,6 +17,7 @@ package co.cask.cdap.api.common;
 
 import java.io.DataOutput;
 import java.io.IOException;
+import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -84,7 +85,10 @@ public class Bytes {
   /**
    * Byte array comparator class.
    */
-  public static class ByteArrayComparator implements Comparator<byte []> {
+  public static class ByteArrayComparator implements Comparator<byte []>, Serializable {
+
+    private static final long serialVersionUID = -7139477985270503953L;
+
     /**
      * Constructor.
      */

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Put.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Put.java
@@ -18,13 +18,17 @@ package co.cask.cdap.api.dataset.table;
 
 import co.cask.cdap.api.common.Bytes;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.TreeMap;
 
 /**
  * Writes the specified value(s) in one or more columns of a row -- this overrides existing values.
  */
-public class Put {
+public class Put implements Serializable {
+
+  private static final long serialVersionUID = 5869452950547737896L;
+
   /** row to write to. */
   private final byte[] row;
 

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/pom.xml
@@ -26,25 +26,29 @@
     <version>3.5.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>cdap-data-pipeline</artifactId>
-  <name>CDAP Data Pipeline Application</name>
+  <artifactId>cdap-data-streams</artifactId>
+  <name>CDAP Data Streams Application</name>
   <packaging>jar</packaging>
 
   <properties>
-    <app.main.class>co.cask.cdap.datapipeline.DataPipelineApp</app.main.class>
+    <app.main.class>co.cask.cdap.datastreams.DataStreamsApp</app.main.class>
   </properties>
 
   <dependencies>
     <dependency>
-      <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-etl-batch</artifactId>
-      <version>${project.version}</version>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-api</artifactId>
       <version>${project.version}</version>
-      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-api-spark</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
@@ -54,6 +58,16 @@
     <dependency>
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-etl-api-spark</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-etl-proto</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-etl-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -69,19 +83,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.10</artifactId>
+      <artifactId>spark-streaming_2.10</artifactId>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-mllib_2.10</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.spark</groupId>
-          <artifactId>spark-streaming_2.10</artifactId>
-        </exclusion>
-      </exclusions>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -107,7 +110,7 @@
               <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
               <Embed-Transitive>true</Embed-Transitive>
               <Embed-Directory>lib</Embed-Directory>
-              <_exportcontents>co.cask.cdap.etl.api.*;org.apache.avro.*</_exportcontents>
+              <_exportcontents>co.cask.cdap.etl.api.*</_exportcontents>
             </instructions>
           </configuration>
           <executions>

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsApp.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsApp.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.datastreams;
+
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.cdap.etl.api.streaming.StreamingSource;
+import co.cask.cdap.etl.proto.v2.DataStreamsConfig;
+import co.cask.cdap.etl.spec.PipelineSpecGenerator;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * Data Streams Application.
+ */
+public class DataStreamsApp extends AbstractApplication<DataStreamsConfig> {
+
+  @Override
+  public void configure() {
+    DataStreamsConfig config = getConfig();
+    setDescription("Data Streams Application");
+
+    PipelineSpecGenerator<DataStreamsConfig, DataStreamsPipelineSpec> specGenerator =
+      new DataStreamsPipelineSpecGenerator(
+        getConfigurer(),
+        ImmutableSet.of(StreamingSource.PLUGIN_TYPE),
+        ImmutableSet.of(BatchSink.PLUGIN_TYPE)
+      );
+    DataStreamsPipelineSpec spec = specGenerator.generateSpec(config);
+    addSpark(new DataStreamsSparkLauncher(spec, config.isUnitTest()));
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsPipelineSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsPipelineSpec.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.datastreams;
+
+import co.cask.cdap.api.Resources;
+import co.cask.cdap.etl.proto.Connection;
+import co.cask.cdap.etl.spec.PipelineSpec;
+import co.cask.cdap.etl.spec.StageSpec;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Spec for data streams pipelines.
+ */
+public class DataStreamsPipelineSpec extends PipelineSpec {
+  private final long batchIntervalMillis;
+  private final Resources driverResources;
+
+  private DataStreamsPipelineSpec(Set<StageSpec> stages, Set<Connection> connections,
+                                  Resources resources, Resources driverResources,
+                                  boolean stageLoggingEnabled, long batchIntervalMillis) {
+    super(stages, connections, resources, stageLoggingEnabled);
+    this.driverResources = driverResources;
+    this.batchIntervalMillis = batchIntervalMillis;
+  }
+
+  public long getBatchIntervalMillis() {
+    return batchIntervalMillis;
+  }
+
+  public Resources getDriverResources() {
+    return driverResources;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    DataStreamsPipelineSpec that = (DataStreamsPipelineSpec) o;
+
+    return batchIntervalMillis == that.batchIntervalMillis && Objects.equals(driverResources, that.driverResources);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), driverResources, batchIntervalMillis);
+  }
+
+  @Override
+  public String toString() {
+    return "DataStreamsPipelineSpec{" +
+      "batchIntervalMillis=" + batchIntervalMillis +
+      ", driverResources=" + driverResources +
+      "} " + super.toString();
+  }
+
+  public static Builder builder(long batchIntervalMillis) {
+    return new Builder(batchIntervalMillis);
+  }
+
+  /**
+   * Builder for creating a BatchPipelineSpec.
+   */
+  public static class Builder extends PipelineSpec.Builder<Builder> {
+    private final long batchIntervalMillis;
+    private Resources driverResources;
+
+    public Builder(long batchIntervalMillis) {
+      this.batchIntervalMillis = batchIntervalMillis;
+    }
+
+    public Builder setDriverResources(Resources resources) {
+      this.driverResources = resources;
+      return this;
+    }
+
+    public DataStreamsPipelineSpec build() {
+      return new DataStreamsPipelineSpec(stages, connections, resources,
+                                         driverResources == null ? resources : driverResources,
+                                         stageLoggingEnabled, batchIntervalMillis);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsPipelineSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsPipelineSpec.java
@@ -30,13 +30,16 @@ import java.util.Set;
 public class DataStreamsPipelineSpec extends PipelineSpec {
   private final long batchIntervalMillis;
   private final Resources driverResources;
+  private final String extraJavaOpts;
 
   private DataStreamsPipelineSpec(Set<StageSpec> stages, Set<Connection> connections,
                                   Resources resources, Resources driverResources,
-                                  boolean stageLoggingEnabled, long batchIntervalMillis) {
+                                  boolean stageLoggingEnabled, long batchIntervalMillis,
+                                  String extraJavaOpts) {
     super(stages, connections, resources, stageLoggingEnabled);
     this.driverResources = driverResources;
     this.batchIntervalMillis = batchIntervalMillis;
+    this.extraJavaOpts = extraJavaOpts;
   }
 
   public long getBatchIntervalMillis() {
@@ -45,6 +48,10 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
 
   public Resources getDriverResources() {
     return driverResources;
+  }
+
+  public String getExtraJavaOpts() {
+    return extraJavaOpts;
   }
 
   @Override
@@ -61,12 +68,14 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
 
     DataStreamsPipelineSpec that = (DataStreamsPipelineSpec) o;
 
-    return batchIntervalMillis == that.batchIntervalMillis && Objects.equals(driverResources, that.driverResources);
+    return batchIntervalMillis == that.batchIntervalMillis &&
+      Objects.equals(driverResources, that.driverResources) &&
+      Objects.equals(extraJavaOpts, that.extraJavaOpts);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), driverResources, batchIntervalMillis);
+    return Objects.hash(super.hashCode(), driverResources, batchIntervalMillis, extraJavaOpts);
   }
 
   @Override
@@ -74,6 +83,7 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
     return "DataStreamsPipelineSpec{" +
       "batchIntervalMillis=" + batchIntervalMillis +
       ", driverResources=" + driverResources +
+      ", extraJavaOpts='" + extraJavaOpts + '\'' +
       "} " + super.toString();
   }
 
@@ -87,6 +97,7 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
   public static class Builder extends PipelineSpec.Builder<Builder> {
     private final long batchIntervalMillis;
     private Resources driverResources;
+    private String extraJavaOpts;
 
     public Builder(long batchIntervalMillis) {
       this.batchIntervalMillis = batchIntervalMillis;
@@ -97,10 +108,15 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
       return this;
     }
 
+    public Builder setExtraJavaOpts(String extraJavaOpts) {
+      this.extraJavaOpts = extraJavaOpts;
+      return this;
+    }
+
     public DataStreamsPipelineSpec build() {
       return new DataStreamsPipelineSpec(stages, connections, resources,
                                          driverResources == null ? resources : driverResources,
-                                         stageLoggingEnabled, batchIntervalMillis);
+                                         stageLoggingEnabled, batchIntervalMillis, extraJavaOpts);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsPipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsPipelineSpecGenerator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.datastreams;
+
+import co.cask.cdap.api.plugin.PluginConfigurer;
+import co.cask.cdap.etl.common.macro.TimeParser;
+import co.cask.cdap.etl.proto.v2.DataStreamsConfig;
+import co.cask.cdap.etl.spec.PipelineSpecGenerator;
+
+import java.util.Set;
+
+/**
+ * Generates specs for data stream pipelines.
+ */
+public class DataStreamsPipelineSpecGenerator
+  extends PipelineSpecGenerator<DataStreamsConfig, DataStreamsPipelineSpec> {
+
+  public DataStreamsPipelineSpecGenerator(PluginConfigurer configurer, Set<String> sourcePluginTypes,
+                                          Set<String> sinkPluginTypes) {
+    super(configurer, sourcePluginTypes, sinkPluginTypes, null, null);
+  }
+
+  @Override
+  public DataStreamsPipelineSpec generateSpec(DataStreamsConfig config) {
+    long batchIntervalMillis;
+    try {
+      batchIntervalMillis = TimeParser.parseDuration(config.getBatchInterval());
+    } catch (Exception e) {
+      throw new IllegalArgumentException(
+        String.format("Unable to parse batchInterval '%s'", config.getBatchInterval()), e);
+    }
+    DataStreamsPipelineSpec.Builder specBuilder = DataStreamsPipelineSpec.builder(batchIntervalMillis)
+      .setDriverResources(config.getDriverResources());
+    configureStages(config, specBuilder);
+    return specBuilder.build();
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsPipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsPipelineSpecGenerator.java
@@ -41,10 +41,11 @@ public class DataStreamsPipelineSpecGenerator
       batchIntervalMillis = TimeParser.parseDuration(config.getBatchInterval());
     } catch (Exception e) {
       throw new IllegalArgumentException(
-        String.format("Unable to parse batchInterval '%s'", config.getBatchInterval()), e);
+        String.format("Unable to parse batchInterval '%s'", config.getBatchInterval()));
     }
     DataStreamsPipelineSpec.Builder specBuilder = DataStreamsPipelineSpec.builder(batchIntervalMillis)
-      .setDriverResources(config.getDriverResources());
+      .setDriverResources(config.getDriverResources())
+      .setExtraJavaOpts(config.getExtraJavaOpts());
     configureStages(config, specBuilder);
     return specBuilder.build();
   }

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsSparkLauncher.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsSparkLauncher.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.datastreams;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.spark.AbstractSpark;
+import co.cask.cdap.api.spark.SparkClientContext;
+import co.cask.cdap.etl.api.streaming.StreamingSource;
+import co.cask.cdap.etl.common.Constants;
+import co.cask.cdap.etl.spec.StageSpec;
+import co.cask.cdap.internal.io.SchemaTypeAdapter;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.spark.SparkConf;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * CDAP Spark client that configures and launches the actual Spark program.
+ */
+public class DataStreamsSparkLauncher extends AbstractSpark {
+  public static final String NAME = "DataStreamsSparkStreaming";
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
+    .create();
+
+  private final DataStreamsPipelineSpec pipelineSpec;
+  private final boolean isUnitTest;
+
+  public DataStreamsSparkLauncher(DataStreamsPipelineSpec pipelineSpec, boolean isUnitTest) {
+    this.pipelineSpec = pipelineSpec;
+    this.isUnitTest = isUnitTest;
+  }
+
+  @Override
+  protected void configure() {
+    setName(NAME);
+    setMainClass(SparkStreamingPipelineDriver.class);
+
+    setExecutorResources(pipelineSpec.getResources());
+    setDriverResources(pipelineSpec.getDriverResources());
+
+    int numSources = 0;
+    for (StageSpec stageSpec : pipelineSpec.getStages()) {
+      if (StreamingSource.PLUGIN_TYPE.equals(stageSpec.getPlugin().getType())) {
+        numSources++;
+      }
+    }
+
+    // add source, sink, transform ids to the properties. These are needed at runtime to instantiate the plugins
+    Map<String, String> properties = new HashMap<>();
+    properties.put(Constants.PIPELINEID, GSON.toJson(pipelineSpec));
+    properties.put("cask.is.unit.test", String.valueOf(isUnitTest));
+    properties.put("cask.num.sources", String.valueOf(numSources));
+    setProperties(properties);
+  }
+
+  @Override
+  public void beforeSubmit(SparkClientContext context) throws Exception {
+    SparkConf sparkConf = new SparkConf();
+    sparkConf.set("spark.driver.extraJavaOptions", "-XX:MaxPermSize=256m");
+    sparkConf.set("spark.executor.extraJavaOptions", "-XX:MaxPermSize=256m");
+    // spark... makes you set this to at least the number of receivers (streaming sources)
+    // because it holds one thread per receiver, or one core in distributed mode.
+    // so... we have to set this hacky master variable based on the isUnitTest setting in the config
+    Map<String, String> programProperties = context.getSpecification().getProperties();
+    Boolean isUnitTest = Boolean.valueOf(programProperties.get("cask.is.unit.test"));
+    if (isUnitTest) {
+      Integer numSources = Integer.valueOf(programProperties.get("cask.num.sources"));
+      sparkConf.setMaster(String.format("local[%d]", numSources + 1));
+    }
+    context.setSparkConf(sparkConf);
+  }
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineDriver.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.datastreams;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.spark.JavaSparkExecutionContext;
+import co.cask.cdap.api.spark.JavaSparkMain;
+import co.cask.cdap.etl.api.Transform;
+import co.cask.cdap.etl.api.batch.BatchAggregator;
+import co.cask.cdap.etl.api.batch.BatchJoiner;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.cdap.etl.api.batch.SparkCompute;
+import co.cask.cdap.etl.api.streaming.StreamingSource;
+import co.cask.cdap.etl.api.streaming.Windower;
+import co.cask.cdap.etl.common.Constants;
+import co.cask.cdap.etl.common.PipelinePhase;
+import co.cask.cdap.etl.planner.StageInfo;
+import co.cask.cdap.etl.spark.SparkCollection;
+import co.cask.cdap.etl.spark.SparkPipelineDriver;
+import co.cask.cdap.etl.spark.function.PluginFunctionContext;
+import co.cask.cdap.etl.spark.streaming.DStreamCollection;
+import co.cask.cdap.etl.spec.StageSpec;
+import co.cask.cdap.internal.io.SchemaTypeAdapter;
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.streaming.Durations;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+
+import java.util.HashMap;
+import java.util.Set;
+
+/**
+ * Driver for running pipelines using Spark Streaming.
+ */
+public class SparkStreamingPipelineDriver extends SparkPipelineDriver implements JavaSparkMain {
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
+    .create();
+  private static final Set<String> SUPPORTED_PLUGIN_TYPES = ImmutableSet.of(
+    StreamingSource.PLUGIN_TYPE, BatchSink.PLUGIN_TYPE, Transform.PLUGIN_TYPE, BatchAggregator.PLUGIN_TYPE,
+    BatchJoiner.PLUGIN_TYPE, SparkCompute.PLUGIN_TYPE, Windower.PLUGIN_TYPE);
+  private JavaSparkExecutionContext sec;
+  private JavaSparkContext sparkContext;
+  private JavaStreamingContext streamingContext;
+
+  @Override
+  protected SparkCollection<Object> getSource(String stageName,
+                                              PluginFunctionContext pluginFunctionContext) throws Exception {
+    StreamingSource<Object> source = sec.getPluginContext().newPluginInstance(stageName);
+    return new DStreamCollection<>(sec, sparkContext, source.getStream(streamingContext));
+  }
+
+  @Override
+  public void run(JavaSparkExecutionContext sec) throws Exception {
+    this.sec = sec;
+
+    DataStreamsPipelineSpec pipelineSpec = GSON.fromJson(sec.getSpecification().getProperty(Constants.PIPELINEID),
+                                                         DataStreamsPipelineSpec.class);
+
+
+    PipelinePhase.Builder phaseBuilder = PipelinePhase.builder(SUPPORTED_PLUGIN_TYPES)
+      .addConnections(pipelineSpec.getConnections());
+    for (StageSpec stageSpec : pipelineSpec.getStages()) {
+      phaseBuilder.addStage(StageInfo.builder(stageSpec.getName(), stageSpec.getPlugin().getType())
+                              .addInputs(stageSpec.getInputs())
+                              .addOutputs(stageSpec.getOutputs())
+                              .addInputSchemas(stageSpec.getInputSchemas())
+                              .setOutputSchema(stageSpec.getOutputSchema())
+                              .build());
+    }
+    PipelinePhase pipelinePhase = phaseBuilder.build();
+
+    sparkContext = new JavaSparkContext();
+    streamingContext = new JavaStreamingContext(sparkContext,
+                                                Durations.milliseconds(pipelineSpec.getBatchIntervalMillis()));
+    // TODO: figure out how to get partitions to use for aggregators and joiners.
+    // Seems like they should be set at configure time instead of runtime? but that requires an API change.
+    runPipeline(pipelinePhase, StreamingSource.PLUGIN_TYPE, sec, new HashMap<String, Integer>());
+
+    streamingContext.start();
+    boolean stopped = false;
+    try {
+      // most programs will just keep running forever.
+      // however, when CDAP stops the program, we get an interrupted exception.
+      // at that point, we need to call stop on jssc, otherwise the program will hang and never stop.
+      stopped = streamingContext.awaitTerminationOrTimeout(Long.MAX_VALUE);
+    } finally {
+      if (!stopped) {
+        streamingContext.stop(true, true);
+      }
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/DataStreamsTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/DataStreamsTest.java
@@ -1,0 +1,527 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.datastreams;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.utils.Tasks;
+import co.cask.cdap.etl.mock.batch.MockSink;
+import co.cask.cdap.etl.mock.batch.aggregator.FieldCountAggregator;
+import co.cask.cdap.etl.mock.batch.joiner.MockJoiner;
+import co.cask.cdap.etl.mock.spark.Window;
+import co.cask.cdap.etl.mock.spark.compute.StringValueFilterCompute;
+import co.cask.cdap.etl.mock.spark.streaming.MockSource;
+import co.cask.cdap.etl.mock.test.HydratorTestBase;
+import co.cask.cdap.etl.mock.transform.FieldsPrefixTransform;
+import co.cask.cdap.etl.mock.transform.StringValueFilterTransform;
+import co.cask.cdap.etl.proto.v2.DataStreamsConfig;
+import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.DataSetManager;
+import co.cask.cdap.test.SparkManager;
+import co.cask.cdap.test.TestConfiguration;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ *
+ */
+public class DataStreamsTest extends HydratorTestBase {
+
+  protected static final ArtifactId APP_ARTIFACT_ID =
+    new ArtifactId(NamespaceId.DEFAULT.getNamespace(), "app", "1.0.0");
+  protected static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("app", "1.0.0");
+  private static int startCount = 0;
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
+
+  @BeforeClass
+  public static void setupTest() throws Exception {
+    if (startCount++ > 0) {
+      return;
+    }
+
+    setupStreamingArtifacts(APP_ARTIFACT_ID, DataStreamsApp.class);
+  }
+
+  @Test
+  public void testTransformCompute() throws Exception {
+    Schema schema = Schema.recordOf(
+      "test",
+      Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("name", Schema.of(Schema.Type.STRING))
+    );
+    List<StructuredRecord> input = new ArrayList<>();
+    StructuredRecord samuelRecord = StructuredRecord.builder(schema).set("id", "123").set("name", "samuel").build();
+    StructuredRecord jacksonRecord = StructuredRecord.builder(schema).set("id", "456").set("name", "jackson").build();
+    StructuredRecord dwayneRecord = StructuredRecord.builder(schema).set("id", "789").set("name", "dwayne").build();
+    StructuredRecord johnsonRecord = StructuredRecord.builder(schema).set("id", "0").set("name", "johnson").build();
+    input.add(samuelRecord);
+    input.add(jacksonRecord);
+    input.add(dwayneRecord);
+    input.add(johnsonRecord);
+
+    DataStreamsConfig etlConfig = DataStreamsConfig.builder()
+      .addStage(new ETLStage("source", MockSource.getPlugin(schema, input)))
+      .addStage(new ETLStage("sink", MockSink.getPlugin("output")))
+      .addStage(new ETLStage("jacksonFilter", StringValueFilterTransform.getPlugin("name", "jackson")))
+      .addStage(new ETLStage("dwayneFilter", StringValueFilterCompute.getPlugin("name", "dwayne")))
+      .addConnection("source", "jacksonFilter")
+      .addConnection("jacksonFilter", "dwayneFilter")
+      .addConnection("dwayneFilter", "sink")
+      .setBatchInterval("1s")
+      .build();
+
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "simpleApp");
+    AppRequest<DataStreamsConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig);
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    SparkManager sparkManager = appManager.getSparkManager(DataStreamsSparkLauncher.NAME);
+    sparkManager.start();
+    sparkManager.waitForStatus(true, 10, 1);
+
+    final DataSetManager<Table> outputManager = getDataset("output");
+    final Set<StructuredRecord> expected = new HashSet<>();
+    expected.add(samuelRecord);
+    expected.add(johnsonRecord);
+    Tasks.waitFor(
+      true,
+      new Callable<Boolean>() {
+        @Override
+        public Boolean call() throws Exception {
+          outputManager.flush();
+          Set<StructuredRecord> outputRecords = new HashSet<>();
+          outputRecords.addAll(MockSink.readOutput(outputManager));
+          return expected.equals(outputRecords);
+        }
+      },
+      1,
+      TimeUnit.MINUTES);
+
+    sparkManager.stop();
+    sparkManager.waitForStatus(false, 10, 1);
+  }
+
+  @Test
+  public void testParallelAggregators() throws Exception {
+    String sink1Name = "pAggOutput1";
+    String sink2Name = "pAggOutput2";
+
+    Schema inputSchema = Schema.recordOf(
+      "testRecord",
+      Schema.Field.of("user", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("item", Schema.of(Schema.Type.LONG))
+    );
+
+    List<StructuredRecord> input1 = ImmutableList.of(
+      StructuredRecord.builder(inputSchema).set("user", "samuel").set("item", 1L).build(),
+      StructuredRecord.builder(inputSchema).set("user", "samuel").set("item", 2L).build());
+
+    List<StructuredRecord> input2 = ImmutableList.of(
+      StructuredRecord.builder(inputSchema).set("user", "samuel").set("item", 3L).build(),
+      StructuredRecord.builder(inputSchema).set("user", "john").set("item", 4L).build(),
+      StructuredRecord.builder(inputSchema).set("user", "john").set("item", 3L).build());
+
+    /*
+       source1 --|--> agg1 --> sink1
+                 |
+       source2 --|--> agg2 --> sink2
+     */
+    DataStreamsConfig pipelineConfig = DataStreamsConfig.builder()
+      .setBatchInterval("5s")
+      .addStage(new ETLStage("source1", MockSource.getPlugin(inputSchema, input1)))
+      .addStage(new ETLStage("source2", MockSource.getPlugin(inputSchema, input2)))
+      .addStage(new ETLStage("sink1", MockSink.getPlugin(sink1Name)))
+      .addStage(new ETLStage("sink2", MockSink.getPlugin(sink2Name)))
+      .addStage(new ETLStage("agg1", FieldCountAggregator.getPlugin("user", "string")))
+      .addStage(new ETLStage("agg2", FieldCountAggregator.getPlugin("item", "long")))
+      .addConnection("source1", "agg1")
+      .addConnection("source1", "agg2")
+      .addConnection("source2", "agg1")
+      .addConnection("source2", "agg2")
+      .addConnection("agg1", "sink1")
+      .addConnection("agg2", "sink2")
+      .build();
+
+    AppRequest<DataStreamsConfig> appRequest = new AppRequest<>(APP_ARTIFACT, pipelineConfig);
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "ParallelAggApp");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    SparkManager sparkManager = appManager.getSparkManager(DataStreamsSparkLauncher.NAME);
+    sparkManager.start();
+    sparkManager.waitForStatus(true, 10, 1);
+
+    Schema outputSchema1 = Schema.recordOf(
+      "user.count",
+      Schema.Field.of("user", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("ct", Schema.of(Schema.Type.LONG))
+    );
+    Schema outputSchema2 = Schema.recordOf(
+      "item.count",
+      Schema.Field.of("item", Schema.of(Schema.Type.LONG)),
+      Schema.Field.of("ct", Schema.of(Schema.Type.LONG))
+    );
+
+    // check output
+    final DataSetManager<Table> sinkManager1 = getDataset(sink1Name);
+    final Set<StructuredRecord> expected1 = ImmutableSet.of(
+      StructuredRecord.builder(outputSchema1).set("user", "all").set("ct", 5L).build(),
+      StructuredRecord.builder(outputSchema1).set("user", "samuel").set("ct", 3L).build(),
+      StructuredRecord.builder(outputSchema1).set("user", "john").set("ct", 2L).build());
+
+    Tasks.waitFor(
+      true,
+      new Callable<Boolean>() {
+        @Override
+        public Boolean call() throws Exception {
+          sinkManager1.flush();
+          Set<StructuredRecord> outputRecords = new HashSet<>();
+          outputRecords.addAll(MockSink.readOutput(sinkManager1));
+          return expected1.equals(outputRecords);
+        }
+      },
+      1,
+      TimeUnit.MINUTES);
+
+    final DataSetManager<Table> sinkManager2 = getDataset(sink2Name);
+    final Set<StructuredRecord> expected2 = ImmutableSet.of(
+      StructuredRecord.builder(outputSchema2).set("item", 0L).set("ct", 5L).build(),
+      StructuredRecord.builder(outputSchema2).set("item", 1L).set("ct", 1L).build(),
+      StructuredRecord.builder(outputSchema2).set("item", 2L).set("ct", 1L).build(),
+      StructuredRecord.builder(outputSchema2).set("item", 3L).set("ct", 2L).build(),
+      StructuredRecord.builder(outputSchema2).set("item", 4L).set("ct", 1L).build());
+
+    Tasks.waitFor(
+      true,
+      new Callable<Boolean>() {
+        @Override
+        public Boolean call() throws Exception {
+          sinkManager2.flush();
+          Set<StructuredRecord> outputRecords = new HashSet<>();
+          outputRecords.addAll(MockSink.readOutput(sinkManager2));
+          return expected2.equals(outputRecords);
+        }
+      },
+      1,
+      TimeUnit.MINUTES);
+
+    sparkManager.stop();
+    sparkManager.waitForStatus(false, 10, 1);
+  }
+
+  @Test
+  public void testWindower() throws Exception {
+    /*
+     *           |--> window1(width=1,interval=1) --> aggregator1 --> filter1 --> sink1
+     *           |
+     * source1 --|--> window2(width=2,interval=1) --> aggregator2 --> filter2 --> sink2
+     *           |
+     *           |--> window3(width=2,interval=2) --> aggregator3 --> filter3 --> sink3
+     */
+    Schema schema = Schema.recordOf("data", Schema.Field.of("x", Schema.of(Schema.Type.STRING)));
+    List<StructuredRecord> input = ImmutableList.of(
+      StructuredRecord.builder(schema).set("x", "abc").build(),
+      StructuredRecord.builder(schema).set("x", "abc").build(),
+      StructuredRecord.builder(schema).set("x", "abc").build(),
+      StructuredRecord.builder(schema).set("x", "abc").build());
+
+    String sink1Name = "windowOut1";
+    String sink2Name = "windowOut2";
+    String sink3Name = "windowOut3";
+    // source sleeps 1 second between outputs
+    DataStreamsConfig etlConfig = DataStreamsConfig.builder()
+      .addStage(new ETLStage("source", MockSource.getPlugin(schema, input, 1000L)))
+      .addStage(new ETLStage("window1", Window.getPlugin(1, 1)))
+      .addStage(new ETLStage("window2", Window.getPlugin(2, 1)))
+      .addStage(new ETLStage("window3", Window.getPlugin(2, 2)))
+      .addStage(new ETLStage("agg1", FieldCountAggregator.getPlugin("x", "string")))
+      .addStage(new ETLStage("agg2", FieldCountAggregator.getPlugin("x", "string")))
+      .addStage(new ETLStage("agg3", FieldCountAggregator.getPlugin("x", "string")))
+      .addStage(new ETLStage("filter1", StringValueFilterTransform.getPlugin("x", "all")))
+      .addStage(new ETLStage("filter2", StringValueFilterTransform.getPlugin("x", "all")))
+      .addStage(new ETLStage("filter3", StringValueFilterTransform.getPlugin("x", "all")))
+      .addStage(new ETLStage("sink1", MockSink.getPlugin(sink1Name)))
+      .addStage(new ETLStage("sink2", MockSink.getPlugin(sink2Name)))
+      .addStage(new ETLStage("sink3", MockSink.getPlugin(sink3Name)))
+      .addConnection("source", "window1")
+      .addConnection("source", "window2")
+      .addConnection("source", "window3")
+      .addConnection("window1", "agg1")
+      .addConnection("window2", "agg2")
+      .addConnection("window3", "agg3")
+      .addConnection("agg1", "filter1")
+      .addConnection("agg2", "filter2")
+      .addConnection("agg3", "filter3")
+      .addConnection("filter1", "sink1")
+      .addConnection("filter2", "sink2")
+      .addConnection("filter3", "sink3")
+      .setBatchInterval("1s")
+      .build();
+
+    AppRequest<DataStreamsConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig);
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "WindowerApp");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    SparkManager sparkManager = appManager.getSparkManager(DataStreamsSparkLauncher.NAME);
+    sparkManager.start();
+    sparkManager.waitForStatus(true, 10, 1);
+
+    Schema outputSchema = Schema.recordOf("x.count",
+                                          Schema.Field.of("x", Schema.of(Schema.Type.STRING)),
+                                          Schema.Field.of("ct", Schema.of(Schema.Type.LONG)));
+
+    // the first sink should have one record per time window
+    final List<StructuredRecord> expected1 = ImmutableList.of(
+      StructuredRecord.builder(outputSchema).set("x", "abc").set("ct", 1L).build(),
+      StructuredRecord.builder(outputSchema).set("x", "abc").set("ct", 1L).build(),
+      StructuredRecord.builder(outputSchema).set("x", "abc").set("ct", 1L).build(),
+      StructuredRecord.builder(outputSchema).set("x", "abc").set("ct", 1L).build()
+    );
+    final DataSetManager<Table> outputManager1 = getDataset(sink1Name);
+    Tasks.waitFor(
+      true,
+      new Callable<Boolean>() {
+        @Override
+        public Boolean call() throws Exception {
+          outputManager1.flush();
+          return expected1.equals(MockSink.readOutput(outputManager1));
+        }
+      },
+      4,
+      TimeUnit.MINUTES);
+
+    // the second sink should have 2 windows with one record, and 3 windows with 2 records
+    // To visualize, with records: r1 r2 r3 r4
+    // window1: - r1
+    // window2: r1 r2
+    // window3: r2 r3
+    // window4: r3 r4
+    // window5: r4 -
+    final List<StructuredRecord> expected2 = ImmutableList.of(
+      StructuredRecord.builder(outputSchema).set("x", "abc").set("ct", 1L).build(),
+      StructuredRecord.builder(outputSchema).set("x", "abc").set("ct", 2L).build(),
+      StructuredRecord.builder(outputSchema).set("x", "abc").set("ct", 2L).build(),
+      StructuredRecord.builder(outputSchema).set("x", "abc").set("ct", 2L).build(),
+      StructuredRecord.builder(outputSchema).set("x", "abc").set("ct", 1L).build()
+    );
+    final DataSetManager<Table> outputManager2 = getDataset(sink2Name);
+    Tasks.waitFor(
+      true,
+      new Callable<Boolean>() {
+        @Override
+        public Boolean call() throws Exception {
+          outputManager2.flush();
+          return expected2.equals(MockSink.readOutput(outputManager2));
+        }
+      },
+      4,
+      TimeUnit.MINUTES);
+
+    // the third sink will depend on which slot the sliding window starts
+    // To visualize, with records: r1 r2 r3 r4
+    // window1: - r1   or   r1 r2
+    // window2: r2 r3  or   r3 r4
+    // window3: r4 -   or nothing
+    final List<StructuredRecord> possible1 = ImmutableList.of(
+      StructuredRecord.builder(outputSchema).set("x", "abc").set("ct", 1L).build(),
+      StructuredRecord.builder(outputSchema).set("x", "abc").set("ct", 2L).build(),
+      StructuredRecord.builder(outputSchema).set("x", "abc").set("ct", 1L).build()
+    );
+    final List<StructuredRecord> possible2 = ImmutableList.of(
+      StructuredRecord.builder(outputSchema).set("x", "abc").set("ct", 2L).build(),
+      StructuredRecord.builder(outputSchema).set("x", "abc").set("ct", 2L).build()
+    );
+    final DataSetManager<Table> outputManager3 = getDataset(sink3Name);
+    Tasks.waitFor(
+      true,
+      new Callable<Boolean>() {
+        @Override
+        public Boolean call() throws Exception {
+          outputManager3.flush();
+          List<StructuredRecord> actual = MockSink.readOutput(outputManager3);
+          return possible1.equals(actual) || possible2.equals(actual);
+        }
+      },
+      4,
+      TimeUnit.MINUTES);
+
+    sparkManager.stop();
+    sparkManager.waitForStatus(false, 10, 1);
+  }
+
+  @Test
+  public void testJoin() throws Exception {
+    /*
+     * source1 ----> t1 ------
+     *                        | --> innerjoin ----> t4 ------
+     * source2 ----> t2 ------                                 |
+     *                                                         | ---> outerjoin --> sink1
+     *                                                         |
+     * source3 -------------------- t3 ------------------------
+     */
+
+    Schema inputSchema1 = Schema.recordOf(
+      "customerRecord",
+      Schema.Field.of("customer_id", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("customer_name", Schema.of(Schema.Type.STRING))
+    );
+
+    Schema inputSchema2 = Schema.recordOf(
+      "itemRecord",
+      Schema.Field.of("item_id", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("item_price", Schema.of(Schema.Type.LONG)),
+      Schema.Field.of("cust_id", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("cust_name", Schema.of(Schema.Type.STRING))
+    );
+
+    Schema inputSchema3 = Schema.recordOf(
+      "transactionRecord",
+      Schema.Field.of("t_id", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("c_id", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("i_id", Schema.of(Schema.Type.STRING))
+    );
+
+    Schema outSchema1 = Schema.recordOf(
+      "join.output",
+      Schema.Field.of("customer_id", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("customer_name", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("item_id", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("item_price", Schema.of(Schema.Type.LONG)),
+      Schema.Field.of("cust_id", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("cust_name", Schema.of(Schema.Type.STRING))
+    );
+
+    Schema outSchema2 = Schema.recordOf(
+      "join.output",
+      Schema.Field.of("t_id", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("c_id", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("i_id", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("customer_id", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("customer_name", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("item_id", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("item_price", Schema.nullableOf(Schema.of(Schema.Type.LONG))),
+      Schema.Field.of("cust_id", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("cust_name", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
+    );
+
+    StructuredRecord recordSamuel = StructuredRecord.builder(inputSchema1).set("customer_id", "1")
+      .set("customer_name", "samuel").build();
+    StructuredRecord recordBob = StructuredRecord.builder(inputSchema1).set("customer_id", "2")
+      .set("customer_name", "bob").build();
+    StructuredRecord recordJane = StructuredRecord.builder(inputSchema1).set("customer_id", "3")
+      .set("customer_name", "jane").build();
+
+    StructuredRecord recordCar = StructuredRecord.builder(inputSchema2).set("item_id", "11").set("item_price", 10000L)
+      .set("cust_id", "1").set("cust_name", "samuel").build();
+    StructuredRecord recordBike = StructuredRecord.builder(inputSchema2).set("item_id", "22").set("item_price", 100L)
+      .set("cust_id", "3").set("cust_name", "jane").build();
+
+    StructuredRecord recordTrasCar = StructuredRecord.builder(inputSchema3).set("t_id", "1").set("c_id", "1")
+      .set("i_id", "11").build();
+    StructuredRecord recordTrasBike = StructuredRecord.builder(inputSchema3).set("t_id", "2").set("c_id", "3")
+      .set("i_id", "22").build();
+    StructuredRecord recordTrasPlane = StructuredRecord.builder(inputSchema3).set("t_id", "3").set("c_id", "4")
+      .set("i_id", "33").build();
+
+    List<StructuredRecord> input1 = ImmutableList.of(recordSamuel, recordBob, recordJane);
+    List<StructuredRecord> input2 = ImmutableList.of(recordCar, recordBike);
+    List<StructuredRecord> input3 = ImmutableList.of(recordTrasCar, recordTrasBike, recordTrasPlane);
+
+    String outputName = "multiJoinOutputSink";
+    DataStreamsConfig etlConfig = DataStreamsConfig.builder()
+      .addStage(new ETLStage("source1", MockSource.getPlugin(inputSchema1, input1)))
+      .addStage(new ETLStage("source2", MockSource.getPlugin(inputSchema2, input2)))
+      .addStage(new ETLStage("source3", MockSource.getPlugin(inputSchema3, input3)))
+      .addStage(new ETLStage("t1", FieldsPrefixTransform.getPlugin("", inputSchema1.toString())))
+      .addStage(new ETLStage("t2", FieldsPrefixTransform.getPlugin("", inputSchema2.toString())))
+      .addStage(new ETLStage("t3", FieldsPrefixTransform.getPlugin("", inputSchema3.toString())))
+      .addStage(new ETLStage("t4", FieldsPrefixTransform.getPlugin("", outSchema1.toString())))
+      .addStage(new ETLStage("innerjoin", MockJoiner.getPlugin("t1.customer_id=t2.cust_id",
+                                                               "t1,t2", "")))
+      .addStage(new ETLStage("outerjoin", MockJoiner.getPlugin("t4.item_id=t3.i_id",
+                                                                 "", "")))
+      .addStage(new ETLStage("multijoinSink", MockSink.getPlugin(outputName)))
+      .addConnection("source1", "t1")
+      .addConnection("source2", "t2")
+      .addConnection("source3", "t3")
+      .addConnection("t1", "innerjoin")
+      .addConnection("t2", "innerjoin")
+      .addConnection("innerjoin", "t4")
+      .addConnection("t3", "outerjoin")
+      .addConnection("t4", "outerjoin")
+      .addConnection("outerjoin", "multijoinSink")
+      .setBatchInterval("5s")
+      .build();
+
+    AppRequest<DataStreamsConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig);
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "JoinerApp");
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    SparkManager sparkManager = appManager.getSparkManager(DataStreamsSparkLauncher.NAME);
+    sparkManager.start();
+    sparkManager.waitForStatus(true, 10, 1);
+
+    StructuredRecord joinRecordSamuel = StructuredRecord.builder(outSchema2)
+      .set("customer_id", "1").set("customer_name", "samuel")
+      .set("item_id", "11").set("item_price", 10000L).set("cust_id", "1").set("cust_name", "samuel")
+      .set("t_id", "1").set("c_id", "1").set("i_id", "11").build();
+
+    StructuredRecord joinRecordJane = StructuredRecord.builder(outSchema2)
+      .set("customer_id", "3").set("customer_name", "jane")
+      .set("item_id", "22").set("item_price", 100L).set("cust_id", "3").set("cust_name", "jane")
+      .set("t_id", "2").set("c_id", "3").set("i_id", "22").build();
+
+    StructuredRecord joinRecordPlane = StructuredRecord.builder(outSchema2)
+      .set("t_id", "3").set("c_id", "4").set("i_id", "33").build();
+    final Set<StructuredRecord> expected = ImmutableSet.of(joinRecordSamuel, joinRecordJane, joinRecordPlane);
+
+    final DataSetManager<Table> outputManager = getDataset(outputName);
+    Tasks.waitFor(
+      true,
+      new Callable<Boolean>() {
+        @Override
+        public Boolean call() throws Exception {
+          outputManager.flush();
+          Set<StructuredRecord> outputRecords = new HashSet<>();
+          outputRecords.addAll(MockSink.readOutput(outputManager));
+          return expected.equals(outputRecords);
+        }
+      },
+      4,
+      TimeUnit.MINUTES);
+
+    sparkManager.stop();
+    sparkManager.waitForStatus(false, 10, 1);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/pom.xml
@@ -48,6 +48,11 @@
       <artifactId>spark-core_2.10</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-streaming_2.10</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/co/cask/cdap/etl/api/streaming/StreamingSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/co/cask/cdap/etl/api/streaming/StreamingSource.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.api.streaming;
+
+import co.cask.cdap.etl.api.PipelineConfigurable;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import org.apache.spark.streaming.api.java.JavaDStream;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+
+import java.io.Serializable;
+
+/**
+ * Source for Spark Streaming pipelines.
+ *
+ * @param <T> type of object contained in the stream
+ */
+public abstract class StreamingSource<T> implements PipelineConfigurable, Serializable {
+
+  public static final String PLUGIN_TYPE = "streamingsource";
+
+  private static final long serialVersionUID = -7949508317034247623L;
+
+  /**
+   * Get the stream to read from.
+   *
+   * @param jsc spark context
+   * @return the stream to read from.
+   */
+  public abstract JavaDStream<T> getStream(JavaStreamingContext jsc) throws Exception;
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
+    // no-op
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/co/cask/cdap/etl/api/streaming/Windower.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/co/cask/cdap/etl/api/streaming/Windower.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.api.streaming;
+
+import co.cask.cdap.etl.api.PipelineConfigurable;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+
+import java.io.Serializable;
+
+/**
+ * Windowing plugin.
+ */
+public abstract class Windower implements PipelineConfigurable, Serializable {
+
+  public static final String PLUGIN_TYPE = "windower";
+
+  private static final long serialVersionUID = -7949508317034247623L;
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
+    // no-op
+  }
+
+  /**
+   * @return the width of the window in seconds. Must be a multiple of the underlying batch interval.
+   */
+  public abstract long getWidth();
+
+  /**
+   * @return the slide interval of the window in seconds. Must be a multiple of the underlying batch interval.
+   */
+  public abstract long getSlideInterval();
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/pom.xml
@@ -95,6 +95,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-streaming_2.10</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/PipelinePhase.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/PipelinePhase.java
@@ -224,6 +224,11 @@ public class PipelinePhase implements Iterable<StageInfo> {
       return this;
     }
 
+    public Builder addConnections(Collection<co.cask.cdap.etl.proto.Connection> connections) {
+      this.connections.addAll(connections);
+      return this;
+    }
+
     public PipelinePhase build() {
       return new PipelinePhase(stages, connections.isEmpty() ? null : new Dag(connections));
     }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/realtime/RealtimePipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/realtime/RealtimePipelineSpecGenerator.java
@@ -41,7 +41,7 @@ public class RealtimePipelineSpecGenerator extends PipelineSpecGenerator<ETLReal
 
   @Override
   public PipelineSpec generateSpec(ETLRealtimeConfig config) {
-    BatchPipelineSpec.Builder specBuilder = BatchPipelineSpec.builder();
+    PipelineSpec.Builder specBuilder = PipelineSpec.builder();
     configureStages(config, specBuilder);
     return specBuilder.build();
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpec.java
@@ -39,10 +39,10 @@ public class PipelineSpec {
   private final Resources resources;
   private final boolean stageLoggingEnabled;
 
-  public PipelineSpec(Set<StageSpec> stages,
-                      Set<Connection> connections,
-                      Resources resources,
-                      boolean stageLoggingEnabled) {
+  protected PipelineSpec(Set<StageSpec> stages,
+                         Set<Connection> connections,
+                         Resources resources,
+                         boolean stageLoggingEnabled) {
     this.stages = ImmutableSet.copyOf(stages);
     this.connections = ImmutableSet.copyOf(connections);
     this.resources = resources;
@@ -98,10 +98,17 @@ public class PipelineSpec {
   }
 
   /**
+   * @return builder to create a spec.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
    * Base builder for creating pipeline specs.
    */
   @SuppressWarnings("unchecked")
-  protected static class Builder<T extends Builder> {
+  public static class Builder<T extends Builder> {
     protected Set<StageSpec> stages;
     protected Set<Connection> connections;
     protected Resources resources;
@@ -116,6 +123,11 @@ public class PipelineSpec {
 
     public T addStage(StageSpec stage) {
       stages.add(stage);
+      return (T) this;
+    }
+
+    public T addStages(Collection<StageSpec> stages) {
+      this.stages.addAll(stages);
       return (T) this;
     }
 
@@ -137,6 +149,10 @@ public class PipelineSpec {
     public T setStageLoggingEnabled(boolean stageLoggingEnabled) {
       this.stageLoggingEnabled = stageLoggingEnabled;
       return (T) this;
+    }
+
+    public PipelineSpec build() {
+      return new PipelineSpec(stages, connections, resources, stageLoggingEnabled);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/PipelinePlannerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/planner/PipelinePlannerTest.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.etl.planner;
 
-import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.artifact.ArtifactId;
 import co.cask.cdap.api.artifact.ArtifactScope;
 import co.cask.cdap.api.artifact.ArtifactVersion;
@@ -139,7 +138,7 @@ public class PipelinePlannerTest {
     Set<String> reduceTypes = ImmutableSet.of(AGGREGATOR);
     Set<String> isolationTypes = ImmutableSet.of();
     PipelinePlanner planner = new PipelinePlanner(pluginTypes, reduceTypes, isolationTypes);
-    PipelineSpec pipelineSpec = new PipelineSpec(stageSpecs, connections, new Resources(), true);
+    PipelineSpec pipelineSpec = PipelineSpec.builder().addStages(stageSpecs).addConnections(connections).build();
 
     Map<String, PipelinePhase> phases = new HashMap<>();
     /*

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/v2/DataStreamsConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/v2/DataStreamsConfig.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.proto.v2;
+
+import co.cask.cdap.api.Resources;
+import co.cask.cdap.etl.proto.Connection;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Data Streams Configuration.
+ */
+public final class DataStreamsConfig extends ETLConfig {
+  private final String batchInterval;
+  private final Resources driverResources;
+  // See comments in DataStreamsSparkLauncher for explanation on why we need this.
+  private final boolean isUnitTest;
+
+  private DataStreamsConfig(Set<ETLStage> stages,
+                            Set<Connection> connections,
+                            Resources resources,
+                            Resources driverResources,
+                            boolean stageLoggingEnabled,
+                            String batchInterval,
+                            boolean isUnitTest) {
+    super(stages, connections, resources, stageLoggingEnabled);
+    this.batchInterval = batchInterval;
+    this.driverResources = driverResources;
+    this.isUnitTest = isUnitTest;
+  }
+
+  public Resources getDriverResources() {
+    return driverResources;
+  }
+
+  public String getBatchInterval() {
+    return batchInterval;
+  }
+
+  public boolean isUnitTest() {
+    return isUnitTest;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    DataStreamsConfig that = (DataStreamsConfig) o;
+
+    return Objects.equals(batchInterval, that.batchInterval) && Objects.equals(driverResources, that.driverResources);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), batchInterval, driverResources);
+  }
+
+  @Override
+  public String toString() {
+    return "DataStreamsConfig{" +
+      "batchInterval='" + batchInterval + '\'' +
+      ", driverResources=" + driverResources +
+      "} " + super.toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Builder to create data stream configs.
+   */
+  public static class Builder extends ETLConfig.Builder<Builder> {
+    private final boolean isUnitTest;
+    private String batchInterval;
+    private Resources driverResources;
+
+    public Builder() {
+      this.isUnitTest = true;
+      this.batchInterval = "1m";
+      this.driverResources = new Resources();
+    }
+
+    public Builder setBatchInterval(String batchInterval) {
+      this.batchInterval = batchInterval;
+      return this;
+    }
+
+    public Builder setDriverResources(Resources driverResources) {
+      this.driverResources = driverResources;
+      return this;
+    }
+
+    public DataStreamsConfig build() {
+      return new DataStreamsConfig(stages, connections, resources, driverResources,
+                                   stageLoggingEnabled, batchInterval, isUnitTest);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/v2/DataStreamsConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/v2/DataStreamsConfig.java
@@ -28,6 +28,7 @@ import java.util.Set;
 public final class DataStreamsConfig extends ETLConfig {
   private final String batchInterval;
   private final Resources driverResources;
+  private final String extraJavaOpts;
   // See comments in DataStreamsSparkLauncher for explanation on why we need this.
   private final boolean isUnitTest;
 
@@ -42,6 +43,7 @@ public final class DataStreamsConfig extends ETLConfig {
     this.batchInterval = batchInterval;
     this.driverResources = driverResources;
     this.isUnitTest = isUnitTest;
+    this.extraJavaOpts = "";
   }
 
   public Resources getDriverResources() {
@@ -54,6 +56,10 @@ public final class DataStreamsConfig extends ETLConfig {
 
   public boolean isUnitTest() {
     return isUnitTest;
+  }
+
+  public String getExtraJavaOpts() {
+    return extraJavaOpts == null || extraJavaOpts.isEmpty() ? "-XX:MaxPermSize=256m" : extraJavaOpts;
   }
 
   @Override
@@ -70,12 +76,14 @@ public final class DataStreamsConfig extends ETLConfig {
 
     DataStreamsConfig that = (DataStreamsConfig) o;
 
-    return Objects.equals(batchInterval, that.batchInterval) && Objects.equals(driverResources, that.driverResources);
+    return Objects.equals(batchInterval, that.batchInterval) &&
+      Objects.equals(driverResources, that.driverResources) &&
+      Objects.equals(extraJavaOpts, that.extraJavaOpts);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), batchInterval, driverResources);
+    return Objects.hash(super.hashCode(), batchInterval, driverResources, extraJavaOpts);
   }
 
   @Override
@@ -83,6 +91,8 @@ public final class DataStreamsConfig extends ETLConfig {
     return "DataStreamsConfig{" +
       "batchInterval='" + batchInterval + '\'' +
       ", driverResources=" + driverResources +
+      ", extraJavaOpts='" + extraJavaOpts + '\'' +
+      ", isUnitTest=" + isUnitTest +
       "} " + super.toString();
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/SparkCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/SparkCollection.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark;
+
+import co.cask.cdap.etl.api.batch.SparkCompute;
+import co.cask.cdap.etl.api.batch.SparkSink;
+import co.cask.cdap.etl.api.streaming.Windower;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.PairFlatMapFunction;
+
+/**
+ * Abstraction over different types of spark collections with common shared operations on those collections.
+ * For example, both JavaRDD and JavaDStream support the flatMap operation, but don't share a higher interface.
+ * This allows us to perform a common operation and have the implementation take care of whether it happens
+ * on an RDD, DStream, DataFrame, etc.
+ *
+ * Also handles other Hydrator specific operations, such as performing a SparkCompute operation.
+ *
+ * @param <T> type of elements in the spark collection
+ */
+public interface SparkCollection<T> {
+
+  <C> C getUnderlying();
+
+  SparkCollection<T> cache();
+
+  SparkCollection<T> union(SparkCollection<T> other);
+
+  <U> SparkCollection<U> flatMap(FlatMapFunction<T, U> function);
+
+  <K, V> SparkPairCollection<K, V> flatMapToPair(PairFlatMapFunction<T, K, V> function);
+
+  <U> SparkCollection<U> compute(String stageName, SparkCompute<T, U> compute) throws Exception;
+
+  void store(String stageName, PairFlatMapFunction<T, Object, Object> sinkFunction);
+
+  void store(String stageName, SparkSink<T> sink) throws Exception;
+
+  SparkCollection<T> window(Windower windower);
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/SparkPairCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/SparkPairCollection.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark;
+
+import com.google.common.base.Optional;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.Function;
+import scala.Tuple2;
+
+/**
+ * Abstraction over different types of spark pair collections with common shared operations on those collections.
+ * For example, both JavaPairRDD and JavaPairDStream support the flatMap operation, but don't share a higher interface.
+ * This allows us to perform a common operation and have the implementation take care of whether it happens
+ * on a PairRDD, PairDStream, or whatever other object is being used.
+ *
+ * @param <K> type of key in the collection
+ * @param <V> type of value in the collection
+ */
+public interface SparkPairCollection<K, V> {
+
+  <C> C getUnderlying();
+
+  <T> SparkCollection<T> flatMap(FlatMapFunction<Tuple2<K, V>, T> function);
+
+  <T> SparkPairCollection<K, T> mapValues(Function<V, T> function);
+
+  SparkPairCollection<K, Iterable<V>> groupByKey();
+
+  SparkPairCollection<K, Iterable<V>> groupByKey(int numPartitions);
+
+  <T> SparkPairCollection<K, Tuple2<V, T>> join(SparkPairCollection<K, T> other);
+
+  <T> SparkPairCollection<K, Tuple2<V, T>> join(SparkPairCollection<K, T> other, int numPartitions);
+
+  <T> SparkPairCollection<K, Tuple2<V, Optional<T>>> leftOuterJoin(SparkPairCollection<K, T> other);
+
+  <T> SparkPairCollection<K, Tuple2<V, Optional<T>>> leftOuterJoin(SparkPairCollection<K, T> other,
+                                                                   int numPartitions);
+
+  <T> SparkPairCollection<K, Tuple2<Optional<V>, Optional<T>>> fullOuterJoin(SparkPairCollection<K, T> other);
+
+  <T> SparkPairCollection<K, Tuple2<Optional<V>, Optional<T>>> fullOuterJoin(SparkPairCollection<K, T> other,
+                                                                             int numPartitions);
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/SparkPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/SparkPipelineDriver.java
@@ -18,6 +18,7 @@ package co.cask.cdap.etl.spark;
 
 import co.cask.cdap.api.macro.MacroEvaluator;
 import co.cask.cdap.api.spark.JavaSparkExecutionContext;
+import co.cask.cdap.etl.api.JoinElement;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.api.batch.BatchAggregator;
 import co.cask.cdap.etl.api.batch.BatchJoiner;
@@ -25,17 +26,27 @@ import co.cask.cdap.etl.api.batch.BatchJoinerRuntimeContext;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.SparkCompute;
 import co.cask.cdap.etl.api.batch.SparkSink;
+import co.cask.cdap.etl.api.streaming.Windower;
 import co.cask.cdap.etl.common.DefaultMacroEvaluator;
 import co.cask.cdap.etl.common.PipelinePhase;
 import co.cask.cdap.etl.planner.StageInfo;
 import co.cask.cdap.etl.spark.function.AggregatorAggregateFunction;
 import co.cask.cdap.etl.spark.function.AggregatorGroupByFunction;
 import co.cask.cdap.etl.spark.function.BatchSinkFunction;
+import co.cask.cdap.etl.spark.function.InitialJoinFunction;
+import co.cask.cdap.etl.spark.function.JoinFlattenFunction;
+import co.cask.cdap.etl.spark.function.JoinMergeFunction;
+import co.cask.cdap.etl.spark.function.JoinOnFunction;
+import co.cask.cdap.etl.spark.function.LeftJoinFlattenFunction;
+import co.cask.cdap.etl.spark.function.OuterJoinFlattenFunction;
 import co.cask.cdap.etl.spark.function.PluginFunctionContext;
 import co.cask.cdap.etl.spark.function.TransformFunction;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.PairFlatMapFunction;
+import scala.Tuple2;
 
-import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -43,49 +54,33 @@ import java.util.Set;
 
 /**
  * Base Spark program to run a Hydrator pipeline.
- *
- * @param <T> type of Spark object the pipeline operates on.
  */
-public abstract class SparkPipelineDriver<T> {
+public abstract class SparkPipelineDriver {
 
-  protected abstract T union(T input1, T input2);
-
-  protected abstract void cache(T data);
-
-  protected abstract T getSource(String stageName, PluginFunctionContext pluginFunctionContext);
-
-  protected abstract T handleTransform(String stageName, T inputData, TransformFunction function);
-
-  protected abstract T handleSparkCompute(String stageName, T inputData,
-                                          SparkCompute<Object, Object> plugin) throws Exception;
-
-  protected abstract T handleAggregator(String stageName, T inputData,
-                                        AggregatorGroupByFunction groupByFunction,
-                                        AggregatorAggregateFunction aggregateFunction);
-
-  protected abstract T handleJoin(String stageName,
-                                  BatchJoiner<Object, Object, Object> joiner,
-                                  Map<String, T> inputData,
-                                  PluginFunctionContext pluginFunctionContext) throws Exception;
-
-  protected abstract void handleBatchSink(String stageName, T inputData, BatchSinkFunction sinkFunction);
-
-  protected abstract void handleSparkSink(String stageName, T inputData, SparkSink<Object> plugin) throws Exception;
+  protected abstract SparkCollection<Object> getSource(String stageName,
+                                                       PluginFunctionContext pluginFunctionContext) throws Exception;
 
   public void runPipeline(PipelinePhase pipelinePhase, String sourcePluginType,
-                          JavaSparkExecutionContext sec) throws Exception {
+                          JavaSparkExecutionContext sec,
+                          Map<String, Integer> stagePartitions) throws Exception {
 
     MacroEvaluator macroEvaluator =
       new DefaultMacroEvaluator(sec.getWorkflowToken(), sec.getRuntimeArguments(), sec.getLogicalStartTime(), sec,
                                 sec.getNamespace());
-    Map<String, T> stageDataCollections = new HashMap<>();
+    Map<String, SparkCollection<Object>> stageDataCollections = new HashMap<>();
+
+    // should never happen, but removes warning
+    if (pipelinePhase.getDag() == null) {
+      throw new IllegalStateException("Pipeline phase has no connections.");
+    }
+
     for (String stageName : pipelinePhase.getDag().getTopologicalOrder()) {
       StageInfo stageInfo = pipelinePhase.getStage(stageName);
       String pluginType = stageInfo.getPluginType();
 
-      T stageData = null;
+      SparkCollection<Object> stageData = null;
 
-      Map<String, T> inputDataCollections = new HashMap<>();
+      Map<String, SparkCollection<Object>> inputDataCollections = new HashMap<>();
       for (String inputStageName : stageInfo.getInputs()) {
         inputDataCollections.put(inputStageName, stageDataCollections.get(inputStageName));
       }
@@ -93,16 +88,17 @@ public abstract class SparkPipelineDriver<T> {
       // if this stage has multiple inputs, and is not a joiner plugin,
       // initialize the stageRDD as the union of all input RDDs.
       if (!inputDataCollections.isEmpty()) {
-        Iterator<T> inputRDDIter = inputDataCollections.values().iterator();
-        stageData = inputRDDIter.next();
+        Iterator<SparkCollection<Object>> inputCollectionIter = inputDataCollections.values().iterator();
+        stageData = inputCollectionIter.next();
         // don't union if we're joining
-        while (!BatchJoiner.PLUGIN_TYPE.equals(pluginType) && inputRDDIter.hasNext()) {
-          stageData = union(stageData, inputRDDIter.next());
+        while (!BatchJoiner.PLUGIN_TYPE.equals(pluginType) && inputCollectionIter.hasNext()) {
+          stageData = stageData.union(inputCollectionIter.next());
         }
       }
 
       PluginFunctionContext pluginFunctionContext = new PluginFunctionContext(stageName, sec, pipelinePhase);
       if (stageData == null) {
+
         // this if-else is nested inside the stageRDD null check to avoid warnings about stageRDD possibly being
         // null in the other else-if conditions
         if (sourcePluginType.equals(pluginType)) {
@@ -110,34 +106,119 @@ public abstract class SparkPipelineDriver<T> {
         } else {
           throw new IllegalStateException(String.format("Stage '%s' has no input and is not a source.", stageName));
         }
+
       } else if (BatchSink.PLUGIN_TYPE.equals(pluginType)) {
-        handleBatchSink(stageName, stageData, new BatchSinkFunction(pluginFunctionContext));
+
+        stageData.store(stageName, new BatchSinkFunction(pluginFunctionContext));
+
       } else if (Transform.PLUGIN_TYPE.equals(pluginType)) {
-        stageData = handleTransform(stageName, stageData, new TransformFunction(pluginFunctionContext));
+
+        stageData = stageData.flatMap(new TransformFunction(pluginFunctionContext));
+
       } else if (SparkCompute.PLUGIN_TYPE.equals(pluginType)) {
+
         SparkCompute<Object, Object> sparkCompute =
           sec.getPluginContext().newPluginInstance(stageName, macroEvaluator);
-        stageData = handleSparkCompute(stageName, stageData, sparkCompute);
+        stageData = stageData.compute(stageName, sparkCompute);
+
       } else if (SparkSink.PLUGIN_TYPE.equals(pluginType)) {
+
         SparkSink<Object> sparkSink = sec.getPluginContext().newPluginInstance(stageName, macroEvaluator);
-        handleSparkSink(stageName, stageData, sparkSink);
+        stageData.store(stageName, sparkSink);
+
       } else if (BatchAggregator.PLUGIN_TYPE.equals(pluginType)) {
-        stageData = handleAggregator(stageName, stageData,
-                                     new AggregatorGroupByFunction(pluginFunctionContext),
-                                     new AggregatorAggregateFunction(pluginFunctionContext));
+
+        PairFlatMapFunction<Object, Object, Object> groupByFunction =
+          new AggregatorGroupByFunction(pluginFunctionContext);
+        FlatMapFunction<Tuple2<Object, Iterable<Object>>, Object> aggregateFunction =
+          new AggregatorAggregateFunction(pluginFunctionContext);
+
+        Integer partitions = stagePartitions.get(stageName);
+        SparkPairCollection<Object, Object> keyedCollection = stageData.flatMapToPair(groupByFunction);
+
+        SparkPairCollection<Object, Iterable<Object>> groupedCollection = partitions == null ?
+          keyedCollection.groupByKey() : keyedCollection.groupByKey(partitions);
+        stageData = groupedCollection.flatMap(aggregateFunction);
+
       } else if (BatchJoiner.PLUGIN_TYPE.equals(pluginType)) {
+
         BatchJoiner<Object, Object, Object> joiner =
           sec.getPluginContext().newPluginInstance(stageName, macroEvaluator);
         BatchJoinerRuntimeContext joinerRuntimeContext = pluginFunctionContext.createJoinerRuntimeContext();
         joiner.initialize(joinerRuntimeContext);
-        stageData = handleJoin(stageName, joiner, inputDataCollections, pluginFunctionContext);
+
+        Map<String, SparkPairCollection<Object, Object>> preJoinStreams = new HashMap<>();
+        for (Map.Entry<String, SparkCollection<Object>> inputStreamEntry : inputDataCollections.entrySet()) {
+          String inputStage = inputStreamEntry.getKey();
+          SparkCollection<Object> inputStream = inputStreamEntry.getValue();
+          preJoinStreams.put(inputStage,
+                             inputStream.flatMapToPair(new JoinOnFunction(pluginFunctionContext, inputStage)));
+        }
+
+        Set<String> remainingInputs = new HashSet<>();
+        remainingInputs.addAll(inputDataCollections.keySet());
+
+        Integer numPartitions = stagePartitions.get(stageName);
+
+        SparkPairCollection<Object, List<JoinElement<Object>>> joinedInputs = null;
+        // inner join on required inputs
+        for (final String inputStageName : joiner.getJoinConfig().getRequiredInputs()) {
+          SparkPairCollection<Object, Object> preJoinCollection = preJoinStreams.get(inputStageName);
+
+          if (joinedInputs == null) {
+            joinedInputs = preJoinCollection.mapValues(new InitialJoinFunction(inputStageName));
+          } else {
+            JoinFlattenFunction joinFlattenFunction = new JoinFlattenFunction(inputStageName);
+            joinedInputs = numPartitions == null ?
+              joinedInputs.join(preJoinCollection).mapValues(joinFlattenFunction) :
+              joinedInputs.join(preJoinCollection, numPartitions).mapValues(joinFlattenFunction);
+          }
+          remainingInputs.remove(inputStageName);
+        }
+
+        // outer join on non-required inputs
+        boolean isFullOuter = joinedInputs == null;
+        for (final String inputStageName : remainingInputs) {
+          SparkPairCollection<Object, Object> preJoinStream = preJoinStreams.get(inputStageName);
+
+          if (joinedInputs == null) {
+            joinedInputs = preJoinStream.mapValues(new InitialJoinFunction(inputStageName));
+          } else {
+            if (isFullOuter) {
+              OuterJoinFlattenFunction outerJoinFlattenFunction = new OuterJoinFlattenFunction(inputStageName);
+
+              joinedInputs = numPartitions == null ?
+                joinedInputs.fullOuterJoin(preJoinStream).mapValues(outerJoinFlattenFunction) :
+                joinedInputs.fullOuterJoin(preJoinStream, numPartitions).mapValues(outerJoinFlattenFunction);
+            } else {
+              LeftJoinFlattenFunction joinFlattenFunction = new LeftJoinFlattenFunction(inputStageName);
+
+              joinedInputs = numPartitions == null ?
+                joinedInputs.leftOuterJoin(preJoinStream).mapValues(joinFlattenFunction) :
+                joinedInputs.leftOuterJoin(preJoinStream, numPartitions).mapValues(joinFlattenFunction);
+            }
+          }
+        }
+
+        // should never happen, but removes warnings
+        if (joinedInputs == null) {
+          throw new IllegalStateException("There are no inputs into join stage " + stageName);
+        }
+
+        stageData = joinedInputs.flatMap(new JoinMergeFunction(pluginFunctionContext)).cache();
+
+      } else if (Windower.PLUGIN_TYPE.equals(pluginType)) {
+
+        Windower windower = sec.getPluginContext().newPluginInstance(stageName, macroEvaluator);
+        stageData = stageData.window(windower);
+
       } else {
         throw new IllegalStateException(String.format("Stage %s is of unsupported plugin type %s.",
                                                       stageName, pluginType));
       }
 
       if (shouldCache(pipelinePhase, stageInfo)) {
-        cache(stageData);
+        stageData = stageData.cache();
       }
       stageDataCollections.put(stageName, stageData);
     }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/AbstractSparkBatchContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/AbstractSparkBatchContext.java
@@ -16,27 +16,32 @@
 
 package co.cask.cdap.etl.spark.batch;
 
+import co.cask.cdap.api.Admin;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.spark.JavaSparkExecutionContext;
 import co.cask.cdap.api.spark.SparkClientContext;
 import co.cask.cdap.etl.api.LookupProvider;
 import co.cask.cdap.etl.api.batch.BatchContext;
 import co.cask.cdap.etl.batch.AbstractBatchContext;
+import co.cask.cdap.etl.spark.NoLookupProvider;
 
 /**
  * Abstract implementation of {@link BatchContext} using {@link SparkClientContext}.
  */
 public abstract class AbstractSparkBatchContext extends AbstractBatchContext implements BatchContext {
+  protected final Admin admin;
 
-  protected final SparkClientContext sparkContext;
-
-  public AbstractSparkBatchContext(SparkClientContext sparkContext, LookupProvider lookupProvider, String stageId) {
+  protected AbstractSparkBatchContext(SparkClientContext sparkContext, LookupProvider lookupProvider, String stageId) {
     super(sparkContext, sparkContext, sparkContext.getMetrics(), lookupProvider, stageId,
           sparkContext.getLogicalStartTime(), sparkContext.getRuntimeArguments(), sparkContext.getAdmin());
-    this.sparkContext = sparkContext;
+    this.admin = sparkContext.getAdmin();
   }
 
-  @Override
-  public long getLogicalStartTime() {
-    return sparkContext.getLogicalStartTime();
+  protected AbstractSparkBatchContext(JavaSparkExecutionContext sec, DatasetContext datasetContext,
+                                      String stageName, long logicalStartTime) {
+    super(sec.getPluginContext(), datasetContext, sec.getMetrics(), NoLookupProvider.INSTANCE,
+          stageName, logicalStartTime, sec.getRuntimeArguments(), sec.getAdmin());
+    admin = sec.getAdmin();
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
@@ -21,53 +21,31 @@ import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.spark.JavaSparkExecutionContext;
 import co.cask.cdap.api.spark.JavaSparkMain;
-import co.cask.cdap.etl.api.JoinElement;
-import co.cask.cdap.etl.api.StageMetrics;
-import co.cask.cdap.etl.api.batch.BatchJoiner;
 import co.cask.cdap.etl.api.batch.BatchSource;
-import co.cask.cdap.etl.api.batch.SparkCompute;
-import co.cask.cdap.etl.api.batch.SparkExecutionPluginContext;
-import co.cask.cdap.etl.api.batch.SparkSink;
 import co.cask.cdap.etl.batch.BatchPhaseSpec;
 import co.cask.cdap.etl.common.Constants;
-import co.cask.cdap.etl.common.DefaultStageMetrics;
 import co.cask.cdap.etl.common.SetMultimapCodec;
+import co.cask.cdap.etl.spark.SparkCollection;
 import co.cask.cdap.etl.spark.SparkPipelineDriver;
-import co.cask.cdap.etl.spark.function.AggregatorAggregateFunction;
-import co.cask.cdap.etl.spark.function.AggregatorGroupByFunction;
-import co.cask.cdap.etl.spark.function.BatchSinkFunction;
 import co.cask.cdap.etl.spark.function.BatchSourceFunction;
-import co.cask.cdap.etl.spark.function.InitialJoinFunction;
-import co.cask.cdap.etl.spark.function.JoinFlattenFunction;
-import co.cask.cdap.etl.spark.function.JoinMergeFunction;
-import co.cask.cdap.etl.spark.function.JoinOnFunction;
-import co.cask.cdap.etl.spark.function.LeftJoinFlattenFunction;
-import co.cask.cdap.etl.spark.function.OuterJoinFlattenFunction;
 import co.cask.cdap.etl.spark.function.PluginFunctionContext;
-import co.cask.cdap.etl.spark.function.TransformFunction;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
 import com.google.common.collect.SetMultimap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
-import org.apache.spark.api.java.JavaPairRDD;
-import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 
 import java.io.DataInputStream;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.lang.reflect.Type;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Batch Spark pipeline driver.
  */
-public class BatchSparkPipelineDriver extends SparkPipelineDriver<JavaRDD<Object>>
+public class BatchSparkPipelineDriver extends SparkPipelineDriver
   implements JavaSparkMain, TxRunnable {
   private static final Type MAP_TYPE = new TypeToken<Map<String, String>>() { }.getType();
   private static final Gson GSON = new GsonBuilder()
@@ -83,140 +61,10 @@ public class BatchSparkPipelineDriver extends SparkPipelineDriver<JavaRDD<Object
   private transient Map<String, Integer> stagePartitions;
 
   @Override
-  protected JavaRDD<Object> union(JavaRDD<Object> input1, JavaRDD<Object> input2) {
-    return input1.union(input2);
-  }
-
-  @Override
-  protected void cache(JavaRDD<Object> data) {
-    data.cache();
-  }
-
-  @Override
-  protected JavaRDD<Object> getSource(String stageName, PluginFunctionContext pluginFunctionContext) {
-    return sourceFactory.createRDD(sec, jsc, stageName, Object.class, Object.class)
-        .flatMap(new BatchSourceFunction(pluginFunctionContext));
-  }
-
-  @Override
-  protected JavaRDD<Object> handleTransform(String stageName, JavaRDD<Object> inputData, TransformFunction function) {
-    return inputData.flatMap(function);
-  }
-
-  @Override
-  protected void handleBatchSink(String stageName, JavaRDD<Object> inputData,
-                                 BatchSinkFunction sinkFunction) {
-    JavaPairRDD<Object, Object> sinkRDD = inputData.flatMapToPair(sinkFunction);
-    sinkFactory.writeFromRDD(sinkRDD, sec, stageName, Object.class, Object.class);
-  }
-
-  @Override
-  protected JavaRDD<Object> handleSparkCompute(String stageName, JavaRDD<Object> inputData,
-                                               SparkCompute<Object, Object> plugin) throws Exception {
-    SparkExecutionPluginContext sparkPluginContext =
-      new BasicSparkExecutionPluginContext(sec, jsc, datasetContext, stageName);
-
-    // TODO: figure out how to do this in a better way...
-    long recordsIn = inputData.cache().count();
-    StageMetrics stageMetrics = new DefaultStageMetrics(sec.getMetrics(), stageName);
-    stageMetrics.gauge("records.in", recordsIn);
-
-    JavaRDD<Object> computedRDD = plugin.transform(sparkPluginContext, inputData).cache();
-    long recordsOut = computedRDD.count();
-    stageMetrics.gauge("records.out", recordsOut);
-    return computedRDD;
-  }
-
-  @Override
-  protected void handleSparkSink(String stageName, JavaRDD<Object> inputData,
-                                 SparkSink<Object> plugin) throws Exception {
-    SparkExecutionPluginContext sparkPluginContext =
-      new BasicSparkExecutionPluginContext(sec, jsc, datasetContext, stageName);
-
-    // TODO: figure out how to do this in a better way...
-    long recordsIn = inputData.cache().count();
-    StageMetrics stageMetrics = new DefaultStageMetrics(sec.getMetrics(), stageName);
-    stageMetrics.gauge("records.in", recordsIn);
-
-    plugin.run(sparkPluginContext, inputData);
-  }
-
-  @Override
-  protected JavaRDD<Object> handleAggregator(String stageName, JavaRDD<Object> inputData,
-                                             AggregatorGroupByFunction groupByFunction,
-                                             AggregatorAggregateFunction aggregateFunction) {
-    Integer partitions = stagePartitions.get(stageName);
-    JavaPairRDD<Object, Object> keyedRDD = inputData.flatMapToPair(groupByFunction);
-    JavaPairRDD<Object, Iterable<Object>> groupedRDD = partitions == null ?
-      keyedRDD.groupByKey() : keyedRDD.groupByKey(partitions);
-    return groupedRDD.flatMap(aggregateFunction);
-  }
-
-  @Override
-  protected JavaRDD<Object> handleJoin(String stageName,
-                                       final BatchJoiner<Object, Object, Object> joiner,
-                                       Map<String, JavaRDD<Object>> inputData,
-                                       PluginFunctionContext pluginFunctionContext) throws Exception {
-
-    Map<String, JavaPairRDD<Object, Object>> preJoinRDDs = new HashMap<>();
-    for (Map.Entry<String, JavaRDD<Object>> inputRDDEntry : inputData.entrySet()) {
-      String inputStage = inputRDDEntry.getKey();
-      JavaRDD<Object> inputRDD = inputRDDEntry.getValue();
-      preJoinRDDs.put(inputStage,
-                      inputRDD.flatMapToPair(new JoinOnFunction(pluginFunctionContext, inputStage)));
-    }
-
-    Set<String> remainingInputs = new HashSet<>();
-    remainingInputs.addAll(inputData.keySet());
-
-    Integer numPartitions = stagePartitions.get(stageName);
-
-    JavaPairRDD<Object, List<JoinElement<Object>>> joinedInputs = null;
-    // inner join on required inputs
-    for (final String inputStageName : joiner.getJoinConfig().getRequiredInputs()) {
-      JavaPairRDD<Object, Object> preJoinRDD = preJoinRDDs.get(inputStageName);
-
-      if (joinedInputs == null) {
-        joinedInputs = preJoinRDD.mapValues(new InitialJoinFunction(inputStageName));
-      } else {
-        JoinFlattenFunction joinFlattenFunction = new JoinFlattenFunction(inputStageName);
-        joinedInputs = numPartitions == null ?
-          joinedInputs.join(preJoinRDD).mapValues(joinFlattenFunction) :
-          joinedInputs.join(preJoinRDD, numPartitions).mapValues(joinFlattenFunction);
-      }
-      remainingInputs.remove(inputStageName);
-    }
-
-    // outer join on non-required inputs
-    boolean isFullOuter = joinedInputs == null;
-    for (final String inputStageName : remainingInputs) {
-      JavaPairRDD<Object, Object> preJoinRDD = preJoinRDDs.get(inputStageName);
-
-      if (joinedInputs == null) {
-        joinedInputs = preJoinRDD.mapValues(new InitialJoinFunction(inputStageName));
-      } else {
-        if (isFullOuter) {
-          OuterJoinFlattenFunction outerJoinFlattenFunction = new OuterJoinFlattenFunction(inputStageName);
-
-          joinedInputs = numPartitions == null ?
-            joinedInputs.fullOuterJoin(preJoinRDD).mapValues(outerJoinFlattenFunction) :
-            joinedInputs.fullOuterJoin(preJoinRDD, numPartitions).mapValues(outerJoinFlattenFunction);
-        } else {
-          LeftJoinFlattenFunction joinFlattenFunction = new LeftJoinFlattenFunction(inputStageName);
-
-          joinedInputs = numPartitions == null ?
-            joinedInputs.leftOuterJoin(preJoinRDD).mapValues(joinFlattenFunction) :
-            joinedInputs.leftOuterJoin(preJoinRDD, numPartitions).mapValues(joinFlattenFunction);
-        }
-      }
-    }
-
-    // should never happen, but removes warnings
-    if (joinedInputs == null) {
-      throw new IllegalStateException("There are no inputs into join stage " + stageName);
-    }
-
-    return joinedInputs.flatMap(new JoinMergeFunction(pluginFunctionContext)).cache();
+  protected SparkCollection<Object> getSource(String stageName, PluginFunctionContext pluginFunctionContext) {
+    return new RDDCollection<>(sec, jsc, datasetContext, sinkFactory,
+                               sourceFactory.createRDD(sec, jsc, stageName, Object.class, Object.class)
+                                 .flatMap(new BatchSourceFunction(pluginFunctionContext)));
   }
 
   @Override
@@ -235,13 +83,13 @@ public class BatchSparkPipelineDriver extends SparkPipelineDriver<JavaRDD<Object
     BatchPhaseSpec phaseSpec = GSON.fromJson(sec.getSpecification().getProperty(Constants.PIPELINEID),
                                              BatchPhaseSpec.class);
 
-    try (InputStream is = new FileInputStream(sec.getLocalizationContext().getLocalFile("ETLSpark.config"))) {
+    try (InputStream is = new FileInputStream(sec.getLocalizationContext().getLocalFile("HydratorSpark.config"))) {
       sourceFactory = SparkBatchSourceFactory.deserialize(is);
       sinkFactory = SparkBatchSinkFactory.deserialize(is);
       DataInputStream dataInputStream = new DataInputStream(is);
       stagePartitions = GSON.fromJson(dataInputStream.readUTF(), MAP_TYPE);
     }
     datasetContext = context;
-    runPipeline(phaseSpec.getPhase(), BatchSource.PLUGIN_TYPE, sec);
+    runPipeline(phaseSpec.getPhase(), BatchSource.PLUGIN_TYPE, sec, stagePartitions);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/ETLSpark.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/ETLSpark.java
@@ -144,7 +144,7 @@ public class ETLSpark extends AbstractSpark {
       }
     }
 
-    File configFile = File.createTempFile("ETLSpark", ".config");
+    File configFile = File.createTempFile("HydratorSpark", ".config");
     cleanupFiles.add(configFile);
     try (OutputStream os = new FileOutputStream(configFile)) {
       sourceFactory.serialize(os);
@@ -154,7 +154,7 @@ public class ETLSpark extends AbstractSpark {
     }
 
     finisher = finishers.build();
-    context.localize("ETLSpark.config", configFile.toURI());
+    context.localize("HydratorSpark.config", configFile.toURI());
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/PairRDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/PairRDDCollection.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark.batch;
+
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.spark.JavaSparkExecutionContext;
+import co.cask.cdap.etl.spark.SparkCollection;
+import co.cask.cdap.etl.spark.SparkPairCollection;
+import com.google.common.base.Optional;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.Function;
+import scala.Tuple2;
+
+/**
+ * Implementation of {@link SparkCollection} that is backed by a JavaPairRDD.
+ *
+ * @param <K> type of key in the collection
+ * @param <V> type of value in the collection
+ */
+public class PairRDDCollection<K, V> implements SparkPairCollection<K, V> {
+  private final JavaSparkExecutionContext sec;
+  private final JavaSparkContext jsc;
+  private final DatasetContext datasetContext;
+  private final SparkBatchSinkFactory sinkFactory;
+  private final JavaPairRDD<K, V> pairRDD;
+
+  public PairRDDCollection(JavaSparkExecutionContext sec, JavaSparkContext jsc, DatasetContext datasetContext,
+                           SparkBatchSinkFactory sinkFactory, JavaPairRDD<K, V> pairRDD) {
+    this.sec = sec;
+    this.jsc = jsc;
+    this.datasetContext = datasetContext;
+    this.sinkFactory = sinkFactory;
+    this.pairRDD = pairRDD;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public JavaPairRDD<K, V> getUnderlying() {
+    return pairRDD;
+  }
+
+  @Override
+  public <T> SparkCollection<T> flatMap(FlatMapFunction<Tuple2<K, V>, T> function) {
+    return new RDDCollection<>(sec, jsc, datasetContext, sinkFactory, pairRDD.flatMap(function));
+  }
+
+  @Override
+  public <T> SparkPairCollection<K, T> mapValues(Function<V, T> function) {
+    return wrap(pairRDD.mapValues(function));
+  }
+
+  @Override
+  public SparkPairCollection<K, Iterable<V>> groupByKey() {
+    return wrap(pairRDD.groupByKey());
+  }
+
+  @Override
+  public SparkPairCollection<K, Iterable<V>> groupByKey(int numPartitions) {
+    return wrap(pairRDD.groupByKey(numPartitions));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> SparkPairCollection<K, Tuple2<V, T>> join(SparkPairCollection<K, T> other) {
+    return wrap(pairRDD.join((JavaPairRDD<K, T>) other.getUnderlying()));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> SparkPairCollection<K, Tuple2<V, T>> join(SparkPairCollection<K, T> other, int numPartitions) {
+    return wrap(pairRDD.join((JavaPairRDD<K, T>) other.getUnderlying(), numPartitions));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> SparkPairCollection<K, Tuple2<V, Optional<T>>> leftOuterJoin(SparkPairCollection<K, T> other) {
+    return wrap(pairRDD.leftOuterJoin((JavaPairRDD<K, T>) other.getUnderlying()));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> SparkPairCollection<K, Tuple2<V, Optional<T>>> leftOuterJoin(SparkPairCollection<K, T> other,
+                                                                          int numPartitions) {
+    return wrap(pairRDD.leftOuterJoin((JavaPairRDD<K, T>) other.getUnderlying(), numPartitions));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> SparkPairCollection<K, Tuple2<Optional<V>, Optional<T>>> fullOuterJoin(SparkPairCollection<K, T> other) {
+    return wrap(pairRDD.fullOuterJoin((JavaPairRDD<K, T>) other.getUnderlying()));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> SparkPairCollection<K, Tuple2<Optional<V>, Optional<T>>> fullOuterJoin(SparkPairCollection<K, T> other,
+                                                                                    int numPartitions) {
+    return wrap(pairRDD.fullOuterJoin((JavaPairRDD<K, T>) other.getUnderlying(), numPartitions));
+  }
+
+  private <X, Y> SparkPairCollection<X, Y> wrap(JavaPairRDD<X, Y> javaPairRDD) {
+    return new PairRDDCollection<>(sec, jsc, datasetContext, sinkFactory, javaPairRDD);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/RDDCollection.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark.batch;
+
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.spark.JavaSparkExecutionContext;
+import co.cask.cdap.etl.api.StageMetrics;
+import co.cask.cdap.etl.api.batch.SparkCompute;
+import co.cask.cdap.etl.api.batch.SparkExecutionPluginContext;
+import co.cask.cdap.etl.api.batch.SparkSink;
+import co.cask.cdap.etl.api.streaming.Windower;
+import co.cask.cdap.etl.common.DefaultStageMetrics;
+import co.cask.cdap.etl.spark.SparkCollection;
+import co.cask.cdap.etl.spark.SparkPairCollection;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.PairFlatMapFunction;
+
+
+/**
+ * Implementation of {@link SparkCollection} that is backed by a JavaRDD.
+ *
+ * @param <T> type of object in the collection
+ */
+public class RDDCollection<T> implements SparkCollection<T> {
+  private final JavaSparkExecutionContext sec;
+  private final JavaSparkContext jsc;
+  private final DatasetContext datasetContext;
+  private final SparkBatchSinkFactory sinkFactory;
+  private final JavaRDD<T> rdd;
+
+  public RDDCollection(JavaSparkExecutionContext sec, JavaSparkContext jsc,
+                       DatasetContext datasetContext, SparkBatchSinkFactory sinkFactory, JavaRDD<T> rdd) {
+    this.sec = sec;
+    this.jsc = jsc;
+    this.datasetContext = datasetContext;
+    this.sinkFactory = sinkFactory;
+    this.rdd = rdd;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public JavaRDD<T> getUnderlying() {
+    return rdd;
+  }
+
+  @Override
+  public SparkCollection<T> cache() {
+    return wrap(rdd.cache());
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SparkCollection<T> union(SparkCollection<T> other) {
+    return wrap(rdd.union((JavaRDD<T>) other.getUnderlying()));
+  }
+
+  @Override
+  public <U> SparkCollection<U> flatMap(FlatMapFunction<T, U> function) {
+    return wrap(rdd.flatMap(function));
+  }
+
+  @Override
+  public <K, V> SparkPairCollection<K, V> flatMapToPair(PairFlatMapFunction<T, K, V> function) {
+    return new PairRDDCollection<>(sec, jsc, datasetContext, sinkFactory, rdd.flatMapToPair(function));
+  }
+
+  @Override
+  public <U> SparkCollection<U> compute(String stageName, SparkCompute<T, U> compute) throws Exception {
+    SparkExecutionPluginContext sparkPluginContext =
+      new BasicSparkExecutionPluginContext(sec, jsc, datasetContext, stageName);
+
+    // TODO: figure out how to do this in a better way...
+    long recordsIn = rdd.cache().count();
+    StageMetrics stageMetrics = new DefaultStageMetrics(sec.getMetrics(), stageName);
+    stageMetrics.gauge("records.in", recordsIn);
+
+    JavaRDD<U> computedRDD = compute.transform(sparkPluginContext, rdd).cache();
+    long recordsOut = computedRDD.count();
+    stageMetrics.gauge("records.out", recordsOut);
+    return wrap(computedRDD);
+  }
+
+  @Override
+  public void store(String stageName, PairFlatMapFunction<T, Object, Object> sinkFunction) {
+    JavaPairRDD<Object, Object> sinkRDD = rdd.flatMapToPair(sinkFunction);
+    sinkFactory.writeFromRDD(sinkRDD, sec, stageName, Object.class, Object.class);
+  }
+
+  @Override
+  public void store(String stageName, SparkSink<T> sink) throws Exception {
+    SparkExecutionPluginContext sparkPluginContext =
+      new BasicSparkExecutionPluginContext(sec, jsc, datasetContext, stageName);
+
+    // TODO: figure out how to do this in a better way...
+    long recordsIn = rdd.cache().count();
+    StageMetrics stageMetrics = new DefaultStageMetrics(sec.getMetrics(), stageName);
+    stageMetrics.gauge("records.in", recordsIn);
+
+    sink.run(sparkPluginContext, rdd);
+  }
+
+  @Override
+  public SparkCollection<T> window(Windower windower) {
+    throw new UnsupportedOperationException("Windowing is not supported on RDDs.");
+  }
+
+  private <U> RDDCollection<U> wrap(JavaRDD<U> rdd) {
+    return new RDDCollection<>(sec, jsc, datasetContext, sinkFactory, rdd);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/RDDCollection.java
@@ -86,7 +86,7 @@ public class RDDCollection<T> implements SparkCollection<T> {
     SparkExecutionPluginContext sparkPluginContext =
       new BasicSparkExecutionPluginContext(sec, jsc, datasetContext, stageName);
 
-    // TODO: figure out how to do this in a better way...
+    // TODO:(Hydra-364) figure out how to do this in a better way...
     long recordsIn = rdd.cache().count();
     StageMetrics stageMetrics = new DefaultStageMetrics(sec.getMetrics(), stageName);
     stageMetrics.gauge("records.in", recordsIn);
@@ -108,7 +108,7 @@ public class RDDCollection<T> implements SparkCollection<T> {
     SparkExecutionPluginContext sparkPluginContext =
       new BasicSparkExecutionPluginContext(sec, jsc, datasetContext, stageName);
 
-    // TODO: figure out how to do this in a better way...
+    // TODO:(Hydra-364) figure out how to do this in a better way...
     long recordsIn = rdd.cache().count();
     StageMetrics stageMetrics = new DefaultStageMetrics(sec.getMetrics(), stageName);
     stageMetrics.gauge("records.in", recordsIn);

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/SparkAggregatorContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/SparkAggregatorContext.java
@@ -16,9 +16,12 @@
 
 package co.cask.cdap.etl.spark.batch;
 
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.spark.JavaSparkExecutionContext;
 import co.cask.cdap.api.spark.SparkClientContext;
 import co.cask.cdap.etl.api.LookupProvider;
 import co.cask.cdap.etl.batch.AbstractAggregatorContext;
+import co.cask.cdap.etl.common.DatasetContextLookupProvider;
 
 /**
  * Spark Aggregator Context.
@@ -28,6 +31,13 @@ public class SparkAggregatorContext extends AbstractAggregatorContext {
   public SparkAggregatorContext(SparkClientContext context, LookupProvider lookup, String stageName) {
     super(context, context, context.getMetrics(),
           lookup, stageName, context.getLogicalStartTime(), context.getRuntimeArguments(), context.getAdmin());
+  }
+
+  public SparkAggregatorContext(JavaSparkExecutionContext sec, DatasetContext datasetContext,
+                                String stageName, long logicalStartTime) {
+    super(sec.getPluginContext(), datasetContext, sec.getMetrics(),
+          new DatasetContextLookupProvider(datasetContext), stageName,
+          logicalStartTime, sec.getRuntimeArguments(), sec.getAdmin());
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/SparkBatchSinkContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/SparkBatchSinkContext.java
@@ -16,8 +16,10 @@
 
 package co.cask.cdap.etl.spark.batch;
 
+import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.batch.Output;
 import co.cask.cdap.api.data.batch.OutputFormatProvider;
+import co.cask.cdap.api.spark.JavaSparkExecutionContext;
 import co.cask.cdap.api.spark.SparkClientContext;
 import co.cask.cdap.etl.api.LookupProvider;
 import co.cask.cdap.etl.api.batch.BatchSinkContext;
@@ -31,12 +33,17 @@ import java.util.UUID;
  * Default implementation of {@link BatchSinkContext} for spark contexts.
  */
 public class SparkBatchSinkContext extends AbstractSparkBatchContext implements BatchSinkContext {
-
   private final SparkBatchSinkFactory sinkFactory;
 
   public SparkBatchSinkContext(SparkBatchSinkFactory sinkFactory, SparkClientContext sparkContext,
                                LookupProvider lookupProvider, String stageId) {
     super(sparkContext, lookupProvider, stageId);
+    this.sinkFactory = sinkFactory;
+  }
+
+  public SparkBatchSinkContext(SparkBatchSinkFactory sinkFactory, JavaSparkExecutionContext sec,
+                               DatasetContext datasetContext, String stageName, long logicalStartTime) {
+    super(sec, datasetContext, stageName, logicalStartTime);
     this.sinkFactory = sinkFactory;
   }
 
@@ -57,7 +64,7 @@ public class SparkBatchSinkContext extends AbstractSparkBatchContext implements 
 
   @Override
   public void addOutput(Output output) {
-    Output trackableOutput = ExternalDatasets.makeTrackable(sparkContext.getAdmin(), suffixOutput(output));
+    Output trackableOutput = ExternalDatasets.makeTrackable(admin, suffixOutput(output));
     sinkFactory.addOutput(getStageName(), trackableOutput);
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/SparkBatchSinkFactory.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/SparkBatchSinkFactory.java
@@ -69,7 +69,7 @@ public final class SparkBatchSinkFactory {
   private final Map<String, DatasetInfo> datasetInfos;
   private final Map<String, Set<String>> sinkOutputs;
 
-  SparkBatchSinkFactory() {
+  public SparkBatchSinkFactory() {
     this.outputFormatProviders = new HashMap<>();
     this.datasetInfos = new HashMap<>();
     this.sinkOutputs = new HashMap<>();

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/SparkBatchSourceContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/SparkBatchSourceContext.java
@@ -35,7 +35,6 @@ import java.util.UUID;
  * Default implementation of {@link BatchSourceContext} for spark contexts.
  */
 public class SparkBatchSourceContext extends AbstractSparkBatchContext implements BatchSourceContext {
-
   private final SparkBatchSourceFactory sourceFactory;
 
   public SparkBatchSourceContext(SparkBatchSourceFactory sourceFactory, SparkClientContext sparkContext,
@@ -85,7 +84,7 @@ public class SparkBatchSourceContext extends AbstractSparkBatchContext implement
 
   @Override
   public void setInput(Input input) {
-    Input trackableInput = ExternalDatasets.makeTrackable(sparkContext.getAdmin(), suffixInput(input));
+    Input trackableInput = ExternalDatasets.makeTrackable(admin, suffixInput(input));
     sourceFactory.addInput(getStageName(), trackableInput);
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/PluginFunctionContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/PluginFunctionContext.java
@@ -70,8 +70,10 @@ public class PluginFunctionContext implements Serializable {
     Map<String, String> arguments = new HashMap<>();
     arguments.putAll(sec.getRuntimeArguments());
     WorkflowToken token = sec.getWorkflowToken();
-    for (String tokenKey : token.getAll(WorkflowToken.Scope.USER).keySet()) {
-      arguments.put(tokenKey, token.get(tokenKey, WorkflowToken.Scope.USER).toString());
+    if (token != null) {
+      for (String tokenKey : token.getAll(WorkflowToken.Scope.USER).keySet()) {
+        arguments.put(tokenKey, token.get(tokenKey, WorkflowToken.Scope.USER).toString());
+      }
     }
     this.arguments = arguments;
     this.pipelineStr = GSON.toJson(pipelinePhase);

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/DStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/DStreamCollection.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark.streaming;
+
+import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.macro.MacroEvaluator;
+import co.cask.cdap.api.spark.JavaSparkExecutionContext;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.cdap.etl.api.batch.SparkCompute;
+import co.cask.cdap.etl.api.batch.SparkExecutionPluginContext;
+import co.cask.cdap.etl.api.batch.SparkSink;
+import co.cask.cdap.etl.api.streaming.Windower;
+import co.cask.cdap.etl.common.DefaultMacroEvaluator;
+import co.cask.cdap.etl.spark.SparkCollection;
+import co.cask.cdap.etl.spark.SparkPairCollection;
+import co.cask.cdap.etl.spark.batch.SparkBatchSinkContext;
+import co.cask.cdap.etl.spark.batch.SparkBatchSinkFactory;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.api.java.function.PairFlatMapFunction;
+import org.apache.spark.streaming.Durations;
+import org.apache.spark.streaming.Time;
+import org.apache.spark.streaming.api.java.JavaDStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * JavaDStream backed {@link co.cask.cdap.etl.spark.SparkCollection}
+ *
+ * @param <T> type of objects in the collection
+ */
+public class DStreamCollection<T> implements SparkCollection<T> {
+  private static final Logger LOG = LoggerFactory.getLogger(DStreamCollection.class);
+  private final JavaSparkExecutionContext sec;
+  private final JavaSparkContext sparkContext;
+  private final JavaDStream<T> stream;
+
+  public DStreamCollection(JavaSparkExecutionContext sec, JavaSparkContext sparkContext, JavaDStream<T> stream) {
+    this.sec = sec;
+    this.sparkContext = sparkContext;
+    this.stream = stream;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public JavaDStream<T> getUnderlying() {
+    return stream;
+  }
+
+  @Override
+  public SparkCollection<T> cache() {
+    return wrap(stream.cache());
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public SparkCollection<T> union(SparkCollection<T> other) {
+    return wrap(stream.union((JavaDStream<T>) other.getUnderlying()));
+  }
+
+  @Override
+  public <U> SparkCollection<U> flatMap(FlatMapFunction<T, U> function) {
+    return wrap(stream.flatMap(function));
+  }
+
+  @Override
+  public <K, V> SparkPairCollection<K, V> flatMapToPair(PairFlatMapFunction<T, K, V> function) {
+    return new PairDStreamCollection<>(sec, sparkContext, stream.flatMapToPair(function));
+  }
+
+  @Override
+  public <U> SparkCollection<U> compute(final String stageName, final SparkCompute<T, U> compute) throws Exception {
+    return wrap(stream.transform(new Function2<JavaRDD<T>, Time, JavaRDD<U>>() {
+                  @Override
+                  public JavaRDD<U> call(JavaRDD<T> data, Time batchTime) throws Exception {
+                    SparkExecutionPluginContext sparkPluginContext =
+                      new SparkStreamingExecutionContext(sec, sparkContext, stageName, batchTime.milliseconds());
+                    return compute.transform(sparkPluginContext, data);
+                  }
+                }));
+  }
+
+  @Override
+  public void store(final String stageName, final PairFlatMapFunction<T, Object, Object> sinkFunction) {
+    // note: not using foreachRDD(VoidFunction2) method, because spark 1.3 doesn't have VoidFunction2
+    stream.foreachRDD(new Function2<JavaRDD<T>, Time, Void>() {
+      @Override
+      public Void call(JavaRDD<T> data, Time batchTime) throws Exception {
+        final long logicalStartTime = batchTime.milliseconds();
+        MacroEvaluator evaluator = new DefaultMacroEvaluator(sec.getWorkflowToken(),
+                                                             sec.getRuntimeArguments(),
+                                                             logicalStartTime,
+                                                             sec.getSecureStore(),
+                                                             sec.getNamespace());
+        final SparkBatchSinkFactory sinkFactory = new SparkBatchSinkFactory();
+        final BatchSink<Object, Object, Object> batchSink =
+          sec.getPluginContext().newPluginInstance(stageName, evaluator);
+        boolean isPrepared = false;
+        boolean isDone = false;
+
+        try {
+          sec.execute(new TxRunnable() {
+            @Override
+            public void run(DatasetContext datasetContext) throws Exception {
+              SparkBatchSinkContext sinkContext =
+                new SparkBatchSinkContext(sinkFactory, sec, datasetContext, stageName, logicalStartTime);
+              batchSink.prepareRun(sinkContext);
+            }
+          });
+          isPrepared = true;
+
+          sinkFactory.writeFromRDD(data.flatMapToPair(sinkFunction), sec, stageName, Object.class, Object.class);
+          isDone = true;
+          sec.execute(new TxRunnable() {
+            @Override
+            public void run(DatasetContext datasetContext) throws Exception {
+              SparkBatchSinkContext sinkContext =
+                new SparkBatchSinkContext(sinkFactory, sec, datasetContext, stageName, logicalStartTime);
+              batchSink.onRunFinish(true, sinkContext);
+            }
+          });
+        } catch (Exception e) {
+          LOG.error("Error writing to sink {} for the batch for time {}.", stageName, logicalStartTime, e);
+        } finally {
+          if (isPrepared && !isDone) {
+            sec.execute(new TxRunnable() {
+              @Override
+              public void run(DatasetContext datasetContext) throws Exception {
+                SparkBatchSinkContext sinkContext =
+                  new SparkBatchSinkContext(sinkFactory, sec, datasetContext, stageName, logicalStartTime);
+                batchSink.onRunFinish(false, sinkContext);
+              }
+            });
+          }
+        }
+        return null;
+      }
+    });
+  }
+
+  @Override
+  public void store(String stageName, SparkSink<T> sink) throws Exception {
+    // should never be called.
+    throw new UnsupportedOperationException("Spark sink not supported in Spark Streaming.");
+  }
+
+  @Override
+  public SparkCollection<T> window(Windower windower) {
+    return wrap(stream.window(Durations.seconds(windower.getWidth()), Durations.seconds(windower.getSlideInterval())));
+  }
+
+  private <U> SparkCollection<U> wrap(JavaDStream<U> stream) {
+    return new DStreamCollection<>(sec, sparkContext, stream);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/PairDStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/PairDStreamCollection.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark.streaming;
+
+import co.cask.cdap.api.spark.JavaSparkExecutionContext;
+import co.cask.cdap.etl.spark.SparkCollection;
+import co.cask.cdap.etl.spark.SparkPairCollection;
+import com.google.common.base.Optional;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.streaming.api.java.JavaPairDStream;
+import scala.Tuple2;
+
+/**
+ * JavaPairDStream backed {@link SparkPairCollection}
+ *
+ * @param <K> type of key in the collection
+ * @param <V> type of value in the collection
+ */
+public class PairDStreamCollection<K, V> implements SparkPairCollection<K, V> {
+  private final JavaSparkExecutionContext sec;
+  private final JavaSparkContext sparkContext;
+  private final JavaPairDStream<K, V> pairStream;
+
+  public PairDStreamCollection(JavaSparkExecutionContext sec, JavaSparkContext sparkContext,
+                               JavaPairDStream<K, V> pairStream) {
+    this.sec = sec;
+    this.sparkContext = sparkContext;
+    this.pairStream = pairStream;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public JavaPairDStream<K, V> getUnderlying() {
+    return pairStream;
+  }
+
+  @Override
+  public <T> SparkCollection<T> flatMap(FlatMapFunction<Tuple2<K, V>, T> function) {
+    return new DStreamCollection<>(sec, sparkContext, pairStream.flatMap(function));
+  }
+
+  @Override
+  public <T> SparkPairCollection<K, T> mapValues(Function<V, T> function) {
+    return wrap(pairStream.mapValues(function));
+  }
+
+  @Override
+  public SparkPairCollection<K, Iterable<V>> groupByKey() {
+    return wrap(pairStream.groupByKey());
+  }
+
+  @Override
+  public SparkPairCollection<K, Iterable<V>> groupByKey(int numPartitions) {
+    return wrap(pairStream.groupByKey(numPartitions));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> SparkPairCollection<K, Tuple2<V, T>> join(SparkPairCollection<K, T> other) {
+    return wrap(pairStream.join((JavaPairDStream<K, T>) other.getUnderlying()));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> SparkPairCollection<K, Tuple2<V, T>> join(SparkPairCollection<K, T> other, int numPartitions) {
+    return wrap(pairStream.join((JavaPairDStream<K, T>) other.getUnderlying(), numPartitions));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> SparkPairCollection<K, Tuple2<V, Optional<T>>> leftOuterJoin(SparkPairCollection<K, T> other) {
+    return wrap(pairStream.leftOuterJoin((JavaPairDStream<K, T>) other.getUnderlying()));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> SparkPairCollection<K, Tuple2<V, Optional<T>>> leftOuterJoin(SparkPairCollection<K, T> other,
+                                                                          int numPartitions) {
+    return wrap(pairStream.leftOuterJoin((JavaPairDStream<K, T>) other.getUnderlying(), numPartitions));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> SparkPairCollection<K, Tuple2<Optional<V>, Optional<T>>> fullOuterJoin(SparkPairCollection<K, T> other) {
+    return wrap(pairStream.fullOuterJoin((JavaPairDStream<K, T>) other.getUnderlying()));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> SparkPairCollection<K, Tuple2<Optional<V>, Optional<T>>> fullOuterJoin(SparkPairCollection<K, T> other,
+                                                                                    int numPartitions) {
+    return wrap(pairStream.fullOuterJoin((JavaPairDStream<K, T>) other.getUnderlying(), numPartitions));
+  }
+
+  private <T, U> PairDStreamCollection<T, U> wrap(JavaPairDStream<T, U> pairStream) {
+    return new PairDStreamCollection<>(sec, sparkContext, pairStream);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/SparkStreamingExecutionContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/SparkStreamingExecutionContext.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark.streaming;
+
+import co.cask.cdap.api.data.DatasetInstantiationException;
+import co.cask.cdap.api.data.batch.Split;
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.flow.flowlet.StreamEvent;
+import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.api.spark.JavaSparkExecutionContext;
+import co.cask.cdap.api.stream.StreamEventDecoder;
+import co.cask.cdap.etl.api.Lookup;
+import co.cask.cdap.etl.api.batch.SparkExecutionPluginContext;
+import co.cask.cdap.etl.common.AbstractTransformContext;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Implementation of {@link SparkExecutionPluginContext} by delegating to {@link JavaSparkExecutionContext}.
+ */
+public class SparkStreamingExecutionContext extends AbstractTransformContext implements SparkExecutionPluginContext {
+
+  private final JavaSparkExecutionContext sec;
+  private final JavaSparkContext jsc;
+  private final long batchTime;
+
+  public SparkStreamingExecutionContext(JavaSparkExecutionContext sec, JavaSparkContext jsc,
+                                        String stageName, long batchTime) {
+    super(sec.getPluginContext(), sec.getMetrics(), null, stageName);
+    this.sec = sec;
+    this.jsc = jsc;
+    this.batchTime = batchTime;
+  }
+
+  @Override
+  public long getLogicalStartTime() {
+    return batchTime;
+  }
+
+  @Override
+  public Map<String, String> getRuntimeArguments() {
+    return sec.getRuntimeArguments();
+  }
+
+  @Override
+  public <K, V> JavaPairRDD<K, V> fromDataset(String datasetName) {
+    return sec.fromDataset(datasetName);
+  }
+
+  @Override
+  public <K, V> JavaPairRDD<K, V> fromDataset(String datasetName, Map<String, String> arguments) {
+    return sec.fromDataset(datasetName, arguments);
+  }
+
+  @Override
+  public <K, V> JavaPairRDD<K, V> fromDataset(String datasetName, Map<String, String> arguments,
+                                              @Nullable Iterable<? extends Split> splits) {
+    return sec.fromDataset(datasetName, arguments, splits);
+  }
+
+  @Override
+  public JavaRDD<StreamEvent> fromStream(String streamName) {
+    return sec.fromStream(streamName);
+  }
+
+  @Override
+  public JavaRDD<StreamEvent> fromStream(String streamName, long startTime, long endTime) {
+    return sec.fromStream(streamName, startTime, endTime);
+  }
+
+  @Override
+  public <V> JavaPairRDD<Long, V> fromStream(String streamName, Class<V> valueType) {
+    return sec.fromStream(streamName, valueType);
+  }
+
+  @Override
+  public <V> JavaPairRDD<Long, V> fromStream(String streamName, long startTime, long endTime, Class<V> valueType) {
+    return sec.fromStream(streamName, startTime, endTime, valueType);
+  }
+
+  @Override
+  public <K, V> JavaPairRDD<K, V> fromStream(String streamName, long startTime, long endTime,
+                                             Class<? extends StreamEventDecoder<K, V>> decoderClass,
+                                             Class<K> keyType, Class<V> valueType) {
+    return sec.fromStream(streamName, startTime, endTime, decoderClass, keyType, valueType);
+  }
+
+  @Override
+  public <K, V> void saveAsDataset(JavaPairRDD<K, V> rdd, String datasetName) {
+    sec.saveAsDataset(rdd, datasetName);
+  }
+
+  @Override
+  public <K, V> void saveAsDataset(JavaPairRDD<K, V> rdd, String datasetName, Map<String, String> arguments) {
+    sec.saveAsDataset(rdd, datasetName, arguments);
+  }
+
+  @Override
+  public JavaSparkContext getSparkContext() {
+    return jsc;
+  }
+
+  @Override
+  public PluginContext getPluginContext() {
+    return sec.getPluginContext();
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String name) throws DatasetInstantiationException {
+    throw new UnsupportedOperationException("Not supported in Spark Streaming.");
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String namespace, String name) throws DatasetInstantiationException {
+    throw new UnsupportedOperationException("Not supported in Spark Streaming.");
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String name,
+                                          Map<String, String> arguments) throws DatasetInstantiationException {
+    throw new UnsupportedOperationException("Not supported in Spark Streaming.");
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String namespace, String name,
+                                          Map<String, String> arguments) throws DatasetInstantiationException {
+    throw new UnsupportedOperationException("Not supported in Spark Streaming.");
+  }
+
+  @Override
+  public void releaseDataset(Dataset dataset) {
+    throw new UnsupportedOperationException("Not supported in Spark Streaming.");
+  }
+
+  @Override
+  public void discardDataset(Dataset dataset) {
+    throw new UnsupportedOperationException("Not supported in Spark Streaming.");
+  }
+
+  @Override
+  public <T> Lookup<T> provide(String table, Map<String, String> arguments) {
+    throw new UnsupportedOperationException("Not supported in Spark Streaming.");
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/pom.xml
+++ b/cdap-app-templates/cdap-etl/hydrator-test/pom.xml
@@ -38,6 +38,11 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-etl-api-spark</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-etl-proto</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockSink.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/MockSink.java
@@ -86,7 +86,8 @@ public class MockSink extends BatchSink<StructuredRecord, byte[], Put> {
 
   @Override
   public void transform(StructuredRecord input, Emitter<KeyValue<byte[], Put>> emitter) throws Exception {
-    byte[] rowkey = Bytes.toBytes(UUID.randomUUID());
+    byte[] ts = Bytes.toBytes(System.currentTimeMillis());
+    byte[] rowkey = Bytes.concat(ts, Bytes.toBytes(UUID.randomUUID()));
     Put put = new Put(rowkey);
     put.add(SCHEMA_COL, input.getSchema().toString());
     put.add(RECORD_COL, StructuredRecordStringConverter.toJsonString(input));

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/spark/Window.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/spark/Window.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.spark;
+
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginPropertyField;
+import co.cask.cdap.etl.api.streaming.Windower;
+import co.cask.cdap.etl.proto.v2.ETLPlugin;
+import com.google.common.collect.ImmutableMap;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Window plugin.
+ */
+public class Window extends Windower {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
+  private final Conf conf;
+
+  public Window(Conf conf) {
+    this.conf = conf;
+  }
+
+  @Override
+  public long getWidth() {
+    return conf.width;
+  }
+
+  @Override
+  public long getSlideInterval() {
+    return conf.slideInterval;
+  }
+
+  /**
+   * Config for window plugin.
+   */
+  public static class Conf {
+    long width;
+
+    long slideInterval;
+  }
+
+  public static ETLPlugin getPlugin(long width, long slideInterval) throws IOException {
+    return new ETLPlugin("Window", Windower.PLUGIN_TYPE,
+                         ImmutableMap.of("width", String.valueOf(width),
+                                         "slideInterval", String.valueOf(slideInterval)),
+                         null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("width", new PluginPropertyField("width", "", "long", true, false));
+    properties.put("slideInterval", new PluginPropertyField("slideInterval", "", "long", true, false));
+    return new PluginClass(Windower.PLUGIN_TYPE, "Window", "", Window.class.getName(), "conf", properties);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/spark/compute/StringValueFilterCompute.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/spark/compute/StringValueFilterCompute.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.spark.compute;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginPropertyField;
+import co.cask.cdap.etl.api.batch.SparkCompute;
+import co.cask.cdap.etl.api.batch.SparkExecutionPluginContext;
+import co.cask.cdap.etl.proto.v2.ETLPlugin;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.Function;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Transform that filters out records whose configured field is a configured value.
+ * For example, can filter all records whose 'foo' field is equal to 'bar'. Assumes the field is of type string.
+ */
+@Plugin(type = SparkCompute.PLUGIN_TYPE)
+@Name("StringValueFilterCompute")
+public class StringValueFilterCompute extends SparkCompute<StructuredRecord, StructuredRecord> {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
+  private final Conf conf;
+
+  public StringValueFilterCompute(Conf conf) {
+    this.conf = conf;
+  }
+
+  @Override
+  public JavaRDD<StructuredRecord> transform(SparkExecutionPluginContext context,
+                                             JavaRDD<StructuredRecord> input) throws Exception {
+    return input.filter(new Function<StructuredRecord, Boolean>() {
+      @Override
+      public Boolean call(StructuredRecord v1) throws Exception {
+        return !conf.value.equals(v1.get(conf.field));
+      }
+    });
+  }
+
+  /**
+   * Config for the plugin.
+   */
+  public static class Conf extends PluginConfig {
+    private String field;
+    private String value;
+  }
+
+  public static ETLPlugin getPlugin(String field, String value) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("field", field);
+    properties.put("value", value);
+    return new ETLPlugin("StringValueFilterCompute", SparkCompute.PLUGIN_TYPE, properties, null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("field", new PluginPropertyField("field", "", "string", true, false));
+    properties.put("value", new PluginPropertyField("value", "", "string", true, false));
+    return new PluginClass(SparkCompute.PLUGIN_TYPE, "StringValueFilterCompute", "",
+                           StringValueFilterCompute.class.getName(),
+                           "conf", properties);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/spark/streaming/MockSource.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/spark/streaming/MockSource.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.spark.streaming;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginPropertyField;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.streaming.StreamingSource;
+import co.cask.cdap.etl.proto.v2.ETLPlugin;
+import co.cask.cdap.format.StructuredRecordStringConverter;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.apache.spark.storage.StorageLevel;
+import org.apache.spark.streaming.api.java.JavaDStream;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import org.apache.spark.streaming.receiver.Receiver;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Mock source for spark streaming unit tests.
+ */
+@Plugin(type = StreamingSource.PLUGIN_TYPE)
+@Name("Mock")
+public class MockSource extends StreamingSource<StructuredRecord> {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
+  private static final Gson GSON = new Gson();
+  private static final Type STRING_LIST_TYPE = new TypeToken<List<String>>() { }.getType();
+
+  private final Conf conf;
+
+  public MockSource(Conf conf) {
+    this.conf = conf;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    try {
+      pipelineConfigurer.getStageConfigurer().setOutputSchema(Schema.parseJson(conf.schema));
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Could not parse schema " + conf.schema);
+    }
+  }
+
+  @Override
+  public JavaDStream<StructuredRecord> getStream(JavaStreamingContext jssc) throws Exception {
+    Schema schema = Schema.parseJson(conf.schema);
+    List<String> recordsAsStrings = new Gson().fromJson(conf.records, STRING_LIST_TYPE);
+    final List<StructuredRecord> inputRecords = new ArrayList<>();
+    for (String recordStr : recordsAsStrings) {
+      inputRecords.add(StructuredRecordStringConverter.fromJsonString(recordStr, schema));
+    }
+
+    return jssc.receiverStream(new Receiver<StructuredRecord>(StorageLevel.MEMORY_ONLY()) {
+      @Override
+      public StorageLevel storageLevel() {
+        return StorageLevel.MEMORY_ONLY();
+      }
+
+      @Override
+      public void onStart() {
+        new Thread() {
+
+          @Override
+          public void run() {
+            for (StructuredRecord record : inputRecords) {
+              if (isStarted()) {
+                store(record);
+                try {
+                  TimeUnit.MILLISECONDS.sleep(conf.intervalMillis);
+                } catch (InterruptedException e) {
+                  throw new RuntimeException(e);
+                }
+              }
+            }
+          }
+
+          @Override
+          public void interrupt() {
+            super.interrupt();
+          }
+        }.start();
+      }
+
+      @Override
+      public void onStop() {
+
+      }
+    });
+  }
+
+  /**
+   * Config for mock source.
+   */
+  public static class Conf extends PluginConfig {
+    private String schema;
+    private String records;
+    @Nullable
+    private Long intervalMillis;
+
+    public Conf() {
+      intervalMillis = 0L;
+    }
+  }
+
+  public static ETLPlugin getPlugin(Schema schema, List<StructuredRecord> records) throws IOException {
+    return getPlugin(schema, records, 0L);
+  }
+
+  public static ETLPlugin getPlugin(Schema schema, List<StructuredRecord> records,
+                                    Long intervalMillis) throws IOException {
+    List<String> recordsStrs = new ArrayList<>(records.size());
+    for (StructuredRecord record : records) {
+      recordsStrs.add(StructuredRecordStringConverter.toJsonString(record));
+    }
+    return new ETLPlugin("Mock", StreamingSource.PLUGIN_TYPE,
+                         ImmutableMap.of("schema", schema.toString(),
+                                         "records", GSON.toJson(recordsStrs),
+                                         "intervalMillis", intervalMillis.toString()),
+                         null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("schema", new PluginPropertyField("schema", "", "string", true, false));
+    properties.put("records", new PluginPropertyField("records", "", "string", true, false));
+    properties.put("intervalMillis", new PluginPropertyField("intervalMillis", "", "long", false, false));
+    return new PluginClass(StreamingSource.PLUGIN_TYPE, "Mock", "", MockSource.class.getName(), "conf", properties);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/test/HydratorTestBase.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/test/HydratorTestBase.java
@@ -18,9 +18,12 @@ package co.cask.cdap.etl.mock.test;
 
 import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.etl.api.PipelineConfigurable;
+import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.api.action.Action;
 import co.cask.cdap.etl.api.batch.BatchSource;
+import co.cask.cdap.etl.api.batch.SparkCompute;
 import co.cask.cdap.etl.api.realtime.RealtimeSource;
+import co.cask.cdap.etl.api.streaming.StreamingSource;
 import co.cask.cdap.etl.mock.action.MockAction;
 import co.cask.cdap.etl.mock.batch.MockExternalSink;
 import co.cask.cdap.etl.mock.batch.MockExternalSource;
@@ -33,6 +36,8 @@ import co.cask.cdap.etl.mock.batch.joiner.MockJoiner;
 import co.cask.cdap.etl.mock.realtime.LookupSource;
 import co.cask.cdap.etl.mock.realtime.MockSink;
 import co.cask.cdap.etl.mock.realtime.MockSource;
+import co.cask.cdap.etl.mock.spark.Window;
+import co.cask.cdap.etl.mock.spark.compute.StringValueFilterCompute;
 import co.cask.cdap.etl.mock.transform.DoubleTransform;
 import co.cask.cdap.etl.mock.transform.ErrorTransform;
 import co.cask.cdap.etl.mock.transform.FieldsPrefixTransform;
@@ -43,13 +48,18 @@ import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.test.TestBase;
 import com.google.common.collect.ImmutableSet;
 
-import java.util.HashSet;
 import java.util.Set;
 
 /**
  * Performs common setup logic
  */
 public class HydratorTestBase extends TestBase {
+  // need to specify each PluginClass so that they can be used outside of this project. If we don't do this,
+  // when the plugin jar is created, it will add lib/hydrator-test.jar to the plugin jar.
+  // The ArtifactInspector will not examine any library jars for plugins, because it assumes plugins are always
+  // .class files in the jar and never in the dependencies, which is normally a reasonable assumption.
+  // So since the plugins are in lib/hydrator-test.jar, CDAP won't find any plugins in the jar.
+  // To work around, we'll just explicitly specify each plugin.
   private static final Set<PluginClass> REALTIME_MOCK_PLUGINS = ImmutableSet.of(
     LookupSource.PLUGIN_CLASS, MockSink.PLUGIN_CLASS, MockSource.PLUGIN_CLASS,
     DoubleTransform.PLUGIN_CLASS, ErrorTransform.PLUGIN_CLASS, IdentityTransform.PLUGIN_CLASS,
@@ -62,7 +72,15 @@ public class HydratorTestBase extends TestBase {
     MockExternalSource.PLUGIN_CLASS, MockExternalSink.PLUGIN_CLASS,
     DoubleTransform.PLUGIN_CLASS, ErrorTransform.PLUGIN_CLASS, IdentityTransform.PLUGIN_CLASS,
     FieldsPrefixTransform.PLUGIN_CLASS, IntValueFilterTransform.PLUGIN_CLASS, StringValueFilterTransform.PLUGIN_CLASS,
-    MockAction.PLUGIN_CLASS
+    MockAction.PLUGIN_CLASS, StringValueFilterCompute.PLUGIN_CLASS
+  );
+  private static final Set<PluginClass> STREAMING_MOCK_PLUGINS = ImmutableSet.of(
+    co.cask.cdap.etl.mock.spark.streaming.MockSource.PLUGIN_CLASS,
+    co.cask.cdap.etl.mock.batch.MockSink.PLUGIN_CLASS,
+    DoubleTransform.PLUGIN_CLASS, ErrorTransform.PLUGIN_CLASS, IdentityTransform.PLUGIN_CLASS,
+    IntValueFilterTransform.PLUGIN_CLASS, StringValueFilterTransform.PLUGIN_CLASS,
+    FieldCountAggregator.PLUGIN_CLASS, IdentityAggregator.PLUGIN_CLASS, MockJoiner.PLUGIN_CLASS,
+    StringValueFilterCompute.PLUGIN_CLASS, Window.PLUGIN_CLASS
   );
 
   public HydratorTestBase() {
@@ -72,14 +90,6 @@ public class HydratorTestBase extends TestBase {
     addAppArtifact(artifactId, appClass,
                    RealtimeSource.class.getPackage().getName(),
                    PipelineConfigurable.class.getPackage().getName());
-
-    // need to specify each PluginClass so that they can be used outside of this project. If we don't do this,
-    // when the plugin jar is created, it will add lib/hydrator-test.jar to the plugin jar.
-    // The ArtifactInspector will not examine any library jars for plugins, because it assumes plugins are always
-    // .class files in the jar and never in the dependencies, which is normally a reasonable assumption.
-    // So since the plugins are in lib/hydrator-test.jar, CDAP won't find any plugins in the jar.
-    // To work around, we'll just explicitly specify each plugin.
-    Set<PluginClass> pluginClasses = new HashSet<>();
 
     addPluginArtifact(new ArtifactId(artifactId.getNamespace(), artifactId.getArtifact() + "-mocks", "1.0.0"),
                       artifactId,
@@ -107,7 +117,28 @@ public class HydratorTestBase extends TestBase {
                       DoubleTransform.class, ErrorTransform.class, IdentityTransform.class,
                       IntValueFilterTransform.class, StringValueFilterTransform.class,
                       FieldCountAggregator.class, IdentityAggregator.class, FieldsPrefixTransform.class,
+                      StringValueFilterCompute.class,
                       NodeStatesAction.class);
+  }
+
+  protected static void setupStreamingArtifacts(ArtifactId artifactId, Class<?> appClass) throws Exception {
+    // add the app artifact
+    addAppArtifact(artifactId, appClass,
+                   StreamingSource.class.getPackage().getName(),
+                   Transform.class.getPackage().getName(),
+                   SparkCompute.class.getPackage().getName(),
+                   PipelineConfigurable.class.getPackage().getName());
+
+
+    // add plugins artifact
+    addPluginArtifact(new ArtifactId(artifactId.getNamespace(), artifactId.getArtifact() + "-mocks", "1.0.0"),
+                      artifactId,
+                      STREAMING_MOCK_PLUGINS,
+                      co.cask.cdap.etl.mock.spark.streaming.MockSource.class,
+                      co.cask.cdap.etl.mock.batch.MockSink.class,
+                      DoubleTransform.class, ErrorTransform.class, IdentityTransform.class,
+                      IntValueFilterTransform.class, StringValueFilterTransform.class,
+                      StringValueFilterCompute.class, Window.class);
   }
 
 }

--- a/cdap-app-templates/cdap-etl/pom.xml
+++ b/cdap-app-templates/cdap-etl/pom.xml
@@ -31,6 +31,7 @@
 
   <modules>
     <module>cdap-data-pipeline</module>
+    <module>cdap-data-streams</module>
     <module>cdap-etl-api</module>
     <module>cdap-etl-api-spark</module>
     <module>cdap-etl-archetypes</module>

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -283,6 +283,14 @@
                         <include>cdap-data-pipeline-${project.version}.jar</include>
                       </includes>
                     </resource>
+                    <resource>
+                      <directory>
+                        ${project.parent.basedir}/cdap-app-templates/cdap-etl/cdap-data-streams/target
+                      </directory>
+                      <includes>
+                        <include>cdap-data-streams-${project.version}.jar</include>
+                      </includes>
+                    </resource>
                   </resources>
                 </configuration>
               </execution>

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -466,6 +466,14 @@
                         <include>cdap-data-pipeline-${project.version}.jar</include>
                       </includes>
                     </resource>
+                    <resource>
+                      <directory>
+                        ${project.parent.basedir}/cdap-app-templates/cdap-etl/cdap-data-streams/target
+                      </directory>
+                      <includes>
+                        <include>cdap-data-streams-${project.version}.jar</include>
+                      </includes>
+                    </resource>
                   </resources>
                 </configuration>
               </execution>


### PR DESCRIPTION
Added apis for new StreamingSource and Windower plugin
types for the data streams application.

Also doing some more refactoring on the spark program so that both
the data streams and data pipeline apps can share almost all the
same logic. Introduced the SparkCollection and SparkPairCollection
interfaces which the main driver performs operations on.
The data pipeline app implements them with RDDs while the data
streams app implements it with DStreams.
