### PR TITLE
(CDAP-5601) Configurable flowlet batch size

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/annotation/Batch.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/annotation/Batch.java
@@ -57,13 +57,37 @@ import java.lang.annotation.Target;
  *   ...
  * }
  * </code></pre>
- * </p>
- * 
- * <p>
+ *
  * By doing so, the process method will be called repeatedly by the system for each input in the dequeued batch within
  * single transaction.
  * </p>
  *
+ * <p>
+ * The batch size can also be controlled through flowlet properties or runtime arguments. You can specify the key to use
+ * for looking up the batch size value with a {@code @Batch} annotation.
+ * </p>
+ *
+ * <p>
+ * <pre><code>
+ * {@literal @}Batch(key = "batch.size", value = 100)
+ * {@literal @}ProcessInput
+ * public void process(String word) {
+ *   ...
+ * }
+ * </code></pre>
+ *
+ * By specifying the {@code key} element in the {@code @Batch} annotation, the runtime system will resolve the
+ * batch size in this order (highest precedence first):
+ *
+ * <ol>
+ *   <li>Runtime argument with name = {@code flowlet.<flowletName>.<key>}</li>
+ *   <li>Runtime argument with name = {@code flowlet.*.<key>}</li>
+ *   <li>Runtime argument with name = {@code <key>}</li>
+ *   <li>Flowlet properties with name = {@code <key>}</li>
+ *   <li>The {@code value} element specified in the {@code @Batch} annotation</li>
+ * </ol>
+ * </p>
+ * 
  * <p>
  * If you use batch processing, your transactions can take longer and the probability of a conflict due
  * to a failed process increases (see {@link HashPartition hash partitioning}).
@@ -83,4 +107,11 @@ public @interface Batch {
    * Declare the maximum number of objects that can be processed in a batch.
    */
   int value();
+
+  /**
+   * Declare the key to use for looking up batch size value from the runtime arguments or the flowlet properties.
+   * If the given key cannot be found in neither of them, then the value returned by
+   * {@link #value()} will be used.
+   */
+  String key() default "";
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/common/Scope.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/common/Scope.java
@@ -25,7 +25,8 @@ import java.util.Map;
 public enum Scope {
   DATASET("dataset"),
   MAPREDUCE("mapreduce"),
-  SPARK("spark");
+  SPARK("spark"),
+  FLOWLET("flowlet");
 
   private final String displayName;
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
@@ -20,6 +20,8 @@ import co.cask.cdap.api.annotation.Batch;
 import co.cask.cdap.api.annotation.ProcessInput;
 import co.cask.cdap.api.annotation.Tick;
 import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.api.common.RuntimeArguments;
+import co.cask.cdap.api.common.Scope;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.data.schema.UnsupportedTypeException;
 import co.cask.cdap.api.flow.FlowSpecification;
@@ -367,7 +369,7 @@ public final class FlowletProgramRunner implements ProgramRunner {
           // If batch mode then generate schema for Iterator's parameter type
           dataType = flowletType.resolveType(method.getGenericParameterTypes()[0]);
           consumerConfig = getConsumerConfig(flowletContext, method);
-          Integer processBatchSize = getBatchSize(method);
+          Integer processBatchSize = getBatchSize(method, flowletContext);
 
           if (processBatchSize != null) {
             if (dataType.getRawType().equals(Iterator.class)) {
@@ -415,11 +417,38 @@ public final class FlowletProgramRunner implements ProgramRunner {
   /**
    * Returns the user specify batch size or {@code null} if not specified.
    */
-  private Integer getBatchSize(Method method) {
+  private Integer getBatchSize(Method method, BasicFlowletContext flowletContext) {
     // Determine queue batch size, if any
     Batch batch = method.getAnnotation(Batch.class);
     if (batch != null) {
       int batchSize = batch.value();
+      String key = batch.key();
+      if (!key.isEmpty()) {
+        // Try to lookup the value from runtime arguments
+        Map<String, String> args = RuntimeArguments.extractScope(Scope.FLOWLET, flowletContext.getName(),
+                                                                 flowletContext.getRuntimeArguments());
+        String value = args.get(key);
+        String sourceName = "runtime arguments";
+        if (value == null) {
+          // Try to lookup the value from the flowlet properties
+          value = flowletContext.getSpecification().getProperty(key);
+          sourceName = "flowlet properties";
+        }
+
+        if (value != null) {
+          try {
+            batchSize = Integer.parseInt(value);
+            LOG.debug("Using batch size {} from {} with key={} for flowlet={}, method={}",
+                      batchSize, sourceName, key, flowletContext, method);
+          } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Failed to parse batch size from " + sourceName + " with key=" + key);
+          }
+        } else {
+          LOG.debug("No batch size value provided from runtime arguments or flowlet properties. " +
+                      "Key={}, Flowlet={}, Method={}", key, flowletContext, method);
+        }
+      }
+
       Preconditions.checkArgument(batchSize > 0, "Batch size should be > 0: %s", method.getName());
       return batchSize;
     }

--- a/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/batch-execution.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/batch-execution.rst
@@ -28,3 +28,21 @@ as the method argument::
 
 In this case, the **process** will be called once per transaction and the **Iterator**
 will contain up to 100 data objects read from the input.
+
+The batch size can also be controlled through flowlet properties or runtime arguments. You can specify the *key*
+to use for looking up the batch size value with a ``@Batch`` annotation::
+
+  @Batch(key = "batch.size", value = 100)
+  @ProcessInput
+  public void process(String word) {
+    ...
+  }
+
+By specifying the **key** element in the ``@Batch`` annotation, the runtime system will resolve the
+batch size in this order (highest precedence first):
+
+1. Runtime argument with name = **flowlet.<flowletName>.<key>**
+#. Runtime argument with name = **flowlet.\*.<key>**
+#. Runtime argument with name = **<key>**
+#. Flowlet properties with name = **<key>**
+#. The **value** element specified in the ``@Batch`` annotation


### PR DESCRIPTION
- Added the key() attribute for the @Batch annotation
- Dynamically lookup the batch size from runtime arguments/flowlet properties
