### PR TITLE
CDAP-6716 Delete data inside custom mapped direcotory

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/AbstractStorageProviderNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/AbstractStorageProviderNamespaceAdmin.java
@@ -103,8 +103,12 @@ abstract class AbstractStorageProviderNamespaceAdmin implements StorageProviderN
     Location namespaceHome = namespacedLocationFactory.get(namespaceId.toId());
     try {
       if (hasCustomLocation(namespaceQueryAdmin.get(namespaceId.toId()))) {
-        LOG.debug("Custom location mapping %s was found while deleting namespace %s. Skipping location delete.",
-                  namespaceHome, namespaceId);
+        LOG.debug("Custom location mapping %s was found while deleting namespace %s. Deleting all data inside it but" +
+                    "skipping namespace home directory delete.", namespaceHome, namespaceId);
+        // delete everything inside the namespace home but not the namespace home as its user owned directory
+        for (Location childLocation : namespaceHome.list()) {
+          childLocation.delete(true);
+        }
       } else {
         // a custom location was not provided for this namespace so cdap is responsible for managing the lifecycle of
         // the location hence delete it.

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/namespace/StorageProviderNamespaceAdminTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/namespace/StorageProviderNamespaceAdminTest.java
@@ -126,10 +126,23 @@ public class StorageProviderNamespaceAdminTest {
     }
     // delete the content of the custom location and retry creating the namespace
     Assert.assertTrue(dir1.delete());
+
     storageProviderNamespaceAdmin.create(customSpaceMeta);
+    // create some directories and files inside the custom mapped location
+    dir1 = new File(custom, "dir1");
+    Assert.assertTrue(dir1.mkdir());
+    File dir2 = new File(custom, "dir2");
+    Assert.assertTrue(dir2.mkdir());
+    File file1 = new File(dir1, "file1");
+    Assert.assertTrue(file1.createNewFile());
+
+    // delete the namespace
     storageProviderNamespaceAdmin.delete(customSpace);
     namespaceStore.delete(customSpace.toId());
-    // custom namespace location should still exists
+    // the data inside the custom location should have been deleted
+    Assert.assertFalse("Data inside the custom location still exists.", (dir1.exists() || dir2.exists() ||
+      file1.exists()));
+    // but custom namespace location should still exists
     Assert.assertTrue(custom.exists());
     custom.delete();
   }


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/CDAP-6716
Build: http://builds.cask.co/browse/CDAP-DUT4522-1

Deletes all the data inside custom mapped directory except the namespace directory itself.

This is the behavior which we do for custom mapped hbase namespaces too.

Related issue for further consideration: https://issues.cask.co/browse/CDAP-6640
