### PR TITLE
Require either both keytab and principal or neither.

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
@@ -40,6 +40,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import org.apache.http.HttpResponse;
+import org.apache.http.util.EntityUtils;
 import org.apache.twill.filesystem.Location;
 import org.junit.Assert;
 import org.junit.Test;
@@ -166,6 +167,25 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
     Assert.assertTrue(customLocation.exists());
     // delete it manually
     Assert.assertTrue(customLocation.delete(true));
+  }
+
+  @Test
+  public void testInvalidConfiguration() throws Exception {
+    // test that the namespace create handler doesn't allow configuring only one of the following two:
+    // principal, keytabURI
+    NamespaceMeta namespaceMeta = new NamespaceMeta.Builder().setName("test_ns").setPrincipal("somePrincipal").build();
+    HttpResponse response = createNamespace(GSON.toJson(namespaceMeta), "test_ns");
+    assertResponseCode(400, response);
+    String responseMessage = EntityUtils.toString(response.getEntity());
+    Assert.assertTrue(
+      responseMessage.contains("Either neither or both of the following two configurations must be configured"));
+
+    namespaceMeta = new NamespaceMeta.Builder().setName("test_ns").setKeytabURI("/some/path").build();
+    response = createNamespace(GSON.toJson(namespaceMeta), "test_ns");
+    assertResponseCode(400, response);
+    responseMessage = EntityUtils.toString(response.getEntity());
+    Assert.assertTrue(
+      responseMessage.contains("Either neither or both of the following two configurations must be configured"));
   }
 
   @Test


### PR DESCRIPTION
For configuring impersonation, require either both keytab and principal or neither.

https://issues.cask.co/browse/CDAP-6796
http://builds.cask.co/browse/CDAP-DUT4627-3
