### PR TITLE
Backport Docker/VM scripts from release/3.5

### DIFF
--- a/cdap-distributions/src/Dockerfile
+++ b/cdap-distributions/src/Dockerfile
@@ -21,25 +21,46 @@
 FROM ubuntu:12.04
 MAINTAINER Cask Data <ops@cask.co>
 
-# Copy scripts
-COPY packer/scripts /tmp/scripts
+# grab gosu for easy step-down from root
+ENV GOSU_VERSION 1.7
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+    curl \
+    git && \
+  curl -vL \
+    "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" > \
+    /usr/local/bin/gosu && \
+  curl -vL \
+    "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" > \
+    /usr/local/bin/gosu.asc && \
+  export GNUPGHOME="$(mktemp -d)" && \
+  gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
+  gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
+  rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc && \
+  chmod +x /usr/local/bin/gosu && \
+  gosu nobody true
 
-# Copy json
+# Copy scripts and files before using them below
+COPY packer/scripts /tmp/scripts
 COPY packer/files /tmp/files
 
-# build cdap-standalone zip file, copy it to container and extract it
-RUN apt-get update && \
-    apt-get install -y curl git && \
-    curl -L http://chef.io/chef/install.sh | bash -s -- -v 12.4.3 && \
+# Install Chef, setup APT, run Chef cdap::sdk recipe, then clean up
+RUN curl -vL http://chef.io/chef/install.sh | bash -s -- -v 12.4.3 && \
     for i in apt-setup.sh cookbook-dir.sh cookbook-setup.sh ; do /tmp/scripts/$i ; done && \
     chef-solo -o cdap::sdk -j /tmp/files/cdap-sdk.json && \
     for i in remove-chef.sh sdk-cleanup.sh apt-cleanup.sh ; do /tmp/scripts/$i ; done && \
     rm -rf /root/.m2 /var/cache/debconf/*-old /usr/share/{doc,man} /tmp/scripts /tmp/files \
-    /usr/share/locale/{a,b,c,d,e{l,o,s,t,u},f,g,h,i,j,k,lt,lv,m,n,o,p,r,s,t,u,v,w,x,z}*
+      /var/lib/apt/lists/* \
+      /usr/share/locale/{a,b,c,d,e{l,o,s,t,u},f,g,h,i,j,k,lt,lv,m,n,o,p,r,s,t,u,v,w,x,z}*
+
+ENV PATH /opt/cdap/sdk/bin:${PATH}
+
+# Copy entrypoint
+COPY docker-entrypoint.sh /
 
 # Expose Ports (9999 & 10000 for CDAP)
 EXPOSE 9999 10000
 
 # start CDAP in the background and tail in the foreground
-ENTRYPOINT /opt/cdap/sdk/bin/cdap.sh start && \
-    /usr/bin/tail -F /opt/cdap/sdk/logs/*.log
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["cdap.sh","start","--foreground"]

--- a/cdap-distributions/src/docker-entrypoint.sh
+++ b/cdap-distributions/src/docker-entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Copyright © 2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# Shamelessly "borrowed" from https://github.com/docker-library/elasticsearch :-)
+
+set -e
+
+export PATH=${PATH}:/opt/cdap/sdk/bin
+
+# Add cdap.sh start as command if needed
+if [ "${1:0:1}" = '-' ]; then
+  set -- cdap.sh start --foreground "$@"
+fi
+
+# Drop root privileges if we are running cdap.sh
+# allow the container to be started with `--user`
+if [ "${1}" = 'cdap.sh' -a "$(id -u)" = '0' ]; then
+  # Change the ownership of /opt/cdap/sdk to cdap
+  chown -R cdap:cdap /opt/cdap/sdk
+  set -- gosu cdap "$@"
+fi
+
+# As argument is not related to cdap,
+# then assume that user wants to run his own process,
+# for example a `bash` shell to explore this image
+exec "$@"

--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -60,8 +60,8 @@
     },
     {
       "type": "chef-solo",
-      "remote_cookbook_paths": "/var/chef/cookbooks",
       "install_command": "curl -L https://www.chef.io/chef/install.sh | {{if .Sudo}}sudo{{end}} bash -s -- -v 12.4.3",
+      "remote_cookbook_paths": "/var/chef/cookbooks",
       "pause_before": "10s"
     },
     {

--- a/cdap-distributions/src/packer/scripts/lxde.sh
+++ b/cdap-distributions/src/packer/scripts/lxde.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -15,11 +15,12 @@
 # the License.
 
 #
-# Install and configure fluxbox
+# Install and configure lxde
 #
 
 # Install
-apt-get install -y lxde
+apt-get install -y --no-install-recommends lxde
+apt-get install -y --no-install-recommends chromium-browser
 
 # Symlink idea
 ln -sf /opt/idea* /opt/idea || (echo "Unable to symlink IDEA" && exit 1)
@@ -78,10 +79,34 @@ Icon=cdap
 Categories=GNOME;GTK;Development;
 EOF
 
+# CDAP SDK Menu Entry
+cat > /usr/share/applications/cdap-sdk.desktop << EOF
+[Desktop Entry]
+Encoding=UTF-8
+Name=CDAP SDK
+Comment=CDAP SDK directory
+Exec=xdg-open /opt/cdap/sdk
+Type=Application
+Icon=cdap
+Categories=GNOME;GTK;Development;
+EOF
+
+# CDAP Examples Menu Entry
+cat > /usr/share/applications/cdap-examples.desktop << EOF
+[Desktop Entry]
+Encoding=UTF-8
+Name=CDAP Examples
+Comment=CDAP Examples directory
+Exec=xdg-open /opt/cdap/sdk/examples
+Type=Application
+Icon=cdap
+Categories=GNOME;GTK;Development;
+EOF
+
 # Copy welcome.txt and some icons to the desktop
 mkdir -p ~cdap/Desktop
 cp /etc/welcome.txt ~cdap/Desktop
-for i in cdap-ui cdap-docs eclipse idea lxterminal ; do
+for i in cdap-ui cdap-sdk cdap-examples cdap-docs eclipse idea lxterminal ; do
   cp /usr/share/applications/${i}.desktop ~cdap/Desktop
 done
 

--- a/cdap-distributions/src/packer/scripts/random-root-password.sh
+++ b/cdap-distributions/src/packer/scripts/random-root-password.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -19,7 +19,7 @@
 #
 
 # Install apg
-apt-get install -y apg
+apt-get install -y --no-install-recommends apg
 
 # Setup cdap for sudo
 usermod -G sudo,adm,cdrom,dip,plugdev,lpadmin,sambashare cdap

--- a/cdap-distributions/src/packer/scripts/sdk-cleanup.sh
+++ b/cdap-distributions/src/packer/scripts/sdk-cleanup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -21,8 +21,8 @@
 # Stop SDK
 /etc/init.d/cdap-sdk stop
 
-# Remove conf, data, and logs directories
-rm -rf /opt/cdap/conf /opt/cdap/sdk/data /opt/cdap/sdk/logs
+# Remove data and logs directories
+rm -rf /opt/cdap/sdk/data /opt/cdap/sdk/logs
 
 # Make cdap own /opt/cdap
 chown -R cdap:cdap /opt/cdap

--- a/cdap-distributions/src/packer/scripts/slim.sh
+++ b/cdap-distributions/src/packer/scripts/slim.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -19,7 +19,7 @@
 #
 
 # Install
-apt-get install -y slim
+apt-get install -y --no-install-recommends slim
 
 # Global configuration and auto-login
 echo 'sessiondir /usr/share/xsessions/' >> /etc/slim.conf

--- a/cdap-distributions/src/packer/scripts/xorg.sh
+++ b/cdap-distributions/src/packer/scripts/xorg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -19,7 +19,7 @@
 #
 
 # Install xorg
-apt-get install -y xorg
+apt-get install -y --no-install-recommends xorg
 
 # Remove X11 video drivers
 for i in ati cirrus fbdev intel mach64 mga neomagic nouveau openchrome qxl r128 radeon s3 savage siliconmotion sis sisusb tdfx trident ; do 

--- a/cdap-standalone/bin/cdap.sh
+++ b/cdap-standalone/bin/cdap.sh
@@ -100,7 +100,7 @@ fi
 
 # java version check
 JAVA_VERSION=`$JAVACMD -version 2>&1 | grep "java version" | awk '{print $3}' | awk -F '.' '{print $2}'`
-if [ $JAVA_VERSION -ne 7 ] && [ $JAVA_VERSION -ne 8 ]; then
+if [ ! -z $JAVA_VERSION ] && [ $JAVA_VERSION -ne 7 ] && [ $JAVA_VERSION -ne 8 ]; then
   die "ERROR: Java version not supported
 Please install Java 7 or 8 - other versions of Java are not supported."
 fi
@@ -208,6 +208,7 @@ rotate_log () {
 }
 
 start() {
+    foreground=$1; shift
     debug=$1; shift
     port=$1; shift
 
@@ -218,37 +219,49 @@ start() {
     rotate_log "$APP_HOME/logs/cdap-debug.log"
 
     if test -e /proc/1/cgroup && grep docker /proc/1/cgroup 2>&1 >/dev/null; then
-        ROUTER_OPTS="-Drouter.address=`hostname -i`"
+        if $foreground; then
+            echo "Docker detected, running in the foreground with output to STDOUT"
+        else
+            echo "WARN: Docker detected, but running in the background! This may fail!"
+        fi
+        ROUTER_OPTS="-Drouter.address=`hostname -i`" # -i is safe here since we know we're on Linux
     fi
 
-    nohup nice -1 "$JAVACMD" "${JVM_OPTS[@]}" ${ROUTER_OPTS} -classpath "$CLASSPATH" co.cask.cdap.StandaloneMain >> \
-        "$APP_HOME/logs/cdap.log" 2>&1 < /dev/null &
-    echo $! > $pid
+    if $foreground; then
+        nice -1 "${JAVACMD}" ${JVM_OPTS[@]} ${ROUTER_OPTS} -classpath "${CLASSPATH}" co.cask.cdap.StandaloneMain \
+              | tee -a "${APP_HOME}"/logs/cdap.log
+        ret=$?
+        return ${ret}
+    else
+        nohup nice -1 "${JAVACMD}" ${JVM_OPTS[@]} ${ROUTER_OPTS} -classpath "${CLASSPATH}" co.cask.cdap.StandaloneMain \
+              2>&1 < /dev/null >> "${APP_HOME}"/logs/cdap.log &
+        background_process=$!
+        echo $background_process > $pid
 
-    echo -n "Starting Standalone CDAP ..."
+        echo -n "Starting Standalone CDAP ..."
 
-    background_process=$!
-    while kill -0 $background_process >/dev/null 2>/dev/null ; do
-      if grep '..* started successfully' "$APP_HOME/logs/cdap.log" > /dev/null 2>&1; then
-        if $debug ; then
-          echo; echo "Remote debugger agent started on port $port."
-        else
-          echo
+        while kill -0 $background_process >/dev/null 2>/dev/null ; do
+          if grep '..* started successfully' "$APP_HOME/logs/cdap.log" > /dev/null 2>&1; then
+            if $debug ; then
+              echo; echo "Remote debugger agent started on port $port."
+            else
+              echo
+            fi
+            grep -A 1 '..* started successfully' "$APP_HOME/logs/cdap.log"
+            break
+          elif grep 'Failed to start server' "$APP_HOME/logs/cdap.log" > /dev/null 2>&1; then
+            echo; echo "Failed to start server"
+            stop
+            break
+          else
+            echo -n "."
+            sleep 1;
+          fi
+        done
+        echo
+        if ! kill -s 0 $background_process 2>/dev/null >/dev/null; then
+          echo "Failed to start, please check logs for more information."
         fi
-        grep -A 1 '..* started successfully' "$APP_HOME/logs/cdap.log"
-        break
-      elif grep 'Failed to start server' "$APP_HOME/logs/cdap.log" > /dev/null 2>&1; then
-        echo; echo "Failed to start server"
-        stop
-        break
-      else
-        echo -n "."
-        sleep 1;
-      fi
-    done
-    echo
-    if ! kill -s 0 $background_process 2>/dev/null >/dev/null; then
-      echo "Failed to start, please check logs for more information."
     fi
 }
 
@@ -277,7 +290,7 @@ stop() {
 
 restart() {
     stop
-    start $1 $2
+    start $*
 }
 
 status() {
@@ -301,10 +314,12 @@ case "$1" in
   start|restart)
     command=$1; shift
     debug=false
+    foreground=false
     while [ $# -gt 0 ]
     do
       case "$1" in
         --enable-debug) shift; debug=true; port=$1; shift;;
+        --foreground) shift; foreground=true;;
         *) shift; break;;
       esac
     done
@@ -313,13 +328,13 @@ case "$1" in
       if [ -z "$port" ]; then
         port=5005
       elif [ -n "${port##+([0-9])}" ]; then
-        die "port number must be an integer.";
+        die "port number must be an integer."
       elif [ $port -lt 1024 ] || [ $port -gt 65535 ]; then
-        die "port number must be between 1024 and 65535.";
+        die "port number must be between 1024 and 65535."
       fi
       CDAP_OPTS="${CDAP_OPTS} -agentlib:jdwp=transport=dt_socket,address=localhost:$port,server=y,suspend=n"
     fi
-    $command $debug $port
+    $command $foreground $debug $port
   ;;
 
   stop)


### PR DESCRIPTION
This is a copy of `Dockerfile`, `docker-entrypoint.sh`, `packer`, and `cdap.sh` changes to support foreground operation, used by the ENTRYPOINT script.

Build (cloned from CDAP-BUT35):
http://builds.cask.co/browse/CDAP-BDV1-1
