### PR TITLE
Modify UpgradeTool to add version and dataset_prefix to HTableDescriptors

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
@@ -16,6 +16,7 @@
 package co.cask.cdap.data2.dataset2.lib.hbase;
 
 import co.cask.cdap.api.dataset.DatasetAdmin;
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.utils.ProjectInfo;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
@@ -63,13 +64,16 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
 
   protected final TableId tableId;
   protected final Configuration hConf;
+  protected final CConfiguration cConf;
   protected final HBaseTableUtil tableUtil;
 
   private HBaseAdmin admin;
 
-  protected AbstractHBaseDataSetAdmin(TableId tableId, Configuration hConf, HBaseTableUtil tableUtil) {
+  protected AbstractHBaseDataSetAdmin(TableId tableId, Configuration hConf, CConfiguration cConf,
+                                      HBaseTableUtil tableUtil) {
     this.tableId = tableId;
     this.hConf = hConf;
+    this.cConf = cConf;
     this.tableUtil = tableUtil;
   }
 
@@ -157,6 +161,7 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
     }
 
     HBaseTableUtil.setVersion(newDescriptor);
+    HBaseTableUtil.setTablePrefix(newDescriptor, cConf);
 
     LOG.info("Updating table '{}'...", tableId);
     boolean enableTable = false;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
@@ -62,7 +62,7 @@ public class HBaseTableAdmin extends AbstractHBaseDataSetAdmin implements Updata
                          CConfiguration conf,
                          LocationFactory locationFactory) throws IOException {
     super(tableUtil.createHTableId(new NamespaceId(datasetContext.getNamespaceId()), spec.getName()),
-          hConf, tableUtil);
+          hConf, conf, tableUtil);
     this.spec = spec;
     this.conf = conf;
     this.locationFactory = locationFactory;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
@@ -174,7 +174,7 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin implements ProgramContex
     createStateStoreDataset(queueName.getFirstComponent());
 
     TableId tableId = getDataTableId(queueName);
-    try (DatasetAdmin dsAdmin = new DatasetAdmin(tableId, hConf, tableUtil, properties)) {
+    try (DatasetAdmin dsAdmin = new DatasetAdmin(tableId, hConf, cConf, tableUtil, properties)) {
       dsAdmin.create();
     }
   }
@@ -414,7 +414,7 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin implements ProgramContex
   }
 
   private void upgrade(TableId tableId, Properties properties) throws Exception {
-    try (AbstractHBaseDataSetAdmin dsAdmin = new DatasetAdmin(tableId, hConf, tableUtil, properties)) {
+    try (AbstractHBaseDataSetAdmin dsAdmin = new DatasetAdmin(tableId, hConf, cConf, tableUtil, properties)) {
       dsAdmin.upgrade();
     }
   }
@@ -450,8 +450,9 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin implements ProgramContex
   private final class DatasetAdmin extends AbstractHBaseDataSetAdmin {
     private final Properties properties;
 
-    private DatasetAdmin(TableId tableId, Configuration hConf, HBaseTableUtil tableUtil, Properties properties) {
-      super(tableId, hConf, tableUtil);
+    private DatasetAdmin(TableId tableId, Configuration hConf, CConfiguration cConf,
+                         HBaseTableUtil tableUtil, Properties properties) {
+      super(tableId, hConf, cConf, tableUtil);
       this.properties = properties;
     }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
@@ -116,9 +116,7 @@ public abstract class HBaseTableUtil {
   protected NamespaceQueryAdmin namespaceQueryAdmin;
 
   public void setCConf(CConfiguration cConf) {
-    if (cConf != null) {
-      this.tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
-    }
+    this.tablePrefix = getTablePrefix(cConf);
   }
 
   public void setNamespaceQueryAdmin(NamespaceQueryAdmin namespaceQueryAdmin) {
@@ -302,6 +300,14 @@ public abstract class HBaseTableUtil {
 
   // For simplicity we allow max 255 splits per bucket for now
   private static final int MAX_SPLIT_COUNT_PER_BUCKET = 0xff;
+
+  public static void setTablePrefix(HTableDescriptorBuilder tableDescriptorBuilder, CConfiguration cConf) {
+    tableDescriptorBuilder.setValue(Constants.Dataset.TABLE_PREFIX, getTablePrefix(cConf));
+  }
+
+  private static String getTablePrefix(@Nullable CConfiguration cConf) {
+    return cConf == null ? null : cConf.get(Constants.Dataset.TABLE_PREFIX);
+  }
 
   public static void setVersion(HTableDescriptorBuilder tableDescriptorBuilder) {
     tableDescriptorBuilder.setValue(CDAP_VERSION, ProjectInfo.getVersion().toString());


### PR DESCRIPTION
JIRA : https://issues.cask.co/browse/CDAP-6450
Build : http://builds.cask.co/browse/CDAP-DUT4588-1

Blocker: https://issues.cask.co/browse/CDAP-6870

This will add cdap.version and dataset.table.prefix to all CDAP Tables (except cdap_system:configuration and cdap_system:cdap.services.instances).

Note: The two tables which are not updated are not created using DatasetAdmin or QueueAdmin. But since they don't use coprocessors, it should not be a problem. Currently I don't think there is even a way to update these tables other than hardcoding their names in the UpgradeTool.
