### PR TITLE
Fix broken documentation build.

### DIFF
--- a/cdap-docs/developers-manual/build.sh
+++ b/cdap-docs/developers-manual/build.sh
@@ -15,13 +15,6 @@
 # the License.
   
 # Build script for docs
-# Builds the docs (all except javadocs and PDFs) from the .rst source files using Sphinx
-# Builds the javadocs and copies them into place
-# Zips everything up so it can be staged
-# REST PDF is built as a separate target and checked in, as it is only used in SDK and not website
-# Target for building the SDK
-# Targets for both a limited and complete set of javadocs
-# Targets not included in usage are intended for internal usage by script
 
 source ../vars
 source ../_common/common-build.sh
@@ -65,7 +58,7 @@ function download_includes() {
 # https://raw.githubusercontent.com/caskdata/cdap-clients/develop/cdap-authentication-clients/java/README.rst
   local clients_url="${github_url}/cdap-clients/${clients_branch}"
 
-  download_readme_file_and_test ${includes_dir} ${clients_url} f99720412e7085fdc3e350205ce21bcc cdap-authentication-clients/java
+  download_readme_file_and_test ${includes_dir} ${clients_url} 25b715da9e3f65e93204a9663d19c90b cdap-authentication-clients/java
 #   download_readme_file_and_test ${includes_dir} ${clients_url} f075935545e48a132d014c6a8d32122a cdap-authentication-clients/javascript
   download_readme_file_and_test ${includes_dir} ${clients_url} 1f8330e0370b3895c38452f9af72506a cdap-authentication-clients/python
 #   download_readme_file_and_test ${includes_dir} ${clients_url} c16bf5ce7c1f0a2a4a680974a848cdd0 cdap-authentication-clients/ruby


### PR DESCRIPTION
Remove old comments that don't apply any more. 
Updated MD5 hash, as the source file was changed in the referenced repo to fix a formatting error.

Running as [Quick Build 1](http://builds.cask.co/browse/CDAP-DQB60-1)
