### PR TITLE
CDAP-6666 When stream cleanup fails, log the entire exception

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
@@ -96,7 +96,7 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
     Preconditions.checkArgument(programType == ProgramType.WORKER, "Only Worker process type is supported.");
 
     WorkerSpecification workerSpec = appSpec.getWorkers().get(program.getName());
-    Preconditions.checkArgument(workerSpec != null, "Missing Worker specification for {}", program.getId());
+    Preconditions.checkArgument(workerSpec != null, "Missing Worker specification for %s", program.getId());
     String instances = options.getArguments().getOption(ProgramOptionConstants.INSTANCES,
                                                         String.valueOf(workerSpec.getInstances()));
     String resourceString = options.getArguments().getOption(ProgramOptionConstants.RESOURCES, null);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/LocationStreamFileWriterFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/LocationStreamFileWriterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -57,7 +57,7 @@ public final class LocationStreamFileWriterFactory implements StreamFileWriterFa
   @Override
   public FileWriter<StreamEvent> create(final StreamConfig config, final int generation) throws IOException {
     try {
-      Preconditions.checkNotNull(config.getLocation(), "Location for stream {} is unknown.", config.getStreamId());
+      Preconditions.checkNotNull(config.getLocation(), "Location for stream %s is unknown.", config.getStreamId());
 
       Location baseLocation = impersonator.doAs(new NamespaceId(config.getStreamId().getNamespaceId()),
                                                 new Callable<Location>() {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/LocalStreamFileJanitorService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/LocalStreamFileJanitorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.data.stream.service;
 
 import co.cask.cdap.common.conf.CConfiguration;
@@ -67,7 +68,7 @@ public final class LocalStreamFileJanitorService extends AbstractService impleme
           janitor.cleanAll();
           LOG.debug("Completed stream file cleanup.");
         } catch (Throwable e) {
-          LOG.warn("Failed to cleanup stream file: {}", e.getMessage());
+          LOG.warn("Failed to cleanup stream files.", e);
         } finally {
           // Compute the next cleanup time. It is aligned to work clock based on the period.
           long now = System.currentTimeMillis();


### PR DESCRIPTION
When stream cleanup fails, log the entire exception; not just the message.

Otherwise, it's difficult to know what the actual cause of the error is.

Also fix 2 other log messages, using the wrong notation (`%s` vs `{}`)

http://builds.cask.co/browse/CDAP-DUT4521-1
