### PR TITLE
Copy security extension JARs in standalone

### DIFF
--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -211,9 +211,13 @@
         <stage.lib.dir>${stage.opt.dir}/lib</stage.lib.dir>
         <stage.libexec.dir>${stage.opt.dir}/libexec</stage.libexec.dir>
         <stage.artifacts.dir>${stage.opt.dir}/artifacts</stage.artifacts.dir>
+        <stage.security.ext.dir>${stage.opt.dir}/ext/security</stage.security.ext.dir>
         <additional.artifacts.jar.pattern>**/target/*.jar</additional.artifacts.jar.pattern>
         <additional.artifacts.config.pattern>**/target/*.json</additional.artifacts.config.pattern>
         <additional.artifacts.exclude.pattern>**/target/*-tests.jar</additional.artifacts.exclude.pattern>
+        <security.ext.jar.pattern>**/target/*.jar</security.ext.jar.pattern>
+        <security.ext.config.pattern>**/target/*.json</security.ext.config.pattern>
+        <security.ext.exclude.pattern>**/target/*-tests.jar</security.ext.exclude.pattern>
       </properties>
 
       <!-- Add dependencies on spark api and core. It just for making sure those artifacts are built before this -->
@@ -573,6 +577,26 @@
                         <include name="${additional.artifacts.jar.pattern}"/>
                         <include name="${additional.artifacts.config.pattern}"/>
                         <exclude name="${additional.artifacts.exclude.pattern}"/>
+                        <exclude name="**/target/*-sources.jar"/>
+                        <exclude name="**/target/*-javadoc.jar"/>
+                      </fileset>
+                    </copy>
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>copy-security-extensions-artifacts</id>
+                <phase>process-resources</phase>
+                <configuration>
+                  <target if="security.extensions.dir">
+                    <copy todir="${stage.security.ext.dir}" flatten="true">
+                      <fileset dir="${security.extensions.dir}">
+                        <include name="${security.ext.jar.pattern}"/>
+                        <include name="${security.ext.config.pattern}"/>
+                        <exclude name="${security.ext.exclude.pattern}"/>
                         <exclude name="**/target/*-sources.jar"/>
                         <exclude name="**/target/*-javadoc.jar"/>
                       </fileset>


### PR DESCRIPTION
The `cdap-authorization-dataset-extn` is usable in standalone, so we should be able to include it in the packaging.
