### PR TITLE
Expose MapReduceTaskContext to MapReduce partitioner/comparator classes

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
@@ -313,4 +313,11 @@ public class MapReduceLifecycleContext<KEY, VALUE> implements MapReduceTaskConte
   public SecureStoreData getSecureData(String namespace, String name) throws Exception {
     return delegate.getSecureData(namespace, name);
   }
+
+  @Override
+  public String toString() {
+    return "MapReduceLifecycleContext{" +
+      "delegate=" + delegate +
+      '}';
+  }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -244,9 +244,13 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
       TaskType.MAP.setResources(mapredConf, context.getMapperResources());
       TaskType.REDUCE.setResources(mapredConf, context.getReducerResources());
 
-      // replace user's Mapper & Reducer's with our wrappers in job config
+      // replace user's Mapper, Reducer, Partitioner, and Comparator classes with our wrappers in job config
       MapperWrapper.wrap(job);
       ReducerWrapper.wrap(job);
+      PartitionerWrapper.wrap(job);
+      RawComparatorWrapper.CombinerGroupComparatorWrapper.wrap(job);
+      RawComparatorWrapper.GroupComparatorWrapper.wrap(job);
+      RawComparatorWrapper.KeyComparatorWrapper.wrap(job);
 
       // packaging job jar which includes cdap classes with dependencies
       File jobJar = buildJobJar(job, tempDir);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/PartitionerWrapper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/PartitionerWrapper.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch;
+
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.MRJobConfig;
+import org.apache.hadoop.mapreduce.Partitioner;
+
+/**
+ * Wraps user-defined implementation of {@link Partitioner} class which allows to perform extra configuration.
+ */
+public class PartitionerWrapper extends Partitioner implements Configurable {
+
+  private static final String ATTR_CLASS = "c.partitioner.class";
+
+  private Partitioner delegate;
+  private Configuration conf;
+
+  /**
+   * Wraps the partitioner defined in the job with this {@link PartitionerWrapper} if it is defined.
+   * @param job The MapReduce job
+   */
+  public static void wrap(Job job) {
+    if (WrapperUtil.setIfDefined(job, MRJobConfig.PARTITIONER_CLASS_ATTR, ATTR_CLASS)) {
+      job.setPartitionerClass(PartitionerWrapper.class);
+    }
+  }
+
+  @Override
+  public int getPartition(Object o, Object o2, int numPartitions) {
+    return delegate.getPartition(o, o2, numPartitions);
+  }
+
+  @Override
+  public void setConf(Configuration conf) {
+    this.conf = conf;
+    this.delegate = WrapperUtil.createDelegate(conf, ATTR_CLASS);
+  }
+
+  @Override
+  public Configuration getConf() {
+    return conf;
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/RawComparatorWrapper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/RawComparatorWrapper.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch;
+
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.RawComparator;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.MRJobConfig;
+
+/**
+ * Wraps user-defined implementation of {@link RawComparator} class which allows to perform extra configuration,
+ * such as initialization with MapReduceTaskContext, if the delegate class implements ProgramLifeCycle.
+ */
+abstract class RawComparatorWrapper implements RawComparator, Configurable {
+
+  private RawComparator delegate;
+  private Configuration conf;
+
+  abstract String getDelegateClassAttr();
+
+  @Override
+  public void setConf(Configuration conf) {
+    this.conf = conf;
+    this.delegate = WrapperUtil.createDelegate(conf, getDelegateClassAttr());
+  }
+
+  @Override
+  public Configuration getConf() {
+    return conf;
+  }
+
+  @Override
+  public int compare(byte[] b1, int s1, int l1, byte[] b2, int s2, int l2) {
+    return delegate.compare(b1, s1, l1, b2, s2, l2);
+  }
+
+  @Override
+  public int compare(Object o1, Object o2) {
+    return delegate.compare(o1, o2);
+  }
+
+  static final class CombinerGroupComparatorWrapper extends RawComparatorWrapper {
+    private static final String ATTR_CLASS = "c.combiner.group.comparator.class";
+
+    /**
+     * Wraps the combiner group comparator defined in the job with this {@link CombinerGroupComparatorWrapper} if it is
+     * defined.
+     * @param job The MapReduce job
+     */
+    static void wrap(Job job) {
+      if (WrapperUtil.setIfDefined(job, MRJobConfig.COMBINER_GROUP_COMPARATOR_CLASS, ATTR_CLASS)) {
+        job.setCombinerKeyGroupingComparatorClass(CombinerGroupComparatorWrapper.class);
+      }
+    }
+
+    @Override
+    String getDelegateClassAttr() {
+      return ATTR_CLASS;
+    }
+  }
+
+  static final class GroupComparatorWrapper extends RawComparatorWrapper {
+    private static final String ATTR_CLASS = "c.group.comparator.class";
+
+    /**
+     * Wraps the group comparator defined in the job with this {@link GroupComparatorWrapper} if it is defined.
+     * @param job The MapReduce job
+     */
+    static void wrap(Job job) {
+      if (WrapperUtil.setIfDefined(job, MRJobConfig.GROUP_COMPARATOR_CLASS, ATTR_CLASS)) {
+        job.setGroupingComparatorClass(GroupComparatorWrapper.class);
+      }
+    }
+
+    @Override
+    String getDelegateClassAttr() {
+      return ATTR_CLASS;
+    }
+  }
+
+  static final class KeyComparatorWrapper extends RawComparatorWrapper {
+    private static final String ATTR_CLASS = "c.key.comparator.class";
+
+    /**
+     * Wraps the key comparator defined in the job with this {@link KeyComparatorWrapper} if it is defined.
+     * @param job The MapReduce job
+     */
+    static void wrap(Job job) {
+      if (WrapperUtil.setIfDefined(job, MRJobConfig.KEY_COMPARATOR, ATTR_CLASS)) {
+        job.setSortComparatorClass(KeyComparatorWrapper.class);
+      }
+    }
+
+    @Override
+    String getDelegateClassAttr() {
+      return ATTR_CLASS;
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/WrapperUtil.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/WrapperUtil.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch;
+
+import co.cask.cdap.api.ProgramLifecycle;
+import co.cask.cdap.common.lang.ClassLoaders;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class that helps with creating and initializing objects from, based upon an attribute in
+ * a {@link Configuration}.
+ */
+public final class WrapperUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(WrapperUtil.class);
+
+  private WrapperUtil() {
+  }
+
+  // instantiates and initializes (if its a ProgramLifeCycle) the class specified by the attribute
+  static <T> T createDelegate(Configuration conf, String attrClass) {
+    String delegateClassName = conf.get(attrClass);
+    Class<?> delegateClass = conf.getClassByNameOrNull(delegateClassName);
+    Preconditions.checkNotNull(delegateClass, "Class could not be found: ", delegateClassName);
+    T delegate = (T) ReflectionUtils.newInstance(delegateClass, conf);
+
+    if (!(delegate instanceof ProgramLifecycle)) {
+      return delegate;
+    }
+
+    MapReduceClassLoader classLoader = MapReduceClassLoader.getFromConfiguration(conf);
+    BasicMapReduceTaskContext basicMapReduceContext = classLoader.getTaskContextProvider().get(conf);
+    ClassLoader programClassLoader = classLoader.getProgramClassLoader();
+
+    ClassLoader oldClassLoader = ClassLoaders.setContextClassLoader(programClassLoader);
+    try {
+      ProgramLifecycle programLifecycle = (ProgramLifecycle) delegate;
+      programLifecycle.initialize(new MapReduceLifecycleContext(basicMapReduceContext));
+
+      // register it so that its destroy method can get called when the BasicMapReduceTaskContext is closed
+      basicMapReduceContext.registerProgramLifecycle(programLifecycle);
+      return delegate;
+    } catch (Exception e) {
+      LOG.error("Failed to initialize delegate with {}", basicMapReduceContext, e);
+      throw Throwables.propagate(e);
+    } finally {
+      ClassLoaders.setContextClassLoader(oldClassLoader);
+    }
+  }
+
+  // copies the value from src key to destination key
+  // return true if the src key had a corresponding value
+  static boolean setIfDefined(Job job, String srcKey, String destinationKey) {
+    // NOTE: we don't use job.getXClass or conf.getClass as we don't need to load user class here
+    Configuration conf = job.getConfiguration();
+    String srcVal = conf.get(srcKey);
+    if (srcVal != null) {
+      conf.set(destinationKey, srcVal);
+      return true;
+    }
+    return false;
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
@@ -388,6 +388,13 @@ public class MapReduceProgramRunnerTest extends MapReduceRunnerTestBase {
 
     runProgram(app, AppWithMapReduce.ClassicWordCount.class, false, true);
 
+    Assert.assertEquals("true", System.getProperty("partitioner.initialize"));
+    Assert.assertEquals("true", System.getProperty("partitioner.destroy"));
+    Assert.assertEquals("true", System.getProperty("partitioner.set.conf"));
+    Assert.assertEquals("true", System.getProperty("comparator.initialize"));
+    Assert.assertEquals("true", System.getProperty("comparator.destroy"));
+    Assert.assertEquals("true", System.getProperty("comparator.set.conf"));
+
     File[] outputFiles = outputDir.listFiles(new FilenameFilter() {
       @Override
       public boolean accept(File dir, String name) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DynamicDatasetCache.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DynamicDatasetCache.java
@@ -22,7 +22,6 @@ import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.DatasetInstantiationException;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.dataset.DatasetDefinition;
-import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.common.lang.ClassLoaders;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
@@ -62,7 +61,6 @@ public abstract class DynamicDatasetCache implements DatasetContext, Supplier<Tr
   protected final TransactionSystemClient txClient;
   protected final NamespaceId namespace;
   protected final Map<String, String> runtimeArguments;
-  protected final MetricsContext metricsContext;
 
   /**
    * Create a dynamic dataset factory.
@@ -72,19 +70,15 @@ public abstract class DynamicDatasetCache implements DatasetContext, Supplier<Tr
    * @param runtimeArguments all runtime arguments that are available to datasets in the context. Runtime arguments
    *                         are expected to be scoped so that arguments for one dataset do not override arguments
    *                         of other datasets.
-   * @param metricsContext if non-null, this context is used as the context for dataset metrics,
-   *                       with an additional tag for the dataset name.
    */
   public DynamicDatasetCache(SystemDatasetInstantiator instantiator,
                              TransactionSystemClient txClient,
                              NamespaceId namespace,
-                             Map<String, String> runtimeArguments,
-                             @Nullable MetricsContext metricsContext) {
+                             Map<String, String> runtimeArguments) {
     this.instantiator = instantiator;
     this.txClient = txClient;
     this.namespace = namespace;
     this.runtimeArguments = runtimeArguments;
-    this.metricsContext = metricsContext;
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/MultiThreadDatasetCache.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/MultiThreadDatasetCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -61,7 +61,7 @@ public class MultiThreadDatasetCache extends DynamicDatasetCache {
                                  final Map<String, String> runtimeArguments,
                                  @Nullable final MetricsContext metricsContext,
                                  @Nullable final Map<String, Map<String, String>> staticDatasets) {
-    super(instantiator, txClient, namespace, runtimeArguments, metricsContext);
+    super(instantiator, txClient, namespace, runtimeArguments);
     this.perThreadMap = CacheBuilder.newBuilder()
       .weakKeys()
       .removalListener(new RemovalListener<Thread, DynamicDatasetCache>() {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/SingleThreadDatasetCache.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/SingleThreadDatasetCache.java
@@ -87,7 +87,7 @@ public class SingleThreadDatasetCache extends DynamicDatasetCache {
                                   Map<String, String> runtimeArguments,
                                   @Nullable final MetricsContext metricsContext,
                                   @Nullable Map<String, Map<String, String>> staticDatasets) {
-    super(instantiator, txClient, namespace, runtimeArguments, metricsContext);
+    super(instantiator, txClient, namespace, runtimeArguments);
     this.datasetLoader = new CacheLoader<DatasetCacheKey, Dataset>() {
       @Override
       @ParametersAreNonnullByDefault


### PR DESCRIPTION
Basically, allow MapReduce Partitioner/Comparator classes to have access to MapReduceTaskContext. This is done by having Wrapper classes that delegate to the user's implementation of these classes.

See JIRA for more details on use case.

https://issues.cask.co/browse/CDAP-5740
http://builds.cask.co/browse/CDAP-RUT114-3
