### PR TITLE
Fix the default for security.store.provider to be kms, since file cau…

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1727,7 +1727,7 @@
 
   <property>
     <name>security.store.provider</name>
-    <value>file</value>
+    <value>kms</value>
     <description>
       Backend provider for the secure store
     </description>

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="3d22866379b41f7a4b54de78b5d1edf5"
+DEFAULT_XML_MD5_HASH="da31a1100b62cba191e61132bb667a0d"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-standalone/src/main/resources/cdap-site.xml
+++ b/cdap-standalone/src/main/resources/cdap-site.xml
@@ -197,4 +197,12 @@
     </description>
   </property>
 
+  <property>
+    <name>security.store.provider</name>
+    <value>file</value>
+    <description>
+      Backend provider for the secure store
+    </description>
+  </property>
+
 </configuration>


### PR DESCRIPTION
…ses guice failures in master startup. Add file as the default for standalone. Update md5 hash
