### PR TITLE
Remove system.user as a configuration setting, and instead just use t…

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/SystemArtifactsAuthorizationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/SystemArtifactsAuthorizationTest.java
@@ -34,7 +34,6 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
-import co.cask.cdap.security.auth.context.AuthenticationTestContext;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.authorization.InMemoryAuthorizer;
@@ -77,7 +76,6 @@ public class SystemArtifactsAuthorizationTest {
   private static AuthorizationEnforcementService authEnforcerService;
   private static InstanceId instance;
   private static NamespaceAdmin namespaceAdmin;
-  private static String systemUser;
 
   @BeforeClass
   public static void setup() throws Exception {
@@ -95,8 +93,6 @@ public class SystemArtifactsAuthorizationTest {
     File systemArtifactsDir = TMP_FOLDER.newFolder();
     cConf.set(Constants.AppFabric.SYSTEM_ARTIFACTS_DIR, systemArtifactsDir.getAbsolutePath());
     createSystemArtifact(systemArtifactsDir);
-    systemUser = new AuthenticationTestContext().getPrincipal().getName();
-    cConf.set(Constants.Security.Authorization.SYSTEM_USER, systemUser);
     Injector injector = AppFabricTestHelper.getInjector(cConf);
     artifactRepository = injector.getInstance(ArtifactRepository.class);
     AuthorizerInstantiator instantiatorService = injector.getInstance(AuthorizerInstantiator.class);
@@ -109,8 +105,6 @@ public class SystemArtifactsAuthorizationTest {
 
   @Test
   public void testAuthorizationForSystemArtifacts() throws Exception {
-    // the system user must be able to add system artifacts
-    SecurityRequestContext.setUserId(systemUser);
     artifactRepository.addSystemArtifacts();
     // alice should not be able to refresh system artifacts because she does not have write privileges on the
     // CDAP instance

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/DefaultSecureStoreServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/DefaultSecureStoreServiceTest.java
@@ -32,7 +32,6 @@ import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.proto.security.SecureKeyCreateRequest;
 import co.cask.cdap.proto.security.SecureKeyListEntry;
-import co.cask.cdap.security.auth.context.MasterAuthenticationContext;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.authorization.InMemoryAuthorizer;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
@@ -113,7 +112,6 @@ public class DefaultSecureStoreServiceTest {
     // we only want to test authorization, but we don't specify principal/keytab, so disable kerberos
     cConf.setBoolean(Constants.Security.KERBEROS_ENABLED, false);
     cConf.setBoolean(Constants.Security.Authorization.CACHE_ENABLED, false);
-    cConf.set(Constants.Security.Authorization.SYSTEM_USER, new MasterAuthenticationContext().getPrincipal().getName());
 
     LocationFactory locationFactory = new LocalLocationFactory(TEMPORARY_FOLDER.newFolder());
     Location authorizerJar = AppJarHelper.createDeploymentJar(locationFactory, InMemoryAuthorizer.class);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemotePrivilegesTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemotePrivilegesTest.java
@@ -30,7 +30,6 @@ import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
-import co.cask.cdap.security.auth.context.MasterAuthenticationContext;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.authorization.InMemoryAuthorizer;
 import co.cask.cdap.security.spi.authorization.Authorizer;
@@ -86,7 +85,6 @@ public class RemotePrivilegesTest {
     cConf.setBoolean(Constants.Security.KERBEROS_ENABLED, false);
     cConf.setBoolean(Constants.Security.Authorization.ENABLED, true);
     cConf.setBoolean(Constants.Security.Authorization.CACHE_ENABLED, false);
-    cConf.set(Constants.Security.Authorization.SYSTEM_USER, new MasterAuthenticationContext().getPrincipal().getName());
     Manifest manifest = new Manifest();
     manifest.getMainAttributes().put(Attributes.Name.MAIN_CLASS, InMemoryAuthorizer.class.getName());
     LocationFactory locationFactory = new LocalLocationFactory(TEMPORARY_FOLDER.newFolder());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
@@ -27,7 +27,6 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
-import co.cask.cdap.security.auth.context.MasterAuthenticationContext;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.authorization.InMemoryAuthorizer;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
@@ -99,7 +98,6 @@ public class MetadataAdminAuthorizationTest {
     LocationFactory locationFactory = new LocalLocationFactory(new File(TEMPORARY_FOLDER.newFolder().toURI()));
     Location authorizerJar = AppJarHelper.createDeploymentJar(locationFactory, InMemoryAuthorizer.class);
     cConf.set(Constants.Security.Authorization.EXTENSION_JAR_PATH, authorizerJar.toURI().getPath());
-    cConf.set(Constants.Security.Authorization.SYSTEM_USER, new MasterAuthenticationContext().getPrincipal().getName());
     return cConf;
   }
 }

--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/AuthorizationCLITest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/AuthorizationCLITest.java
@@ -25,7 +25,6 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Role;
-import co.cask.cdap.security.auth.context.MasterAuthenticationContext;
 import co.cask.cdap.security.authorization.InMemoryAuthorizer;
 import co.cask.cdap.security.server.BasicAuthenticationHandler;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
@@ -93,7 +92,6 @@ public class AuthorizationCLITest extends CLITestBase {
         Constants.Security.Authorization.ENABLED, "true",
         Constants.Security.Authorization.CACHE_ENABLED, "false",
         Constants.Security.Authorization.EXTENSION_JAR_PATH, authExtensionJar.toURI().getPath(),
-        Constants.Security.Authorization.SYSTEM_USER, new MasterAuthenticationContext().getPrincipal().getName(),
         // Bypass authorization enforcement for grant/revoke operations in this test. Authorization enforcement for
         // grant/revoke is tested in AuthorizationHandlerTest
         Constants.Security.Authorization.EXTENSION_CONFIG_PREFIX + "superusers", "*",

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -707,7 +707,6 @@ public final class Constants {
       /** Prefix for extension properties */
       public static final String EXTENSION_CONFIG_PREFIX =
         "security.authorization.extension.config.";
-      public static final String SYSTEM_USER = "security.authorization.system.user";
       public static final String CACHE_ENABLED = "security.authorization.cache.enabled";
       public static final String CACHE_TTL_SECS = "security.authorization.cache.ttl.secs";
       public static final String CACHE_REFRESH_INTERVAL_SECS = "security.authorization.cache.refresh.interval.secs";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1701,18 +1701,6 @@
   </property>
 
   <property>
-    <name>security.authorization.system.user</name>
-    <value>cdap</value>
-    <description>
-      Determines a user for whom specific privileges are granted during CDAP startup.
-      This is the user used for creating the default namespace, deploying system artifacts and deploying dataset
-      modules. This user is also granted ALL privileges on the system namespace, so it can access datasets and other
-      entities in the system namespace. This user does not get any other privileges on user namespaces. Defaults to
-      'cdap'. Please set this to the user that the CDAP Master runs as in a secure, authorization-enabled environment.
-    </description>
-  </property>
-
-  <property>
     <name>security.data.keyfile.path</name>
     <value>${local.data.dir}/security/keyfile</value>
     <description>

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="4b7bf6d4258eb7714a6f028d4d4c92ae"
+DEFAULT_XML_MD5_HASH="b505ffb17ac2a2dc01c310fc2febf1c5"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizationBootstrapper.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizationBootstrapper.java
@@ -23,14 +23,14 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.security.spi.authorization.PrivilegesManager;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
-import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.inject.Inject;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -53,11 +53,18 @@ public class AuthorizationBootstrapper {
   AuthorizationBootstrapper(CConfiguration cConf, PrivilegesManager privilegesManager) {
     this.enabled =
       cConf.getBoolean(Constants.Security.ENABLED) && cConf.getBoolean(Constants.Security.Authorization.ENABLED);
-    this.systemUser =
-      new Principal(cConf.get(Constants.Security.Authorization.SYSTEM_USER), Principal.PrincipalType.USER);
+    String currentUser;
+    try {
+      currentUser = UserGroupInformation.getCurrentUser().getShortUserName();
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+    this.systemUser = new Principal(currentUser, Principal.PrincipalType.USER);
     this.adminUsers = getAdminUsers(cConf);
+    if (enabled && adminUsers.isEmpty()) {
+      LOG.info("Admin users specified by {} is empty.", Constants.Security.Authorization.ADMIN_USERS);
+    }
     this.instanceId = new InstanceId(cConf.get(Constants.INSTANCE_NAME));
-    validateConfiguration();
     this.privilegesManager = privilegesManager;
   }
 
@@ -93,22 +100,5 @@ public class AuthorizationBootstrapper {
       }
     }
     return admins;
-  }
-
-  private void validateConfiguration() {
-    if (!enabled) {
-      return;
-    }
-    Preconditions.checkArgument(
-      !Strings.isNullOrEmpty(systemUser.getName()),
-      "The CDAP system user specified by %s is null or empty. Without this setting, CDAP will not be able to " +
-        "create a default namespace, system artifacts or initialize its metadata. It is recommended to set this to " +
-        "the user that the CDAP Master runs as.", Constants.Security.Authorization.SYSTEM_USER);
-    if (adminUsers.isEmpty()) {
-      LOG.warn("Admin users specified by {} is empty. It may not be possible to bootstrap CDAP without this setting. " +
-                 "To get rid of this warning, please set {} to a comma-separated list of users who will be granted " +
-                 "admin privileges on the CDAP instance so that they can create namespaces in CDAP.",
-               Constants.Security.Authorization.ADMIN_USERS, Constants.Security.Authorization.ADMIN_USERS);
-    }
   }
 }

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/DefaultAuthorizationEnforcementServiceTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/DefaultAuthorizationEnforcementServiceTest.java
@@ -33,6 +33,7 @@ import co.cask.cdap.security.spi.authorization.PrivilegesFetcher;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Service;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.twill.filesystem.Location;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -247,8 +248,8 @@ public class DefaultAuthorizationEnforcementServiceTest extends AuthorizationTes
   @Test
   public void testSystemUser() throws Exception {
     CConfiguration cConfCopy = CConfiguration.copy(CCONF);
-    Principal systemUser = AUTH_CONTEXT.getPrincipal();
-    cConfCopy.set(Constants.Security.Authorization.SYSTEM_USER, systemUser.getName());
+    Principal systemUser =
+      new Principal(UserGroupInformation.getCurrentUser().getShortUserName(), Principal.PrincipalType.USER);
     cConfCopy.setInt(Constants.Security.Authorization.CACHE_REFRESH_INTERVAL_SECS, 1);
     try (AuthorizerInstantiator authorizerInstantiator = new AuthorizerInstantiator(cConfCopy, AUTH_CONTEXT_FACTORY)) {
       Authorizer authorizer = authorizerInstantiator.get();

--- a/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
@@ -44,7 +44,6 @@ import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
-import co.cask.cdap.security.auth.context.MasterAuthenticationContext;
 import co.cask.cdap.security.authorization.InMemoryAuthorizer;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import co.cask.cdap.security.spi.authorization.Authorizer;
@@ -149,7 +148,6 @@ public class AuthorizationTest extends TestBase {
         Constants.Security.Authorization.EXTENSION_JAR_PATH, authExtensionJar.toURI().getPath(),
         // we only want to test authorization, but we don't specify principal/keytab, so disable kerberos
         Constants.Security.KERBEROS_ENABLED, "false",
-        Constants.Security.Authorization.SYSTEM_USER, new MasterAuthenticationContext().getPrincipal().getName()
       };
     }
   }


### PR DESCRIPTION
…he current user of that the Master is running as for bootstrapping.

Build: http://builds.cask.co/browse/CDAP-RUT113
