### PR TITLE
HYDRA-372 fix streaming source api

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineDriver.java
@@ -24,6 +24,7 @@ import co.cask.cdap.etl.api.batch.BatchAggregator;
 import co.cask.cdap.etl.api.batch.BatchJoiner;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.SparkCompute;
+import co.cask.cdap.etl.api.streaming.StreamingContext;
 import co.cask.cdap.etl.api.streaming.StreamingSource;
 import co.cask.cdap.etl.api.streaming.Windower;
 import co.cask.cdap.etl.common.Constants;
@@ -33,6 +34,7 @@ import co.cask.cdap.etl.spark.SparkCollection;
 import co.cask.cdap.etl.spark.SparkPipelineDriver;
 import co.cask.cdap.etl.spark.function.PluginFunctionContext;
 import co.cask.cdap.etl.spark.streaming.DStreamCollection;
+import co.cask.cdap.etl.spark.streaming.DefaultStreamingContext;
 import co.cask.cdap.etl.spec.StageSpec;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
 import com.google.common.collect.ImmutableSet;
@@ -63,7 +65,8 @@ public class SparkStreamingPipelineDriver extends SparkPipelineDriver implements
   protected SparkCollection<Object> getSource(String stageName,
                                               PluginFunctionContext pluginFunctionContext) throws Exception {
     StreamingSource<Object> source = sec.getPluginContext().newPluginInstance(stageName);
-    return new DStreamCollection<>(sec, sparkContext, source.getStream(streamingContext));
+    StreamingContext context = new DefaultStreamingContext(stageName, sec, streamingContext);
+    return new DStreamCollection<>(sec, sparkContext, source.getStream(context));
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/co/cask/cdap/etl/api/streaming/StreamingContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/co/cask/cdap/etl/api/streaming/StreamingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,14 +14,22 @@
  * the License.
  */
 
-package co.cask.cdap.etl.api;
+package co.cask.cdap.etl.api.streaming;
 
+import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.etl.api.StageContext;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
 
 /**
- * Context passed to ETL stages.
+ * Context for streaming plugin stages.
  */
 @Beta
-public interface TransformContext extends StageContext, LookupProvider {
+public interface StreamingContext extends StageContext, Transactional {
+
+  /**
+   * @return Spark JavaStreamingContext for the pipeline.
+   */
+  JavaStreamingContext getSparkStreamingContext();
 
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/co/cask/cdap/etl/api/streaming/StreamingSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/co/cask/cdap/etl/api/streaming/StreamingSource.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.etl.api.streaming;
 
+import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.spark.JavaSparkExecutionContext;
 import co.cask.cdap.etl.api.PipelineConfigurable;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import org.apache.spark.streaming.api.java.JavaDStream;
@@ -28,6 +30,7 @@ import java.io.Serializable;
  *
  * @param <T> type of object contained in the stream
  */
+@Beta
 public abstract class StreamingSource<T> implements PipelineConfigurable, Serializable {
 
   public static final String PLUGIN_TYPE = "streamingsource";
@@ -37,10 +40,10 @@ public abstract class StreamingSource<T> implements PipelineConfigurable, Serial
   /**
    * Get the stream to read from.
    *
-   * @param jsc spark context
+   * @param context the streaming context for this stage of the pipeline
    * @return the stream to read from.
    */
-  public abstract JavaDStream<T> getStream(JavaStreamingContext jsc) throws Exception;
+  public abstract JavaDStream<T> getStream(StreamingContext context) throws Exception;
 
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {

--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/co/cask/cdap/etl/api/streaming/Windower.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/co/cask/cdap/etl/api/streaming/Windower.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.etl.api.streaming;
 
+import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.etl.api.PipelineConfigurable;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 
@@ -24,6 +25,7 @@ import java.io.Serializable;
 /**
  * Windowing plugin.
  */
+@Beta
 public abstract class Windower implements PipelineConfigurable, Serializable {
 
   public static final String PLUGIN_TYPE = "windower";

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/StageContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/StageContext.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.api;
+
+import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginConfigurer;
+import co.cask.cdap.api.plugin.PluginProperties;
+
+/**
+ * Context for a pipeline stage, providing access to information about the stage, metrics, and plugins.
+ */
+@Beta
+public interface StageContext {
+
+  /**
+   * Gets the unique stage name of the transform, useful for setting the context of logging in transforms.
+   *
+   * @return stage name
+   */
+  String getStageName();
+
+  /**
+   * Get an instance of {@link StageMetrics}, used to collect metrics for this stage. Metrics emitted from one stage
+   * are independent from metrics emitted in another.
+   *
+   * @return {@link StageMetrics} for collecting metrics
+   */
+  StageMetrics getMetrics();
+
+  /**
+   * Gets the {@link PluginProperties} associated with the stage.
+   *
+   * @return the {@link PluginProperties}.
+   */
+  PluginProperties getPluginProperties();
+
+  /**
+   * Gets the {@link PluginProperties} associated with the given plugin id.
+   *
+   * @param pluginId the unique identifier provide when declaring plugin usage in the program.
+   * @return the {@link PluginProperties}.
+   * @throws IllegalArgumentException if pluginId is not found
+   * @throws UnsupportedOperationException if the program does not support plugin
+   */
+  PluginProperties getPluginProperties(String pluginId);
+
+  /**
+   * Loads and returns a plugin class as specified by the given plugin id.
+   *
+   * @param pluginId the unique identifier provide when declaring plugin usage in the program.
+   * @param <T> the class type of the plugin
+   * @return the resulting plugin {@link Class}.
+   * @throws IllegalArgumentException if pluginId is not found
+   * @throws UnsupportedOperationException if the program does not support plugin
+   */
+  <T> Class<T> loadPluginClass(String pluginId);
+
+  /**
+   * Creates a new instance of a plugin. The instance returned will have the {@link PluginConfig} setup with
+   * {@link PluginProperties} provided at the time when the
+   * {@link PluginConfigurer#usePlugin(String, String, String, PluginProperties)} was called during the
+   * program configuration time.
+   *
+   * @param pluginId the unique identifier provide when declaring plugin usage in the program.
+   * @param <T> the class type of the plugin
+   * @return A new instance of the plugin being specified by the arguments
+   *
+   * @throws InstantiationException if failed create a new instance
+   * @throws IllegalArgumentException if pluginId is not found
+   * @throws UnsupportedOperationException if the program does not support plugin
+   */
+  <T> T newPluginInstance(String pluginId) throws InstantiationException;
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/AbstractStageContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/AbstractStageContext.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.common;
+
+import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.etl.api.StageContext;
+import co.cask.cdap.etl.api.StageMetrics;
+import co.cask.cdap.etl.log.LogContext;
+import com.google.common.base.Throwables;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Base implementation of {@link StageContext} for common functionality.
+ * This context scopes plugin ids by the id of the stage. This allows multiple transforms to use plugins with
+ * the same id without clobbering each other.
+ */
+public abstract class AbstractStageContext implements StageContext {
+
+  private final PluginContext pluginContext;
+  private final String stageName;
+  private final StageMetrics metrics;
+
+  public AbstractStageContext(PluginContext pluginContext, Metrics metrics, String stageName) {
+    this.pluginContext = pluginContext;
+    this.stageName = stageName;
+    this.metrics = new DefaultStageMetrics(metrics, stageName);
+  }
+
+  @Override
+  public final PluginProperties getPluginProperties(final String pluginId) {
+    return LogContext.runWithoutLoggingUnchecked(new Callable<PluginProperties>() {
+      @Override
+      public PluginProperties call() throws Exception {
+        return pluginContext.getPluginProperties(scopePluginId(pluginId));
+      }
+    });
+  }
+
+  @Override
+  public final <T> T newPluginInstance(final String pluginId) throws InstantiationException {
+    try {
+      return LogContext.runWithoutLogging(new Callable<T>() {
+        @Override
+        public T call() throws Exception {
+          return pluginContext.newPluginInstance(scopePluginId(pluginId));
+        }
+      });
+    } catch (Exception e) {
+      Throwables.propagateIfInstanceOf(e, InstantiationException.class);
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public final <T> Class<T> loadPluginClass(final String pluginId) {
+    return LogContext.runWithoutLoggingUnchecked(new Callable<Class<T>>() {
+      @Override
+      public Class<T> call() throws Exception {
+        return pluginContext.loadPluginClass(scopePluginId(pluginId));
+      }
+    });
+  }
+
+  @Override
+  public final PluginProperties getPluginProperties() {
+    return LogContext.runWithoutLoggingUnchecked(new Callable<PluginProperties>() {
+      @Override
+      public PluginProperties call() throws Exception {
+        return pluginContext.getPluginProperties(stageName);
+      }
+    });
+  }
+
+  @Override
+  public final String getStageName() {
+    return stageName;
+  }
+
+  @Override
+  public final StageMetrics getMetrics() {
+    return metrics;
+  }
+
+  private String scopePluginId(String childPluginId) {
+    return String.format("%s%s%s", stageName, Constants.ID_SEPARATOR, childPluginId);
+  }
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/AbstractTransformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/AbstractTransformContext.java
@@ -16,113 +16,27 @@
 
 package co.cask.cdap.etl.common;
 
-import co.cask.cdap.api.macro.MacroEvaluator;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginContext;
-import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.etl.api.Lookup;
 import co.cask.cdap.etl.api.LookupProvider;
-import co.cask.cdap.etl.api.StageMetrics;
 import co.cask.cdap.etl.api.TransformContext;
-import co.cask.cdap.etl.log.LogContext;
-import com.google.common.base.Throwables;
 
 import java.util.Map;
-import java.util.concurrent.Callable;
 
 /**
  * Base implementation of {@link TransformContext} for common functionality.
  * This context scopes plugin ids by the id of the stage. This allows multiple transforms to use plugins with
  * the same id without clobbering each other.
  */
-public abstract class AbstractTransformContext implements TransformContext {
+public abstract class AbstractTransformContext extends AbstractStageContext implements TransformContext {
 
-  private final PluginContext pluginContext;
-  private final String stageName;
-  private final StageMetrics metrics;
   private final LookupProvider lookup;
 
   public AbstractTransformContext(PluginContext pluginContext,
                                   Metrics metrics, LookupProvider lookup, String stageName) {
-    this.pluginContext = pluginContext;
-    this.stageName = stageName;
+    super(pluginContext, metrics, stageName);
     this.lookup = lookup;
-    this.metrics = new DefaultStageMetrics(metrics, stageName);
-  }
-
-  @Override
-  public final PluginProperties getPluginProperties(final String pluginId) {
-    return LogContext.runWithoutLoggingUnchecked(new Callable<PluginProperties>() {
-      @Override
-      public PluginProperties call() throws Exception {
-        return pluginContext.getPluginProperties(scopePluginId(pluginId));
-      }
-    });
-  }
-
-  @Override
-  public final <T> T newPluginInstance(final String pluginId) throws InstantiationException {
-    try {
-      return LogContext.runWithoutLogging(new Callable<T>() {
-        @Override
-        public T call() throws Exception {
-          return pluginContext.newPluginInstance(scopePluginId(pluginId));
-        }
-      });
-    } catch (Exception e) {
-      Throwables.propagateIfInstanceOf(e, InstantiationException.class);
-      throw Throwables.propagate(e);
-    }
-  }
-
-  @Override
-  public final <T> T newPluginInstance(final String pluginId,
-                                       final MacroEvaluator evaluator) throws InstantiationException {
-    try {
-      return LogContext.runWithoutLogging(new Callable<T>() {
-        @Override
-        public T call() throws Exception {
-          return pluginContext.newPluginInstance(scopePluginId(pluginId), evaluator);
-        }
-      });
-    } catch (Exception e) {
-      Throwables.propagateIfInstanceOf(e, InstantiationException.class);
-      throw Throwables.propagate(e);
-    }
-  }
-
-  @Override
-  public final <T> Class<T> loadPluginClass(final String pluginId) {
-    return LogContext.runWithoutLoggingUnchecked(new Callable<Class<T>>() {
-      @Override
-      public Class<T> call() throws Exception {
-        return pluginContext.loadPluginClass(scopePluginId(pluginId));
-      }
-    });
-  }
-
-  @Override
-  public final PluginProperties getPluginProperties() {
-    return LogContext.runWithoutLoggingUnchecked(new Callable<PluginProperties>() {
-      @Override
-      public PluginProperties call() throws Exception {
-        return pluginContext.getPluginProperties(stageName);
-      }
-    });
-  }
-
-  @Override
-  public final String getStageName() {
-    return stageName;
-  }
-
-  @Override
-  public final StageMetrics getMetrics() {
-    return metrics;
-  }
-
-  private String scopePluginId(String childPluginId) {
-    return String.format("%s%s%s", stageName, Constants.ID_SEPARATOR, childPluginId);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/DefaultStreamingContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/DefaultStreamingContext.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark.streaming;
+
+import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.spark.JavaSparkExecutionContext;
+import co.cask.cdap.etl.api.streaming.StreamingContext;
+import co.cask.cdap.etl.common.AbstractStageContext;
+import co.cask.tephra.TransactionFailureException;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+
+/**
+ * Default implementation of StreamingContext for Spark.
+ */
+public class DefaultStreamingContext extends AbstractStageContext implements StreamingContext {
+  private final JavaSparkExecutionContext sec;
+  private final JavaStreamingContext jsc;
+
+  public DefaultStreamingContext(String stageName, JavaSparkExecutionContext sec, JavaStreamingContext jsc) {
+    super(sec.getPluginContext(), sec.getMetrics(), stageName);
+    this.sec = sec;
+    this.jsc = jsc;
+  }
+
+  @Override
+  public JavaStreamingContext getSparkStreamingContext() {
+    return jsc;
+  }
+
+  @Override
+  public void execute(TxRunnable runnable) throws TransactionFailureException {
+    sec.execute(runnable);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/spark/streaming/MockSource.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/spark/streaming/MockSource.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.streaming.StreamingContext;
 import co.cask.cdap.etl.api.streaming.StreamingSource;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 import co.cask.cdap.format.StructuredRecordStringConverter;
@@ -70,7 +71,7 @@ public class MockSource extends StreamingSource<StructuredRecord> {
   }
 
   @Override
-  public JavaDStream<StructuredRecord> getStream(JavaStreamingContext jssc) throws Exception {
+  public JavaDStream<StructuredRecord> getStream(StreamingContext context) throws Exception {
     Schema schema = Schema.parseJson(conf.schema);
     List<String> recordsAsStrings = new Gson().fromJson(conf.records, STRING_LIST_TYPE);
     final List<StructuredRecord> inputRecords = new ArrayList<>();
@@ -78,7 +79,8 @@ public class MockSource extends StreamingSource<StructuredRecord> {
       inputRecords.add(StructuredRecordStringConverter.fromJsonString(recordStr, schema));
     }
 
-    return jssc.receiverStream(new Receiver<StructuredRecord>(StorageLevel.MEMORY_ONLY()) {
+    JavaStreamingContext jsc = context.getSparkStreamingContext();
+    return jsc.receiverStream(new Receiver<StructuredRecord>(StorageLevel.MEMORY_ONLY()) {
       @Override
       public StorageLevel storageLevel() {
         return StorageLevel.MEMORY_ONLY();


### PR DESCRIPTION
Fixing the interface so that it takes a Hydrator context instead
of only the Spark context. This gives sources access to additional
information, such as metrics, the stage name, plugins, etc.

Along the way, refactoring common stage related methods into a
StageContext interface that everything inherits from. This changes
the TransformContext so that it does not directly extend the CDAP
PluginContext, as that interface may contain methods that dont
make sense for Hydrator, such as the method that takes a
MacroEvaluator to instantiate a plugin.
