### PR TITLE
Fix broken documentation build.

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1769,9 +1769,9 @@
 
   <property>
     <name>security.store.provider</name>
-    <value></value>
+    <value>none</value>
     <description>
-      Backend provider for the secure store
+      Backend provider for the secure store; use 'none' if no secure store
     </description>
   </property>
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1769,7 +1769,7 @@
 
   <property>
     <name>security.store.provider</name>
-    <value>none</value>
+    <value></value>
     <description>
       Backend provider for the secure store
     </description>

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="2c2c0d57a6bf329ee2efb2c98d5428ba"
+DEFAULT_XML_MD5_HASH="c9535111824a91a340b3ca1c2cfc2d5c"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="c9535111824a91a340b3ca1c2cfc2d5c"
+DEFAULT_XML_MD5_HASH="c40cb0a4578bd8b99d36a565f923d71b"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
Fix broken doc build:
- Replaces the description of the "none" value
- Updates MD5 hash

Running as [Quick Build 2](http://builds.cask.co/browse/CDAP-DQB78-2)
