### PR TITLE
Stream authorization for REST endpoints

### DIFF
--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamFileJanitorTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamFileJanitorTest.java
@@ -47,6 +47,8 @@ import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
+import co.cask.cdap.security.authorization.AuthorizationTestModule;
 import co.cask.cdap.store.NamespaceStore;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -112,8 +114,9 @@ public class DFSStreamFileJanitorTest extends StreamFileJanitorTestBase {
       }),
       new ExploreClientModule(),
       new ViewAdminModules().getInMemoryModules(),
+      new AuthorizationTestModule(),
+      new AuthorizationEnforcementModule().getInMemoryModules(),
       Modules.override(new StreamAdminModules().getDistributedModules()).with(new AbstractModule() {
-
         @Override
         protected void configure() {
           // Tests are running in same process, hence no need to have ZK to coordinate

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DistributedStreamCoordinatorClientTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DistributedStreamCoordinatorClientTest.java
@@ -37,6 +37,8 @@ import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModule;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
+import co.cask.cdap.security.authorization.AuthorizationTestModule;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -99,6 +101,8 @@ public class DistributedStreamCoordinatorClientTest extends StreamCoordinatorTes
       },
       new ExploreClientModule(),
       new ViewAdminModules().getInMemoryModules(),
+      new AuthorizationTestModule(),
+      new AuthorizationEnforcementModule().getInMemoryModules(),
       Modules.override(new StreamAdminModules().getDistributedModules())
         .with(new AbstractModule() {
           @Override

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/InMemoryStreamCoordinatorClientTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/InMemoryStreamCoordinatorClientTest.java
@@ -33,6 +33,9 @@ import co.cask.cdap.data2.security.UnsupportedUGIProvider;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModule;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
+import co.cask.cdap.security.authorization.AuthorizationTestModule;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -64,14 +67,17 @@ public class InMemoryStreamCoordinatorClientTest extends StreamCoordinatorTestBa
       new NotificationFeedServiceRuntimeModule().getInMemoryModules(),
       new ExploreClientModule(),
       new ViewAdminModules().getInMemoryModules(),
+      new AuthorizationTestModule(),
+      new AuthenticationContextModules().getNoOpModule(),
+      new AuthorizationEnforcementModule().getInMemoryModules(),
       Modules.override(new StreamAdminModules().getInMemoryModules())
         .with(new AbstractModule() {
-                @Override
-                protected void configure() {
-                  bind(StreamMetaStore.class).to(InMemoryStreamMetaStore.class);
-                  bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
-                }
-              })
+          @Override
+          protected void configure() {
+            bind(StreamMetaStore.class).to(InMemoryStreamMetaStore.class);
+            bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
+          }
+        })
     );
 
     setupNamespaces(injector.getInstance(NamespacedLocationFactory.class));

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalStreamFileJanitorTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalStreamFileJanitorTest.java
@@ -42,6 +42,9 @@ import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
+import co.cask.cdap.security.authorization.AuthorizationTestModule;
 import co.cask.cdap.store.NamespaceStore;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -81,6 +84,9 @@ public class LocalStreamFileJanitorTest extends StreamFileJanitorTestBase {
       new NamespaceClientRuntimeModule().getInMemoryModules(),
       new ExploreClientModule(),
       new ViewAdminModules().getInMemoryModules(),
+      new AuthorizationTestModule(),
+      new AuthorizationEnforcementModule().getInMemoryModules(),
+      new AuthenticationContextModules().getNoOpModule(),
       Modules.override(new StreamAdminModules().getStandaloneModules()).with(new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseConsumerStateTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseConsumerStateTest.java
@@ -45,6 +45,9 @@ import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
+import co.cask.cdap.security.authorization.AuthorizationTestModule;
 import co.cask.cdap.test.SlowTests;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -104,6 +107,9 @@ public class HBaseConsumerStateTest extends StreamConsumerStateTestBase {
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new ExploreClientModule(),
       new ViewAdminModules().getInMemoryModules(),
+      new AuthorizationTestModule(),
+      new AuthorizationEnforcementModule().getInMemoryModules(),
+      new AuthenticationContextModules().getNoOpModule(),
       Modules.override(new StreamAdminModules().getDistributedModules())
         .with(new AbstractModule() {
           @Override

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerTest.java
@@ -46,6 +46,9 @@ import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
+import co.cask.cdap.security.authorization.AuthorizationTestModule;
 import co.cask.cdap.test.SlowTests;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.TransactionSystemClient;
@@ -111,6 +114,9 @@ public class HBaseStreamConsumerTest extends StreamConsumerTestBase {
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new ExploreClientModule(),
       new ViewAdminModules().getInMemoryModules(),
+      new AuthorizationTestModule(),
+      new AuthorizationEnforcementModule().getInMemoryModules(),
+      new AuthenticationContextModules().getNoOpModule(),
       Modules.override(new DataFabricDistributedModule(), new StreamAdminModules().getDistributedModules())
         .with(new AbstractModule() {
           @Override

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerStateTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerStateTest.java
@@ -41,6 +41,9 @@ import co.cask.cdap.data2.transaction.stream.StreamConsumerStateTestBase;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
+import co.cask.cdap.security.authorization.AuthorizationTestModule;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -80,6 +83,9 @@ public class LevelDBStreamConsumerStateTest extends StreamConsumerStateTestBase 
       new ExploreClientModule(),
       new ViewAdminModules().getInMemoryModules(),
       new NamespaceClientRuntimeModule().getInMemoryModules(),
+      new AuthorizationTestModule(),
+      new AuthorizationEnforcementModule().getInMemoryModules(),
+      new AuthenticationContextModules().getNoOpModule(),
       Modules.override(new StreamAdminModules().getStandaloneModules())
         .with(new AbstractModule() {
           @Override

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerTest.java
@@ -40,6 +40,9 @@ import co.cask.cdap.data2.transaction.stream.StreamConsumerTestBase;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
+import co.cask.cdap.security.authorization.AuthorizationTestModule;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.inject.AbstractModule;
@@ -82,6 +85,9 @@ public class LevelDBStreamConsumerTest extends StreamConsumerTestBase {
       new ExploreClientModule(),
       new ViewAdminModules().getInMemoryModules(),
       new NamespaceClientRuntimeModule().getInMemoryModules(),
+      new AuthorizationTestModule(),
+      new AuthorizationEnforcementModule().getInMemoryModules(),
+      new AuthenticationContextModules().getNoOpModule(),
       Modules.override(new StreamAdminModules().getStandaloneModules())
         .with(new AbstractModule() {
           @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamAdmin.java
@@ -75,10 +75,11 @@ public interface StreamAdmin {
 
   /**
    * Overwrites existing configuration for the given stream.
-   * @param streamId Id of the stream whose properties are being updated
+   * @param streamId Id of the stream whose properties are being updated.
    * @param properties New configuration of the stream.
+   * @throws Exception if the update of the stream configuration failed
    */
-  void updateConfig(Id.Stream streamId, StreamProperties properties) throws IOException;
+  void updateConfig(Id.Stream streamId, StreamProperties properties) throws Exception;
 
   /**
    * @param streamId Id of the stream.

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/LocalQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/LocalQueueTest.java
@@ -42,6 +42,8 @@ import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
+import co.cask.cdap.security.authorization.AuthorizationTestModule;
 import co.cask.tephra.TransactionExecutorFactory;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.TransactionSystemClient;
@@ -103,8 +105,10 @@ public class LocalQueueTest extends QueueTest {
       new DataSetsModules().getStandaloneModules(),
       new ExploreClientModule(),
       new ViewAdminModules().getStandaloneModules(),
+      new AuthorizationEnforcementModule().getStandaloneModules(),
       new AuthenticationContextModules().getMasterModule(),
       new NamespaceClientRuntimeModule().getStandaloneModules(),
+      new AuthorizationTestModule(),
       Modules.override(new StreamAdminModules().getStandaloneModules())
         .with(new AbstractModule() {
           @Override

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/context/ContextManager.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/context/ContextManager.java
@@ -19,6 +19,7 @@ package co.cask.cdap.hive.context;
 import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.app.guice.AuthorizationModule;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.ConfigurationUtil;
 import co.cask.cdap.common.conf.Constants;
@@ -48,6 +49,8 @@ import co.cask.cdap.hive.stream.StreamSerDe;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
+import co.cask.cdap.security.guice.SecureStoreModules;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.inject.AbstractModule;
@@ -134,6 +137,9 @@ public class ContextManager {
       new NotificationFeedClientModule(),
       new KafkaClientModule(),
       new AuditModule().getDistributedModules(),
+      new AuthorizationModule(),
+      new AuthorizationEnforcementModule().getDistributedModules(),
+      new SecureStoreModules().getDistributedModules(),
       new AuthenticationContextModules().getMasterModule(),
       new AbstractModule() {
         @Override

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ExploreServiceTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ExploreServiceTwillRunnable.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.data.runtime.main;
 
+import co.cask.cdap.app.guice.AuthorizationModule;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
@@ -46,6 +47,8 @@ import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
+import co.cask.cdap.security.guice.SecureStoreModules;
 import co.cask.cdap.store.DefaultNamespaceStore;
 import co.cask.cdap.store.NamespaceStore;
 import com.google.common.annotations.VisibleForTesting;
@@ -131,6 +134,9 @@ public class ExploreServiceTwillRunnable extends AbstractMasterTwillRunnable {
       new NotificationFeedClientModule(),
       new AuditModule().getDistributedModules(),
       new AuthenticationContextModules().getMasterModule(),
+      new SecureStoreModules().getDistributedModules(),
+      new AuthorizationEnforcementModule().getDistributedModules(),
+      new AuthorizationModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/StreamHandlerRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/StreamHandlerRunnable.java
@@ -16,6 +16,7 @@
 package co.cask.cdap.data.runtime.main;
 
 import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.app.guice.AuthorizationModule;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
@@ -47,6 +48,9 @@ import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
+import co.cask.cdap.security.guice.SecureStoreModules;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.Service;
@@ -102,6 +106,7 @@ public class StreamHandlerRunnable extends AbstractMasterTwillRunnable {
     services.add(injector.getInstance(MetricsCollectionService.class));
     services.add(injector.getInstance(StreamHttpService.class));
     services.add(injector.getInstance(StreamService.class));
+    services.add(injector.getInstance(AuthorizationEnforcementService.class));
   }
 
   @VisibleForTesting
@@ -127,7 +132,10 @@ public class StreamHandlerRunnable extends AbstractMasterTwillRunnable {
       new NotificationServiceRuntimeModule().getDistributedModules(),
       new NamespaceClientRuntimeModule().getDistributedModules(),
       new AuditModule().getDistributedModules(),
+      new AuthorizationEnforcementModule().getDistributedModules(),
       new AuthenticationContextModules().getMasterModule(),
+      new SecureStoreModules().getDistributedModules(),
+      new AuthorizationModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
@@ -33,6 +33,7 @@ import co.cask.cdap.proto.id.Ids;
 import co.cask.cdap.proto.id.InstanceId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
@@ -199,6 +200,7 @@ public class AuthorizationTest extends TestBase {
       Ids.namespace(dummyAppId.getNamespace()).artifact(artifact.getName(), artifact.getVersion());
     ProgramId greetingServiceId = dummyAppId.service(DummyApp.Greeting.SERVICE_NAME);
     DatasetId dsId = AUTH_NAMESPACE.dataset("whom");
+    StreamId streamId = AUTH_NAMESPACE.stream("who");
     Assert.assertEquals(
       ImmutableSet.of(
         new Privilege(instance, Action.ADMIN),
@@ -206,7 +208,8 @@ public class AuthorizationTest extends TestBase {
         new Privilege(dummyAppId, Action.ALL),
         new Privilege(dummyArtifact, Action.ALL),
         new Privilege(greetingServiceId, Action.ALL),
-        new Privilege(dsId, Action.ALL)
+        new Privilege(dsId, Action.ALL),
+        new Privilege(streamId, Action.ALL)
       ),
       authorizer.listPrivileges(ALICE)
     );
@@ -251,7 +254,8 @@ public class AuthorizationTest extends TestBase {
         new Privilege(instance, Action.ADMIN),
         new Privilege(AUTH_NAMESPACE, Action.ALL),
         new Privilege(dummyArtifact, Action.ALL),
-        new Privilege(dsId, Action.ALL)
+        new Privilege(dsId, Action.ALL),
+        new Privilege(streamId, Action.ALL)
       ),
       authorizer.listPrivileges(ALICE)
     );
@@ -281,6 +285,7 @@ public class AuthorizationTest extends TestBase {
     DatasetId kvt2 = AUTH_NAMESPACE.dataset(AllProgramsApp.DATASET_NAME2);
     DatasetId kvt3 = AUTH_NAMESPACE.dataset(AllProgramsApp.DATASET_NAME3);
     DatasetId dsWithSchema = AUTH_NAMESPACE.dataset(AllProgramsApp.DS_WITH_SCHEMA_NAME);
+    StreamId sId = AUTH_NAMESPACE.stream(AllProgramsApp.STREAM_NAME);
 
     Assert.assertEquals(
       ImmutableSet.of(
@@ -290,6 +295,7 @@ public class AuthorizationTest extends TestBase {
         new Privilege(updatedDummyArtifact, Action.ALL),
         new Privilege(workflowArtifact, Action.ALL),
         new Privilege(dummyAppId, Action.ALL),
+        new Privilege(streamId, Action.ALL),
         new Privilege(workflowAppId, Action.ALL),
         new Privilege(greetingServiceId, Action.ALL),
         new Privilege(flowId, Action.ALL),
@@ -303,7 +309,8 @@ public class AuthorizationTest extends TestBase {
         new Privilege(kvt, Action.ALL),
         new Privilege(kvt2, Action.ALL),
         new Privilege(kvt3, Action.ALL),
-        new Privilege(dsWithSchema, Action.ALL)
+        new Privilege(dsWithSchema, Action.ALL),
+        new Privilege(sId, Action.ALL)
       ),
       authorizer.listPrivileges(ALICE)
     );
@@ -326,12 +333,14 @@ public class AuthorizationTest extends TestBase {
         new Privilege(updatedDummyArtifact, Action.ALL),
         new Privilege(workflowArtifact, Action.ALL),
         new Privilege(dummyAppId, Action.ALL),
+        new Privilege(streamId, Action.ALL),
         new Privilege(greetingServiceId, Action.ALL),
         new Privilege(dsId, Action.ALL),
         new Privilege(kvt, Action.ALL),
         new Privilege(kvt2, Action.ALL),
         new Privilege(kvt3, Action.ALL),
-        new Privilege(dsWithSchema, Action.ALL)
+        new Privilege(dsWithSchema, Action.ALL),
+        new Privilege(sId, Action.ALL)
       ),
       authorizer.listPrivileges(ALICE)
     );
@@ -352,13 +361,15 @@ public class AuthorizationTest extends TestBase {
         new Privilege(instance, Action.ADMIN),
         new Privilege(AUTH_NAMESPACE, Action.ALL),
         new Privilege(dummyArtifact, Action.ALL),
+        new Privilege(streamId, Action.ALL),
         new Privilege(updatedDummyArtifact, Action.ALL),
         new Privilege(workflowArtifact, Action.ALL),
         new Privilege(dsId, Action.ALL),
         new Privilege(kvt, Action.ALL),
         new Privilege(kvt2, Action.ALL),
         new Privilege(kvt3, Action.ALL),
-        new Privilege(dsWithSchema, Action.ALL)
+        new Privilege(dsWithSchema, Action.ALL),
+        new Privilege(sId, Action.ALL)
       ),
       authorizer.listPrivileges(ALICE)
     );
@@ -465,6 +476,7 @@ public class AuthorizationTest extends TestBase {
     ApplicationId appId = AUTH_NAMESPACE.app(DummyApp.class.getSimpleName());
     final ProgramId serviceId = appId.service(DummyApp.Greeting.SERVICE_NAME);
     DatasetId dsId = AUTH_NAMESPACE.dataset("whom");
+    StreamId streamId = AUTH_NAMESPACE.stream("who");
     Assert.assertEquals(
       ImmutableSet.of(
         new Privilege(instance, Action.ADMIN),
@@ -472,7 +484,8 @@ public class AuthorizationTest extends TestBase {
         new Privilege(dummyArtifact, Action.ALL),
         new Privilege(appId, Action.ALL),
         new Privilege(serviceId, Action.ALL),
-        new Privilege(dsId, Action.ALL)
+        new Privilege(dsId, Action.ALL),
+        new Privilege(streamId, Action.ALL)
       ),
       authorizer.listPrivileges(ALICE)
     );


### PR DESCRIPTION
JIRA : https://issues.cask.co/browse/CDAP-882

Build : http://builds.cask.co/browse/CDAP-DUT4535

Summary:
Add authorization checks for Stream REST endpoints according to the guidelines mentioned here: https://wiki.cask.co/display/CE/Authorization+-+CDAP+3.5.

Coming up:
Authorization checks in programs => Flow/MR/Spark when they try to read events from Streams. Also in Worker (rather in StreamWriter) to make sure those requests have the required auth to perform stream writes.
