### PR TITLE
CDAP-6881 Generate broker id based on the hostname to make it compatible with the release 3.4

### DIFF
--- a/cdap-kafka/src/main/java/co/cask/cdap/kafka/run/KafkaServerMain.java
+++ b/cdap-kafka/src/main/java/co/cask/cdap/kafka/run/KafkaServerMain.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.Properties;
 
@@ -92,6 +93,11 @@ public class KafkaServerMain extends DaemonMain {
     if (hostname != null) {
       if (address.isAnyLocalAddress()) {
         kafkaProperties.remove("host.name");
+        try {
+          address = InetAddress.getLocalHost();
+        } catch (UnknownHostException e) {
+          throw Throwables.propagate(e);
+        }
       } else {
         hostname = address.getCanonicalHostName();
         kafkaProperties.setProperty("host.name", hostname);


### PR DESCRIPTION
Verified the upgrade from 3.4 to 3.5. Same broker id is generated.
