### PR TITLE
Impersonate updating delegation tokens

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ImpersonationHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ImpersonationHandler.java
@@ -20,7 +20,6 @@ import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.data2.security.ImpersonationInfo;
 import co.cask.cdap.data2.security.ImpersonationUtils;
 import co.cask.cdap.data2.security.UGIProvider;
-import co.cask.cdap.security.DefaultUGIProvider;
 import co.cask.cdap.security.TokenSecureStoreUpdater;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpResponder;
@@ -82,7 +81,7 @@ public class ImpersonationHandler extends AbstractHttpHandler {
     Credentials credentials = ImpersonationUtils.doAs(ugi, new Callable<Credentials>() {
       @Override
       public Credentials call() throws Exception {
-        SecureStore update = tokenSecureStoreUpdater.update(null, null);
+        SecureStore update = tokenSecureStoreUpdater.update();
         return update.getStore();
       }
     });

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
@@ -259,7 +259,7 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
               // Add secure tokens
               if (User.isHBaseSecurityEnabled(hConf) || UserGroupInformation.isSecurityEnabled()) {
                 // TokenSecureStoreUpdater.update() ignores parameters
-                twillPreparer.addSecureStore(secureStoreUpdater.update(null, null));
+                twillPreparer.addSecureStore(secureStoreUpdater.update());
               }
 
               Iterable<Class<?>> dependencies = Iterables.concat(

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillApplication.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -28,7 +28,6 @@ import org.apache.twill.api.TwillApplication;
 import org.apache.twill.api.TwillRunnable;
 import org.apache.twill.api.TwillSpecification;
 import org.apache.twill.api.TwillSpecification.Builder;
-import org.apache.twill.filesystem.Location;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,6 +58,9 @@ public abstract class AbstractProgramTwillApplication implements TwillApplicatio
     this.program = program;
     this.localizeResources = ImmutableMap.copyOf(localizeResources);
     this.eventHandler = eventHandler;
+    // sanity check, that should not fail, unless there's a bug elsewhere in the code
+    Preconditions.checkArgument(getType().equals(program.getType()),
+                                "Expected=%s, actual=%s", getType(), program.getType());
   }
 
   /**
@@ -97,9 +99,7 @@ public abstract class AbstractProgramTwillApplication implements TwillApplicatio
     addRunnables(runnables);
 
     Builder.MoreRunnable moreRunnable = Builder.with()
-      .setName(String.format("%s.%s.%s.%s",
-                             getType().name().toLowerCase(),
-                             program.getNamespaceId(), program.getApplicationId(), program.getName()))
+      .setName(TwillAppNames.toTwillAppName(program.getId().toEntityId()))
       .withRunnable();
 
     Builder.RunnableSetter runnableSetter = null;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/TwillAppNames.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/TwillAppNames.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.distributed;
+
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ProgramId;
+import com.google.common.base.Preconditions;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+
+/**
+ * Utility class to convert to and from the Twill application name for a {@link ProgramId}, since Twill application
+ * name is a simple String and must encode all identifying information of a program.
+ */
+public final class TwillAppNames {
+
+  // Pattern to split a Twill App name into [type].[namespaceId].[appName].[programName]
+  private static final Pattern APP_NAME_PATTERN = Pattern.compile("^(\\S+)\\.(\\S+)\\.(\\S+)\\.(\\S+)$");
+
+  private TwillAppNames() { }
+
+  /**
+   * Returns the Twill app name to be used for a Twill app launched for a given program.
+   */
+  static String toTwillAppName(ProgramId programId) {
+    return String.format("%s.%s.%s.%s", programId.getType().name().toLowerCase(),
+                         programId.getNamespace(), programId.getApplication(), programId.getProgram());
+  }
+
+  /**
+   * Given a Twill app name, returns the id of the program that was used to construct this Twill app name.
+   *
+   * @throws IllegalArgumentException if the given app name does not match the {@link #APP_NAME_PATTERN}.
+   */
+  public static ProgramId fromTwillAppName(String twillAppName) {
+    return fromTwillAppName(twillAppName, true);
+  }
+
+  /**
+   * Given a Twill app name, returns the id of the program that was used to construct this Twill app name.
+   * @return {@code null} if mustMatch is false, and if the specified Twill app name does
+   * not match the {@link #APP_NAME_PATTERN}.
+   * For instance, for the Constants.Service.MASTER_SERVICES Twill app, it will return null.
+   *
+   * @throws IllegalArgumentException if the given app name does not match the {@link #APP_NAME_PATTERN}
+   *                                  and mustMatch is true.
+   */
+  @Nullable
+  static ProgramId fromTwillAppName(String twillAppName, boolean mustMatch) {
+    Matcher matcher = APP_NAME_PATTERN.matcher(twillAppName);
+    if (!matcher.matches()) {
+      Preconditions.checkArgument(!mustMatch, "Twill app name '%s' does not match pattern for programs", twillAppName);
+      return null;
+    }
+    // this exception shouldn't happen (unless someone changes the pattern), because the pattern has 4 groups
+    Preconditions.checkArgument(4 == matcher.groupCount(),
+                                "Expected matcher for '%s' to have 4 groups, but it had %s groups.",
+                                twillAppName, matcher.groupCount());
+    ProgramType type = ProgramType.valueOf(matcher.group(1).toUpperCase());
+    return new ProgramId(matcher.group(2), matcher.group(3), type, matcher.group(4));
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/security/TokenSecureStoreUpdater.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/security/TokenSecureStoreUpdater.java
@@ -21,7 +21,10 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.security.DelegationTokensUpdater;
 import co.cask.cdap.common.security.YarnTokenUtils;
 import co.cask.cdap.data.security.HBaseTokenUtils;
+import co.cask.cdap.data2.security.Impersonator;
 import co.cask.cdap.hive.ExploreUtils;
+import co.cask.cdap.internal.app.runtime.distributed.TwillAppNames;
+import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.security.hive.HiveTokenUtils;
 import co.cask.cdap.security.hive.JobHistoryServerTokenUtils;
 import com.google.common.base.Throwables;
@@ -54,6 +57,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -67,16 +71,19 @@ public final class TokenSecureStoreUpdater implements SecureStoreUpdater {
   private final co.cask.cdap.api.security.store.SecureStore secureStore;
   private final long updateInterval;
   private final boolean secureExplore;
+  private final Impersonator impersonator;
 
   @Inject
   TokenSecureStoreUpdater(YarnConfiguration hConf, CConfiguration cConf,
                           LocationFactory locationFactory,
-                          co.cask.cdap.api.security.store.SecureStore secureStore) {
+                          co.cask.cdap.api.security.store.SecureStore secureStore,
+                          Impersonator impersonator) {
     this.hConf = hConf;
     this.locationFactory = locationFactory;
     this.secureStore = secureStore;
     secureExplore = cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED) && UserGroupInformation.isSecurityEnabled();
     updateInterval = calculateUpdateInterval();
+    this.impersonator = impersonator;
   }
 
   private Credentials refreshCredentials() {
@@ -231,8 +238,36 @@ public final class TokenSecureStoreUpdater implements SecureStoreUpdater {
 
   @Override
   public SecureStore update(String application, RunId runId) {
+    try {
+      if (Constants.Service.MASTER_SERVICES.equals(application)) {
+        // don't impersonate for the master.services Twill app
+        return update();
+      }
+
+      ProgramId programId = TwillAppNames.fromTwillAppName(application);
+      return impersonator.doAs(programId.getNamespaceId(), new Callable<SecureStore>() {
+        @Override
+        public SecureStore call() throws Exception {
+          return update();
+        }
+      });
+    } catch (Exception e) {
+      // it should already be a runtime exception anyways, since none of the methods in the above callable
+      // throw any checked exceptions
+      throw Throwables.propagate(e);
+    }
+  }
+
+  /**
+   * Invoked when an update to secure store is needed, but without impersonation
+   */
+  public SecureStore update() {
     Credentials credentials = refreshCredentials();
     LOG.info("Updated credentials {}", credentials.getAllTokens());
-    return YarnSecureStore.create(credentials);
+    try {
+      return YarnSecureStore.create(credentials, UserGroupInformation.getCurrentUser());
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
   }
 }

--- a/cdap-app-fabric/src/main/java/org/apache/twill/yarn/YarnSecureStore.java
+++ b/cdap-app-fabric/src/main/java/org/apache/twill/yarn/YarnSecureStore.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.twill.yarn;
+
+import org.apache.hadoop.security.Credentials;
+import org.apache.twill.api.SecureStore;
+
+/**
+ * A {@link SecureStore} for hadoop credentials.
+ */
+public final class YarnSecureStore implements SecureStore {
+
+  private final Credentials credentials;
+
+  public static SecureStore create(Credentials credentials) {
+    return new YarnSecureStore(credentials);
+  }
+
+  private YarnSecureStore(Credentials credentials) {
+    this.credentials = credentials;
+  }
+
+  @Override
+  public Credentials getStore() {
+    return credentials;
+  }
+}

--- a/cdap-app-fabric/src/main/java/org/apache/twill/yarn/YarnSecureStore.java
+++ b/cdap-app-fabric/src/main/java/org/apache/twill/yarn/YarnSecureStore.java
@@ -17,26 +17,46 @@
  */
 package org.apache.twill.yarn;
 
+import com.google.common.base.Throwables;
 import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.twill.api.SecureStore;
+
+import java.io.IOException;
 
 /**
  * A {@link SecureStore} for hadoop credentials.
+ * TODO: Copied from Twill 0.7 for CDAP-CDAP-6609.
+ * TODO: Remove this after the fix is moved to Twill (TWILL-189).
  */
 public final class YarnSecureStore implements SecureStore {
 
   private final Credentials credentials;
+  private final UserGroupInformation ugi;
 
   public static SecureStore create(Credentials credentials) {
-    return new YarnSecureStore(credentials);
+    try {
+      return create(credentials, UserGroupInformation.getCurrentUser());
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
   }
 
-  private YarnSecureStore(Credentials credentials) {
+  public static SecureStore create(Credentials credentials, UserGroupInformation userGroupInformation) {
+    return new YarnSecureStore(credentials, userGroupInformation);
+  }
+
+  private YarnSecureStore(Credentials credentials, UserGroupInformation ugi) {
     this.credentials = credentials;
+    this.ugi = ugi;
   }
 
   @Override
   public Credentials getStore() {
     return credentials;
+  }
+
+  public UserGroupInformation getUgi() {
+    return ugi;
   }
 }

--- a/cdap-app-fabric/src/main/java/org/apache/twill/yarn/YarnTwillRunnerService.java
+++ b/cdap-app-fabric/src/main/java/org/apache/twill/yarn/YarnTwillRunnerService.java
@@ -1,0 +1,621 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.twill.yarn;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.base.Throwables;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Table;
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.common.util.concurrent.Callables;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.Service;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.twill.api.ResourceSpecification;
+import org.apache.twill.api.RunId;
+import org.apache.twill.api.SecureStore;
+import org.apache.twill.api.SecureStoreUpdater;
+import org.apache.twill.api.TwillApplication;
+import org.apache.twill.api.TwillController;
+import org.apache.twill.api.TwillPreparer;
+import org.apache.twill.api.TwillRunnable;
+import org.apache.twill.api.TwillRunnerService;
+import org.apache.twill.api.TwillSpecification;
+import org.apache.twill.api.logging.LogEntry;
+import org.apache.twill.api.logging.LogHandler;
+import org.apache.twill.common.Cancellable;
+import org.apache.twill.common.Threads;
+import org.apache.twill.filesystem.HDFSLocationFactory;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.apache.twill.internal.Constants;
+import org.apache.twill.internal.ProcessController;
+import org.apache.twill.internal.RunIds;
+import org.apache.twill.internal.SingleRunnableApplication;
+import org.apache.twill.internal.appmaster.ApplicationMasterLiveNodeData;
+import org.apache.twill.internal.yarn.VersionDetectYarnAppClientFactory;
+import org.apache.twill.internal.yarn.YarnAppClient;
+import org.apache.twill.internal.yarn.YarnApplicationReport;
+import org.apache.twill.internal.yarn.YarnUtils;
+import org.apache.twill.zookeeper.NodeChildren;
+import org.apache.twill.zookeeper.NodeData;
+import org.apache.twill.zookeeper.RetryStrategies;
+import org.apache.twill.zookeeper.ZKClient;
+import org.apache.twill.zookeeper.ZKClientService;
+import org.apache.twill.zookeeper.ZKClientServices;
+import org.apache.twill.zookeeper.ZKClients;
+import org.apache.twill.zookeeper.ZKOperations;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * An implementation of {@link org.apache.twill.api.TwillRunnerService} that runs application on a YARN cluster.
+ */
+public final class YarnTwillRunnerService implements TwillRunnerService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(YarnTwillRunnerService.class);
+
+  private static final int ZK_TIMEOUT = 10000;
+  private static final Function<String, RunId> STRING_TO_RUN_ID = new Function<String, RunId>() {
+    @Override
+    public RunId apply(String input) {
+      return RunIds.fromString(input);
+    }
+  };
+  private static final Function<YarnTwillController, TwillController> CAST_CONTROLLER =
+    new Function<YarnTwillController, TwillController>() {
+    @Override
+    public TwillController apply(YarnTwillController controller) {
+      return controller;
+    }
+  };
+
+  private final YarnConfiguration yarnConfig;
+  private final YarnAppClient yarnAppClient;
+  private final ZKClientService zkClientService;
+  private final LocationFactory locationFactory;
+  private final Table<String, RunId, YarnTwillController> controllers;
+  // A Guava service to help the state transition.
+  private final Service serviceDelegate;
+  private ScheduledExecutorService secureStoreScheduler;
+
+  private Iterable<LiveInfo> liveInfos;
+  private Cancellable watchCancellable;
+
+  private volatile String jvmOptions = null;
+
+  /**
+   * Creates an instance with a {@link HDFSLocationFactory} created base on the given configuration with the
+   * user home directory as the location factory namespace.
+   *
+   * @param config Configuration of the yarn cluster
+   * @param zkConnect ZooKeeper connection string
+   */
+  public YarnTwillRunnerService(YarnConfiguration config, String zkConnect) {
+    this(config, zkConnect, createDefaultLocationFactory(config));
+  }
+
+  /**
+   * Creates an instance.
+   *
+   * @param config Configuration of the yarn cluster
+   * @param zkConnect ZooKeeper connection string
+   * @param locationFactory Factory to create {@link Location} instances that are readable and writable by this service
+   */
+  public YarnTwillRunnerService(YarnConfiguration config, String zkConnect, LocationFactory locationFactory) {
+    this.yarnConfig = config;
+    this.yarnAppClient = new VersionDetectYarnAppClientFactory().create(config);
+    this.locationFactory = locationFactory;
+    this.zkClientService = getZKClientService(zkConnect);
+    this.controllers = HashBasedTable.create();
+    this.serviceDelegate = new AbstractIdleService() {
+      @Override
+      protected void startUp() throws Exception {
+        YarnTwillRunnerService.this.startUp();
+      }
+
+      @Override
+      protected void shutDown() throws Exception {
+        YarnTwillRunnerService.this.shutDown();
+      }
+    };
+  }
+
+  @Override
+  public void start() {
+    serviceDelegate.startAndWait();
+  }
+
+  @Override
+  public void stop() {
+    serviceDelegate.stopAndWait();
+  }
+
+  /**
+   * This methods sets the extra JVM options that will be passed to the java command line for every application
+   * started through this {@link YarnTwillRunnerService} instance. It only affects applications that are started
+   * after options is set.
+   *
+   * This is intended for advance usage. All options will be passed unchanged to the java command line. Invalid
+   * options could cause application not able to start.
+   *
+   * @param options extra JVM options.
+   */
+  public void setJVMOptions(String options) {
+    Preconditions.checkArgument(options != null, "JVM options cannot be null.");
+    this.jvmOptions = options;
+  }
+
+  /**
+   * Returns any extra JVM options that have been set.
+   * @see #setJVMOptions(String)
+   */
+  public String getJVMOptions() {
+    return jvmOptions;
+  }
+
+  @Override
+  public Cancellable scheduleSecureStoreUpdate(final SecureStoreUpdater updater,
+                                               long initialDelay, long delay, TimeUnit unit) {
+    if (!UserGroupInformation.isSecurityEnabled()) {
+      return new Cancellable() {
+        @Override
+        public void cancel() {
+          // No-op
+        }
+      };
+    }
+
+    synchronized (this) {
+      if (secureStoreScheduler == null) {
+        secureStoreScheduler = Executors.newSingleThreadScheduledExecutor(
+          Threads.createDaemonThreadFactory("secure-store-updater"));
+      }
+    }
+
+    final ScheduledFuture<?> future = secureStoreScheduler.scheduleWithFixedDelay(new Runnable() {
+      @Override
+      public void run() {
+        // Collects all <application, runId> pairs first
+        Multimap<String, RunId> liveApps = HashMultimap.create();
+        synchronized (YarnTwillRunnerService.this) {
+          for (Table.Cell<String, RunId, YarnTwillController> cell : controllers.cellSet()) {
+            liveApps.put(cell.getRowKey(), cell.getColumnKey());
+          }
+        }
+
+        // Collect all secure stores that needs to be updated.
+        Table<String, RunId, SecureStore> secureStores = HashBasedTable.create();
+        for (Map.Entry<String, RunId> entry : liveApps.entries()) {
+          try {
+            secureStores.put(entry.getKey(), entry.getValue(), updater.update(entry.getKey(), entry.getValue()));
+          } catch (Throwable t) {
+            LOG.warn("Exception thrown by SecureStoreUpdater {}", updater, t);
+          }
+        }
+
+        // Update secure stores.
+        updateSecureStores(secureStores);
+      }
+    }, initialDelay, delay, unit);
+
+    return new Cancellable() {
+      @Override
+      public void cancel() {
+        future.cancel(false);
+      }
+    };
+  }
+
+  @Override
+  public TwillPreparer prepare(TwillRunnable runnable) {
+    return prepare(runnable, ResourceSpecification.BASIC);
+  }
+
+  @Override
+  public TwillPreparer prepare(TwillRunnable runnable, ResourceSpecification resourceSpecification) {
+    return prepare(new SingleRunnableApplication(runnable, resourceSpecification));
+  }
+
+  @Override
+  public TwillPreparer prepare(TwillApplication application) {
+    Preconditions.checkState(serviceDelegate.isRunning(), "Service not start. Please call start() first.");
+    final TwillSpecification twillSpec = application.configure();
+    final String appName = twillSpec.getName();
+
+    return new YarnTwillPreparer(yarnConfig, twillSpec, yarnAppClient, zkClientService.getConnectString(),
+                                 locationFactory, jvmOptions, LogEntry.Level.INFO, new YarnTwillControllerFactory() {
+      @Override
+      public YarnTwillController create(RunId runId, Iterable<LogHandler> logHandlers,
+                                        Callable<ProcessController<YarnApplicationReport>> startUp) {
+        ZKClient zkClient = ZKClients.namespace(zkClientService, "/" + appName);
+        YarnTwillController controller = listenController(new YarnTwillController(appName, runId, zkClient,
+                                                                                  logHandlers, startUp));
+        synchronized (YarnTwillRunnerService.this) {
+          Preconditions.checkArgument(!controllers.contains(appName, runId),
+                                      "Application %s with runId %s is already running.", appName, runId);
+          controllers.put(appName, runId, controller);
+        }
+        return controller;
+      }
+    });
+  }
+
+  @Override
+  public synchronized TwillController lookup(String applicationName, final RunId runId) {
+    return controllers.get(applicationName, runId);
+  }
+
+  @Override
+  public Iterable<TwillController> lookup(final String applicationName) {
+    return new Iterable<TwillController>() {
+      @Override
+      public Iterator<TwillController> iterator() {
+        synchronized (YarnTwillRunnerService.this) {
+          return Iterators.transform(ImmutableList.copyOf(controllers.row(applicationName).values()).iterator(),
+                                     CAST_CONTROLLER);
+        }
+      }
+    };
+  }
+
+  @Override
+  public Iterable<LiveInfo> lookupLive() {
+    return liveInfos;
+  }
+
+  private void startUp() throws Exception {
+    yarnAppClient.startAndWait();
+    zkClientService.startAndWait();
+
+    // Create the root node, so that the namespace root would get created if it is missing
+    // If the exception is caused by node exists, then it's ok. Otherwise propagate the exception.
+    ZKOperations.ignoreError(zkClientService.create("/", null, CreateMode.PERSISTENT),
+                             KeeperException.NodeExistsException.class, null).get();
+
+    watchCancellable = watchLiveApps();
+    liveInfos = createLiveInfos();
+
+    // Schedule an updater for updating HDFS delegation tokens
+    if (UserGroupInformation.isSecurityEnabled()) {
+      long renewalInterval = yarnConfig.getLong(DFSConfigKeys.DFS_NAMENODE_DELEGATION_TOKEN_RENEW_INTERVAL_KEY,
+                                                DFSConfigKeys.DFS_NAMENODE_DELEGATION_TOKEN_RENEW_INTERVAL_DEFAULT);
+      // Schedule it five minutes before it expires.
+      long delay = renewalInterval - TimeUnit.MINUTES.toMillis(5);
+      // Just to safeguard. In practice, the value shouldn't be that small, otherwise nothing could work.
+      if (delay <= 0) {
+        delay = (renewalInterval <= 2) ? 1 : renewalInterval / 2;
+      }
+      scheduleSecureStoreUpdate(new LocationSecureStoreUpdater(yarnConfig, locationFactory),
+                                delay, delay, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  private void shutDown() throws Exception {
+    // Shutdown shouldn't stop any controllers, as stopping this client service should let the remote containers
+    // running. However, this assumes that this TwillRunnerService is a long running service and you only stop it
+    // when the JVM process is about to exit. Hence it is important that threads created in the controllers are
+    // daemon threads.
+    synchronized (this) {
+      if (secureStoreScheduler != null) {
+        secureStoreScheduler.shutdownNow();
+      }
+    }
+    watchCancellable.cancel();
+    zkClientService.stopAndWait();
+    yarnAppClient.stopAndWait();
+  }
+
+  private Cancellable watchLiveApps() {
+    final Map<String, Cancellable> watched = Maps.newConcurrentMap();
+
+    final AtomicBoolean cancelled = new AtomicBoolean(false);
+    // Watch child changes in the root, which gives all application names.
+    final Cancellable cancellable = ZKOperations.watchChildren(zkClientService, "/",
+                                                               new ZKOperations.ChildrenCallback() {
+      @Override
+      public void updated(NodeChildren nodeChildren) {
+        if (cancelled.get()) {
+          return;
+        }
+
+        Set<String> apps = ImmutableSet.copyOf(nodeChildren.getChildren());
+
+        // For each for the application name, watch for ephemeral nodes under /instances.
+        for (final String appName : apps) {
+          if (watched.containsKey(appName)) {
+            continue;
+          }
+
+          final String instancePath = String.format("/%s/instances", appName);
+          watched.put(appName,
+                      ZKOperations.watchChildren(zkClientService, instancePath, new ZKOperations.ChildrenCallback() {
+            @Override
+            public void updated(NodeChildren nodeChildren) {
+              if (cancelled.get()) {
+                return;
+              }
+              if (nodeChildren.getChildren().isEmpty()) {     // No more child, means no live instances
+                Cancellable removed = watched.remove(appName);
+                if (removed != null) {
+                  removed.cancel();
+                }
+                return;
+              }
+              synchronized (YarnTwillRunnerService.this) {
+                // For each of the children, which the node name is the runId,
+                // fetch the application Id and construct TwillController.
+                for (final RunId runId : Iterables.transform(nodeChildren.getChildren(), STRING_TO_RUN_ID)) {
+                  if (controllers.contains(appName, runId)) {
+                    continue;
+                  }
+                  updateController(appName, runId, cancelled);
+                }
+              }
+            }
+          }));
+        }
+
+        // Remove app watches for apps that are gone. Removal of controller from controllers table is done
+        // in the state listener attached to the twill controller.
+        for (String removeApp : Sets.difference(watched.keySet(), apps)) {
+          watched.remove(removeApp).cancel();
+        }
+      }
+    });
+    return new Cancellable() {
+      @Override
+      public void cancel() {
+        cancelled.set(true);
+        cancellable.cancel();
+        for (Cancellable c : watched.values()) {
+          c.cancel();
+        }
+      }
+    };
+  }
+
+  private YarnTwillController listenController(final YarnTwillController controller) {
+    controller.onTerminated(new Runnable() {
+      @Override
+      public void run() {
+        synchronized (YarnTwillRunnerService.this) {
+          Iterables.removeIf(controllers.values(), new Predicate<YarnTwillController>() {
+            @Override
+            public boolean apply(YarnTwillController input) {
+              return input == controller;
+            }
+          });
+        }
+      }
+    }, Threads.SAME_THREAD_EXECUTOR);
+    return controller;
+  }
+
+  private ZKClientService getZKClientService(String zkConnect) {
+    return ZKClientServices.delegate(
+      ZKClients.reWatchOnExpire(
+        ZKClients.retryOnFailure(ZKClientService.Builder.of(zkConnect)
+                                   .setSessionTimeout(ZK_TIMEOUT)
+                                   .build(), RetryStrategies.exponentialDelay(100, 2000, TimeUnit.MILLISECONDS))));
+  }
+
+  private Iterable<LiveInfo> createLiveInfos() {
+    return new Iterable<LiveInfo>() {
+
+      @Override
+      public Iterator<LiveInfo> iterator() {
+        Map<String, Map<RunId, YarnTwillController>> controllerMap;
+        synchronized (YarnTwillRunnerService.this) {
+          controllerMap = ImmutableTable.copyOf(controllers).rowMap();
+        }
+        return Iterators.transform(controllerMap.entrySet().iterator(),
+                                   new Function<Map.Entry<String, Map<RunId, YarnTwillController>>, LiveInfo>() {
+          @Override
+          public LiveInfo apply(final Map.Entry<String, Map<RunId, YarnTwillController>> entry) {
+            return new LiveInfo() {
+              @Override
+              public String getApplicationName() {
+                return entry.getKey();
+              }
+
+              @Override
+              public Iterable<TwillController> getControllers() {
+                return Iterables.transform(entry.getValue().values(), CAST_CONTROLLER);
+              }
+            };
+          }
+        });
+      }
+    };
+  }
+
+  private void updateController(final String appName, final RunId runId, final AtomicBoolean cancelled) {
+    String instancePath = String.format("/%s/instances/%s", appName, runId.getId());
+
+    // Fetch the content node.
+    Futures.addCallback(zkClientService.getData(instancePath), new FutureCallback<NodeData>() {
+      @Override
+      public void onSuccess(NodeData result) {
+        if (cancelled.get()) {
+          return;
+        }
+        ApplicationId appId = getApplicationId(result);
+        if (appId == null) {
+          return;
+        }
+
+        synchronized (YarnTwillRunnerService.this) {
+          if (!controllers.contains(appName, runId)) {
+            ZKClient zkClient = ZKClients.namespace(zkClientService, "/" + appName);
+            YarnTwillController controller = listenController(
+              new YarnTwillController(appName, runId, zkClient,
+                                      Callables.returning(yarnAppClient.createProcessController(appId))));
+            controllers.put(appName, runId, controller);
+            controller.start();
+          }
+        }
+      }
+
+      @Override
+      public void onFailure(Throwable t) {
+        LOG.warn("Failed in fetching application instance node.", t);
+      }
+    }, Threads.SAME_THREAD_EXECUTOR);
+  }
+
+
+  /**
+   * Decodes application ID stored inside the node data.
+   * @param nodeData The node data to decode from. If it is {@code null}, this method would return {@code null}.
+   * @return The ApplicationId or {@code null} if failed to decode.
+   */
+  private ApplicationId getApplicationId(NodeData nodeData) {
+    byte[] data = nodeData == null ? null : nodeData.getData();
+    if (data == null) {
+      return null;
+    }
+
+    Gson gson = new Gson();
+    JsonElement json = gson.fromJson(new String(data, Charsets.UTF_8), JsonElement.class);
+    if (!json.isJsonObject()) {
+      LOG.warn("Unable to decode live data node.");
+      return null;
+    }
+
+    JsonObject jsonObj = json.getAsJsonObject();
+    json = jsonObj.get("data");
+    if (!json.isJsonObject()) {
+      LOG.warn("Property data not found in live data node.");
+      return null;
+    }
+
+    try {
+      ApplicationMasterLiveNodeData amLiveNode = gson.fromJson(json, ApplicationMasterLiveNodeData.class);
+      return YarnUtils.createApplicationId(amLiveNode.getAppIdClusterTime(), amLiveNode.getAppId());
+    } catch (Exception e) {
+      LOG.warn("Failed to decode application live node data.", e);
+      return null;
+    }
+  }
+
+  private void updateSecureStores(Table<String, RunId, SecureStore> secureStores) {
+    for (Table.Cell<String, RunId, SecureStore> cell : secureStores.cellSet()) {
+      Object store = cell.getValue().getStore();
+      if (!(store instanceof Credentials)) {
+        LOG.warn("Only Hadoop Credentials is supported. Ignore update for {}.", cell);
+        continue;
+      }
+
+      Credentials credentials = (Credentials) store;
+      if (credentials.getAllTokens().isEmpty()) {
+        // Nothing to update.
+        continue;
+      }
+
+      try {
+        updateCredentials(cell.getRowKey(), cell.getColumnKey(), credentials);
+        synchronized (YarnTwillRunnerService.this) {
+          // Notify the application for secure store updates if it is still running.
+          YarnTwillController controller = controllers.get(cell.getRowKey(), cell.getColumnKey());
+          if (controller != null) {
+            controller.secureStoreUpdated();
+          }
+        }
+      } catch (Throwable t) {
+        LOG.warn("Failed to update secure store for {}.", cell, t);
+      }
+    }
+  }
+
+  private void updateCredentials(String application, RunId runId, Credentials updates) throws IOException {
+    Location credentialsLocation = locationFactory.create(String.format("/%s/%s/%s", application, runId.getId(),
+                                                                        Constants.Files.CREDENTIALS));
+    // Try to read the old credentials.
+    Credentials credentials = new Credentials();
+    if (credentialsLocation.exists()) {
+      try (DataInputStream is = new DataInputStream(new BufferedInputStream(credentialsLocation.getInputStream()))) {
+        credentials.readTokenStorageStream(is);
+      }
+    }
+
+    // Overwrite with the updates.
+    credentials.addAll(updates);
+
+    // Overwrite the credentials.
+    Location tmpLocation = credentialsLocation.getTempFile(Constants.Files.CREDENTIALS);
+
+    // Save the credentials store with user-only permission.
+    try (DataOutputStream os = new DataOutputStream(new BufferedOutputStream(tmpLocation.getOutputStream("600")))) {
+      credentials.writeTokenStorageToStream(os);
+    }
+
+    // Rename the tmp file into the credentials location
+    tmpLocation.renameTo(credentialsLocation);
+
+    LOG.debug("Secure store for {} {} saved to {}.", application, runId, credentialsLocation);
+  }
+
+  private static LocationFactory createDefaultLocationFactory(Configuration configuration) {
+    try {
+      FileSystem fs = FileSystem.get(configuration);
+      return new HDFSLocationFactory(fs, fs.getHomeDirectory().toUri().getPath());
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/org/apache/twill/yarn/YarnTwillRunnerService.java
+++ b/cdap-app-fabric/src/main/java/org/apache/twill/yarn/YarnTwillRunnerService.java
@@ -92,6 +92,7 @@ import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.security.PrivilegedExceptionAction;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -104,6 +105,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * An implementation of {@link org.apache.twill.api.TwillRunnerService} that runs application on a YARN cluster.
+ * TODO: Copied from Twill 0.7 for CDAP-CDAP-6609.
+ * TODO: Remove this after the fix is moved to Twill (TWILL-189).
  */
 public final class YarnTwillRunnerService implements TwillRunnerService {
 
@@ -329,20 +332,6 @@ public final class YarnTwillRunnerService implements TwillRunnerService {
 
     watchCancellable = watchLiveApps();
     liveInfos = createLiveInfos();
-
-    // Schedule an updater for updating HDFS delegation tokens
-    if (UserGroupInformation.isSecurityEnabled()) {
-      long renewalInterval = yarnConfig.getLong(DFSConfigKeys.DFS_NAMENODE_DELEGATION_TOKEN_RENEW_INTERVAL_KEY,
-                                                DFSConfigKeys.DFS_NAMENODE_DELEGATION_TOKEN_RENEW_INTERVAL_DEFAULT);
-      // Schedule it five minutes before it expires.
-      long delay = renewalInterval - TimeUnit.MINUTES.toMillis(5);
-      // Just to safeguard. In practice, the value shouldn't be that small, otherwise nothing could work.
-      if (delay <= 0) {
-        delay = (renewalInterval <= 2) ? 1 : renewalInterval / 2;
-      }
-      scheduleSecureStoreUpdate(new LocationSecureStoreUpdater(yarnConfig, locationFactory),
-                                delay, delay, TimeUnit.MILLISECONDS);
-    }
   }
 
   private void shutDown() throws Exception {
@@ -555,20 +544,19 @@ public final class YarnTwillRunnerService implements TwillRunnerService {
 
   private void updateSecureStores(Table<String, RunId, SecureStore> secureStores) {
     for (Table.Cell<String, RunId, SecureStore> cell : secureStores.cellSet()) {
-      Object store = cell.getValue().getStore();
-      if (!(store instanceof Credentials)) {
-        LOG.warn("Only Hadoop Credentials is supported. Ignore update for {}.", cell);
+      SecureStore secureStore = cell.getValue();
+      if (!(secureStore instanceof YarnSecureStore)) {
+        LOG.warn("Only Yarn SecureStore is supported. Ignore update for {}.", cell);
         continue;
       }
-
-      Credentials credentials = (Credentials) store;
-      if (credentials.getAllTokens().isEmpty()) {
+      YarnSecureStore yarnSecureStore = (YarnSecureStore) secureStore;
+      if (yarnSecureStore.getStore().getAllTokens().isEmpty()) {
         // Nothing to update.
         continue;
       }
 
       try {
-        updateCredentials(cell.getRowKey(), cell.getColumnKey(), credentials);
+        updateCredentials(cell.getRowKey(), cell.getColumnKey(), yarnSecureStore);
         synchronized (YarnTwillRunnerService.this) {
           // Notify the application for secure store updates if it is still running.
           YarnTwillController controller = controllers.get(cell.getRowKey(), cell.getColumnKey());
@@ -582,9 +570,23 @@ public final class YarnTwillRunnerService implements TwillRunnerService {
     }
   }
 
-  private void updateCredentials(String application, RunId runId, Credentials updates) throws IOException {
-    Location credentialsLocation = locationFactory.create(String.format("/%s/%s/%s", application, runId.getId(),
-                                                                        Constants.Files.CREDENTIALS));
+  private void updateCredentials(final String application, final RunId runId,
+                                 YarnSecureStore yarnSecureStore) throws IOException {
+    Location credentialsLocation;
+    try {
+      credentialsLocation = yarnSecureStore.getUgi().doAs(new PrivilegedExceptionAction<Location>() {
+        @Override
+        public Location run() throws Exception {
+          return locationFactory.create(String.format("/%s/%s/%s", application, runId.getId(),
+                                                      Constants.Files.CREDENTIALS));
+        }
+      });
+    } catch (Exception e) {
+      // the only checked exception thrown in in the above Callable is IOException
+      Throwables.propagateIfInstanceOf(e, IOException.class);
+      throw Throwables.propagate(e);
+    }
+
     // Try to read the old credentials.
     Credentials credentials = new Credentials();
     if (credentialsLocation.exists()) {
@@ -594,7 +596,7 @@ public final class YarnTwillRunnerService implements TwillRunnerService {
     }
 
     // Overwrite with the updates.
-    credentials.addAll(updates);
+    credentials.addAll(yarnSecureStore.getStore());
 
     // Overwrite the credentials.
     Location tmpLocation = credentialsLocation.getTempFile(Constants.Files.CREDENTIALS);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/distributed/TwillAppNamesTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/distributed/TwillAppNamesTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.distributed;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramId;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test cases for {@link TwillAppNames}.
+ */
+public class TwillAppNamesTest {
+
+  @Test
+  public void test() {
+    ProgramId flowId = new NamespaceId("test_ns").app("my_app").flow("my_flow");
+    String flowTwillAppName = TwillAppNames.toTwillAppName(flowId);
+    Assert.assertEquals("flow.test_ns.my_app.my_flow", flowTwillAppName);
+    Assert.assertEquals(flowId, TwillAppNames.fromTwillAppName(flowTwillAppName));
+
+    // parsing from twill app name can be optional (return null)
+    Assert.assertNull(TwillAppNames.fromTwillAppName(Constants.Service.MASTER_SERVICES, false));
+
+    try {
+      // if passing true, throws exception, when parsing is not possible
+      TwillAppNames.fromTwillAppName(Constants.Service.MASTER_SERVICES, true);
+      Assert.fail("Expected not being able to parse ");
+    } catch (IllegalArgumentException e) {
+      // expected
+      Assert.assertTrue(e.getMessage().contains("does not match pattern for programs"));
+    }
+  }
+}

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -800,8 +800,7 @@ public class MasterServiceMain extends DaemonMain {
 
           // Add secure tokens
           if (User.isHBaseSecurityEnabled(hConf) || UserGroupInformation.isSecurityEnabled()) {
-            // TokenSecureStoreUpdater.update() ignores parameters
-            preparer.addSecureStore(secureStoreUpdater.update(null, null));
+            preparer.addSecureStore(secureStoreUpdater.update());
           }
 
           // add hadoop classpath to application classpath and exclude hadoop classes from bundle jar.


### PR DESCRIPTION
Without this, we push cdap's delegation tokens to the applications, when they are running.

First commit simply pulls in relevant classes we need to update from twill (0.7.0-incubating branch).
Second commit has my functional changes.

Changes:
- Implement TwillAppNaming to encapsulate parsing/construction of twill app name.
- Perform impersonation when updating delegation tokens
- Avoid/remove the updating of delegation tokens happening in Twill

https://issues.cask.co/browse/CDAP-6609
http://builds.cask.co/browse/CDAP-RUT33-8
