### PR TITLE
CDAP-6689 Specify the location of overriding settings for Java Heap

### DIFF
--- a/cdap-docs/admin-manual/source/_includes/installation/starting.txt
+++ b/cdap-docs/admin-manual/source/_includes/installation/starting.txt
@@ -32,3 +32,7 @@ can be created by setting these environment variables::
 such as::
 
   $ export AUTH_JAVA_HEAPMAX="-Xmx1024m"
+  
+Add any overriding settings to a file, usually ``/etc/cdap/conf/cdap-env.sh``. As
+described above (in :ref:`|distribution|-configuration`), the location of this file will
+depend on your particular configuration.


### PR DESCRIPTION
Specify the location of overriding settings.

Running as [Quick Build 1](http://builds.cask.co/browse/CDAP-DQB77-1). Failed, but only because `release/3.5` is broken.

Pages of interest:
- [MapR: Starting CDAP Services](http://builds.cask.co/artifact/CDAP-DQB77/shared/build-1/Docs-HTML/3.5.0-SNAPSHOT/en/admin-manual/installation/mapr.html#starting-cdap-services)
- [Packages: Starting CDAP Services](http://builds.cask.co/artifact/CDAP-DQB77/shared/build-1/Docs-HTML/3.5.0-SNAPSHOT/en/admin-manual/installation/packages.html#starting-cdap-services)

Fix for https://issues.cask.co/browse/CDAP-6689
