### PR TITLE
fixes styling in tracker home and metadata tags

### DIFF
--- a/cdap-ui/app/features/tracker/controllers/metadata-ctrl.js
+++ b/cdap-ui/app/features/tracker/controllers/metadata-ctrl.js
@@ -285,6 +285,7 @@ class TrackerMetadataController {
   }
 
   addTag() {
+    this.invalidFormat = false;
     if (!this.newTag) {
       return;
     }
@@ -303,7 +304,9 @@ class TrackerMetadataController {
         this.newTag = '';
 
       }, (err) => {
-        console.log('Error', err);
+        if (err.statusCode === 500) {
+          this.invalidFormat = true;
+        }
       });
   }
 
@@ -336,6 +339,7 @@ class TrackerMetadataController {
 
   escapeInput() {
     this.newTag = '';
+    this.invalidFormat = false;
     this.inputOpen = false;
   }
 

--- a/cdap-ui/app/features/tracker/controllers/metadata-ctrl.js
+++ b/cdap-ui/app/features/tracker/controllers/metadata-ctrl.js
@@ -336,7 +336,7 @@ class TrackerMetadataController {
 
   goToTag(event, tag) {
     event.stopPropagation();
-    this.$state.go('search.objectswithtags', {tag: tag});
+    this.$state.go('tracker.detail.result', {searchQuery: tag});
   }
 
   openTagInput(event) {

--- a/cdap-ui/app/features/tracker/controllers/metadata-ctrl.js
+++ b/cdap-ui/app/features/tracker/controllers/metadata-ctrl.js
@@ -213,6 +213,8 @@ class TrackerMetadataController {
     });
   }
 
+  /* TAGS CONTROL */
+
   fetchEntityTags() {
     let params = {
       namespace: this.$state.params.namespace,
@@ -337,10 +339,22 @@ class TrackerMetadataController {
     this.$state.go('search.objectswithtags', {tag: tag});
   }
 
+  openTagInput(event) {
+    event.stopPropagation();
+    this.inputOpen = true;
+
+    this.eventFunction = () => {
+      this.escapeInput();
+    };
+    document.body.addEventListener('click', this.eventFunction, false);
+  }
+
   escapeInput() {
     this.newTag = '';
     this.invalidFormat = false;
     this.inputOpen = false;
+    document.body.removeEventListener('click', this.eventFunction, false);
+    this.eventFunction = null;
   }
 
 }

--- a/cdap-ui/app/features/tracker/controllers/results-ctrl.js
+++ b/cdap-ui/app/features/tracker/controllers/results-ctrl.js
@@ -130,7 +130,9 @@ class TrackerResultsController {
       .then( (res) => {
         this.fullResults = res.map(this.parseResult.bind(this));
         this.searchResults = angular.copy(this.fullResults);
-        this.fetchTruthMeter();
+        if (this.searchResults.length) {
+          this.fetchTruthMeter();
+        }
         this.loading = false;
       }, (err) => {
         console.log('error', err);

--- a/cdap-ui/app/features/tracker/controllers/tags-ctrl.js
+++ b/cdap-ui/app/features/tracker/controllers/tags-ctrl.js
@@ -198,9 +198,14 @@ function AddPreferredTagsModalCtrl (myTrackerApi, $scope, $state) {
     document.getElementById('file-select').click();
   };
   this.importFiles = (files) => {
+    if (files[0].name.indexOf('.txt') === -1 && files[0].name.indexOf('.csv') === -1) {
+      this.invalidFormat = true;
+      return;
+    }
+
     let reader = new FileReader();
     reader.readAsText(files[0], 'UTF-8');
-
+    this.invalidFormat = false;
     reader.onload = (evt) => {
       let data = evt.target.result;
       this.tags = data;

--- a/cdap-ui/app/features/tracker/directives/top-entity-graph/top-entity-graph.less
+++ b/cdap-ui/app/features/tracker/directives/top-entity-graph/top-entity-graph.less
@@ -41,19 +41,21 @@ my-top-entity-graph {
       }
 
       .app-link {
-        left: 15px;
+        left: 0;
         max-width: 90px;
         color: #aaaaaa;
         font-size: 10px;
+        margin-left: 15px;
       }
 
       .entity-link {
         font-size: 12px;
-        left: 10px;
+        left: 0;
         font-weight: 600;
         color: @font-color;
         transform: translateY(-50%);
         letter-spacing: 0.5px;
+        margin-left: 10px;
         max-width: 110px;
 
         &:hover {

--- a/cdap-ui/app/features/tracker/directives/typeahead-tracker-tags/popup.html
+++ b/cdap-ui/app/features/tracker/directives/typeahead-tracker-tags/popup.html
@@ -14,7 +14,10 @@
   the License.
 -->
 
-<ul class="dropdown-menu" role="listbox" ng-show="isOpen() && !moveInProgress">
+<ul class="dropdown-menu"
+    role="listbox"
+    ng-show="(isOpen() && !moveInProgress)"
+    ng-click="$event.stopPropagation()">
   <li ng-repeat="match in matches track by $index" ng-class="{active: isActive($index), 'preferred-tag': match.model.preferredTag > 0 }"
       ng-mouseenter="selectActive($index)" ng-click="selectMatch($index)" role="option" id="{{::match.id}}">
     <div uib-typeahead-match index="$index" match="match" query="query" template-url="templateUrl"></div>

--- a/cdap-ui/app/features/tracker/directives/typeahead-tracker-tags/typeahead-tracker-tags-ctrl.js
+++ b/cdap-ui/app/features/tracker/directives/typeahead-tracker-tags/typeahead-tracker-tags-ctrl.js
@@ -15,7 +15,7 @@
  */
 
 angular.module(PKG.name + '.feature.tracker')
-  .controller('TypeaheadTrackerTagsCtrl', function() {
+  .controller('TypeaheadTrackerTagsCtrl', function(caskFocusManager) {
     this.modelLoading = false;
     this.isOpen = true;
     this.template = '/assets/features/tracker/directives/typeahead-tracker-tags/popup.html';
@@ -26,4 +26,6 @@ angular.module(PKG.name + '.feature.tracker')
     this.onTagsSelect = function(item) {
       this.model = item.name;
     };
+
+    caskFocusManager.focus('tagInput');
   });

--- a/cdap-ui/app/features/tracker/directives/typeahead-tracker-tags/typeahead-tracker-tags.html
+++ b/cdap-ui/app/features/tracker/directives/typeahead-tracker-tags/typeahead-tracker-tags.html
@@ -16,7 +16,6 @@
 <input
   type="text"
   ng-model="TypeaheadTrackerTagsCtrl.model"
-  ng-model-options="{ debounce: 500 }"
   ng-click="$event.stopPropagation()"
   typeahead-popup-template-url="/assets/features/tracker/directives/typeahead-tracker-tags/popup.html"
   typeahead-min-length="0"
@@ -29,4 +28,5 @@
   uib-typeahead="data.label as data.label for data in TypeaheadTrackerTagsCtrl.list  | filter:{name:$viewValue}"
   max-length="50"
   cask-focus="tagInput"
+  ng-change="TypeaheadTrackerTagsCtrl.onChange()"
 />

--- a/cdap-ui/app/features/tracker/directives/typeahead-tracker-tags/typeahead-tracker-tags.html
+++ b/cdap-ui/app/features/tracker/directives/typeahead-tracker-tags/typeahead-tracker-tags.html
@@ -20,7 +20,7 @@
   typeahead-popup-template-url="/assets/features/tracker/directives/typeahead-tracker-tags/popup.html"
   typeahead-min-length="0"
   class="form-control"
-  placeholder="Enter new Tag"
+  placeholder="Enter a tag"
   typeahead-show-hint="true"
   data-watch-options="true"
   typeahead-select-on-exact="false"

--- a/cdap-ui/app/features/tracker/directives/typeahead-tracker-tags/typeahead-tracker-tags.html
+++ b/cdap-ui/app/features/tracker/directives/typeahead-tracker-tags/typeahead-tracker-tags.html
@@ -27,4 +27,5 @@
   typeahead-on-select="TypeaheadTrackerTagsCtrl.onTagsSelect($item, $model, $label, $event)"
   uib-typeahead="data.label as data.label for data in TypeaheadTrackerTagsCtrl.list  | filter:{name:$viewValue}"
   max-length="50"
+  cask-focus="tagInput"
 />

--- a/cdap-ui/app/features/tracker/directives/typeahead-tracker-tags/typeahead-tracker-tags.html
+++ b/cdap-ui/app/features/tracker/directives/typeahead-tracker-tags/typeahead-tracker-tags.html
@@ -17,6 +17,7 @@
   type="text"
   ng-model="TypeaheadTrackerTagsCtrl.model"
   ng-model-options="{ debounce: 500 }"
+  ng-click="$event.stopPropagation()"
   typeahead-popup-template-url="/assets/features/tracker/directives/typeahead-tracker-tags/popup.html"
   typeahead-min-length="0"
   class="form-control"

--- a/cdap-ui/app/features/tracker/directives/typeahead-tracker-tags/typeahead-tracker-tags.html
+++ b/cdap-ui/app/features/tracker/directives/typeahead-tracker-tags/typeahead-tracker-tags.html
@@ -16,6 +16,7 @@
 <input
   type="text"
   ng-model="TypeaheadTrackerTagsCtrl.model"
+  ng-model-options="{ debounce: 500 }"
   typeahead-popup-template-url="/assets/features/tracker/directives/typeahead-tracker-tags/popup.html"
   typeahead-min-length="0"
   class="form-control"
@@ -24,5 +25,6 @@
   data-watch-options="true"
   typeahead-select-on-exact="false"
   typeahead-on-select="TypeaheadTrackerTagsCtrl.onTagsSelect($item, $model, $label, $event)"
-  uib-typeahead="data.label as data.label for data in TypeaheadTrackerTagsCtrl.list | filter:{name:$viewValue}"
+  uib-typeahead="data.label as data.label for data in TypeaheadTrackerTagsCtrl.list  | filter:{name:$viewValue}"
+  max-length="50"
 />

--- a/cdap-ui/app/features/tracker/directives/typeahead-tracker-tags/typeahead-tracker-tags.js
+++ b/cdap-ui/app/features/tracker/directives/typeahead-tracker-tags/typeahead-tracker-tags.js
@@ -21,7 +21,8 @@ angular.module(PKG.name + '.feature.tracker')
       templateUrl: '/assets/features/tracker/directives/typeahead-tracker-tags/typeahead-tracker-tags.html',
       scope: {
         list: '=',
-        model: '='
+        model: '=',
+        onChange: '&'
       },
       controller: 'TypeaheadTrackerTagsCtrl',
       controllerAs: 'TypeaheadTrackerTagsCtrl',

--- a/cdap-ui/app/features/tracker/templates/main.html
+++ b/cdap-ui/app/features/tracker/templates/main.html
@@ -77,7 +77,7 @@
             </thead>
             <tbody>
               <tr ng-repeat="metric in ::MainController.topDatasets">
-                <td class="text-right">
+                <td class="text-left">
 
                   <a ng-if="metric.entityType === 'dataset'"
                     ui-sref="tracker.detail.entity.metadata({entityType: 'datasets', entityId: metric.entityName})">
@@ -87,6 +87,7 @@
                       tooltip-append-to-body="true"
                       tooltip-class="tracker-tooltip"
                       tooltip-placement="top">
+                      <i class="icon-datasets"></i>
                       {{ ::metric.entityName }}
                     </span>
                   </a>
@@ -98,6 +99,7 @@
                       tooltip-append-to-body="true"
                       tooltip-class="tracker-tooltip"
                       tooltip-placement="top">
+                      <i class="icon-streams"></i>
                       {{ ::metric.entityName }}
                     </span>
                   </a>

--- a/cdap-ui/app/features/tracker/templates/metadata.html
+++ b/cdap-ui/app/features/tracker/templates/metadata.html
@@ -65,7 +65,7 @@
           </div>
 
           <div class="add-tag" ng-if="!MetadataController.inputOpen">
-            <a class="btn add" ng-click="MetadataController.inputOpen = true">
+            <a class="btn add" ng-click="MetadataController.openTagInput($event)">
               <span class="fa fa-plus"></span>
             </a>
           </div>
@@ -74,8 +74,10 @@
               ng-class="{'invalid': MetadataController.invalidFormat}">
             <div my-escape-close="MetadataController.escapeInput()"
                 ng-keypress="$event.keyCode === 13 && MetadataController.addTag()">
-              <my-typeahead-tracker-tags list="MetadataController.tags.availableTags"
-                                        model="MetadataController.newTag"></my-typeahead-tracker-tags>
+              <my-typeahead-tracker-tags
+                list="MetadataController.tags.availableTags"
+                model="MetadataController.newTag">
+              </my-typeahead-tracker-tags>
             </div>
           </div>
           <p ng-if="MetadataController.invalidFormat"

--- a/cdap-ui/app/features/tracker/templates/metadata.html
+++ b/cdap-ui/app/features/tracker/templates/metadata.html
@@ -76,7 +76,8 @@
                 ng-keypress="$event.keyCode === 13 && MetadataController.addTag()">
               <my-typeahead-tracker-tags
                 list="MetadataController.tags.availableTags"
-                model="MetadataController.newTag">
+                model="MetadataController.newTag"
+                on-change="MetadataController.invalidFormat = false">
               </my-typeahead-tracker-tags>
             </div>
           </div>

--- a/cdap-ui/app/features/tracker/templates/partial/add-preferred-tags-popover.html
+++ b/cdap-ui/app/features/tracker/templates/partial/add-preferred-tags-popover.html
@@ -72,6 +72,8 @@
 <div class="modal-footer text-right">
   <p class="pull-left text-danger"
      ng-if="!AddTags.proceedToNextStep && AddTags.tagList.invalidTags.length">No special characters allowed in tags.</p>
+  <p class="pull-left text-danger"
+     ng-if="AddTags.invalidFormat">Only .csv, .txt files allowed.</p>
   <button class="btn btn-default"
           ng-click="$dismiss('cancel')">Cancel</button>
   <button ng-if="!AddTags.proceedToNextStep"

--- a/cdap-ui/app/features/tracker/templates/partial/add-preferred-tags-popover.html
+++ b/cdap-ui/app/features/tracker/templates/partial/add-preferred-tags-popover.html
@@ -38,7 +38,7 @@
       <div>
         <span class="fa fa-cloud-upload"
               aria-hidden="true"></span>
-        <div>Drag &amp; Drop or<br />
+        <div>
           <a class="file-import-link" ng-click="AddTags.importTags()">Browse</a> CSV, TXT
         </div>
         <my-file-select class="sr-only" id="file-select" data-button-icon="fa-upload" on-file-select="AddTags.importFiles($files)" data-button-label="Import">

--- a/cdap-ui/app/features/tracker/templates/tags.html
+++ b/cdap-ui/app/features/tracker/templates/tags.html
@@ -37,7 +37,7 @@
           <tr ng-repeat="tag in TagsController.tags.preferredTags | orderBy:sortable.predicate:sortable.reverse | myPaginate:TagsController.currentPreferredPage">
             <td>
               <a class="tag preferred"
-                ui-sref="search.objectswithtags({tag: tag.name})">{{ tag.name }}</a>
+                ui-sref="tracker.detail.result({searchQuery: tag.name})">{{ tag.name }}</a>
             </td>
             <td>
               <span class="tagged-entities">{{ tag.count }}</span>
@@ -87,7 +87,7 @@
           <tr ng-repeat="tag in TagsController.tags.userTags | orderBy:sortable.predicate:sortable.reverse | myPaginate:TagsController.currentUserPage">
             <td>
               <a class="tag user"
-                ui-sref="search.objectswithtags({tag: tag.name})">{{ tag.name }}</a>
+                ui-sref="tracker.detail.result({searchQuery: tag.name})">{{ tag.name }}</a>
             </td>
             <td>
               <span class="action-link"

--- a/cdap-ui/app/features/tracker/tracker.less
+++ b/cdap-ui/app/features/tracker/tracker.less
@@ -161,6 +161,7 @@ body.state-tracker-detail-entity-usage {
             display: block;
             max-width: 100%;
           }
+          [class*="icon-"] { vertical-align: middle; }
         }
       }
     }
@@ -687,9 +688,6 @@ body.state-tracker-detail-entity {
     }
 
     div.add-tag {
-      display: inline-block;
-      line-height: 1.3;
-      vertical-align: initial;
       a.btn {
         .cask-btn(@background: #ffffff, @border: 1px solid @border-color, @border-radius: 4px, @color: @cdap-header, @font-size: 11px, @padding: 5px 8px);
         transition: all 0.2s ease-in-out;
@@ -704,19 +702,22 @@ body.state-tracker-detail-entity {
 
     .tag-input {
       width: 150px;
-      display: inline-block;
-      vertical-align: top;
-
       .form-control {
         background-color: transparent;
         height: 27px;
         border-radius: 4px;
         line-height: 1.3;
         margin-bottom: 5px;
+        transition: border-color 0.2s ease-in-out;
         &:focus {
           border-color: @border-color;
           box-shadow: none;
         }
+      }
+      &.invalid .form-control { border-color: @alert-danger-bg; }
+      + p.text-danger {
+        color: @alert-danger-bg;
+        font-weight: 500;
       }
     }
   }


### PR DESCRIPTION
-  tag links now go to Tracker search results page - [[CDAP-6826](https://issues.cask.co/browse/CDAP-6826)]
-  Adds validation message if user attempts to add a tag containing special characters
-  Adds 50 character max to tag input
-  Moves add tag input to underneath tags
-  Adds datatset/stream icons to top datasets table - [[CDAP-6558](CDAP-6558)]
-  Tracker Meter API is now only called when there are search results to display [[CDAP-6701](https://issues.cask.co/browse/CDAP-6701)]
-  Top Apps/Programs are now consistently left-aligned - [[CDAP-6800](https://issues.cask.co/browse/CDAP-6800)] 

![icons](https://cloud.githubusercontent.com/assets/5335210/17266741/f1b8efb8-55b0-11e6-8cb4-67ab1f6822bc.gif)

![taginput](https://cloud.githubusercontent.com/assets/5335210/17266747/fbc087a0-55b0-11e6-841b-e82e9ac5dfb8.gif)
