### PR TITLE
CDAP-6399 Create ns command cli

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdminTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdminTest.java
@@ -139,7 +139,7 @@ public class DefaultNamespaceAdminTest extends AppFabricTestBase {
     // Updating the HBase namespace for a namespace should fail
     try {
       namespaceAdmin.updateProperties(nsMeta.getNamespaceId().toId(),
-                                      new NamespaceMeta.Builder(nsMeta).setHBaseDatabase("custns").build());
+                                      new NamespaceMeta.Builder(nsMeta).setHBaseNamespace("custns").build());
       Assert.fail();
     } catch (BadRequestException e) {
       // expected

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemoteNamespaceQueryTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemoteNamespaceQueryTest.java
@@ -103,7 +103,7 @@ public class RemoteNamespaceQueryTest {
                             .setDescription(description)
                             .setSchedulerQueueName(schedulerQueue)
                             .setRootDirectory(rootDirectory)
-                            .setHBaseDatabase(hbaseNamespace)
+                            .setHBaseNamespace(hbaseNamespace)
                             .setHiveDatabase(hiveDb)
                             .build());
     NamespaceId namespaceId = new NamespaceId(cdapNamespace);

--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -17,11 +17,13 @@
 package co.cask.cdap.cli;
 
 import co.cask.cdap.StandaloneTester;
+import co.cask.cdap.cli.command.NamespaceCommandUtils;
 import co.cask.cdap.cli.util.RowMaker;
 import co.cask.cdap.cli.util.table.Table;
 import co.cask.cdap.client.DatasetTypeClient;
 import co.cask.cdap.client.NamespaceClient;
 import co.cask.cdap.client.ProgramClient;
+import co.cask.cdap.client.QueryClient;
 import co.cask.cdap.client.app.ConfigTestApp;
 import co.cask.cdap.client.app.FakeApp;
 import co.cask.cdap.client.app.FakeDataset;
@@ -34,13 +36,16 @@ import co.cask.cdap.common.DatasetTypeNotFoundException;
 import co.cask.cdap.common.ProgramNotFoundException;
 import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.explore.client.ExploreExecutionResult;
 import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.proto.DatasetTypeMeta;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.QueryStatus;
 import co.cask.cdap.proto.StreamProperties;
 import co.cask.cdap.proto.WorkflowTokenDetail;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.XSlowTests;
 import co.cask.common.cli.CLI;
 import com.google.common.base.Charsets;
@@ -52,6 +57,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gson.Gson;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
@@ -62,6 +68,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,6 +93,9 @@ public class CLIMainTest extends CLITestBase {
   @ClassRule
   public static final StandaloneTester STANDALONE = new StandaloneTester();
 
+  @ClassRule
+  public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
   private static final Logger LOG = LoggerFactory.getLogger(CLIMainTest.class);
   private static final Gson GSON = new Gson();
   private static final String PREFIX = "123ff1_";
@@ -101,6 +111,7 @@ public class CLIMainTest extends CLITestBase {
   private final Id.Stream fakeStreamId = Id.Stream.from(Id.Namespace.DEFAULT, FakeApp.STREAM_NAME);
 
   private static ProgramClient programClient;
+  private static QueryClient queryClient;
   private static CLIConfig cliConfig;
   private static CLIMain cliMain;
   private static CLI cli;
@@ -111,6 +122,7 @@ public class CLIMainTest extends CLITestBase {
     LaunchOptions launchOptions = new LaunchOptions(LaunchOptions.DEFAULT.getUri(), true, true, false);
     cliMain = new CLIMain(launchOptions, cliConfig);
     programClient = new ProgramClient(cliConfig.getClientConfig());
+    queryClient = new QueryClient(cliConfig.getClientConfig());
 
     cli = cliMain.getCLI();
 
@@ -450,9 +462,16 @@ public class CLIMainTest extends CLITestBase {
   public void testNamespaces() throws Exception {
     final String name = PREFIX + "testNamespace";
     final String description = "testDescription";
+    final String keytab = "keytab";
+    final String principal = "principal";
+    final String hbaseNamespace = "hbase";
+    final String hiveDatabase = "hiveDB";
+    final String schedulerQueueName = "queue";
+    File rootdir = TEMPORARY_FOLDER.newFolder("rootdir");
+    final String rootDirectory = rootdir.getAbsolutePath();
     final String defaultFields = PREFIX + "defaultFields";
     final String doesNotExist = "doesNotExist";
-
+    createHiveDB(hiveDatabase);
     // initially only default namespace should be present
     NamespaceMeta defaultNs = new NamespaceMeta.Builder()
       .setName("default").setDescription("Default Namespace").build();
@@ -468,11 +487,16 @@ public class CLIMainTest extends CLITestBase {
 //                              String.format("Error: namespace '%s' was not found", doesNotExist));
 
     // create a namespace
-    String command = String.format("create namespace %s %s", name, description);
+    String command = String.format("create namespace %s description %s principal %s keytab-URI %s " +
+                                     "hbase-namespace %s hive-database %s root-directory %s scheduler-queue-name %s",
+                                   name, description, principal, keytab, hbaseNamespace,
+                                   hiveDatabase, rootDirectory, schedulerQueueName);
     testCommandOutputContains(cli, command, String.format("Namespace '%s' created successfully.", name));
 
     NamespaceMeta expected = new NamespaceMeta.Builder()
-      .setName(name).setDescription(description).build();
+      .setName(name).setDescription(description).setPrincipal(principal).setKeytabURI(keytab)
+      .setHBaseNamespace(hbaseNamespace).setSchedulerQueueName(schedulerQueueName)
+      .setHiveDatabase(hiveDatabase).setRootDirectory(rootDirectory).build();
     expectedNamespaces = Lists.newArrayList(defaultNs, expected);
     // list namespaces and verify
     testNamespacesOutput(cli, "list namespaces", expectedNamespaces);
@@ -503,6 +527,7 @@ public class CLIMainTest extends CLITestBase {
     // TODO: uncomment when fixed - this makes build hang since it requires confirmation from user
 //    command = String.format("delete namespace %s", name);
 //    testCommandOutputContains(cli, command, String.format("Namespace '%s' deleted successfully.", name));
+    dropHiveDb(hiveDatabase);
   }
 
   @Test
@@ -666,11 +691,12 @@ public class CLIMainTest extends CLITestBase {
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     PrintStream output = new PrintStream(outputStream);
     Table table = Table.builder()
-      .setHeader("name", "description")
+      .setHeader("name", "description", "config")
       .setRows(expected, new RowMaker<NamespaceMeta>() {
         @Override
         public List<?> makeRow(NamespaceMeta object) {
-          return Lists.newArrayList(object.getName(), object.getDescription());
+          return Lists.newArrayList(object.getName(), object.getDescription(),
+                                    NamespaceCommandUtils.prettyPrintNamespaceConfigCLI(object.getConfig()));
         }
       }).build();
     cliMain.getTableRenderer().render(cliConfig, output, table);
@@ -700,5 +726,24 @@ public class CLIMainTest extends CLITestBase {
         return null;
       }
     });
+  }
+
+  private static void createHiveDB(String hiveDb) throws Exception {
+    ListenableFuture<ExploreExecutionResult> future =
+      queryClient.execute(NamespaceId.DEFAULT.toId(), "create database " + hiveDb);
+    assertExploreQuerySuccess(future);
+    future = queryClient.execute(NamespaceId.DEFAULT.toId(), "describe database " + hiveDb);
+    assertExploreQuerySuccess(future);
+  }
+
+  private static void dropHiveDb(String hiveDb) throws Exception {
+    assertExploreQuerySuccess(queryClient.execute(NamespaceId.DEFAULT.toId(), "drop database " + hiveDb));
+  }
+
+  private static void assertExploreQuerySuccess(
+    ListenableFuture<ExploreExecutionResult> dbCreationFuture) throws Exception {
+    ExploreExecutionResult exploreExecutionResult = dbCreationFuture.get(10, TimeUnit.SECONDS);
+    QueryStatus status = exploreExecutionResult.getStatus();
+    Assert.assertEquals(QueryStatus.OpStatus.FINISHED, status.getStatus());
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
@@ -77,7 +77,13 @@ public enum ArgumentName {
   FREQUENCY("frequency"),
 
   NAMESPACE_NAME("namespace-name"),
-  NAMESPACE_DESCRIPTION("namespace-description"),
+  NAMESPACE_DESCRIPTION("description"),
+  NAMESPACE_PRINCIPAL("principal"),
+  NAMESPACE_KEYTAB_PATH("keytab-URI"),
+  NAMESPACE_HBASE_NAMESPACE("hbase-namespace"),
+  NAMESPACE_HIVE_DATABASE("hive-database"),
+  NAMESPACE_ROOT_DIR("root-directory"),
+  NAMESPACE_SCHEDULER_QUEUENAME("scheduler-queue-name"),
 
   INSTANCE("instance-id"),
   COMMAND_CATEGORY("command-category"),

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateNamespaceCommand.java
@@ -45,22 +45,38 @@ public class CreateNamespaceCommand extends AbstractCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     String name = arguments.get(ArgumentName.NAMESPACE_NAME.toString());
-    String description = arguments.get(ArgumentName.NAMESPACE_DESCRIPTION.toString(), "");
-    NamespaceMeta.Builder builder = new NamespaceMeta.Builder();
-    builder.setName(name).setDescription(description);
-    namespaceClient.create(builder.build());
 
+    String description = arguments.getOptional(ArgumentName.NAMESPACE_DESCRIPTION.toString(), null);
+    String principal = arguments.getOptional(ArgumentName.NAMESPACE_PRINCIPAL.toString(), null);
+    String keytabPath = arguments.getOptional(ArgumentName.NAMESPACE_KEYTAB_PATH.toString(), null);
+    String hbaseNamespace = arguments.getOptional(ArgumentName.NAMESPACE_HBASE_NAMESPACE.toString(), null);
+    String hiveDatabase = arguments.getOptional(ArgumentName.NAMESPACE_HIVE_DATABASE.toString(), null);
+    String schedulerQueueName = arguments.getOptional(ArgumentName.NAMESPACE_SCHEDULER_QUEUENAME.toString(), null);
+    String rootDir = arguments.getOptional(ArgumentName.NAMESPACE_ROOT_DIR.toString(), null);
+
+    NamespaceMeta.Builder builder = new NamespaceMeta.Builder();
+    builder.setName(name).setDescription(description).setPrincipal(principal).setKeytabURI(keytabPath)
+      .setRootDirectory(rootDir).setHBaseNamespace(hbaseNamespace).setHiveDatabase(hiveDatabase)
+      .setSchedulerQueueName(schedulerQueueName);
+    namespaceClient.create(builder.build());
     output.println(String.format(SUCCESS_MSG, name));
   }
 
   @Override
   public String getPattern() {
-    return String.format("create namespace <%s> [<%s>]",
-                         ArgumentName.NAMESPACE_NAME, ArgumentName.NAMESPACE_DESCRIPTION);
+    return String.format("create namespace <%s> [%s <%s>] [%s <%s>] [%s <%s>] " +
+                           "[%s <%s>] [%s <%s>] [%s <%s>] [%s <%s>]", ArgumentName.NAMESPACE_NAME,
+                         ArgumentName.NAMESPACE_DESCRIPTION, ArgumentName.NAMESPACE_DESCRIPTION,
+                         ArgumentName.NAMESPACE_PRINCIPAL, ArgumentName.NAMESPACE_PRINCIPAL,
+                         ArgumentName.NAMESPACE_KEYTAB_PATH, ArgumentName.NAMESPACE_KEYTAB_PATH,
+                         ArgumentName.NAMESPACE_HBASE_NAMESPACE, ArgumentName.NAMESPACE_HBASE_NAMESPACE,
+                         ArgumentName.NAMESPACE_HIVE_DATABASE, ArgumentName.NAMESPACE_HIVE_DATABASE,
+                         ArgumentName.NAMESPACE_ROOT_DIR, ArgumentName.NAMESPACE_ROOT_DIR,
+                         ArgumentName.NAMESPACE_SCHEDULER_QUEUENAME, ArgumentName.NAMESPACE_SCHEDULER_QUEUENAME);
   }
 
   @Override
   public String getDescription() {
-    return String.format("Creates a %s in CDAP", ElementType.NAMESPACE.getName());
+    return String.format("Creates a %s in CDAP.", ElementType.NAMESPACE.getName());
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeNamespaceCommand.java
@@ -53,11 +53,12 @@ public class DescribeNamespaceCommand extends AbstractCommand {
     Id.Namespace namespace = Id.Namespace.from(arguments.get(ArgumentName.NAMESPACE_NAME.getName()));
     NamespaceMeta namespaceMeta = namespaceClient.get(namespace);
     Table table = Table.builder()
-      .setHeader("name", "description")
+      .setHeader("name", "description", "config")
       .setRows(Lists.newArrayList(namespaceMeta), new RowMaker<NamespaceMeta>() {
         @Override
         public List<?> makeRow(NamespaceMeta object) {
-          return Lists.newArrayList(object.getName(), object.getDescription());
+          return Lists.newArrayList(object.getName(), object.getDescription(),
+                                    NamespaceCommandUtils.prettyPrintNamespaceConfigCLI(object.getConfig()));
         }
       }).build();
     cliConfig.getTableRenderer().render(cliConfig, output, table);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListNamespacesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListNamespacesCommand.java
@@ -47,11 +47,12 @@ public class ListNamespacesCommand extends AbstractCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     Table table = Table.builder()
-      .setHeader("name", "description")
+      .setHeader("name", "description", "config")
       .setRows(namespaceClient.list(), new RowMaker<NamespaceMeta>() {
         @Override
         public List<?> makeRow(NamespaceMeta object) {
-          return Lists.newArrayList(object.getName(), object.getDescription());
+          return Lists.newArrayList(object.getName(), object.getDescription(),
+                                    NamespaceCommandUtils.prettyPrintNamespaceConfigCLI(object.getConfig()));
         }
       }).build();
     cliConfig.getTableRenderer().render(cliConfig, output, table);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/NamespaceCommandUtils.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/NamespaceCommandUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.cli.command;
+
+import co.cask.cdap.proto.NamespaceConfig;
+
+/**
+ * Helper class for all utils used in Namespace Commands
+ */
+public final class NamespaceCommandUtils {
+
+  private NamespaceCommandUtils() {
+  }
+
+  /**
+   * Pretty print only non-empty field of {@link NamespaceConfig} for CLI usage
+   *
+   * @return the String to print
+   */
+  public static String prettyPrintNamespaceConfigCLI(NamespaceConfig namespaceConfig) {
+    StringBuilder builder = new StringBuilder();
+    if (!namespaceConfig.getSchedulerQueueName().isEmpty()) {
+      builder.append("scheduler-queue-name='").append(namespaceConfig.getSchedulerQueueName()).append("', ");
+    }
+    if (namespaceConfig.getRootDirectory() != null) {
+      builder.append("root-directory='").append(namespaceConfig.getRootDirectory()).append("', ");
+    }
+    if (namespaceConfig.getHbaseNamespace() != null) {
+      builder.append("hbase-namespace='").append(namespaceConfig.getHbaseNamespace()).append("', ");
+    }
+    if (namespaceConfig.getHiveDatabase() != null) {
+      builder.append("hive-database='").append(namespaceConfig.getHiveDatabase()).append("', ");
+    }
+    if (namespaceConfig.getPrincipal() != null) {
+      builder.append("principal='").append(namespaceConfig.getPrincipal()).append("', ");
+    }
+    if (namespaceConfig.getKeytabURI() != null) {
+      builder.append("keytab-URI='").append(namespaceConfig.getKeytabURI()).append("', ");
+    }
+    // Remove the final ", "
+    if (builder.length() > 0) {
+      builder.delete(builder.length() - 2, builder.length());
+    }
+    return builder.toString();
+  }
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/AbstractHBaseTableUtilTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/AbstractHBaseTableUtilTest.java
@@ -72,7 +72,7 @@ public abstract class AbstractHBaseTableUtilTest {
   private static final String CDAP_NS = "ns1";
   private static final String HBASE_NS = "custns1";
   private static final Map<String, NamespaceMeta> customMap =
-    ImmutableMap.of(CDAP_NS, new NamespaceMeta.Builder().setName(CDAP_NS).setHBaseDatabase(HBASE_NS).build());
+    ImmutableMap.of(CDAP_NS, new NamespaceMeta.Builder().setName(CDAP_NS).setHBaseNamespace(HBASE_NS).build());
 
   @BeforeClass
   public static void beforeClass() throws Exception {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceConfig.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceConfig.java
@@ -20,7 +20,6 @@ import com.google.gson.annotations.SerializedName;
 
 import java.util.Objects;
 import javax.annotation.Nullable;
-import javax.ws.rs.HEAD;
 
 /**
  * Represents the configuration of a namespace. This class needs to be GSON serializable.

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceMeta.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceMeta.java
@@ -106,7 +106,7 @@ public final class NamespaceMeta {
       return this;
     }
 
-    public Builder setHBaseDatabase(final String hbaseNamespace) {
+    public Builder setHBaseNamespace(final String hbaseNamespace) {
       this.hbaseNamespace = hbaseNamespace;
       return this;
     }


### PR DESCRIPTION
Enhance the create command of CLI.

Take an extra json of properties to construct the namespace config. 

Example usage here:

`create namespace ns1 decription "hive-database=db1 hbase-namespace=habsens1 principal=Booshan keytab-path=/path/to/keytab"`

JIRA: https://issues.cask.co/browse/CDAP-6399
buid: http://builds.cask.co/browse/CDAP-DUT4586
