### PR TITLE
CDAP-3428 Fix menu display on Firefox.

### DIFF
--- a/cdap-docs/_common/_themes/cdap/static/cdap.css_t
+++ b/cdap-docs/_common/_themes/cdap/static/cdap.css_t
@@ -275,6 +275,15 @@ li.versions {
     top: 6px;
 }
 
+/* -- Fix menu display on Firefox ------------------------- */
+
+@-moz-document url-prefix() { 
+    li.versions {
+        margin-left: -165px;
+        top: -1px;
+    }
+}
+
 div.topic {
     background-color: #eee;
 }


### PR DESCRIPTION
Passes [Quick Build 1](http://builds.cask.co/browse/CDAP-DQB74-1)

Issue https://issues.cask.co/browse/CDAP-3428

[Revised index page](http://builds.cask.co/artifact/CDAP-DQB74/shared/build-1/Docs-HTML/3.5.0-SNAPSHOT/en/index.html) (view in Firefox to see fixed page)

[Current page](http://docs.cask.co/cdap/develop/en/) (view in Firefox to see error on page)

Fixes a long-standing bug that shows up under Firefox: the version menu ends up in the wrong location, because Firefox calculates the size differently than other browsers.

Screen shot showing (from within Firefox) current (left) and revised (right):

![screen shot 2016-08-11 at 3 12 15 pm](https://cloud.githubusercontent.com/assets/6394794/17606765/1c4d06b8-5fd6-11e6-9d15-f59a89ff017b.png)
