### PR TITLE
Expose Hadoop classes to Authorization extensions.

### DIFF
--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizerClassLoader.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizerClassLoader.java
@@ -16,14 +16,12 @@
 
 package co.cask.cdap.security.authorization;
 
-import co.cask.cdap.api.app.Application;
 import co.cask.cdap.common.lang.ClassPathResources;
 import co.cask.cdap.common.lang.DirectoryClassLoader;
 import co.cask.cdap.common.lang.FilterClassLoader;
 import co.cask.cdap.security.spi.authorization.Authorizer;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,33 +39,17 @@ public class AuthorizerClassLoader extends DirectoryClassLoader {
   @VisibleForTesting
   static ClassLoader createParent() {
     ClassLoader baseClassLoader = AuthorizerClassLoader.class.getClassLoader();
-    // Trace dependencies for Authorizer class. This will make classes from cdap-security-spi as well as  cdap-proto
-    // and other dependencies of cdap-security-spi available to the authorizer extension.
-    Set<String> authorizerResources;
-    try {
-      authorizerResources = ClassPathResources.getResourcesWithDependencies(baseClassLoader, Authorizer.class);
-    } catch (IOException e) {
-      LOG.error("Failed to determine resources for authorizer class loader while tracing dependencies of " +
-                  "Authorizer.", e);
-      authorizerResources = ImmutableSet.of();
-    }
 
-    // Trace dependencies of cdap-api and include them as well. This will make classes like slf4j Logger implementation
-    // as well as classes from twill-api and other dependencies required for cdap-api available to the authorizer
-    // extension.
-    Set<String> apiResources;
-    try {
-      apiResources = ClassPathResources.getResourcesWithDependencies(baseClassLoader, Application.class);
-    } catch (IOException e) {
-      LOG.error("Failed to determine resources for authorizer class loader while tracing dependencies of " +
-                  "cdap-api.", e);
-      apiResources = ImmutableSet.of();
-    }
-    final Set<String> finalAuthorizerResources = Sets.union(authorizerResources, apiResources);
+    final Set<String> authorizerResources = traceSecurityDependencies(baseClassLoader);
+    // by default, FilterClassLoader's defaultFilter allows all hadoop classes, which makes it so that
+    // the authorizer extension can share the same instance of UserGroupInformation. This allows kerberos credential
+    // renewal to also renew for any extension
+    final FilterClassLoader.Filter defaultFilter = FilterClassLoader.defaultFilter();
+
     return new FilterClassLoader(baseClassLoader, new FilterClassLoader.Filter() {
       @Override
       public boolean acceptResource(String resource) {
-        return finalAuthorizerResources.contains(resource);
+        return defaultFilter.acceptResource(resource) || authorizerResources.contains(resource);
       }
 
       @Override
@@ -75,6 +57,18 @@ public class AuthorizerClassLoader extends DirectoryClassLoader {
         return true;
       }
     });
+  }
+
+  private static Set<String> traceSecurityDependencies(ClassLoader baseClassLoader) {
+    try {
+      // Trace dependencies for Authorizer class. This will make classes from cdap-security-spi as well as cdap-proto
+      // and other dependencies of cdap-security-spi available to the authorizer extension.
+      return ClassPathResources.getResourcesWithDependencies(baseClassLoader, Authorizer.class);
+    } catch (IOException e) {
+      LOG.error("Failed to determine resources for authorizer class loader while tracing dependencies of " +
+                  "Authorizer.", e);
+      return ImmutableSet.of();
+    }
   }
 
   AuthorizerClassLoader(File unpackedJarDir) {

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizerClassLoaderTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizerClassLoaderTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.twill.filesystem.LocationFactory;
 import org.junit.Assert;
 import org.junit.Test;
@@ -58,14 +59,15 @@ public class AuthorizerClassLoaderTest {
     // classes from cdap-security-spi should be available
     parent.loadClass(Authorizer.class.getName());
     parent.loadClass(UnauthorizedException.class.getName());
+    // classes from hadoop should be available
+    parent.loadClass(Configuration.class.getName());
+    parent.loadClass(UserGroupInformation.class.getName());
   }
 
   @Test
   public void testAuthorizerClassLoaderParentUnavailableClasses() {
     // classes from guava should not be available
     assertClassUnavailable(ImmutableList.class);
-    // classes from hadoop should not be available
-    assertClassUnavailable(Configuration.class);
     // classes from hbase should not be available
     assertClassUnavailable(HTable.class);
     // classes from spark should not be available


### PR DESCRIPTION
Expose Hadoop classes to Authorization extensions.
This fixes Sentry Kerberos issues, by allowing extensions to share the same instance of the UserGroupInformation class as the rest of CDAP master.

https://issues.cask.co/browse/CDAP-6833
http://builds.cask.co/browse/CDAP-RUT87-2
