### PR TITLE
CDAP-6147 Fix error message when wrong role name is input

### DIFF
--- a/cdap-client/src/main/java/co/cask/cdap/client/AuthorizationClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/AuthorizationClient.java
@@ -104,7 +104,7 @@ public class AuthorizationClient extends AbstractAuthorizer {
 
     URL url = config.resolveURLV3(AUTHORIZATION_BASE + "/privileges/grant");
     HttpRequest request = HttpRequest.post(url).withBody(GSON.toJson(grantRequest)).build();
-    executePrivilegeRequest(entity, request);
+    executePrivilegeRequest(request);
   }
 
   @Override
@@ -185,7 +185,7 @@ public class AuthorizationClient extends AbstractAuthorizer {
     throws IOException, UnauthenticatedException, FeatureDisabledException, UnauthorizedException, NotFoundException {
     URL url = config.resolveURLV3(AUTHORIZATION_BASE + "/privileges/revoke");
     HttpRequest request = HttpRequest.post(url).withBody(GSON.toJson(revokeRequest)).build();
-    executePrivilegeRequest(revokeRequest.getEntity(), request);
+    executePrivilegeRequest(request);
   }
 
   private Set<Role> listRolesHelper(@Nullable Principal principal) throws IOException, FeatureDisabledException,
@@ -210,11 +210,11 @@ public class AuthorizationClient extends AbstractAuthorizer {
     }
   }
 
-  private HttpResponse executePrivilegeRequest(EntityId entityId, HttpRequest request) throws FeatureDisabledException,
+  private HttpResponse executePrivilegeRequest(HttpRequest request) throws FeatureDisabledException,
     UnauthenticatedException, IOException, NotFoundException, UnauthorizedException {
     HttpResponse httpResponse = doExecuteRequest(request, HttpURLConnection.HTTP_NOT_FOUND);
     if (HttpURLConnection.HTTP_NOT_FOUND == httpResponse.getResponseCode()) {
-      throw new NotFoundException(entityId);
+      throw new NotFoundException(httpResponse.getResponseBodyAsString());
     }
     return httpResponse;
   }

--- a/cdap-client/src/main/java/co/cask/cdap/client/LineageClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/LineageClient.java
@@ -208,7 +208,7 @@ public class LineageClient {
       throw new BadRequestException(response.getResponseBodyAsString());
     }
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
-      throw new NotFoundException(namespacedId);
+      throw new NotFoundException(response.getResponseBodyAsString());
     }
     return GSON.fromJson(response.getResponseBodyAsString(), LineageRecord.class);
   }


### PR DESCRIPTION
A small fix. When 404 is returned from server side, it can either be entity not found or principal not found. Simply changed to use the response body as the error message.

JIRA: https://issues.cask.co/browse/CDAP-6147
