### PR TITLE
Update checkstyle and comment RedundantModifier

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ETLConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/ETLConfig.java
@@ -170,6 +170,8 @@ public class ETLConfig extends Config {
 
   /**
    * Builder for creating configs.
+   *
+   * @param <T> The actual builder type
    */
   @SuppressWarnings("unchecked")
   public abstract static class Builder<T extends Builder> {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamAdminModules.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamAdminModules.java
@@ -96,7 +96,7 @@ public class StreamAdminModules extends RuntimeModule {
       if (factoryName != null) {
         try {
           factoryClass = (Class<? extends AbstractStreamFileConsumerFactory>) Class.forName(factoryName.trim());
-        } catch (ClassCastException|ClassNotFoundException ex) {
+        } catch (ClassCastException | ClassNotFoundException ex) {
           // Guice frowns on throwing exceptions from Providers, but if necesary use RuntimeException
           throw new RuntimeException("Unable to obtain stream consumer factory extension class", ex);
         }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/AbstractExploreMetadataHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/AbstractExploreMetadataHttpHandler.java
@@ -89,6 +89,8 @@ public class AbstractExploreMetadataHttpHandler extends AbstractHttpHandler {
 
   /**
    * Represents the core execution of an endpoint.
+   *
+   * @param <T> The actual builder type
    */
   protected interface EndpointCoreExecution<T> {
     T execute(HttpRequest request, HttpResponder responder)

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/JAASLoginService.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/JAASLoginService.java
@@ -181,8 +181,7 @@ public class JAASLoginService extends AbstractLifeCycle implements LoginService 
 
       if (callbackHandlerClass == null) {
         callbackHandler = new CallbackHandler() {
-          public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException
-          {
+          public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
             for (Callback callback: callbacks) {
               if (callback instanceof NameCallback) {
                 ((NameCallback) callback).setName(username);

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -317,14 +317,15 @@ page at http://checkstyle.sourceforge.net/config.html -->
         -->
     </module>
 
+    <!-- Commented per Terence since there will be very little new code in this branch
     <module name="RedundantModifier">
-      <!-- Checks for redundant modifiers in:
+      <!- Checks for redundant modifiers in:
            - interface and annotation definitions,
            - the final modifier on methods of final classes, and
            - inner interface declarations that are declared as static.
-        -->
+        ->
     </module>
-
+    -->
 
     <!--
 
@@ -386,8 +387,14 @@ page at http://checkstyle.sourceforge.net/config.html -->
 
   </module>
 
+  <!--
+    Optional suppression filter. It is optional because when running with Maven, it should be the
+     checkstyle plugin who provides it. It is only used when this file is used in IntelliJ.
+    -->
+
   <module name="SuppressionFilter">
     <property name="file" value="suppressions.xml"/>
+    <property name="optional" value="true"/>
   </module>
 
   <module name="SuppressionCommentFilter">

--- a/pom.xml
+++ b/pom.xml
@@ -1430,7 +1430,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>2.12.1</version>
+          <version>2.17</version>
           <executions>
             <execution>
               <id>validate</id>
@@ -1448,6 +1448,13 @@
               </goals>
             </execution>
           </executions>
+          <dependencies>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>6.19</version>
+            </dependency>
+          </dependencies>
         </plugin>
 
         <!-- GPG signature -->
@@ -1492,7 +1499,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.12.1</version>
+        <version>2.17</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Since this branch is a bug-fix only branch, @chtyim recommended that I disable this check versus trying to fix all of the places in the code which will fail checkstyle. There was a bug in the older checkstyle that caused it to miss some of these modifiers, which has been fixed in the newer checkstyle.

http://builds.cask.co/browse/CDAP-DRC4193-5
