### PR TITLE
Log Saver handle bad datanode exceptions

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogWriterPlugin.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogWriterPlugin.java
@@ -241,6 +241,7 @@ public class KafkaLogWriterPlugin extends AbstractKafkaLogProcessor {
   @Override
   public void stop() {
     try {
+      LOG.info("Stopping log writer plugin for partition {}", partition);
       if (countDownLatch != null) {
         countDownLatch.countDown();
       }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaMessageCallback.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaMessageCallback.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 public class KafkaMessageCallback implements KafkaConsumer.MessageCallback {
   private static final Logger LOG = LoggerFactory.getLogger(KafkaMessageCallback.class);
 
+  private final int partition;
   private final Set<KafkaLogProcessor> kafkaLogProcessors;
   private final LoggingEventSerializer serializer;
   private final CountDownLatch stopLatch;
@@ -51,6 +52,7 @@ public class KafkaMessageCallback implements KafkaConsumer.MessageCallback {
   public KafkaMessageCallback(int partition, CountDownLatch stopLatch,
                               Set<KafkaLogProcessor> kafkaLogProcessors,
                               MetricsContext metricsContext) throws Exception {
+    this.partition = partition;
     this.kafkaLogProcessors = kafkaLogProcessors;
     this.serializer = new LoggingEventSerializer();
     this.stopLatch = stopLatch;
@@ -64,7 +66,7 @@ public class KafkaMessageCallback implements KafkaConsumer.MessageCallback {
     try {
       if (stopLatch.await(1, TimeUnit.NANOSECONDS)) {
         // if count down occurred return
-        LOG.info("Returning since callback is cancelled.");
+        LOG.debug("Returning since callback is cancelled.");
         return;
       }
     } catch (InterruptedException e) {
@@ -117,6 +119,6 @@ public class KafkaMessageCallback implements KafkaConsumer.MessageCallback {
 
   @Override
   public void finished() {
-    LOG.info("KafkaMessageCallback finished.");
+    LOG.info("KafkaMessageCallback finished for partition {}.", partition);
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/AvroFileWriter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/AvroFileWriter.java
@@ -144,12 +144,19 @@ public final class AvroFileWriter implements Closeable, Flushable {
 
     for (Iterator<Map.Entry<String, AvroFile>> it = fileMap.entrySet().iterator(); it.hasNext();) {
       AvroFile avroFile = it.next().getValue();
-      avroFile.sync();
-
-      // Close inactive files
-      if (currentTs - avroFile.getLastModifiedTs() > inactiveIntervalMs) {
-        avroFile.close();
+      // TODO: refactor fileMap into a class so that all these checks (and creation of files) can move there CDAP-6475
+      if (!avroFile.isOpen()) {
+        // If the file is already closed (due to an exception),
+        // then remove it from the map so that a new one gets created later
         it.remove();
+      } else {
+        avroFile.sync();
+
+        // Close inactive files
+        if (currentTs - avroFile.getLastModifiedTs() > inactiveIntervalMs) {
+          avroFile.close();
+          it.remove();
+        }
       }
     }
   }
@@ -197,6 +204,10 @@ public final class AvroFileWriter implements Closeable, Flushable {
   }
 
   private AvroFile rotateFile(AvroFile avroFile, LoggingContext loggingContext, long timestamp) throws Exception {
+    if (!avroFile.isOpen()) {
+      LOG.info("Rotating a closed file {}", avroFile.getLocation());
+      return createAvroFile(loggingContext, timestamp);
+    }
     if (avroFile.getPos() > maxFileSize) {
       LOG.info("Rotating file {}", avroFile.getLocation());
       avroFile.close();
@@ -251,7 +262,7 @@ public final class AvroFileWriter implements Closeable, Flushable {
         this.lastModifiedTs = System.currentTimeMillis();
       } catch (Exception e) {
         close();
-        throw e;
+        throw new IOException("Exception while creating file " + location, e);
       }
       this.isOpen = true;
     }
@@ -270,7 +281,7 @@ public final class AvroFileWriter implements Closeable, Flushable {
         lastModifiedTs = System.currentTimeMillis();
       } catch (Exception e) {
         close();
-        throw e;
+        throw new IOException("Exception while appending to file " + location, e);
       }
     }
 
@@ -279,7 +290,7 @@ public final class AvroFileWriter implements Closeable, Flushable {
         return outputStream.getPos();
       } catch (Exception e) {
         close();
-        throw e;
+        throw new IOException("Exception while getting position of file " + location, e);
       }
     }
 
@@ -293,7 +304,7 @@ public final class AvroFileWriter implements Closeable, Flushable {
         outputStream.hflush();
       } catch (Exception e) {
         close();
-        throw e;
+        throw new IOException("Exception while flushing file " + location, e);
       }
     }
 
@@ -303,7 +314,7 @@ public final class AvroFileWriter implements Closeable, Flushable {
         outputStream.hsync();
       } catch (Exception e) {
         close();
-        throw e;
+        throw new IOException("Exception while syncing file " + location, e);
       }
     }
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/AvroFileWriter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/AvroFileWriter.java
@@ -127,7 +127,7 @@ public final class AvroFileWriter implements Closeable, Flushable {
     }
 
     // Close all files
-    LOG.info("Closing all files");
+    LOG.debug("Closing all files");
     for (Map.Entry<String, AvroFile> entry : fileMap.entrySet()) {
       try {
         entry.getValue().close();


### PR DESCRIPTION
JIRA - https://issues.cask.co/browse/CDAP-6852
Build - http://builds.cask.co/browse/CDAP-DUT4575-4

This PR has two commits -
1. Remove open files that are invalid during flush and rotate
2. Re-order the stop sequence to stop Kafka consumer threads after stopping the processors

It would be easier to review the commits one by one.
