### PR TITLE
A few fixes in namespaces:

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/AbstractStorageProviderNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/AbstractStorageProviderNamespaceAdmin.java
@@ -57,19 +57,21 @@ abstract class AbstractStorageProviderNamespaceAdmin implements StorageProviderN
   }
 
   /**
-   * Create a namespace in the File System and Hive.
+   * Create a namespace in the File System and Hive. The hive database is only created for non-default namespaces.
    *
    * @param namespaceMeta {@link NamespaceMeta} for the namespace to create
    * @throws IOException if there are errors while creating the namespace in the File System
-   * @throws ExploreException if there are errors while deleting the namespace in Hive
-   * @throws SQLException if there are errors while deleting the namespace in Hive
+   * @throws ExploreException if there are errors while creating the namespace in Hive
+   * @throws SQLException if there are errors while creating the namespace in Hive
    */
   @Override
   public void create(NamespaceMeta namespaceMeta) throws IOException, ExploreException, SQLException {
 
     createLocation(namespaceMeta);
 
-    if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED)) {
+    // only create non-default namespaces in Hive
+    if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED) &&
+      !NamespaceId.DEFAULT.equals(namespaceMeta.getNamespaceId())) {
       try {
         exploreFacade.createNamespace(namespaceMeta);
       } catch (ExploreException | SQLException e) {
@@ -93,7 +95,7 @@ abstract class AbstractStorageProviderNamespaceAdmin implements StorageProviderN
 
     deleteLocation(namespaceId);
 
-    if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED)) {
+    if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED) && !NamespaceId.DEFAULT.equals(namespaceId)) {
       exploreFacade.removeNamespace(namespaceId.toId());
     }
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceQueryAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceQueryAdmin.java
@@ -18,7 +18,6 @@ package co.cask.cdap.internal.app.namespace;
 
 import co.cask.cdap.api.Predicate;
 import co.cask.cdap.common.NamespaceNotFoundException;
-import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
@@ -103,11 +102,6 @@ public class DefaultNamespaceQueryAdmin implements NamespaceQueryAdmin {
    */
   @Override
   public boolean exists(Id.Namespace namespaceId) throws Exception {
-    try {
-      get(namespaceId);
-    } catch (NotFoundException e) {
-      return false;
-    }
-    return true;
+    return nsStore.get(namespaceId) != null;
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DistributedStorageProviderNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DistributedStorageProviderNamespaceAdmin.java
@@ -62,6 +62,10 @@ public final class DistributedStorageProviderNamespaceAdmin extends AbstractStor
   public void create(NamespaceMeta namespaceMeta) throws IOException, ExploreException, SQLException {
     // create filesystem directory
     super.create(namespaceMeta);
+    // skip namespace creation in HBase for default namespace
+    if (NamespaceId.DEFAULT.equals(namespaceMeta.getNamespaceId())) {
+      return;
+    }
     // TODO: CDAP-1519: Create base directory for filesets under namespace home
     // create HBase namespace
     String hbaseNamespace = tableUtil.getHBaseNamespace(namespaceMeta);
@@ -85,8 +89,11 @@ public final class DistributedStorageProviderNamespaceAdmin extends AbstractStor
   @SuppressWarnings("ConstantConditions")
   @Override
   public void delete(NamespaceId namespaceId) throws IOException, ExploreException, SQLException {
-    // soft delete namespace directory from filesystem
+    // delete namespace directory from filesystem
     super.delete(namespaceId);
+    if (NamespaceId.DEFAULT.equals(namespaceId)) {
+      return;
+    }
     // delete HBase namespace
     NamespaceConfig namespaceConfig;
     try {
@@ -95,17 +102,17 @@ public final class DistributedStorageProviderNamespaceAdmin extends AbstractStor
       throw new IOException("Could not fetch custom HBase mapping.", ex);
     }
 
-    if (Strings.isNullOrEmpty(namespaceConfig.getHbaseNamespace())) {
-      // delete HBase namespace
-      String namespace = tableUtil.getHBaseNamespace(namespaceId);
-      try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
-        tableUtil.deleteNamespaceIfExists(admin, namespace);
-      }
-    } else {
+    if (!Strings.isNullOrEmpty(namespaceConfig.getHbaseNamespace())) {
       // custom namespace mapping is set for HBase, hence don't do anything during delete since the lifecycle of the
       // namespace will be managed by the user
       LOG.debug("Custom HBase mapping {} was found while deleting {}. Hence skipping deletion of HBase namespace",
                 namespaceConfig.getHbaseNamespace(), namespaceId);
+      return;
+    }
+    // delete HBase namespace
+    String namespace = tableUtil.getHBaseNamespace(namespaceId);
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      tableUtil.deleteNamespaceIfExists(admin, namespace);
     }
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdminTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdminTest.java
@@ -164,6 +164,24 @@ public class DefaultNamespaceAdminTest extends AppFabricTestBase {
       //expected
     }
 
+    // updating the principal for an existing namespace should fail
+    try {
+      namespaceAdmin.updateProperties(nsMeta.getNamespaceId().toId(),
+                                      new NamespaceMeta.Builder(nsMeta).setPrincipal("newPrincipal").build());
+      Assert.fail();
+    } catch (BadRequestException e) {
+      // expected
+    }
+
+    // updating the keytabURI for an existing namespace should fail
+    try {
+      namespaceAdmin.updateProperties(nsMeta.getNamespaceId().toId(),
+                                      new NamespaceMeta.Builder(nsMeta).setKeytabURI("/new/keytab/uri").build());
+      Assert.fail();
+    } catch (BadRequestException e) {
+      // expected
+    }
+
     //clean up
     namespaceAdmin.delete(namespaceId);
     Locations.deleteQuietly(customlocation);

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/AbstractNamespaceQueryClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/AbstractNamespaceQueryClient.java
@@ -76,6 +76,9 @@ public abstract class AbstractNamespaceQueryClient implements NamespaceQueryAdmi
       get(namespaceId);
     } catch (NamespaceNotFoundException e) {
       return false;
+    } catch (UnauthorizedException e) {
+      // get throws UnauthorizedException only after ensuring that the namespace exists. Ignoring since we have
+      // semantics that user can check for existence without having access
     }
     return true;
   }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceConfig.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceConfig.java
@@ -18,7 +18,9 @@ package co.cask.cdap.proto;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -86,6 +88,35 @@ public class NamespaceConfig {
   @Nullable
   public String getKeytabURI() {
     return keytabURI;
+  }
+
+  public Set<String> getDifference(@Nullable NamespaceConfig other) {
+    Set<String> difference = new HashSet<>();
+    if (other == null) {
+      // nothing to validate
+      return difference;
+    }
+
+    if (!Objects.equals(this.rootDirectory, other.rootDirectory)) {
+      difference.add(ROOT_DIRECTORY);
+    }
+
+    if (!Objects.equals(this.hbaseNamespace, other.hbaseNamespace)) {
+      difference.add(HBASE_NAMESPACE);
+    }
+
+    if (!Objects.equals(this.hiveDatabase, other.hiveDatabase)) {
+      difference.add(HIVE_DATABASE);
+    }
+
+    if (!Objects.equals(this.principal, other.principal)) {
+      difference.add("principal");
+    }
+
+    if (!Objects.equals(this.keytabURI, other.keytabURI)) {
+      difference.add("keytabURI");
+    }
+    return difference;
   }
 
   @Override


### PR DESCRIPTION
1. (CDAP-7026) Grant the namespace user all access on the namespace if the namespace is created with impersonation enabled.
2. (CDAP-7050) The exists() method in namespaces no longer has authorization enforcement
3. Fixed namespace update code to bail out if impersonation properties are updated
4. Attempt at fixing the ClicksAndViewsMapReduceTest by not creating/deleting Hive and HBase default namespaces.

Jiras:
[CDAP-7026](https://issues.cask.co/browse/CDAP-7026)
[CDAP-7050](https://issues.cask.co/browse/CDAP-7050)

Build:
http://builds.cask.co/browse/CDAP-RUT70
