### PR TITLE
HYDRA-693 add initialize to spark compute

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/co/cask/cdap/etl/api/batch/SparkCompute.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/co/cask/cdap/etl/api/batch/SparkCompute.java
@@ -19,6 +19,7 @@ package co.cask.cdap.etl.api.batch;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.etl.api.PipelineConfigurable;
 import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageLifecycle;
 import org.apache.spark.api.java.JavaRDD;
 
 import java.io.Serializable;
@@ -37,7 +38,7 @@ public abstract class SparkCompute<IN, OUT> implements PipelineConfigurable, Ser
 
 
   /**
-   * Configure an ETL pipeline.
+   * Configure a pipeline.
    *
    * @param pipelineConfigurer the configurer used to add required datasets and streams
    * @throws IllegalArgumentException if the given config is invalid
@@ -48,11 +49,22 @@ public abstract class SparkCompute<IN, OUT> implements PipelineConfigurable, Ser
   }
 
   /**
+   * Initialize the plugin. Will be called before any calls to {@link #transform(SparkExecutionPluginContext, JavaRDD)}
+   * are made.
+   *
+   * @param context {@link SparkExecutionPluginContext} for this job
+   * @throws Exception if there is an error initializing
+   */
+  public void initialize(SparkExecutionPluginContext context) throws Exception {
+    //no-op
+  }
+
+  /**
    * Transform the input and return the output to be sent to the next stage in the pipeline.
    *
    * @param context {@link SparkExecutionPluginContext} for this job
    * @param input input data to be transformed
-   * @throws Exception if there's an error during this method invocation
+   * @throws Exception if there is an error during this method invocation
    */
   public abstract JavaRDD<OUT> transform(SparkExecutionPluginContext context, JavaRDD<IN> input) throws Exception;
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/SparkPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/SparkPipelineDriver.java
@@ -25,11 +25,13 @@ import co.cask.cdap.etl.api.batch.BatchJoiner;
 import co.cask.cdap.etl.api.batch.BatchJoinerRuntimeContext;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.SparkCompute;
+import co.cask.cdap.etl.api.batch.SparkExecutionPluginContext;
 import co.cask.cdap.etl.api.batch.SparkSink;
 import co.cask.cdap.etl.api.streaming.Windower;
 import co.cask.cdap.etl.common.DefaultMacroEvaluator;
 import co.cask.cdap.etl.common.PipelinePhase;
 import co.cask.cdap.etl.planner.StageInfo;
+import co.cask.cdap.etl.spark.batch.BasicSparkExecutionPluginContext;
 import co.cask.cdap.etl.spark.function.AggregatorAggregateFunction;
 import co.cask.cdap.etl.spark.function.AggregatorGroupByFunction;
 import co.cask.cdap.etl.spark.function.BatchSinkFunction;
@@ -119,6 +121,7 @@ public abstract class SparkPipelineDriver {
 
         SparkCompute<Object, Object> sparkCompute =
           sec.getPluginContext().newPluginInstance(stageName, macroEvaluator);
+
         stageData = stageData.compute(stageName, sparkCompute);
 
       } else if (SparkSink.PLUGIN_TYPE.equals(pluginType)) {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/SparkPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/SparkPipelineDriver.java
@@ -25,13 +25,11 @@ import co.cask.cdap.etl.api.batch.BatchJoiner;
 import co.cask.cdap.etl.api.batch.BatchJoinerRuntimeContext;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.SparkCompute;
-import co.cask.cdap.etl.api.batch.SparkExecutionPluginContext;
 import co.cask.cdap.etl.api.batch.SparkSink;
 import co.cask.cdap.etl.api.streaming.Windower;
 import co.cask.cdap.etl.common.DefaultMacroEvaluator;
 import co.cask.cdap.etl.common.PipelinePhase;
 import co.cask.cdap.etl.planner.StageInfo;
-import co.cask.cdap.etl.spark.batch.BasicSparkExecutionPluginContext;
 import co.cask.cdap.etl.spark.function.AggregatorAggregateFunction;
 import co.cask.cdap.etl.spark.function.AggregatorGroupByFunction;
 import co.cask.cdap.etl.spark.function.BatchSinkFunction;
@@ -121,7 +119,6 @@ public abstract class SparkPipelineDriver {
 
         SparkCompute<Object, Object> sparkCompute =
           sec.getPluginContext().newPluginInstance(stageName, macroEvaluator);
-
         stageData = stageData.compute(stageName, sparkCompute);
 
       } else if (SparkSink.PLUGIN_TYPE.equals(pluginType)) {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/RDDCollection.java
@@ -85,6 +85,7 @@ public class RDDCollection<T> implements SparkCollection<T> {
   public <U> SparkCollection<U> compute(String stageName, SparkCompute<T, U> compute) throws Exception {
     SparkExecutionPluginContext sparkPluginContext =
       new BasicSparkExecutionPluginContext(sec, jsc, datasetContext, stageName);
+    compute.initialize(sparkPluginContext);
 
     // TODO:(Hydra-364) figure out how to do this in a better way...
     long recordsIn = rdd.cache().count();


### PR DESCRIPTION
Adding an initialize method to spark compute to better support
streaming use cases. This will allow plugins like classifier
plugins to load a model once and use it to repeatedly classify
elements in multiple rdds.
