### PR TITLE
(CDAP-6825) Temporary workaround to use authorizer directly to enforc…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -49,8 +49,8 @@ import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
-import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
+import co.cask.cdap.security.spi.authorization.Authorizer;
 import co.cask.cdap.store.NamespaceStore;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
@@ -85,7 +85,8 @@ public final class DefaultNamespaceAdmin extends DefaultNamespaceQueryAdmin impl
   private final Scheduler scheduler;
   private final ApplicationLifecycleService applicationLifecycleService;
   private final ArtifactRepository artifactRepository;
-  private final AuthorizerInstantiator authorizerInstantiator;
+  private final Authorizer authorizer;
+  private final AuthorizationEnforcer authorizationEnforcer;
   private final InstanceId instanceId;
   private final StorageProviderNamespaceAdmin storageProviderNamespaceAdmin;
   private final Impersonator impersonator;
@@ -114,7 +115,8 @@ public final class DefaultNamespaceAdmin extends DefaultNamespaceQueryAdmin impl
     this.metricStore = metricStore;
     this.applicationLifecycleService = applicationLifecycleService;
     this.artifactRepository = artifactRepository;
-    this.authorizerInstantiator = authorizerInstantiator;
+    this.authorizer = authorizerInstantiator.get();
+    this.authorizationEnforcer = authorizationEnforcer;
     this.instanceId = createInstanceId(cConf);
     this.storageProviderNamespaceAdmin = storageProviderNamespaceAdmin;
     this.impersonator = impersonator;
@@ -136,12 +138,12 @@ public final class DefaultNamespaceAdmin extends DefaultNamespaceQueryAdmin impl
     }
 
     // Namespace can be created. Check if the user is authorized now.
-    Principal principal = SecurityRequestContext.toPrincipal();
+    Principal principal = authenticationContext.getPrincipal();
     // Skip authorization enforcement for the system user and the default namespace, so the DefaultNamespaceEnsurer
     // thread can successfully create the default namespace
     if (!(Principal.SYSTEM.equals(principal) && NamespaceId.DEFAULT.equals(namespace))) {
-      authorizerInstantiator.get().enforce(instanceId, principal, Action.ADMIN);
-      authorizerInstantiator.get().grant(namespace, principal, ImmutableSet.of(Action.ALL));
+      authorizationEnforcer.enforce(instanceId, principal, Action.ADMIN);
+      authorizer.grant(namespace, principal, ImmutableSet.of(Action.ALL));
     }
 
     // store the meta first in the namespace store because namespacedlocationfactory need to look up location
@@ -160,7 +162,7 @@ public final class DefaultNamespaceAdmin extends DefaultNamespaceQueryAdmin impl
       // failed to create namespace in underlying storage so delete the namespace meta stored in the store earlier
       nsStore.delete(metadata.getNamespaceId().toId());
       if (!(Principal.SYSTEM.equals(principal) && NamespaceId.DEFAULT.equals(namespace))) {
-        authorizerInstantiator.get().revoke(namespace);
+        authorizer.revoke(namespace);
       }
       throw new NamespaceCannotBeCreatedException(namespace.toId(), e);
     }
@@ -189,7 +191,7 @@ public final class DefaultNamespaceAdmin extends DefaultNamespaceQueryAdmin impl
                                                                 namespaceId));
     }
 
-    authorizerInstantiator.get().enforce(namespace, SecurityRequestContext.toPrincipal(), Action.ADMIN);
+    authorizationEnforcer.enforce(namespace, authenticationContext.getPrincipal(), Action.ADMIN);
 
     LOG.info("Deleting namespace '{}'.", namespaceId);
     try {
@@ -237,7 +239,7 @@ public final class DefaultNamespaceAdmin extends DefaultNamespaceQueryAdmin impl
       LOG.warn("Error while deleting namespace {}", namespaceId, e);
       throw new NamespaceCannotBeDeletedException(namespaceId, e);
     } finally {
-      authorizerInstantiator.get().revoke(namespace);
+      authorizer.revoke(namespace);
     }
     LOG.info("All data for namespace '{}' deleted.", namespaceId);
 
@@ -245,7 +247,7 @@ public final class DefaultNamespaceAdmin extends DefaultNamespaceQueryAdmin impl
     // deletion fails, we may have a valid (or invalid) namespace in the system, that no one has privileges on,
     // so no one can clean up. This may result in orphaned privileges, which will be cleaned up by the create API
     // if the same namespace is successfully re-created.
-    authorizerInstantiator.get().revoke(namespace);
+    authorizer.revoke(namespace);
   }
 
   private void deleteMetrics(NamespaceId namespaceId) throws Exception {
@@ -272,8 +274,7 @@ public final class DefaultNamespaceAdmin extends DefaultNamespaceQueryAdmin impl
     }
 
     // Namespace data can be deleted. Revoke all privileges first
-    authorizerInstantiator.get().enforce(namespaceId.toEntityId(), SecurityRequestContext.toPrincipal(),
-                                                Action.ADMIN);
+    authorizationEnforcer.enforce(namespaceId.toEntityId(), authenticationContext.getPrincipal(), Action.ADMIN);
     try {
       dsFramework.deleteAllInstances(namespaceId);
     } catch (DatasetManagementException | IOException e) {
@@ -288,10 +289,11 @@ public final class DefaultNamespaceAdmin extends DefaultNamespaceQueryAdmin impl
     if (!exists(namespaceId)) {
       throw new NamespaceNotFoundException(namespaceId);
     }
-    authorizerInstantiator.get().enforce(namespaceId.toEntityId(), SecurityRequestContext.toPrincipal(),
-                                         Action.ADMIN);
+    authorizationEnforcer.enforce(namespaceId.toEntityId(), authenticationContext.getPrincipal(), Action.ADMIN);
 
     NamespaceMeta existingMeta = nsStore.get(namespaceId);
+    // Already ensured that namespace exists, so namespace meta should not be null
+    Preconditions.checkNotNull(existingMeta);
     NamespaceMeta.Builder builder = new NamespaceMeta.Builder(existingMeta);
 
     if (namespaceMeta.getDescription() != null) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceQueryAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceQueryAdmin.java
@@ -45,9 +45,9 @@ public class DefaultNamespaceQueryAdmin implements NamespaceQueryAdmin {
   protected final AuthenticationContext authenticationContext;
 
   @Inject
-  public DefaultNamespaceQueryAdmin(NamespaceStore nsStore,
-                                    AuthorizationEnforcer authorizationEnforcer,
-                                    AuthenticationContext authenticationContext) {
+  DefaultNamespaceQueryAdmin(NamespaceStore nsStore,
+                             AuthorizationEnforcer authorizationEnforcer,
+                             AuthenticationContext authenticationContext) {
     this.nsStore = nsStore;
     this.authorizationEnforcer = authorizationEnforcer;
     this.authenticationContext = authenticationContext;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/AuthorizationHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/AuthorizationHandlerTest.java
@@ -34,6 +34,7 @@ import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.proto.security.Role;
+import co.cask.cdap.security.auth.context.MasterAuthenticationContext;
 import co.cask.cdap.security.authorization.AuthorizationContextFactory;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.authorization.InMemoryAuthorizer;
@@ -97,7 +98,7 @@ public class AuthorizationHandlerTest {
           public Authorizer get() {
             return auth;
           }
-        }, conf, entityExistenceVerifier)))
+        }, conf, new MasterAuthenticationContext(), entityExistenceVerifier)))
       .modifyChannelPipeline(new Function<ChannelPipeline, ChannelPipeline>() {
         @Override
         public ChannelPipeline apply(ChannelPipeline input) {
@@ -151,7 +152,7 @@ public class AuthorizationHandlerTest {
           public Authorizer get() {
             return new InMemoryAuthorizer();
           }
-        }, cConf, entityExistenceVerifier)))
+        }, cConf, new MasterAuthenticationContext(), entityExistenceVerifier)))
       .build();
     service.startAndWait();
     try {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
@@ -28,6 +28,7 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.authorization.InMemoryAuthorizer;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
@@ -60,6 +61,7 @@ public class MetadataAdminAuthorizationTest {
   private static CConfiguration cConf;
   private static MetadataAdmin metadataAdmin;
   private static Authorizer authorizer;
+  private static AuthorizationEnforcementService authorizationEnforcementService;
   private static RemoteSystemOperationsService remoteSystemOperationsService;
 
   @BeforeClass
@@ -69,6 +71,8 @@ public class MetadataAdminAuthorizationTest {
     metadataAdmin = injector.getInstance(MetadataAdmin.class);
     authorizer = injector.getInstance(AuthorizerInstantiator.class).get();
     authorizer.grant(new InstanceId(cConf.get(Constants.INSTANCE_NAME)), ALICE, Collections.singleton(Action.ADMIN));
+    authorizationEnforcementService = injector.getInstance(AuthorizationEnforcementService.class);
+    authorizationEnforcementService.startAndWait();
     remoteSystemOperationsService = injector.getInstance(RemoteSystemOperationsService.class);
     remoteSystemOperationsService.startAndWait();
   }
@@ -88,6 +92,7 @@ public class MetadataAdminAuthorizationTest {
   @AfterClass
   public static void tearDown() {
     remoteSystemOperationsService.stopAndWait();
+    authorizationEnforcementService.stopAndWait();
   }
 
   private static CConfiguration createCConf() throws IOException {

--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/AuthorizationCLITest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/AuthorizationCLITest.java
@@ -17,8 +17,10 @@
 package co.cask.cdap.cli;
 
 import co.cask.cdap.StandaloneTester;
+import co.cask.cdap.client.AuthorizationClient;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.internal.test.AppJarHelper;
+import co.cask.cdap.proto.id.InstanceId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
@@ -30,6 +32,7 @@ import co.cask.common.cli.CLI;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -43,6 +46,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -101,7 +105,10 @@ public class AuthorizationCLITest extends CLITestBase {
   @ClassRule
   public static final StandaloneTesterWithAuthorization AUTH_STANDALONE = new StandaloneTesterWithAuthorization();
 
+  private static final InstanceId INSTANCE_ID = new InstanceId("cdap");
+
   private static CLI cli;
+  private static AuthorizationClient authorizationClient;
 
   @BeforeClass
   public static void setup() throws Exception {
@@ -110,6 +117,13 @@ public class AuthorizationCLITest extends CLITestBase {
     CLIMain cliMain = new CLIMain(launchOptions, cliConfig);
     cli = cliMain.getCLI();
     testCommandOutputContains(cli, "connect " + AUTH_STANDALONE.getBaseURI(), "Successfully connected");
+    authorizationClient = new AuthorizationClient(cliConfig.getClientConfig());
+    // Grant the privileges on the instance first. This is so that the current user can create a namespace.
+    // This needs to be done using the client because in these tests, it is impossible to set the
+    // SecurityRequestContext to a non-null value. Having a null user name is fine, but when it is used as null via a
+    // CLI command, the null is serialized to the String "null" which causes issues during enforcement, when the user
+    // is received as null, and not the String "null".
+    authorizationClient.grant(INSTANCE_ID, SecurityRequestContext.toPrincipal(), Collections.singleton(Action.ADMIN));
   }
 
   @Test
@@ -118,11 +132,6 @@ public class AuthorizationCLITest extends CLITestBase {
     Principal principal = new Principal("spiderman", Principal.PrincipalType.USER);
 
     NamespaceId namespaceId = new NamespaceId("ns1");
-    // Grant the privileges on ns1 first
-    getCommandOutput(cli, String.format("grant actions %s on entity %s to %s %s",
-                                        Action.ADMIN.name().toLowerCase(), "instance:cdap",
-                                        Principal.PrincipalType.USER.name().toLowerCase(),
-                                        SecurityRequestContext.toPrincipal().getName()));
 
     testCommandOutputContains(cli, String.format("create namespace %s", namespaceId.getNamespace()),
                               String.format("Namespace '%s' created successfully", namespaceId.getNamespace()));
@@ -189,5 +198,10 @@ public class AuthorizationCLITest extends CLITestBase {
                                                  principal.getName()),
                               String.format("Successfully removed role '%s' from %s '%s'", role.getName(),
                                             principal.getType(), principal.getName()));
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    authorizationClient.revoke(INSTANCE_ID);
   }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -61,7 +61,6 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
-import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
 import co.cask.cdap.security.authorization.AuthorizationTestModule;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
@@ -105,7 +104,6 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
   public void before() throws Exception {
     cConf.set(Constants.Dataset.Manager.ADDRESS, "localhost");
     cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, true);
-
 
     Configuration txConf = HBaseConfiguration.create();
     CConfigurationUtil.copyTxProperties(cConf, txConf);
@@ -168,8 +166,6 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
     ExploreFacade exploreFacade = new ExploreFacade(new DiscoveryExploreClient(cConf, discoveryServiceClient), cConf);
     TransactionExecutorFactory txExecutorFactory = new DynamicTransactionExecutorFactory(txSystemClient);
     AuthorizationEnforcer authorizationEnforcer = injector.getInstance(AuthorizationEnforcer.class);
-    AuthorizationEnforcementService authEnforcementService =
-      injector.getInstance(AuthorizationEnforcementService.class);
 
     DatasetTypeManager typeManager = new DatasetTypeManager(cConf, locationFactory, txSystemClientService,
                                                             txExecutorFactory, mdsFramework, DEFAULT_MODULES,
@@ -188,7 +184,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
 
     service = new DatasetService(cConf, discoveryService, discoveryServiceClient, typeManager, metricsCollectionService,
                                  new InMemoryDatasetOpExecutor(framework), new HashSet<DatasetMetricsReporter>(),
-                                 typeService, instanceService, authEnforcementService);
+                                 typeService, instanceService);
     // Start dataset service, wait for it to be discoverable
     service.startAndWait();
     EndpointStrategy endpointStrategy = new RandomEndpointStrategy(discoveryServiceClient.discover(

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -65,6 +65,7 @@ import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.TokenSecureStoreUpdater;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.store.guice.NamespaceStoreModule;
 import com.google.common.annotations.VisibleForTesting;
@@ -552,6 +553,7 @@ public class MasterServiceMain extends DaemonMain {
 
       services.add(getAndStart(injector, KafkaClientService.class));
       services.add(getAndStart(injector, MetricsCollectionService.class));
+      services.add(getAndStart(injector, AuthorizationEnforcementService.class));
       serviceStore = getAndStart(injector, ServiceStore.class);
       services.add(serviceStore);
 

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -88,6 +88,7 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.authorization.InvalidAuthorizerException;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
@@ -176,6 +177,7 @@ public class TestBase {
   private static AuthorizerInstantiator authorizerInstantiator;
   private static SecureStore secureStore;
   private static SecureStoreManager secureStoreManager;
+  private static AuthorizationEnforcementService authorizationEnforcementService;
 
   // This list is to record ApplicationManager create inside @Test method
   private static final List<ApplicationManager> applicationManagers = new ArrayList<>();
@@ -260,6 +262,8 @@ public class TestBase {
       }
     );
 
+    authorizationEnforcementService = injector.getInstance(AuthorizationEnforcementService.class);
+    authorizationEnforcementService.startAndWait();
     txService = injector.getInstance(TransactionManager.class);
     txService.startAndWait();
     dsOpService = injector.getInstance(DatasetOpExecutor.class);
@@ -282,6 +286,7 @@ public class TestBase {
     testManager = injector.getInstance(UnitTestManager.class);
     metricsManager = injector.getInstance(MetricsManager.class);
     authorizerInstantiator = injector.getInstance(AuthorizerInstantiator.class);
+
     // This is needed so the logged-in user can successfully create the default namespace
     if (cConf.getBoolean(Constants.Security.Authorization.ENABLED)) {
       String user = System.getProperty("user.name");
@@ -434,6 +439,7 @@ public class TestBase {
     datasetService.stopAndWait();
     dsOpService.stopAndWait();
     txService.stopAndWait();
+    authorizationEnforcementService.stopAndWait();
   }
 
   protected MetricsManager getMetricsManager() {


### PR DESCRIPTION
…e authorization for dataset types while creating a new dataset instance. This is necessary for apps that deploy custom datasets. When they successfully create the custom dataset type, they're granted ALL privileges on the dataset, but the authorization cache is not updated with this grant, by the time a new instance is created.
- Start AuthorizationEnforcementService in MasterServiceMain and StandaloneMain instead of DatasetService, since App Fabric also uses it (this was not a problem, but just comes across as strange).
- Other minor cleanup in authorization code
  - Have Authorizer as a class member where possible instead of AuthorizerInstantiator.
  - Use AuthorizationEnforcer for enforcing privileges where possible.

Jira: [CDAP-6825](https://issues.cask.co/browse/CDAP-6825)
Build: http://builds.cask.co/browse/CDAP-DUT4582
