### PR TITLE
(CDAP-7033) Perform authorization based on the getDataset access type

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/internal/dataset/DatasetRuntimeContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/dataset/DatasetRuntimeContext.java
@@ -47,7 +47,7 @@ public abstract class DatasetRuntimeContext {
     // For user dataset, there is always one being set.
     return new DatasetRuntimeContext() {
       @Override
-      public void onMethodEntry(@Nullable Class<? extends Annotation> annotation) {
+      public void onMethodEntry(boolean constructor, @Nullable Class<? extends Annotation> annotation) {
         // no-op
       }
 
@@ -94,11 +94,12 @@ public abstract class DatasetRuntimeContext {
   /**
    * Method to call when a dataset method is invoked.
    *
+   * @param constructor true if the call comes from constructor
    * @param annotation one of the {@link ReadOnly}, {@link WriteOnly} or {@link ReadWrite} annotation
    *                   on the method. Use {@code null} for method that is not annotated,
    */
   @SuppressWarnings("unused")
-  public abstract void onMethodEntry(@Nullable Class<? extends Annotation> annotation);
+  public abstract void onMethodEntry(boolean constructor, @Nullable Class<? extends Annotation> annotation);
 
   /**
    * Method to call when a dataset method is about to return.

--- a/cdap-common/src/main/java/co/cask/cdap/common/dataset/DatasetClassRewriter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/dataset/DatasetClassRewriter.java
@@ -161,13 +161,15 @@ public final class DatasetClassRewriter implements ClassRewriter {
 
           Type methodAnnotationType = getMethodAnnotationType(hasRead, hasWrite);
 
-          // this._datasetRuntimeContext.onMethodEntry(methodAnnotation);
+          // this._datasetRuntimeContext.onMethodEntry(isConstructor, methodAnnotation);
           // try {
           loadThis();
           getField(datasetType, datasetRuntimeContextField, DATASET_RUNTIME_CONTEXT_TYPE);
+          visitLdcInsn(isConstructor);
           push(methodAnnotationType);
           invokeVirtual(DATASET_RUNTIME_CONTEXT_TYPE,
-                        new Method("onMethodEntry", Type.getMethodDescriptor(Type.VOID_TYPE, CLASS_TYPE)));
+                        new Method("onMethodEntry", Type.getMethodDescriptor(Type.VOID_TYPE,
+                                                                             Type.BOOLEAN_TYPE, CLASS_TYPE)));
           beginTry();
         }
 

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationEnforcementService.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationEnforcementService.java
@@ -32,7 +32,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -77,7 +76,7 @@ public class DefaultAuthorizationEnforcementService extends AbstractAuthorizatio
       return ALLOW_ALL;
     }
     Map<EntityId, Set<Action>> privileges = getPrivileges(principal);
-    final Set<EntityId> allowedEntities = privileges != null ? privileges.keySet() : new HashSet<EntityId>();
+    final Set<EntityId> allowedEntities = privileges != null ? privileges.keySet() : Collections.<EntityId>emptySet();
 
     return new Predicate<EntityId>() {
       @Override


### PR DESCRIPTION
- If access type is known, then authorization, lineage and audit will be enforced/recorded
  based on the access type
- If access type is unknown, authorization still need to perform to make sure the user has
  some access right on the entity
