### PR TITLE
CDAP-6864 authorization for system datasets

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -45,6 +45,7 @@ import co.cask.common.http.HttpResponse;
 import com.google.common.base.Joiner;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
@@ -52,6 +53,7 @@ import com.google.common.io.InputSupplier;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.authentication.util.KerberosName;
 import org.apache.twill.discovery.Discoverable;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.filesystem.Location;
@@ -86,7 +88,7 @@ class DatasetServiceClient {
   private final boolean securityEnabled;
   private final boolean kerberosEnabled;
   private final AuthenticationContext authenticationContext;
-  private final String masterPrincipal;
+  private final String masterPrincipalShortName;
 
   DatasetServiceClient(final DiscoveryServiceClient discoveryClient, NamespaceId namespaceId,
                        CConfiguration cConf, AuthenticationContext authenticationContext) {
@@ -102,7 +104,12 @@ class DatasetServiceClient {
     this.securityEnabled = cConf.getBoolean(Constants.Security.ENABLED);
     this.kerberosEnabled = SecurityUtil.isKerberosEnabled(cConf);
     this.authenticationContext = authenticationContext;
-    this.masterPrincipal = cConf.get(Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL);
+    try {
+      this.masterPrincipalShortName =
+        new KerberosName(cConf.get(Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL)).getShortName();
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
   }
 
   @Nullable
@@ -327,7 +334,9 @@ class DatasetServiceClient {
     }
     String userId;
     if (NamespaceId.SYSTEM.equals(namespaceId) &&
-      (!kerberosEnabled || masterPrincipal.equals(UserGroupInformation.getCurrentUser().getUserName()))) {
+      // we compare short name, because in some YARN containers launched by CDAP, the current username isn't the full
+      // configured principal
+      (!kerberosEnabled || UserGroupInformation.getCurrentUser().getShortUserName().equals(masterPrincipalShortName))) {
       // For getting a system dataset like MDS, use the system principal, if the current user is the same as the
       // CDAP kerberos principal. If a user tries to access a system dataset from an app, either:
       // 1. The request will go through if the user is impersonating as the cdap principal - which means that
@@ -336,7 +345,7 @@ class DatasetServiceClient {
       // 3. The request will go through, if kerberos is disabled
       LOG.debug("Acessing dataset in system namespace using the system principal because the current user's " +
                   "kerberos principal {} is the same as the CDAP master's kerberos principal {}.",
-                masterPrincipal, UserGroupInformation.getCurrentUser().getUserName());
+                masterPrincipalShortName, UserGroupInformation.getCurrentUser().getShortUserName());
       userId = Principal.SYSTEM.getName();
     } else {
       // If the request originated from the router and was forwarded to any service other than dataset service, before


### PR DESCRIPTION
When checking if the current user is cdap system user, use the short name of the UGI, since the full name may not be set in YARN containers

https://issues.cask.co/browse/CDAP-6864
http://builds.cask.co/browse/CDAP-DUT4593-1
