### PR TITLE
CDAP-6935 Fix live-info endpoint to work for Workflow, Worker, MR, Spark

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
@@ -19,7 +19,6 @@ import co.cask.cdap.api.flow.FlowSpecification;
 import co.cask.cdap.api.flow.FlowletDefinition;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.metrics.MetricsContext;
-import co.cask.cdap.app.program.Program;
 import co.cask.cdap.app.program.ProgramDescriptor;
 import co.cask.cdap.app.queue.QueueSpecification;
 import co.cask.cdap.app.queue.QueueSpecificationGenerator;

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Containers.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Containers.java
@@ -37,9 +37,9 @@ public interface Containers {
   void addContainer(Containers.ContainerInfo container);
 
   /**
-   * ContainerTypes - System Service, Flowlet and Service
+   * ContainerTypes - System Service, and for various program types
    */
-  enum ContainerType { SYSTEM_SERVICE, FLOWLET, SERVICE }
+  enum ContainerType { SYSTEM_SERVICE, FLOWLET, SERVICE, MAPREDUCE, WORKFLOW, SPARK, WORKER }
 
   /**
    * POJO holding information about container running in YARN.
@@ -54,8 +54,9 @@ public interface Containers {
     private final Integer virtualCores;
     private final Integer debugPort;
 
-    public ContainerInfo(ContainerType type, String name, @Nullable Integer instance, @Nullable String container,
-                  String host, @Nullable Integer memory, @Nullable Integer virtualCores, @Nullable Integer debugPort) {
+    public ContainerInfo(ContainerType type, String name,
+                         @Nullable Integer instance, @Nullable String container, String host,
+                         @Nullable Integer memory, @Nullable Integer virtualCores, @Nullable Integer debugPort) {
       this.type = type.name().toLowerCase();
       this.name = name;
       this.instance = instance;


### PR DESCRIPTION
Fix live-info endpoint to work for Workflow, Worker, Mapreduce, Spark.

See JIRA for the error that was happening.
The codepath for which it previously failed does not get executed in unit tests.

https://issues.cask.co/browse/CDAP-6935
http://builds.cask.co/browse/CDAP-DUT4634-1
