### PR TITLE
[CDAP-6858] - Fixes route navigation to unauthorized namespaces (or no namespace) in UI

### DIFF
--- a/cdap-ui/app/features/home/home-ctrl.js
+++ b/cdap-ui/app/features/home/home-ctrl.js
@@ -15,7 +15,11 @@
  */
 
 angular.module(PKG.name + '.feature.home')
-  .controller('HomeController', function ($state, rNsList, mySessionStorage, myLoadingService, $filter) {
+  .controller('HomeController', function ($state, $stateParams, rNsList, mySessionStorage, myLoadingService, $filter) {
+    if (!rNsList.length) {
+      $state.go('unauthorized');
+      return;
+    }
     // Needed to inject StatusFactory here for angular to instantiate the service and start polling.
     // check that $state.params.namespace is valid
     var n = rNsList.filter(function (one) {

--- a/cdap-ui/app/features/home/routes.js
+++ b/cdap-ui/app/features/home/routes.js
@@ -70,12 +70,7 @@ angular.module(PKG.name+'.feature.home')
             return myNamespace.getList();
           }
         },
-        controller: 'HomeController',
-        onEnter: function ($stateParams, $state) {
-          if (!$stateParams.namespace) {
-            $state.go('home');
-          }
-        }
+        controller: 'HomeController'
       })
 
       .state('404', {


### PR DESCRIPTION
Moves the navigation to `unauthorized` state from `onEnter` on `home` state to  `HomeController`.

Bamboo build: http://builds.cask.co/browse/CDAP-DRC4154-2
