### PR TITLE
(CDAP-6943) Removed the need for authorizer configuration in dataset …

### DIFF
--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -62,9 +62,9 @@ import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationTestModule;
-import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
+import co.cask.cdap.security.spi.authorization.PrivilegesManager;
 import co.cask.http.HttpHandler;
 import co.cask.tephra.TransactionManager;
 import co.cask.tephra.inmemory.InMemoryTxSystemClient;
@@ -172,14 +172,14 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
                                                             impersonator);
     DatasetInstanceManager instanceManager = new DatasetInstanceManager(txSystemClientService, txExecutorFactory,
                                                                         mdsFramework);
-    AuthorizerInstantiator authorizerInstantiator = injector.getInstance(AuthorizerInstantiator.class);
+    PrivilegesManager privilegesManager = injector.getInstance(PrivilegesManager.class);
     DatasetTypeService typeService = new DatasetTypeService(typeManager, namespaceQueryAdmin, namespacedLocationFactory,
-                                                            authorizationEnforcer, authorizerInstantiator,
+                                                            authorizationEnforcer, privilegesManager,
                                                             authenticationContext, cConf, impersonator);
     DatasetOpExecutor opExecutor = new LocalDatasetOpExecutor(cConf, discoveryServiceClient, opExecutorService);
     DatasetInstanceService instanceService = new DatasetInstanceService(
       typeManager, instanceManager, opExecutor, exploreFacade, namespaceQueryAdmin, authorizationEnforcer,
-      authorizerInstantiator, authenticationContext);
+      privilegesManager, authenticationContext);
     instanceService.setAuditPublisher(inMemoryAuditPublisher);
 
     service = new DatasetService(cConf, discoveryService, discoveryServiceClient, typeManager, metricsCollectionService,

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.data.runtime.main;
 
 import co.cask.cdap.api.metrics.MetricsCollectionService;
-import co.cask.cdap.app.guice.AuthorizationModule;
 import co.cask.cdap.app.guice.EntityVerifierModule;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.conf.CConfiguration;
@@ -55,7 +54,9 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
+import co.cask.cdap.security.authorization.RemotePrivilegesManager;
 import co.cask.cdap.security.guice.SecureStoreModules;
+import co.cask.cdap.security.spi.authorization.PrivilegesManager;
 import co.cask.cdap.store.guice.NamespaceStoreModule;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.Service;
@@ -122,7 +123,6 @@ public class DatasetOpExecutorServerTwillRunnable extends AbstractMasterTwillRun
       new AuditModule().getDistributedModules(),
       new EntityVerifierModule(),
       new SecureStoreModules().getDistributedModules(),
-      new AuthorizationModule(),
       new AuthorizationEnforcementModule().getDistributedModules(),
       new AuthenticationContextModules().getProgramContainerModule(),
       new AbstractModule() {
@@ -130,6 +130,7 @@ public class DatasetOpExecutorServerTwillRunnable extends AbstractMasterTwillRun
         protected void configure() {
           bind(Store.class).to(DefaultStore.class);
           bind(UGIProvider.class).to(RemoteUGIProvider.class).in(Scopes.SINGLETON);
+          bind(PrivilegesManager.class).to(RemotePrivilegesManager.class);
         }
       });
   }


### PR DESCRIPTION
…op executor service and explore service

Jira: [CDAP-6943](https://issues.cask.co/browse/CDAP-6943)
Build: http://builds.cask.co/browse/CDAP-RUT12

Tested on a 5 node cluster with authorizer extension configs and jars only on the CDAP master node. Don't see guice (or other errors)
