### PR TITLE
Copy security extensions files to correct staging location

### DIFF
--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -415,7 +415,7 @@
                 <phase>process-resources</phase>
                 <configuration>
                   <target if="security.extensions.dir">
-                    <copy todir="${stage.artifacts.dir}" flatten="true">
+                    <copy todir="${stage.security.ext.dir}" flatten="true">
                       <fileset dir="${security.extensions.dir}">
                         <include name="${security.ext.jar.pattern}"/>
                         <include name="${security.ext.config.pattern}"/>


### PR DESCRIPTION
Currently, the JARs end up in artifacts:

```
/opt/cdap/master/artifacts/cdap-sentry-binding-0.2.0-SNAPSHOT.jar
/opt/cdap/master/artifacts/cdap-sentry-model-0.2.0-SNAPSHOT.jar
/opt/cdap/master/artifacts/cdap-sentry-policy-0.2.0-SNAPSHOT.jar
```

This will copy the security extension JARs to the correct location.
