### PR TITLE
[CDAP-7072] Initialize macroFields to an empty set in PluginConfig

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginConfig.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/plugin/PluginConfig.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.Config;
 import co.cask.cdap.api.annotation.Beta;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -33,6 +34,11 @@ public abstract class PluginConfig extends Config implements Serializable {
   // below fields are set using reflection
   private PluginProperties properties;
   private Set<String> macroFields;
+
+  protected PluginConfig() {
+    this.properties = PluginProperties.builder().build();
+    this.macroFields = Collections.emptySet();
+  }
 
   /**
    * Returns the {@link PluginProperties}.


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/CDAP-7072
Build: http://builds.cask.co/browse/CDAP-DUT4681-1
