### PR TITLE
CDAP-4775 remove some checks (for parameters that are not configurable).

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/master/startup/ConfigurationCheck.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/startup/ConfigurationCheck.java
@@ -91,15 +91,7 @@ class ConfigurationCheck extends AbstractMasterCheck {
 
   private void checkBindAddresses() {
     // check if service bind addresses are loopback addresses
-    Set<String> bindAddressKeys = ImmutableSet.of(
-      Constants.AppFabric.SERVER_ADDRESS,
-      Constants.Dataset.Executor.ADDRESS,
-      Constants.Stream.ADDRESS,
-      Constants.Router.ADDRESS,
-      Constants.Metrics.ADDRESS,
-      Constants.LogSaver.ADDRESS,
-      Constants.Explore.SERVER_ADDRESS,
-      Constants.Metadata.SERVICE_BIND_ADDRESS);
+    Set<String> bindAddressKeys = ImmutableSet.of(Constants.AppFabric.SERVER_ADDRESS, Constants.Router.ADDRESS);
 
     for (String bindAddressKey : bindAddressKeys) {
       String bindAddress = cConf.get(bindAddressKey);


### PR DESCRIPTION
Avoid checking for some parameters in the CConf, since they're not configurable by the user (and they're not in cdap-default.xml).
We always bind to a random port, and announce that for discovery.

Otherwise, you'll see this on a fully functioning cluster (I'm pretty sure it always logs the following 3 on clusters provisioned before this PR and after https://github.com/caskdata/cdap/pull/5905):

```
2016-08-18 01:03:23,093 WARN co.cask.cdap.master.startup.ConfigurationCheck: dataset.executor.bind.address is set to null. The service may not be discoverable on a multinode Hadoop cluster.
2016-08-18 01:03:23,093 WARN co.cask.cdap.master.startup.ConfigurationCheck: metrics.bind.address is set to null. The service may not be discoverable on a multinode Hadoop cluster.
2016-08-18 01:03:23,094 WARN co.cask.cdap.master.startup.ConfigurationCheck: explore.service.bind.address is set to null. The service may not be discoverable on a multinode Hadoop cluster.
```

Original issue: https://issues.cask.co/browse/CDAP-4775

http://builds.cask.co/browse/CDAP-RUT112-2
