### PR TITLE
Backport GitHub PR #6334 to release/3.0

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -380,6 +380,7 @@ page at http://checkstyle.sourceforge.net/config.html -->
 
   <module name="SuppressionFilter">
     <property name="file" value="suppressions.xml"/>
+    <property name="optional" value="true"/>
   </module>
 
   <module name="SuppressionCommentFilter">

--- a/pom.xml
+++ b/pom.xml
@@ -1326,7 +1326,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>2.12.1</version>
+          <version>2.17</version>
           <executions>
             <execution>
               <id>validate</id>
@@ -1344,6 +1344,13 @@
               </goals>
             </execution>
           </executions>
+          <dependencies>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>6.19</version>
+            </dependency>
+          </dependencies>
         </plugin>
 
         <!-- GPG signature -->
@@ -1388,7 +1395,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.12.1</version>
+        <version>2.17</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This allows `cdap` to be built from an external repository using this one as a submodule.
