### PR TITLE
(CDAP-7006) Workaround for Apache Sentry metastore columns not being …

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
@@ -59,7 +59,6 @@ import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -203,10 +202,8 @@ public class ArtifactRepository {
   /**
    * Get all artifacts that match artifacts in the given ranges.
    *
-   * @namespace namespace
    * @param range the range to match artifacts in
-   * @return an unmodifiable list of all artifacts that match the given ranges. If none exist, an empty list
-   *         is returned
+   * @return an unmodifiable list of all artifacts that match the given ranges. If none exist, an empty list is returned
    */
   public List<ArtifactDetail> getArtifacts(final ArtifactRange range) throws Exception {
     List<ArtifactDetail> artifacts = artifactStore.getArtifacts(range);

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/SmartWorkflow.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/SmartWorkflow.java
@@ -58,7 +58,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 
 /**
  * Data Pipeline Smart Workflow.
@@ -85,6 +84,8 @@ public class SmartWorkflow extends AbstractWorkflow {
   // injected by cdap
   @SuppressWarnings("unused")
   private Metrics workflowMetrics;
+
+  private int connectorNum = 0;
 
   public SmartWorkflow(BatchPipelineSpec spec,
                        Set<String> supportedPluginTypes,
@@ -250,7 +251,7 @@ public class SmartWorkflow extends AbstractWorkflow {
       String connectorName = connectorInfo.getName();
       String datasetName = connectorDatasets.get(connectorName);
       if (datasetName == null) {
-        datasetName = UUID.randomUUID().toString();
+        datasetName = "conn-" + connectorNum++;
         connectorDatasets.put(connectorName, datasetName);
         // add the local dataset
         ConnectorSource connectorSource = new ConnectorSource(datasetName, null);


### PR DESCRIPTION
…wide-enough to support long dataset names - used auto-incrementing number instead of a random UUID for local dataset names in DataPipelineApp.

Jira: [CDAP-7006](https://issues.cask.co/browse/CDAP-7006)
Build: http://builds.cask.co/browse/CDAP-RUT93

Still needs some more testing.
