### PR TITLE
(CDAP-6833) Made the privilege fetcher in RemoteOpsService a proxy, t…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -61,6 +61,7 @@ import co.cask.cdap.gateway.handlers.UsageHandler;
 import co.cask.cdap.gateway.handlers.VersionHandler;
 import co.cask.cdap.gateway.handlers.WorkflowHttpHandler;
 import co.cask.cdap.gateway.handlers.WorkflowStatsSLAHttpHandler;
+import co.cask.cdap.gateway.handlers.meta.RemotePrivilegesFetcherHandler;
 import co.cask.cdap.internal.app.deploy.LocalApplicationManager;
 import co.cask.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
 import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
@@ -344,6 +345,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       handlerBinder.addBinding().to(WorkflowStatsSLAHttpHandler.class);
       handlerBinder.addBinding().to(AuthorizationHandler.class);
       handlerBinder.addBinding().to(SecureStoreHandler.class);
+      handlerBinder.addBinding().to(RemotePrivilegesFetcherHandler.class);
 
       for (Class<? extends HttpHandler> handlerClass : handlerClasses) {
         handlerBinder.addBinding().to(handlerClass);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/AbstractRemotePrivilegesFetcherHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/AbstractRemotePrivilegesFetcherHandler.java
@@ -19,8 +19,7 @@ package co.cask.cdap.gateway.handlers.meta;
 import co.cask.cdap.common.internal.remote.MethodArgument;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
-import co.cask.cdap.security.authorization.AuthorizerInstantiator;
-import co.cask.cdap.security.spi.authorization.Authorizer;
+import co.cask.cdap.security.spi.authorization.PrivilegesFetcher;
 import co.cask.http.HttpResponder;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
@@ -29,32 +28,25 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Iterator;
 import java.util.Set;
-import javax.inject.Inject;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
 
 /**
  * An {@link AbstractRemoteSystemOpsHandler} for serving HTTP requests to list privileges of a user.
  */
-@Path(AbstractRemoteSystemOpsHandler.VERSION + "/execute")
-public class RemotePrivilegeFetcherHandler extends AbstractRemoteSystemOpsHandler {
-  private static final Logger LOG = LoggerFactory.getLogger(RemotePrivilegeFetcherHandler.class);
+public class AbstractRemotePrivilegesFetcherHandler extends AbstractRemoteSystemOpsHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(RemotePrivilegesFetcherProxyHandler.class);
 
-  private final Authorizer authorizer;
+  private final PrivilegesFetcher privilegesFetcher;
 
-  @Inject
-  RemotePrivilegeFetcherHandler(AuthorizerInstantiator authorizerInstantiator) {
-    this.authorizer = authorizerInstantiator.get();
+  protected AbstractRemotePrivilegesFetcherHandler(PrivilegesFetcher privilegesFetcher) {
+    this.privilegesFetcher = privilegesFetcher;
   }
 
-  @POST
-  @Path("/listPrivileges")
-  public void listPrivileges(HttpRequest request, HttpResponder responder) throws Exception {
+  protected void doListPrivileges(HttpRequest request, HttpResponder responder) throws Exception {
     Iterator<MethodArgument> arguments = parseArguments(request);
     Principal principal = deserializeNext(arguments);
     LOG.trace("Listing privileges for principal {}", principal);
-    Set<Privilege> privileges = authorizer.listPrivileges(principal);
-    LOG.debug("Returning privileges for principal {} as {}", principal, privileges);
+    Set<Privilege> privileges = privilegesFetcher.listPrivileges(principal);
+    LOG.debug("Returning privileges for principal {} as {} via {}", principal, privileges, privilegesFetcher);
     responder.sendJson(HttpResponseStatus.OK, privileges);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemotePrivilegesFetcherHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemotePrivilegesFetcherHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.handlers.meta;
+
+import co.cask.cdap.security.authorization.AuthorizerInstantiator;
+import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
+import co.cask.http.HttpResponder;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+
+import javax.inject.Inject;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+/**
+ * An {@link AbstractRemotePrivilegesFetcherHandler} that runs inside the master and communicates directly with
+ * an authorization backend to fetch privileges.
+ */
+@Path(AbstractRemoteSystemOpsHandler.VERSION + "/execute")
+public class RemotePrivilegesFetcherHandler extends AbstractRemotePrivilegesFetcherHandler {
+
+  @Inject
+  RemotePrivilegesFetcherHandler(AuthorizerInstantiator authorizerInstantiator) {
+    super(authorizerInstantiator.get());
+  }
+
+  @POST
+  @Path("/listPrivileges")
+  public void listPrivileges(HttpRequest request, HttpResponder responder) throws Exception {
+    doListPrivileges(request, responder);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemotePrivilegesFetcherProxyHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemotePrivilegesFetcherProxyHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.handlers.meta;
+
+import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
+import co.cask.cdap.security.spi.authorization.PrivilegesFetcher;
+import co.cask.http.HttpResponder;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+/**
+ * An {@link AbstractRemotePrivilegesFetcherHandler} that runs in the {@link RemoteSystemOperationsService}
+ * and proxies list privileges requests to the master.
+ */
+@Path(AbstractRemoteSystemOpsHandler.VERSION + "/execute")
+public class RemotePrivilegesFetcherProxyHandler extends AbstractRemotePrivilegesFetcherHandler {
+
+  @Inject
+  RemotePrivilegesFetcherProxyHandler(
+    @Named(AuthorizationEnforcementModule.PRIVILEGES_FETCHER_PROXY_CACHE) PrivilegesFetcher privilegesFetcher) {
+    super(privilegesFetcher);
+  }
+
+  @POST
+  @Path("/listPrivileges")
+  public void listPrivileges(HttpRequest request, HttpResponder responder) throws Exception {
+    doListPrivileges(request, responder);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteSystemOperationsServiceModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteSystemOperationsServiceModule.java
@@ -39,7 +39,7 @@ public class RemoteSystemOperationsServiceModule extends PrivateModule {
 
     CommonHandlers.add(handlerBinder);
     handlerBinder.addBinding().to(RemoteLineageWriterHandler.class);
-    handlerBinder.addBinding().to(RemotePrivilegeFetcherHandler.class);
+    handlerBinder.addBinding().to(RemotePrivilegesFetcherProxyHandler.class);
     handlerBinder.addBinding().to(RemoteRuntimeStoreHandler.class);
     handlerBinder.addBinding().to(RemoteUsageRegistryHandler.class);
     handlerBinder.addBinding().to(RemoteNamespaceQueryHandler.class);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteLineageWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteLineageWriter.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app.store.remote;
 
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.internal.remote.RemoteOpsClient;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.data2.metadata.writer.BasicLineageWriter;
@@ -39,7 +40,7 @@ public class RemoteLineageWriter extends RemoteOpsClient implements LineageWrite
 
   @Inject
   RemoteLineageWriter(CConfiguration cConf, DiscoveryServiceClient discoveryClient) {
-    super(cConf, discoveryClient);
+    super(cConf, discoveryClient, Constants.Service.REMOTE_SYSTEM_OPERATION);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeStore.java
@@ -19,6 +19,7 @@ package co.cask.cdap.internal.app.store.remote;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.app.store.RuntimeStore;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.internal.remote.RemoteOpsClient;
 import co.cask.cdap.proto.BasicThrowable;
 import co.cask.cdap.proto.Id;
@@ -39,7 +40,7 @@ public class RemoteRuntimeStore extends RemoteOpsClient implements RuntimeStore 
 
   @Inject
   RemoteRuntimeStore(CConfiguration cConf, DiscoveryServiceClient discoveryClient) {
-    super(cConf, discoveryClient);
+    super(cConf, discoveryClient, Constants.Service.REMOTE_SYSTEM_OPERATION);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeUsageRegistry.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeUsageRegistry.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app.store.remote;
 
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.internal.remote.RemoteOpsClient;
 import co.cask.cdap.data2.registry.DatasetUsageKey;
 import co.cask.cdap.data2.registry.RuntimeUsageRegistry;
@@ -37,7 +38,7 @@ public class RemoteRuntimeUsageRegistry extends RemoteOpsClient implements Runti
 
   @Inject
   RemoteRuntimeUsageRegistry(CConfiguration cConf, DiscoveryServiceClient discoveryClient) {
-    super(cConf, discoveryClient);
+    super(cConf, discoveryClient, Constants.Service.REMOTE_SYSTEM_OPERATION);
   }
 
   @Override

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
@@ -29,6 +29,7 @@ import co.cask.cdap.app.runtime.Arguments;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.app.runtime.ProgramRunnerFactory;
+import co.cask.cdap.common.NamespaceAlreadyExistsException;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
@@ -147,7 +148,11 @@ public class AppFabricTestHelper {
   public static void ensureNamespaceExists(Id.Namespace namespace, CConfiguration cConf) throws Exception {
     NamespaceAdmin namespaceAdmin = getInjector(cConf).getInstance(NamespaceAdmin.class);
     if (!namespaceAdmin.exists(namespace)) {
-      namespaceAdmin.create(new NamespaceMeta.Builder().setName(namespace).build());
+      try {
+        namespaceAdmin.create(new NamespaceMeta.Builder().setName(namespace).build());
+      } catch (NamespaceAlreadyExistsException e) {
+        // ok to ignore, since we're just ensuring the existence of this namespace
+      }
     }
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
@@ -21,6 +21,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsService;
 import co.cask.cdap.internal.AppFabricTestHelper;
+import co.cask.cdap.internal.app.services.AppFabricServer;
 import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.InstanceId;
@@ -33,6 +34,7 @@ import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.authorization.InMemoryAuthorizer;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import co.cask.cdap.security.spi.authorization.Authorizer;
+import co.cask.tephra.TransactionManager;
 import com.google.inject.Injector;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
@@ -62,6 +64,7 @@ public class MetadataAdminAuthorizationTest {
   private static MetadataAdmin metadataAdmin;
   private static Authorizer authorizer;
   private static AuthorizationEnforcementService authorizationEnforcementService;
+  private static AppFabricServer appFabricServer;
   private static RemoteSystemOperationsService remoteSystemOperationsService;
 
   @BeforeClass
@@ -73,6 +76,8 @@ public class MetadataAdminAuthorizationTest {
     authorizer.grant(new InstanceId(cConf.get(Constants.INSTANCE_NAME)), ALICE, Collections.singleton(Action.ADMIN));
     authorizationEnforcementService = injector.getInstance(AuthorizationEnforcementService.class);
     authorizationEnforcementService.startAndWait();
+    appFabricServer = injector.getInstance(AppFabricServer.class);
+    appFabricServer.startAndWait();
     remoteSystemOperationsService = injector.getInstance(RemoteSystemOperationsService.class);
     remoteSystemOperationsService.startAndWait();
   }
@@ -92,6 +97,7 @@ public class MetadataAdminAuthorizationTest {
   @AfterClass
   public static void tearDown() {
     remoteSystemOperationsService.stopAndWait();
+    appFabricServer.stopAndWait();
     authorizationEnforcementService.stopAndWait();
   }
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
@@ -122,7 +122,7 @@ public class DatasetOpExecutorServerTwillRunnable extends AbstractMasterTwillRun
       new EntityVerifierModule(),
       new SecureStoreModules().getDistributedModules(),
       new AuthorizationModule(),
-      new AuthorizationEnforcementModule().getDistributedModules(),
+      new AuthorizationEnforcementModule().getProxyModule(),
       new AuthenticationContextModules().getProgramContainerModule(),
       new AbstractModule() {
         @Override

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -502,7 +502,7 @@ public class MasterServiceMain extends DaemonMain {
       new NamespaceStoreModule().getDistributedModules(),
       new AuditModule().getDistributedModules(),
       new AuthorizationModule(),
-      new AuthorizationEnforcementModule().getDistributedModules(),
+      new AuthorizationEnforcementModule().getMasterModule(),
       new TwillModule(),
       new ServiceStoreModules().getDistributedModules(),
       new AppFabricServiceRuntimeModule().getDistributedModules(),

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetServiceManager.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetServiceManager.java
@@ -35,7 +35,6 @@ import co.cask.cdap.data2.datafabric.dataset.RemoteDatasetFramework;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutorService;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
-import co.cask.cdap.data2.security.ImpersonationInfo;
 import co.cask.cdap.data2.security.UGIProvider;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsService;
@@ -56,10 +55,8 @@ import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.twill.zookeeper.ZKClientService;
 
-import java.io.IOException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
@@ -144,7 +141,8 @@ public class DatasetServiceManager extends AbstractIdleService {
       new RemoteSystemOperationsServiceModule(),
       new SecureStoreModules().getDistributedModules(),
       new AuthorizationModule(),
-      new AuthorizationEnforcementModule().getDistributedModules(),
+      // we use the proxy module here because this class starts up dataset service
+      new AuthorizationEnforcementModule().getProxyModule(),
       new AuthenticationContextModules().getMasterModule(),
       new AbstractModule() {
         @Override

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/AbstractAuthorizationService.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/AbstractAuthorizationService.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.proto.security.Privilege;
+import co.cask.cdap.security.spi.authorization.PrivilegesFetcher;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.AbstractScheduledService;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.twill.common.Threads;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An {@link AbstractScheduledService} that maintains a cache of privileges. The cache is updated periodically using
+ * the provided {@link PrivilegesFetcher}.
+ */
+public class AbstractAuthorizationService extends AbstractScheduledService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractAuthorizationService.class);
+  private static final EnumSet<State> SERVICE_AVAILABLE_STATES =
+    EnumSet.of(State.STARTING, State.RUNNING, State.STOPPING);
+
+  protected final boolean securityEnabled;
+  protected final boolean authorizationEnabled;
+  protected final boolean cacheEnabled;
+
+  private final PrivilegesFetcher privilegesFetcher;
+  private final int cacheTtlSecs;
+  private final int cacheRefreshIntervalSecs;
+  private final LoadingCache<Principal, Map<EntityId, Set<Action>>> authPolicyCache;
+  private final String serviceName;
+
+  private ScheduledExecutorService executor;
+
+  protected AbstractAuthorizationService(PrivilegesFetcher privilegesFetcher, CConfiguration cConf,
+                                         String serviceName) {
+    this.privilegesFetcher = privilegesFetcher;
+    this.securityEnabled = cConf.getBoolean(Constants.Security.ENABLED);
+    this.authorizationEnabled = cConf.getBoolean(Constants.Security.Authorization.ENABLED);
+    this.cacheEnabled = cConf.getBoolean(Constants.Security.Authorization.CACHE_ENABLED);
+    this.cacheTtlSecs = cConf.getInt(Constants.Security.Authorization.CACHE_TTL_SECS);
+    this.cacheRefreshIntervalSecs = cConf.getInt(Constants.Security.Authorization.CACHE_REFRESH_INTERVAL_SECS);
+    this.serviceName = serviceName;
+    validateCacheConfig();
+    this.authPolicyCache = CacheBuilder.newBuilder()
+      .expireAfterWrite(cacheTtlSecs, TimeUnit.SECONDS)
+      .build(new CacheLoader<Principal, Map<EntityId, Set<Action>>>() {
+        @SuppressWarnings("NullableProblems")
+        @Override
+        public Map<EntityId, Set<Action>> load(Principal principal) throws Exception {
+          return fetchPrivileges(principal);
+        }
+      });
+  }
+
+  @Override
+  protected Scheduler scheduler() {
+    return Scheduler.newFixedDelaySchedule(0, cacheRefreshIntervalSecs, TimeUnit.SECONDS);
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    if (isAuthCacheEnabled()) {
+      updatePrivilegesOfCurrentUser();
+    }
+    LOG.info("Started authorization {} service...", serviceName);
+  }
+
+  @Override
+  protected void runOneIteration() {
+    if (!isAuthCacheEnabled()) {
+      LOG.debug("Authorization cache is disabled security: {}; authorization: {}; cache: {}",
+               securityEnabled, authorizationEnabled, cacheEnabled);
+      return;
+    }
+    LOG.info("Running authorization {} service iteration...", serviceName);
+    for (Principal principal : authPolicyCache.asMap().keySet()) {
+      try {
+        updatePrivileges(principal);
+      } catch (Exception e) {
+        // Ok to silently ignore because the cache entries have a ttl as well, so even if repeated failures occur,
+        // eventually cache entries will expire and there won't be stale privileges
+        LOG.debug("Error while updating privileges for {}", principal, e);
+        LOG.warn("Error while updating privileges for {}.", principal);
+      }
+    }
+  }
+
+  @Override
+  protected ScheduledExecutorService executor() {
+    executor = Executors.newSingleThreadScheduledExecutor(
+      Threads.createDaemonThreadFactory(String.format("authorization-%s-service", serviceName)));
+    return executor;
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    LOG.debug("Shutting down authorization {} service...", serviceName);
+    authPolicyCache.invalidateAll();
+    if (executor != null) {
+      executor.shutdownNow();
+    }
+    LOG.info("Shutdown authorization {} service successfully.", serviceName);
+  }
+
+  @VisibleForTesting
+  Map<Principal, Map<EntityId, Set<Action>>> getCache() {
+    return authPolicyCache.asMap();
+  }
+
+  protected Map<EntityId, Set<Action>> fetchPrivileges(Principal principal) throws Exception {
+    State serviceState = state();
+    // The only states in which the service can be used are:
+    // 1. STARTING - while pre-populating the cache with the current user's privileges
+    // 2. RUNNING - from calls to enforce() during program execution, after the service has been started successfully
+    // 3. STOPPING - while invalidating the cache during service stop.
+    if (!SERVICE_AVAILABLE_STATES.contains(serviceState)) {
+      throw new IllegalStateException(
+        String.format("Cannot use authorization %s service because it has not been started. Its current state is %s.",
+                      serviceName, serviceState)
+      );
+    }
+    Map<EntityId, Set<Action>> result = new HashMap<>();
+    Set<Privilege> privileges = privilegesFetcher.listPrivileges(principal);
+    if (privileges == null) {
+      return result;
+    }
+
+    for (Privilege privilege : privileges) {
+      Set<Action> actions = result.get(privilege.getEntity());
+      if (actions == null) {
+        actions = EnumSet.noneOf(Action.class);
+        result.put(privilege.getEntity(), actions);
+      }
+      actions.add(privilege.getAction());
+    }
+
+    return result;
+  }
+
+  protected Map<EntityId, Set<Action>> getPrivileges(Principal principal) throws Exception {
+    return cacheEnabled ? authPolicyCache.get(principal) : fetchPrivileges(principal);
+  }
+
+  /**
+   * On an authorization-enabled cluster, if caching is enabled too, updates the cache in the
+   * {@link AuthorizationEnforcementService} with the privileges of the user running the program.
+   */
+  private void updatePrivilegesOfCurrentUser() {
+    String userName;
+    try {
+      userName = UserGroupInformation.getCurrentUser().getShortUserName();
+    } catch (IOException e) {
+      LOG.warn("Error while determining the currently logged in user. Skipping pre-population of authorization cache.",
+               e);
+      return;
+    }
+    Principal principal = new Principal(userName, Principal.PrincipalType.USER);
+    try {
+      updatePrivileges(principal);
+      LOG.info("Updated privileges for current user {}", principal);
+    } catch (Exception e) {
+      LOG.warn("Error while updating privileges for {}. Authorization cache will not be pre-populated for this user.",
+                principal, e);
+    }
+  }
+
+  /**
+   * Updates privileges of the specified user in the cache.
+   */
+  private void updatePrivileges(Principal principal) throws Exception {
+    Map<EntityId, Set<Action>> privileges = fetchPrivileges(principal);
+    authPolicyCache.put(principal, privileges);
+    LOG.info("Updated privileges for principal {} as {}", principal, privileges);
+  }
+
+  private void validateCacheConfig() {
+    if (!isAuthCacheEnabled()) {
+      if (cacheEnabled) {
+        LOG.warn("Authorization policy caching is enabled ({} is set to true), however, this setting will have no " +
+                   "effect because authorization is disabled ({} is set to false). ",
+                 Constants.Security.Authorization.CACHE_ENABLED, Constants.Security.Authorization.ENABLED);
+      }
+      return;
+    }
+    Preconditions.checkArgument(
+      cacheRefreshIntervalSecs > 0,
+      "The refresh interval for authorization cache specified by the parameter '%s' must be greater than zero. " +
+        "It is currently set to %s.",
+      Constants.Security.Authorization.CACHE_REFRESH_INTERVAL_SECS, cacheRefreshIntervalSecs);
+    Preconditions.checkArgument(
+      cacheTtlSecs > 0,
+      "The TTL for authorization cache entries specified by the parameter '%s' must be greater than zero. " +
+        "It is currently set to %s.",
+      Constants.Security.Authorization.CACHE_TTL_SECS, cacheTtlSecs);
+    if (cacheTtlSecs <= cacheRefreshIntervalSecs) {
+      LOG.warn("The refresh interval for authorization cache specified by the parameter '{}' (set to {}) is " +
+                 "greater than the TTL for authorization cache entries specified by the parameter '{}' " +
+                 "(set to {}). This may result in authorization errors. Please set the refresh interval to a " +
+                 "few seconds less than the TTL to fix this.");
+    }
+  }
+
+  private boolean isAuthCacheEnabled() {
+    return authorizationEnabled && cacheEnabled;
+  }
+}

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/AbstractPrivilegesFetcherClient.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/AbstractPrivilegesFetcherClient.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.internal.remote.RemoteOpsClient;
+import co.cask.cdap.internal.guava.reflect.TypeToken;
+import co.cask.cdap.proto.codec.EntityIdTypeAdapter;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.proto.security.Privilege;
+import co.cask.cdap.security.spi.authorization.PrivilegesFetcher;
+import co.cask.common.http.HttpResponse;
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Type;
+import java.util.Set;
+
+/**
+ * A {@link RemoteOpsClient} for making requests to list privileges to the specified service.
+ */
+abstract class AbstractPrivilegesFetcherClient extends RemoteOpsClient implements PrivilegesFetcher {
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractPrivilegesFetcherClient.class);
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(EntityId.class, new EntityIdTypeAdapter())
+    .create();
+  private static final Type SET_PRIVILEGES_TYPE = new TypeToken<Set<Privilege>>() { }.getType();
+
+  private final String privilegeFetcherServiceName;
+
+  protected AbstractPrivilegesFetcherClient(CConfiguration cConf, DiscoveryServiceClient discoveryClient,
+                                            String privilegeFetcherServiceName) {
+    super(cConf, discoveryClient, privilegeFetcherServiceName);
+    this.privilegeFetcherServiceName = privilegeFetcherServiceName;
+  }
+
+  @Override
+  public Set<Privilege> listPrivileges(Principal principal) throws Exception {
+    LOG.trace("Making list privileges request for principal {} to service {}", principal, privilegeFetcherServiceName);
+    HttpResponse httpResponse = executeRequest("listPrivileges", principal);
+    String responseBody = httpResponse.getResponseBodyAsString();
+    Preconditions.checkArgument(httpResponse.getResponseCode() == HttpResponseStatus.OK.getCode(),
+                                "Error listing privileges for %s: Code - %s; Message - %s", principal,
+                                httpResponse.getResponseCode(), responseBody);
+    LOG.debug("List privileges response for principal {}: {} from service: {}",
+              principal, responseBody, privilegeFetcherServiceName);
+    return GSON.fromJson(responseBody, SET_PRIVILEGES_TYPE);
+  }
+}

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizationEnforcementModule.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizationEnforcementModule.java
@@ -18,17 +18,21 @@ package co.cask.cdap.security.authorization;
 
 import co.cask.cdap.common.runtime.RuntimeModule;
 import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
+import co.cask.cdap.security.spi.authorization.Authorizer;
 import co.cask.cdap.security.spi.authorization.PrivilegesFetcher;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Module;
 import com.google.inject.Provider;
 import com.google.inject.Scopes;
+import com.google.inject.name.Names;
 
 /**
  * A module that contains bindings for {@link AuthorizationEnforcementService} and {@link PrivilegesFetcher}.
  */
 public class AuthorizationEnforcementModule extends RuntimeModule {
+  public static final String PRIVILEGES_FETCHER_PROXY_CACHE = "privileges-fetcher-proxy-cache";
+  public static final String PRIVILEGES_FETCHER_PROXY_CLIENT = "privileges-fetcher-proxy-client";
 
   @Override
   public Module getInMemoryModules() {
@@ -41,7 +45,7 @@ public class AuthorizationEnforcementModule extends RuntimeModule {
           .in(Scopes.SINGLETON);
         // bind AuthorizationEnforcer to AuthorizationEnforcementService
         bind(AuthorizationEnforcer.class).to(AuthorizationEnforcementService.class).in(Scopes.SINGLETON);
-        bind(PrivilegesFetcher.class).toProvider(InMemoryPrivilegesFetcherProvider.class).in(Scopes.SINGLETON);
+        bind(PrivilegesFetcher.class).toProvider(AuthorizerAsPrivilegesFetcherProvider.class).in(Scopes.SINGLETON);
       }
     };
   }
@@ -57,11 +61,25 @@ public class AuthorizationEnforcementModule extends RuntimeModule {
           .in(Scopes.SINGLETON);
         // bind AuthorizationEnforcer to AuthorizationEnforcementService
         bind(AuthorizationEnforcer.class).to(AuthorizationEnforcementService.class).in(Scopes.SINGLETON);
+
+        bind(PrivilegesFetcherProxyService.class).to(DefaultPrivilegesFetcherProxyService.class)
+          .in(Scopes.SINGLETON);
         bind(PrivilegesFetcher.class).to(RemotePrivilegesFetcher.class);
+        bind(PrivilegesFetcher.class)
+          .annotatedWith(Names.named(PRIVILEGES_FETCHER_PROXY_CACHE))
+          .to(PrivilegesFetcherProxyService.class);
+        bind(PrivilegesFetcher.class)
+          .annotatedWith(Names.named(PRIVILEGES_FETCHER_PROXY_CLIENT))
+          .to(PrivilegesFetcherProxyClient.class);
       }
     };
   }
 
+  /**
+   * Used by program containers and system services (viz explore service, stream service) that need to enforce
+   * authorization in distributed mode. For fetching privileges, these components are expected to proxy via a proxy
+   * service, which in turn uses the authorization enforcement modules defined by #getProxyModule
+   */
   @Override
   public Module getDistributedModules() {
     return new AbstractModule() {
@@ -78,11 +96,76 @@ public class AuthorizationEnforcementModule extends RuntimeModule {
     };
   }
 
-  private static class InMemoryPrivilegesFetcherProvider implements Provider<PrivilegesFetcher> {
+  /**
+   * Returns an {@link AbstractModule} containing bindings for authorization enforcement to be used in the Master.
+   */
+  public AbstractModule getMasterModule() {
+    return new AbstractModule() {
+      @Override
+      protected void configure() {
+        // bind AuthorizationEnforcementService as a singleton. This binding is used while starting/stopping
+        // the service itself.
+        bind(AuthorizationEnforcementService.class).to(DefaultAuthorizationEnforcementService.class)
+          .in(Scopes.SINGLETON);
+        // bind AuthorizationEnforcer to AuthorizationEnforcementService
+        bind(AuthorizationEnforcer.class).to(AuthorizationEnforcementService.class).in(Scopes.SINGLETON);
+
+        // Master should have access to authorization backends, so no need to fetch privileges remotely
+        bind(PrivilegesFetcher.class).toProvider(AuthorizerAsPrivilegesFetcherProvider.class);
+
+        // Master is expected to have (kerberos) credentials to communicate with authorization backends. Hence, it
+        // doesn't need to start a proxy to fetch privileges from authorization backends, so no need to bind
+        // PrivilegesFetcherProxyService
+      }
+    };
+  }
+
+  public AbstractModule getProxyModule() {
+    return new AbstractModule() {
+      @Override
+      protected void configure() {
+        // bind AuthorizationEnforcementService as a singleton. This binding is used while starting/stopping
+        // the service itself.
+        bind(AuthorizationEnforcementService.class).to(DefaultAuthorizationEnforcementService.class)
+          .in(Scopes.SINGLETON);
+        // bind AuthorizationEnforcer to AuthorizationEnforcementService
+        bind(AuthorizationEnforcer.class).to(AuthorizationEnforcementService.class).in(Scopes.SINGLETON);
+
+        // The RemoteSystemOperations service acts as a proxy to Master for fetching privileges from authorization
+        // backends, since it does not have access to make requests to authorization backends.
+        // e.g. Apache Sentry currently does not support proxy authentication or issue delegation tokens. As a result,
+        // all requests to Sentry need to be proxied via Master, which is whitelisted.
+        // Hence, bind PrivilegesFetcher to a proxy implementation, that makes a proxy call to master for fetching
+        // privileges
+        // bind PrivilegesFetcherProxyService as a singleton. This binding is used while starting/stopping
+        // the service itself.
+        bind(PrivilegesFetcherProxyService.class).to(DefaultPrivilegesFetcherProxyService.class)
+          .in(Scopes.SINGLETON);
+        // inside program containers, for enforcing privileges, bind PrivilegeFetcher to a remote implementation
+        // that can make a call to a dedicated proxy service
+        bind(PrivilegesFetcher.class).to(RemotePrivilegesFetcher.class);
+        // bind PrivilegesFetcher to the PrivilegesFetcherProxyService, so privileges can be fetched from a cache
+        // inside the proxy if caching is enabled.
+        bind(PrivilegesFetcher.class)
+          .annotatedWith(Names.named(PRIVILEGES_FETCHER_PROXY_CACHE))
+          .to(PrivilegesFetcherProxyService.class);
+        // The PrivilegesFetcherProxyService itself uses a PrivilegesFetcher that proxies requests to master to
+        // refresh cached privileges periodically.
+        bind(PrivilegesFetcher.class)
+          .annotatedWith(Names.named(PRIVILEGES_FETCHER_PROXY_CLIENT))
+          .to(PrivilegesFetcherProxyClient.class);
+      }
+    };
+  }
+
+  /**
+   * Provides {@link Authorizer} as the binding for {@link PrivilegesFetcher}.
+   */
+  private static class AuthorizerAsPrivilegesFetcherProvider implements Provider<PrivilegesFetcher> {
     private final AuthorizerInstantiator authorizerInstantiator;
 
     @Inject
-    private InMemoryPrivilegesFetcherProvider(AuthorizerInstantiator authorizerInstantiator) {
+    private AuthorizerAsPrivilegesFetcherProvider(AuthorizerInstantiator authorizerInstantiator) {
       this.authorizerInstantiator = authorizerInstantiator;
     }
 

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationEnforcementService.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationEnforcementService.java
@@ -18,48 +18,30 @@ package co.cask.cdap.security.authorization;
 
 import co.cask.cdap.api.Predicate;
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
-import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.security.spi.authorization.PrivilegesFetcher;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.AbstractScheduledService;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Default implementation of {@link AuthorizationEnforcementService}.
  */
 @Singleton
-public class DefaultAuthorizationEnforcementService extends AbstractScheduledService
+public class DefaultAuthorizationEnforcementService extends AbstractAuthorizationService
   implements AuthorizationEnforcementService {
 
   private static final Logger LOG = LoggerFactory.getLogger(DefaultAuthorizationEnforcementService.class);
-  private static final EnumSet<State> SERVICE_AVAILABLE_STATES =
-    EnumSet.of(State.STARTING, State.RUNNING, State.STOPPING);
   private static final Predicate<EntityId> ALLOW_ALL = new Predicate<EntityId>() {
     @Override
     public boolean apply(EntityId entityId) {
@@ -67,63 +49,9 @@ public class DefaultAuthorizationEnforcementService extends AbstractScheduledSer
     }
   };
 
-  private final PrivilegesFetcher privilegesFetcher;
-  private final boolean authorizationEnabled;
-  private final boolean cacheEnabled;
-  private final int cacheTtlSecs;
-  private final int cacheRefreshIntervalSecs;
-  private final LoadingCache<Principal, Map<EntityId, Set<Action>>> authPolicyCache;
-
-  private ScheduledExecutorService executor;
-
   @Inject
   DefaultAuthorizationEnforcementService(PrivilegesFetcher privilegesFetcher, CConfiguration cConf) {
-    this.privilegesFetcher = privilegesFetcher;
-    this.authorizationEnabled = cConf.getBoolean(Constants.Security.Authorization.ENABLED);
-    this.cacheEnabled = cConf.getBoolean(Constants.Security.Authorization.CACHE_ENABLED);
-    this.cacheTtlSecs = cConf.getInt(Constants.Security.Authorization.CACHE_TTL_SECS);
-    this.cacheRefreshIntervalSecs = cConf.getInt(Constants.Security.Authorization.CACHE_REFRESH_INTERVAL_SECS);
-    validateCacheConfig();
-    this.authPolicyCache = CacheBuilder.newBuilder()
-      .expireAfterWrite(cacheTtlSecs, TimeUnit.SECONDS)
-      .build(new CacheLoader<Principal, Map<EntityId, Set<Action>>>() {
-        @SuppressWarnings("NullableProblems")
-        @Override
-        public Map<EntityId, Set<Action>> load(Principal principal) throws Exception {
-          return fetchPrivileges(principal);
-        }
-      });
-  }
-
-  @Override
-  protected Scheduler scheduler() {
-    return Scheduler.newFixedDelaySchedule(0, cacheRefreshIntervalSecs, TimeUnit.SECONDS);
-  }
-
-  @Override
-  protected void startUp() throws Exception {
-    LOG.info("Starting authorization enforcement service...");
-    if (isAuthCacheEnabled()) {
-      updatePrivilegesOfCurrentUser();
-    }
-  }
-
-  @Override
-  protected void runOneIteration() {
-    if (!isAuthCacheEnabled()) {
-      return;
-    }
-    LOG.trace("Running authorization enforcement service iteration...");
-    for (Principal principal : authPolicyCache.asMap().keySet()) {
-      try {
-        updatePrivileges(principal);
-      } catch (Exception e) {
-        // Ok to silently ignore because the cache entries have a ttl as well, so even if repeated failures occur,
-        // eventually cache entries will expire and there won't be stale privileges
-        LOG.debug("Error while updating privileges for {}", principal, e);
-        LOG.warn("Error while updating privileges for {}.", principal);
-      }
-    }
+    super(privilegesFetcher, cConf, "enforcement");
   }
 
   @Override
@@ -172,124 +100,5 @@ public class DefaultAuthorizationEnforcementService extends AbstractScheduledSer
         return allowedEntities.contains(entityId);
       }
     };
-  }
-
-  @Override
-  protected ScheduledExecutorService executor() {
-    executor = Executors.newSingleThreadScheduledExecutor(
-      Threads.createDaemonThreadFactory("authorization-enforcement-service"));
-    return executor;
-  }
-
-  @Override
-  protected void shutDown() throws Exception {
-    LOG.debug("Shutting down authorization enforcement service...");
-    authPolicyCache.invalidateAll();
-    if (executor != null) {
-      executor.shutdownNow();
-    }
-    LOG.info("Shutdown authorization enforcement service successfully.");
-  }
-
-  @VisibleForTesting
-  Map<Principal, Map<EntityId, Set<Action>>> getCache() {
-    return authPolicyCache.asMap();
-  }
-
-  private Map<EntityId, Set<Action>> fetchPrivileges(Principal principal) throws Exception {
-    State serviceState = state();
-    // The only states in which the service can be used are:
-    // 1. STARTING - while pre-populating the cache with the current user's privileges
-    // 2. RUNNING - from calls to enforce() during program execution, after the service has been started successfully
-    // 3. STOPPING - while invalidating the cache during service stop.
-    if (!SERVICE_AVAILABLE_STATES.contains(serviceState)) {
-      throw new IllegalStateException(
-        String.format("Cannot use %s because it has not been started. Its current state is %s.",
-                      AuthorizationEnforcementService.class.getName(), serviceState)
-      );
-    }
-    Map<EntityId, Set<Action>> result = new HashMap<>();
-    Set<Privilege> privileges = privilegesFetcher.listPrivileges(principal);
-    if (privileges == null) {
-      return result;
-    }
-
-    for (Privilege privilege : privileges) {
-      Set<Action> actions = result.get(privilege.getEntity());
-      if (actions == null) {
-        actions = EnumSet.noneOf(Action.class);
-        result.put(privilege.getEntity(), actions);
-      }
-      actions.add(privilege.getAction());
-    }
-
-    return result;
-  }
-
-  private Map<EntityId, Set<Action>> getPrivileges(Principal principal) throws Exception {
-    return cacheEnabled ? authPolicyCache.get(principal) : fetchPrivileges(principal);
-  }
-
-  /**
-   * On an authorization-enabled cluster, if caching is enabled too, updates the cache in the
-   * {@link AuthorizationEnforcementService} with the privileges of the user running the program.
-   */
-  private void updatePrivilegesOfCurrentUser() {
-    String userName;
-    try {
-      userName = UserGroupInformation.getCurrentUser().getShortUserName();
-    } catch (IOException e) {
-      LOG.warn("Error while determining the currently logged in user. Skipping pre-population of authorization cache.",
-               e);
-      return;
-    }
-    Principal principal = new Principal(userName, Principal.PrincipalType.USER);
-    try {
-      updatePrivileges(principal);
-      LOG.info("Updated privileges for current user {}", principal);
-    } catch (Exception e) {
-      LOG.warn("Error while updating privileges for {}. Authorization cache will not be pre-populated for this user.",
-                principal);
-    }
-  }
-
-  /**
-   * Updates privileges of the specified user in the cache.
-   */
-  private void updatePrivileges(Principal principal) throws Exception {
-    Map<EntityId, Set<Action>> privileges = fetchPrivileges(principal);
-    authPolicyCache.put(principal, privileges);
-    LOG.debug("Updated privileges for principal {} as {}", principal, privileges);
-  }
-
-  private void validateCacheConfig() {
-    if (!isAuthCacheEnabled()) {
-      if (cacheEnabled) {
-        LOG.warn("Authorization policy caching is enabled ({} is set to true), however, this setting will have no " +
-                   "effect because authorization is disabled ({} is set to false). ",
-                 Constants.Security.Authorization.CACHE_ENABLED, Constants.Security.Authorization.ENABLED);
-      }
-      return;
-    }
-    Preconditions.checkArgument(
-      cacheRefreshIntervalSecs > 0,
-      "The refresh interval for authorization cache specified by the parameter '%s' must be greater than zero. " +
-        "It is currently set to %s.",
-      Constants.Security.Authorization.CACHE_REFRESH_INTERVAL_SECS, cacheRefreshIntervalSecs);
-    Preconditions.checkArgument(
-      cacheTtlSecs > 0,
-      "The TTL for authorization cache entries specified by the parameter '%s' must be greater than zero. " +
-        "It is currently set to %s.",
-      Constants.Security.Authorization.CACHE_TTL_SECS, cacheTtlSecs);
-    if (cacheTtlSecs <= cacheRefreshIntervalSecs) {
-      LOG.warn("The refresh interval for authorization cache specified by the parameter '{}' (set to {}) is " +
-                 "greater than the TTL for authorization cache entries specified by the parameter '{}' " +
-                 "(set to {}). This may result in authorization errors. Please set the refresh interval to a " +
-                 "few seconds less than the TTL to fix this.");
-    }
-  }
-
-  private boolean isAuthCacheEnabled() {
-    return authorizationEnabled && cacheEnabled;
   }
 }

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultPrivilegesFetcherProxyService.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultPrivilegesFetcherProxyService.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.proto.security.Privilege;
+import co.cask.cdap.security.spi.authorization.PrivilegesFetcher;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Default implementation of {@link PrivilegesFetcherProxyService}. It maintains a cache of privileges fetched from
+ * the master so every request for privileges does not have to go through the master. The cache is updated periodically
+ * using {@link PrivilegesFetcherProxyClient}.
+ */
+@Singleton
+public class DefaultPrivilegesFetcherProxyService extends AbstractAuthorizationService
+  implements PrivilegesFetcherProxyService {
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultPrivilegesFetcherProxyService.class);
+
+  @Inject
+  DefaultPrivilegesFetcherProxyService(
+    @Named(AuthorizationEnforcementModule.PRIVILEGES_FETCHER_PROXY_CLIENT) PrivilegesFetcher privilegeFetcher,
+    CConfiguration cConf) {
+    super(privilegeFetcher, cConf, "privileges-fetcher-proxy");
+  }
+
+  @Override
+  public Set<Privilege> listPrivileges(Principal principal) throws Exception {
+    ImmutableSet.Builder<Privilege> privileges = ImmutableSet.builder();
+    for (Map.Entry<EntityId, Set<Action>> entry : getPrivileges(principal).entrySet()) {
+      for (Action action : entry.getValue()) {
+        privileges.add(new Privilege(entry.getKey(), action));
+      }
+    }
+    LOG.debug("Fetched privileges for principal {} as {}", privileges.build());
+    return privileges.build();
+  }
+}

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/PrivilegesFetcherProxyClient.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/PrivilegesFetcherProxyClient.java
@@ -22,15 +22,15 @@ import com.google.inject.Inject;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
 /**
- * A {@link AbstractPrivilegesFetcherClient} to make requests to fetch privileges from program containers and system
- * services to a dedicated system service (RemoteSystemOperationsService)
- * Communication over HTTP is necessary because program containers, which use this class (and run as the user running
- * the program) may not be white-listed to make calls to authorization providers (like Apache Sentry).
+ * A {@link AbstractPrivilegesFetcherClient} to proxy requests to list privileges from program containers and system
+ * services to the master (appfabric). It runs inside a dedicated service (RemoteSystemOperationsService) and needs to
+ * proxy requests to the master because non-master services may not have access to authorization backends, since they
+ * do not have the Kerberos credentials of the master.
  */
-class RemotePrivilegesFetcher extends AbstractPrivilegesFetcherClient {
+class PrivilegesFetcherProxyClient extends AbstractPrivilegesFetcherClient {
 
   @Inject
-  RemotePrivilegesFetcher(CConfiguration cConf, DiscoveryServiceClient discoveryClient) {
-    super(cConf, discoveryClient, Constants.Service.REMOTE_SYSTEM_OPERATION);
+  PrivilegesFetcherProxyClient(CConfiguration cConf, final DiscoveryServiceClient discoveryClient) {
+    super(cConf, discoveryClient, Constants.Service.APP_FABRIC_HTTP);
   }
 }

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/PrivilegesFetcherProxyService.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/PrivilegesFetcherProxyService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.security.spi.authorization.PrivilegesFetcher;
+import com.google.common.util.concurrent.Service;
+
+/**
+ * A service that runs inside a system service to act as a proxy for requests to list privileges from system services
+ * (explore, stream service) or program containers.
+ */
+public interface PrivilegesFetcherProxyService extends Service, PrivilegesFetcher {
+}


### PR DESCRIPTION
…hat simply proxies list privilege requests to the master, which can communicate with authorization backends.
- DatasetOpExecutor which runs the proxy, now also maintains an authorization cache inside PrivilegeFetcherProxyService, which is similar to the authorization enforcement cache used by program containers, except that it updates itself by fetching privileges via the master.
- Refactored DefaultAuthorizationEnforcementService to move non-enforcement code into an AbstractAuthorizationService class, which is also used by the PrivilegesFetcherProxyService
- Refactored Remote client and handlers for fetching privileges to move common code to abstract classes, which are extended by:
  - RemotePrivilegesFetcherHandler: runs inside master, communicates with authorization backends directly
  - RemotePrivilegesFetcherProxyHandler: runs inside RemoteSystemOpsService, proxies requests from RemotePrivilegesFetcher to RemotePrivilegesFetcherHandler, via PrivilegesFetcherProxyClient
- (CDAP-6639) Updates to authorization cache in the master now do not go via the RemoteSystemOpsService, since master can communicate with Authorization backends directly
  - Fixed MasterAuthenticationContext to get the user id from UserGroupInformation, when requests are made to authorization backends periodically for updating master's authorization cache. Without this, the authentication context would expect SecurityRequestContext to be set, which is null when requests do not go via the Router.
- Most logic of this change is in AuthorizationEnforcementModule.

Jira: 
- [CDAP-6833](https://issues.cask.co/browse/CDAP-6833)
- [CDAP-6639](https://issues.cask.co/browse/CDAP-6639)

Build: http://builds.cask.co/browse/CDAP-DUT4577
