### PR TITLE
Upgrade checkstyle and checkstyle plugin

### DIFF
--- a/cdap-api-common/src/main/java/co/cask/cdap/api/stream/StreamEventDecoder.java
+++ b/cdap-api-common/src/main/java/co/cask/cdap/api/stream/StreamEventDecoder.java
@@ -44,7 +44,7 @@ public interface StreamEventDecoder<K, V>  {
    * @param <V> Type of value.
    */
   @NotThreadSafe
-  static final class DecodeResult<K, V> {
+  final class DecodeResult<K, V> {
     private K key;
     private V value;
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/common/Scope.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/common/Scope.java
@@ -32,7 +32,7 @@ public enum Scope {
   /**
    * Private constructor to force using the enum values.
    */
-  private Scope(String name) {
+  Scope(String name) {
     displayName = name;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/services/Data.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/services/Data.java
@@ -26,7 +26,7 @@ public enum Data {
   private final int dataType;
   private final String name;
 
-  private Data(int type, String prettyName) {
+  Data(int type, String prettyName) {
     this.dataType = type;
     this.name = prettyName;
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/verification/VerifyResult.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/verification/VerifyResult.java
@@ -25,7 +25,7 @@ public final class VerifyResult {
   /**
    * Status of verification.
    */
-  public static enum Status {
+  public enum Status {
     SUCCESS,
     FAILED
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
@@ -998,7 +998,7 @@ public class ArtifactStore {
     private final NamespaceId namespace;
     private final String className;
 
-    public AppClassKey(NamespaceId namespace, String className) {
+    AppClassKey(NamespaceId namespace, String className) {
       this.namespace = namespace;
       this.className = className;
     }
@@ -1088,7 +1088,7 @@ public class ArtifactStore {
     private final URI locationURI;
     private final ArtifactMeta meta;
 
-    public ArtifactData(Location location, ArtifactMeta meta) {
+    ArtifactData(Location location, ArtifactMeta meta) {
       this.locationURI = location.toURI();
       this.meta = meta;
     }
@@ -1100,7 +1100,7 @@ public class ArtifactStore {
     private final ArtifactRange usableBy;
     private final URI artifactLocationURI;
 
-    public PluginData(PluginClass pluginClass, ArtifactRange usableBy, Location artifactLocation) {
+    PluginData(PluginClass pluginClass, ArtifactRange usableBy, Location artifactLocation) {
       this.pluginClass = pluginClass;
       this.usableBy = usableBy;
       this.artifactLocationURI = artifactLocation.toURI();
@@ -1112,7 +1112,7 @@ public class ArtifactStore {
     private final ApplicationClass appClass;
     private final URI artifactLocationURI;
 
-    public AppData(ApplicationClass appClass, Location artifactLocation) {
+    AppData(ApplicationClass appClass, Location artifactLocation) {
       this.appClass = appClass;
       this.artifactLocationURI = artifactLocation.toURI();
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/AbstractBatchReadableInputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/AbstractBatchReadableInputFormat.java
@@ -155,7 +155,7 @@ public abstract class AbstractBatchReadableInputFormat<KEY, VALUE> extends Input
 
     private final SplitReader<KEY, VALUE> splitReader;
 
-    public SplitReaderRecordReader(final SplitReader<KEY, VALUE> splitReader) {
+    SplitReaderRecordReader(final SplitReader<KEY, VALUE> splitReader) {
       this.splitReader = splitReader;
     }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/MultipleOutputs.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/MultipleOutputs.java
@@ -266,7 +266,7 @@ public class MultipleOutputs implements Closeable {
     private final String counterName;
     private final TaskInputOutputContext context;
 
-    public MeteredRecordWriter(RecordWriter<K, V> writer, TaskInputOutputContext context) {
+    MeteredRecordWriter(RecordWriter<K, V> writer, TaskInputOutputContext context) {
       this.writer = writer;
       this.context = context;
       this.groupName = TaskCounter.class.getName();
@@ -299,7 +299,7 @@ public class MultipleOutputs implements Closeable {
 
     TaskAttemptContext context;
 
-    public WrappedStatusReporter(TaskAttemptContext context) {
+    WrappedStatusReporter(TaskAttemptContext context) {
       this.context = context;
     }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginInstantiator.java
@@ -377,7 +377,7 @@ public class PluginInstantiator implements Closeable {
     private final ArtifactId artifactId;
     private final Set<String> macroFields;
 
-    public ConfigFieldSetter(PluginClass pluginClass, ArtifactId artifactId,
+    ConfigFieldSetter(PluginClass pluginClass, ArtifactId artifactId,
                              PluginProperties properties, Set<String> macroFields) {
       this.pluginClass = pluginClass;
       this.artifactId = artifactId;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStore.java
@@ -350,7 +350,7 @@ public class DatasetBasedTimeScheduleStore extends RAMJobStore {
       this.state = state;
     }
 
-    public TriggerStatusV2() {
+    TriggerStatusV2() {
       // no-op
     }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/WorkflowDataset.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/WorkflowDataset.java
@@ -295,7 +295,7 @@ public class WorkflowDataset extends AbstractDataset {
     private final ProgramType programType;
     private final List<Long> programRunList;
 
-    public ProgramRunDetails(String name, ProgramType programType, List<Long> programRunList) {
+    ProgramRunDetails(String name, ProgramType programType, List<Long> programRunList) {
       this.name = name;
       this.programType = programType;
       this.programRunList = programRunList;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/security/ApplicationPermissionCollection.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/security/ApplicationPermissionCollection.java
@@ -47,7 +47,7 @@ class ApplicationPermissionCollection extends PermissionCollection {
   /**
    * Constructor that defines some predefined {@link Permission}
    */
-  public ApplicationPermissionCollection() {
+  ApplicationPermissionCollection() {
     perms.add(new RuntimePermission("getenv.*"));
     perms.add(new RuntimePermission("setContextClassLoader"));
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/security/hive/JobHistoryServerTokenUtils.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/security/hive/JobHistoryServerTokenUtils.java
@@ -83,7 +83,7 @@ public final class JobHistoryServerTokenUtils {
    */
   private static class MRClientCache extends ClientCache {
 
-    public MRClientCache(Configuration conf, ResourceMgrDelegate rm) {
+    MRClientCache(Configuration conf, ResourceMgrDelegate rm) {
       super(conf, rm);
     }
 

--- a/cdap-app-fabric/src/main/java/org/apache/hadoop/mapred/LocalDistributedCacheManagerWithFix.java
+++ b/cdap-app-fabric/src/main/java/org/apache/hadoop/mapred/LocalDistributedCacheManagerWithFix.java
@@ -78,7 +78,7 @@ class LocalDistributedCacheManagerWithFix {
   private boolean setupCalled = false;
   private JobID jobId;
 
-  public LocalDistributedCacheManagerWithFix(JobID jobId) {
+  LocalDistributedCacheManagerWithFix(JobID jobId) {
     this.jobId = jobId;
   }
 

--- a/cdap-app-fabric/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterMain.java
+++ b/cdap-app-fabric/src/main/java/org/apache/twill/internal/appmaster/ApplicationMasterMain.java
@@ -255,7 +255,7 @@ public final class ApplicationMasterMain extends ServiceMain {
     private static final Logger LOG = LoggerFactory.getLogger(AppMasterTwillZKPathService.class);
     private final ZKClient zkClient;
 
-    public AppMasterTwillZKPathService(ZKClient zkClient, RunId runId) {
+    AppMasterTwillZKPathService(ZKClient zkClient, RunId runId) {
       super(zkClient, runId);
       this.zkClient = zkClient;
     }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/MultiOutputWriter.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/MultiOutputWriter.java
@@ -31,7 +31,7 @@ class MultiOutputWriter<KEY_OUT, VAL_OUT> extends OutputWriter<KEY_OUT, VAL_OUT>
   // sink name -> outputs for that sink
   private final Map<String, SinkOutput> sinkOutputs;
 
-  public MultiOutputWriter(MapReduceTaskContext<KEY_OUT, VAL_OUT> context, Map<String, SinkOutput> sinkOutputs) {
+  MultiOutputWriter(MapReduceTaskContext<KEY_OUT, VAL_OUT> context, Map<String, SinkOutput> sinkOutputs) {
     super(context);
     this.sinkOutputs = sinkOutputs;
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/OutputWriter.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/OutputWriter.java
@@ -31,7 +31,7 @@ import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
 abstract class OutputWriter<KEY_OUT, VAL_OUT> {
   protected final MapReduceTaskContext<KEY_OUT, VAL_OUT> context;
 
-  public OutputWriter(MapReduceTaskContext<KEY_OUT, VAL_OUT> context) {
+  OutputWriter(MapReduceTaskContext<KEY_OUT, VAL_OUT> context) {
     this.context = context;
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ETLConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ETLConfig.java
@@ -173,6 +173,8 @@ public class ETLConfig extends Config {
 
   /**
    * Builder for creating configs.
+   *
+   * @param <T> The actual builder type
    */
   @SuppressWarnings("unchecked")
   public abstract static class Builder<T extends Builder> {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/macro/TimeParser.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/macro/TimeParser.java
@@ -115,7 +115,7 @@ public class TimeParser {
   private static class ValueNode implements MathNode {
     private long value;
 
-    public ValueNode(long value) {
+    ValueNode(long value) {
       this.value = value;
     }
 
@@ -128,7 +128,7 @@ public class TimeParser {
     private final MathNode left;
     private final MathNode right;
 
-    public AddNode(MathNode left, MathNode right) {
+    AddNode(MathNode left, MathNode right) {
       this.left = left;
       this.right = right;
     }
@@ -143,7 +143,7 @@ public class TimeParser {
     private final MathNode left;
     private final MathNode right;
 
-    public SubtractNode(MathNode left, MathNode right) {
+    SubtractNode(MathNode left, MathNode right) {
       this.left = left;
       this.right = right;
     }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/log/LogStageAppender.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/log/LogStageAppender.java
@@ -74,7 +74,7 @@ public class LogStageAppender extends AppenderBase<ILoggingEvent> {
     private final String eventMessage;
     private final String formattedMessage;
 
-    public StageEvent(ILoggingEvent event) {
+    StageEvent(ILoggingEvent event) {
       this.event = event;
       Map<String, String> mdcMap = event.getMDCPropertyMap();
       String stage = mdcMap.get(LogContext.STAGE);

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpec.java
@@ -106,6 +106,8 @@ public class PipelineSpec {
 
   /**
    * Base builder for creating pipeline specs.
+   *
+   * @param <T> the actual builder type
    */
   @SuppressWarnings("unchecked")
   public static class Builder<T extends Builder> {

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/v1/ETLConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/v1/ETLConfig.java
@@ -193,6 +193,8 @@ public class ETLConfig extends Config {
 
   /**
    * Builder for creating configs.
+   *
+   * @param <T> The actual builder type
    */
   @SuppressWarnings("unchecked")
   public abstract static class Builder<T extends Builder> {

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/v2/ETLConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/v2/ETLConfig.java
@@ -167,6 +167,8 @@ public class ETLConfig extends Config implements UpgradeableConfig {
 
   /**
    * Builder for creating configs.
+   *
+   * @param <T> The actual builder type
    */
   @SuppressWarnings("unchecked")
   public abstract static class Builder<T extends Builder> {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/AggregatorAggregateFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/AggregatorAggregateFunction.java
@@ -57,7 +57,7 @@ public class AggregatorAggregateFunction implements FlatMapFunction<Tuple2<Objec
     implements Transformation<Tuple2<GROUP_KEY, Iterable<GROUP_VAL>>, OUT_VAL> {
     private final BatchAggregator<GROUP_KEY, GROUP_VAL, OUT_VAL> aggregator;
 
-    public AggregateTransform(BatchAggregator<GROUP_KEY, GROUP_VAL, OUT_VAL> aggregator) {
+    AggregateTransform(BatchAggregator<GROUP_KEY, GROUP_VAL, OUT_VAL> aggregator) {
       this.aggregator = aggregator;
     }
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/AggregatorGroupByFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/AggregatorGroupByFunction.java
@@ -58,7 +58,7 @@ public class AggregatorGroupByFunction implements PairFlatMapFunction<Object, Ob
     private final BatchAggregator<GROUP_KEY, GROUP_VAL, ?> aggregator;
     private final DefaultEmitter<GROUP_KEY> keyEmitter;
 
-    public GroupByTransform(BatchAggregator<GROUP_KEY, GROUP_VAL, ?> aggregator) {
+    GroupByTransform(BatchAggregator<GROUP_KEY, GROUP_VAL, ?> aggregator) {
       this.aggregator = aggregator;
       this.keyEmitter = new DefaultEmitter<>();
     }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/JoinMergeFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/JoinMergeFunction.java
@@ -62,7 +62,7 @@ public class JoinMergeFunction implements FlatMapFunction<Tuple2<Object, List<Jo
     implements Transformation<Tuple2<JOIN_KEY, List<JoinElement<INPUT>>>, OUT> {
     private final BatchJoiner<JOIN_KEY, INPUT, OUT> joiner;
 
-    public JoinOnTransform(BatchJoiner<JOIN_KEY, INPUT, OUT> joiner) {
+    JoinOnTransform(BatchJoiner<JOIN_KEY, INPUT, OUT> joiner) {
       this.joiner = joiner;
     }
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/JoinOnFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/JoinOnFunction.java
@@ -61,7 +61,7 @@ public class JoinOnFunction implements PairFlatMapFunction<Object, Object, Objec
     private final BatchJoiner<JOIN_KEY, INPUT, ?> joiner;
     private final String inputStageName;
 
-    public JoinOnTransform(BatchJoiner<JOIN_KEY, INPUT, ?> joiner, String inputStageName) {
+    JoinOnTransform(BatchJoiner<JOIN_KEY, INPUT, ?> joiner, String inputStageName) {
       this.joiner = joiner;
       this.inputStageName = inputStageName;
     }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/CLIConfig.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/CLIConfig.java
@@ -89,7 +89,7 @@ public class CLIConfig implements TableRendererConfig {
     private final AccessToken accessToken;
     private final String username;
 
-    public UserAccessToken(AccessToken accessToken, String username) {
+    UserAccessToken(AccessToken accessToken, String username) {
       this.accessToken = accessToken;
       this.username = username;
     }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetStreamStatsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetStreamStatsCommand.java
@@ -272,7 +272,7 @@ public class GetStreamStatsCommand extends AbstractCommand {
     private static final int BUCKET_SIZE = 100;
     private final CLIConfig cliConfig;
 
-    public HistogramProcessor(CLIConfig cliConfig) {
+    HistogramProcessor(CLIConfig cliConfig) {
       this.cliConfig = cliConfig;
     }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/ScheduleCommands.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/ScheduleCommands.java
@@ -191,7 +191,7 @@ public class ScheduleCommands extends CommandSet<Command> implements Categorized
     private final ScheduleClient scheduleClient;
 
     @Inject
-    public ListWorkflowSchedulesCommand(CLIConfig cliConfig, ScheduleClient scheduleClient) {
+    ListWorkflowSchedulesCommand(CLIConfig cliConfig, ScheduleClient scheduleClient) {
       super(cliConfig);
       this.scheduleClient = scheduleClient;
     }

--- a/cdap-client-tests/src/main/java/co/cask/cdap/client/app/ConfigTestApp.java
+++ b/cdap-client-tests/src/main/java/co/cask/cdap/client/app/ConfigTestApp.java
@@ -90,7 +90,7 @@ public class ConfigTestApp extends AbstractApplication<ConfigTestApp.ConfigClass
     private final String streamName;
     private final String datasetName;
 
-    public SimpleFlow(String streamName, String datasetName) {
+    SimpleFlow(String streamName, String datasetName) {
       this.streamName = streamName;
       this.datasetName = datasetName;
     }
@@ -108,7 +108,7 @@ public class ConfigTestApp extends AbstractApplication<ConfigTestApp.ConfigClass
     @Property
     private final String datasetName;
 
-    public SimpleFlowlet(String datasetName) {
+    SimpleFlowlet(String datasetName) {
       this.datasetName = datasetName;
     }
 
@@ -124,7 +124,7 @@ public class ConfigTestApp extends AbstractApplication<ConfigTestApp.ConfigClass
     private final String streamName;
     private volatile boolean stopped;
 
-    public DefaultWorker(String streamName) {
+    DefaultWorker(String streamName) {
       this.streamName = streamName;
     }
 

--- a/cdap-client-tests/src/main/java/co/cask/cdap/client/app/ConfigurableProgramsApp.java
+++ b/cdap-client-tests/src/main/java/co/cask/cdap/client/app/ConfigurableProgramsApp.java
@@ -79,7 +79,7 @@ public class ConfigurableProgramsApp extends AbstractApplication<ConfigurablePro
     private final String stream;
     private final String dataset;
 
-    public Floh(String name, String stream, String dataset) {
+    Floh(String name, String stream, String dataset) {
       this.name = name;
       this.stream = stream;
       this.dataset = dataset;
@@ -100,7 +100,7 @@ public class ConfigurableProgramsApp extends AbstractApplication<ConfigurablePro
 
     private KeyValueTable keyValueTable;
 
-    public Flohlet(String datasetName) {
+    Flohlet(String datasetName) {
       this.datasetName = datasetName;
     }
 
@@ -122,7 +122,7 @@ public class ConfigurableProgramsApp extends AbstractApplication<ConfigurablePro
     private final String streamName;
     private volatile boolean running;
 
-    public Wurker(String streamName) {
+    Wurker(String streamName) {
       this.streamName = streamName;
     }
 

--- a/cdap-client-tests/src/main/java/co/cask/cdap/client/app/ConfigurableProgramsApp2.java
+++ b/cdap-client-tests/src/main/java/co/cask/cdap/client/app/ConfigurableProgramsApp2.java
@@ -86,7 +86,7 @@ public class ConfigurableProgramsApp2 extends AbstractApplication<ConfigurablePr
     private final String stream;
     private final String dataset;
 
-    public Floh(String name, String stream, String dataset) {
+    Floh(String name, String stream, String dataset) {
       this.name = name;
       this.stream = stream;
       this.dataset = dataset;
@@ -107,7 +107,7 @@ public class ConfigurableProgramsApp2 extends AbstractApplication<ConfigurablePr
 
     private KeyValueTable keyValueTable;
 
-    public Flohlet(String datasetName) {
+    Flohlet(String datasetName) {
       this.datasetName = datasetName;
     }
 
@@ -129,7 +129,7 @@ public class ConfigurableProgramsApp2 extends AbstractApplication<ConfigurablePr
     private final String streamName;
     private volatile boolean running;
 
-    public Wurker(String streamName) {
+    Wurker(String streamName) {
       this.streamName = streamName;
     }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/app/RunIds.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/app/RunIds.java
@@ -135,7 +135,7 @@ public final class RunIds {
   private static class RunIdImpl implements RunId {
     private final UUID id;
 
-    public RunIdImpl(UUID id) {
+    RunIdImpl(UUID id) {
       this.id = id;
     }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/ArtifactConfigReader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/ArtifactConfigReader.java
@@ -104,7 +104,7 @@ public class ArtifactConfigReader {
   private static class ArtifactRangeDeserializer implements JsonDeserializer<ArtifactRange> {
     private final Id.Namespace namespace;
 
-    public ArtifactRangeDeserializer(Id.Namespace namespace) {
+    ArtifactRangeDeserializer(Id.Namespace namespace) {
       this.namespace = namespace;
     }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Configuration.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Configuration.java
@@ -1073,7 +1073,7 @@ public class Configuration implements Iterable<Map.Entry<String, String>> {
       int at;
       int end;
 
-      public RangeNumberIterator(List<Range> ranges) {
+      RangeNumberIterator(List<Range> ranges) {
         if (ranges != null) {
           internal = ranges.iterator();
         }
@@ -1982,7 +1982,7 @@ public class Configuration implements Iterable<Map.Entry<String, String>> {
     private String currentName;
     private Iterator<String> nameIter;
 
-    public ConfigurationIterator() {
+    ConfigurationIterator() {
       nameIter = getProps().stringPropertyNames().iterator();
     }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/StringUtils.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/StringUtils.java
@@ -107,7 +107,7 @@ public class StringUtils {
    * which can be represented by a 64-bit integer.
    * TraditionalBinaryPrefix symbol are case insensitive.
    */
-  public static enum TraditionalBinaryPrefix {
+  public enum TraditionalBinaryPrefix {
     KILO(1024),
     MEGA(KILO.value << 10),
     GIGA(MEGA.value << 10),

--- a/cdap-common/src/main/java/org/apache/twill/filesystem/FileContextLocation.java
+++ b/cdap-common/src/main/java/org/apache/twill/filesystem/FileContextLocation.java
@@ -220,5 +220,7 @@ final class FileContextLocation implements Location {
   }
 
   @Override
-  public String toString() { return toURI().toString(); }
+  public String toString() {
+    return toURI().toString();
+  }
 }

--- a/cdap-common/src/main/java/org/apache/twill/internal/yarn/Hadoop21YarnAppClient.java
+++ b/cdap-common/src/main/java/org/apache/twill/internal/yarn/Hadoop21YarnAppClient.java
@@ -168,7 +168,7 @@ public final class Hadoop21YarnAppClient extends AbstractIdleService implements 
     private final YarnClient yarnClient;
     private final ApplicationId appId;
 
-    public ProcessControllerImpl(YarnClient yarnClient, ApplicationId appId) {
+    ProcessControllerImpl(YarnClient yarnClient, ApplicationId appId) {
       this.yarnClient = yarnClient;
       this.appId = appId;
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamFileType.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamFileType.java
@@ -25,7 +25,7 @@ public enum StreamFileType {
 
   private final String suffix;
 
-  private StreamFileType(String suffix) {
+  StreamFileType(String suffix) {
     this.suffix = suffix;
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/AvroStreamBodyConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/AvroStreamBodyConsumer.java
@@ -135,7 +135,7 @@ final class AvroStreamBodyConsumer extends BodyConsumer {
     private final ContentWriterFactory contentWriterFactory;
     private volatile Throwable failure;
 
-    public ContentWriterThread(InputStream contentStream, ContentWriterFactory contentWriterFactory) {
+    ContentWriterThread(InputStream contentStream, ContentWriterFactory contentWriterFactory) {
       super("avro-uploader-" + contentWriterFactory.getStream() + "-" + id.getAndIncrement());
       this.contentStream = contentStream;
       this.contentWriterFactory = contentWriterFactory;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/audit/AuditModule.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/audit/AuditModule.java
@@ -72,7 +72,7 @@ public class AuditModule extends RuntimeModule {
     private final CConfiguration cConf;
 
     @Inject
-    public KafkaAuditPublisherProvider(Injector injector, CConfiguration cConf) {
+    KafkaAuditPublisherProvider(Injector injector, CConfiguration cConf) {
       this.injector = injector;
       this.cConf = cConf;
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/InternalDatasetDropParams.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/InternalDatasetDropParams.java
@@ -27,7 +27,7 @@ final class InternalDatasetDropParams {
   private final DatasetTypeMeta typeMeta;
   private final DatasetSpecification instanceSpec;
 
-  public InternalDatasetDropParams(DatasetTypeMeta typeMeta, DatasetSpecification instanceSpec) {
+  InternalDatasetDropParams(DatasetTypeMeta typeMeta, DatasetSpecification instanceSpec) {
     this.typeMeta = typeMeta;
     this.instanceSpec = instanceSpec;
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DirectoryClassLoaderProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DirectoryClassLoaderProvider.java
@@ -95,7 +95,7 @@ public class DirectoryClassLoaderProvider implements DatasetClassLoaderProvider 
     private final URI uri;
     private final ClassLoader parentClassLoader;
 
-    public CacheKey(URI uri, ClassLoader parentClassLoader) {
+    CacheKey(URI uri, ClassLoader parentClassLoader) {
       this.uri = uri;
       this.parentClassLoader = parentClassLoader;
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/cube/MetricsTableOnTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/cube/MetricsTableOnTable.java
@@ -36,7 +36,7 @@ import javax.annotation.Nullable;
 class MetricsTableOnTable implements MetricsTable {
   private final Table table;
 
-  public MetricsTableOnTable(Table table) {
+  MetricsTableOnTable(Table table) {
     this.table = table;
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/cube/TimeSeriesInterpolator.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/cube/TimeSeriesInterpolator.java
@@ -53,8 +53,7 @@ class TimeSeriesInterpolator implements Iterable<TimeValue> {
   private final Interpolator interpolator;
   private final int resolution;
 
-  public TimeSeriesInterpolator(Collection<TimeValue> timeValues,
-                                @Nullable Interpolator interpolator, int resolution) {
+  TimeSeriesInterpolator(Collection<TimeValue> timeValues, @Nullable Interpolator interpolator, int resolution) {
     this.timeSeries = ImmutableList.copyOf(timeValues);
     this.interpolator = interpolator;
     this.resolution = resolution;
@@ -110,7 +109,7 @@ class TimeSeriesInterpolator implements Iterable<TimeValue> {
       PeekingIterator<TimeValue> iter;
       TimeValue lastValue;
 
-      public BiDirectionalPeekingIterator(PeekingIterator<TimeValue> iter) {
+      BiDirectionalPeekingIterator(PeekingIterator<TimeValue> iter) {
         this.iter = iter;
         this.lastValue = null;
       }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PathOperation.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PathOperation.java
@@ -28,7 +28,7 @@ final class PathOperation {
     CREATE, DROP
   }
 
-  public PathOperation(String relativePath, OperationType operationType) {
+  PathOperation(String relativePath, OperationType operationType) {
     this.relativePath = relativePath;
     this.operationType = operationType;
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/FuzzyRowFilter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/FuzzyRowFilter.java
@@ -146,7 +146,7 @@ public final class FuzzyRowFilter implements Filter {
 
   // Utility methods
 
-  static enum SatisfiesCode {
+  enum SatisfiesCode {
     // row satisfies fuzzy rule
     YES,
     // row doesn't satisfy fuzzy rule, but there's possible greater row that does

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/MetricHBaseTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/MetricHBaseTableUtil.java
@@ -35,7 +35,7 @@ public class MetricHBaseTableUtil {
   /**
    * Denotes version of Metric System's HBase table.
    */
-  public static enum Version {
+  public enum Version {
     VERSION_2_6_OR_LOWER,
     VERSION_2_7,
     VERSION_2_8_OR_HIGHER

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/KeyValue.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/KeyValue.java
@@ -76,7 +76,7 @@ public class KeyValue {
    * Has space for other key types to be added later.  Cannot rely on
    * enum ordinals . They change if item is removed or moved.  Do our own codes.
    */
-  public static enum Type {
+  public enum Type {
     Minimum((byte) 0),
     Put((byte) 4),
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableCore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableCore.java
@@ -491,8 +491,8 @@ public class LevelDBTableCore {
     private final byte[][] columns;
     private final FuzzyRowFilter filter;
 
-    public LevelDBScanner(DBIterator iterator, byte[] endKey,
-                          @Nullable FuzzyRowFilter filter, @Nullable byte[][] columns, @Nullable Transaction tx) {
+    LevelDBScanner(DBIterator iterator, byte[] endKey,
+                   @Nullable FuzzyRowFilter filter, @Nullable byte[][] columns, @Nullable Transaction tx) {
       this.tx = tx;
       this.endKey = endKey;
       this.iterator = iterator;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageCollapser.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageCollapser.java
@@ -96,7 +96,7 @@ public final class LineageCollapser {
     private RunId run;
     private Set<Id.NamespacedId> components;
 
-    public CollapseKeyBuilder(Id.NamespacedId data, Id.Program program) {
+    CollapseKeyBuilder(Id.NamespacedId data, Id.Program program) {
       this.data = data;
       this.program = program;
     }
@@ -136,8 +136,8 @@ public final class LineageCollapser {
     private final RunId run;
     private final Set<? extends Id.NamespacedId> components;
 
-    public CollapseKey(Id.NamespacedId data, Id.Program program, AccessType access, RunId run,
-                       Set<? extends Id.NamespacedId> components) {
+    CollapseKey(Id.NamespacedId data, Id.Program program, AccessType access, RunId run,
+                Set<? extends Id.NamespacedId> components) {
       this.data = data;
       this.program = program;
       this.access = access;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageDataset.java
@@ -525,7 +525,7 @@ public class LineageDataset extends AbstractDataset {
     private final Id.NamespacedId data;
     private final RunId runId;
 
-    public RowKey(Id.Program program, Id.NamespacedId data, RunId runId) {
+    RowKey(Id.Program program, Id.NamespacedId data, RunId runId) {
       this.program = program;
       this.data = data;
       this.runId = runId;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/queue/DequeueResult.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/queue/DequeueResult.java
@@ -67,7 +67,7 @@ public interface DequeueResult<T> extends Iterable<T> {
   /**
    * Static helper class for creating empty result of different result type.
    */
-  static final class Empty {
+  final class Empty {
     public static <T> DequeueResult<T> result() {
       return new DequeueResult<T>() {
         @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/ConsumerEntryState.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/ConsumerEntryState.java
@@ -25,7 +25,7 @@ public enum ConsumerEntryState {
 
   private final byte state;
 
-  private ConsumerEntryState(int state) {
+  ConsumerEntryState(int state) {
     this.state = (byte) state;
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/QueueEntryRow.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/QueueEntryRow.java
@@ -210,7 +210,7 @@ public class QueueEntryRow {
   /**
    * Defines if queue entry can be consumed
    */
-  public static enum CanConsume {
+  public enum CanConsume {
     YES,
     NO,
     NO_INCLUDING_ALL_OLDER

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueScanner.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueScanner.java
@@ -38,7 +38,7 @@ final class HBaseQueueScanner implements QueueScanner {
   private final int numRows;
   private final Function<byte[], byte[]> rowKeyConverter;
 
-  public HBaseQueueScanner(ResultScanner scanner, int numRows, Function<byte[], byte[]> rowKeyConverter) {
+  HBaseQueueScanner(ResultScanner scanner, int numRows, Function<byte[], byte[]> rowKeyConverter) {
     this.scanner = scanner;
     this.numRows = numRows;
     this.rowKeyConverter = rowKeyConverter;

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/service/MetaDataInfo.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/service/MetaDataInfo.java
@@ -76,7 +76,7 @@ public class MetaDataInfo {
 
     private final MetaDataInfo defaultValue;
 
-    private InfoType(MetaDataInfo defaultValue) {
+    InfoType(MetaDataInfo defaultValue) {
       this.defaultValue = defaultValue;
     }
 

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/AbstractExploreMetadataHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/AbstractExploreMetadataHttpHandler.java
@@ -89,6 +89,8 @@ public class AbstractExploreMetadataHttpHandler extends AbstractHttpHandler {
 
   /**
    * Represents the core execution of an endpoint.
+   *
+   * @param <T> type of result object from the {@link #execute(HttpRequest, HttpResponder)} method
    */
   protected interface EndpointCoreExecution<T> {
     T execute(HttpRequest request, HttpResponder responder)

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
@@ -121,7 +121,7 @@ public class ExploreRuntimeModule extends RuntimeModule {
   private static final class ExploreLocalModule extends PrivateModule {
     private final boolean isInMemory;
 
-    public ExploreLocalModule(boolean isInMemory) {
+    ExploreLocalModule(boolean isInMemory) {
       this.isInMemory = isInMemory;
     }
 
@@ -141,7 +141,7 @@ public class ExploreRuntimeModule extends RuntimeModule {
       private final CConfiguration cConf;
 
       @Inject
-      public PreviewsDirProvider(CConfiguration cConf) {
+      PreviewsDirProvider(CConfiguration cConf) {
         this.cConf = cConf;
       }
 
@@ -162,7 +162,7 @@ public class ExploreRuntimeModule extends RuntimeModule {
       private final boolean isInMemory;
 
       @Inject
-      public ExploreServiceProvider(CConfiguration cConf, Configuration hConf,
+      ExploreServiceProvider(CConfiguration cConf, Configuration hConf,
                                     @Named("explore.service.impl") ExploreService exploreService,
                                     @Named("explore.inmemory") boolean isInMemory) {
         this.exploreService = exploreService;

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetInputFormat.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetInputFormat.java
@@ -153,7 +153,7 @@ public class DatasetInputFormat implements InputFormat<Void, ObjectWritable> {
     private RecordScannable recordScannable;
     private RecordScanner recordScanner;
 
-    public DatasetRecordReader(Configuration conf, DatasetInputSplit datasetInputSplit) throws IOException {
+    DatasetRecordReader(Configuration conf, DatasetInputSplit datasetInputSplit) throws IOException {
       this.initialized = new AtomicBoolean(false);
       this.datasetAccessor = new DatasetAccessor(conf);
       this.datasetInputSplit = datasetInputSplit;

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetOutputFormat.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetOutputFormat.java
@@ -88,7 +88,7 @@ public class DatasetOutputFormat implements OutputFormat<Void, Text> {
     private final Type recordType;
     private Schema recordSchema;
 
-    public DatasetRecordWriter(DatasetAccessor datasetAccessor) {
+    DatasetRecordWriter(DatasetAccessor datasetAccessor) {
       this.datasetAccessor = datasetAccessor;
       this.recordWritable = datasetAccessor.getDataset();
       this.recordType = recordWritable.getRecordType();

--- a/cdap-formats/src/main/java/co/cask/cdap/format/AvroRecordFormat.java
+++ b/cdap-formats/src/main/java/co/cask/cdap/format/AvroRecordFormat.java
@@ -123,7 +123,7 @@ public class AvroRecordFormat extends AbstractStreamEventRecordFormat<Structured
 
     private ByteBuffer buffer;
 
-    public ByteBufferInputStream(ByteBuffer buffer) {
+    ByteBufferInputStream(ByteBuffer buffer) {
       reset(buffer);
     }
 

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterModules.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterModules.java
@@ -56,7 +56,7 @@ public class RouterModules extends RuntimeModule {
       @Provides
       @Named(Constants.Router.ADDRESS)
       @SuppressWarnings("unused")
-      public final InetAddress providesHostname(CConfiguration cConf) {
+      public InetAddress providesHostname(CConfiguration cConf) {
         return Networks.resolve(cConf.get(Constants.Router.ADDRESS),
                                 new InetSocketAddress("localhost", 0).getAddress());
       }

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementSummingScanner.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/increment/hbase96/IncrementSummingScanner.java
@@ -286,7 +286,7 @@ class IncrementSummingScanner implements RegionScanner {
     private int currentIdx;
     private final InternalScanner scanner;
 
-    public WrappedScanner(InternalScanner scanner) {
+    WrappedScanner(InternalScanner scanner) {
       this.scanner = scanner;
     }
 

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementSummingScanner.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementSummingScanner.java
@@ -286,7 +286,7 @@ class IncrementSummingScanner implements RegionScanner {
     private int currentIdx;
     private final InternalScanner scanner;
 
-    public WrappedScanner(InternalScanner scanner) {
+    WrappedScanner(InternalScanner scanner) {
       this.scanner = scanner;
     }
 

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementSummingScanner.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementSummingScanner.java
@@ -286,7 +286,7 @@ class IncrementSummingScanner implements RegionScanner {
     private int currentIdx;
     private final InternalScanner scanner;
 
-    public WrappedScanner(InternalScanner scanner) {
+    WrappedScanner(InternalScanner scanner) {
       this.scanner = scanner;
     }
 

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/increment/hbase10cdh550/IncrementSummingScanner.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/increment/hbase10cdh550/IncrementSummingScanner.java
@@ -331,7 +331,7 @@ class IncrementSummingScanner implements RegionScanner {
     private int currentIdx;
     private final InternalScanner scanner;
 
-    public WrappedScanner(InternalScanner scanner) {
+    WrappedScanner(InternalScanner scanner) {
       this.scanner = scanner;
     }
 

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/increment/hbase10/IncrementSummingScanner.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/increment/hbase10/IncrementSummingScanner.java
@@ -286,7 +286,7 @@ class IncrementSummingScanner implements RegionScanner {
     private int currentIdx;
     private final InternalScanner scanner;
 
-    public WrappedScanner(InternalScanner scanner) {
+    WrappedScanner(InternalScanner scanner) {
       this.scanner = scanner;
     }
 

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/increment/hbase11/IncrementSummingScanner.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/increment/hbase11/IncrementSummingScanner.java
@@ -336,7 +336,7 @@ class IncrementSummingScanner implements RegionScanner {
     private int currentIdx;
     private final InternalScanner scanner;
 
-    public WrappedScanner(InternalScanner scanner) {
+    WrappedScanner(InternalScanner scanner) {
       this.scanner = scanner;
     }
 

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/increment/hbase12cdh570/IncrementSummingScanner.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/increment/hbase12cdh570/IncrementSummingScanner.java
@@ -336,7 +336,7 @@ class IncrementSummingScanner implements RegionScanner {
     private int currentIdx;
     private final InternalScanner scanner;
 
-    public WrappedScanner(InternalScanner scanner) {
+    WrappedScanner(InternalScanner scanner) {
       this.scanner = scanner;
     }
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DataMigration.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DataMigration.java
@@ -60,7 +60,7 @@ public class DataMigration {
 
     private final String description;
 
-    private Action(String description) {
+    Action(String description) {
       this.description = description;
     }
 
@@ -167,7 +167,7 @@ public class DataMigration {
 
     boolean keepOldMetricsData;
 
-    public MetricsMigration(boolean keepOldMetricsData) {
+    MetricsMigration(boolean keepOldMetricsData) {
       this.keepOldMetricsData = keepOldMetricsData;
     }
 

--- a/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/kafka/KafkaMessage.java
+++ b/cdap-notifications/src/main/java/co/cask/cdap/notifications/service/kafka/KafkaMessage.java
@@ -26,7 +26,7 @@ class KafkaMessage {
   private final String messageKey;
   private final JsonElement notificationJson;
 
-  public KafkaMessage(String messageKey, JsonElement notificationJson) {
+  KafkaMessage(String messageKey, JsonElement notificationJson) {
     this.messageKey = messageKey;
     this.notificationJson = notificationJson;
   }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramType.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ProgramType.java
@@ -164,7 +164,7 @@ public enum ProgramType {
     private final String categoryName;
     private final SchedulableProgramType schedulableType;
 
-    public Parameters(String prettyName, Boolean listable, String categoryName,
+    Parameters(String prettyName, Boolean listable, String categoryName,
                       @Nullable SchedulableProgramType schedulableType) {
       if (prettyName == null) {
         throw new IllegalArgumentException("prettyName cannot be null");

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/KeyManager.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/KeyManager.java
@@ -30,7 +30,7 @@ public interface KeyManager extends Service {
    * Represents the combination of a digest computed on a message using a secret key, and the ID of the secret key
    * used to compute the digest.  Both elements are needed in order to later recompute (validate) the digest.
    */
-  public static class DigestId {
+  class DigestId {
     private final int id;
     private final byte[] digest;
 

--- a/cdap-security/src/main/java/co/cask/cdap/security/guice/SecurityModule.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/guice/SecurityModule.java
@@ -121,7 +121,7 @@ public abstract class SecurityModule extends PrivateModule {
     private final Map<String, Object> handlerMap;
 
     @Inject
-    public AuthenticationHandlerMapProvider(@Named("security.handlers.map") Map<String, Object> handlers) {
+    AuthenticationHandlerMapProvider(@Named("security.handlers.map") Map<String, Object> handlers) {
       handlerMap = new HashMap<>(handlers);
     }
 

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/JAASLoginService.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/JAASLoginService.java
@@ -181,8 +181,7 @@ public class JAASLoginService extends AbstractLifeCycle implements LoginService 
 
       if (callbackHandlerClass == null) {
         callbackHandler = new CallbackHandler() {
-          public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException
-          {
+          public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
             for (Callback callback: callbacks) {
               if (callback instanceof NameCallback) {
                 ((NameCallback) callback).setName(username);

--- a/cdap-standalone/src/main/java/co/cask/cdap/UserInterfaceService.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/UserInterfaceService.java
@@ -62,7 +62,7 @@ final class UserInterfaceService extends AbstractExecutionThreadService {
   private File sConfJsonFile;
 
   @Inject
-  public UserInterfaceService(CConfiguration cConf, SConfiguration sConf) {
+  UserInterfaceService(CConfiguration cConf, SConfiguration sConf) {
     this.cConf = cConf;
     this.sConf = sConf;
   }

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/LogMarkerFilterList.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/LogMarkerFilterList.java
@@ -26,7 +26,7 @@ package co.cask.cdap.api.log;
  */
 public class LogMarkerFilterList implements LogMarkerFilter {
   /** Set operator. */
-  public static enum Operator {
+  public enum Operator {
     /* !AND */
     MUST_PASS_ALL,
     /* !OR */

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/LogMessage.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/LogMessage.java
@@ -24,7 +24,7 @@ public interface LogMessage {
   /**
    *
    */
-  public static enum LogLevel {
+  enum LogLevel {
     TRACE,
     DEBUG,
     INFO,

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/AggregatedMetricsEmitter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/AggregatedMetricsEmitter.java
@@ -36,7 +36,7 @@ final class AggregatedMetricsEmitter implements MetricsEmitter {
   // specifies if the metric type is gauge or counter
   private final AtomicBoolean gaugeUsed;
 
-  public AggregatedMetricsEmitter(String name) {
+  AggregatedMetricsEmitter(String name) {
     if (name == null || name.isEmpty()) {
       LOG.warn("Creating emmitter with " + (name == null ? "null" : "empty") + " name, ");
     }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricQueryParser.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricQueryParser.java
@@ -75,7 +75,7 @@ final class MetricQueryParser {
     private final String code;
     private final String tagName;
 
-    private ProgramType(String code, String tagName) {
+    ProgramType(String code, String tagName) {
       this.code = code;
       this.tagName = tagName;
     }
@@ -95,7 +95,7 @@ final class MetricQueryParser {
 
     private final String id;
 
-    private MapReduceType(String id) {
+    MapReduceType(String id) {
       this.id = id;
     }
 
@@ -110,7 +110,7 @@ final class MetricQueryParser {
     HOUR(3600);
 
     private int resolution;
-    private Resolution(int resolution) {
+    Resolution(int resolution) {
       this.resolution = resolution;
     }
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/upgrade/MetricsEntityType.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/upgrade/MetricsEntityType.java
@@ -26,7 +26,7 @@ public enum MetricsEntityType {
 
   private final String type;
 
-  private MetricsEntityType(String type) {
+  MetricsEntityType(String type) {
     this.type = type;
   }
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -386,8 +386,13 @@ page at http://checkstyle.sourceforge.net/config.html -->
 
   </module>
 
+  <!--
+    Optional suppression filter. It is optional because when running with Maven, it should be the
+     checkstyle plugin who provides it. It is only used when this file is used in IntelliJ.
+    -->
   <module name="SuppressionFilter">
     <property name="file" value="suppressions.xml"/>
+    <property name="optional" value="true"/>
   </module>
 
   <module name="SuppressionCommentFilter">

--- a/pom.xml
+++ b/pom.xml
@@ -1541,7 +1541,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>2.12.1</version>
+          <version>2.17</version>
           <executions>
             <execution>
               <id>validate</id>
@@ -1559,6 +1559,13 @@
               </goals>
             </execution>
           </executions>
+          <dependencies>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>6.19</version>
+            </dependency>
+          </dependencies>
         </plugin>
 
         <!-- Scala code compilation -->
@@ -1639,7 +1646,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.12.1</version>
+        <version>2.17</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -30,6 +30,8 @@
   <suppress checks="JavadocStyle" files=".*[/\\]src[/\\](main|integration)[/\\]java[/\\].*" />
   <suppress checks="JavadocStyle" files=".*[/\\]src[/\\].*[/\\]internal[/\\].*" />
 
+  <suppress checks="RedundantModifier" files=".*[/\\]src[/\\]test[/\\]java[/\\].*" />
+
 
   <!-- copied from apache hadoop, won't fix style to keep diff minimal -->
   <suppress checks=".*" files=".*[/\\]LocalJobRunnerWithFix.java" />


### PR DESCRIPTION
```
- The upgrade allows ignoring the missing suppression.xml file
  - The file is copied and provided by the plugin
  - It is needed so that mvn can run from a different directory
- Also fixes the RedundantModifier problem detected by newer checkstyle
```
