### PR TITLE
Fix Documentation Build.

### DIFF
--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="3d22866379b41f7a4b54de78b5d1edf5"
+DEFAULT_XML_MD5_HASH="45d1f34a6ee85be599caaf8cf7fc3e79"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
Update MD5 hash after reviewing changes of guarded file.

Running as a [Quick Build](http://builds.cask.co/browse/CDAP-DQB65-1)
