### PR TITLE
CDAP-6911 fix data streams tests for slow machines

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsSparkLauncher.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsSparkLauncher.java
@@ -87,6 +87,8 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
     if (isUnitTest) {
       Integer numSources = Integer.valueOf(programProperties.get("cask.hydrator.num.sources"));
       sparkConf.setMaster(String.format("local[%d]", numSources + 1));
+      // without this, stopping will hang on machines with few cores.
+      sparkConf.set("spark.rpc.netty.dispatcher.numThreads", String.valueOf(numSources + 2));
     }
     context.setSparkConf(sparkConf);
   }


### PR DESCRIPTION
More specifically, if the machine has a low number of cores,
stopping can hang due to SPARK-13906.
