### PR TITLE
[CDAP-7046] Use empty set of macros for plugins at runtime

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/plugin/PluginInstantiator.java
@@ -61,6 +61,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -206,11 +207,12 @@ public class PluginInstantiator implements Closeable {
       TypeToken<?> configFieldType = pluginType.resolveType(field.getGenericType());
       Object config = instantiatorFactory.get(configFieldType).create();
 
-      // perform macro substitution if an evaluator is provided
+      // perform macro substitution if an evaluator is provided, collect fields with macros only at configure time
       PluginProperties pluginProperties = substituteMacros(plugin, macroEvaluator);
+      Set<String> macroFields = (macroEvaluator == null) ? getFieldsWithMacro(plugin) : Collections.<String>emptySet();
+
       Reflections.visit(config, configFieldType.getType(),
-                        new ConfigFieldSetter(pluginClass, plugin.getArtifactId(), pluginProperties,
-                                              getFieldsWithMacro(plugin)));
+                        new ConfigFieldSetter(pluginClass, plugin.getArtifactId(), pluginProperties, macroFields));
 
       // Create the plugin instance
       return newInstance(pluginType, field, configFieldType, config);


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/CDAP-7046
Build: http://builds.cask.co/browse/CDAP-RUT61-1

This allows `containsMacro(propertyName)` to behavior more intuitively to guard against early validation and still allow validation at runtime.
