### PR TITLE
[CDAP-5135] Workaround to get correct program status from Twill 

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
@@ -315,7 +315,7 @@ public class ProgramLifecycleService extends AbstractIdleService {
 
         @Override
         public void killed() {
-          LOG.debug("Program {} killed.", programId.getNamespaceId());
+          LOG.debug("Program {} killed.", programId);
           store.setStop(programId.toId(), runId, TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()),
                         ProgramController.State.KILLED.getRunStatus());
         }


### PR DESCRIPTION
…if program fails or gets killed.

Also a question: Does anybody know why the UI sill still show a status of FAILED even though I set the status to KILLED?
