### PR TITLE
CDAP-6817 CDAP-6736 Fix a bug in Stream batch upload

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/LengthBasedContentWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/LengthBasedContentWriter.java
@@ -105,7 +105,6 @@ final class LengthBasedContentWriter implements ContentWriter {
   private boolean updateWriter(long length) throws IOException {
     bodySize += length;
     if (bodySize >= bufferThreshold) {
-      ContentWriter fileContentWriter;
       try {
         fileContentWriter = impersonator.doAs(streamId.getParent(), new Callable<ContentWriter>() {
           @Override


### PR DESCRIPTION
Introduced during stream impersonation work. Unit test file sizes were not large enough to catch this. If I increase the file sizes to hit this scenario, it increases the test run time by 3 seconds. If that is acceptable, I can include it in this PR. Otherwise, tested by running Standalone IDE (was able to reproduce this issue earlier in IDE without this fix).

JIRAs:
https://issues.cask.co/browse/CDAP-6817
https://issues.cask.co/browse/CDAP-6736

Build : http://builds.cask.co/browse/CDAP-RUT36-1
