### PR TITLE
(CDAP-5794) Added Credentials refresh for Spark

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
@@ -222,8 +222,12 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
   public void stop() {
     try {
       LOG.info("Stopping runnable: {}.", name);
-      controller.stop().get();
-      logAppenderInitializer.close();
+      if (controller != null) {
+        controller.stop().get();
+      }
+      if (logAppenderInitializer != null) {
+        logAppenderInitializer.close();
+      }
     } catch (InterruptedException e) {
       LOG.debug("Interrupted while stopping runnable: {}.", name, e);
       Thread.currentThread().interrupt();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/security/TokenSecureStoreUpdater.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/security/TokenSecureStoreUpdater.java
@@ -70,8 +70,8 @@ public final class TokenSecureStoreUpdater implements SecureStoreUpdater {
 
   @Inject
   TokenSecureStoreUpdater(YarnConfiguration hConf, CConfiguration cConf,
-                                 LocationFactory locationFactory,
-                                 co.cask.cdap.api.security.store.SecureStore secureStore) {
+                          LocationFactory locationFactory,
+                          co.cask.cdap.api.security.store.SecureStore secureStore) {
     this.hConf = hConf;
     this.locationFactory = locationFactory;
     this.secureStore = secureStore;

--- a/cdap-common/src/main/java/co/cask/cdap/common/io/Locations.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/io/Locations.java
@@ -67,7 +67,8 @@ public final class Locations {
     new FunctionWithException<FileStatus, LocationStatus, IOException>() {
       @Override
       public LocationStatus apply(FileStatus status) throws IOException {
-        return new LocationStatus(status.getPath().toUri(), status.getLen(), status.isDirectory());
+        return new LocationStatus(status.getPath().toUri(), status.getLen(),
+                                  status.isDirectory(), status.getModificationTime());
       }
     };
   // For converting Location to LocationStatus
@@ -75,7 +76,8 @@ public final class Locations {
     new FunctionWithException<Location, LocationStatus, IOException>() {
       @Override
       public LocationStatus apply(Location location) throws IOException {
-        return new LocationStatus(location.toURI(), location.length(), location.isDirectory());
+        return new LocationStatus(location.toURI(), location.length(), location.isDirectory(),
+                                  location.lastModified());
       }
     };
 

--- a/cdap-spark-core/pom.xml
+++ b/cdap-spark-core/pom.xml
@@ -157,7 +157,10 @@
       <version>6.5.6</version>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-minicluster</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkCredentialsUpdater.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkCredentialsUpdater.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark;
+
+import co.cask.cdap.common.io.LocationStatus;
+import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.io.Processor;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import com.google.common.util.concurrent.AbstractIdleService;
+import org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenIdentifier;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.security.token.TokenIdentifier;
+import org.apache.twill.common.Threads;
+import org.apache.twill.filesystem.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This class is responsible for writing credentials to a location that Spark executor is expecting for
+ * secure credentials update for long running process.
+ */
+public class SparkCredentialsUpdater extends AbstractIdleService implements Runnable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SparkCredentialsUpdater.class);
+
+  // The following constants are copied from Spark because not all versions of Spark have them defined
+  private static final String SPARK_YARN_CREDS_TEMP_EXTENSION = ".tmp";
+  private static final String SPARK_YARN_CREDS_COUNTER_DELIM = "-";
+
+  private final Supplier<Credentials> credentialsSupplier;
+  private final Location credentialsDir;
+  private final String fileNamePrefix;
+  private final long updateIntervalMs;
+  private final long cleanupExpireMs;
+  private final int minFilesToKeep;
+  private final Pattern fileNamePattern;
+  private ScheduledExecutorService scheduler;
+  private int generation;
+
+  public SparkCredentialsUpdater(Supplier<Credentials> credentialsSupplier,
+                                 Location credentialsDir, String fileNamePrefix, long updateIntervalMs,
+                                 long cleanupExpireMs, int minFilesToKeep) {
+    Preconditions.checkArgument(updateIntervalMs > 0, "Update interval must be positive");
+    Preconditions.checkArgument(cleanupExpireMs > 0, "Cleanup expire time must be positive");
+    Preconditions.checkArgument(minFilesToKeep >= 0, "Minimum files to keep must be non-zero");
+
+    this.credentialsSupplier = credentialsSupplier;
+    this.credentialsDir = credentialsDir;
+    this.fileNamePrefix = fileNamePrefix;
+    this.updateIntervalMs = updateIntervalMs;
+    this.cleanupExpireMs = cleanupExpireMs;
+    this.minFilesToKeep = minFilesToKeep;
+    this.fileNamePattern = Pattern.compile(fileNamePrefix + SPARK_YARN_CREDS_COUNTER_DELIM + "(\\d+)");
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    scheduler = Executors.newSingleThreadScheduledExecutor(Threads.createDaemonThreadFactory("credentials-updater"));
+    scheduler.submit(this).get();
+
+    LOG.info("Credentials updater started");
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    ExecutorService executor = scheduler;
+    if (executor != null) {
+      executor.shutdownNow();
+    }
+
+    LOG.info("Credentials updater stopped");
+  }
+
+  @Override
+  public void run() {
+    long nextUpdateTime = updateIntervalMs;
+    try {
+      if (generation == 0) {
+        generation = findLatestGeneration();
+      }
+
+      // Write to the next generation file. It's ok to skip some generation if the write failed.
+      generation++;
+
+      Location credentialsFile = credentialsDir.append(fileNamePrefix + SPARK_YARN_CREDS_COUNTER_DELIM + generation);
+      Location tempFile = credentialsDir.append(credentialsFile.getName() + SPARK_YARN_CREDS_TEMP_EXTENSION);
+
+      // Writes the credentials to temp location, then rename to the final one
+      Credentials credentials = credentialsSupplier.get();
+      try (DataOutputStream os = new DataOutputStream(tempFile.getOutputStream("600"))) {
+        credentials.writeTokenStorageToStream(os);
+      }
+
+      if (!credentialsFile.equals(tempFile.renameTo(credentialsFile))) {
+        throw new IOException("Failed to rename from " + tempFile + " to " + credentialsFile);
+      }
+
+      LOG.info("Credentials written to {}", credentialsFile);
+
+      // Schedule the next update.
+      // Use the same logic as the Spark executor to calculate the update time.
+      nextUpdateTime = getNextUpdateDelay(credentials);
+
+      LOG.debug("Next credentials refresh at {}ms later", nextUpdateTime);
+      scheduler.schedule(this, nextUpdateTime, TimeUnit.MILLISECONDS);
+      cleanup();
+
+    } catch (Exception e) {
+      // Retry time is the min(1 minute, update interval)
+      long retryDelay = Math.min(60000, nextUpdateTime);
+      LOG.warn("Exception raised when saving credentials. Retry in {}ms", retryDelay, e);
+      scheduler.schedule(this, retryDelay, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  @VisibleForTesting
+  long getNextUpdateDelay(Credentials credentials) throws IOException {
+    long now = System.currentTimeMillis();
+
+    // This is almost the same logic as in SparkHadoopUtil.getTimeFromNowToRenewal
+    for (Token<? extends TokenIdentifier> token : credentials.getAllTokens()) {
+      if (DelegationTokenIdentifier.HDFS_DELEGATION_KIND.equals(token.getKind())) {
+        DelegationTokenIdentifier identifier = new DelegationTokenIdentifier();
+        try (DataInputStream input = new DataInputStream(new ByteArrayInputStream(token.getIdentifier()))) {
+          identifier.readFields(input);
+
+          // speed up by 2 seconds to account for any time race between driver and executor
+          return Math.max(0L, (long) (identifier.getIssueDate() + 0.8 * updateIntervalMs) - now - 2000);
+        }
+      }
+    }
+    return 0L;
+  }
+
+  private void cleanup() {
+    try {
+      // Locations.processLocations is more efficient in getting the location last modified time
+      Locations.processLocations(credentialsDir, false, new Processor<LocationStatus, Runnable>() {
+
+        private final List<LocationStatus> cleanupFiles = new ArrayList<>();
+
+        @Override
+        public boolean process(LocationStatus status) {
+          if (!status.isDir()) {
+            cleanupFiles.add(status);
+          }
+          return true;
+        }
+
+        @Override
+        public Runnable getResult() {
+          return new Runnable() {
+            @Override
+            public void run() {
+              if (cleanupFiles.size() <= minFilesToKeep) {
+                return;
+              }
+
+              // Sort the list of files in descending order of last modified time.
+              Collections.sort(cleanupFiles, new Comparator<LocationStatus>() {
+                @Override
+                public int compare(LocationStatus o1, LocationStatus o2) {
+                  return Long.compare(o2.getLastModified(), o1.getLastModified());
+                }
+              });
+
+              final long thresholdTime = System.currentTimeMillis() - cleanupExpireMs;
+
+              // Remove the tail of the list, keep the top "minFilesToKeep"
+              for (LocationStatus locationStatus : cleanupFiles.subList(minFilesToKeep, cleanupFiles.size())) {
+                if (locationStatus.getLastModified() >= thresholdTime) {
+                  continue;
+                }
+
+                Location location = credentialsDir.getLocationFactory().create(locationStatus.getUri());
+                try {
+                  location.delete();
+                  LOG.debug("Removed old credential file {}", location);
+                } catch (Exception e) {
+                  LOG.warn("Failed to cleanup old credential file {}", location, e);
+                }
+              }
+            }
+          };
+        }
+      }).run();
+    } catch (Exception e) {
+      LOG.warn("Exception raised when cleaning up credential files in {}", credentialsDir, e);
+    }
+  }
+
+  private int findLatestGeneration() throws IOException {
+    int max = 0;
+
+    for (Location location : credentialsDir.list()) {
+      Matcher matcher = fileNamePattern.matcher(location.getName());
+      if (matcher.matches()) {
+        int generation = Integer.parseInt(matcher.group(1));
+        if (generation > max) {
+          max = generation;
+        }
+      }
+    }
+
+    return max;
+  }
+}

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextConfig.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextConfig.java
@@ -49,6 +49,7 @@ public class SparkRuntimeContextConfig {
    * Configuration key for boolean value to tell whether Spark program is executed on a cluster or not.
    */
   public static final String HCONF_ATTR_CLUSTER_MODE = "cdap.spark.cluster.mode";
+  public static final String HCONF_ATTR_CREDENTIALS_UPDATE_INTERVAL_MS = "cdap.spark.credentials.update.interval.ms";
 
   private static final String HCONF_ATTR_APP_SPEC = "cdap.spark.app.spec";
   private static final String HCONF_ATTR_PROGRAM_ID = "cdap.spark.program.id";

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/CredentialsRequest.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/CredentialsRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,40 +14,22 @@
  * the License.
  */
 
-package co.cask.cdap.common.io;
+package co.cask.cdap.app.runtime.spark.distributed;
 
 import java.net.URI;
 
 /**
- * Status of a location.
+ * Request object for the write credentials request.
  */
-public class LocationStatus {
+final class CredentialsRequest {
 
   private final URI uri;
-  private final long length;
-  private final boolean dir;
-  private final long lastModified;
 
-  public LocationStatus(URI uri, long length, boolean dir, long lastModified) {
+  CredentialsRequest(URI uri) {
     this.uri = uri;
-    this.length = length;
-    this.dir = dir;
-    this.lastModified = lastModified;
   }
 
   public URI getUri() {
     return uri;
-  }
-
-  public long getLength() {
-    return length;
-  }
-
-  public boolean isDir() {
-    return dir;
-  }
-
-  public long getLastModified() {
-    return lastModified;
   }
 }

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
@@ -27,6 +27,7 @@ import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.app.runtime.spark.SparkRuntimeContextConfig;
 import co.cask.cdap.app.runtime.spark.SparkRuntimeUtils;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.kerberos.SecurityUtil;
 import co.cask.cdap.common.lang.FilterClassLoader;
 import co.cask.cdap.data2.security.Impersonator;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
@@ -61,7 +62,8 @@ public final class DistributedSparkProgramRunner extends AbstractDistributedProg
   DistributedSparkProgramRunner(TwillRunner twillRunner, YarnConfiguration hConf, CConfiguration cConf,
                                 TokenSecureStoreUpdater tokenSecureStoreUpdater,
                                 Impersonator impersonator) {
-    super(twillRunner, createConfiguration(hConf), cConf, tokenSecureStoreUpdater, impersonator);
+    super(twillRunner, createConfiguration(hConf, cConf, tokenSecureStoreUpdater),
+          cConf, tokenSecureStoreUpdater, impersonator);
   }
 
   @Override
@@ -92,9 +94,18 @@ public final class DistributedSparkProgramRunner extends AbstractDistributedProg
     return new SparkTwillProgramController(program.getId().toEntityId(), controller, runId).startListen();
   }
 
-  private static YarnConfiguration createConfiguration(YarnConfiguration hConf) {
+  private static YarnConfiguration createConfiguration(YarnConfiguration hConf, CConfiguration cConf,
+                                                       TokenSecureStoreUpdater secureStoreUpdater) {
     YarnConfiguration configuration = new YarnConfiguration(hConf);
     configuration.setBoolean(SparkRuntimeContextConfig.HCONF_ATTR_CLUSTER_MODE, true);
+
+    if (SecurityUtil.isKerberosEnabled(cConf)) {
+      // Need to divide the interval by 0.8 because Spark logic has a 0.8 discount on the interval
+      // If we don't offset it, it will look for the new credentials too soon
+      // Also add 5 seconds to the interval to give master time to push the changes to the Spark client container
+      configuration.setLong(SparkRuntimeContextConfig.HCONF_ATTR_CREDENTIALS_UPDATE_INTERVAL_MS,
+                            (long) ((secureStoreUpdater.getUpdateInterval() + 5000) / 0.8));
+    }
     return configuration;
   }
 

--- a/cdap-spark-core/src/test/java/co/cask/cdap/app/runtime/spark/SparkCredentialsUpdaterTest.java
+++ b/cdap-spark-core/src/test/java/co/cask/cdap/app/runtime/spark/SparkCredentialsUpdaterTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.common.io.Locations;
+import com.google.common.base.Supplier;
+import com.google.common.base.Throwables;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.security.token.TokenIdentifier;
+import org.apache.twill.filesystem.Location;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ *
+ */
+public class SparkCredentialsUpdaterTest {
+
+  @ClassRule
+  public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+  @Test
+  public void testUpdater() throws Exception {
+    Location credentialsDir = Locations.toLocation(TEMPORARY_FOLDER.newFolder());
+
+    // Create a updater that don't do any auto-update within the test time and don't cleanup
+    SparkCredentialsUpdater updater = new SparkCredentialsUpdater(createCredentialsSupplier(),
+                                                                  credentialsDir, "credentials",
+                                                                  TimeUnit.DAYS.toMillis(1),
+                                                                  TimeUnit.DAYS.toMillis(1), Integer.MAX_VALUE) {
+      @Override
+      long getNextUpdateDelay(Credentials credentials) throws IOException {
+        return TimeUnit.DAYS.toMillis(1);
+      }
+    };
+
+    // Before the updater starts, the directory is empty
+    Assert.assertTrue(credentialsDir.list().isEmpty());
+
+    UserGroupInformation.getCurrentUser().addToken(new Token<>(Bytes.toBytes("id"), Bytes.toBytes("pass"),
+                                                               new Text("kind"), new Text("service")));
+
+    updater.startAndWait();
+    try {
+      List<Location> expectedFiles = new ArrayList<>();
+      expectedFiles.add(credentialsDir.append("credentials-1"));
+
+      for (int i = 1; i <= 10; i++) {
+        Assert.assertEquals(expectedFiles, listAndSort(credentialsDir));
+
+        // Read the credentials from the last file
+        Credentials newCredentials = new Credentials();
+        try (DataInputStream is = new DataInputStream(expectedFiles.get(expectedFiles.size() - 1).getInputStream())) {
+          newCredentials.readTokenStorageStream(is);
+        }
+
+        // Should contains all tokens of the current user
+        Credentials userCredentials = UserGroupInformation.getCurrentUser().getCredentials();
+        for (Token<? extends TokenIdentifier> token : userCredentials.getAllTokens()) {
+          Assert.assertEquals(token, newCredentials.getToken(token.getService()));
+        }
+
+        UserGroupInformation.getCurrentUser().addToken(new Token<>(Bytes.toBytes("id" + i), Bytes.toBytes("pass" + i),
+                                                                   new Text("kind" + i), new Text("service" + i)));
+        updater.run();
+        expectedFiles.add(credentialsDir.append("credentials-" + (i + 1)));
+      }
+    } finally {
+      updater.stopAndWait();
+    }
+  }
+
+  @Test
+  public void testCleanup() throws IOException, InterruptedException {
+    Location credentialsDir = Locations.toLocation(TEMPORARY_FOLDER.newFolder());
+
+    // Create a updater that don't do any auto-update within the test time
+    SparkCredentialsUpdater updater = new SparkCredentialsUpdater(createCredentialsSupplier(),
+                                                                  credentialsDir, "credentials",
+                                                                  TimeUnit.DAYS.toMillis(1),
+                                                                  TimeUnit.SECONDS.toMillis(3), 3) {
+      @Override
+      long getNextUpdateDelay(Credentials credentials) throws IOException {
+        return TimeUnit.DAYS.toMillis(1);
+      }
+    };
+
+    updater.startAndWait();
+    try {
+      // Expect this loop to finish in 3 seconds because we don't want sleep for too long for testing cleanup
+      for (int i = 1; i <= 5; i++) {
+        Assert.assertEquals(i, credentialsDir.list().size());
+        updater.run();
+      }
+
+      // Sleep for 3 seconds, which is the cleanup expire time
+      TimeUnit.SECONDS.sleep(3);
+
+      // Run the updater again, it should only have three files (2 older than expire time, 1 new)
+      updater.run();
+      Assert.assertEquals(3, credentialsDir.list().size());
+    } finally {
+      updater.stopAndWait();
+    }
+  }
+
+  /**
+   * List all files under the given directory in ascending order of the suffix number.
+   */
+  private List<Location> listAndSort(Location dir) throws IOException {
+    final Pattern pattern = Pattern.compile("-(\\d+)$");
+
+    List<Location> locations = new ArrayList<>(dir.list());
+    Collections.sort(locations, new Comparator<Location>() {
+      @Override
+      public int compare(Location o1, Location o2) {
+        try {
+          Matcher matcher1 = pattern.matcher(o1.getName());
+          Matcher matcher2 = pattern.matcher(o2.getName());
+
+          if (matcher1.find() && matcher2.find()) {
+            return Long.compare(Long.parseLong(matcher1.group(1)), Long.parseLong(matcher2.group(1)));
+          }
+          throw new IllegalArgumentException("Expect name ended with number suffix");
+        } catch (Exception e) {
+          throw Throwables.propagate(e);
+        }
+      }
+    });
+    return locations;
+  }
+
+  private Supplier<Credentials> createCredentialsSupplier() {
+    return new Supplier<Credentials>() {
+      @Override
+      public Credentials get() {
+        try {
+          return UserGroupInformation.getCurrentUser().getCredentials();
+        } catch (Exception e) {
+          throw Throwables.propagate(e);
+        }
+      }
+    };
+  }
+}

--- a/cdap-spark-core/src/test/java/co/cask/cdap/app/runtime/spark/distributed/SparkExecutionServiceTest.java
+++ b/cdap-spark-core/src/test/java/co/cask/cdap/app/runtime/spark/distributed/SparkExecutionServiceTest.java
@@ -25,11 +25,27 @@ import co.cask.cdap.proto.id.ProgramRunId;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Service;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsAction;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.security.Credentials;
+import org.apache.twill.filesystem.FileContextLocationFactory;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import java.io.DataInputStream;
+import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
@@ -38,25 +54,49 @@ import java.util.concurrent.TimeUnit;
  */
 public class SparkExecutionServiceTest {
 
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+  private static LocationFactory locationFactory;
+  private static MiniDFSCluster dfsCluster;
+
+  @BeforeClass
+  public static void init() throws IOException {
+    Configuration hConf = new Configuration();
+    hConf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, TEMP_FOLDER.newFolder().getAbsolutePath());
+    dfsCluster = new MiniDFSCluster.Builder(hConf).numDataNodes(1).build();
+    dfsCluster.waitClusterUp();
+    locationFactory = new FileContextLocationFactory(dfsCluster.getFileSystem().getConf());
+  }
+
+  @AfterClass
+  public static void finish() {
+    dfsCluster.shutdown();
+  }
+
   @Test
   public void testCompletion() throws Exception {
     ProgramRunId programRunId = new ProgramRunId("ns", "app", ProgramType.SPARK, "test", RunIds.generate().getId());
 
     // Start a service that no token is supported
-    SparkExecutionService service = new SparkExecutionService(InetAddress.getLoopbackAddress().getCanonicalHostName(),
+    SparkExecutionService service = new SparkExecutionService(locationFactory,
+                                                              InetAddress.getLoopbackAddress().getCanonicalHostName(),
                                                               programRunId, null);
     service.startAndWait();
-    SparkExecutionClient client = new SparkExecutionClient(service.getBaseURI(), programRunId);
+    try {
+      SparkExecutionClient client = new SparkExecutionClient(service.getBaseURI(), programRunId);
 
-    // Heartbeats multiple times.
-    for (int i = 0; i < 5; i++) {
-      Assert.assertNull(client.heartbeat(null));
-      TimeUnit.MILLISECONDS.sleep(50);
+      // Heartbeats multiple times.
+      for (int i = 0; i < 5; i++) {
+        Assert.assertNull(client.heartbeat(null));
+        TimeUnit.MILLISECONDS.sleep(50);
+      }
+
+      // Call complete to notify the service it has been stopped
+      client.completed(null);
+    } finally {
+      service.stopAndWait();
     }
-
-    // Call complete to notify the service it has been stopped
-    client.completed(null);
-    service.stopAndWait();
   }
 
   @Test
@@ -64,33 +104,38 @@ public class SparkExecutionServiceTest {
     ProgramRunId programRunId = new ProgramRunId("ns", "app", ProgramType.SPARK, "test", RunIds.generate().getId());
 
     // Start a service that no token is supported
-    SparkExecutionService service = new SparkExecutionService(InetAddress.getLoopbackAddress().getCanonicalHostName(),
+    SparkExecutionService service = new SparkExecutionService(locationFactory,
+                                                              InetAddress.getLoopbackAddress().getCanonicalHostName(),
                                                               programRunId, null);
     service.startAndWait();
-    final SparkExecutionClient client = new SparkExecutionClient(service.getBaseURI(), programRunId);
+    try {
+      final SparkExecutionClient client = new SparkExecutionClient(service.getBaseURI(), programRunId);
 
-    // Heartbeats multiple times.
-    for (int i = 0; i < 5; i++) {
-      Assert.assertNull(client.heartbeat(null));
-      TimeUnit.MILLISECONDS.sleep(50);
-    }
-
-    // Stop the program from the service side
-    ListenableFuture<Service.State> stopFuture = service.stop();
-
-    // Expect some future heartbeats will receive the STOP command
-    Tasks.waitFor(SparkCommand.STOP, new Callable<SparkCommand>() {
-      @Override
-      public SparkCommand call() throws Exception {
-        return client.heartbeat(null);
+      // Heartbeats multiple times.
+      for (int i = 0; i < 5; i++) {
+        Assert.assertNull(client.heartbeat(null));
+        TimeUnit.MILLISECONDS.sleep(50);
       }
-    }, 10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
 
-    // Call complete to notify the service it has been stopped
-    client.completed(null);
+      // Stop the program from the service side
+      ListenableFuture<Service.State> stopFuture = service.stop();
 
-    // The stop future of the service should be completed after the client.completed call.
-    stopFuture.get(5, TimeUnit.SECONDS);
+      // Expect some future heartbeats will receive the STOP command
+      Tasks.waitFor(SparkCommand.STOP, new Callable<SparkCommand>() {
+        @Override
+        public SparkCommand call() throws Exception {
+          return client.heartbeat(null);
+        }
+      }, 10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+
+      // Call complete to notify the service it has been stopped
+      client.completed(null);
+
+      // The stop future of the service should be completed after the client.completed call.
+      stopFuture.get(5, TimeUnit.SECONDS);
+    } finally {
+      service.stopAndWait();
+    }
   }
 
   @Test
@@ -100,27 +145,30 @@ public class SparkExecutionServiceTest {
     // Start a service with empty workflow token
     BasicWorkflowToken token = new BasicWorkflowToken(10);
     token.setCurrentNode("spark");
-    SparkExecutionService service = new SparkExecutionService(InetAddress.getLoopbackAddress().getCanonicalHostName(),
+    SparkExecutionService service = new SparkExecutionService(locationFactory,
+                                                              InetAddress.getLoopbackAddress().getCanonicalHostName(),
                                                               programRunId, token);
     service.startAndWait();
-    SparkExecutionClient client = new SparkExecutionClient(service.getBaseURI(), programRunId);
+    try {
+      SparkExecutionClient client = new SparkExecutionClient(service.getBaseURI(), programRunId);
 
-    // Update token via heartbeat
-    BasicWorkflowToken clientToken = new BasicWorkflowToken(10);
-    clientToken.setCurrentNode("spark");
+      // Update token via heartbeat
+      BasicWorkflowToken clientToken = new BasicWorkflowToken(10);
+      clientToken.setCurrentNode("spark");
 
-    for (int i = 0; i < 5; i++) {
-      clientToken.put("key", "value" + i);
-      client.heartbeat(clientToken);
+      for (int i = 0; i < 5; i++) {
+        clientToken.put("key", "value" + i);
+        client.heartbeat(clientToken);
 
-      // The server side token should get updated
-      Assert.assertEquals(Value.of("value" + i), token.get("key", "spark"));
+        // The server side token should get updated
+        Assert.assertEquals(Value.of("value" + i), token.get("key", "spark"));
+      }
+
+      clientToken.put("completed", "true");
+      client.completed(clientToken);
+    } finally {
+      service.stopAndWait();
     }
-
-    clientToken.put("completed", "true");
-    client.completed(clientToken);
-
-    service.stopAndWait();
 
     // The token on the service side should get updated after the completed call.
     Map<String, Value> values = token.getAllFromNode("spark");
@@ -129,5 +177,39 @@ public class SparkExecutionServiceTest {
       "completed", Value.of("true")
     );
     Assert.assertEquals(expected, values);
+  }
+
+  @Test
+  public void testWriteCredentials() throws Exception {
+    ProgramRunId programRunId = new ProgramRunId("ns", "app", ProgramType.SPARK, "test", RunIds.generate().getId());
+
+    // Start a service that doesn't support workflow token
+    SparkExecutionService service = new SparkExecutionService(locationFactory,
+                                                              InetAddress.getLoopbackAddress().getCanonicalHostName(),
+                                                              programRunId, null);
+    service.startAndWait();
+    try {
+      SparkExecutionClient client = new SparkExecutionClient(service.getBaseURI(), programRunId);
+
+      Location targetLocation = locationFactory.create(UUID.randomUUID().toString()).append("credentials");
+      client.writeCredentials(targetLocation);
+
+      FileStatus status = dfsCluster.getFileSystem().getFileStatus(new Path(targetLocation.toURI()));
+      // Verify the file permission is 600
+      Assert.assertEquals(FsAction.READ_WRITE, status.getPermission().getUserAction());
+      Assert.assertEquals(FsAction.NONE, status.getPermission().getGroupAction());
+      Assert.assertEquals(FsAction.NONE, status.getPermission().getOtherAction());
+
+      // Should be able to deserialize back to credentials
+      Credentials credentials = new Credentials();
+      try (DataInputStream is = new DataInputStream(targetLocation.getInputStream())) {
+        credentials.readTokenStorageStream(is);
+      }
+
+      // Call complete to notify the service it has been stopped
+      client.completed(null);
+    } finally {
+      service.stopAndWait();
+    }
   }
 }


### PR DESCRIPTION
- Added a new writeCredentials endpoint to the SparkExecutionService to write out latest Credentails of the Spark Client Container
  - CDAP master is responsible for updating the Credentials for the client container
- Add a SparkCredentialsUpdater that runs in Spark driver process
  - Periodically hit the writeCredentials endpoint of the SparkExecutionService
  - Update the credentials of the current driver process
  - Write out credentials file to Spark staging directory for executor processes to pickup
