### PR TITLE
disable UI compression for running behind Azure HDInsight Gateway proxy

### DIFF
--- a/cdap-distributions/src/hdinsight/cdap-conf.json
+++ b/cdap-distributions/src/hdinsight/cdap-conf.json
@@ -17,11 +17,5 @@
   "hadoop": {
     "distribution": "hdp",
     "distribution_version": "{{HDP_VERSION}}"
-  },
-  "ntp": {
-    "servers": [
-      "time.windows.com",
-      "ntp.ubuntu.com"
-    ]
   }
 }

--- a/cdap-distributions/src/hdinsight/cdap-conf.json
+++ b/cdap-distributions/src/hdinsight/cdap-conf.json
@@ -6,6 +6,7 @@
       "explore.enabled": "{{EXPLORE_ENABLED}}"
     },
     "cdap_env": {
+      "cdap_ui_compression_enabled": "false",
       "tez_home": "/usr/hdp/{{HDP_VERSION}}/tez",
       "tez_conf_dir": "/etc/tez/conf"
     },


### PR DESCRIPTION
For Azure HDInsight:
- [x] set the environment variable added in [CDAP-6452](https://issues.cask.co/browse/CDAP-6452) to disable UI compression.  This makes UI accessible behind HDInsight's proxy
- [x] remove unnecessary ntp configuration, as it is preconfigured in the "v2" platform, (previously removed from the runlist already)
