### PR TITLE
CDAP-4175, 6469 Add example of creating an HDFS user other than "yarn"

### DIFF
--- a/cdap-docs/admin-manual/source/_includes/installation/configuration.txt
+++ b/cdap-docs/admin-manual/source/_includes/installation/configuration.txt
@@ -1,3 +1,5 @@
+.. |my_username| replace:: ``my_username``
+
 .. _|distribution|-configuration:
 
 .. _|distribution|-configuration-central:
@@ -101,20 +103,28 @@ for CDAP to run successfully.
   
       #. Check that the default HDFS user |hdfs-user| owns that HDFS directory.
   
-   #. If you want to use **an HDFS user** other than |hdfs-user|:
+   #. If you want to use **an HDFS user** other than |hdfs-user|, such as |my_username|:
 
       1. Check that there is |---| and create if necessary |---| a corresponding user on all machines
          in the cluster on which YARN is running (typically, all of the machines).
       #. Create an ``hdfs.user`` property for that user in ``conf/cdap-site.xml``::
   
-           <property>
-             <name>hdfs.user</name>
-             <value>my_username</value>
-             <description>User for accessing HDFS</description>
-           </property>
+             <property>
+               <name>hdfs.user</name>
+               <value>my_username</value>
+               <description>User for accessing HDFS</description>
+             </property>
   
       #. Check that the HDFS user owns the HDFS directory described by ``hdfs.namespace`` on all machines.
-      #. Check that there exists in HDFS a ``/user/`` directory for that HDFS user, as described above.
+      #. Check that there exists in HDFS a ``/user/`` directory for that HDFS user, as described above, such as:
+      
+         .. container:: highlight
+       
+           .. parsed-literal::
+         
+             |$| su hdfs
+             |$| hdfs dfs -mkdir -p /user/|my_username| && hadoop fs -chown |my_username| /user/|my_username| && hadoop fs -chgrp |my_username| /user/|my_username|
+      
    
    #. To use the **ad-hoc querying capabilities of CDAP,** ensure the cluster has a
       compatible version of Hive installed. See the section on :ref:`Hadoop Compatibility

--- a/cdap-docs/admin-manual/source/_includes/installation/configuration.txt
+++ b/cdap-docs/admin-manual/source/_includes/installation/configuration.txt
@@ -109,11 +109,11 @@ for CDAP to run successfully.
          in the cluster on which YARN is running (typically, all of the machines).
       #. Create an ``hdfs.user`` property for that user in ``conf/cdap-site.xml``::
   
-             <property>
-               <name>hdfs.user</name>
-               <value>my_username</value>
-               <description>User for accessing HDFS</description>
-             </property>
+           <property>
+             <name>hdfs.user</name>
+             <value>my_username</value>
+             <description>User for accessing HDFS</description>
+           </property>
   
       #. Check that the HDFS user owns the HDFS directory described by ``hdfs.namespace`` on all machines.
       #. Check that there exists in HDFS a ``/user/`` directory for that HDFS user, as described above, such as:

--- a/cdap-docs/admin-manual/source/_includes/installation/configuration.txt
+++ b/cdap-docs/admin-manual/source/_includes/installation/configuration.txt
@@ -125,6 +125,13 @@ for CDAP to run successfully.
              |$| su hdfs
              |$| hdfs dfs -mkdir -p /user/|my_username| && hadoop fs -chown |my_username| /user/|my_username| && hadoop fs -chgrp |my_username| /user/|my_username|
       
+      #. If you use an HDFS user other than |hdfs-user|, you must use either a secure
+         cluster or use the `LinuxContainerExecutor
+         <https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/SecureContainer.html>`__ 
+         instead of the ``DefaultContainerExecutor``. (Because of how ``DefaultContainerExecutor``
+         works, other containers will launch as |hdfs-user| rather than the specified
+         ``hdfs.user``.) On Kerberos-enabled clusters, you must use ``LinuxContainerExecutor``
+         as the ``DefaultContainerExecutor`` will not work correctly.
    
    #. To use the **ad-hoc querying capabilities of CDAP,** ensure the cluster has a
       compatible version of Hive installed. See the section on :ref:`Hadoop Compatibility


### PR DESCRIPTION
Running as [Quick Build 3](http://builds.cask.co/browse/CDAP-DQB73-3)

Add example usage of creating an HDFS user other than `yarn`. Adds note about using a LinuxContainerExecutor.

Page of interest: [Admin Manual, Installation](http://builds.cask.co/artifact/CDAP-DQB73/shared/build-3/Docs-HTML/3.5.0-SNAPSHOT/en/admin-manual/installation/packages.html#cdap-configuration): see step "3.v".

Fix for https://issues.cask.co/browse/CDAP-4175 and https://issues.cask.co/browse/CDAP-6469
