### PR TITLE
Bug/auth bootstrap

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -147,12 +147,8 @@ public final class DefaultNamespaceAdmin extends DefaultNamespaceQueryAdmin impl
 
     // Namespace can be created. Check if the user is authorized now.
     Principal principal = authenticationContext.getPrincipal();
-    // Skip authorization enforcement for the system user and the default namespace, so the DefaultNamespaceEnsurer
-    // thread can successfully create the default namespace
-    if (!(Principal.SYSTEM.equals(principal) && NamespaceId.DEFAULT.equals(namespace))) {
-      authorizationEnforcer.enforce(instanceId, principal, Action.ADMIN);
-      authorizer.grant(namespace, principal, ImmutableSet.of(Action.ALL));
-    }
+    authorizationEnforcer.enforce(instanceId, principal, Action.ADMIN);
+    authorizer.grant(namespace, principal, ImmutableSet.of(Action.ALL));
 
     // store the meta first in the namespace store because namespacedlocationfactory need to look up location
     // mapping from namespace config
@@ -169,9 +165,7 @@ public final class DefaultNamespaceAdmin extends DefaultNamespaceQueryAdmin impl
     } catch (IOException | ExploreException | SQLException e) {
       // failed to create namespace in underlying storage so delete the namespace meta stored in the store earlier
       nsStore.delete(metadata.getNamespaceId().toId());
-      if (!(Principal.SYSTEM.equals(principal) && NamespaceId.DEFAULT.equals(namespace))) {
-        authorizer.revoke(namespace);
-      }
+      authorizer.revoke(namespace);
       throw new NamespaceCannotBeCreatedException(namespace.toId(), e);
     }
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceEnsurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceEnsurer.java
@@ -21,8 +21,6 @@ import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.service.RetryOnStartFailureService;
 import co.cask.cdap.common.service.RetryStrategies;
 import co.cask.cdap.proto.NamespaceMeta;
-import co.cask.cdap.proto.security.Principal;
-import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.AbstractService;
 import com.google.common.util.concurrent.Service;
@@ -49,9 +47,7 @@ public final class DefaultNamespaceEnsurer extends AbstractService {
         return new AbstractService() {
           @Override
           protected void doStart() {
-            String oldUserId = SecurityRequestContext.getUserId();
             try {
-              SecurityRequestContext.setUserId(Principal.SYSTEM.getName());
               namespaceAdmin.create(NamespaceMeta.DEFAULT);
               // if there is no exception, assume successfully created and break
               LOG.info("Created default namespace successfully.");
@@ -62,8 +58,6 @@ public final class DefaultNamespaceEnsurer extends AbstractService {
               notifyStarted();
             } catch (Exception e) {
               notifyFailed(e);
-            } finally {
-              SecurityRequestContext.setUserId(oldUserId);
             }
           }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceQueryAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceQueryAdmin.java
@@ -89,7 +89,7 @@ public class DefaultNamespaceQueryAdmin implements NamespaceQueryAdmin {
     }
     Principal principal = authenticationContext.getPrincipal();
     Predicate<EntityId> filter = authorizationEnforcer.createFilter(principal);
-    if (!Principal.SYSTEM.equals(principal) && !filter.apply(namespaceId.toEntityId())) {
+    if (!filter.apply(namespaceId.toEntityId())) {
       throw new UnauthorizedException(principal, namespaceId.toEntityId());
     }
     return ns;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/SystemArtifactLoader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/SystemArtifactLoader.java
@@ -18,8 +18,6 @@ package co.cask.cdap.internal.app.runtime.artifact;
 
 import co.cask.cdap.common.service.RetryOnStartFailureService;
 import co.cask.cdap.common.service.RetryStrategies;
-import co.cask.cdap.proto.security.Principal;
-import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.AbstractService;
 import com.google.common.util.concurrent.Service;
@@ -42,17 +40,13 @@ public final class SystemArtifactLoader extends AbstractService {
         return new AbstractService() {
           @Override
           protected void doStart() {
-            String oldUserId = SecurityRequestContext.getUserId();
             try {
-              SecurityRequestContext.setUserId(Principal.SYSTEM.getName());
               artifactRepository.addSystemArtifacts();
               // if there is no exception, all good, continue on
               notifyStarted();
             } catch (Exception e) {
               // transient error, fail it and retry
               notifyFailed(e);
-            } finally {
-              SecurityRequestContext.setUserId(oldUserId);
             }
           }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
@@ -31,7 +31,7 @@ import co.cask.cdap.internal.app.runtime.artifact.SystemArtifactLoader;
 import co.cask.cdap.internal.app.runtime.plugin.PluginService;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
 import co.cask.cdap.notifications.service.NotificationService;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.authorization.PrivilegesFetcherProxyService;
 import co.cask.http.HandlerHook;
 import co.cask.http.HttpHandler;
@@ -126,7 +126,7 @@ public class AppFabricServer extends AbstractIdleService {
    */
   @Override
   protected void startUp() throws Exception {
-    LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Id.Namespace.SYSTEM.getId(),
+    LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(NamespaceId.SYSTEM.getNamespace(),
                                                                        Constants.Logging.COMPONENT_NAME,
                                                                        Constants.Service.APP_FABRIC_HTTP));
     Futures.allAsList(

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -679,7 +679,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
   private void ensureAccess(ApplicationId appId) throws Exception {
     Principal principal = authenticationContext.getPrincipal();
     Predicate<EntityId> filter = authorizationEnforcer.createFilter(principal);
-    if (!Principal.SYSTEM.equals(principal) && !filter.apply(appId)) {
+    if (!filter.apply(appId)) {
       throw new UnauthorizedException(principal, appId);
     }
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
@@ -34,7 +34,6 @@ import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.CaseInsensitiveEnumTypeAdapterFactory;
-import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.config.PreferencesStore;
 import co.cask.cdap.internal.app.ApplicationSpecificationAdapter;
 import co.cask.cdap.internal.app.runtime.AbstractListener;
@@ -56,7 +55,6 @@ import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
-import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
@@ -108,16 +106,13 @@ public class ProgramLifecycleService extends AbstractIdleService {
   private final NamespaceStore nsStore;
   private final PropertiesResolver propertiesResolver;
   private final PreferencesStore preferencesStore;
-  private final AuthorizerInstantiator authorizerInstantiator;
   private final AuthorizationEnforcer authorizationEnforcer;
   private final AuthenticationContext authenticationContext;
 
   @Inject
   ProgramLifecycleService(Store store, NamespaceStore nsStore, ProgramRuntimeService runtimeService,
                           CConfiguration cConf, PropertiesResolver propertiesResolver,
-                          NamespacedLocationFactory namespacedLocationFactory, PreferencesStore preferencesStore,
-                          AuthorizerInstantiator authorizerInstantiator,
-                          AuthorizationEnforcer authorizationEnforcer,
+                          PreferencesStore preferencesStore, AuthorizationEnforcer authorizationEnforcer,
                           AuthenticationContext authenticationContext) {
     this.store = store;
     this.nsStore = nsStore;
@@ -126,7 +121,6 @@ public class ProgramLifecycleService extends AbstractIdleService {
     this.scheduledExecutorService = Executors.newScheduledThreadPool(1);
     this.cConf = cConf;
     this.preferencesStore = preferencesStore;
-    this.authorizerInstantiator = authorizerInstantiator;
     this.authorizationEnforcer = authorizationEnforcer;
     this.authenticationContext = authenticationContext;
   }
@@ -567,7 +561,7 @@ public class ProgramLifecycleService extends AbstractIdleService {
   private boolean hasAccess(ProgramId programId) throws Exception {
     Principal principal = authenticationContext.getPrincipal();
     Predicate<EntityId> filter = authorizationEnforcer.createFilter(principal);
-    return Principal.SYSTEM.equals(principal) || filter.apply(programId);
+    return filter.apply(programId);
   }
 
   private void setWorkerInstances(ProgramId programId, int instances) throws ExecutionException, InterruptedException {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
@@ -33,6 +33,7 @@ import co.cask.cdap.common.NamespaceAlreadyExistsException;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.conf.SConfiguration;
 import co.cask.cdap.common.lang.jar.BundleJarUtil;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.utils.DirUtils;
@@ -48,7 +49,6 @@ import co.cask.cdap.internal.app.runtime.BasicArguments;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactDescriptor;
-import co.cask.cdap.internal.app.runtime.artifact.ArtifactRangeCodec;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import co.cask.cdap.internal.app.runtime.artifact.Artifacts;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
@@ -57,12 +57,11 @@ import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.notifications.service.NotificationService;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
-import co.cask.cdap.proto.artifact.ArtifactRange;
+import co.cask.cdap.security.authorization.AuthorizationBootstrapper;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
 import co.cask.tephra.TransactionManager;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMap;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -83,13 +82,9 @@ import javax.annotation.Nullable;
 /**
  * This is helper class to make calls to AppFabricHttpHandler methods directly.
  * TODO: remove it, see CDAP-5
- *
  */
 public class AppFabricTestHelper {
   public static final TempFolder TEMP_FOLDER = new TempFolder();
-  private static final Gson GSON = new GsonBuilder()
-    .registerTypeAdapter(ArtifactRange.class, new ArtifactRangeCodec())
-    .create();
 
   public static CConfiguration configuration;
   private static Injector injector;
@@ -107,13 +102,23 @@ public class AppFabricTestHelper {
     });
   }
 
-  public static synchronized Injector getInjector(CConfiguration conf, Module overrides) {
+  public static Injector getInjector(CConfiguration cConf, Module overrides) {
+    return getInjector(cConf, null, overrides);
+  }
+
+  public static synchronized Injector getInjector(CConfiguration conf, @Nullable SConfiguration sConf,
+                                                  Module overrides) {
     if (injector == null) {
       configuration = conf;
       configuration.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder("data").getAbsolutePath());
       configuration.set(Constants.AppFabric.REST_PORT, Integer.toString(Networks.getRandomPort()));
       configuration.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, true);
-      injector = Guice.createInjector(Modules.override(new AppFabricTestModule(configuration)).with(overrides));
+      injector = Guice.createInjector(Modules.override(new AppFabricTestModule(configuration, sConf)).with(overrides));
+      if (configuration.getBoolean(Constants.Security.ENABLED) &&
+        configuration.getBoolean(Constants.Security.Authorization.ENABLED)) {
+        injector.getInstance(AuthorizationBootstrapper.class).run();
+        injector.getInstance(AuthorizationEnforcementService.class).startAndWait();
+      }
       injector.getInstance(TransactionManager.class).startAndWait();
       injector.getInstance(DatasetOpExecutor.class).startAndWait();
       injector.getInstance(DatasetService.class).startAndWait();
@@ -126,12 +131,13 @@ public class AppFabricTestHelper {
   }
 
   /**
-   * @return Returns an instance of {@link LocalApplicationManager}
+   * @return an instance of {@link LocalApplicationManager}
    */
   public static Manager<AppDeploymentInfo, ApplicationWithPrograms> getLocalManager() {
     ManagerFactory<AppDeploymentInfo, ApplicationWithPrograms> factory =
-      getInjector().getInstance(Key.get(new TypeLiteral<ManagerFactory<AppDeploymentInfo, ApplicationWithPrograms>>() {
-      }));
+      getInjector().getInstance(Key.get(
+        new TypeLiteral<ManagerFactory<AppDeploymentInfo, ApplicationWithPrograms>>() { }
+      ));
 
     return factory.create(new ProgramTerminator() {
       @Override

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/DefaultSecureStoreServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/DefaultSecureStoreServiceTest.java
@@ -19,13 +19,9 @@ package co.cask.cdap.internal.app.services;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.conf.SConfiguration;
-import co.cask.cdap.common.discovery.EndpointStrategy;
-import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.utils.Tasks;
-import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
-import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
-import co.cask.cdap.internal.guice.AppFabricTestModule;
+import co.cask.cdap.internal.AppFabricTestHelper;
 import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.EntityId;
@@ -36,20 +32,17 @@ import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.proto.security.SecureKeyCreateRequest;
 import co.cask.cdap.proto.security.SecureKeyListEntry;
-import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
+import co.cask.cdap.security.auth.context.MasterAuthenticationContext;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.authorization.InMemoryAuthorizer;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import co.cask.cdap.security.spi.authorization.Authorizer;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
-import co.cask.tephra.TransactionManager;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import com.google.inject.Guice;
+import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
-import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
@@ -77,9 +70,7 @@ public class DefaultSecureStoreServiceTest {
 
   private static SecureStoreService secureStoreService;
   private static Authorizer authorizer;
-  private static AuthorizationEnforcementService authorizationEnforcementService;
   private static AppFabricServer appFabricServer;
-  private static DiscoveryServiceClient discoveryServiceClient;
 
   @ClassRule
   public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
@@ -88,21 +79,16 @@ public class DefaultSecureStoreServiceTest {
   public static void setup() throws Exception {
     SConfiguration sConf = SConfiguration.create();
     sConf.set(Constants.Security.Store.FILE_PASSWORD, "secret");
-    final Injector injector = Guice.createInjector(new AppFabricTestModule(createCConf(), sConf));
-    injector.getInstance(TransactionManager.class).startAndWait();
-    injector.getInstance(DatasetOpExecutor.class).startAndWait();
-    discoveryServiceClient = injector.getInstance(DiscoveryServiceClient.class);
-    DatasetService datasetService = injector.getInstance(DatasetService.class);
-    datasetService.startAndWait();
-    waitForService(Constants.Service.DATASET_EXECUTOR);
+    final Injector injector = AppFabricTestHelper.getInjector(createCConf(), sConf, new AbstractModule() {
+      @Override
+      protected void configure() {
+        // no overrides
+      }
+    });
     appFabricServer = injector.getInstance(AppFabricServer.class);
     appFabricServer.startAndWait();
-    authorizationEnforcementService = injector.getInstance(AuthorizationEnforcementService.class);
-    authorizationEnforcementService.startAndWait();
     secureStoreService = injector.getInstance(SecureStoreService.class);
     authorizer = injector.getInstance(AuthorizerInstantiator.class).get();
-    SecurityRequestContext.setUserId(ALICE.getName());
-
     secureStoreService = injector.getInstance(SecureStoreService.class);
     authorizer.grant(NamespaceId.DEFAULT, ALICE, Collections.singleton(Action.READ));
     Tasks.waitFor(true, new Callable<Boolean>() {
@@ -117,7 +103,6 @@ public class DefaultSecureStoreServiceTest {
   @AfterClass
   public static void cleanup() {
     appFabricServer.stopAndWait();
-    authorizationEnforcementService.stopAndWait();
   }
 
   private static CConfiguration createCConf() throws Exception {
@@ -128,7 +113,7 @@ public class DefaultSecureStoreServiceTest {
     // we only want to test authorization, but we don't specify principal/keytab, so disable kerberos
     cConf.setBoolean(Constants.Security.KERBEROS_ENABLED, false);
     cConf.setBoolean(Constants.Security.Authorization.CACHE_ENABLED, false);
-    cConf.set(Constants.Security.Authorization.SUPERUSERS, "hulk");
+    cConf.set(Constants.Security.Authorization.SYSTEM_USER, new MasterAuthenticationContext().getPrincipal().getName());
 
     LocationFactory locationFactory = new LocalLocationFactory(TEMPORARY_FOLDER.newFolder());
     Location authorizerJar = AppJarHelper.createDeploymentJar(locationFactory, InMemoryAuthorizer.class);
@@ -195,12 +180,6 @@ public class DefaultSecureStoreServiceTest {
     };
     Assert.assertTrue(Sets.filter(authorizer.listPrivileges(ALICE), secureKeyIdFilter).isEmpty());
     Assert.assertTrue(Sets.filter(authorizer.listPrivileges(BOB), secureKeyIdFilter).isEmpty());
-  }
-
-  private static void waitForService(String service) {
-    EndpointStrategy endpointStrategy = new RandomEndpointStrategy(discoveryServiceClient.discover(service));
-    Preconditions.checkNotNull(endpointStrategy.pick(5, TimeUnit.SECONDS),
-                               "%s service is not up after 5 seconds", service);
   }
 
   private void grantAndAssertSuccess(EntityId entityId, Principal principal, Set<Action> actions) throws Exception {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AuthorizationBootstrapperTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AuthorizationBootstrapperTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.services.http;
+
+import co.cask.cdap.api.Predicate;
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.app.program.ManifestFields;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.discovery.EndpointStrategy;
+import co.cask.cdap.common.discovery.RandomEndpointStrategy;
+import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
+import co.cask.cdap.common.utils.DirUtils;
+import co.cask.cdap.common.utils.Tasks;
+import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
+import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.internal.app.namespace.DefaultNamespaceEnsurer;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import co.cask.cdap.internal.app.runtime.artifact.SystemArtifactLoader;
+import co.cask.cdap.internal.app.runtime.artifact.app.plugin.PluginTestApp;
+import co.cask.cdap.internal.app.runtime.artifact.app.plugin.PluginTestRunnable;
+import co.cask.cdap.internal.guice.AppFabricTestModule;
+import co.cask.cdap.internal.test.AppJarHelper;
+import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.id.InstanceId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.security.auth.context.MasterAuthenticationContext;
+import co.cask.cdap.security.authorization.AuthorizationBootstrapper;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
+import co.cask.cdap.security.authorization.InMemoryAuthorizer;
+import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
+import co.cask.cdap.security.spi.authorization.UnauthorizedException;
+import co.cask.tephra.TransactionManager;
+import com.google.common.base.Preconditions;
+import com.google.common.io.Files;
+import com.google.common.util.concurrent.AbstractService;
+import com.google.common.util.concurrent.Service;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.apache.twill.filesystem.LocalLocationFactory;
+import org.apache.twill.filesystem.Location;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.jar.Manifest;
+
+/**
+ * Tests authorization for default namespace, system artifacts, system datasets, etc
+ */
+public class AuthorizationBootstrapperTest {
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+  private static final ArtifactId SYSTEM_ARTIFACT = NamespaceId.SYSTEM.artifact("system-artifact", "1.0.0");
+
+  private static AuthorizationBootstrapper authorizationBootstrapper;
+  private static TransactionManager txManager;
+  private static DatasetService datasetService;
+  private static DefaultNamespaceEnsurer defaultNamespaceEnsurer;
+  private static SystemArtifactLoader systemArtifactLoader;
+  private static NamespaceQueryAdmin namespaceQueryAdmin;
+  private static NamespaceAdmin namespaceAdmin;
+  private static AuthorizationEnforcementService authorizationEnforcementService;
+  private static ArtifactRepository artifactRepository;
+  private static DatasetFramework dsFramework;
+  private static DiscoveryServiceClient discoveryServiceClient;
+  private static Principal systemUser;
+  private static InstanceId instanceId;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, TMP_FOLDER.newFolder().getAbsolutePath());
+    cConf.setBoolean(Constants.Security.ENABLED, true);
+    cConf.setBoolean(Constants.Security.KERBEROS_ENABLED, false);
+    cConf.setBoolean(Constants.Security.Authorization.ENABLED, true);
+    cConf.setBoolean(Constants.Security.Authorization.CACHE_ENABLED, false);
+    Location deploymentJar = AppJarHelper.createDeploymentJar(new LocalLocationFactory(TMP_FOLDER.newFolder()),
+                                                              InMemoryAuthorizer.class);
+    cConf.set(Constants.Security.Authorization.EXTENSION_JAR_PATH, deploymentJar.toURI().getPath());
+    systemUser = new MasterAuthenticationContext().getPrincipal();
+    cConf.set(Constants.Security.Authorization.SYSTEM_USER, systemUser.getName());
+    // make Alice an admin user, so she can create namespaces
+    cConf.set(Constants.Security.Authorization.ADMIN_USERS, "alice");
+    instanceId = new InstanceId(cConf.get(Constants.INSTANCE_NAME));
+    // setup a system artifact
+    File systemArtifactsDir = TMP_FOLDER.newFolder();
+    cConf.set(Constants.AppFabric.SYSTEM_ARTIFACTS_DIR, systemArtifactsDir.getAbsolutePath());
+    createSystemArtifact(systemArtifactsDir);
+    Injector injector =  Guice.createInjector(new AppFabricTestModule(cConf));
+    defaultNamespaceEnsurer = injector.getInstance(DefaultNamespaceEnsurer.class);
+    discoveryServiceClient = injector.getInstance(DiscoveryServiceClient.class);
+    txManager = injector.getInstance(TransactionManager.class);
+    datasetService = injector.getInstance(DatasetService.class);
+    authorizationEnforcementService = injector.getInstance(AuthorizationEnforcementService.class);
+    authorizationEnforcementService.startAndWait();
+    systemArtifactLoader = injector.getInstance(SystemArtifactLoader.class);
+    authorizationBootstrapper = injector.getInstance(AuthorizationBootstrapper.class);
+    namespaceQueryAdmin = injector.getInstance(NamespaceQueryAdmin.class);
+    namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
+    artifactRepository = injector.getInstance(ArtifactRepository.class);
+    dsFramework = injector.getInstance(DatasetFramework.class);
+  }
+
+  @Test
+  public void test() throws Exception {
+    authorizationBootstrapper.run();
+    Tasks.waitFor(true, new Callable<Boolean>() {
+      @Override
+      public Boolean call() throws Exception {
+        Predicate<EntityId> systemUserFilter = authorizationEnforcementService.createFilter(systemUser);
+        return systemUserFilter.apply(instanceId) && systemUserFilter.apply(NamespaceId.SYSTEM);
+      }
+    }, 10, TimeUnit.SECONDS);
+    txManager.startAndWait();
+    datasetService.startAndWait();
+    waitForService(Constants.Service.DATASET_MANAGER);
+    defaultNamespaceEnsurer.startAndWait();
+    systemArtifactLoader.startAndWait();
+    waitForService(defaultNamespaceEnsurer);
+    waitForService(systemArtifactLoader);
+    // ensure that the default namespace was created, and that the system user has privileges to access it
+    Tasks.waitFor(true, new Callable<Boolean>() {
+      @Override
+      public Boolean call() throws Exception {
+        try {
+          return namespaceQueryAdmin.exists(NamespaceId.DEFAULT.toId());
+        } catch (Exception e) {
+          return false;
+        }
+      }
+    }, 10, TimeUnit.SECONDS);
+    Assert.assertTrue(defaultNamespaceEnsurer.isRunning());
+    // ensure that the system artifact was deployed, and that the system user has privileges to access it
+    // this will throw an ArtifactNotFoundException if the artifact was not deployed, and UnauthorizedException if
+    // the user does not have required privileges
+    Tasks.waitFor(true, new Callable<Boolean>() {
+      @Override
+      public Boolean call() throws Exception {
+        try {
+          artifactRepository.getArtifact(SYSTEM_ARTIFACT.toId());
+          return true;
+        } catch (Exception e) {
+          return false;
+        }
+      }
+    }, 20, TimeUnit.SECONDS);
+    Assert.assertTrue(systemArtifactLoader.isRunning());
+    // ensure that system datasets can be created by the system user
+    Dataset systemDataset = DatasetsUtil.getOrCreateDataset(
+      dsFramework, NamespaceId.SYSTEM.dataset("system-dataset").toId(), Table.class.getName(), DatasetProperties.EMPTY,
+      Collections.<String, String>emptyMap(), this.getClass().getClassLoader());
+    Assert.assertNotNull(systemDataset);
+    // as part of bootstrapping, admin users were also granted admin privileges on the CDAP instance, so they can
+    // create namespaces
+    SecurityRequestContext.setUserId("alice");
+    namespaceAdmin.create(new NamespaceMeta.Builder().setName("success").build());
+    SecurityRequestContext.setUserId("bob");
+    try {
+      namespaceAdmin.create(new NamespaceMeta.Builder().setName("failure").build());
+      Assert.fail("Bob should not have been able to create a namespace since he is not an admin user");
+    } catch (UnauthorizedException expected) {
+      // expected
+    }
+  }
+
+  @AfterClass
+  public static void teardown() {
+    datasetService.stopAndWait();
+    txManager.stopAndWait();
+    authorizationEnforcementService.stopAndWait();
+  }
+
+  private void waitForService(final AbstractService service) throws Exception {
+    Tasks.waitFor(Service.State.RUNNING, new Callable<Service.State>() {
+      @Override
+      public Service.State call() throws Exception {
+        return service.state();
+      }
+    }, 10, TimeUnit.SECONDS);
+  }
+
+  private void waitForService(String discoverableName) throws InterruptedException {
+    EndpointStrategy endpointStrategy = new RandomEndpointStrategy(discoveryServiceClient.discover(discoverableName));
+    Preconditions.checkNotNull(endpointStrategy.pick(5, TimeUnit.SECONDS),
+                               "%s service is not up after 5 seconds", discoverableName);
+  }
+
+  private static File createAppJar(Class<?> cls, File destFile, Manifest manifest) throws IOException {
+    Location deploymentJar = AppJarHelper.createDeploymentJar(new LocalLocationFactory(TMP_FOLDER.newFolder()),
+                                                              cls, manifest);
+    DirUtils.mkdirs(destFile.getParentFile());
+    Files.copy(Locations.newInputSupplier(deploymentJar), destFile);
+    return destFile;
+  }
+
+  private static void createSystemArtifact(File systemArtifactsDir) throws IOException {
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().put(ManifestFields.EXPORT_PACKAGE, PluginTestRunnable.class.getPackage().getName());
+    File systemArtifact = new File(
+      systemArtifactsDir, String.format("%s-%s.jar", SYSTEM_ARTIFACT.getArtifact(), SYSTEM_ARTIFACT.getVersion())
+    );
+    createAppJar(PluginTestApp.class, systemArtifact, manifest);
+
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
@@ -19,17 +19,15 @@ package co.cask.cdap.metadata;
 import co.cask.cdap.AllProgramsApp;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsService;
 import co.cask.cdap.internal.AppFabricTestHelper;
 import co.cask.cdap.internal.app.services.AppFabricServer;
 import co.cask.cdap.internal.test.AppJarHelper;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.proto.id.InstanceId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
-import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
+import co.cask.cdap.security.auth.context.MasterAuthenticationContext;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.authorization.InMemoryAuthorizer;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
@@ -62,23 +60,16 @@ public class MetadataAdminAuthorizationTest {
   private static CConfiguration cConf;
   private static MetadataAdmin metadataAdmin;
   private static Authorizer authorizer;
-  private static AuthorizationEnforcementService authorizationEnforcementService;
   private static AppFabricServer appFabricServer;
-  private static RemoteSystemOperationsService remoteSystemOperationsService;
 
   @BeforeClass
   public static void setup() throws Exception {
     cConf = createCConf();
-    Injector injector = AppFabricTestHelper.getInjector(cConf);
+    final Injector injector = AppFabricTestHelper.getInjector(cConf);
     metadataAdmin = injector.getInstance(MetadataAdmin.class);
     authorizer = injector.getInstance(AuthorizerInstantiator.class).get();
-    authorizer.grant(new InstanceId(cConf.get(Constants.INSTANCE_NAME)), ALICE, Collections.singleton(Action.ADMIN));
-    authorizationEnforcementService = injector.getInstance(AuthorizationEnforcementService.class);
-    authorizationEnforcementService.startAndWait();
     appFabricServer = injector.getInstance(AppFabricServer.class);
     appFabricServer.startAndWait();
-    remoteSystemOperationsService = injector.getInstance(RemoteSystemOperationsService.class);
-    remoteSystemOperationsService.startAndWait();
   }
 
   @Test
@@ -95,9 +86,7 @@ public class MetadataAdminAuthorizationTest {
 
   @AfterClass
   public static void tearDown() {
-    remoteSystemOperationsService.stopAndWait();
     appFabricServer.stopAndWait();
-    authorizationEnforcementService.stopAndWait();
   }
 
   private static CConfiguration createCConf() throws IOException {
@@ -110,7 +99,7 @@ public class MetadataAdminAuthorizationTest {
     LocationFactory locationFactory = new LocalLocationFactory(new File(TEMPORARY_FOLDER.newFolder().toURI()));
     Location authorizerJar = AppJarHelper.createDeploymentJar(locationFactory, InMemoryAuthorizer.class);
     cConf.set(Constants.Security.Authorization.EXTENSION_JAR_PATH, authorizerJar.toURI().getPath());
-    cConf.set(Constants.Security.Authorization.SUPERUSERS, "hulk");
+    cConf.set(Constants.Security.Authorization.SYSTEM_USER, new MasterAuthenticationContext().getPrincipal().getName());
     return cConf;
   }
 }

--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/AuthorizationCLITest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/AuthorizationCLITest.java
@@ -25,6 +25,7 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Role;
+import co.cask.cdap.security.auth.context.MasterAuthenticationContext;
 import co.cask.cdap.security.authorization.InMemoryAuthorizer;
 import co.cask.cdap.security.server.BasicAuthenticationHandler;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
@@ -92,6 +93,7 @@ public class AuthorizationCLITest extends CLITestBase {
         Constants.Security.Authorization.ENABLED, "true",
         Constants.Security.Authorization.CACHE_ENABLED, "false",
         Constants.Security.Authorization.EXTENSION_JAR_PATH, authExtensionJar.toURI().getPath(),
+        Constants.Security.Authorization.SYSTEM_USER, new MasterAuthenticationContext().getPrincipal().getName(),
         // Bypass authorization enforcement for grant/revoke operations in this test. Authorization enforcement for
         // grant/revoke is tested in AuthorizationHandlerTest
         Constants.Security.Authorization.EXTENSION_CONFIG_PREFIX + "superusers", "*",

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -707,11 +707,11 @@ public final class Constants {
       /** Prefix for extension properties */
       public static final String EXTENSION_CONFIG_PREFIX =
         "security.authorization.extension.config.";
-      // Currently, superusers is used both by CDAP (for caching) and by extensions.
-      public static final String SUPERUSERS = EXTENSION_CONFIG_PREFIX + "superusers";
+      public static final String SYSTEM_USER = "security.authorization.system.user";
       public static final String CACHE_ENABLED = "security.authorization.cache.enabled";
       public static final String CACHE_TTL_SECS = "security.authorization.cache.ttl.secs";
       public static final String CACHE_REFRESH_INTERVAL_SECS = "security.authorization.cache.refresh.interval.secs";
+      public static final String ADMIN_USERS = "security.authorization.admin.users";
     }
 
     /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1634,6 +1634,17 @@
   </property>
 
   <property>
+    <name>security.authorization.admin.users</name>
+    <value></value>
+    <description>
+      Determines a comma-separated list of users for whom admin privileges are granted on the CDAP instance
+      during CDAP startup, so these users can create namespaces and in-effect bootstrap CDAP on an authorization
+      enabled cluster. Defaults to empty, in which case no users have access to create namespaces. In this scenario, it
+      may be impossible to bootstrap CDAP, so it is recommended that at least one user be provided as the admin user.
+    </description>
+  </property>
+
+  <property>
     <name>security.authorization.cache.enabled</name>
     <value>true</value>
     <description>
@@ -1690,12 +1701,14 @@
   </property>
 
   <property>
-    <name>security.authorization.extension.config.superusers</name>
-    <value>test</value>
+    <name>security.authorization.system.user</name>
+    <value>cdap</value>
     <description>
-      Determines a comma-separated list of users for whom authorization is bypassed.
-      This is necessary for bootstrapping authorization in CDAP, hence it is required
-      that at least one super user be defined.
+      Determines a user for whom specific privileges are granted during CDAP startup.
+      This is the user used for creating the default namespace, deploying system artifacts and deploying dataset
+      modules. This user is also granted ALL privileges on the system namespace, so it can access datasets and other
+      entities in the system namespace. This user does not get any other privileges on user namespaces. Defaults to
+      'cdap'. Please set this to the user that the CDAP Master runs as in a secure, authorization-enabled environment.
     </description>
   </property>
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
@@ -542,7 +542,7 @@ public class DatasetInstanceService {
   private void ensureAccess(DatasetId datasetId) throws Exception {
     Principal principal = authenticationContext.getPrincipal();
     Predicate<EntityId> filter = authorizationEnforcer.createFilter(principal);
-    if (!Principal.SYSTEM.equals(principal) && !filter.apply(datasetId)) {
+    if (!filter.apply(datasetId)) {
       throw new UnauthorizedException(principal, datasetId);
     }
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeService.java
@@ -204,7 +204,7 @@ public class DatasetTypeService extends AbstractIdleService {
     }
     Principal principal = authenticationContext.getPrincipal();
     final Predicate<EntityId> filter = authorizationEnforcer.createFilter(principal);
-    if (!Principal.SYSTEM.equals(principal) && !filter.apply(datasetModuleId)) {
+    if (!filter.apply(datasetModuleId)) {
       throw new UnauthorizedException(principal, datasetModuleId);
     }
     return moduleMeta;
@@ -343,6 +343,7 @@ public class DatasetTypeService extends AbstractIdleService {
     }
 
     // All principals can access system dataset types
+    // TODO: Test if this can be removed
     if (NamespaceId.SYSTEM.equals(datasetTypeId.getParent())) {
       return typeMeta;
     }
@@ -350,7 +351,7 @@ public class DatasetTypeService extends AbstractIdleService {
     // only return the type if the user has some privileges on it
     Principal principal = authenticationContext.getPrincipal();
     Predicate<EntityId> authFilter = authorizationEnforcer.createFilter(principal);
-    if (!Principal.SYSTEM.equals(principal) && !authFilter.apply(datasetTypeId)) {
+    if (!authFilter.apply(datasetTypeId)) {
       throw new UnauthorizedException(principal, datasetTypeId);
     }
     return typeMeta;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
@@ -806,7 +806,7 @@ public class FileStreamAdmin implements StreamAdmin {
   private <T extends EntityId> void ensureAccess(T entityId) throws Exception {
     Principal principal = authenticationContext.getPrincipal();
     Predicate<EntityId> filter = authorizationEnforcer.createFilter(principal);
-    if (!Principal.SYSTEM.equals(principal) && !filter.apply(entityId)) {
+    if (!filter.apply(entityId)) {
       throw new UnauthorizedException(principal, entityId);
     }
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceAuthorizationTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceAuthorizationTest.java
@@ -80,7 +80,6 @@ public class DatasetServiceAuthorizationTest extends DatasetServiceTestBase {
     // we only want to test authorization, but we don't specify principal/keytab, so disable kerberos
     cConf.setBoolean(Constants.Security.KERBEROS_ENABLED, false);
     cConf.setBoolean(Constants.Security.Authorization.CACHE_ENABLED, false);
-    cConf.set(Constants.Security.Authorization.SUPERUSERS, "hulk");
     Location authorizerJar = AppJarHelper.createDeploymentJar(locationFactory, InMemoryAuthorizer.class);
     cConf.set(Constants.Security.Authorization.EXTENSION_JAR_PATH, authorizerJar.toURI().getPath());
     return cConf;

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="c40cb0a4578bd8b99d36a565f923d71b"
+DEFAULT_XML_MD5_HASH="4b7bf6d4258eb7714a6f028d4d4c92ae"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceStreamTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceStreamTest.java
@@ -31,7 +31,6 @@ import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
-import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import co.cask.cdap.security.spi.authorization.Authorizer;
@@ -86,7 +85,6 @@ public class HiveExploreServiceStreamTest extends BaseHiveExploreServiceTest {
   private static final Map<String, String> headers = ImmutableMap.of("header1", "val1", "header2", "val2");
   private static final Type headerType = new TypeToken<Map<String, String>>() { }.getType();
 
-  private static AuthorizationEnforcementService authorizationEnforcementService;
   private static Authorizer authorizer;
 
   @BeforeClass
@@ -95,8 +93,6 @@ public class HiveExploreServiceStreamTest extends BaseHiveExploreServiceTest {
     // to determine input splits. also enable authorization.
     initialize(CConfiguration.create(), tmpFolder, true, true);
     authorizer = injector.getInstance(AuthorizerInstantiator.class).get();
-    authorizationEnforcementService = injector.getInstance(AuthorizationEnforcementService.class);
-    authorizationEnforcementService.startAndWait();
     SecurityRequestContext.setUserId(USER.getName());
     grantAndAssertSuccess(NAMESPACE_ID.toEntityId(), USER, ImmutableSet.of(Action.ALL));
 
@@ -111,9 +107,6 @@ public class HiveExploreServiceStreamTest extends BaseHiveExploreServiceTest {
   public static void finish() throws Exception {
     dropStream(Id.Stream.from(NAMESPACE_ID, streamName));
     revokeAndAssertSuccess(NAMESPACE_ID.toEntityId(), USER, ImmutableSet.of(Action.ALL));
-    if (authorizationEnforcementService != null) {
-      authorizationEnforcementService.stopAndWait();
-    }
   }
 
   @Test

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -64,6 +64,7 @@ import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModu
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.TokenSecureStoreUpdater;
+import co.cask.cdap.security.authorization.AuthorizationBootstrapper;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;
@@ -550,7 +551,9 @@ public class MasterServiceMain extends DaemonMain {
       }
 
       authorizerInstantiator = injector.getInstance(AuthorizerInstantiator.class);
-
+      // Authorization bootstrapping is a blocking call, because CDAP will not start successfully if it does not
+      // succeed on an authorization-enabled cluster
+      injector.getInstance(AuthorizationBootstrapper.class).run();
       services.add(getAndStart(injector, KafkaClientService.class));
       services.add(getAndStart(injector, MetricsCollectionService.class));
       services.add(getAndStart(injector, AuthorizationEnforcementService.class));

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/security/Principal.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/security/Principal.java
@@ -26,7 +26,6 @@ import java.util.Objects;
  */
 @Beta
 public class Principal {
-  public static final Principal SYSTEM = new Principal(".cdap", PrincipalType.USER);
   /**
    * Identifies the type of {@link Principal}.
    */

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/AbstractAuthorizer.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/AbstractAuthorizer.java
@@ -63,10 +63,6 @@ public abstract class AbstractAuthorizer implements Authorizer {
 
   @Override
   public Predicate<EntityId> createFilter(Principal principal) throws Exception {
-    if (Principal.SYSTEM.equals(principal)) {
-      return ALLOW_ALL;
-    }
-
     Set<Privilege> privileges = listPrivileges(principal);
     final Set<EntityId> allowedEntities = new HashSet<>();
     for (Privilege privilege : privileges) {

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizationBootstrapper.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizationBootstrapper.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.id.InstanceId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.security.spi.authorization.PrivilegesManager;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A class to bootstrap authorization
+ */
+public class AuthorizationBootstrapper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AuthorizationBootstrapper.class);
+
+  private final boolean enabled;
+  private final PrivilegesManager privilegesManager;
+  private final Principal systemUser;
+  private final Set<Principal> adminUsers;
+  private final InstanceId instanceId;
+
+  @Inject
+  AuthorizationBootstrapper(CConfiguration cConf, PrivilegesManager privilegesManager) {
+    this.enabled =
+      cConf.getBoolean(Constants.Security.ENABLED) && cConf.getBoolean(Constants.Security.Authorization.ENABLED);
+    this.systemUser =
+      new Principal(cConf.get(Constants.Security.Authorization.SYSTEM_USER), Principal.PrincipalType.USER);
+    this.adminUsers = getAdminUsers(cConf);
+    this.instanceId = new InstanceId(cConf.get(Constants.INSTANCE_NAME));
+    validateConfiguration();
+    this.privilegesManager = privilegesManager;
+  }
+
+  public void run() {
+    if (!enabled) {
+      return;
+    }
+    LOG.debug("Bootstrapping authorization for CDAP instance {}, principal {}", instanceId, systemUser);
+    try {
+      // grant admin on instance, so the system user can create default (and other) namespaces
+      privilegesManager.grant(instanceId, systemUser, Collections.singleton(Action.ADMIN));
+      // grant ALL on the system namespace, so the system user can create and access tables in the system namespace
+      // also required by SystemArtifactsLoader to add system artifacts
+      privilegesManager.grant(NamespaceId.SYSTEM, systemUser, Collections.singleton(Action.ALL));
+      // also grant admin privileges on the CDAP instance to the admin users, so they can create namespaces
+      for (Principal adminUser : adminUsers) {
+        privilegesManager.grant(instanceId, adminUser, Collections.singleton(Action.ADMIN));
+      }
+      LOG.info("Successfully bootstrapped authorization for CDAP instance {}, principal {}", instanceId, systemUser);
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  private Set<Principal> getAdminUsers(CConfiguration cConf) {
+    Set<Principal> admins = new HashSet<>();
+    String adminUsers = cConf.get(Constants.Security.Authorization.ADMIN_USERS);
+    if (adminUsers != null) {
+      for (String adminUser : Splitter.on(",").omitEmptyStrings().trimResults().split(adminUsers)) {
+        admins.add(new Principal(adminUser, Principal.PrincipalType.USER));
+      }
+    }
+    return admins;
+  }
+
+  private void validateConfiguration() {
+    if (!enabled) {
+      return;
+    }
+    Preconditions.checkArgument(
+      !Strings.isNullOrEmpty(systemUser.getName()),
+      "The CDAP system user specified by %s is null or empty. Without this setting, CDAP will not be able to " +
+        "create a default namespace, system artifacts or initialize its metadata. It is recommended to set this to " +
+        "the user that the CDAP Master runs as.", Constants.Security.Authorization.SYSTEM_USER);
+    if (adminUsers.isEmpty()) {
+      LOG.warn("Admin users specified by {} is empty. It may not be possible to bootstrap CDAP without this setting. " +
+                 "To get rid of this warning, please set {} to a comma-separated list of users who will be granted " +
+                 "admin privileges on the CDAP instance so that they can create namespaces in CDAP.",
+               Constants.Security.Authorization.ADMIN_USERS, Constants.Security.Authorization.ADMIN_USERS);
+    }
+  }
+}

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationEnforcementService.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationEnforcementService.java
@@ -18,16 +18,13 @@ package co.cask.cdap.security.authorization;
 
 import co.cask.cdap.api.Predicate;
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.ParentedId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.cdap.security.spi.authorization.PrivilegesFetcher;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -38,7 +35,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 /**
  * Default implementation of {@link AuthorizationEnforcementService}.
@@ -55,16 +51,10 @@ public class DefaultAuthorizationEnforcementService extends AbstractAuthorizatio
     }
   };
 
-  private final Set<Principal> superUsers;
-
   @Inject
-  DefaultAuthorizationEnforcementService(PrivilegesFetcher privilegesFetcher, CConfiguration cConf) {
-    super(privilegesFetcher, cConf, "enforcement");
-    this.superUsers = getSuperUsers(cConf.get(Constants.Security.Authorization.SUPERUSERS));
-    Preconditions.checkArgument(
-      !superUsers.isEmpty(), "No super users specified. Without this setting, it may be impossible to bootstrap CDAP " +
-        "with authorization enabled. Please set %s to a comma separated list of superusers who can bypass " +
-        "authorization policies in CDAP.", Constants.Security.Authorization.SUPERUSERS);
+  DefaultAuthorizationEnforcementService(PrivilegesFetcher privilegesFetcher, CConfiguration cConf,
+                                         AuthenticationContext authenticationContext) {
+    super(cConf, privilegesFetcher, authenticationContext, "enforcement");
   }
 
   @Override
@@ -77,14 +67,6 @@ public class DefaultAuthorizationEnforcementService extends AbstractAuthorizatio
     if (!isSecurityAuthorizationEnabled()) {
       return;
     }
-    // For accessing system datasets for internal operations like recording metadata, usage, lineage, etc
-    if (Principal.SYSTEM.equals(principal)) {
-      return;
-    }
-    // If the principal is a superuser, allow access
-    if (isSuperUser(principal)) {
-      return;
-    }
 
     doEnforce(entity, principal, actions, true);
   }
@@ -92,14 +74,6 @@ public class DefaultAuthorizationEnforcementService extends AbstractAuthorizatio
   @Override
   public Predicate<EntityId> createFilter(Principal principal) throws Exception {
     if (!isSecurityAuthorizationEnabled()) {
-      return ALLOW_ALL;
-    }
-    // For accessing system datasets for internal operations like recording metadata, usage, lineage, etc
-    if (Principal.SYSTEM.equals(principal)) {
-      return ALLOW_ALL;
-    }
-    // If the principal is a super user, do not filter
-    if (isSuperUser(principal)) {
       return ALLOW_ALL;
     }
     Map<EntityId, Set<Action>> privileges = getPrivileges(principal);
@@ -115,20 +89,6 @@ public class DefaultAuthorizationEnforcementService extends AbstractAuthorizatio
         return (parentPassed || allowedEntities.contains(entityId));
       }
     };
-  }
-
-  private Set<Principal> getSuperUsers(@Nullable String superUsers) {
-    ImmutableSet.Builder<Principal> result = new ImmutableSet.Builder<>();
-    if (superUsers != null) {
-      for (String curUser : Splitter.on(",").trimResults().split(superUsers)) {
-        result.add(new Principal(curUser, Principal.PrincipalType.USER));
-      }
-    }
-    return result.build();
-  }
-
-  private boolean isSuperUser(Principal principal) {
-    return superUsers.contains(principal) || superUsers.contains(new Principal("*", Principal.PrincipalType.USER));
   }
 
   protected boolean isSecurityAuthorizationEnabled() {

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultPrivilegesFetcherProxyService.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultPrivilegesFetcherProxyService.java
@@ -21,6 +21,7 @@ import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
+import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.cdap.security.spi.authorization.Authorizer;
 import co.cask.cdap.security.spi.authorization.PrivilegesFetcher;
 import com.google.common.collect.ImmutableSet;
@@ -46,8 +47,8 @@ public class DefaultPrivilegesFetcherProxyService extends AbstractAuthorizationS
   @Inject
   DefaultPrivilegesFetcherProxyService(
     @Named(AuthorizationEnforcementModule.PRIVILEGES_FETCHER_PROXY) PrivilegesFetcher privilegeFetcher,
-    CConfiguration cConf) {
-    super(privilegeFetcher, cConf, "privileges-fetcher-proxy");
+    CConfiguration cConf, AuthenticationContext authenticationContext) {
+    super(cConf, privilegeFetcher, authenticationContext, "privileges-fetcher-proxy");
   }
 
   @Override

--- a/cdap-security/src/main/java/co/cask/cdap/security/guice/SecureStoreModules.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/guice/SecureStoreModules.java
@@ -21,7 +21,6 @@ import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.conf.SConfiguration;
-import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.runtime.RuntimeModule;
 import co.cask.cdap.security.store.DummySecureStore;
 import co.cask.cdap.security.store.FileSecureStore;

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizationTestBase.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizationTestBase.java
@@ -41,7 +41,6 @@ public class AuthorizationTestBase {
     CCONF.set(Constants.CFG_LOCAL_DATA_DIR, TEMPORARY_FOLDER.newFolder().getAbsolutePath());
     CCONF.setBoolean(Constants.Security.ENABLED, true);
     CCONF.setBoolean(Constants.Security.Authorization.ENABLED, true);
-    CCONF.set(Constants.Security.Authorization.SUPERUSERS, "hulk");
     locationFactory = new LocalLocationFactory(TEMPORARY_FOLDER.newFolder());
   }
 }

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizerInstantiatorTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizerInstantiatorTest.java
@@ -209,7 +209,6 @@ public class AuthorizerInstantiatorTest extends AuthorizationTestBase {
       ValidExternalAuthorizer validAuthorizer = gson.fromJson(gson.toJson(externalAuthorizer1),
                                                               ValidExternalAuthorizer.class);
       Properties expectedProps = new Properties();
-      expectedProps.put("superusers", "hulk");
       expectedProps.put("config.path", "/path/config.ini");
       expectedProps.put("service.address", "http://foo.bar.co:5555");
       Properties actualProps = validAuthorizer.getProperties();

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -88,6 +88,7 @@ import co.cask.cdap.proto.id.InstanceId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.security.authorization.AuthorizationBootstrapper;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;
@@ -181,6 +182,7 @@ public class TestBase {
   private static SecureStore secureStore;
   private static SecureStoreManager secureStoreManager;
   private static AuthorizationEnforcementService authorizationEnforcementService;
+  private static AuthorizationBootstrapper authorizationBootstrapper;
 
   // This list is to record ApplicationManager create inside @Test method
   private static final List<ApplicationManager> applicationManagers = new ArrayList<>();
@@ -265,6 +267,8 @@ public class TestBase {
       }
     );
 
+    authorizationBootstrapper = injector.getInstance(AuthorizationBootstrapper.class);
+    authorizationBootstrapper.run();
     authorizationEnforcementService = injector.getInstance(AuthorizationEnforcementService.class);
     authorizationEnforcementService.startAndWait();
     txService = injector.getInstance(TransactionManager.class);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
@@ -41,6 +41,7 @@ import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
+import co.cask.cdap.security.auth.context.MasterAuthenticationContext;
 import co.cask.cdap.security.authorization.InMemoryAuthorizer;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import co.cask.cdap.security.spi.authorization.Authorizer;
@@ -143,7 +144,7 @@ public class AuthorizationTest extends TestBase {
         Constants.Security.Authorization.EXTENSION_JAR_PATH, authExtensionJar.toURI().getPath(),
         // we only want to test authorization, but we don't specify principal/keytab, so disable kerberos
         Constants.Security.KERBEROS_ENABLED, "false",
-        Constants.Security.Authorization.SUPERUSERS, "hulk"
+        Constants.Security.Authorization.SYSTEM_USER, new MasterAuthenticationContext().getPrincipal().getName()
       };
     }
   }


### PR DESCRIPTION
Jiras:
- [CDAP-6901](https://issues.cask.co/browse/CDAP-6901) 
  Added a bootstrap step for authorization.
  This step reads a "security.authorization.system.user" setting from cdap-site.xml and grants it ADMIN on instance:cdap and ALL on namespace:system.
  From then on, everything in the system namespace has authorization, which succeeds because of the bootstrap step. Removed hacks using `Principal.SYSTEM` for accessing system datasets and artifacts.
  It also reads a "security.authorization.admin.users" setting from cdap-site.xml and grants these users ADMIN on instance:cdap, so they can create namespaces, and bootstrap CDAP.
  Also removed the concept of super-users getting blanket authorization for all operations.
- [CDAP-6887](https://issues.cask.co/browse/CDAP-6887) 
  Removed unnecessary authorization logs when authorization is disabled.

Build:
http://builds.cask.co/browse/CDAP-RUT15
