### PR TITLE
Fixes for CDAP-6115, CDAP-6121, CDAP-6206

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -22,7 +22,10 @@ import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.common.PropertyProvider;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -35,18 +38,20 @@ public final class SparkSpecification implements ProgramSpecification, PropertyP
   private final String name;
   private final String description;
   private final String mainClassName;
+  private final Set<String> datasets;
   private final Map<String, String> properties;
   private final Resources driverResources;
   private final Resources executorResources;
 
   public SparkSpecification(String className, String name, String description,
-                            String mainClassName, Map<String, String> properties,
+                            String mainClassName, Set<String> datasets, Map<String, String> properties,
                             @Nullable Resources driverResources, @Nullable Resources executorResources) {
     this.className = className;
     this.name = name;
     this.description = description;
     this.mainClassName = mainClassName;
-    this.properties = Collections.unmodifiableMap(properties);
+    this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
+    this.datasets = Collections.unmodifiableSet(new HashSet<>(datasets));
     this.driverResources = driverResources;
     this.executorResources = executorResources;
   }
@@ -76,6 +81,13 @@ public final class SparkSpecification implements ProgramSpecification, PropertyP
   @Override
   public Map<String, String> getProperties() {
     return properties;
+  }
+
+  /**
+   * Returns the set of static datasets used by the Spark program.
+   */
+  public Set<String> getDatasets() {
+    return datasets;
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/InMemoryConfigurator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/InMemoryConfigurator.java
@@ -166,7 +166,8 @@ public final class InMemoryConfigurator implements Configurator {
               // Spark is not available, it is most likely caused by missing Spark in the platform
               throw new IllegalStateException(
                 "Missing Spark related class " + missingClass +
-                  ". It may be caused by unavailability of Spark in the platform.", t);
+                  ". It may be caused by unavailability of Spark. " +
+                  "Please verify environment variable " + SparkUtils.SPARK_HOME + " is set correctly", t);
             }
 
             // Spark is available, can be caused by incompatible Spark version
@@ -177,7 +178,7 @@ public final class InMemoryConfigurator implements Configurator {
 
           }
           // If Spark is available or the missing class is not a spark related class,
-          // then the missing class is most lifely due to some missing library in the artifact jar
+          // then the missing class is most likely due to some missing library in the artifact jar
           throw new InvalidArtifactException(
             "Missing class " + missingClass +
               ". It may be caused by missing dependency jar(s) in the artifact jar.", t);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationRegistrationStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationRegistrationStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -24,6 +24,7 @@ import co.cask.cdap.api.flow.FlowletDefinition;
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
 import co.cask.cdap.api.service.ServiceSpecification;
 import co.cask.cdap.api.service.http.HttpServiceHandlerSpecification;
+import co.cask.cdap.api.spark.SparkSpecification;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.registry.UsageRegistry;
@@ -91,6 +92,13 @@ public class ApplicationRegistrationStage extends AbstractStage<ApplicationWithP
       if (inputDatasetName != null && inputDatasetName.startsWith(Constants.Stream.URL_PREFIX)) {
         StreamBatchReadable stream = new StreamBatchReadable(URI.create(inputDatasetName));
         usageRegistry.register(programId, namespaceId.stream(stream.getStreamName()).toId());
+      }
+    }
+
+    for (SparkSpecification sparkSpec : appSpec.getSpark().values()) {
+      Id.Program programId = appId.spark(sparkSpec.getName()).toId();
+      for (String dataset : sparkSpec.getDatasets()) {
+        usageRegistry.register(programId, namespaceId.dataset(dataset).toId());
       }
     }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -102,7 +102,7 @@ final class BasicMapReduceContext extends AbstractContext implements MapReduceCo
                         @Nullable PluginInstantiator pluginInstantiator,
                         SecureStore secureStore,
                         SecureStoreManager secureStoreManager) {
-    super(program, programOptions, Collections.<String>emptySet(), dsFramework, txClient, discoveryServiceClient, false,
+    super(program, programOptions, spec.getDataSets(), dsFramework, txClient, discoveryServiceClient, false,
           metricsCollectionService, createMetricsTags(workflowProgramInfo), secureStore, secureStoreManager,
           pluginInstantiator);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkUtils.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/spark/SparkUtils.java
@@ -53,7 +53,7 @@ public final class SparkUtils {
   // Environment variable name for locating spark assembly jar file
   private static final String SPARK_ASSEMBLY_JAR = "SPARK_ASSEMBLY_JAR";
   // Environment variable name for locating spark home directory
-  private static final String SPARK_HOME = Constants.SPARK_HOME;
+  public static final String SPARK_HOME = Constants.SPARK_HOME;
 
   // File name of the Spark conf directory as defined by the Spark framework
   // This is for the Hack to workaround CDAP-5019 (SPARK-13441)

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowActionConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowActionConfigurer.java
@@ -39,27 +39,18 @@ import java.util.Set;
 @Deprecated
 public class DefaultWorkflowActionConfigurer implements WorkflowActionConfigurer {
 
-  private final String className;
-  private final Map<String, String> propertyFields;
-  private final Set<String> datasetFields;
-
+  private final WorkflowAction workflowAction;
   private String name;
   private String description;
   private Map<String, String> properties;
   private Set<String> datasets;
 
   private DefaultWorkflowActionConfigurer(WorkflowAction workflowAction) {
+    this.workflowAction = workflowAction;
     this.name = workflowAction.getClass().getSimpleName();
     this.description = "";
-    this.className = workflowAction.getClass().getName();
-    this.propertyFields = new HashMap<>();
-    this.datasetFields = new HashSet<>();
     this.properties = new HashMap<>();
     this.datasets = new HashSet<>();
-
-    Reflections.visit(workflowAction, workflowAction.getClass(),
-                      new PropertyFieldExtractor(propertyFields),
-                      new DataSetFieldExtractor(datasetFields));
   }
 
   @Override
@@ -89,11 +80,11 @@ public class DefaultWorkflowActionConfigurer implements WorkflowActionConfigurer
   }
 
   private DefaultWorkflowActionSpecification createSpecification() {
-    Map<String, String> properties = new HashMap<>(this.properties);
-    properties.putAll(propertyFields);
-    Set<String> datasets = new HashSet<>(this.datasets);
-    datasets.addAll(datasetFields);
-    return new DefaultWorkflowActionSpecification(className, name, description, properties, datasets);
+    Reflections.visit(workflowAction, workflowAction.getClass(),
+                      new PropertyFieldExtractor(properties),
+                      new DataSetFieldExtractor(datasets));
+    return new DefaultWorkflowActionSpecification(workflowAction.getClass().getName(), name,
+                                                  description, properties, datasets);
   }
 
   public static WorkflowActionSpecification configureAction(WorkflowAction action) {

--- a/cdap-common/src/main/java/co/cask/cdap/internal/io/DatumWriterGenerator.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/io/DatumWriterGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -404,9 +404,15 @@ final class DatumWriterGenerator {
     TypeToken<?> encodeType = type;
     mg.loadArg(encoder);
     mg.loadArg(value);
-    if (Primitives.isWrapperType(encodeType.getRawType())) {
+
+    boolean isPrimitiveBoxType = Primitives.isWrapperType(encodeType.getRawType());
+    if (encodeType.getRawType().isPrimitive() || isPrimitiveBoxType) {
+      // Unwrap it if it is boxed type, otherwise it won't change the encodeType.
       encodeType = TypeToken.of(Primitives.unwrap(encodeType.getRawType()));
-      mg.unbox(Type.getType(encodeType.getRawType()));
+
+      if (isPrimitiveBoxType) {
+        mg.unbox(Type.getType(encodeType.getRawType()));
+      }
       // A special case since INT type represents (byte, char, short and int).
       if (schema.getType() == Schema.Type.INT && !int.class.equals(encodeType.getRawType())) {
         encodeType = TypeToken.of(int.class);

--- a/cdap-common/src/test/java/co/cask/cdap/io/ASMDatumCodecTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/io/ASMDatumCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -59,7 +59,7 @@ public class ASMDatumCodecTest {
   /**
    *
    */
-  public static enum TestEnum {
+  public enum TestEnum {
     VALUE1, VALUE2, VALUE3, VALUE4
   }
 
@@ -252,7 +252,7 @@ public class ASMDatumCodecTest {
     private List<String> list;
     private TestEnum e;
 
-    public Record(int i, String s, List<String> list, TestEnum e) {
+    Record(int i, String s, List<String> list, TestEnum e) {
       this.i = i;
       this.s = s;
       this.list = list;
@@ -333,12 +333,14 @@ public class ASMDatumCodecTest {
    *
    */
   public static final class Node {
-    public int data;
+    public short data;
+    public Short boxedData;
     public Node left;
     public Node right;
 
-    public Node(int data, Node left, Node right) {
+    public Node(short data, Node left, Node right) {
       this.data = data;
+      this.boxedData = data;
       this.left = left;
       this.right = right;
     }
@@ -372,7 +374,11 @@ public class ASMDatumCodecTest {
     PipedInputStream is = new PipedInputStream(os);
 
     DatumWriter<Node> writer = getWriter(type);
-    Node root = new Node(1, new Node(2, null, new Node(3, null, null)), new Node(4, new Node(5, null, null), null));
+    Node root = new Node((short) 1,
+                         new Node((short) 2, null,
+                                  new Node((short) 3, null, null)),
+                         new Node((short) 4,
+                                  new Node((short) 5, null, null), null));
     writer.encode(root, new BinaryEncoder(os));
 
     ReflectionDatumReader<Node> reader = new ReflectionDatumReader<>(getSchema(type), type);
@@ -408,8 +414,8 @@ public class ASMDatumCodecTest {
     long startTime;
     long endTime;
 
-    Node writeValue = new Node(1, new Node(2, null, new Node(3, null, null)),
-                               new Node(4, new Node(5, null, null), null));
+    Node writeValue = new Node((short) 1, new Node((short) 2, null, new Node((short) 3, null, null)),
+                               new Node((short) 4, new Node((short) 5, null, null), null));
 
     DatumWriter<Node> writer = getWriter(type);
     startTime = System.nanoTime();

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/SparkSpecificationCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/SparkSpecificationCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *  
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -27,6 +27,7 @@ import com.google.gson.JsonSerializationContext;
 
 import java.lang.reflect.Type;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -42,6 +43,7 @@ public final class SparkSpecificationCodec extends AbstractSpecificationCodec<Sp
     jsonObj.add("name", new JsonPrimitive(src.getName()));
     jsonObj.add("description", new JsonPrimitive(src.getDescription()));
     jsonObj.add("mainClassName", new JsonPrimitive(src.getMainClassName()));
+    jsonObj.add("datasets", serializeSet(src.getDatasets(), context, String.class));
     jsonObj.add("properties", serializeMap(src.getProperties(), context, String.class));
 
     if (src.getDriverResources() != null) {
@@ -63,13 +65,14 @@ public final class SparkSpecificationCodec extends AbstractSpecificationCodec<Sp
     String name = jsonObj.get("name").getAsString();
     String description = jsonObj.get("description").getAsString();
     String mainClassName = jsonObj.get("mainClassName").getAsString();
+    Set<String> datasets = deserializeSet(jsonObj.get("datasets"), context, String.class);
     Map<String, String> properties = deserializeMap(jsonObj.get("properties"), context, String.class);
 
     Resources driverResources = deserializeResources(jsonObj, "driver", context);
     Resources executorResources = deserializeResources(jsonObj, "executor", context);
 
     return new SparkSpecification(className, name, description, mainClassName,
-                                  properties, driverResources, executorResources);
+                                  datasets, properties, driverResources, executorResources);
   }
 
   /**

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRunner.java
@@ -174,12 +174,6 @@ final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
       Spark spark;
       try {
         spark = new InstantiatorFactory(false).get(TypeToken.of(program.<Spark>getMainClass())).create();
-
-        // Fields injection
-        Reflections.visit(spark, spark.getClass(),
-                          new PropertyFieldSetter(spec.getProperties()),
-                          new DataSetFieldSetter(runtimeContext.getDatasetCache()),
-                          new MetricsFieldSetter(runtimeContext));
       } catch (Exception e) {
         LOG.error("Failed to instantiate Spark class for {}", spec.getClassName(), e);
         throw Throwables.propagate(e);

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContext.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContext.java
@@ -46,7 +46,6 @@ import org.apache.twill.api.RunId;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
 import java.io.Closeable;
-import java.util.Collections;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -76,9 +75,9 @@ public final class SparkRuntimeContext extends AbstractContext implements Metric
                       SecureStoreManager secureStoreManager,
                       AuthorizationEnforcer authorizationEnforcer,
                       AuthenticationContext authenticationContext) {
-    super(program, programOptions, Collections.<String>emptySet(), datasetFramework, txClient, discoveryServiceClient,
-          true, metricsCollectionService, createMetricsTags(workflowProgramInfo), secureStore, secureStoreManager,
-          pluginInstantiator);
+    super(program, programOptions, getSparkSpecification(program).getDatasets(), datasetFramework, txClient,
+          discoveryServiceClient, true, metricsCollectionService, createMetricsTags(workflowProgramInfo),
+          secureStore, secureStoreManager, pluginInstantiator);
 
     this.hConf = hConf;
     this.txClient = txClient;
@@ -118,9 +117,13 @@ public final class SparkRuntimeContext extends AbstractContext implements Metric
    * Returns the {@link SparkSpecification} of the spark program of this context.
    */
   public SparkSpecification getSparkSpecification() {
-    SparkSpecification spec = getApplicationSpecification().getSpark().get(getProgram().getName());
+    return getSparkSpecification(getProgram());
+  }
+
+  private static SparkSpecification getSparkSpecification(Program program) {
+    SparkSpecification spec = program.getApplicationSpecification().getSpark().get(program.getName());
     // Spec shouldn't be null, otherwise the spark program won't even get started
-    Preconditions.checkState(spec != null, "SparkSpecification not found for %s", getProgram().getId());
+    Preconditions.checkState(spec != null, "SparkSpecification not found for %s", program.getId());
     return spec;
   }
 

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/SparkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/SparkTestRun.java
@@ -38,9 +38,11 @@ import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.spark.app.CharCountProgram;
+import co.cask.cdap.spark.app.ClassicSparkProgram;
 import co.cask.cdap.spark.app.DatasetSQLSpark;
 import co.cask.cdap.spark.app.Person;
 import co.cask.cdap.spark.app.ScalaCharCountProgram;
+import co.cask.cdap.spark.app.ScalaClassicSparkProgram;
 import co.cask.cdap.spark.app.ScalaCrossNSDatasetProgram;
 import co.cask.cdap.spark.app.ScalaCrossNSStreamProgram;
 import co.cask.cdap.spark.app.ScalaSparkLogParser;
@@ -169,6 +171,10 @@ public class SparkTestRun extends TestFrameworkTestBase {
         }
       }, 10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
     }
+
+    KeyValueTable resultTable = this.<KeyValueTable>getDataset("ResultTable").get();
+    Assert.assertEquals(1L, Bytes.toLong(resultTable.read(ClassicSparkProgram.class.getName())));
+    Assert.assertEquals(1L, Bytes.toLong(resultTable.read(ScalaClassicSparkProgram.class.getName())));
   }
 
   @Test


### PR DESCRIPTION
- (CDAP-6115) Handle both primitive and boxed type upscaling
- (CDAP-6121) Allow @UseDataset usage in Spark init and destroy
  - Also did a cleanup of existing configurer code
- (CDAP-6206) Improve error message if Spark is missing
