### PR TITLE
[CDAP-6711]: Custom Actions do not evaluate macro-enabled properties

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/customaction/PipelineAction.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/customaction/PipelineAction.java
@@ -70,7 +70,13 @@ public class PipelineAction extends AbstractCustomAction {
     BatchPhaseSpec phaseSpec = GSON.fromJson(properties.get(Constants.PIPELINEID), BatchPhaseSpec.class);
     PipelinePhase phase = phaseSpec.getPhase();
     StageInfo stageInfo = phase.iterator().next();
-    Action action = context.newPluginInstance(stageInfo.getName());
+    Action action =
+      context.newPluginInstance(stageInfo.getName(),
+                                new DefaultMacroEvaluator(context.getWorkflowToken(),
+                                                          context.getRuntimeArguments(),
+                                                          context.getLogicalStartTime(),
+                                                          context,
+                                                          context.getNamespace()));
     ActionContext actionContext = new BasicActionContext(context);
     action.run(actionContext);
     WorkflowToken token = context.getWorkflowToken();


### PR DESCRIPTION
When custom action instance is created, it is not passed a MacroEvaluator, so all macros in its configs are kept at the default `null` values.
