### PR TITLE
[CDAP-6611] disable all endpoints on detail view

### DIFF
--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -143,12 +143,20 @@ angular.module(PKG.name + '.commons')
             uuids: [sourceId, targetId]
           };
 
-          if (vm.isDisabled) {
-            connObj.detachable = false;
-          }
-
           vm.instance.connect(connObj);
         });
+
+        if (vm.isDisabled) {
+          // Disable all endpoints
+          angular.forEach(endpoints, function (node) {
+            var endpointArr = vm.instance.getEndpoints(node);
+
+            // There should only be 2 endpoints per nodes, left and right
+            angular.forEach(endpointArr, function (endpoint) {
+              endpoint.setEnabled(false);
+            });
+          });
+        }
 
         // Process metrics data
         if ($scope.showMetrics) {


### PR DESCRIPTION
Currently, if you have a pipeline that ends with sink or custom actions, the last endpoint can have a connection dragged out from the endpoint in detail view. This PR is to fix that bug.
