### PR TITLE
CDAP-6912 Instantiate application and configure it under impersonation

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/LocalArtifactLoaderStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/LocalArtifactLoaderStage.java
@@ -95,6 +95,7 @@ public class LocalArtifactLoaderStage extends AbstractStage<AppDeploymentInfo> {
     InMemoryConfigurator inMemoryConfigurator = new InMemoryConfigurator(cConf, deploymentInfo.getNamespaceId().toId(),
                                                                          artifactId.toId(), appClassName,
                                                                          artifactRepository, artifactClassLoader,
+                                                                         impersonator,
                                                                          deploymentInfo.getApplicationName(),
                                                                          configString);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
@@ -107,7 +107,7 @@ public class ArtifactRepository {
                             AuthenticationContext authenticationContext) {
     this.artifactStore = artifactStore;
     this.artifactClassLoaderFactory = new ArtifactClassLoaderFactory(cConf, programRunnerFactory);
-    this.artifactInspector = new ArtifactInspector(cConf, artifactClassLoaderFactory);
+    this.artifactInspector = new ArtifactInspector(cConf, artifactClassLoaderFactory, impersonator);
     this.systemArtifactDirs = new ArrayList<>();
     for (String dir : cConf.get(Constants.AppFabric.SYSTEM_ARTIFACTS_DIR).split(";")) {
       File file = new File(dir);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/ConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/ConfiguratorTest.java
@@ -89,20 +89,20 @@ public class ConfiguratorTest {
     LocationFactory locationFactory = new LocalLocationFactory(TMP_FOLDER.newFolder());
     Location appJar = AppJarHelper.createDeploymentJar(locationFactory, WordCountApp.class);
     Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, WordCountApp.class.getSimpleName(), "1.0.0");
+    Impersonator impersonator = new Impersonator(CConfiguration.create(), null, null);
     ArtifactRepository artifactRepo = new ArtifactRepository(conf, null, null, authorizerInstantiator,
                                                              new DummyProgramRunnerFactory(),
-                                                             new Impersonator(CConfiguration.create(), null, null),
+                                                             impersonator,
                                                              authEnforcer, authenticationContext);
 
     // Create a configurator that is testable. Provide it a application.
     try (CloseableClassLoader artifactClassLoader =
            artifactRepo.createArtifactClassLoader(appJar,
                                                   new NamespacedImpersonator(artifactId.getNamespace().toEntityId(),
-                                                                             new Impersonator(CConfiguration.create(),
-                                                                                              null, null)))) {
+                                                                             impersonator))) {
       Configurator configurator = new InMemoryConfigurator(conf, Id.Namespace.DEFAULT, artifactId,
                                                            WordCountApp.class.getName(), artifactRepo,
-                                                           artifactClassLoader, null, "");
+                                                           artifactClassLoader, impersonator, null, "");
       // Extract response from the configurator.
       ListenableFuture<ConfigResponse> result = configurator.config();
       ConfigResponse response = result.get(10, TimeUnit.SECONDS);
@@ -122,9 +122,10 @@ public class ConfiguratorTest {
     LocationFactory locationFactory = new LocalLocationFactory(TMP_FOLDER.newFolder());
     Location appJar = AppJarHelper.createDeploymentJar(locationFactory, ConfigTestApp.class);
     Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, ConfigTestApp.class.getSimpleName(), "1.0.0");
+    Impersonator impersonator = new Impersonator(CConfiguration.create(), null, null);
     ArtifactRepository artifactRepo = new ArtifactRepository(conf, null, null, authorizerInstantiator,
                                                              new DummyProgramRunnerFactory(),
-                                                             new Impersonator(CConfiguration.create(), null, null),
+                                                             impersonator,
                                                              authEnforcer, authenticationContext);
 
     ConfigTestApp.ConfigClass config = new ConfigTestApp.ConfigClass("myStream", "myTable");
@@ -132,11 +133,10 @@ public class ConfiguratorTest {
     try (CloseableClassLoader artifactClassLoader =
            artifactRepo.createArtifactClassLoader(appJar,
                                                   new NamespacedImpersonator(artifactId.getNamespace().toEntityId(),
-                                                                             new Impersonator(CConfiguration.create(),
-                                                                                              null, null)))) {
+                                                                             impersonator))) {
       Configurator configuratorWithConfig =
         new InMemoryConfigurator(conf, Id.Namespace.DEFAULT, artifactId, ConfigTestApp.class.getName(),
-                                 artifactRepo, artifactClassLoader, null, new Gson().toJson(config));
+                                 artifactRepo, artifactClassLoader, impersonator, null, new Gson().toJson(config));
 
       ListenableFuture<ConfigResponse> result = configuratorWithConfig.config();
       ConfigResponse response = result.get(10, TimeUnit.SECONDS);
@@ -152,7 +152,7 @@ public class ConfiguratorTest {
 
       Configurator configuratorWithoutConfig = new InMemoryConfigurator(
         conf, Id.Namespace.DEFAULT, artifactId, ConfigTestApp.class.getName(),
-        artifactRepo, artifactClassLoader, null, null);
+        artifactRepo, artifactClassLoader, impersonator, null, null);
       result = configuratorWithoutConfig.config();
       response = result.get(10, TimeUnit.SECONDS);
       Assert.assertNotNull(response);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
@@ -65,7 +65,7 @@ public class ArtifactInspectorTest {
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TMP_FOLDER.newFolder().getAbsolutePath());
 
     classLoaderFactory = new ArtifactClassLoaderFactory(cConf, new DummyProgramRunnerFactory());
-    artifactInspector = new ArtifactInspector(cConf, classLoaderFactory);
+    artifactInspector = new ArtifactInspector(cConf, classLoaderFactory, new Impersonator(cConf, null, null));
   }
 
   @Test(expected = InvalidArtifactException.class)


### PR DESCRIPTION
Instantiate application and configure it under impersonation.
This is so that user can not easily perform operations as the cdap system user, via user code.

https://issues.cask.co/browse/CDAP-6912
http://builds.cask.co/browse/CDAP-RUT28-4
