### PR TITLE
fixes positioning issue with time/date picker

### DIFF
--- a/cdap-ui/app/features/streams/streams.less
+++ b/cdap-ui/app/features/streams/streams.less
@@ -41,7 +41,11 @@ body.state-streams-detail {
         margin-right: 10px;
       }
     }
-
+    // fixes issue with datepicker/timepicker being partially covered by other elements
+    .panel-explore .collapse {
+      overflow: inherit;
+      animation-duration: 0.1s;
+    }
     .panel-body > form {
       margin-bottom: 2em;
     }


### PR DESCRIPTION
-  Fixes positioning issue causing time/date picker in stream explore view to be covered up by the panel underneath

![datetime](https://cloud.githubusercontent.com/assets/5335210/17124019/e1c098ac-529c-11e6-8d2e-41ed70c4fb31.gif)
