### PR TITLE
Fix log statements.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/security/DefaultUGIProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/security/DefaultUGIProvider.java
@@ -87,7 +87,7 @@ public class DefaultUGIProvider implements UGIProvider {
       LOG.debug("Logging in as: principal={}, keytab={}", expandedPrincipal, localKeytabFile);
 
       Preconditions.checkArgument(java.nio.file.Files.isReadable(localKeytabFile.toPath()),
-                                  "Keytab file is not a readable file: {}", localKeytabFile);
+                                  "Keytab file is not a readable file: %s", localKeytabFile);
 
       return UserGroupInformation.loginUserFromKeytabAndReturnUGI(expandedPrincipal, localKeytabFile.getAbsolutePath());
     } finally {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/PipelineTypeValidator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/PipelineTypeValidator.java
@@ -90,7 +90,7 @@ public class PipelineTypeValidator {
       Type secondType = resTypeList.get(i + 1);
       // Check if secondType can accept firstType
       Preconditions.checkArgument(TypeToken.of(secondType).isAssignableFrom(firstType),
-                                  "Types between stages didn't match. Mismatch between {} -> {}",
+                                  "Types between stages didn't match. Mismatch between %s -> %s",
                                   firstType, secondType);
     }
   }

--- a/cdap-common/src/main/java/co/cask/cdap/common/kerberos/SecurityUtil.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/kerberos/SecurityUtil.java
@@ -85,7 +85,7 @@ public final class SecurityUtil {
 
     File keytabFile = new File(cConf.get(Constants.Security.CFG_CDAP_MASTER_KRB_KEYTAB_PATH));
     Preconditions.checkArgument(Files.isReadable(keytabFile.toPath()),
-                                "Keytab file is not a readable file: {}", keytabFile);
+                                "Keytab file is not a readable file: %s", keytabFile);
 
     LOG.info("Using Kerberos principal {} and keytab {}", principal, keytabFile.getAbsolutePath());
 
@@ -148,7 +148,7 @@ public final class SecurityUtil {
     if (UserGroupInformation.isSecurityEnabled()) {
       Path keytabFile = Paths.get(keytabPath);
       Preconditions.checkArgument(Files.isReadable(keytabFile),
-                                  "Keytab file is not a readable file: {}", keytabFile);
+                                  "Keytab file is not a readable file: %s", keytabFile);
       String expandedPrincipal = expandPrincipal(principal);
       LOG.info("Logging in as: principal={}, keytab={}", principal, keytabPath);
       UserGroupInformation.loginUserFromKeytab(expandedPrincipal, keytabPath);

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/ResourceRequirement.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/coordination/ResourceRequirement.java
@@ -202,7 +202,7 @@ public final class ResourceRequirement {
      */
     public Builder addPartition(Partition partition) {
       Preconditions.checkArgument(!partitions.containsKey(partition.getName()),
-                                  "Partition {} already added.", partition);
+                                  "Partition %s already added.", partition);
       partitions.put(partition.getName(), partition);
       return this;
     }

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
@@ -189,7 +189,7 @@ public abstract class IntegrationTestBase {
   private void assertUnrecoverableResetEnabled() throws IOException, UnauthenticatedException {
     ConfigEntry configEntry = getMetaClient().getCDAPConfig().get(Constants.Dangerous.UNRECOVERABLE_RESET);
     Preconditions.checkNotNull(configEntry,
-                               "Missing key from CDAP Configuration: {}", Constants.Dangerous.UNRECOVERABLE_RESET);
+                               "Missing key from CDAP Configuration: %s", Constants.Dangerous.UNRECOVERABLE_RESET);
     Preconditions.checkState(Boolean.parseBoolean(configEntry.getValue()), "UnrecoverableReset not enabled.");
   }
 


### PR DESCRIPTION
Preconditions uses `%s`, instead of `{}` for string interpolation.
This PR fixes some incorrect usages.
