### PR TITLE
Avoid recording lineage for queue state store and stream state store.

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetAdminService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetAdminService.java
@@ -257,7 +257,7 @@ public class DatasetAdminService {
   }
 
   //TODO: CDAP-4627 - Figure out a better way to identify system datasets in user namespaces
-  private boolean isUserDataset(Id.DatasetInstance datasetInstanceId) {
+  public static boolean isUserDataset(Id.DatasetInstance datasetInstanceId) {
     return !Id.Namespace.SYSTEM.equals(datasetInstanceId.getNamespace()) &&
       !"system.queue.config".equals(datasetInstanceId.getId()) &&
       !datasetInstanceId.getId().startsWith("system.sharded.queue") &&

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriterDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriterDatasetFramework.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data2.audit.AuditPublisher;
 import co.cask.cdap.data2.audit.AuditPublishers;
+import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetAdminService;
 import co.cask.cdap.data2.datafabric.dataset.type.ConstantClassLoaderProvider;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
@@ -151,7 +152,7 @@ public class LineageWriterDatasetFramework extends ForwardingDatasetFramework im
       // For non-system dataset, always perform authorization and lineage.
       AuthorizationEnforcer enforcer;
       DefaultDatasetRuntimeContext.DatasetAccessRecorder accessRecorder;
-      if (Id.Namespace.SYSTEM.equals(datasetInstanceId.getNamespace())) {
+      if (!DatasetAdminService.isUserDataset(datasetInstanceId)) {
         enforcer = SYSTEM_NAMESPACE_ENFORCER;
         accessRecorder = SYSTEM_NAMESPACE_ACCESS_RECORDER;
       } else {


### PR DESCRIPTION
Avoid recording lineage for queue state store and stream state store.

Note: see https://github.com/caskdata/cdap/pull/6179#issuecomment-236849633

Resolves:

```
Caused by: java.lang.NullPointerException: null
        at co.cask.cdap.data2.audit.AuditPublishers.publishAccess(AuditPublishers.java:90) ~[cdap-data-fabric-3.5.0.jar:na]
        at co.cask.cdap.data2.metadata.writer.LineageWriterDatasetFramework.publishAudit(LineageWriterDatasetFramework.java:200) ~[cdap-data-fabric-3.5.0.jar:na]
        at co.cask.cdap.data2.metadata.writer.LineageWriterDatasetFramework.writeLineage(LineageWriterDatasetFramework.java:180) ~[cdap-data-fabric-3.5.0.jar:na]
        at co.cask.cdap.data2.metadata.writer.LineageWriterDatasetFramework$BasicDatasetAccessRecorder.recordLineage(LineageWriterDatasetFramework.java:224) ~[cdap-data-fabric-3.5.0.jar:na]
        at co.cask.cdap.data2.dataset2.DefaultDatasetRuntimeContext.recordAccess(DefaultDatasetRuntimeContext.java:171) ~[cdap-data-fabric-3.5.0.jar:na]
        at co.cask.cdap.data2.dataset2.DefaultDatasetRuntimeContext.onMethodEntry(DefaultDatasetRuntimeContext.java:159) ~[cdap-data-fabric-3.5.0.jar:na]
        at co.cask.cdap.data2.dataset2.lib.table.AbstractTable.<init>(AbstractTable.java:73) ~[na:na]
        at co.cask.cdap.data2.dataset2.lib.table.BufferingTable.<init>(BufferingTable.java:137) ~[na:na]
        at co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTable.<init>(HBaseTable.java:98) ~[na:na]
        at co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTableDefinition.getDataset(HBaseTableDefinition.java:50) ~[cdap-data-fabric-3.5.0.jar:na]
        at co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTableDefinition.getDataset(HBaseTableDefinition.java:34) ~[cdap-data-fabric-3.5.0.jar:na]
        at co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueDatasetModule$HBaseConsumerStateStoreDefinition.getDataset(HBaseQueueDatasetModule.java:89) ~[cdap-data-fabric-3.5.0.jar:na]
        at co.cask.cdap.data2.transaction.queue.hbase.HBaseQueueDatasetModule$HBaseConsumerStateStoreDefinition.getDataset(HBaseQueueDatasetModule.java:58) ~[cdap-data-fabric-3.5.0.jar:na]
        at co.cask.cdap.data2.datafabric.dataset.DatasetType.getDataset(DatasetType.java:73) ~[cdap-data-fabric-3.5.0.jar:na]
        at co.cask.cdap.data2.datafabric.dataset.RemoteDatasetFramework.getDataset(RemoteDatasetFramework.java:249) ~[cdap-data-fabric-3.5.0.jar:na]
        at co.cask.cdap.data2.dataset2.ForwardingDatasetFramework.getDataset(ForwardingDatasetFramework.java:160) ~[cdap-data-fabric-3.5.0.jar:na]
        at co.cask.cdap.data2.metadata.writer.LineageWriterDatasetFramework.access$101(LineageWriterDatasetFramework.java:50) ~[cdap-data-fabric-3.5.0.jar:na]
        at co.cask.cdap.data2.metadata.writer.LineageWriterDatasetFramework$2.call(LineageWriterDatasetFramework.java:166) ~[cdap-data-fabric-3.5.0.jar:na]
        at co.cask.cdap.data2.metadata.writer.LineageWriterDatasetFramework$2.call(LineageWriterDatasetFramework.java:163) ~[cdap-data-fabric-3.5.0.jar:na]
        at co.cask.cdap.data2.dataset2.DefaultDatasetRuntimeContext.execute(DefaultDatasetRuntimeContext.java:115) ~[cdap-data-fabric-3.5.0.jar:na]
        at co.cask.cdap.data2.metadata.writer.LineageWriterDatasetFramework.getDataset(LineageWriterDatasetFramework.java:162) ~[cdap-data-fabric-3.5.0.jar:na]
        ... 16 common frames omitted
```
