### PR TITLE
RemoteUGIProvider is responsible for delegation token cleanup

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/RemoteUGIProvider.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/security/RemoteUGIProvider.java
@@ -116,6 +116,10 @@ public class RemoteUGIProvider implements UGIProvider {
 
     Location location = locationFactory.create(URI.create(credentialsURI));
     Credentials credentials = readCredentials(location);
+    boolean deleted = location.delete();
+    if (!deleted) {
+      LOG.warn("Failed to delete location: {}", location);
+    }
     impersonatedUGI.addCredentials(credentials);
     return impersonatedUGI;
   }


### PR DESCRIPTION
RemoteUGIProvider is responsible for deleting the delegation tokens after reading them.
App fabric simply writes them to hdfs, whenever the RemoteUGIProvider asks for them.

This can be revisited, once we decide on how we want to do caching for these delegation tokens.

https://issues.cask.co/browse/CDAP-6539
http://builds.cask.co/browse/CDAP-RUT55-1
