### PR TITLE
enforce authorization in list progrom APIs

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -776,7 +776,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/flows")
   public void getAllFlows(HttpRequest request, HttpResponder responder,
                           @PathParam("namespace-id") String namespaceId) throws Exception {
-    programList(responder, namespaceId, ProgramType.FLOW, store);
+    responder.sendJson(HttpResponseStatus.OK, lifecycleService.list(new NamespaceId(namespaceId), ProgramType.FLOW));
   }
 
   /**
@@ -786,7 +786,8 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/mapreduce")
   public void getAllMapReduce(HttpRequest request, HttpResponder responder,
                               @PathParam("namespace-id") String namespaceId) throws Exception {
-    programList(responder, namespaceId, ProgramType.MAPREDUCE, store);
+    responder.sendJson(HttpResponseStatus.OK,
+                       lifecycleService.list(new NamespaceId(namespaceId), ProgramType.MAPREDUCE));
   }
 
   /**
@@ -796,7 +797,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/spark")
   public void getAllSpark(HttpRequest request, HttpResponder responder,
                           @PathParam("namespace-id") String namespaceId) throws Exception {
-    programList(responder, namespaceId, ProgramType.SPARK, store);
+    responder.sendJson(HttpResponseStatus.OK, lifecycleService.list(new NamespaceId(namespaceId), ProgramType.SPARK));
   }
 
   /**
@@ -806,7 +807,8 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/workflows")
   public void getAllWorkflows(HttpRequest request, HttpResponder responder,
                               @PathParam("namespace-id") String namespaceId) throws Exception {
-    programList(responder, namespaceId, ProgramType.WORKFLOW, store);
+    responder.sendJson(HttpResponseStatus.OK,
+                       lifecycleService.list(new NamespaceId(namespaceId), ProgramType.WORKFLOW));
   }
 
   /**
@@ -816,14 +818,14 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/services")
   public void getAllServices(HttpRequest request, HttpResponder responder,
                              @PathParam("namespace-id") String namespaceId) throws Exception {
-    programList(responder, namespaceId, ProgramType.SERVICE, store);
+    responder.sendJson(HttpResponseStatus.OK, lifecycleService.list(new NamespaceId(namespaceId), ProgramType.SERVICE));
   }
 
   @GET
   @Path("/workers")
   public void getAllWorkers(HttpRequest request, HttpResponder responder,
                             @PathParam("namespace-id") String namespaceId) throws Exception {
-    programList(responder, namespaceId, ProgramType.WORKER, store);
+    responder.sendJson(HttpResponseStatus.OK, lifecycleService.list(new NamespaceId(namespaceId), ProgramType.WORKER));
   }
 
   /**
@@ -1059,7 +1061,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     // This synchronization works in HA mode because even in HA mode there is only one leader at a time.
     NamespaceId namespace = Ids.namespace(namespaceId);
     try {
-      List<ProgramRecord> flows = listPrograms(namespace, ProgramType.FLOW, store);
+      List<ProgramRecord> flows = lifecycleService.list(new NamespaceId(namespaceId), ProgramType.FLOW);
       for (ProgramRecord flow : flows) {
         String appId = flow.getApp();
         String flowId = flow.getName();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ProgramLifecycleServiceAuthorizationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ProgramLifecycleServiceAuthorizationTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.services;
+
+import co.cask.cdap.AllProgramsApp;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.internal.AppFabricTestHelper;
+import co.cask.cdap.internal.test.AppJarHelper;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.InstanceId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
+import co.cask.cdap.security.authorization.AuthorizerInstantiator;
+import co.cask.cdap.security.authorization.InMemoryAuthorizer;
+import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
+import co.cask.cdap.security.spi.authorization.Authorizer;
+import com.google.inject.Injector;
+import org.apache.twill.filesystem.LocalLocationFactory;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+
+/**
+ * Test authorization for ProgramLifeCycleService
+ */
+public class ProgramLifecycleServiceAuthorizationTest {
+
+  @ClassRule
+  public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+  private static final Principal ALICE = new Principal("alice", Principal.PrincipalType.USER);
+
+  private static CConfiguration cConf;
+  private static Authorizer authorizer;
+  private static AuthorizationEnforcementService authorizationEnforcementService;
+  private static AppFabricServer appFabricServer;
+  private static ProgramLifecycleService programLifecycleService;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    cConf = createCConf();
+    Injector injector = AppFabricTestHelper.getInjector(cConf);
+    authorizer = injector.getInstance(AuthorizerInstantiator.class).get();
+    authorizer.grant(new InstanceId(cConf.get(Constants.INSTANCE_NAME)), ALICE, Collections.singleton(Action.ADMIN));
+    authorizationEnforcementService = injector.getInstance(AuthorizationEnforcementService.class);
+    authorizationEnforcementService.startAndWait();
+    appFabricServer = injector.getInstance(AppFabricServer.class);
+    appFabricServer.startAndWait();
+    programLifecycleService = injector.getInstance(ProgramLifecycleService.class);
+  }
+
+  @Test
+  public void testProgramList() throws Exception {
+    SecurityRequestContext.setUserId(ALICE.getName());
+    authorizer.grant(NamespaceId.DEFAULT, ALICE, Collections.singleton(Action.WRITE));
+    AppFabricTestHelper.deployApplication(Id.Namespace.DEFAULT, AllProgramsApp.class, null, cConf);
+    for (ProgramType type : ProgramType.values()) {
+      if (!type.equals(ProgramType.CUSTOM_ACTION) && !type.equals(ProgramType.WEBAPP)) {
+        Assert.assertFalse(
+          programLifecycleService.list(NamespaceId.DEFAULT, type).isEmpty()
+        );
+        SecurityRequestContext.setUserId("bob");
+        Assert.assertTrue(programLifecycleService.list(NamespaceId.DEFAULT, type).isEmpty());
+        SecurityRequestContext.setUserId("alice");
+      }
+    }
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    appFabricServer.stopAndWait();
+    authorizationEnforcementService.stopAndWait();
+  }
+
+  private static CConfiguration createCConf() throws IOException {
+    CConfiguration cConf = CConfiguration.create();
+    cConf.setBoolean(Constants.Security.ENABLED, true);
+    cConf.setBoolean(Constants.Security.Authorization.ENABLED, true);
+    // we only want to test authorization, but we don't specify principal/keytab, so disable kerberos
+    cConf.setBoolean(Constants.Security.KERBEROS_ENABLED, false);
+    cConf.setBoolean(Constants.Security.Authorization.CACHE_ENABLED, false);
+    LocationFactory locationFactory = new LocalLocationFactory(new File(TEMPORARY_FOLDER.newFolder().toURI()));
+    Location authorizerJar = AppJarHelper.createDeploymentJar(locationFactory, InMemoryAuthorizer.class);
+    cConf.set(Constants.Security.Authorization.EXTENSION_JAR_PATH, authorizerJar.toURI().getPath());
+    cConf.set(Constants.Security.Authorization.SUPERUSERS, "hulk");
+    return cConf;
+  }
+}


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-6993
Builds: http://builds.cask.co/browse/CDAP-RUT45-1

Authorization is not enforced on program list APIs. Reason for that is we do not check the access of the programs in ProgramLifecycleService.

Fix: Moved ProgramList method from AbstractAppFabricHttpHandler.java to ProgramLifecycleService.java, and checkAccess before adding programs to the list.
