### PR TITLE
Backport GitHub PR #6334 to release/3.1

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -317,13 +317,15 @@ page at http://checkstyle.sourceforge.net/config.html -->
         -->
     </module>
 
+    <!-- Commented per Terence since there will be very little new code in this branch
     <module name="RedundantModifier">
-      <!-- Checks for redundant modifiers in:
+      <!- Checks for redundant modifiers in:
            - interface and annotation definitions,
            - the final modifier on methods of final classes, and
            - inner interface declarations that are declared as static.
-        -->
+        ->
     </module>
+    -->
 
 
     <!--
@@ -388,6 +390,7 @@ page at http://checkstyle.sourceforge.net/config.html -->
 
   <module name="SuppressionFilter">
     <property name="file" value="suppressions.xml"/>
+    <property name="optional" value="true"/>
   </module>
 
   <module name="SuppressionCommentFilter">

--- a/pom.xml
+++ b/pom.xml
@@ -1259,7 +1259,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>2.12.1</version>
+          <version>2.17</version>
           <executions>
             <execution>
               <id>validate</id>
@@ -1277,6 +1277,13 @@
               </goals>
             </execution>
           </executions>
+          <dependencies>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>6.19</version>
+            </dependency>
+          </dependencies>
         </plugin>
 
         <!-- GPG signature -->
@@ -1321,7 +1328,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.12.1</version>
+        <version>2.17</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This allows `cdap` to be built from an external repository using this one as a submodule.
