### PR TITLE
CDAP-6794 Support cross namespace write for map reduce program through Output class

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/Output.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/Output.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.common.RuntimeArguments;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Defines output of a program, such as MapReduce.
@@ -66,17 +67,16 @@ public abstract class Output {
    *
    * @param datasetName the name of the output dataset
    */
-  public static Output ofDataset(String datasetName) {
+  public static DatasetOutput ofDataset(String datasetName) {
     return ofDataset(datasetName, RuntimeArguments.NO_ARGUMENTS);
   }
 
   /**
    * Returns an Output defined by a dataset.
-   *
-   * @param datasetName the name of the output dataset
+   *  @param datasetName the name of the output dataset
    * @param arguments the arguments to use when instantiating the dataset
    */
-  public static Output ofDataset(String datasetName, Map<String, String> arguments) {
+  public static DatasetOutput ofDataset(String datasetName, Map<String, String> arguments) {
     return new DatasetOutput(datasetName, arguments);
   }
 
@@ -95,6 +95,7 @@ public abstract class Output {
   public static class DatasetOutput extends Output {
 
     private final Map<String, String> arguments;
+    private String namespace;
 
     private DatasetOutput(String name, Map<String, String> arguments) {
       super(name);
@@ -103,6 +104,17 @@ public abstract class Output {
 
     public Map<String, String> getArguments() {
       return arguments;
+    }
+
+    public DatasetOutput fromNamespace(String namespace) {
+      DatasetOutput datasetOutput = new DatasetOutput(super.name, arguments);
+      datasetOutput.namespace = namespace;
+      return datasetOutput;
+    }
+
+    @Nullable
+    public String getNamespace() {
+      return namespace;
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -277,6 +277,11 @@ final class BasicMapReduceContext extends AbstractContext implements MapReduceCo
   @Override
   public void addOutput(Output output) {
     if (output instanceof Output.DatasetOutput) {
+      Output.DatasetOutput datasetOutput = ((Output.DatasetOutput) output);
+      String datasetNamespace = datasetOutput.getNamespace();
+      if (datasetNamespace == null) {
+        datasetNamespace = getNamespace();
+      }
       String datasetName = output.getName();
       Map<String, String> arguments = ((Output.DatasetOutput) output).getArguments();
 
@@ -285,8 +290,8 @@ final class BasicMapReduceContext extends AbstractContext implements MapReduceCo
       // bring about code complexity without much benefit. Once #setOutput(String, Dataset) is removed, we can postpone
       // this dataset instantiation
       DatasetOutputFormatProvider outputFormatProvider =
-        new DatasetOutputFormatProvider(datasetName, arguments,
-                                        getDataset(datasetName, arguments, AccessType.WRITE),
+        new DatasetOutputFormatProvider(datasetNamespace, datasetName, arguments,
+                                        getDataset(datasetNamespace, datasetName, arguments, AccessType.WRITE),
                                         MapReduceBatchWritableOutputFormat.class);
       addOutput(output.getAlias(), outputFormatProvider);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
@@ -209,21 +209,32 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
     }
   }
 
-  /**
-   * This delegates the instantiation of the dataset to the super class, but in addition, if
-   * the dataset is a new transaction-aware, it starts the transaction and remembers the dataset.
-   */
   @Override
   protected <T extends Dataset> T getDataset(String name, Map<String, String> arguments, AccessType accessType)
     throws DatasetInstantiationException {
     T dataset = super.getDataset(name, arguments, accessType);
+    startDatasetTransaction(dataset);
+    return dataset;
+  }
+
+  @Override
+  protected <T extends Dataset> T getDataset(String namespace, String name, Map<String, String> arguments,
+                                             AccessType accessType) throws DatasetInstantiationException {
+    T dataset = super.getDataset(namespace, name, arguments, accessType);
+    startDatasetTransaction(dataset);
+    return dataset;
+  }
+
+  /**
+   * If a dataset is a new transaction-aware, it starts the transaction and remembers the dataset.
+   */
+  private <T extends Dataset> void startDatasetTransaction(T dataset) {
     if (dataset instanceof TransactionAware) {
       TransactionAware txAware = (TransactionAware) dataset;
       if (txAwares.add(txAware)) {
         txAware.startTx(transaction);
       }
     }
-    return dataset;
   }
 
   @Override
@@ -308,10 +319,12 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
   /**
    * Returns a {@link CloseableBatchWritable} that writes data to the given dataset.
    */
-  <K, V> CloseableBatchWritable<K, V> getBatchWritable(String datasetName, Map<String, String> datasetArgs) {
-    Dataset dataset = getDataset(datasetName, datasetArgs, AccessType.WRITE);
+  <K, V> CloseableBatchWritable<K, V> getBatchWritable(String namespace, String datasetName,
+                                                       Map<String, String> datasetArgs) {
+    Dataset dataset = getDataset(namespace, datasetName, datasetArgs, AccessType.WRITE);
     // Must be BatchWritable.
-    Preconditions.checkArgument(dataset instanceof BatchWritable, "Dataset '%s' is not a BatchWritable.", datasetName);
+    Preconditions.checkArgument(dataset instanceof BatchWritable,
+                                "Dataset '%s:%s' is not a BatchWritable.", namespace, datasetName);
 
     @SuppressWarnings("unchecked") final
     BatchWritable<K, V> delegate = (BatchWritable<K, V>) dataset;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceBatchWritableOutputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceBatchWritableOutputFormat.java
@@ -33,10 +33,11 @@ public class MapReduceBatchWritableOutputFormat<KEY, VALUE> extends AbstractBatc
 
   @Override
   protected CloseableBatchWritable<KEY, VALUE> createBatchWritable(TaskAttemptContext context,
+                                                                   String namespace,
                                                                    String datasetName,
                                                                    Map<String, String> datasetArgs) {
     MapReduceClassLoader classLoader = MapReduceClassLoader.getFromConfiguration(context.getConfiguration());
     BasicMapReduceTaskContext<?, ?> taskContext = classLoader.getTaskContextProvider().get(context);
-    return taskContext.getBatchWritable(datasetName, datasetArgs);
+    return taskContext.getBatchWritable(namespace, datasetName, datasetArgs);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/AbstractBatchWritableOutputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/AbstractBatchWritableOutputFormat.java
@@ -41,6 +41,7 @@ public abstract class AbstractBatchWritableOutputFormat<KEY, VALUE> extends Outp
   private static final Gson GSON = new Gson();
   private static final Type DATASET_ARGS_TYPE = new TypeToken<Map<String, String>>() { }.getType();
 
+  private static final String DATASET_NAMESPACE = "output.datasetoutputformat.dataset.namespace";
   private static final String DATASET_NAME = "output.datasetoutputformat.dataset.name";
   private static final String DATASET_ARGS = "output.datasetoutputformat.dataset.args";
 
@@ -51,7 +52,9 @@ public abstract class AbstractBatchWritableOutputFormat<KEY, VALUE> extends Outp
    * @param datasetName name of the dataset
    * @param datasetArgs arguments for the dataset
    */
-  public static void setDataset(Configuration hConf, String datasetName, Map<String, String> datasetArgs) {
+  public static void setDataset(Configuration hConf, String namespace,
+                                String datasetName, Map<String, String> datasetArgs) {
+    hConf.set(DATASET_NAMESPACE, namespace);
     hConf.set(DATASET_NAME, datasetName);
     hConf.set(DATASET_ARGS, GSON.toJson(datasetArgs, DATASET_ARGS_TYPE));
   }
@@ -59,15 +62,16 @@ public abstract class AbstractBatchWritableOutputFormat<KEY, VALUE> extends Outp
   @Override
   public RecordWriter<KEY, VALUE> getRecordWriter(TaskAttemptContext context) throws IOException, InterruptedException {
     Configuration conf = context.getConfiguration();
+    String namespace = conf.get(DATASET_NAMESPACE);
     String datasetName = conf.get(DATASET_NAME);
     Map<String, String> datasetArgs = GSON.fromJson(conf.get(DATASET_ARGS), DATASET_ARGS_TYPE);
-    return new BatchWritableRecordWriter<>(createBatchWritable(context, datasetName, datasetArgs));
+    return new BatchWritableRecordWriter<>(createBatchWritable(context, namespace, datasetName, datasetArgs));
   }
 
   @Override
   public void checkOutputSpecs(JobContext context) throws IOException, InterruptedException {
     Configuration hConf = context.getConfiguration();
-    if (hConf.get(DATASET_NAME) == null || hConf.get(DATASET_ARGS) == null) {
+    if (hConf.get(DATASET_NAMESPACE) == null || hConf.get(DATASET_NAME) == null || hConf.get(DATASET_ARGS) == null) {
       throw new IOException("Dataset configurations are missing in the job configuration");
     }
   }
@@ -82,10 +86,12 @@ public abstract class AbstractBatchWritableOutputFormat<KEY, VALUE> extends Outp
    * the given dataset.
    *
    * @param context the hadoop task context
+   * @param namespace namespace of the dataset to write to
    * @param datasetName name of the dataset to write to
    * @param datasetArgs arguments of the dataset to write to
    */
   protected abstract CloseableBatchWritable<KEY, VALUE> createBatchWritable(TaskAttemptContext context,
+                                                                            String namespace,
                                                                             String datasetName,
                                                                             Map<String, String> datasetArgs);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DatasetOutputFormatProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DatasetOutputFormatProvider.java
@@ -35,14 +35,15 @@ public class DatasetOutputFormatProvider implements OutputFormatProvider, Datase
   private final Map<String, String> configuration;
   private final Dataset dataset;
 
-  public DatasetOutputFormatProvider(String datasetName, Map<String, String> datasetArgs, Dataset dataset,
+  public DatasetOutputFormatProvider(String namespace, String datasetName,
+                                     Map<String, String> datasetArgs, Dataset dataset,
                                      Class<? extends AbstractBatchWritableOutputFormat> batchWritableOutputFormat) {
     if (dataset instanceof OutputFormatProvider) {
       this.outputFormatClassName = ((OutputFormatProvider) dataset).getOutputFormatClassName();
       this.configuration = ((OutputFormatProvider) dataset).getOutputFormatConfiguration();
     } else if (dataset instanceof BatchWritable) {
       this.outputFormatClassName = batchWritableOutputFormat.getName();
-      this.configuration = createDatasetConfiguration(datasetName, datasetArgs);
+      this.configuration = createDatasetConfiguration(namespace, datasetName, datasetArgs);
     } else {
       throw new IllegalArgumentException("Dataset '" + dataset +
                                            "' is neither OutputFormatProvider nor BatchWritable.");
@@ -60,10 +61,11 @@ public class DatasetOutputFormatProvider implements OutputFormatProvider, Datase
     return configuration;
   }
 
-  private Map<String, String> createDatasetConfiguration(String datasetName, Map<String, String> datasetArgs) {
+  private Map<String, String> createDatasetConfiguration(String namespace, String datasetName,
+                                                         Map<String, String> datasetArgs) {
     Configuration hConf = new Configuration();
     hConf.clear();
-    AbstractBatchWritableOutputFormat.setDataset(hConf, datasetName, datasetArgs);
+    AbstractBatchWritableOutputFormat.setDataset(hConf, namespace, datasetName, datasetArgs);
     return ConfigurationUtil.toMap(hConf);
   }
 

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DatasetCrossNSAccessWithMAPApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DatasetCrossNSAccessWithMAPApp.java
@@ -29,12 +29,13 @@ import java.io.IOException;
 /**
  * App which copies data from one KVTable to another using a MapReduce program.
  */
-public class DatasetFromOtherSpaceWithMPApp extends AbstractApplication {
+public class DatasetCrossNSAccessWithMAPApp extends AbstractApplication {
 
   public static final String INPUT_KEY = "input";
   public static final String OUTPUT_KEY = "output";
   public static final String MAPREDUCE_PROGRAM = "copymr";
-  public static final String DATASETSPACE = "datasetSpace";
+  public static final String DATASET_INPUT_SPACE = "datasetInputSpace";
+  public static final String DATASET_OUTPUT_SPACE = "datasetOutputSpace";
 
   @Override
   public void configure() {
@@ -52,8 +53,10 @@ public class DatasetFromOtherSpaceWithMPApp extends AbstractApplication {
     @Override
     public void initialize() {
       MapReduceContext context = getContext();
-      context.addInput(Input.ofDataset(context.getRuntimeArguments().get(INPUT_KEY)).fromNamespace(DATASETSPACE));
-      context.addOutput(Output.ofDataset(context.getRuntimeArguments().get(OUTPUT_KEY)));
+      context.addInput(Input.ofDataset(context.getRuntimeArguments()
+                                         .get(INPUT_KEY)).fromNamespace(DATASET_INPUT_SPACE));
+      context.addOutput(Output.ofDataset(context.getRuntimeArguments()
+                                           .get(OUTPUT_KEY)).fromNamespace(DATASET_OUTPUT_SPACE));
       Job hadoopJob = context.getHadoopJob();
       hadoopJob.setMapperClass(IdentityMapper.class);
       hadoopJob.setNumReduceTasks(0);


### PR DESCRIPTION
Support cross namespace write for map reduce program through `Output` class. 

Use the API as:  `context.addOutput(Output.ofDataset(datasetName).fromNamespace(namespace))`.

Similar to do `Input` change.

JIRA: https://issues.cask.co/browse/CDAP-6794
Build: http://builds.cask.co/browse/CDAP-DUT4550
