### PR TITLE
CDAP CLI gives better error message when role is not found.

### DIFF
--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/AuthorizationCLITest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/AuthorizationCLITest.java
@@ -198,6 +198,12 @@ public class AuthorizationCLITest extends CLITestBase {
                                                  principal.getName()),
                               String.format("Successfully removed role '%s' from %s '%s'", role.getName(),
                                             principal.getType(), principal.getName()));
+
+    // test remove role (which doesn't exist) from principal
+    Role nonexistentRole = new Role("nonexistent_role");
+    testCommandOutputContains(cli, String.format("remove role %s from %s %s", nonexistentRole.getName(),
+                                                 principal.getType(), principal.getName()),
+                              String.format("Error: %s not found", nonexistentRole));
   }
 
   @AfterClass

--- a/cdap-common/src/main/java/co/cask/cdap/common/NotFoundException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/NotFoundException.java
@@ -21,6 +21,8 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.EntityId;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
+import javax.annotation.Nullable;
+
 /**
  * Thrown when an element is not found
  */
@@ -53,6 +55,16 @@ public class NotFoundException extends Exception implements HttpErrorStatusProvi
     this.object = object;
   }
 
+  public NotFoundException(String errorMessage) {
+    super(errorMessage);
+    this.object = null;
+  }
+
+  /**
+   * Return the object which could not be found. Returns null, if the entity is not known, such as when thrown from
+   * cdap-clients.
+   */
+  @Nullable
   public Object getObject() {
     return object;
   }


### PR DESCRIPTION
CDAP CLI gives better error message when role is not found.

Without this change:

```
cdap (http://<HostAndPort>/namespace:default)> grant actions ALL on entity namespace:q to user bhooshan
Error: ''namespace:q' was not found.' was not found.
```

Now:

```
cdap (http://authtest11848-1000.dev.continuuity.net:11015/namespace:default)> grant actions ALL on entity namespace:q to user bhooshan
ant actions ALL on entity namespace:q to user bhooshan
Error: 'namespace:q' was not found.
```

https://issues.cask.co/browse/CDAP-6147
