### PR TITLE
[CDAP-6448] upgrade path for old tracker artifacts

### DIFF
--- a/cdap-ui/app/features/tracker/routes.js
+++ b/cdap-ui/app/features/tracker/routes.js
@@ -36,7 +36,12 @@ angular.module(PKG.name + '.feature.tracker')
 
             myTrackerApi.getTrackerApp(params)
               .$promise
-              .then( () => {
+              .then( (appConfig) => {
+                if (appConfig.artifact.version !== UI_CONFIG.tracker.artifact.version) {
+                  defer.resolve(true);
+                  return;
+                }
+
                 let trackerServiceParams = {
                   namespace: $stateParams.namespace,
                   programType: 'services',
@@ -93,7 +98,12 @@ angular.module(PKG.name + '.feature.tracker')
 
             myTrackerApi.getTrackerApp(params)
               .$promise
-              .then( () => {
+              .then( (appConfig) => {
+                if (appConfig.artifact.version !== UI_CONFIG.tracker.artifact.version) {
+                  $state.go('tracker-enable', $stateParams);
+                  return;
+                }
+
                 let trackerServiceParams = {
                   namespace: $stateParams.namespace,
                   programType: 'services',

--- a/cdap-ui/app/features/tracker/services/my-tracker-api.js
+++ b/cdap-ui/app/features/tracker/services/my-tracker-api.js
@@ -55,6 +55,7 @@ function myTrackerApi(myCdapUrl, $resource, myAuth, myHelpers, UI_CONFIG) {
     toggleNavigator: myHelpers.getConfig('POST', 'REQUEST', navigatorPath + '/flows/MetadataFlow/:action', false),
     getTrackerApp: myHelpers.getConfig('GET', 'REQUEST', trackerApp, false, { suppressErrors: true }),
     deployTrackerApp: myHelpers.getConfig('PUT', 'REQUEST', trackerApp),
+    stopMultiplePrograms: myHelpers.getConfig('POST', 'REQUEST', '/namespaces/:namespace/stop', true, { suppressErrors: true }),
     startTrackerProgram: myHelpers.getConfig('POST', 'REQUEST', trackerApp + '/:programType/:programId/start', false, { suppressErrors: true }),
     trackerProgramStatus: myHelpers.getConfig('GET', 'REQUEST', trackerApp + '/:programType/:programId/status', false, { suppressErrors: true }),
     getTopEntities: myHelpers.getConfig('GET', 'REQUEST', topEntitiesPath, true, { suppressErrors: true }),


### PR DESCRIPTION
Ability to upgrade Tracker app from the UI to use the new Tracker API.

JIRA: https://issues.cask.co/browse/CDAP-6448
Build: http://builds.cask.co/browse/CDAP-DRC4252-1
