### PR TITLE
Use exclude patterns, not assembly classifiers

### DIFF
--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -400,8 +400,8 @@
                         <include name="${additional.artifacts.jar.pattern}"/>
                         <include name="${additional.artifacts.config.pattern}"/>
                         <exclude name="${additional.artifacts.exclude.pattern}"/>
-                        <exclude name="*:sources"/>
-                        <exclude name="*:javadoc"/>
+                        <exclude name="**/target/*-sources.jar"/>
+                        <exclude name="**/target/*-javadoc.jar"/>
                       </fileset>
                     </copy>
                   </target>
@@ -420,8 +420,8 @@
                         <include name="${security.ext.jar.pattern}"/>
                         <include name="${security.ext.config.pattern}"/>
                         <exclude name="${security.ext.exclude.pattern}"/>
-                        <exclude name="*:sources"/>
-                        <exclude name="*:javadoc"/>
+                        <exclude name="**/target/*-sources.jar"/>
+                        <exclude name="**/target/*-javadoc.jar"/>
                       </fileset>
                     </copy>
                   </target>

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -573,8 +573,8 @@
                         <include name="${additional.artifacts.jar.pattern}"/>
                         <include name="${additional.artifacts.config.pattern}"/>
                         <exclude name="${additional.artifacts.exclude.pattern}"/>
-                        <exclude name="*:sources"/>
-                        <exclude name="*:javadoc"/>
+                        <exclude name="**/target/*-sources.jar"/>
+                        <exclude name="**/target/*-javadoc.jar"/>
                       </fileset>
                     </copy>
                   </target>


### PR DESCRIPTION
The `maven-antrun-plugin` uses file name matching. Matching by classifiers is supported in `maven-assembly-plugin` which isn't used in this case.

Before:

```
/opt/cdap/master/artifacts/copybookreader-plugins-1.4.0-SNAPSHOT.jar
/opt/cdap/master/artifacts/copybookreader-plugins-1.4.0-SNAPSHOT-javadoc.jar
/opt/cdap/master/artifacts/copybookreader-plugins-1.4.0-SNAPSHOT-sources.jar
/opt/cdap/master/artifacts/copybookreader-plugins-1.4.0-SNAPSHOT.json
/opt/cdap/master/artifacts/core-plugins-1.4.0-SNAPSHOT.jar
/opt/cdap/master/artifacts/core-plugins-1.4.0-SNAPSHOT-javadoc.jar
/opt/cdap/master/artifacts/core-plugins-1.4.0-SNAPSHOT-sources.jar
/opt/cdap/master/artifacts/core-plugins-1.4.0-SNAPSHOT.json
```

After:

```
/opt/cdap/master/artifacts/copybookreader-plugins-1.4.0-SNAPSHOT.jar
/opt/cdap/master/artifacts/copybookreader-plugins-1.4.0-SNAPSHOT.json
/opt/cdap/master/artifacts/core-plugins-1.4.0-SNAPSHOT.jar
/opt/cdap/master/artifacts/core-plugins-1.4.0-SNAPSHOT.json
```
