### PR TITLE
Install chromium-browser

### DIFF
--- a/cdap-distributions/src/packer/scripts/lxde.sh
+++ b/cdap-distributions/src/packer/scripts/lxde.sh
@@ -15,11 +15,12 @@
 # the License.
 
 #
-# Install and configure fluxbox
+# Install and configure lxde
 #
 
 # Install
 apt-get install -y --no-install-recommends lxde
+apt-get install -y --no-install-recommends chromium-browser
 
 # Symlink idea
 ln -sf /opt/idea* /opt/idea || (echo "Unable to symlink IDEA" && exit 1)


### PR DESCRIPTION
We added `--no-install-recommends` in #6002 but `chromium-browser` is a `recommends` for `lxde`. This will explicitly install it into the system.
