### PR TITLE
Moved initialization of system dataset modules to DatasetTypeService,…

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
@@ -30,8 +30,6 @@ import co.cask.http.HttpResponder;
 import com.google.inject.Inject;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
@@ -49,7 +47,6 @@ import javax.ws.rs.QueryParam;
 // todo: do we want to make it authenticated? or do we treat it always as "internal" piece?
 @Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
 public class DatasetInstanceHandler extends AbstractHttpHandler {
-  private static final Logger LOG = LoggerFactory.getLogger(DatasetInstanceHandler.class);
 
   private final DatasetInstanceService instanceService;
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeService.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data2.datafabric.dataset.service;
 
 import co.cask.cdap.api.Predicate;
+import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.api.dataset.module.DatasetType;
 import co.cask.cdap.common.ConflictException;
@@ -32,9 +33,19 @@ import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.utils.DirUtils;
+import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
+import co.cask.cdap.data2.datafabric.dataset.DatasetMetaTableUtil;
+import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
+import co.cask.cdap.data2.datafabric.dataset.service.mds.DatasetInstanceMDS;
+import co.cask.cdap.data2.datafabric.dataset.service.mds.DatasetTypeMDS;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetModuleConflictException;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetTypeManager;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.DynamicDatasetCache;
+import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
 import co.cask.cdap.data2.security.Impersonator;
+import co.cask.cdap.data2.transaction.TransactionExecutorFactory;
+import co.cask.cdap.data2.transaction.TransactionSystemClientService;
 import co.cask.cdap.proto.DatasetModuleMeta;
 import co.cask.cdap.proto.DatasetTypeMeta;
 import co.cask.cdap.proto.Id;
@@ -50,13 +61,19 @@ import co.cask.cdap.security.spi.authorization.PrivilegesManager;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.http.BodyConsumer;
 import co.cask.http.HttpResponder;
+import co.cask.tephra.TransactionExecutor;
+import co.cask.tephra.TransactionFailureException;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
+import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
 import org.apache.twill.filesystem.Location;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
@@ -64,9 +81,12 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import javax.annotation.Nullable;
@@ -74,7 +94,7 @@ import javax.annotation.Nullable;
 /**
  * Manages lifecycle of dataset {@link DatasetType types} and {@link DatasetModule modules}.
  */
-public class DatasetTypeService {
+public class DatasetTypeService extends AbstractIdleService {
   private static final Logger LOG = LoggerFactory.getLogger(DatasetTypeService.class);
 
   private final DatasetTypeManager typeManager;
@@ -85,6 +105,12 @@ public class DatasetTypeService {
   private final AuthenticationContext authenticationContext;
   private final CConfiguration cConf;
   private final Impersonator impersonator;
+  private final TransactionSystemClientService txClientService;
+  private final DatasetFramework datasetFramework;
+  private final TransactionExecutorFactory txExecutorFactory;
+  private final DynamicDatasetCache datasetCache;
+  private final Map<String, DatasetModule> defaultModules;
+  private final Map<String, DatasetModule> extensionModules;
 
   @Inject
   @VisibleForTesting
@@ -92,7 +118,11 @@ public class DatasetTypeService {
                             NamespacedLocationFactory namespacedLocationFactory,
                             AuthorizationEnforcer authorizationEnforcer, PrivilegesManager privilegesManager,
                             AuthenticationContext authenticationContext,
-                            CConfiguration cConf, Impersonator impersonator) {
+                            CConfiguration cConf, Impersonator impersonator,
+                            TransactionSystemClientService txClientService,
+                            @Named("datasetMDS") DatasetFramework datasetFramework,
+                            TransactionExecutorFactory txExecutorFactory,
+                            @Named("defaultDatasetModules") Map<String, DatasetModule> defaultModules) {
     this.typeManager = typeManager;
     this.namespaceQueryAdmin = namespaceQueryAdmin;
     this.namespacedLocationFactory = namespacedLocationFactory;
@@ -101,6 +131,39 @@ public class DatasetTypeService {
     this.authenticationContext = authenticationContext;
     this.cConf = cConf;
     this.impersonator = impersonator;
+    this.txClientService = txClientService;
+    this.datasetFramework = datasetFramework;
+    this.txExecutorFactory = txExecutorFactory;
+    Map<String, String> emptyArgs = Collections.emptyMap();
+    this.datasetCache = new MultiThreadDatasetCache(
+      new SystemDatasetInstantiator(datasetFramework, null, null), txClientService, NamespaceId.SYSTEM, emptyArgs, null,
+      ImmutableMap.of(
+        DatasetMetaTableUtil.META_TABLE_NAME, emptyArgs,
+        DatasetMetaTableUtil.INSTANCE_TABLE_NAME, emptyArgs
+      ));
+    this.defaultModules = new LinkedHashMap<>(defaultModules);
+    this.extensionModules = getExtensionModules(cConf);
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    txClientService.startAndWait();
+
+    // Bootstrap the meta and instance tables. Make sure the underlying table exists.
+    DatasetsUtil.createIfNotExists(datasetFramework, DatasetMetaTableUtil.META_TABLE_INSTANCE_ID,
+                                   DatasetTypeMDS.class.getName(), DatasetProperties.EMPTY);
+    DatasetsUtil.createIfNotExists(datasetFramework, DatasetMetaTableUtil.INSTANCE_TABLE_INSTANCE_ID,
+                                   DatasetInstanceMDS.class.getName(), DatasetProperties.EMPTY);
+    deleteSystemModules();
+    deployDefaultModules();
+    if (!extensionModules.isEmpty()) {
+      deployExtensionModules();
+    }
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    txClientService.stopAndWait();
   }
 
   /**
@@ -387,10 +450,91 @@ public class DatasetTypeService {
     };
   }
 
+  private void deleteSystemModules() throws InterruptedException, TransactionFailureException {
+    final DatasetTypeMDS datasetTypeMDS = datasetCache.getDataset(DatasetMetaTableUtil.META_TABLE_NAME);
+    txExecutorFactory.createExecutor(datasetCache).execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        Collection<DatasetModuleMeta> allDatasets = datasetTypeMDS.getModules(Id.Namespace.SYSTEM);
+        for (DatasetModuleMeta ds : allDatasets) {
+          if (ds.getJarLocation() == null) {
+            LOG.debug("Deleting system dataset module: {}", ds.toString());
+            Id.DatasetModule moduleId = Id.DatasetModule.from(Id.Namespace.SYSTEM, ds.getName());
+            datasetTypeMDS.deleteModule(moduleId);
+            revokeAllPrivilegesOnModule(moduleId.toEntityId(), ds);
+          }
+        }
+      }
+    });
+  }
+
+  private void deployDefaultModules() {
+    // adding default modules to be available in dataset manager service
+    for (Map.Entry<String, DatasetModule> module : defaultModules.entrySet()) {
+      try {
+        // NOTE: we assume default modules are always in classpath, hence passing null for jar location
+        // NOTE: we add default modules in the system namespace
+        Id.DatasetModule defaultModule = Id.DatasetModule.from(Id.Namespace.SYSTEM, module.getKey());
+        typeManager.addModule(defaultModule, module.getValue().getClass().getName(), null, false);
+        grantAllPrivilegesOnModule(defaultModule.toEntityId(), authenticationContext.getPrincipal());
+      } catch (DatasetModuleConflictException e) {
+        // perfectly fine: we need to add default modules only the very first time service is started
+        LOG.debug("Not adding {} module: it already exists", module.getKey());
+      } catch (Throwable th) {
+        LOG.error("Failed to add {} module. Aborting.", module.getKey(), th);
+        throw Throwables.propagate(th);
+      }
+    }
+  }
+
+  private Map<String, DatasetModule> getExtensionModules(CConfiguration cConf) {
+    Map<String, DatasetModule> modules = new LinkedHashMap<String, DatasetModule>();
+    String moduleStr = cConf.get(Constants.Dataset.Extensions.MODULES);
+    if (moduleStr != null) {
+      for (String moduleName : Splitter.on(',').omitEmptyStrings().split(moduleStr)) {
+        // create DatasetModule object
+        try {
+          Class tableModuleClass = Class.forName(moduleName);
+          DatasetModule module = (DatasetModule) tableModuleClass.newInstance();
+          modules.put(moduleName, module);
+        } catch (ClassCastException | ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
+          LOG.error("Failed to add {} extension module: {}", moduleName, ex.toString());
+        }
+      }
+    }
+    return modules;
+  }
+
+  private void deployExtensionModules() {
+    // adding any defined extension modules to be available in dataset manager service
+    for (Map.Entry<String, DatasetModule> module : extensionModules.entrySet()) {
+      try {
+        // NOTE: we assume extension modules are always in classpath, hence passing null for jar location
+        // NOTE: we add extension modules in the system namespace
+        Id.DatasetModule theModule = Id.DatasetModule.from(Id.Namespace.SYSTEM, module.getKey());
+        typeManager.addModule(theModule, module.getValue().getClass().getName(), null, false);
+        grantAllPrivilegesOnModule(theModule.toEntityId(), authenticationContext.getPrincipal());
+      } catch (DatasetModuleConflictException e) {
+        // perfectly fine: we need to add the modules only the very first time service is started
+        LOG.debug("Not adding {} extension module: it already exists", module.getKey());
+      } catch (Throwable th) {
+        LOG.error("Failed to add {} extension module. Aborting.", module.getKey(), th);
+        throw Throwables.propagate(th);
+      }
+    }
+  }
+
   private void grantAllPrivilegesOnModule(DatasetModuleId moduleId, Principal principal) throws Exception {
+    grantAllPrivilegesOnModule(moduleId, principal, null);
+  }
+
+  private void grantAllPrivilegesOnModule(DatasetModuleId moduleId, Principal principal,
+                                          @Nullable DatasetModuleMeta moduleMeta) throws Exception {
     Set<Action> allActions = ImmutableSet.of(Action.ALL);
     privilegesManager.grant(moduleId, principal, allActions);
-    DatasetModuleMeta moduleMeta = typeManager.getModule(moduleId.toId());
+    if (moduleMeta == null) {
+      moduleMeta = typeManager.getModule(moduleId.toId());
+    }
     if (moduleMeta == null) {
       LOG.debug("Could not find metadata for module {}. Not granting privileges for its types.", moduleId);
       return;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DatasetTypeManager.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/type/DatasetTypeManager.java
@@ -17,10 +17,8 @@
 package co.cask.cdap.data2.datafabric.dataset.type;
 
 import co.cask.cdap.api.dataset.DatasetDefinition;
-import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
-import co.cask.cdap.api.dataset.module.DatasetModule;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.lang.DirectoryClassLoader;
@@ -29,7 +27,6 @@ import co.cask.cdap.common.lang.jar.BundleJarUtil;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
 import co.cask.cdap.data2.datafabric.dataset.DatasetMetaTableUtil;
-import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.datafabric.dataset.service.mds.DatasetInstanceMDS;
 import co.cask.cdap.data2.datafabric.dataset.service.mds.DatasetTypeMDS;
 import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistries;
@@ -49,14 +46,12 @@ import co.cask.tephra.TransactionExecutor;
 import co.cask.tephra.TransactionFailureException;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.io.Closeables;
-import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import org.apache.twill.filesystem.Location;
@@ -74,7 +69,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -85,18 +79,13 @@ import javax.annotation.Nullable;
 /**
  * Manages dataset types and modules metadata
  */
-public class DatasetTypeManager extends AbstractIdleService {
+public class DatasetTypeManager {
   private static final Logger LOG = LoggerFactory.getLogger(DatasetTypeManager.class);
 
   private final CConfiguration cConf;
   private final LocationFactory locationFactory;
-  private final TransactionSystemClientService txClientService;
   private final TransactionExecutorFactory txExecutorFactory;
-  private final DatasetFramework datasetFramework;
   private final DynamicDatasetCache datasetCache;
-
-  private final Map<String, DatasetModule> defaultModules;
-  private final Map<String, DatasetModule> extensionModules;
   private final Path systemTempPath;
   private final Impersonator impersonator;
 
@@ -106,15 +95,10 @@ public class DatasetTypeManager extends AbstractIdleService {
                             TransactionSystemClientService txClientService,
                             TransactionExecutorFactory txExecutorFactory,
                             @Named("datasetMDS") DatasetFramework datasetFramework,
-                            @Named("defaultDatasetModules") Map<String, DatasetModule> defaultModules,
                             Impersonator impersonator) {
     this.cConf = cConf;
     this.locationFactory = locationFactory;
-    this.txClientService = txClientService;
-    this.defaultModules = new LinkedHashMap<>(defaultModules);
-    this.extensionModules = getExtensionModules(cConf);
     this.txExecutorFactory = txExecutorFactory;
-    this.datasetFramework = datasetFramework;
     this.impersonator = impersonator;
 
     Map<String, String> emptyArgs = Collections.emptyMap();
@@ -126,45 +110,6 @@ public class DatasetTypeManager extends AbstractIdleService {
                                                     ));
     this.systemTempPath = Paths.get(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
                                     cConf.get(Constants.AppFabric.TEMP_DIR)).toAbsolutePath();
-  }
-
-  @Override
-  protected void startUp() throws Exception {
-    txClientService.startAndWait();
-
-    // Bootstrap the meta and instance tables. Make sure the underlying table exists.
-    DatasetsUtil.createIfNotExists(datasetFramework, DatasetMetaTableUtil.META_TABLE_INSTANCE_ID,
-                                   DatasetTypeMDS.class.getName(), DatasetProperties.EMPTY);
-    DatasetsUtil.createIfNotExists(datasetFramework, DatasetMetaTableUtil.INSTANCE_TABLE_INSTANCE_ID,
-                                   DatasetInstanceMDS.class.getName(), DatasetProperties.EMPTY);
-    deleteSystemModules();
-    deployDefaultModules();
-    if (!extensionModules.isEmpty()) {
-      deployExtensionModules();
-    }
-  }
-
-  @Override
-  protected void shutDown() throws Exception {
-    txClientService.stopAndWait();
-  }
-
-  private Map<String, DatasetModule> getExtensionModules(CConfiguration cConf) {
-    Map<String, DatasetModule> modules = new LinkedHashMap<String, DatasetModule>();
-    String moduleStr = cConf.get(Constants.Dataset.Extensions.MODULES);
-    if (moduleStr != null) {
-      for (String moduleName : Splitter.on(',').omitEmptyStrings().split(moduleStr)) {
-        // create DatasetModule object
-        try {
-          Class tableModuleClass = Class.forName(moduleName);
-          DatasetModule module = (DatasetModule) tableModuleClass.newInstance();
-          modules.put(moduleName, module);
-        } catch (ClassCastException | ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
-          LOG.error("Failed to add {} extension module: {}", moduleName, ex.toString());
-        }
-      }
-    }
-    return modules;
   }
 
   /**
@@ -512,58 +457,6 @@ public class DatasetTypeManager extends AbstractIdleService {
       LOG.error("Operation failed", e);
       throw Throwables.propagate(e);
     }
-  }
-
-  private void deployDefaultModules() {
-    // adding default modules to be available in dataset manager service
-    for (Map.Entry<String, DatasetModule> module : defaultModules.entrySet()) {
-      try {
-        // NOTE: we assume default modules are always in classpath, hence passing null for jar location
-        // NOTE: we add default modules in the system namespace
-        Id.DatasetModule defaultModule = Id.DatasetModule.from(Id.Namespace.SYSTEM, module.getKey());
-        addModule(defaultModule, module.getValue().getClass().getName(), null, false);
-      } catch (DatasetModuleConflictException e) {
-        // perfectly fine: we need to add default modules only the very first time service is started
-        LOG.debug("Not adding {} module: it already exists", module.getKey());
-      } catch (Throwable th) {
-        LOG.error("Failed to add {} module. Aborting.", module.getKey(), th);
-        throw Throwables.propagate(th);
-      }
-    }
-  }
-
-  private void deployExtensionModules() {
-    // adding any defined extension modules to be available in dataset manager service
-    for (Map.Entry<String, DatasetModule> module : extensionModules.entrySet()) {
-      try {
-        // NOTE: we assume extension modules are always in classpath, hence passing null for jar location
-        // NOTE: we add extension modules in the system namespace
-        Id.DatasetModule theModule = Id.DatasetModule.from(Id.Namespace.SYSTEM, module.getKey());
-        addModule(theModule, module.getValue().getClass().getName(), null, false);
-      } catch (DatasetModuleConflictException e) {
-        // perfectly fine: we need to add the modules only the very first time service is started
-        LOG.debug("Not adding {} extension module: it already exists", module.getKey());
-      } catch (Throwable th) {
-        LOG.error("Failed to add {} extension module. Aborting.", module.getKey(), th);
-        throw Throwables.propagate(th);
-      }
-    }
-  }
-
-  private void deleteSystemModules() throws InterruptedException, TransactionFailureException {
-    final DatasetTypeMDS datasetTypeMDS = datasetCache.getDataset(DatasetMetaTableUtil.META_TABLE_NAME);
-    txExecutorFactory.createExecutor(datasetCache).execute(new TransactionExecutor.Subroutine() {
-      @Override
-      public void apply() throws Exception {
-        Collection<DatasetModuleMeta> allDatasets = datasetTypeMDS.getModules(Id.Namespace.SYSTEM);
-        for (DatasetModuleMeta ds : allDatasets) {
-          if (ds.getJarLocation() == null) {
-            LOG.debug("Deleting system dataset module: {}", ds.toString());
-            datasetTypeMDS.deleteModule(Id.DatasetModule.from(Id.Namespace.SYSTEM, ds.getName()));
-          }
-        }
-      }
-    });
   }
 
   private class DependencyTrackingRegistry implements DatasetDefinitionRegistry {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -168,21 +168,22 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
     AuthorizationEnforcer authorizationEnforcer = injector.getInstance(AuthorizationEnforcer.class);
 
     DatasetTypeManager typeManager = new DatasetTypeManager(cConf, locationFactory, txSystemClientService,
-                                                            txExecutorFactory, mdsFramework, DEFAULT_MODULES,
-                                                            impersonator);
+                                                            txExecutorFactory, mdsFramework, impersonator);
     DatasetInstanceManager instanceManager = new DatasetInstanceManager(txSystemClientService, txExecutorFactory,
                                                                         mdsFramework);
     PrivilegesManager privilegesManager = injector.getInstance(PrivilegesManager.class);
     DatasetTypeService typeService = new DatasetTypeService(typeManager, namespaceQueryAdmin, namespacedLocationFactory,
                                                             authorizationEnforcer, privilegesManager,
-                                                            authenticationContext, cConf, impersonator);
+                                                            authenticationContext, cConf, impersonator,
+                                                            txSystemClientService, mdsFramework, txExecutorFactory,
+                                                            DEFAULT_MODULES);
     DatasetOpExecutor opExecutor = new LocalDatasetOpExecutor(cConf, discoveryServiceClient, opExecutorService);
     DatasetInstanceService instanceService = new DatasetInstanceService(
       typeManager, instanceManager, opExecutor, exploreFacade, namespaceQueryAdmin, authorizationEnforcer,
       privilegesManager, authenticationContext);
     instanceService.setAuditPublisher(inMemoryAuditPublisher);
 
-    service = new DatasetService(cConf, discoveryService, discoveryServiceClient, typeManager, metricsCollectionService,
+    service = new DatasetService(cConf, discoveryService, discoveryServiceClient, metricsCollectionService,
                                  new InMemoryDatasetOpExecutor(framework), new HashSet<DatasetMetricsReporter>(),
                                  typeService, instanceService);
     // Start dataset service, wait for it to be discoverable

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -222,9 +222,7 @@ public abstract class DatasetServiceTestBase {
     NamespaceQueryAdmin namespaceQueryAdmin = injector.getInstance(NamespaceQueryAdmin.class);
     TransactionExecutorFactory txExecutorFactory = new DynamicTransactionExecutorFactory(txSystemClient);
     DatasetTypeManager typeManager = new DatasetTypeManager(cConf, locationFactory, txSystemClientService,
-                                                            txExecutorFactory,
-                                                            inMemoryDatasetFramework, defaultModules,
-                                                            impersonator);
+                                                            txExecutorFactory, inMemoryDatasetFramework, impersonator);
     DatasetOpExecutor opExecutor = new InMemoryDatasetOpExecutor(dsFramework);
     DatasetInstanceManager instanceManager =
       new DatasetInstanceManager(txSystemClientService, txExecutorFactory, inMemoryDatasetFramework);
@@ -233,10 +231,10 @@ public abstract class DatasetServiceTestBase {
                                                  namespaceQueryAdmin, authEnforcer, privilegesManager,
                                                  authenticationContext);
 
-    DatasetTypeService typeService = new DatasetTypeService(typeManager, namespaceAdmin, namespacedLocationFactory,
-                                                            authEnforcer, privilegesManager, authenticationContext,
-                                                            cConf, impersonator);
-    service = new DatasetService(cConf, discoveryService, discoveryServiceClient, typeManager, metricsCollectionService,
+    DatasetTypeService typeService = new DatasetTypeService(
+      typeManager, namespaceAdmin, namespacedLocationFactory, authEnforcer, privilegesManager, authenticationContext,
+      cConf, impersonator, txSystemClientService, inMemoryDatasetFramework, txExecutorFactory, defaultModules);
+    service = new DatasetService(cConf, discoveryService, discoveryServiceClient, metricsCollectionService,
                                  opExecutor, new HashSet<DatasetMetricsReporter>(), typeService, instanceService);
 
     // Start dataset service, wait for it to be discoverable


### PR DESCRIPTION
… so they can be governed by authorization enforcement rules as well, just like other entities.

This is needed, so during an upcoming bootstrap step for authorization, when default modules are added, the user adding them also gets privileges on them, just like authorization works for other, non-system modules.

Build: http://builds.cask.co/browse/CDAP-RUT16
