### PR TITLE
Consolidate duplicated material on scaling CDAP components

### DIFF
--- a/cdap-docs/admin-manual/source/index.rst
+++ b/cdap-docs/admin-manual/source/index.rst
@@ -119,7 +119,7 @@ installation and its security configuration.
     .. |scaling-instances| replace:: **Scaling Instances:**
     .. _scaling-instances: operations/scaling-instances.html
 
-    - |scaling-instances|_ Covers **querying and setting the number of instances of flowlets and services.** 
+    - |scaling-instances|_ Covers **querying and setting the number of instances of flowlets, services, and workers.** 
 
     .. |resource-guarantees| replace:: **Resource Guarantees:**
     .. _resource-guarantees: operations/resource-guarantees.html

--- a/cdap-docs/admin-manual/source/operations/scaling-instances.rst
+++ b/cdap-docs/admin-manual/source/operations/scaling-instances.rst
@@ -1,111 +1,23 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2016 Cask Data, Inc.
 
-============================================
+=================
 Scaling Instances
-============================================
+=================
 
-You can scale CDAP components using:
+You can scale CDAP components (instances of flowlets, services, and workers) using:
 
-- the :ref:`Scaling<http-restful-api-lifecycle-scale>` methods of the 
-  :ref:`Lifecycle HTTP RESTful API<http-restful-api-lifecycle>`;
-- the :ref:`ProgramClient API<program-client>` of the 
-  :ref:`Java Client API<java-client-api>`; or
-- the :ref:`Get/Set Commands<cli-available-commands>` of the 
-  :ref:`Command Line Interface<cli>`.
+- the :ref:`Scaling <http-restful-api-lifecycle-scale>` methods of the 
+  :ref:`Lifecycle HTTP RESTful API <http-restful-api-lifecycle>`;
+- the :ref:`Get/Set Commands <cli-available-commands>` of the 
+  :ref:`Command Line Interface <cli>`; or
+- the :ref:`ProgramClient API <program-client>` of the 
+  :ref:`Java Client API <java-client-api>`.
 
-The examples given below use the :ref:`Lifecycle HTTP RESTful API<http-restful-api-lifecycle-scale>`.
+The examples given below use the :ref:`Lifecycle HTTP RESTful API
+<http-restful-api-lifecycle-scale>`.
 
-.. highlight:: console
-
-Scaling Flowlets
-----------------
-You can query and set the number of instances executing a given flowlet
-by using the ``instances`` parameter with HTTP GET and PUT methods::
-
-  GET /v3/namespaces/default/apps/<app-id>/flows/<flow-id>/flowlets/<flowlet-id>/instances
-  PUT /v3/namespaces/default/apps/<app-id>/flows/<flow-id>/flowlets/<flowlet-id>/instances
-
-with the arguments as a JSON string in the body::
-
-  { "instances" : <quantity> }
-
-Where:
-
-.. list-table::
-   :widths: 20 80
-   :header-rows: 1
-
-   * - Parameter
-     - Description
-   * - ``<app-id>``
-     - Name of the application
-   * - ``<flow-id>``
-     - Name of the flow
-   * - ``<flowlet-id>``
-     - Name of the flowlet
-   * - ``<quantity>``
-     - Number of instances to be used
-
-Example: Find out the number of instances of the flowlet *saver* in
-the flow *WhoFlow* of the application *HelloWorld*::
-
-  GET /v3/namespaces/default/apps/HelloWorld/flows/WhoFlow/flowlets/saver/instances
-
-Example: Change the number of instances of the flowlet *saver*
-in the flow *WhoFlow* of the application *HelloWorld*::
-
-  PUT /v3/namespaces/default/apps/HelloWorld/flows/WhoFlow/flowlets/saver/instances
-
-with the arguments as a JSON string in the body::
-
-  { "instances" : 2 }
-
-
-Scaling Services
-------------------
-
-In a similar way to `Scaling Flowlets`_, you can query or change the number of handler instances of a service
-by using the ``instances`` parameter with HTTP GET and PUT methods::
-
-  GET /v3/namespaces/default/apps/<app-id>/services/<service-id>/instances
-  PUT /v3/namespaces/default/apps/<app-id>/services/<service-id>/instances
-
-with the arguments as a JSON string in the body::
-
-  { "instances" : <quantity> }
-
-Where:
-
-.. list-table::
-   :widths: 20 80
-   :header-rows: 1
-
-   * - Parameter
-     - Description
-   * - ``<app-id>``
-     - Name of the application
-   * - ``<service-id>``
-     - Name of the service
-   * - ``<quantity>``
-     - Number of handler instances requested
-  
-Example: Find out the number of handler instances of the service *RetrieveCounts*
-of the application *WordCount*::
-
-  GET /v3/namespaces/default/apps/WordCount/services/RetrieveCounts/instances
-
-Example: Change the number of handler instances of the service *RetrieveCounts*
-of the application *WordCount*::
-
-  PUT /v3/namespaces/default/apps/WordCount/services/RetrieveCounts/instances
-
-with the arguments as a JSON string in the body::
-
-  { "instances" : 2 }
-  
-Example using the :ref:`CDAP Standalone SDK <standalone-index>` and ``curl`` (reformatted to fit)::
-
-  curl -w'\n' -X PUT 'http://localhost:10000/v3/namespaces/default/apps/WordCount/services/RetrieveCounts/instances' \
-    -d '{ "instances" : 2 }'
+.. include:: /../../reference-manual/source/http-restful-api/lifecycle.rst
+    :start-after: .. _rest-scaling-flowlets:
+    :end-before: .. _rest-program-runs:

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -733,7 +733,7 @@ The response will be the same JSON array as submitted with additional parameters
        ``{"appId":"MyApp3","programType":"Service","programId":"MySvc1,``
        ``"runnableId":"MyHandler1","statusCode":404,"error":"Runnable: MyHandler1 not found"}]``
    * - Description
-     - Try to get the instances of the flowlet *MyFlowlet5* in the flow *MyFlow1* in the
+     - Attempt to retrieve the instances of the flowlet *MyFlowlet5* in the flow *MyFlow1* in the
        application *MyApp1*, and the service handler *MyHandler1* in the user service
        *MySvc1* in the application *MyApp3*, all in the namespace *default*
 
@@ -770,32 +770,20 @@ with the arguments as a JSON string in the body::
 
 .. rubric:: Examples
 
-.. list-table::
-   :widths: 20 80
-   :stub-columns: 1
+- Retrieve the number of instances of the flowlet *saver* in the flow *WhoFlow* of the
+  application *HelloWorld* in the namespace *default*::
 
-   * - HTTP Method
-     - ``GET /v3/namespaces/default/apps/HelloWorld/flows/WhoFlow/flowlets/saver/``
-       ``instances``
-   * - Description
-     - Find out the number of instances of the flowlet *saver*
-       in the flow *WhoFlow* of the application *HelloWorld* in the namespace *default*
+    GET /v3/namespaces/default/apps/HelloWorld/flows/WhoFlow/flowlets/saver/instances
 
-.. list-table::
-   :widths: 20 80
-   :stub-columns: 1
+- Set the number of instances of the flowlet *saver* in the flow *WhoFlow* of the
+  application *HelloWorld* in the namespace *default*::
 
-   * - HTTP Method
-     - ``PUT /v3/namespaces/default/apps/HelloWorld/flows/WhoFlow/flowlets/saver/``
-       ``instances``
+    PUT /v3/namespaces/default/apps/HelloWorld/flows/WhoFlow/flowlets/saver/instances
 
-       with the arguments as a JSON string in the body::
+  with the arguments as a JSON string in the body::
 
-         { "instances" : 2 }
+    { "instances" : 2 }
 
-   * - Description
-     - Change the number of instances of the flowlet *saver* in the flow *WhoFlow* of the
-       application *HelloWorld* in the namespace *default*
 
 Scaling Services
 ----------------
@@ -824,16 +812,31 @@ with the arguments as a JSON string in the body::
    * - ``quantity``
      - Number of instances to be used
 
-.. rubric:: Example
-.. list-table::
-   :widths: 20 80
-   :stub-columns: 1
+**Note:** You can scale system services using the Monitor HTTP RESTful API 
+:ref:`Scaling System Services <http-restful-api-monitor-scaling-system-services>`.
 
-   * - HTTP Method
-     - ``GET /v3/namespaces/default/apps/PurchaseHistory/services/CatalogLookup/instances``
-   * - Description
-     - Retrieve the number of instances of the service *CatalogLookup* in the application
-       *PurchaseHistory* in the namespace *default*
+.. rubric:: Examples
+
+- Retrieve the number of instances of the service *CatalogLookup* in the application
+  *PurchaseHistory* in the namespace *default*::
+
+    GET /v3/namespaces/default/apps/PurchaseHistory/services/CatalogLookup/instances
+
+- Set the number of handler instances of the service *RetrieveCounts*
+  of the application *WordCount*::
+
+    PUT /v3/namespaces/default/apps/WordCount/services/RetrieveCounts/instances
+
+  with the arguments as a JSON string in the body::
+
+    { "instances" : 2 }
+  
+- Using ``curl`` and the :ref:`CDAP Standalone SDK <standalone-index>`:
+
+  .. tabbed-parsed-literal::
+
+    $ curl -w"\n" -X PUT "http://localhost:10000/v3/namespaces/default/apps/WordCount/services/RetrieveCounts/instances" \
+      -d '{ "instances" : 2 }'
 
 Scaling Workers
 ---------------
@@ -864,16 +867,10 @@ with the arguments as a JSON string in the body::
 
 .. rubric:: Example
 
-.. list-table::
-   :widths: 20 80
-   :stub-columns: 1
+Retrieve the number of instances of the worker *DataWorker* in the application
+*HelloWorld* in the namespace *default*::
 
-   * - HTTP Method
-     - ``GET /v3/namespaces/default/apps/HelloWorld/workers/DataWorker/instances``
-       ``instances``
-   * - Description
-     - Retrieve the number of instances of the worker *DataWorker*
-       in the application *HelloWorld* in the namespace *default*
+  GET /v3/namespaces/default/apps/HelloWorld/workers/DataWorker/instances
 
 .. _rest-program-runs:
 

--- a/cdap-docs/reference-manual/source/http-restful-api/monitor.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/monitor.rst
@@ -233,6 +233,7 @@ The response body will contain a JSON-formatted status of the last restart attem
    * - ``500 Internal error``
      - Internal error encountered when processing the request
 
+.. _http-restful-api-monitor-scaling-system-services:
 
 Scaling System Services
 =======================


### PR DESCRIPTION
Passes [Quick Build 2](http://builds.cask.co/browse/CDAP-DQB75-2)

New [Lifecycle RESTful API, Scaling Flowlets](http://builds.cask.co/artifact/CDAP-DQB75/shared/build-2/Docs-HTML/3.5.0-SNAPSHOT/en/reference-manual/http-restful-api/lifecycle.html#scaling-flowlets)
New [Admin Operations](http://builds.cask.co/artifact/CDAP-DQB75/shared/build-2/Docs-HTML/3.5.0-SNAPSHOT/en/admin-manual/operations/scaling-instances.html)

This consolidates the material of scaling of CDAP components that was duplicated in the both the Lifecycle RESTful API and in the Admin operations manual.

It ends up with just material in one place (the RESTful API) and includes (using an reST include) a copy in the Admin operations manual.
