### PR TITLE
CDAP-6026 Cancel the workflow service only if it is started.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramController.java
@@ -96,7 +96,11 @@ final class WorkflowProgramController extends AbstractProgramController {
       @Override
       public void failed(Service.State from, Throwable failure) {
         LOG.info("Workflow service failed from {}. Un-registering service {}.", from, serviceName, failure);
-        cancelAnnounce.cancel();
+        if (cancelAnnounce != null) {
+          // if there is an exception before workflow enters into the RUNNING state, cancelAnnounce will be null
+          // since it is initialized in the running method
+          cancelAnnounce.cancel();
+        }
         LOG.info("Service {} unregistered.", serviceName);
         error(failure);
       }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-6026
When Workflow fails before announcing the service, we attempt to cancel the service which is not yet started. This throws an exception causing Workflow container to be running indefinitely. 
