### PR TITLE
CDAP-6827 local.data.dir should be resolved properly

### DIFF
--- a/cdap-kafka/src/main/java/co/cask/cdap/kafka/run/KafkaServerMain.java
+++ b/cdap-kafka/src/main/java/co/cask/cdap/kafka/run/KafkaServerMain.java
@@ -25,7 +25,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.net.InetAddresses;
 import com.google.common.util.concurrent.Service;
-import org.apache.commons.collections.functors.ExceptionClosure;
 import org.apache.twill.internal.kafka.EmbeddedKafkaServer;
 import org.apache.twill.zookeeper.ZKClientService;
 import org.apache.twill.zookeeper.ZKOperations;
@@ -36,7 +35,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.Properties;
 
@@ -144,8 +142,9 @@ public class KafkaServerMain extends DaemonMain {
     Map<String, String> propConfigs = cConf.getValByRegex("^(kafka\\.server\\.)");
     for (Map.Entry<String, String> pair : propConfigs.entrySet()) {
       String key = pair.getKey();
+      String value = cConf.get(key);
       String trimmedKey = key.substring(13);
-      prop.setProperty(trimmedKey, pair.getValue());
+      prop.setProperty(trimmedKey, value);
     }
     return prop;
   }

--- a/cdap-standalone/src/main/resources/cdap-site.xml
+++ b/cdap-standalone/src/main/resources/cdap-site.xml
@@ -175,7 +175,7 @@
   </property>
 
   <property>
-    <name>kafka.log.dir</name>
+    <name>kafka.server.log.dirs</name>
     <value>${local.data.dir}/kafka-logs</value>
     <description>
       Log directory for Kafka server


### PR DESCRIPTION
JIRA : https://issues.cask.co/browse/CDAP-6827
Build : http://builds.cask.co/browse/CDAP-RUT63

Summary:
KafkaServerMain looks for properties with prefix "kafka.server.". So override the kafka.server.log.dirs in cdap-site.xml (cdap-standalone). Also when cConf.getValByRegex is used, it doesn't resolve the values. So call cConf.get for every property that starts with "kafka.server.".

Verified with a SDK build and kafka-logs appear under data directory.
