### PR TITLE
[CDAP-7032] fix check for datetime-picker to ignore 0 for hour/minute

### DIFF
--- a/cdap-ui/app/directives/datetime-picker/datetime.js
+++ b/cdap-ui/app/directives/datetime-picker/datetime.js
@@ -54,7 +54,7 @@ function DatetimeController($scope) {
         hour = vm.hour,
         minutes = vm.minutes;
 
-    $scope.dateObject = !hour || !minutes ? null : new Date(year, month, day, hour, minutes, 0);
+    $scope.dateObject = (!hour && hour !== 0) || (!minutes && minutes !== 0) ? null : new Date(year, month, day, hour, minutes, 0);
   }
 
 }


### PR DESCRIPTION
 fix check for datetime-picker to ignore 0 for hour/minute

JIRA: https://issues.cask.co/browse/CDAP-7032
Build: http://builds.cask.co/browse/CDAP-DRC4254-1
