### PR TITLE
Fix Javadocs build

### DIFF
--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -245,8 +245,8 @@ function build_javadocs() {
 function build_javadocs_api() {
   local javadoc_type=${1}
   set_mvn_environment
-  echo "CLASSPATH: ${CLASSPATH}"
   echo "JAVA_HOME: ${JAVA_HOME}"
+  echo "JAVA Version: `java -version`"
   local javadoc_run="mvn javadoc:aggregate -P release"
   if [ "${javadoc_type}" == "${DOCS}" ]; then
     javadoc_run="mvn clean site -P templates"

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -245,6 +245,8 @@ function build_javadocs() {
 function build_javadocs_api() {
   local javadoc_type=${1}
   set_mvn_environment
+  echo "CLASSPATH: ${CLASSPATH}"
+  echo "JAVA_HOME: ${JAVA_HOME}"
   local javadoc_run="mvn javadoc:aggregate -P release"
   if [ "${javadoc_type}" == "${DOCS}" ]; then
     javadoc_run="mvn clean site -P templates"
@@ -255,6 +257,7 @@ function build_javadocs_api() {
   fi
   local start=`date`
   MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean install -P examples,templates,release -DskipTests -Dgpg.skip=true && ${javadoc_run} -DskipTests -DisOffline=false ${debug_flag}
+  echo
   echo "Javadocs Build Start: ${start}"
   echo "                 End: `date`"
 }

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -246,7 +246,8 @@ function build_javadocs_api() {
   local javadoc_type=${1}
   set_mvn_environment
   echo "JAVA_HOME: ${JAVA_HOME}"
-  echo "JAVA Version: `java -version`"
+  echo "JAVA Version:"
+  java -version
   local javadoc_run="mvn javadoc:aggregate -P release"
   if [ "${javadoc_type}" == "${DOCS}" ]; then
     javadoc_run="mvn clean site -P templates"

--- a/pom.xml
+++ b/pom.xml
@@ -1771,7 +1771,7 @@
                 </bottom>
                 <doctitle>${project.name} ${project.version}</doctitle>
                 <links>
-                  <link>http://caskdata.github.io/documentation/jsr305-3.0.1-javadoc/</link>
+                  <link>http://caskdata.github.io/docs-site/hosted-javadocs/jsr305-3.0.1-javadoc/</link>
                   <link>http://avro.apache.org/docs/${avro.version}/api/java/</link>
                   <link>http://docs.oracle.com/javaee/${jee.version}/api/</link>
                   <link>http://hadoop.apache.org/docs/r${hadoop.version}/api/</link>
@@ -2535,7 +2535,7 @@
           </bottom>
           <doctitle>${project.name} ${project.version}</doctitle>
           <links>
-            <link>http://caskdata.github.io/documentation/jsr305-3.0.1-javadoc/</link>
+            <link>http://caskdata.github.io/docs-site/hosted-javadocs/jsr305-3.0.1-javadoc/</link>
             <link>http://avro.apache.org/docs/${avro.version}/api/java/</link>
             <link>http://docs.oracle.com/javaee/${jee.version}/api/</link>
             <link>http://hadoop.apache.org/docs/r${hadoop.version}/api/</link>

--- a/pom.xml
+++ b/pom.xml
@@ -1771,7 +1771,7 @@
                 </bottom>
                 <doctitle>${project.name} ${project.version}</doctitle>
                 <links>
-                  <link>https://raw.githubusercontent.com/chromium-googlesource-mirror/jsr-305/master/javadoc/</link>
+                  <link>http://caskdata.github.io/documentation/jsr305-3.0.1-javadoc/</link>
                   <link>http://avro.apache.org/docs/${avro.version}/api/java/</link>
                   <link>http://docs.oracle.com/javaee/${jee.version}/api/</link>
                   <link>http://hadoop.apache.org/docs/r${hadoop.version}/api/</link>
@@ -2535,7 +2535,7 @@
           </bottom>
           <doctitle>${project.name} ${project.version}</doctitle>
           <links>
-            <link>https://raw.githubusercontent.com/chromium-googlesource-mirror/jsr-305/master/javadoc/</link>
+            <link>http://caskdata.github.io/documentation/jsr305-3.0.1-javadoc/</link>
             <link>http://avro.apache.org/docs/${avro.version}/api/java/</link>
             <link>http://docs.oracle.com/javaee/${jee.version}/api/</link>
             <link>http://hadoop.apache.org/docs/r${hadoop.version}/api/</link>

--- a/pom.xml
+++ b/pom.xml
@@ -1771,7 +1771,7 @@
                 </bottom>
                 <doctitle>${project.name} ${project.version}</doctitle>
                 <links>
-                  <link>http://caskdata.github.io/docs-site/hosted-javadocs/jsr305-3.0.1-javadoc/</link>
+                  <link>http://caskdata.github.io/docs-site/hosted-javadocs/jsr305-${findbugs.jsr305.version}-javadoc/</link>
                   <link>http://avro.apache.org/docs/${avro.version}/api/java/</link>
                   <link>http://docs.oracle.com/javaee/${jee.version}/api/</link>
                   <link>http://hadoop.apache.org/docs/r${hadoop.version}/api/</link>
@@ -2535,7 +2535,7 @@
           </bottom>
           <doctitle>${project.name} ${project.version}</doctitle>
           <links>
-            <link>http://caskdata.github.io/docs-site/hosted-javadocs/jsr305-3.0.1-javadoc/</link>
+            <link>http://caskdata.github.io/docs-site/hosted-javadocs/jsr305-${findbugs.jsr305.version}-javadoc/</link>
             <link>http://avro.apache.org/docs/${avro.version}/api/java/</link>
             <link>http://docs.oracle.com/javaee/${jee.version}/api/</link>
             <link>http://hadoop.apache.org/docs/r${hadoop.version}/api/</link>

--- a/pom.xml
+++ b/pom.xml
@@ -1771,7 +1771,7 @@
                 </bottom>
                 <doctitle>${project.name} ${project.version}</doctitle>
                 <links>
-                  <link>http://jsr-305.googlecode.com/svn/trunk/javadoc/</link>
+                  <link>https://raw.githubusercontent.com/chromium-googlesource-mirror/jsr-305/master/javadoc/</link>
                   <link>http://avro.apache.org/docs/${avro.version}/api/java/</link>
                   <link>http://docs.oracle.com/javaee/${jee.version}/api/</link>
                   <link>http://hadoop.apache.org/docs/r${hadoop.version}/api/</link>
@@ -2535,7 +2535,7 @@
           </bottom>
           <doctitle>${project.name} ${project.version}</doctitle>
           <links>
-            <link>http://jsr-305.googlecode.com/svn/trunk/javadoc/</link>
+            <link>https://raw.githubusercontent.com/chromium-googlesource-mirror/jsr-305/master/javadoc/</link>
             <link>http://avro.apache.org/docs/${avro.version}/api/java/</link>
             <link>http://docs.oracle.com/javaee/${jee.version}/api/</link>
             <link>http://hadoop.apache.org/docs/r${hadoop.version}/api/</link>

--- a/pom.xml
+++ b/pom.xml
@@ -1771,7 +1771,7 @@
                 </bottom>
                 <doctitle>${project.name} ${project.version}</doctitle>
                 <links>
-                  <link>http://caskdata.github.io/docs-site/hosted-javadocs/jsr305-${findbugs.jsr305.version}-javadoc/</link>
+                  <link>https://caskdata.github.io/docs-site/hosted-javadocs/jsr305-${findbugs.jsr305.version}-javadoc/</link>
                   <link>http://avro.apache.org/docs/${avro.version}/api/java/</link>
                   <link>http://docs.oracle.com/javaee/${jee.version}/api/</link>
                   <link>http://hadoop.apache.org/docs/r${hadoop.version}/api/</link>
@@ -2535,7 +2535,7 @@
           </bottom>
           <doctitle>${project.name} ${project.version}</doctitle>
           <links>
-            <link>http://caskdata.github.io/docs-site/hosted-javadocs/jsr305-${findbugs.jsr305.version}-javadoc/</link>
+            <link>https://caskdata.github.io/docs-site/hosted-javadocs/jsr305-${findbugs.jsr305.version}-javadoc/</link>
             <link>http://avro.apache.org/docs/${avro.version}/api/java/</link>
             <link>http://docs.oracle.com/javaee/${jee.version}/api/</link>
             <link>http://hadoop.apache.org/docs/r${hadoop.version}/api/</link>


### PR DESCRIPTION
Fixes a long-standing bug in our Javadocs build: a reference to a dead URL for the jar-305 Javadocs.

As they are no longer hosted anywhere, we are now hosting them on a GitHub pages site (at http://caskdata.github.io/docs-site/ or http://caskdata.github.io/docs-site/hosted-javadocs/jsr305-2.0.1-javadoc/).

Building as [Docs Develop Build 5](http://builds.cask.co/browse/CDAP-DDB44-5)

If you look at the current Javadocs for the [OnSuccess](http://docs.cask.co/cdap/develop/en/reference-manual/javadocs/co/cask/cdap/api/flow/flowlet/Callback.html#onSuccess%28java.lang.Object,%20co.cask.cdap.api.flow.flowlet.InputContext%29) method, you can see that the `@Nullable` link goes to a 404 page at Oracle. 

The revised page (http://builds.cask.co/artifact/CDAP-DDB44/shared/build-5/Docs-HTML/3.5.0-SNAPSHOT/en/reference-manual/javadocs/co/cask/cdap/api/flow/flowlet/Callback.html#onSuccess(java.lang.Object,%20co.cask.cdap.api.flow.flowlet.InputContext)) links the `@Nullable` to the correct location.
