### PR TITLE
[CDAP-6524] Add support for char property type for plugins

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginConfig.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginConfig.java
@@ -36,6 +36,19 @@ public abstract class PluginConfig extends Config implements Serializable {
 
   /**
    * Returns the {@link PluginProperties}.
+   *
+   * All plugin properties that are macro-enabled and were configured with macro syntax present will be substituted
+   * with Java's default values based on the property's type at configuration time. The default values are:
+   *  - boolean: false
+   *  - byte: 0
+   *  - char: '\u0000'
+   *  - double: 0.0d
+   *  - float: 0.0f
+   *  - int: 0
+   *  - long: 0L
+   *  - short: 0
+   *  - String: null
+   *
    */
   public final PluginProperties getProperties() {
     return properties;

--- a/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginContext.java
@@ -53,17 +53,6 @@ public interface PluginContext {
    * {@link PluginConfigurer#usePlugin(String, String, String, PluginProperties)} was called during the
    * program configuration time.
    *
-   * All plugin properties that are macro-enabled and were configured with macro syntax present will be substituted
-   * with Java's default values based on the property's type at configuration time. The default values are:
-   *  - boolean: false
-   *  - byte: 0
-   *  - double: 0.0d
-   *  - float: 0.0f
-   *  - int: 0
-   *  - long: 0L
-   *  - short: 0
-   *  - String: null
-   *
    * @param pluginId the unique identifier provide when declaring plugin usage in the program.
    * @param <T> the class type of the plugin
    * @return A new instance of the plugin being specified by the arguments

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginInstantiator.java
@@ -80,6 +80,7 @@ public class PluginInstantiator implements Closeable {
   private static final Map<String, Class> PROPERTY_TYPES = ImmutableMap.<String, Class>builder()
     .put("boolean", boolean.class)
     .put("byte", byte.class)
+    .put("char", char.class)
     .put("double", double.class)
     .put("int", int.class)
     .put("float", float.class)
@@ -428,6 +429,14 @@ public class PluginInstantiator implements Closeable {
 
       if (rawType.isPrimitive()) {
         rawType = Primitives.wrap(rawType);
+      }
+
+      if (Character.class.equals(rawType)) {
+        if (value.length() != 1) {
+          throw new InvalidPluginConfigException(String.format("Property of type char is not length 1: '%s'", value));
+        } else {
+          return value.charAt(0);
+        }
       }
 
       if (Primitives.isWrapperType(rawType)) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/plugins/test/TestPlugin.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/plugins/test/TestPlugin.java
@@ -37,8 +37,8 @@ public class TestPlugin implements Callable<String> {
   @Override
   public String call() throws Exception {
     if (config.nullableLongFlag != null && config.nullableLongFlag % 2 == 0) {
-        return config.host + "," + Joiner.on(',').join(config.aBoolean, config.aByte, config.aDouble, config.aFloat,
-                                   config.anInt, config.aLong, config.aShort);
+        return config.host + "," + Joiner.on(',').join(config.aBoolean, config.aByte, config.aChar, config.aDouble,
+                                                       config.aFloat, config.anInt, config.aLong, config.aShort);
     }
     return null;
   }
@@ -56,6 +56,9 @@ public class TestPlugin implements Callable<String> {
 
     @Macro
     private byte aByte;
+
+    @Macro
+    private char aChar;
 
     @Macro
     private double aDouble;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
@@ -302,9 +302,10 @@ public class ArtifactRepositoryTest {
           Plugin pluginInfo = new Plugin(entry.getKey().getArtifactId(), pluginClass,
                                          PluginProperties.builder().add("class.name", TEST_EMPTY_CLASS)
                                            .add("nullableLongFlag", "10")
-                                           .add("host", "${expansiveHostname}")
+                                           .add("host", "example.com")
                                            .add("aBoolean", "${aBoolean}")
                                            .add("aByte", "${aByte}")
+                                           .add("aChar", "${aChar}")
                                            .add("aDouble", "${aDouble}")
                                            .add("anInt", "${anInt}")
                                            .add("aFloat", "${aFloat}")
@@ -312,7 +313,7 @@ public class ArtifactRepositoryTest {
                                            .add("aShort", "${aShort}")
                                            .build());
           Callable<String> plugin = instantiator.newInstance(pluginInfo);
-          Assert.assertEquals("null,false,0,0.0,0.0,0,0,0", plugin.call());
+          Assert.assertEquals("example.com,false,0,\u0000,0.0,0.0,0,0,0", plugin.call());
         }
       }
     }
@@ -365,6 +366,7 @@ public class ArtifactRepositoryTest {
       .put("secondPortDigit", "0")
       .put("aBoolean", "true")
       .put("aByte", "101")
+      .put("aChar", "k")
       .put("aDouble", "64.0")
       .put("aFloat", "52.0")
       .put("anInt", "42")
@@ -382,6 +384,7 @@ public class ArtifactRepositoryTest {
                                            .add("host", "${expansiveHostname}")
                                            .add("aBoolean", "${aBoolean}")
                                            .add("aByte", "${aByte}")
+                                           .add("aChar", "${aChar}")
                                            .add("aDouble", "${aDouble}")
                                            .add("anInt", "${anInt}")
                                            .add("aFloat", "${aFloat}")
@@ -392,7 +395,7 @@ public class ArtifactRepositoryTest {
           TestMacroEvaluator testMacroEvaluator = new TestMacroEvaluator(propertySubstitutions,
                                                                          new HashMap<String, String>());
           Callable<String> plugin = instantiator.newInstance(pluginInfo, testMacroEvaluator);
-          Assert.assertEquals("localhost/index.html:80,true,101,64.0,52.0,42,32,81", plugin.call());
+          Assert.assertEquals("localhost/index.html:80,true,101,k,64.0,52.0,42,32,81", plugin.call());
         }
       }
     }


### PR DESCRIPTION
PluginInstantiator throws an exception if an unsupported type is used for a plugin property:
`throw new UnsupportedTypeException("Only primitive and String types are supported");`
However, the char primitive is currently not supported as `Character.valueOf(...)` does not take a string argument and will throw an exception so must be handled separately.
