### PR TITLE
[CDAP-6880] Set default timeouts for internal HTTPRequests

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/DefaultStreamWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/DefaultStreamWriter.java
@@ -23,6 +23,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.EndpointStrategy;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
+import co.cask.cdap.common.http.DefaultHttpRequestConfig;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
 import co.cask.cdap.data2.registry.RuntimeUsageRegistry;
@@ -113,7 +114,7 @@ public class DefaultStreamWriter implements StreamWriter {
   }
 
   private void writeToStream(Id.Stream stream, HttpRequest request) throws IOException {
-    HttpResponse response = HttpRequests.execute(request);
+    HttpResponse response = HttpRequests.execute(request, new DefaultHttpRequestConfig());
     int responseCode = response.getResponseCode();
     if (responseCode == HttpResponseStatus.NOT_FOUND.getCode()) {
       throw new IOException(String.format("Stream %s not found", stream));

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -42,7 +42,8 @@ public final class Constants {
   public static final String ROOT_NAMESPACE = "root.namespace";
   public static final String COLLECT_CONTAINER_LOGS = "master.collect.containers.log";
   public static final String COLLECT_APP_CONTAINER_LOG_LEVEL = "master.collect.app.containers.log.level";
-  public static final String HTTP_CLIENT_TIMEOUT_MS = "http.client.connection.timeout.ms";
+  public static final String HTTP_CLIENT_CONNECTION_TIMEOUT_MS = "http.client.connection.timeout.ms";
+  public static final String HTTP_CLIENT_READ_TIMEOUT_MS = "http.client.read.timeout.ms";
   /** Uniquely identifies a CDAP instance */
   public static final String INSTANCE_NAME = "instance.name";
   // Environment variable name for spark home

--- a/cdap-common/src/main/java/co/cask/cdap/common/guice/ConfigModule.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/guice/ConfigModule.java
@@ -17,7 +17,9 @@ package co.cask.cdap.common.guice;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.CConfigurationUtil;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.conf.SConfiguration;
+import co.cask.cdap.common.http.DefaultHttpRequestConfig;
 import com.google.inject.AbstractModule;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -54,6 +56,12 @@ public final class ConfigModule extends AbstractModule {
     this.hConf = hConf;
     this.sConf = sConf;
     CConfigurationUtil.copyTxProperties(cConf, hConf);
+
+    // Set system properties for all HTTP requests
+    System.setProperty(DefaultHttpRequestConfig.CONNECTION_TIMEOUT_PROPERTY_NAME,
+                       cConf.get(Constants.HTTP_CLIENT_CONNECTION_TIMEOUT_MS));
+    System.setProperty(DefaultHttpRequestConfig.READ_TIMEOUT_PROPERTY_NAME,
+                       cConf.get(Constants.HTTP_CLIENT_READ_TIMEOUT_MS));
   }
 
   @Override

--- a/cdap-common/src/main/java/co/cask/cdap/common/http/DefaultHttpRequestConfig.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/http/DefaultHttpRequestConfig.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.http;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.common.http.HttpRequestConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.HttpURLConnection;
+
+/**
+ * Class to uniformly configure CDAP HTTP requests with a user-configured timeout
+ */
+public class DefaultHttpRequestConfig extends HttpRequestConfig {
+
+  private static final int DEFAULT_TIMEOUT = 60000;
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultHttpRequestConfig.class);
+  private static final String SYSTEM_PROPERTY_PREFIX = "cdap.";
+
+  // System property names
+  public static final String CONNECTION_TIMEOUT_PROPERTY_NAME =
+    SYSTEM_PROPERTY_PREFIX + Constants.HTTP_CLIENT_CONNECTION_TIMEOUT_MS;
+  public static final String  READ_TIMEOUT_PROPERTY_NAME =
+    SYSTEM_PROPERTY_PREFIX + Constants.HTTP_CLIENT_READ_TIMEOUT_MS;
+
+  public DefaultHttpRequestConfig() {
+    super(getTimeoutFromSystemProperties(CONNECTION_TIMEOUT_PROPERTY_NAME),
+          getTimeoutFromSystemProperties(READ_TIMEOUT_PROPERTY_NAME));
+  }
+
+  /**
+   * @param verifySSLCert false, to disable certificate verifying in SSL connections. By default SSL certificate is
+   *                      verified.
+   */
+  public DefaultHttpRequestConfig(boolean verifySSLCert) {
+    super(getTimeoutFromSystemProperties(CONNECTION_TIMEOUT_PROPERTY_NAME),
+          getTimeoutFromSystemProperties(READ_TIMEOUT_PROPERTY_NAME), verifySSLCert);
+  }
+
+  /**
+   * @param verifySSLCert false, to disable certificate verifying in SSL connections. By default SSL certificate is
+   *                      verified.
+   * @param fixedLengthStreamingThreshold number of bytes in the request body to use fix length request mode. See
+   *                                  {@link HttpURLConnection#setFixedLengthStreamingMode(int)}.
+   */
+  public DefaultHttpRequestConfig(boolean verifySSLCert, int fixedLengthStreamingThreshold) {
+    super(getTimeoutFromSystemProperties(CONNECTION_TIMEOUT_PROPERTY_NAME),
+          getTimeoutFromSystemProperties(READ_TIMEOUT_PROPERTY_NAME),
+          verifySSLCert, fixedLengthStreamingThreshold);
+  }
+
+  private static int getTimeoutFromSystemProperties(String propertyName) {
+    Integer value = Integer.getInteger(propertyName);
+    if (value == null) {
+      LOG.debug("Timeout property {} was not found in system properties.", propertyName);
+      return DEFAULT_TIMEOUT;
+    }
+    return value;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/internal/remote/RemoteOpsClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/internal/remote/RemoteOpsClient.java
@@ -20,6 +20,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.EndpointStrategy;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
+import co.cask.cdap.common.http.DefaultHttpRequestConfig;
 import co.cask.cdap.proto.BasicThrowable;
 import co.cask.cdap.proto.WorkflowTokenDetail;
 import co.cask.cdap.proto.WorkflowTokenNodeDetail;
@@ -74,8 +75,7 @@ public class RemoteOpsClient {
       }
     });
 
-    int httpClientTimeoutMs = cConf.getInt(Constants.HTTP_CLIENT_TIMEOUT_MS);
-    this.httpRequestConfig = new HttpRequestConfig(httpClientTimeoutMs, httpClientTimeoutMs);
+    this.httpRequestConfig = new DefaultHttpRequestConfig();
     this.discoverableServiceName = discoverableServiceName;
   }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/RemoteNamespaceQueryClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/RemoteNamespaceQueryClient.java
@@ -20,6 +20,7 @@ import co.cask.cdap.common.ServiceUnavailableException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.EndpointStrategy;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
+import co.cask.cdap.common.http.DefaultHttpRequestConfig;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequests;
 import co.cask.common.http.HttpResponse;
@@ -54,7 +55,7 @@ public class RemoteNamespaceQueryClient extends AbstractNamespaceQueryClient {
 
   @Override
   protected HttpResponse execute(HttpRequest request) throws IOException {
-    return HttpRequests.execute(request);
+    return HttpRequests.execute(request, new DefaultHttpRequestConfig());
   }
 
   @Override

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2001,7 +2001,15 @@
     <name>http.client.connection.timeout.ms</name>
     <value>60000</value>
     <description>
-      Timeout in milliseconds for internal HTTP requests
+      Connection timeout in milliseconds for internal HTTP requests
+    </description>
+  </property>
+
+  <property>
+    <name>http.client.read.timeout.ms</name>
+    <value>60000</value>
+    <description>
+      Read timeout in milliseconds for internal HTTP requests
     </description>
   </property>
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -25,6 +25,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.EndpointStrategy;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
+import co.cask.cdap.common.http.DefaultHttpRequestConfig;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.kerberos.SecurityUtil;
 import co.cask.cdap.data2.dataset2.ModuleConflictException;
@@ -100,8 +101,7 @@ class DatasetServiceClient {
       }
     });
     this.namespaceId = namespaceId;
-    int httpTimeoutMs = cConf.getInt(Constants.HTTP_CLIENT_TIMEOUT_MS);
-    this.httpRequestConfig = new HttpRequestConfig(httpTimeoutMs, httpTimeoutMs);
+    this.httpRequestConfig = new DefaultHttpRequestConfig();
     this.securityEnabled = cConf.getBoolean(Constants.Security.ENABLED);
     this.kerberosEnabled = SecurityUtil.isKerberosEnabled(cConf);
     this.authenticationContext = authenticationContext;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/RemoteDatasetOpExecutor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/RemoteDatasetOpExecutor.java
@@ -24,6 +24,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.EndpointStrategy;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
+import co.cask.cdap.common.http.DefaultHttpRequestConfig;
 import co.cask.cdap.common.service.UncaughtExceptionIdleService;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.proto.DatasetTypeMeta;
@@ -74,8 +75,7 @@ public abstract class RemoteDatasetOpExecutor extends UncaughtExceptionIdleServi
         return new RandomEndpointStrategy(discoveryClient.discover(Constants.Service.DATASET_EXECUTOR));
       }
     });
-    int httpTimeoutMs = cConf.getInt(Constants.HTTP_CLIENT_TIMEOUT_MS);
-    this.httpRequestConfig = new HttpRequestConfig(httpTimeoutMs, httpTimeoutMs);
+    this.httpRequestConfig = new DefaultHttpRequestConfig();
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/RemoteUGIProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/RemoteUGIProvider.java
@@ -20,7 +20,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.EndpointStrategy;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
-import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.common.http.DefaultHttpRequestConfig;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequestConfig;
 import co.cask.common.http.HttpRequests;
@@ -70,8 +70,7 @@ public class RemoteUGIProvider implements UGIProvider {
     });
     this.locationFactory = locationFactory;
 
-    int httpClientTimeoutMs = cConf.getInt(Constants.HTTP_CLIENT_TIMEOUT_MS);
-    this.httpRequestConfig = new HttpRequestConfig(httpClientTimeoutMs, httpClientTimeoutMs);
+    this.httpRequestConfig = new DefaultHttpRequestConfig();
   }
 
   private String resolve(String resource) {

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/DiscoveryExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/DiscoveryExploreClient.java
@@ -20,6 +20,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.EndpointStrategy;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
+import co.cask.cdap.common.http.DefaultHttpRequestConfig;
 import co.cask.cdap.explore.service.Explore;
 import co.cask.common.http.HttpRequestConfig;
 import com.google.common.base.Supplier;
@@ -50,8 +51,7 @@ public class DiscoveryExploreClient extends AbstractExploreClient {
       }
     });
 
-    int httpClientTimeoutMs = cConf.getInt(Constants.HTTP_CLIENT_TIMEOUT_MS);
-    this.httpRequestConfig = new HttpRequestConfig(httpClientTimeoutMs, httpClientTimeoutMs);
+    this.httpRequestConfig = new DefaultHttpRequestConfig();
   }
 
   @Override

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreHttpClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreHttpClient.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.http.DefaultHttpRequestConfig;
 import co.cask.cdap.explore.service.Explore;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.HandleNotFoundException;
@@ -85,7 +86,7 @@ abstract class ExploreHttpClient implements Explore {
   private static final Type ROW_LIST_TYPE = new TypeToken<List<QueryResult>>() { }.getType();
 
   protected HttpRequestConfig getHttpRequestConfig() {
-    return HttpRequestConfig.DEFAULT;
+    return new DefaultHttpRequestConfig();
   }
 
   protected abstract InetSocketAddress getExploreServiceAddress();

--- a/cdap-notifications-api/src/main/java/co/cask/cdap/notifications/feeds/client/RemoteNotificationFeedManager.java
+++ b/cdap-notifications-api/src/main/java/co/cask/cdap/notifications/feeds/client/RemoteNotificationFeedManager.java
@@ -19,6 +19,7 @@ package co.cask.cdap.notifications.feeds.client;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.EndpointStrategy;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
+import co.cask.cdap.common.http.DefaultHttpRequestConfig;
 import co.cask.cdap.notifications.feeds.NotificationFeedException;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.NotificationFeedNotFoundException;
@@ -143,7 +144,7 @@ public class RemoteNotificationFeedManager implements NotificationFeedManager {
 
   private HttpResponse execute(HttpRequest request) throws NotificationFeedException {
     try {
-      return HttpRequests.execute(request);
+      return HttpRequests.execute(request, new DefaultHttpRequestConfig());
     } catch (IOException e) {
       throw new NotificationFeedException(
         String.format("Error connecting to Notification Feed Service at %s while doing %s",


### PR DESCRIPTION
- HTTP request timeouts specified by the user are now set as system properties. 
- Added a subclass of `HttpRequestConfig` named `DefaultHttpRequestConfig` that reads timeouts from system properties. 
- Replaced old usages of `HttpRequestConfig` class.
- Updated default usages of `HttpRequests.execute(...)` to pass `DefaultHttpRequestConfig`
