### PR TITLE
fixes minor rendering issues issues with hydrator modal content

### DIFF
--- a/cdap-ui/app/directives/complex-schema/complex-schema.less
+++ b/cdap-ui/app/directives/complex-schema/complex-schema.less
@@ -65,7 +65,10 @@ my-complex-schema {
         width: ~"calc(100% - 75px - 80px)";
       }
 
-      .form-control { padding-left: 5px; }
+      .form-control {
+        padding-left: 5px;
+        text-indent: 2px;
+      }
 
       &.header { padding-left: 4px; }
     }

--- a/cdap-ui/app/directives/my-link-button/my-link-button.less
+++ b/cdap-ui/app/directives/my-link-button/my-link-button.less
@@ -19,7 +19,7 @@ my-link-button {
   .btn-my-link {
     color: white;
     background-color: #999999;
-    padding: 5px;
+    padding: 5px 7px;
     transition: background-color 0.1s ease-in-out;
     span.fa { margin-left: 10px; }
     &:hover,

--- a/cdap-ui/app/directives/widget-container/widget-function-dropdown-with-alias/widget-function-dropdown-with-alias.less
+++ b/cdap-ui/app/directives/widget-container/widget-function-dropdown-with-alias/widget-function-dropdown-with-alias.less
@@ -14,6 +14,8 @@
  * the License.
  */
 
+@import "../../../styles/variables.less";
+
 my-function-dropdown-with-alias {
   .row {
     margin-bottom: 5px;
@@ -45,7 +47,9 @@ my-function-dropdown-with-alias {
       }
     }
     .btn-info {
-      margin-top: 5px;
+      @media(min-width: @screen-lg-min) {
+        margin-top: 5px;
+      }
     }
   }
 }

--- a/cdap-ui/app/directives/widget-container/widget-function-dropdown-with-alias/widget-function-dropdown-with-alias.less
+++ b/cdap-ui/app/directives/widget-container/widget-function-dropdown-with-alias/widget-function-dropdown-with-alias.less
@@ -44,5 +44,8 @@ my-function-dropdown-with-alias {
         padding-left: 15px;
       }
     }
+    .btn-info {
+      margin-top: 5px;
+    }
   }
 }

--- a/cdap-ui/app/features/hydratorplusplus/hydrator-modal.less
+++ b/cdap-ui/app/features/hydratorplusplus/hydrator-modal.less
@@ -62,6 +62,13 @@
           max-width: 70%;
         }
 
+        // Adjust max-width of modal title when my-jump-link is present
+        &.with-jump {
+          max-width: ~"calc(100% - 215px)";
+          max-width: ~"-moz-calc(100% - 215px)";
+          max-width: ~"-webkit-calc(100% - 215px)";
+        }
+
         p {
           min-width: 100%;
           text-overflow: ellipsis;

--- a/cdap-ui/app/features/hydratorplusplus/templates/partial/node-config-modal/popover.html
+++ b/cdap-ui/app/features/hydratorplusplus/templates/partial/node-config-modal/popover.html
@@ -15,7 +15,8 @@
 -->
 <div class="modal-header clearfix">
 
-  <h4 class="modal-title pull-left">
+  <h4 class="modal-title pull-left"
+      ng-class="{'with-jump': HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.jumpConfig.datasets.length}">
     <span>
       {{HydratorPlusPlusNodeConfigCtrl.state.node.plugin.name}} Properties
       <small>{{ HydratorPlusPlusNodeConfigCtrl.state.node.plugin.artifact.version }}</small>


### PR DESCRIPTION
-  Adds 2px more right/left padding to my-jump-link (used in modal header) to prevent the button from looking squished
-  Adjusts max-height of modal title whenever my-jump-link is present in the modal header
-  Adds top margin to "+" button in widget-function-dropdown-with-alias so that it's not flush up against the sibling trash button
-  Adds minor text indentation to complex-schema input elements so that the initial cursor isn't up against the left border
