### PR TITLE
fixes tag text and rendering issues

### DIFF
--- a/cdap-ui/app/features/tracker/controllers/tags-ctrl.js
+++ b/cdap-ui/app/features/tracker/controllers/tags-ctrl.js
@@ -177,8 +177,6 @@ function AddPreferredTagsModalCtrl (myTrackerApi, $scope, $state) {
         if (this.tagList.validTags.length > 0) {
           this.proceedToNextStep = true;
         }
-        this.validTagNum = this.tagList.validTags.length > 1 ? 'tags' : 'tag';
-        this.invalidTagNum = this.tagList.invalidTags.length > 1 ? 'tags' : 'tag';
       }, (err) => {
         console.log('Error', err);
       });

--- a/cdap-ui/app/features/tracker/controllers/tags-ctrl.js
+++ b/cdap-ui/app/features/tracker/controllers/tags-ctrl.js
@@ -153,6 +153,9 @@ function AddPreferredTagsModalCtrl (myTrackerApi, $scope, $state) {
       return parsedTags;
     }
     angular.forEach(tags.split('\n'), (line) => {
+      if (!line) {
+        return;
+      }
       parsedTags = parsedTags.concat(line.split(',').map((tag) => {
         return tag.trim();
       }));
@@ -174,6 +177,8 @@ function AddPreferredTagsModalCtrl (myTrackerApi, $scope, $state) {
         if (this.tagList.validTags.length > 0) {
           this.proceedToNextStep = true;
         }
+        this.validTagNum = this.tagList.validTags.length > 1 ? 'tags' : 'tag';
+        this.invalidTagNum = this.tagList.invalidTags.length > 1 ? 'tags' : 'tag';
       }, (err) => {
         console.log('Error', err);
       });

--- a/cdap-ui/app/features/tracker/directives/typeahead-tracker-tags/typeahead-tracker-tags.html
+++ b/cdap-ui/app/features/tracker/directives/typeahead-tracker-tags/typeahead-tracker-tags.html
@@ -22,7 +22,7 @@
   placeholder="Enter new Tag"
   typeahead-show-hint="true"
   data-watch-options="true"
-  typeahead-select-on-exact="true"
+  typeahead-select-on-exact="false"
   typeahead-on-select="TypeaheadTrackerTagsCtrl.onTagsSelect($item, $model, $label, $event)"
-  uib-typeahead="data.label as data.label for data in TypeaheadTrackerTagsCtrl.list  | filter:{name:$viewValue}"
+  uib-typeahead="data.label as data.label for data in TypeaheadTrackerTagsCtrl.list | filter:{name:$viewValue}"
 />

--- a/cdap-ui/app/features/tracker/templates/partial/add-preferred-tags-popover.html
+++ b/cdap-ui/app/features/tracker/templates/partial/add-preferred-tags-popover.html
@@ -49,20 +49,20 @@
   <div ng-if="AddTags.proceedToNextStep"
       class="text-left">
     <div class="valid-tags">
-      <p>{{ AddTags.tagList.validTags.length }} tags loaded.</p>
+      <p>{{ AddTags.tagList.validTags.length }} {{ AddTags.validTagNum }} loaded.</p>
       <span ng-repeat="(key, value) in AddTags.tagList.validTags track by $index"
             class="tag preferred">{{ value }}</a>
     </div>
     <div ng-if="AddTags.tagList.invalidTags.length"
         class="invalid-tags">
-      <p class="text-danger">{{ AddTags.tagList.invalidTags.length }} tags failed to load.</p>
+      <p class="text-danger">{{ AddTags.tagList.invalidTags.length }} {{ AddTags.invalidTagNum }} failed to load.</p>
       <span ng-repeat="(key, value) in AddTags.tagList.invalidTags track by $index">{{ value }}</span>
     </div>
   </div>
 </div>
 <div class="modal-footer text-right">
   <p class="pull-left text-danger"
-    ng-if="!AddTags.proceedToNextStep && AddTags.tagList.invalidTags.length">No special characters allowed in tags.</p>
+     ng-if="!AddTags.proceedToNextStep && AddTags.tagList.invalidTags.length">No special characters allowed in tags.</p>
   <button class="btn btn-default"
           ng-click="$dismiss('cancel')">Cancel</button>
   <button ng-if="!AddTags.proceedToNextStep"

--- a/cdap-ui/app/features/tracker/templates/partial/add-preferred-tags-popover.html
+++ b/cdap-ui/app/features/tracker/templates/partial/add-preferred-tags-popover.html
@@ -49,13 +49,22 @@
   <div ng-if="AddTags.proceedToNextStep"
       class="text-left">
     <div class="valid-tags">
-      <p>{{ AddTags.tagList.validTags.length }} {{ AddTags.validTagNum }} loaded.</p>
+      <p>
+        <span>{{ AddTags.tagList.validTags.length }}</span>
+        <ng-pluralize data-count="AddTags.tagList.validTags.length"
+                      data-when="{'one': ' tag ', 'other': ' tags '}"></ng-pluralize>
+        <span>loaded.</span>
+      </p>
       <span ng-repeat="(key, value) in AddTags.tagList.validTags track by $index"
             class="tag preferred">{{ value }}</a>
     </div>
     <div ng-if="AddTags.tagList.invalidTags.length"
         class="invalid-tags">
-      <p class="text-danger">{{ AddTags.tagList.invalidTags.length }} {{ AddTags.invalidTagNum }} failed to load.</p>
+      <p class="text-danger">
+        <span>{{ AddTags.tagList.invalidTags.length }}</span>
+        <ng-pluralize data-count="AddTags.tagList.invalidTags.length"
+                      data-when="{'one': ' tag ', 'other': ' tags '}"></ng-pluralize>
+        <span>failed to load.</span></p>
       <span ng-repeat="(key, value) in AddTags.tagList.invalidTags track by $index">{{ value }}</span>
     </div>
   </div>

--- a/cdap-ui/app/features/tracker/tracker.less
+++ b/cdap-ui/app/features/tracker/tracker.less
@@ -1312,7 +1312,7 @@ body.state-tracker-tags {
     }
     div.invalid-tags {
       p { margin-top: 10px; }
-      span {
+      > span {
         word-wrap: break-word;
         &:not(:last-child):after { content: ", "; }
       }


### PR DESCRIPTION
-  Fixes issue where newline at the end of a file would create an empty tag on modal confirmation screen - [[CDAP-6679]](https://issues.cask.co/browse/CDAP-6679)
-  Differentiates between tag/tags when adding 1 vs. multiple [[CDAP-6618]](https://issues.cask.co/browse/CDAP-6618)
-  Fixes typeahead directive to not return a stacktrace/type error in console when adding an existing tag manually vs. selecting it from the typeahead dropdown - [[CDAP-6706]]([CDAP-6706])

Screenshot for fix #1:
![import](https://cloud.githubusercontent.com/assets/5335210/17158502/99555b48-534b-11e6-9f63-5ce1785860e8.gif)

Screenshot for fix #2:
![tagtext](https://cloud.githubusercontent.com/assets/5335210/17158486/842bd1d4-534b-11e6-964c-2886970c0ec3.gif)

Screenshot for fix #3:
![console](https://cloud.githubusercontent.com/assets/5335210/17158507/a136d490-534b-11e6-8270-7953a5aa6c5f.gif)
