### PR TITLE
CDAP-6899: Fail MR/Spark jobs if they user doesn't have access to stream

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/DefaultStreamWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/DefaultStreamWriter.java
@@ -119,6 +119,8 @@ public class DefaultStreamWriter implements StreamWriter {
       throw new IOException(String.format("Stream %s not found", stream));
     }
 
+    // Even though we might have UnauthorizedException (FORBIDDEN), we need to register the usage/lineage since
+    // the worker intended to write to the stream
     registerStream(stream);
 
     if (responseCode < 200 || responseCode >= 300) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamRecordReader.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamRecordReader.java
@@ -79,7 +79,6 @@ final class StreamRecordReader<K, V> extends RecordReader<K, V> {
 
   @Override
   public boolean nextKeyValue() throws IOException, InterruptedException {
-    events.clear();
     // Make sure that the user has read access to the stream.
     try {
       authorizationEnforcer.enforce(streamId, principal, Action.READ);
@@ -89,6 +88,7 @@ final class StreamRecordReader<K, V> extends RecordReader<K, V> {
       throw new IOException(e);
     }
 
+    events.clear();
     if (reader.read(events, 1, 0, TimeUnit.SECONDS, readFilter) <= 0) {
       return false;
     }


### PR DESCRIPTION
JIRA : https://issues.cask.co/browse/CDAP-6899
Build : http://builds.cask.co/browse/CDAP-RUT49

Summary:
In a previous PR we added authorization checks for Stream READ in Flow/MR/Spark. In a batch program like MR/Spark, we want to be able to fail before even the start of the program so that failure happens quicker. So this PR adds a check before the launch of the actual MR/Spark job. Though the JIRA talks about doing this in Flow, it is not entirely clear how to do it for a continuously running program like Flow. Also, a Flow can have multiple source flowlets (some of them reading from Streams and some of them being Tick Flowlets) and even if the user doesn't have read access to streams, the Flow can still do some useful work. So this PR doesn't add any additional authorization check for streams in Flow.
