### PR TITLE
HYDRA-388 add metrics for records emitted by streaming sources

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsSparkLauncher.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsSparkLauncher.java
@@ -83,12 +83,12 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
       sparkConf.set("spark.driver.extraJavaOptions", extraOpts);
       sparkConf.set("spark.executor.extraJavaOptions", extraOpts);
     }
+    Integer numSources = Integer.valueOf(programProperties.get("cask.hydrator.num.sources"));
+    // without this, stopping will hang on machines with few cores.
+    sparkConf.set("spark.rpc.netty.dispatcher.numThreads", String.valueOf(numSources + 2));
     Boolean isUnitTest = Boolean.valueOf(programProperties.get("cask.hydrator.is.unit.test"));
     if (isUnitTest) {
-      Integer numSources = Integer.valueOf(programProperties.get("cask.hydrator.num.sources"));
       sparkConf.setMaster(String.format("local[%d]", numSources + 1));
-      // without this, stopping will hang on machines with few cores.
-      sparkConf.set("spark.rpc.netty.dispatcher.numThreads", String.valueOf(numSources + 2));
     }
     context.setSparkConf(sparkConf);
   }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/SparkCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/SparkCollection.java
@@ -50,5 +50,5 @@ public interface SparkCollection<T> {
 
   void store(String stageName, SparkSink<T> sink) throws Exception;
 
-  SparkCollection<T> window(Windower windower);
+  SparkCollection<T> window(String stageName, Windower windower);
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/SparkPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/SparkPipelineDriver.java
@@ -210,7 +210,7 @@ public abstract class SparkPipelineDriver {
       } else if (Windower.PLUGIN_TYPE.equals(pluginType)) {
 
         Windower windower = sec.getPluginContext().newPluginInstance(stageName, macroEvaluator);
-        stageData = stageData.window(windower);
+        stageData = stageData.window(stageName, windower);
 
       } else {
         throw new IllegalStateException(String.format("Stage %s is of unsupported plugin type %s.",

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/RDDCollection.java
@@ -18,14 +18,13 @@ package co.cask.cdap.etl.spark.batch;
 
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.spark.JavaSparkExecutionContext;
-import co.cask.cdap.etl.api.StageMetrics;
 import co.cask.cdap.etl.api.batch.SparkCompute;
 import co.cask.cdap.etl.api.batch.SparkExecutionPluginContext;
 import co.cask.cdap.etl.api.batch.SparkSink;
 import co.cask.cdap.etl.api.streaming.Windower;
-import co.cask.cdap.etl.common.DefaultStageMetrics;
 import co.cask.cdap.etl.spark.SparkCollection;
 import co.cask.cdap.etl.spark.SparkPairCollection;
+import co.cask.cdap.etl.spark.function.CountingFunction;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -86,15 +85,10 @@ public class RDDCollection<T> implements SparkCollection<T> {
     SparkExecutionPluginContext sparkPluginContext =
       new BasicSparkExecutionPluginContext(sec, jsc, datasetContext, stageName);
 
-    // TODO:(Hydra-364) figure out how to do this in a better way...
-    long recordsIn = rdd.cache().count();
-    StageMetrics stageMetrics = new DefaultStageMetrics(sec.getMetrics(), stageName);
-    stageMetrics.gauge("records.in", recordsIn);
+    JavaRDD<T> countedInput = rdd.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in")).cache();
 
-    JavaRDD<U> computedRDD = compute.transform(sparkPluginContext, rdd).cache();
-    long recordsOut = computedRDD.count();
-    stageMetrics.gauge("records.out", recordsOut);
-    return wrap(computedRDD);
+    return wrap(compute.transform(sparkPluginContext, countedInput)
+                  .map(new CountingFunction<U>(stageName, sec.getMetrics(), "records.out")));
   }
 
   @Override
@@ -108,16 +102,12 @@ public class RDDCollection<T> implements SparkCollection<T> {
     SparkExecutionPluginContext sparkPluginContext =
       new BasicSparkExecutionPluginContext(sec, jsc, datasetContext, stageName);
 
-    // TODO:(Hydra-364) figure out how to do this in a better way...
-    long recordsIn = rdd.cache().count();
-    StageMetrics stageMetrics = new DefaultStageMetrics(sec.getMetrics(), stageName);
-    stageMetrics.gauge("records.in", recordsIn);
-
-    sink.run(sparkPluginContext, rdd);
+    JavaRDD<T> countedRDD = rdd.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in")).cache();
+    sink.run(sparkPluginContext, countedRDD);
   }
 
   @Override
-  public SparkCollection<T> window(Windower windower) {
+  public SparkCollection<T> window(String stageName, Windower windower) {
     throw new UnsupportedOperationException("Windowing is not supported on RDDs.");
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/CountingFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/CountingFunction.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark.function;
+
+import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.etl.api.StageMetrics;
+import co.cask.cdap.etl.common.DefaultStageMetrics;
+import org.apache.spark.api.java.function.Function;
+
+/**
+ * Function that doesn't transform anything, but just emits counts for the number of records from that stage.
+ *
+ * @param <T> the type of input object
+ */
+public class CountingFunction<T> implements Function<T, T> {
+  private final String stageName;
+  private final Metrics metrics;
+  private final String metricName;
+  private transient StageMetrics stageMetrics;
+
+  public CountingFunction(String stageName, Metrics metrics, String metricName) {
+    this.stageName = stageName;
+    this.metrics = metrics;
+    this.metricName = metricName;
+  }
+
+  @Override
+  public T call(T in) throws Exception {
+    if (stageMetrics == null) {
+      stageMetrics = new DefaultStageMetrics(metrics, stageName);
+    }
+    stageMetrics.count(metricName, 1);
+    return in;
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/DStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/DStreamCollection.java
@@ -30,9 +30,11 @@ import co.cask.cdap.etl.spark.SparkCollection;
 import co.cask.cdap.etl.spark.SparkPairCollection;
 import co.cask.cdap.etl.spark.batch.SparkBatchSinkContext;
 import co.cask.cdap.etl.spark.batch.SparkBatchSinkFactory;
+import co.cask.cdap.etl.spark.function.CountingFunction;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.Function;
 import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
 import org.apache.spark.streaming.Durations;
@@ -92,7 +94,10 @@ public class DStreamCollection<T> implements SparkCollection<T> {
                   public JavaRDD<U> call(JavaRDD<T> data, Time batchTime) throws Exception {
                     SparkExecutionPluginContext sparkPluginContext =
                       new SparkStreamingExecutionContext(sec, sparkContext, stageName, batchTime.milliseconds());
-                    return compute.transform(sparkPluginContext, data);
+
+                    data = data.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in"));
+                    return compute.transform(sparkPluginContext, data)
+                      .map(new CountingFunction<U>(stageName, sec.getMetrics(), "records.out"));
                   }
                 }));
   }
@@ -126,6 +131,7 @@ public class DStreamCollection<T> implements SparkCollection<T> {
           });
           isPrepared = true;
 
+          data = data.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in"));
           sinkFactory.writeFromRDD(data.flatMapToPair(sinkFunction), sec, stageName, Object.class, Object.class);
           isDone = true;
           sec.execute(new TxRunnable() {
@@ -162,8 +168,21 @@ public class DStreamCollection<T> implements SparkCollection<T> {
   }
 
   @Override
-  public SparkCollection<T> window(Windower windower) {
-    return wrap(stream.window(Durations.seconds(windower.getWidth()), Durations.seconds(windower.getSlideInterval())));
+  public SparkCollection<T> window(final String stageName, Windower windower) {
+    return wrap(stream
+                  .transform(new Function<JavaRDD<T>, JavaRDD<T>>() {
+                    @Override
+                    public JavaRDD<T> call(JavaRDD<T> in) throws Exception {
+                      return in.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in"));
+                    }
+                  })
+                  .window(Durations.seconds(windower.getWidth()), Durations.seconds(windower.getSlideInterval()))
+                  .transform(new Function<JavaRDD<T>, JavaRDD<T>>() {
+                    @Override
+                    public JavaRDD<T> call(JavaRDD<T> in) throws Exception {
+                      return in.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.out"));
+                    }
+                  }));
   }
 
   private <U> SparkCollection<U> wrap(JavaDStream<U> stream) {


### PR DESCRIPTION
Many stages in data streams were not emitted records in and records
out of the stage. Fixed by creating a CountingFunction that is used
before and after these stages that just counts records for that
stage. Also took this opportunity to fix HYDRA-364 using the function
instead of calling count() on rdds.
