### PR TITLE
Revert "Revert "CDAP-6321 Master Service Bind Port Not Configurable""

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -354,8 +354,8 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
     @Named(Constants.AppFabric.SERVER_ADDRESS)
     @SuppressWarnings("unused")
     public InetAddress providesHostname(CConfiguration cConf) {
-      return Networks.resolve(cConf.get(Constants.AppFabric.SERVER_ADDRESS),
-                              new InetSocketAddress("localhost", 0).getAddress());
+      String address = cConf.get(Constants.AppFabric.SERVER_ADDRESS);
+      return Networks.resolve(address, new InetSocketAddress("localhost", 0).getAddress());
     }
 
     /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
@@ -152,6 +152,7 @@ public class AppFabricServer extends AbstractIdleService {
     // Run http service on random port
     httpService = new CommonNettyHttpServiceBuilder(configuration)
       .setHost(hostname.getCanonicalHostName())
+      .setPort(configuration.getInt(Constants.AppFabric.SERVER_PORT))
       .setHandlerHooks(builder.build())
       .addHttpHandlers(handlers)
       .setConnectionBacklog(configuration.getInt(Constants.AppFabric.BACKLOG_CONNECTIONS,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataService.java
@@ -70,6 +70,7 @@ public class MetadataService extends AbstractIdleService {
       .setHandlerHooks(ImmutableList.of(new MetricsReporterHook(metricsCollectionService,
                                                                 Constants.Service.METADATA_SERVICE)))
       .setHost(cConf.get(Constants.Metadata.SERVICE_BIND_ADDRESS))
+      .setPort(cConf.getInt(Constants.Metadata.SERVICE_BIND_PORT))
       .setWorkerThreadPoolSize(cConf.getInt(Constants.Metadata.SERVICE_WORKER_THREADS))
       .setExecThreadPoolSize(cConf.getInt(Constants.Metadata.SERVICE_EXEC_THREADS))
       .setConnectionBacklog(20000)

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -118,6 +118,7 @@ public final class Constants {
      * App Fabric Server.
      */
     public static final String SERVER_ADDRESS = "app.bind.address";
+    public static final String SERVER_PORT = "app.bind.port";
     public static final String OUTPUT_DIR = "app.output.dir";
     public static final String TEMP_DIR = "app.temp.dir";
     public static final String REST_PORT = "app.rest.port";
@@ -261,6 +262,7 @@ public final class Constants {
     public static final class Manager {
       /** for the address (hostname) of the dataset server. */
       public static final String ADDRESS = "dataset.service.bind.address";
+      public static final String PORT = "dataset.service.bind.port";
 
       public static final String BACKLOG_CONNECTIONS = "dataset.service.connection.backlog";
       public static final String EXEC_THREADS = "dataset.service.exec.threads";
@@ -334,6 +336,7 @@ public final class Constants {
     // Stream http service configurations.
     public static final String STREAM_HANDLER = "stream.handler";
     public static final String ADDRESS = "stream.bind.address";
+    public static final String PORT = "stream.bind.port";
     public static final String WORKER_THREADS = "stream.worker.threads";
     public static final String ASYNC_WORKER_THREADS = "stream.async.worker.threads";
     public static final String ASYNC_QUEUE_SIZE = "stream.async.queue.size";
@@ -804,6 +807,7 @@ public final class Constants {
     public static final String CDAP_VERSION = "cdap.version";
 
     public static final String SERVER_ADDRESS = "explore.service.bind.address";
+    public static final String SERVER_PORT = "explore.service.bind.port";
 
     public static final String BACKLOG_CONNECTIONS = "explore.service.connection.backlog";
     public static final String EXEC_THREADS = "explore.service.exec.threads";
@@ -959,6 +963,7 @@ public final class Constants {
   public static final class Metadata {
     public static final String SERVICE_DESCRIPTION = "Service to perform metadata operations.";
     public static final String SERVICE_BIND_ADDRESS = "metadata.service.bind.address";
+    public static final String SERVICE_BIND_PORT = "metadata.service.bind.port";
     public static final String SERVICE_WORKER_THREADS = "metadata.service.worker.threads";
     public static final String SERVICE_EXEC_THREADS = "metadata.service.exec.threads";
     public static final String HANDLERS_NAME = "metadata.handlers";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -244,6 +244,14 @@
   </property>
 
   <property>
+    <name>app.bind.port</name>
+    <value>0</value>
+    <description>
+      App Fabric service bind port
+    </description>
+  </property>
+
+  <property>
     <name>app.output.dir</name>
     <value>/programs</value>
     <description>
@@ -586,6 +594,14 @@
   </property>
 
   <property>
+    <name>dataset.executor.bind.port</name>
+    <value>0</value>
+    <description>
+      Dataset executor bind port
+    </description>
+  </property>
+
+  <property>
     <name>dataset.extensions.dir</name>
     <value>/opt/cdap/ext/lib</value>
     <description>
@@ -598,6 +614,14 @@
     <value>0.0.0.0</value>
     <description>
       Dataset service bind address
+    </description>
+  </property>
+
+  <property>
+    <name>dataset.service.bind.port</name>
+    <value>0</value>
+    <description>
+      Dataset service bind port
     </description>
   </property>
 
@@ -713,6 +737,14 @@
     <description>
       Determines if writing to a table through the CDAP Explore Service (ad-
       hoc SQL queries) is enabled
+    </description>
+  </property>
+
+  <property>
+    <name>explore.service.bind.port</name>
+    <value>0</value>
+    <description>
+      Explore service bind port
     </description>
   </property>
 
@@ -1048,6 +1080,14 @@
     <value>0.0.0.0</value>
     <description>
       Metadata HTTP service bind address
+    </description>
+  </property>
+
+  <property>
+    <name>metadata.service.bind.port</name>
+    <value>0</value>
+    <description>
+      Metadata HTTP service bind port
     </description>
   </property>
 
@@ -1827,6 +1867,14 @@
     <value>0.0.0.0</value>
     <description>
       Stream HTTP service bind address
+    </description>
+  </property>
+
+  <property>
+    <name>stream.bind.port</name>
+    <value>0</value>
+    <description>
+      Stream HTTP service bind port
     </description>
   </property>
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHttpService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHttpService.java
@@ -63,6 +63,7 @@ public final class StreamHttpService extends AbstractIdleService implements Supp
       .setHandlerHooks(ImmutableList.of(new MetricsReporterHook(metricsCollectionService,
                                                                 Constants.Stream.STREAM_HANDLER)))
       .setHost(cConf.get(Constants.Stream.ADDRESS))
+      .setPort(cConf.getInt(Constants.Stream.PORT))
       .setWorkerThreadPoolSize(workerThreads)
       .setExecThreadPoolSize(0)         // Execution happens in the io worker thread directly
       .setConnectionBacklog(20000)

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetService.java
@@ -87,6 +87,8 @@ public class DatasetService extends AbstractExecutionThreadService {
 
     builder.setHost(cConf.get(Constants.Dataset.Manager.ADDRESS));
 
+    builder.setPort(cConf.getInt(Constants.Dataset.Manager.PORT));
+
     builder.setConnectionBacklog(cConf.getInt(Constants.Dataset.Manager.BACKLOG_CONNECTIONS,
                                               Constants.Dataset.Manager.DEFAULT_BACKLOG));
     builder.setExecThreadPoolSize(cConf.getInt(Constants.Dataset.Manager.EXEC_THREADS,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorService.java
@@ -65,6 +65,7 @@ public class DatasetOpExecutorService extends AbstractIdleService {
     this.httpService = new CommonNettyHttpServiceBuilder(cConf)
       .addHttpHandlers(handlers)
       .setHost(cConf.get(Constants.Dataset.Executor.ADDRESS))
+      .setPort(cConf.getInt(Constants.Dataset.Executor.PORT))
       .setHandlerHooks(ImmutableList.of(
         new MetricsReporterHook(metricsCollectionService, Constants.Service.DATASET_EXECUTOR)))
       .setWorkerThreadPoolSize(workerThreads)

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorService.java
@@ -71,6 +71,7 @@ public class ExploreExecutorService extends AbstractIdleService {
     this.httpService = new CommonNettyHttpServiceBuilder(cConf)
         .addHttpHandlers(handlers)
         .setHost(cConf.get(Constants.Explore.SERVER_ADDRESS))
+        .setPort(cConf.getInt(Constants.Explore.SERVER_PORT))
         .setHandlerHooks(ImmutableList.of(
             new MetricsReporterHook(metricsCollectionService, Constants.Service.EXPLORE_HTTP_USER_SERVICE)))
         .setWorkerThreadPoolSize(workerThreads)


### PR DESCRIPTION
Cherry pick the revert of the revert for https://issues.cask.co/browse/CDAP-6321 (https://github.com/caskdata/cdap/pull/6192) for release/3.5.

We had already branched release/3.5 branch, so the change didn't make it to release branch, only to the develop branch.

Original PR by @bennythomps: https://github.com/caskdata/cdap/pull/6099
