### PR TITLE
[HYDRA-398] - Show plugin properties in pipelines using old artifacts

### DIFF
--- a/cdap-ui/app/directives/complex-schema/complex-schema.html
+++ b/cdap-ui/app/directives/complex-schema/complex-schema.html
@@ -15,91 +15,96 @@
 -->
 
 <div class="complex-schema-container" ng-class="{ 'disabled': ComplexSchema.isDisabled }">
+  <div ng-if="!ComplexSchema.emptySchema || !ComplexSchema.isDisabled">
+    <div class="clearfix"
+         ng-if="::!ComplexSchema.hideHeader">
+      <div class="input-column header">
+        <h4>Name</h4>
+      </div>
 
-  <div class="clearfix"
-       ng-if="::!ComplexSchema.hideHeader">
-    <div class="input-column header">
-      <h4>Name</h4>
-    </div>
+      <div class="type-column header">
+        <h4>Type</h4>
+      </div>
 
-    <div class="type-column header">
-      <h4>Type</h4>
-    </div>
-
-    <div class="fields-actions">
-      <div class="nullable-header text-center">
-        <h4>Null</h4>
+      <div class="fields-actions">
+        <div class="nullable-header text-center">
+          <h4>Null</h4>
+        </div>
       </div>
     </div>
-  </div>
 
-  <fieldset ng-disabled="ComplexSchema.isDisabled">
-    <div class="error"
-         ng-if="ComplexSchema.error">
-      {{ ComplexSchema.error }}
-    </div>
+    <fieldset ng-disabled="ComplexSchema.isDisabled">
+      <div class="error"
+           ng-if="ComplexSchema.error">
+        {{ ComplexSchema.error }}
+      </div>
 
-    <fieldset disabled>
-      <my-record-schema
-        ng-model="ComplexSchema.schemaPrefix"
-        is-disabled="ComplexSchema.isDisabled"
-        ng-if="ComplexSchema.schemaPrefix">
-      </my-record-schema>
+      <fieldset disabled>
+        <my-record-schema
+          ng-model="ComplexSchema.schemaPrefix"
+          is-disabled="ComplexSchema.isDisabled"
+          ng-if="ComplexSchema.schemaPrefix">
+        </my-record-schema>
+      </fieldset>
+
+      <div ng-repeat="field in ComplexSchema.parsedSchema track by $index"
+          class="field-row"
+          ng-class="{'nested-row': !field.nested}">
+        <div class="clearfix">
+          <div class="input-column"
+              ng-class="{'tab-header': field.nested}">
+            <div class="tab-header-inner">
+              <input type="text"
+                     id="{{ field.id }}"
+                     class="form-control"
+                     ng-model="field.name"
+                     ng-blur="ComplexSchema.formatOutput()"
+                     ng-keypress="$event.keyCode === 13 && ComplexSchema.addField($index)"
+                     placeholder="Field Name">
+            </div>
+          </div>
+
+          <div class="type-column">
+            <div class="select-wrapper">
+              <select class="form-control"
+                      ng-model="field.displayType"
+                      ng-options="option as option for option in ComplexSchema.SCHEMA_TYPES"
+                      ng-change="ComplexSchema.changeType(field)">
+              </select>
+            </div>
+          </div>
+
+          <div class="fields-actions">
+            <div class="checkbox text-center">
+              <input type="checkbox"
+                     ng-model="field.nullable"
+                     ng-change="ComplexSchema.formatOutput()">
+            </div>
+
+            <div class="actions-buttons text-right" ng-if="!ComplexSchema.isDisabled">
+              <button class="btn btn-link"
+                      ng-click="ComplexSchema.removeField($index)">
+                <i class="text-danger fa fa-trash"></i>
+              </button>
+              <button class="btn btn-link"
+                      ng-click="ComplexSchema.addField($index)">
+                <i class="fa fa-plus"></i>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <my-embedded-schema-selector
+          type="field.type"
+          display-type="field.displayType"
+          parent-format-output="ComplexSchema.formatOutput()"
+          is-disabled="ComplexSchema.isDisabled">
+        </my-embedded-schema-selector>
+      </div>
     </fieldset>
 
-    <div ng-repeat="field in ComplexSchema.parsedSchema track by $index"
-        class="field-row"
-        ng-class="{'nested-row': !field.nested}">
-      <div class="clearfix">
-        <div class="input-column"
-            ng-class="{'tab-header': field.nested}">
-          <div class="tab-header-inner">
-            <input type="text"
-                   id="{{ field.id }}"
-                   class="form-control"
-                   ng-model="field.name"
-                   ng-blur="ComplexSchema.formatOutput()"
-                   ng-keypress="$event.keyCode === 13 && ComplexSchema.addField($index)"
-                   placeholder="Field Name">
-          </div>
-        </div>
-
-        <div class="type-column">
-          <div class="select-wrapper">
-            <select class="form-control"
-                    ng-model="field.displayType"
-                    ng-options="option as option for option in ComplexSchema.SCHEMA_TYPES"
-                    ng-change="ComplexSchema.changeType(field)">
-            </select>
-          </div>
-        </div>
-
-        <div class="fields-actions">
-          <div class="checkbox text-center">
-            <input type="checkbox"
-                   ng-model="field.nullable"
-                   ng-change="ComplexSchema.formatOutput()">
-          </div>
-
-          <div class="actions-buttons text-right" ng-if="!ComplexSchema.isDisabled">
-            <button class="btn btn-link"
-                    ng-click="ComplexSchema.removeField($index)">
-              <i class="text-danger fa fa-trash"></i>
-            </button>
-            <button class="btn btn-link"
-                    ng-click="ComplexSchema.addField($index)">
-              <i class="fa fa-plus"></i>
-            </button>
-          </div>
-        </div>
-      </div>
-
-      <my-embedded-schema-selector
-        type="field.type"
-        display-type="field.displayType"
-        parent-format-output="ComplexSchema.formatOutput()"
-        is-disabled="ComplexSchema.isDisabled">
-      </my-embedded-schema-selector>
-    </div>
-  </fieldset>
+  </div>
+  <div ng-if="ComplexSchema.emptySchema && ComplexSchema.isDisabled">
+    No Schema Available
+  </div>
 </div>

--- a/cdap-ui/app/directives/complex-schema/complex-schema.js
+++ b/cdap-ui/app/directives/complex-schema/complex-schema.js
@@ -73,8 +73,9 @@ function ComplexSchemaController (avsc, SCHEMA_TYPES, $scope, uuid, $timeout, Sc
       if (!schemaJson) {
         return true;
       }
-      // FIXME: The weird _fields was encountered when I used imported through plugin-functions. 
-      if (angular.isObject(schemaJson) && !(schemaJson.fields||schemaJson._fields).length) {
+      // we need to check if schemaJson has fields or is already returned by avsc parser in which case the fields will be
+      // accessed using getFields() function.
+      if (angular.isObject(schemaJson) && !(schemaJson.fields || ( schemaJson.getFields && schemaJson.getFields()) || []).length) {
         return true;
       }
       return false;

--- a/cdap-ui/app/directives/complex-schema/complex-schema.js
+++ b/cdap-ui/app/directives/complex-schema/complex-schema.js
@@ -73,7 +73,8 @@ function ComplexSchemaController (avsc, SCHEMA_TYPES, $scope, uuid, $timeout, Sc
       if (!schemaJson) {
         return true;
       }
-      if (angular.isObject(schemaJson) && !schemaJson.fields.length) {
+      // FIXME: The weird _fields was encountered when I used imported through plugin-functions. 
+      if (angular.isObject(schemaJson) && !(schemaJson.fields||schemaJson._fields).length) {
         return true;
       }
       return false;
@@ -86,6 +87,7 @@ function ComplexSchemaController (avsc, SCHEMA_TYPES, $scope, uuid, $timeout, Sc
     }
     if (isEmptySchema(strJson) && vm.isDisabled) {
       vm.emptySchema = true;
+      return;
     }
     let parsed = avsc.parse(strJson, { wrapUnions: true });
     recordName = vm.recordName || parsed._name;

--- a/cdap-ui/app/directives/complex-schema/complex-schema.js
+++ b/cdap-ui/app/directives/complex-schema/complex-schema.js
@@ -24,6 +24,7 @@ function ComplexSchemaController (avsc, SCHEMA_TYPES, $scope, uuid, $timeout, Sc
   let recordName;
   let timeout;
   let addFieldTimeout;
+  vm.emptySchema = false;
 
   vm.addField = (index) => {
     let placement = index === undefined ? 0 : index + 1;
@@ -68,13 +69,24 @@ function ComplexSchemaController (avsc, SCHEMA_TYPES, $scope, uuid, $timeout, Sc
   };
 
   function init(strJson) {
-    if (!strJson || strJson === 'record') {
-      recordName = vm.recordName || 'a' + uuid.v4().split('-').join('');
+    const isEmptySchema = (schemaJson) => {
+      if (!schemaJson) {
+        return true;
+      }
+      if (angular.isObject(schemaJson) && !schemaJson.fields.length) {
+        return true;
+      }
+      return false;
+    };
+    if ((!strJson || strJson === 'record') && !vm.isDisabled) {
       vm.addField();
+      recordName = vm.recordName || 'a' + uuid.v4().split('-').join('');
       vm.formatOutput();
       return;
     }
-
+    if (isEmptySchema(strJson) && vm.isDisabled) {
+      vm.emptySchema = true;
+    }
     let parsed = avsc.parse(strJson, { wrapUnions: true });
     recordName = vm.recordName || parsed._name;
 

--- a/cdap-ui/app/directives/plugin-functions/functions/output-schema/output-schema.js
+++ b/cdap-ui/app/directives/plugin-functions/functions/output-schema/output-schema.js
@@ -81,7 +81,14 @@ angular.module(PKG.name + '.commons')
                   var obj = {};
 
                   angular.forEach(nodeInfo.inputSchema, (input) => {
-                    obj[input.name] = JSON.parse(input.schema);
+                    let schema;
+                    try {
+                      schema = JSON.parse(input.schema);
+                    } catch(e) {
+                      console.log('ERROR: ', e);
+                      return;
+                    }
+                    obj[input.name] = schema;
                   });
 
                   config.inputSchemas = obj;

--- a/cdap-ui/app/directives/program-preferences/program-preferences.js
+++ b/cdap-ui/app/directives/program-preferences/program-preferences.js
@@ -91,8 +91,14 @@ angular.module(PKG.name+'.commons')
 
     function formatObj(input) {
       var arr = [];
-
-      angular.forEach(JSON.parse(angular.toJson(input)), function(v, k) {
+      var jsonInput;
+      try {
+        jsonInput = JSON.parse(angular.toJson(input));
+      } catch(e) {
+        console.log('ERROR: ', e);
+        return arr;
+      }
+      angular.forEach(jsonInput, function(v, k) {
         arr.push({
           key: k,
           value: v

--- a/cdap-ui/app/directives/widget-container/widget-complex-schema-editor/widget-complex-schema-editor.js
+++ b/cdap-ui/app/directives/widget-container/widget-complex-schema-editor/widget-complex-schema-editor.js
@@ -92,7 +92,15 @@ function ComplexSchemaEditorController($scope, EventPipe, $timeout, myAlertOnVal
       return;
     }
 
-    var schema = JSON.parse(vm.model);
+    var schema;
+    try {
+      schema = JSON.parse(vm.model);
+    } catch(e) {
+      console.log('ERROR: ', e);
+      schema = {
+        fields: []
+      };
+    }
     schema = schema.fields;
 
     if (vm.pluginName === 'Stream') {

--- a/cdap-ui/app/directives/widget-container/widget-input-schema/widget-input-schema.html
+++ b/cdap-ui/app/directives/widget-container/widget-input-schema/widget-input-schema.html
@@ -32,7 +32,7 @@
 -->
 
 <!-- Section that shows input schema(s) -->
-<div ng-if="::(MyInputSchemaCtrl.inputSchemas.length > 0)">
+<div>
 
   <!-- Section that shows multiple inputs -->
   <div ng-if="::(MyInputSchemaCtrl.multipleInputs)">
@@ -48,11 +48,13 @@
           ng-model="inputschema.schema"
           is-disabled="true">
         </my-complex-schema>
-
         <div ng-if="::(inputschema.schema.fields.length === 0 || !inputschema.schema)">
           <p>There is no input schema</p>
         </div>
       </div>
+    </div>
+    <div ng-if="!MyInputSchemaCtrl.inputSchemas.length">
+      No schema available
     </div>
   </div>
 
@@ -64,20 +66,12 @@
     <!-- Section that shows single input schema table-->
 
     <my-complex-schema
-      ng-if="::(!(MyInputSchemaCtrl.inputSchemas[0].schema.fields.length === 0 || !MyInputSchemaCtrl.inputSchemas[0].schema))"
       ng-model="MyInputSchemaCtrl.inputSchemas[0].schema"
       is-disabled="true">
     </my-complex-schema>
 
     <!-- End of section that shows single input schema table-->
 
-    <!-- Section that shows no input schema -->
-
-    <div ng-if="::(MyInputSchemaCtrl.inputSchemas[0].schema.fields.length === 0 || !MyInputSchemaCtrl.inputSchemas[0].schema)">
-      <p>There is no input schema</p>
-    </div>
-
-    <!-- End of section that shows no input schema-->
 
   </div>
 
@@ -86,11 +80,3 @@
 </div>
 
 <!-- End of section that shows input schema(s) -->
-
-<!-- Section that shows no input schema -->
-
-<div ng-if="::(MyInputSchemaCtrl.inputSchemas.length === 0)">
-  <p>There is no input schema</p>
-</div>
-
-<!-- End of section that shows no input schema -->

--- a/cdap-ui/app/directives/widget-container/widget-input-schema/widget-input-schema.html
+++ b/cdap-ui/app/directives/widget-container/widget-input-schema/widget-input-schema.html
@@ -48,9 +48,6 @@
           ng-model="inputschema.schema"
           is-disabled="true">
         </my-complex-schema>
-        <div ng-if="::(inputschema.schema.fields.length === 0 || !inputschema.schema)">
-          <p>There is no input schema</p>
-        </div>
       </div>
     </div>
     <div ng-if="!MyInputSchemaCtrl.inputSchemas.length">

--- a/cdap-ui/app/directives/widget-container/widget-sql-conditions/widget-sql-conditions.js
+++ b/cdap-ui/app/directives/widget-container/widget-sql-conditions/widget-sql-conditions.js
@@ -82,6 +82,7 @@ function SqlConditionsController() {
       } catch (e) {
         console.log('ERROR: ', e);
         vm.error = 'Error parsing input schemas.';
+        vm.mapInputSchema[input.name] = [];
       }
     });
 

--- a/cdap-ui/app/directives/widget-container/widget-sql-select-fields/widget-sql-select-fields.js
+++ b/cdap-ui/app/directives/widget-container/widget-sql-select-fields/widget-sql-select-fields.js
@@ -122,9 +122,11 @@ function SqlSelectorController() {
         schema = JSON.parse(input.schema);
       } catch(e) {
         console.log('ERROR: ', e);
-        return;
+        schema = {
+          fields: []
+        };
       }
-      schema.fields
+      schema = schema.fields
         .map((field) => {
           if (initialModel[input.name] && initialModel[input.name][field.name]) {
             field.selected = true;

--- a/cdap-ui/app/directives/widget-container/widget-sql-select-fields/widget-sql-select-fields.js
+++ b/cdap-ui/app/directives/widget-container/widget-sql-select-fields/widget-sql-select-fields.js
@@ -117,17 +117,25 @@ function SqlSelectorController() {
     }
 
     angular.forEach(vm.inputSchema, (input) => {
-      let schema = JSON.parse(input.schema).fields.map((field) => {
-        if (initialModel[input.name] && initialModel[input.name][field.name]) {
-          field.selected = true;
-          field.alias = initialModel[input.name][field.name] === true ? '' : initialModel[input.name][field.name];
-        } else {
-          field.selected = inputModel ? false : true;
-          field.alias = field.name;
-        }
+      let schema;
+      try {
+        schema = JSON.parse(input.schema);
+      } catch(e) {
+        console.log('ERROR: ', e);
+        return;
+      }
+      schema.fields
+        .map((field) => {
+          if (initialModel[input.name] && initialModel[input.name][field.name]) {
+            field.selected = true;
+            field.alias = initialModel[input.name][field.name] === true ? '' : initialModel[input.name][field.name];
+          } else {
+            field.selected = inputModel ? false : true;
+            field.alias = field.name;
+          }
 
-        return field;
-      });
+          return field;
+        });
 
       vm.parsedInputSchemas.push({
         name: input.name,

--- a/cdap-ui/app/features/admin/controllers/preferences-ctrl.js
+++ b/cdap-ui/app/features/admin/controllers/preferences-ctrl.js
@@ -140,8 +140,14 @@ angular.module(PKG.name + '.feature.admin')
 
     function formatObj(input) {
       var arr = [];
-
-      angular.forEach(JSON.parse(angular.toJson(input)), function(v, k) {
+      var inputJson;
+      try {
+        inputJson = JSON.parse(angular.toJson(input);
+      } catch(e) {
+        console.log('ERROR: ', e);
+        return arr;
+      }
+      angular.forEach(), function(v, k) {
         arr.push({
           key: k,
           value: v

--- a/cdap-ui/app/features/admin/controllers/preferences-ctrl.js
+++ b/cdap-ui/app/features/admin/controllers/preferences-ctrl.js
@@ -142,12 +142,12 @@ angular.module(PKG.name + '.feature.admin')
       var arr = [];
       var inputJson;
       try {
-        inputJson = JSON.parse(angular.toJson(input);
+        inputJson = JSON.parse(angular.toJson(input));
       } catch(e) {
         console.log('ERROR: ', e);
         return arr;
       }
-      angular.forEach(), function(v, k) {
+      angular.forEach(inputJson, function(v, k) {
         arr.push({
           key: k,
           value: v

--- a/cdap-ui/app/features/hydratorplusplus/controllers/create/canvas-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/create/canvas-ctrl.js
@@ -74,8 +74,9 @@ class HydratorPlusPlusCreateCanvasCtrl {
               let sourceConn = HydratorPlusPlusConfigStore
                 .getSourceNodes(pluginId)
                 .filter( node => typeof node.outputSchema === 'string');
+              let artifactVersion = HydratorPlusPlusConfigStore.getArtifact().version;
               return HydratorPlusPlusNodeService
-                .getPluginInfo(pluginNode, appType, sourceConn)
+                .getPluginInfo(pluginNode, appType, sourceConn, artifactVersion)
                 .then((nodeWithInfo) => (
                   {
                     node: nodeWithInfo,

--- a/cdap-ui/app/features/hydratorplusplus/controllers/detail/canvas-ctrl.js
+++ b/cdap-ui/app/features/hydratorplusplus/controllers/detail/canvas-ctrl.js
@@ -64,11 +64,12 @@ angular.module(PKG.name + '.feature.hydratorplusplus')
               rPlugin: ['HydratorPlusPlusNodeService', 'HydratorPlusPlusDetailNonRunsStore', 'GLOBALS', function(HydratorPlusPlusNodeService, HydratorPlusPlusDetailNonRunsStore, GLOBALS) {
                 let pluginId = pluginNode.name;
                 let appType = HydratorPlusPlusDetailNonRunsStore.getAppType();
+                let artifactVersion = HydratorPlusPlusDetailNonRunsStore.getArtifact().version;
                 let sourceConn = HydratorPlusPlusDetailNonRunsStore
                   .getSourceNodes(pluginId)
                   .filter( node => typeof node.outputSchema === 'string');
                 return HydratorPlusPlusNodeService
-                  .getPluginInfo(pluginNode, appType, sourceConn)
+                  .getPluginInfo(pluginNode, appType, sourceConn, artifactVersion)
                   .then((nodeWithInfo) => (
                     {
                       node: nodeWithInfo,

--- a/cdap-ui/app/features/hydratorplusplus/leftpanel.less
+++ b/cdap-ui/app/features/hydratorplusplus/leftpanel.less
@@ -206,7 +206,7 @@ body.theme-cdap.state-hydratorplusplus-create {
                         display: block;
                         font-size: 8px;
                         position: absolute;
-                        left: 120px;
+                        left: 90%;
                         background: #d8d8d8;
                         border-radius: 2px;
                         margin: 0;
@@ -421,15 +421,15 @@ body.theme-cdap.state-hydratorplusplus-create {
                 &.plugin-templates {
                   .plugin-badge {
                     display: block;
-                    font-size: 8px;
+                    font-size: 6px;
                     position: absolute;
-                    left: 38px;
+                    left: 75%;
                     background: #d8d8d8;
                     border-radius: 2px;
                     margin: 0;
                     padding: 3px 3px;
-                    line-height: 8px;
-                    top: 3px;
+                    line-height: 6px;
+                    top: 2px;
                   }
                 }
 

--- a/cdap-ui/app/features/hydratorplusplus/services/hydrator-node-service.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/hydrator-node-service.js
@@ -22,12 +22,12 @@ class HydratorPlusPlusNodeService {
     this.IMPLICIT_SCHEMA = IMPLICIT_SCHEMA;
     this.GLOBALS = GLOBALS;
   }
-  getPluginInfo(node, appType, sourceConn) {
+  getPluginInfo(node, appType, sourceConn, artifactVersion) {
     var promise;
     if (node._backendProperties) {
       promise = this.$q.when(node);
     } else {
-      promise = this.HydratorPlusPlusHydratorService.fetchBackendProperties(node, appType);
+      promise = this.HydratorPlusPlusHydratorService.fetchBackendProperties(node, appType, artifactVersion);
     }
     return promise.then((node) => this.configurePluginInfo(node, appType, sourceConn));
   }

--- a/cdap-ui/app/features/hydratorplusplus/services/hydrator-node-service.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/hydrator-node-service.js
@@ -24,7 +24,7 @@ class HydratorPlusPlusNodeService {
   }
   getPluginInfo(node, appType, sourceConn, artifactVersion) {
     var promise;
-    if (node._backendProperties) {
+    if (angular.isObject(node._backendProperties) && Object.keys(node._backendProperties).length) {
       promise = this.$q.when(node);
     } else {
       promise = this.HydratorPlusPlusHydratorService.fetchBackendProperties(node, appType, artifactVersion);
@@ -36,6 +36,12 @@ class HydratorPlusPlusNodeService {
       var schema = node.outputSchema;
       var isStreamSource = false;
       var inputSchema;
+      const isFieldExists = (field, schema) => {
+        if(angular.isObject(schema) && Array.isArray(schema.fields)) {
+          return schema.fields.filter(schemaField => schemaField.name === field.name).length;
+        }
+        return false;
+      };
       if (node.plugin.name === 'Stream') {
         isStreamSource = true;
       }
@@ -52,20 +58,25 @@ class HydratorPlusPlusNodeService {
         inputSchema = schema;
       }
       if (isStreamSource) {
-        let streamSchemaPrefix = [
-          {
-            name: 'ts',
-            type: 'long'
-          },
-          {
-            name: 'headers',
-            type: {
-              type: 'map',
-              keys: 'string',
-              values: 'string'
-            }
+        let streamSchemaPrefix = [];
+        let tsField = {
+          name: 'ts',
+          type: 'long'
+        };
+        let headersField = {
+          name: 'headers',
+          type: {
+            type: 'map',
+            keys: 'string',
+            values: 'string'
           }
-        ];
+        };
+        if (!isFieldExists(tsField, inputSchema)) {
+          streamSchemaPrefix.push(tsField);
+        }
+        if (!isFieldExists(headersField, inputSchema)) {
+          streamSchemaPrefix.push(headersField);
+        }
 
         inputSchema = this.HydratorPlusPlusHydratorService.formatOutputSchemaToAvro({
           fields: streamSchemaPrefix.concat(this.myHelpers.objectQuery(inputSchema, 'fields') || [])

--- a/cdap-ui/app/features/hydratorplusplus/services/hydrator-service.js
+++ b/cdap-ui/app/features/hydratorplusplus/services/hydrator-service.js
@@ -122,7 +122,7 @@ class HydratorPlusPlusHydratorService {
       connections: connections
     };
   }
-  fetchBackendProperties(node, appType) {
+  fetchBackendProperties(node, appType, artifactVersion) {
     var defer = this.$q.defer();
 
     // This needs to pass on a scope always. Right now there is no cleanup
@@ -130,7 +130,7 @@ class HydratorPlusPlusHydratorService {
     var params = {
       namespace: this.$state.params.namespace,
       pipelineType: appType,
-      version: this.$rootScope.cdapVersion,
+      version: artifactVersion || this.$rootScope.cdapVersion,
       extensionType: node.type,
       pluginName: node.plugin.name
     };

--- a/cdap-ui/app/features/hydratorplusplus/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html
@@ -77,11 +77,6 @@
     </div>
   </fieldset>
 
-  <div ng-if="!HydratorPlusPlusNodeConfigCtrl.state.node.outputSchema && isDisabled && HydratorPlusPlusNodeConfigCtrl.state.node.plugin.properties.format !== 'clf' && HydratorPlusPlusNodeConfigCtrl.state.node.plugin.properties.format !== 'syslog'">
-    <div class="well well-lg">
-      <h4>There is no output schema</h4>
-    </div>
-  </div>
 </div>
 
 <my-file-select class="sr-only" id="schema-import-link" data-button-icon="fa-upload" on-file-select="HydratorPlusPlusNodeConfigCtrl.importFiles($files)" data-button-label="Import">

--- a/cdap-ui/app/features/login/routes.js
+++ b/cdap-ui/app/features/login/routes.js
@@ -71,8 +71,14 @@ angular.module(PKG.name+'.feature.login')
             myAlert.clear();
             if(next) {
               console.log('After login, will redirect to:', next);
-
-              $state.go(next, JSON.parse(decodeURIComponent(nextParams)));
+              var nextState;
+              try {
+                nextState = JSON.parse(decodeURIComponent(nextParams));
+              } catch(e) {
+                console.warn('Unable to decode next state after login. Going to overview', e);
+                $state.go('overview');
+              }
+              $state.go(next, nextState);
 
             } else {
               $state.go('overview');

--- a/cdap-ui/app/features/mapreduce/controllers/tabs/runs/tabs/status-ctrl.js
+++ b/cdap-ui/app/features/mapreduce/controllers/tabs/runs/tabs/status-ctrl.js
@@ -40,7 +40,12 @@ angular.module(PKG.name + '.feature.mapreduce')
         json: false
       }, function (res) {
         res = res.replace(/\bNaN\b/g, '"NaN"');
-        res = JSON.parse(res);
+        try {
+          res = JSON.parse(res);
+        } catch(e) {
+          console.warn('Unable parse response for Mapreduce program: ', params.mapreduceId);
+          res = {};
+        }
 
         this.info = res;
 


### PR DESCRIPTION
#### TL;DR
- Use artifact information from the pipeline once published. UI should not use the CDAP version.
#### Longer version
- UI is currently using CDAP version all the time to query plugin properties on a published pipeline. 
- This might be ok if we are querying for a plugin version that the current CDAP version supports. - - But if we want to open a plugin that was created in older versions in a newer version of Hydrator, we should use the artifact information in the pipeline instead of the CDAP version.

Bamboo build: http://builds.cask.co/browse/CDAP-DRC4220/latest
#### EDIT:
- Have also added fix for handling empty input schemas
- Have fixed every reference of `JSON.parse` to be wrapped in a `try...catch` block
