### PR TITLE
use router.server.port to connect to router

### DIFF
--- a/cdap-ui/server/config/router-check.js
+++ b/cdap-ui/server/config/router-check.js
@@ -60,7 +60,7 @@ AuthAddress.prototype.doPing = function (cdapConfig) {
   if (cdapConfig['ssl.enabled'] === "true") {
     url = 'https://' + url + ':' + cdapConfig['router.ssl.server.port'];
   } else {
-    url = 'http://' + url + ':' + cdapConfig['router.bind.port'];
+    url = 'http://' + url + ':' + cdapConfig['router.server.port'];
   }
   url += PING_PATH;
 


### PR DESCRIPTION
Fixes [CDAP-7002](https://issues.cask.co/browse/CDAP-7002)
- [x] updates UI to use `router.server.port` to connect to router instead of `router.bind.port`
