### PR TITLE
(CDAP-7043) fix failure to grant actions on datasets

### DIFF
--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetId.java
@@ -58,7 +58,7 @@ public class DatasetId extends EntityId implements NamespacedId, ParentedId<Name
 
   @Override
   public NamespaceId getParent() {
-    return namespaceId;
+    return namespaceId != null ? namespaceId : new NamespaceId(namespace);
   }
 
   @Override

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/id/EntityIdTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/id/EntityIdTest.java
@@ -200,6 +200,15 @@ public class EntityIdTest {
   }
 
   @Test
+  public void testDatasetIdGetParent() {
+    DatasetId datasetId = new NamespaceId("foo").dataset("testParent");
+    String datasetIdJson = GSON.toJson(datasetId);
+    Assert.assertEquals(
+      datasetId.getNamespace(), GSON.fromJson(datasetIdJson, DatasetId.class).getParent().getNamespace()
+    );
+  }
+
+  @Test
   public void testInvalidId() {
     try {
       ApplicationId.fromString("application:ns1");


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-7043
Builds: http://builds.cask.co/browse/CDAP-RUT59-1

Grant actions through CLI will fail since namespaceId is transient and thus will be null, fix by checking null in getParent() function, unit test is added to test correctness
