### PR TITLE
CDAP-7108 Disable 'Constants.Explore.START_ON_DEMAND' for now.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/AbstractStorageProviderNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/AbstractStorageProviderNamespaceAdmin.java
@@ -57,7 +57,7 @@ abstract class AbstractStorageProviderNamespaceAdmin implements StorageProviderN
   }
 
   /**
-   * Create a namespace in the File System and Hive. The hive database is only created for non-default namespaces.
+   * Create a namespace in the File System and Hive.
    *
    * @param namespaceMeta {@link NamespaceMeta} for the namespace to create
    * @throws IOException if there are errors while creating the namespace in the File System
@@ -69,9 +69,7 @@ abstract class AbstractStorageProviderNamespaceAdmin implements StorageProviderN
 
     createLocation(namespaceMeta);
 
-    // only create non-default namespaces in Hive
-    if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED) &&
-      !NamespaceId.DEFAULT.equals(namespaceMeta.getNamespaceId())) {
+    if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED)) {
       try {
         exploreFacade.createNamespace(namespaceMeta);
       } catch (ExploreException | SQLException e) {
@@ -95,7 +93,7 @@ abstract class AbstractStorageProviderNamespaceAdmin implements StorageProviderN
 
     deleteLocation(namespaceId);
 
-    if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED) && !NamespaceId.DEFAULT.equals(namespaceId)) {
+    if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED)) {
       exploreFacade.removeNamespace(namespaceId.toId());
     }
   }

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/QueryClientTest.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/QueryClientTest.java
@@ -49,8 +49,7 @@ import java.util.concurrent.ExecutionException;
 public class QueryClientTest extends AbstractClientTest {
 
   @ClassRule
-  public static final SingletonExternalResource STANDALONE = new SingletonExternalResource(
-    new StandaloneTester(Constants.Explore.EXPLORE_ENABLED, true));
+  public static final SingletonExternalResource STANDALONE = new SingletonExternalResource(new StandaloneTester());
 
   private static final Logger LOG = LoggerFactory.getLogger(QueryClientTest.class);
 

--- a/cdap-standalone/src/test/java/co/cask/cdap/StandaloneTester.java
+++ b/cdap-standalone/src/test/java/co/cask/cdap/StandaloneTester.java
@@ -73,7 +73,7 @@ public class StandaloneTester extends ExternalResource {
     cConf.setInt(Constants.Router.ROUTER_PORT, Networks.getRandomPort());
     cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, true);
     cConf.setBoolean(Constants.Explore.EXPLORE_ENABLED, true);
-    cConf.setBoolean(Constants.Explore.START_ON_DEMAND, true);
+    cConf.setBoolean(Constants.Explore.START_ON_DEMAND, false);
     cConf.setBoolean(StandaloneMain.DISABLE_UI, true);
     cConf.setBoolean(Constants.Audit.ENABLED, false);
 

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -367,7 +367,7 @@ public class TestBase {
 
     // Setup defaults that can be overridden by user
     cConf.setBoolean(Constants.Explore.EXPLORE_ENABLED, true);
-    cConf.setBoolean(Constants.Explore.START_ON_DEMAND, true);
+    cConf.setBoolean(Constants.Explore.START_ON_DEMAND, false);
 
     // Setup test case specific configurations.
     // The system properties are usually setup by TestConfiguration class using @ClassRule


### PR DESCRIPTION
CDAP-7108 Disable 'Constants.Explore.START_ON_DEMAND' for now.
This will make the entire test suite slower, but more stable.

Filed a JIRA to investigate the flakiness caused by START_ON_DEMAND later:
https://issues.cask.co/browse/CDAP-7108

Also, revert some of the logic introduced in https://github.com/caskdata/cdap/pull/6441 to skip explore operations for default ns. This is already handled in BaseHiveExploreService.

http://builds.cask.co/browse/CDAP-RUT121-1
