### PR TITLE
CDAP-6730 Deprecate Kafka settings similarly to others

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/KafkaConstants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/KafkaConstants.java
@@ -26,15 +26,20 @@ public final class KafkaConstants {
    */
   public static final class ConfigKeys {
     public static final String NUM_PARTITIONS_CONFIG = "kafka.server.num.partitions";
+    @Deprecated
     public static final String NUM_PARTITIONS_CONFIG_DEPRECATED = "kafka.num.partitions";
     public static final String PORT_CONFIG = "kafka.server.port";
+    @Deprecated
     public static final String PORT_CONFIG_DEPRECATED = "kafka.bind.port";
     public static final String HOSTNAME_CONFIG = "kafka.server.host.name";
+    @Deprecated
     public static final String HOSTNAME_CONFIG_DEPRECATED = "kafka.bind.address";
     public static final String ZOOKEEPER_NAMESPACE_CONFIG = "kafka.zookeeper.namespace";
     public static final String REPLICATION_FACTOR = "kafka.server.default.replication.factor";
+    @Deprecated
     public static final String REPLICATION_FACTOR_DEPRECATED = "kafka.default.replication.factor";
     public static final String LOG_DIRS = "kafka.server.log.dirs";
-    public static final String LOG_DIRS_DEPRECATED = "kafka.log.dirs";
+    @Deprecated
+    public static final String LOG_DIRS_DEPRECATED = "kafka.log.dir";
   }
 }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -755,60 +755,6 @@
   <!-- Kafka Server Configuration -->
 
   <property>
-    <name>kafka.bind.address</name>
-    <value>0.0.0.0</value>
-    <description>
-      CDAP Kafka service bind port (deprecated: replaced with
-      ${kafka.server.host.name})
-    </description>
-  </property>
-
-  <property>
-    <name>kafka.bind.port</name>
-    <value>9092</value>
-    <description>
-      CDAP Kafka service bind port (deprecated: replaced with
-      ${kafka.server.port})
-    </description>
-  </property>
-
-  <property>
-    <name>kafka.default.replication.factor</name>
-    <value>1</value>
-    <description>
-      CDAP Kafka service replication factor (deprecated: replaced with
-      ${kafka.server.default.replication.factor})
-    </description>
-  </property>
-
-  <property>
-    <name>kafka.log.dir</name>
-    <value>/tmp/kafka-logs</value>
-    <description>
-      CDAP Kafka service log storage directory (deprecated: replaced with
-      ${kafka.server.log.dirs})
-    </description>
-  </property>
-
-  <property>
-    <name>kafka.log.retention.hours</name>
-    <value>24</value>
-    <description>
-      The number of hours to keep a log file before deleting it (deprecated:
-      replaced with ${kafka.server.log.retention.hours})
-    </description>
-  </property>
-
-  <property>
-    <name>kafka.num.partitions</name>
-    <value>10</value>
-    <description>
-      Default number of partitions for a topic (deprecated: replaced with
-      ${kafka.server.num.partitions})
-    </description>
-  </property>
-
-  <property>
     <name>kafka.seed.brokers</name>
     <value>127.0.0.1:9092</value>
     <description>
@@ -819,7 +765,7 @@
 
   <property>
     <name>kafka.server.default.replication.factor</name>
-    <value>${kafka.default.replication.factor}</value>
+    <value>1</value>
     <description>
       CDAP Kafka service replication factor; used to replicate Kafka
       messages across multiple machines to prevent data loss in the event of
@@ -832,7 +778,7 @@
 
   <property>
     <name>kafka.server.host.name</name>
-    <value>${kafka.bind.address}</value>
+    <value>0.0.0.0</value>
     <description>
       CDAP Kafka service bind address
     </description>
@@ -840,7 +786,7 @@
 
   <property>
     <name>kafka.server.log.dirs</name>
-    <value>${kafka.log.dir}</value>
+    <value>/tmp/kafka-logs</value>
     <description>
       Comma-separated list of CDAP Kafka service log storage directories
     </description>
@@ -857,7 +803,7 @@
 
   <property>
     <name>kafka.server.log.retention.hours</name>
-    <value>${kafka.log.retention.hours}</value>
+    <value>24</value>
     <description>
       The number of hours to keep a log file before deleting it
     </description>
@@ -865,7 +811,7 @@
 
   <property>
     <name>kafka.server.num.partitions</name>
-    <value>${kafka.num.partitions}</value>
+    <value>10</value>
     <description>
       Default number of partitions for a topic
     </description>
@@ -873,7 +819,7 @@
 
   <property>
     <name>kafka.server.port</name>
-    <value>${kafka.bind.port}</value>
+    <value>9092</value>
     <description>
       CDAP Kafka service bind port
     </description>
@@ -881,20 +827,10 @@
 
   <property>
     <name>kafka.server.zookeeper.connection.timeout.ms</name>
-    <value>${kafka.zookeeper.connection.timeout.ms}</value>
-    <description>
-      The maximum time (in milliseconds) that the client will wait to
-      establish a connection to Zookeeper
-    </description>
-  </property>
-
-  <property>
-    <name>kafka.zookeeper.connection.timeout.ms</name>
     <value>1000000</value>
     <description>
       The maximum time (in milliseconds) that the client will wait to
-      establish a connection to Zookeeper (deprecated: replaced with
-      ${kafka.server.zookeeper.connection.timeout.ms})
+      establish a connection to Zookeeper
     </description>
   </property>
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="5f8e8af76b031ff4daf4628bf058e3e2"
+DEFAULT_XML_MD5_HASH="3d22866379b41f7a4b54de78b5d1edf5"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-kafka/src/main/java/co/cask/cdap/kafka/run/KafkaServerMain.java
+++ b/cdap-kafka/src/main/java/co/cask/cdap/kafka/run/KafkaServerMain.java
@@ -83,9 +83,9 @@ public class KafkaServerMain extends DaemonMain {
 
     kafkaProperties = generateKafkaConfig(cConf);
 
-    Preconditions.checkState(Integer.parseInt(
-      kafkaProperties.getProperty("num.partitions")) > 0,
-                             "Num partitions should be greater than zero.");
+    int partitions = Integer.parseInt(kafkaProperties.getProperty("num.partitions"), 10);
+    Preconditions.checkState(partitions > 0, "Num partitions should be greater than zero.");
+
     int port = Integer.parseInt(kafkaProperties.getProperty("port"), 10);
     Preconditions.checkState(port > 0, "Port number is invalid.");
 


### PR DESCRIPTION
During investigation of CDAP-6730 I noticed that the Kafka settings were not deprecated like the others. Also, I was getting an error that's mentioned in CDAP-6730, so I have explicitly converted that to an integer variable. There was another issue where `LOG_DIRS_DEPRECATED` was set to `kafka.log.dirs` versus `kafka.log.dir` which is what has been used everywhere. In fact, that was the reason why CDAP-6696 was filed, originally.

DRC: http://builds.cask.co/browse/CDAP-DRC4124-2
DUT: http://builds.cask.co/browse/CDAP-DUT4529-2

Docs: http://builds.cask.co/browse/CDAP-DQB61-2
May want to look at: [Appendix: cdap-site.xml](http://builds.cask.co/artifact/CDAP-DQB61/shared/build-2/Docs-HTML/3.5.0-SNAPSHOT/en/admin-manual/appendices/cdap-site.html)

Fixes CDAP-6730
Fixes CDAP-6733
