### PR TITLE
CDAP-6649 Guard against accessing system namespace from programs

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -48,6 +48,7 @@ import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.internal.app.program.ProgramTypeMetricTag;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.tephra.TransactionSystemClient;
 import com.google.common.collect.Maps;
 import org.apache.twill.api.RunId;
@@ -230,6 +231,11 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
 
   protected <T extends Dataset> T getDataset(String namespace, String name, Map<String, String> arguments,
                                              AccessType accessType) throws DatasetInstantiationException {
+    if (NamespaceId.SYSTEM.getNamespace().equalsIgnoreCase(namespace)) {
+      throw new DatasetInstantiationException(String.format("Dataset %s cannot be instantiated from %s namespace. " +
+                                                              "Cannot access %s namespace.",
+                                                            name, NamespaceId.SYSTEM, NamespaceId.SYSTEM));
+    }
     return datasetCache.getDataset(namespace, name, arguments, accessType);
   }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/NamespaceAccessException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/NamespaceAccessException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common;
+
+import co.cask.cdap.proto.id.NamespaceId;
+
+/**
+ * Thrown when a namespace cannot be accessed.
+ */
+public class NamespaceAccessException extends AlreadyExistsException {
+
+  private final NamespaceId id;
+
+  public NamespaceAccessException(NamespaceId id) {
+    super(id);
+    this.id = id;
+  }
+  public NamespaceAccessException(NamespaceId id, String message) {
+    super(id.toId(), message);
+    this.id = id;
+  }
+
+  public NamespaceId getId() {
+    return id;
+  }
+}

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
@@ -404,6 +404,12 @@ public class IntegrationTestManager implements TestManager {
   }
 
   @Override
+  public void deleteDatasetInstance(NamespaceId namespaceId, String datasetInstanceName) throws Exception {
+    Id.DatasetInstance datasetInstance = Id.DatasetInstance.from(namespaceId.toId(), datasetInstanceName);
+    datasetClient.delete(datasetInstance);
+  }
+
+  @Override
   public <T> DataSetManager<T> getDataset(Id.Namespace namespace, String datasetInstanceName) throws Exception {
     throw new UnsupportedOperationException();
   }

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactional.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactional.java
@@ -25,6 +25,7 @@ import co.cask.cdap.api.spark.SparkExecutionContext;
 import co.cask.cdap.data2.dataset2.DynamicDatasetCache;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.data2.transaction.Transactions;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.tephra.Transaction;
 import co.cask.tephra.TransactionAware;
 import co.cask.tephra.TransactionFailureException;
@@ -326,6 +327,12 @@ final class SparkTransactional implements Transactional {
     @Override
     public <T extends Dataset> T getDataset(String namespace, String name, Map<String, String> arguments,
                                             AccessType accessType) throws DatasetInstantiationException {
+
+      if (NamespaceId.SYSTEM.getNamespace().equalsIgnoreCase(namespace)) {
+        throw new DatasetInstantiationException(String.format("Dataset %s cannot be instantiated from %s namespace. " +
+                                                                "Cannot access %s namespace.",
+                                                              name, NamespaceId.SYSTEM, NamespaceId.SYSTEM));
+      }
       T dataset = datasetCache.getDataset(namespace, name, arguments, accessType);
 
       // Only call startTx if the dataset hasn't been seen before

--- a/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/TestManager.java
@@ -401,6 +401,16 @@ public interface TestManager {
                                                 String datasetTypeName, String datasetInstanceName) throws Exception;
 
   /**
+   * Deletes an instance of dataset
+   *
+   * @param namespaceId namespace of the dataset
+   * @param datasetInstanceName instance name
+   * @throws Exception
+   */
+  @Beta
+  void deleteDatasetInstance(NamespaceId namespaceId, String datasetInstanceName) throws Exception;
+
+  /**
    * Gets Dataset manager of Dataset instance of type {@literal <}T>.
    *
    * @param namespace namespace of the dataset

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -864,6 +864,17 @@ public class TestBase {
   }
 
   /**
+   * Deletes an instance of dataset.
+   *
+   * @param namespaceId namespace for the dataset
+   * @param datasetInstanceName instance name
+   * @throws Exception
+   */
+  protected void deleteDatasetInstance(NamespaceId namespaceId, String datasetInstanceName) throws Exception {
+    getTestManager().deleteDatasetInstance(namespaceId, datasetInstanceName);
+  }
+
+  /**
    * Gets Dataset manager of Dataset instance of type {@literal <}T>.
    *
    * @param namespace namespace for the dataset

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -365,6 +365,13 @@ public class UnitTestManager implements TestManager {
     return addDatasetInstance(namespace, datasetTypeName, datasetInstanceName, DatasetProperties.EMPTY);
   }
 
+  @Beta
+  @Override
+  public final void deleteDatasetInstance(NamespaceId namespaceId, String datasetInstanceName) throws Exception {
+    Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(namespaceId.toId(), datasetInstanceName);
+    datasetFramework.deleteInstance(datasetInstanceId);
+  }
+
   /**
    * Gets Dataset manager of Dataset instance of type <T>
    * @param datasetInstanceName - instance name of dataset

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/CrossNsDatasetAccessApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/CrossNsDatasetAccessApp.java
@@ -32,7 +32,8 @@ import co.cask.cdap.api.flow.flowlet.StreamEvent;
 public class CrossNsDatasetAccessApp extends AbstractApplication {
   public static final String STREAM_NAME = "dataStream";
   public static final String FLOW_NAME = "dataFlow";
-  public static final String DATASET_OUTPUT_SPACE = "datasetOutputSpace";
+  public static final String OUTPUT_DATASET_NS = "output.dataset.ns";
+  public static final String OUTPUT_DATASET_NAME = "output.dataset.name";
 
   @Override
   public void configure() {
@@ -72,7 +73,8 @@ public class CrossNsDatasetAccessApp extends AbstractApplication {
     @Override
     public void initialize(FlowletContext context) throws Exception {
       super.initialize(context);
-      whom = context.getDataset(DATASET_OUTPUT_SPACE, "store");
+      whom = context.getDataset(context.getRuntimeArguments().get(OUTPUT_DATASET_NS),
+                                context.getRuntimeArguments().get(OUTPUT_DATASET_NAME));
     }
   }
 }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DatasetCrossNSAccessWithMAPApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/DatasetCrossNSAccessWithMAPApp.java
@@ -31,11 +31,11 @@ import java.io.IOException;
  */
 public class DatasetCrossNSAccessWithMAPApp extends AbstractApplication {
 
-  public static final String INPUT_KEY = "input";
-  public static final String OUTPUT_KEY = "output";
   public static final String MAPREDUCE_PROGRAM = "copymr";
-  public static final String DATASET_INPUT_SPACE = "datasetInputSpace";
-  public static final String DATASET_OUTPUT_SPACE = "datasetOutputSpace";
+  public static final String INPUT_DATASET_NS = "input.dataset.namespace";
+  public static final String OUTPUT_DATASET_NS = "output.dataset.namespace";
+  public static final String INPUT_DATASET_NAME = "input.dataset.name";
+  public static final String OUTPUT_DATASET_NAME = "output.dataset.name";
 
   @Override
   public void configure() {
@@ -53,10 +53,10 @@ public class DatasetCrossNSAccessWithMAPApp extends AbstractApplication {
     @Override
     public void initialize() {
       MapReduceContext context = getContext();
-      context.addInput(Input.ofDataset(context.getRuntimeArguments()
-                                         .get(INPUT_KEY)).fromNamespace(DATASET_INPUT_SPACE));
-      context.addOutput(Output.ofDataset(context.getRuntimeArguments()
-                                           .get(OUTPUT_KEY)).fromNamespace(DATASET_OUTPUT_SPACE));
+      context.addInput(Input.ofDataset(context.getRuntimeArguments().get(INPUT_DATASET_NAME))
+                         .fromNamespace(context.getRuntimeArguments().get(INPUT_DATASET_NS)));
+      context.addOutput(Output.ofDataset(context.getRuntimeArguments().get(OUTPUT_DATASET_NAME))
+                          .fromNamespace(context.getRuntimeArguments().get(OUTPUT_DATASET_NS)));
       Job hadoopJob = context.getHadoopJob();
       hadoopJob.setMapperClass(IdentityMapper.class);
       hadoopJob.setNumReduceTasks(0);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -51,7 +51,6 @@ import co.cask.cdap.proto.WorkflowTokenDetail;
 import co.cask.cdap.proto.WorkflowTokenNodeDetail;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
-import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.FlowManager;
@@ -492,29 +491,30 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
   @Category(SlowTests.class)
   @Test
   public void testCrossNSMapperDatasetAccess() throws Exception {
-    getNamespaceAdmin().create(new NamespaceMeta.Builder()
-                                 .setName(DatasetCrossNSAccessWithMAPApp.DATASET_INPUT_SPACE).build());
-    getNamespaceAdmin().create(new NamespaceMeta.Builder()
-                                 .setName(DatasetCrossNSAccessWithMAPApp.DATASET_OUTPUT_SPACE).build());
-    NamespaceId datasetInputSpace = new NamespaceId(DatasetCrossNSAccessWithMAPApp.DATASET_INPUT_SPACE);
-    NamespaceId datasetOutputSpace = new NamespaceId(DatasetCrossNSAccessWithMAPApp.DATASET_OUTPUT_SPACE);
+    NamespaceMeta inputNS = new NamespaceMeta.Builder().setName("inputNS").build();
+    NamespaceMeta outputNS = new NamespaceMeta.Builder().setName("outputNS").build();
+    getNamespaceAdmin().create(inputNS);
+    getNamespaceAdmin().create(outputNS);
 
-    addDatasetInstance(datasetInputSpace.toId(), "keyValueTable", "table1").create();
-    addDatasetInstance(datasetOutputSpace.toId(), "keyValueTable", "table2").create();
-    DataSetManager<KeyValueTable> tableManager = getDataset(datasetInputSpace.toId(), "table1");
+    addDatasetInstance(inputNS.getNamespaceId().toId(), "keyValueTable", "table1").create();
+    addDatasetInstance(outputNS.getNamespaceId().toId(), "keyValueTable", "table2").create();
+    DataSetManager<KeyValueTable> tableManager = getDataset(inputNS.getNamespaceId().toId(), "table1");
     KeyValueTable inputTable = tableManager.get();
     inputTable.write("hello", "world");
     tableManager.flush();
 
     ApplicationManager appManager = deployApplication(DatasetCrossNSAccessWithMAPApp.class);
-    Map<String, String> argsForMR = ImmutableMap.of(DatasetCrossNSAccessWithMAPApp.INPUT_KEY, "table1",
-                                                    DatasetCrossNSAccessWithMAPApp.OUTPUT_KEY, "table2");
+    Map<String, String> argsForMR = ImmutableMap.of(
+      DatasetCrossNSAccessWithMAPApp.INPUT_DATASET_NS, inputNS.getName(),
+      DatasetCrossNSAccessWithMAPApp.INPUT_DATASET_NAME, "table1",
+      DatasetCrossNSAccessWithMAPApp.OUTPUT_DATASET_NS, outputNS.getName(),
+      DatasetCrossNSAccessWithMAPApp.OUTPUT_DATASET_NAME, "table2");
     MapReduceManager mrManager = appManager.getMapReduceManager(DatasetCrossNSAccessWithMAPApp.MAPREDUCE_PROGRAM)
       .start(argsForMR);
     mrManager.waitForFinish(5, TimeUnit.MINUTES);
     appManager.stopAll();
 
-    DataSetManager<KeyValueTable> outTableManager = getDataset(datasetOutputSpace.toId(), "table2");
+    DataSetManager<KeyValueTable> outTableManager = getDataset(outputNS.getNamespaceId().toId(), "table2");
     verifyMapperJobOutput(DatasetCrossNSAccessWithMAPApp.class, outTableManager);
   }
 


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/CDAP-6649
- Disallow user to use dataset in system namespace through cross namespace APIs.

Note: This PR is opened against feature/CDAP-6793-cross-ns-spark-out branch as it based on the changed for writing cross namespace from spark and should be merged only after PR https://github.com/caskdata/cdap/pull/6403
