### PR TITLE
Minor documentation fixes

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-data-pipeline-plugins-archetype/src/main/resources/archetype-resources/README.md
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-data-pipeline-plugins-archetype/src/main/resources/archetype-resources/README.md
@@ -1,8 +1,8 @@
 Build
 -----
-To build your plugins::
+To build your plugins:
 
-  mvn clean package -DskipTests
+    mvn clean package -DskipTests
 
 The build will create a .jar and .json file under the ``target`` directory.
 These files can be used to deploy your plugins.
@@ -12,8 +12,10 @@ UI Integration
 The Cask Hydrator UI displays each plugin property as a simple textbox. To customize how the plugin properties
 are displayed in the UI, you can place a configuration file in the ``widgets`` directory.
 The file must be named following a convention of ``[plugin-name]-[plugin-type].json``.
-See [Plugin Widget Configuration](http://docs.cdap.io/cdap/current/en/cdap-apps/hydrator/custom.html#plugin-configuration-json)
+
+See [Plugin Widget Configuration](http://docs.cdap.io/cdap/current/en/hydrator-manual/developing-plugins/packaging-plugins.html#plugin-widget-json)
 for details on the configuration file.
+
 The UI will also display a reference doc for your plugin if you place a file in the ``docs`` directory
 that follows the convention of ``[plugin-name]-[plugin-type].md``.
 
@@ -23,10 +25,10 @@ plugins to CDAP.
 
 Deployment
 ----------
-You can deploy your plugins using the CDAP CLI::
+You can deploy your plugins using the CDAP CLI:
 
-  > load artifact <target/plugin.jar> config-file <target/plugin.json>
+    > load artifact <target/plugin.jar> config-file <target/plugin.json>
 
-For example, if your artifact is named 'my-plugins-1.0.0'::
+For example, if your artifact is named 'my-plugins-1.0.0':
 
-  > load artifact target/my-plugins-1.0.0.jar config-file target/my-plugins-1.0.0.json
+    > load artifact target/my-plugins-1.0.0.jar config-file target/my-plugins-1.0.0.json

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-sink-archetype/src/main/resources/archetype-resources/README.md
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-sink-archetype/src/main/resources/archetype-resources/README.md
@@ -1,8 +1,8 @@
 Build
 -----
-To build your plugins::
+To build your plugins:
 
-  mvn clean package -DskipTests
+    mvn clean package -DskipTests
 
 The build will create a .jar and .json file under the ``target`` directory.
 These files can be used to deploy your plugins.
@@ -12,8 +12,10 @@ UI Integration
 The Cask Hydrator UI displays each plugin property as a simple textbox. To customize how the plugin properties
 are displayed in the UI, you can place a configuration file in the ``widgets`` directory.
 The file must be named following a convention of ``[plugin-name]-[plugin-type].json``.
-See [Plugin Widget Configuration](http://docs.cdap.io/cdap/current/en/cdap-apps/hydrator/custom.html#plugin-configuration-json)
+
+See [Plugin Widget Configuration](http://docs.cdap.io/cdap/current/en/hydrator-manual/developing-plugins/packaging-plugins.html#plugin-widget-json)
 for details on the configuration file.
+
 The UI will also display a reference doc for your plugin if you place a file in the ``docs`` directory
 that follows the convention of ``[plugin-name]-[plugin-type].md``.
 
@@ -23,10 +25,10 @@ plugins to CDAP.
 
 Deployment
 ----------
-You can deploy your plugins using the CDAP CLI::
+You can deploy your plugins using the CDAP CLI:
 
-  > load artifact <target/plugin.jar> config-file <target/plugin.json>
+    > load artifact <target/plugin.jar> config-file <target/plugin.json>
 
-For example, if your artifact is named 'my-plugins-1.0.0'::
+For example, if your artifact is named 'my-plugins-1.0.0':
 
-  > load artifact target/my-plugins-1.0.0.jar config-file target/my-plugins-1.0.0.json
+    > load artifact target/my-plugins-1.0.0.jar config-file target/my-plugins-1.0.0.json

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-source-archetype/src/main/resources/archetype-resources/README.md
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-batch-source-archetype/src/main/resources/archetype-resources/README.md
@@ -1,8 +1,8 @@
 Build
 -----
-To build your plugins::
+To build your plugins:
 
-  mvn clean package -DskipTests
+    mvn clean package -DskipTests
 
 The build will create a .jar and .json file under the ``target`` directory.
 These files can be used to deploy your plugins.
@@ -12,8 +12,10 @@ UI Integration
 The Cask Hydrator UI displays each plugin property as a simple textbox. To customize how the plugin properties
 are displayed in the UI, you can place a configuration file in the ``widgets`` directory.
 The file must be named following a convention of ``[plugin-name]-[plugin-type].json``.
-See [Plugin Widget Configuration](http://docs.cdap.io/cdap/current/en/cdap-apps/hydrator/custom.html#plugin-configuration-json)
+
+See [Plugin Widget Configuration](http://docs.cdap.io/cdap/current/en/hydrator-manual/developing-plugins/packaging-plugins.html#plugin-widget-json)
 for details on the configuration file.
+
 The UI will also display a reference doc for your plugin if you place a file in the ``docs`` directory
 that follows the convention of ``[plugin-name]-[plugin-type].md``.
 
@@ -23,10 +25,10 @@ plugins to CDAP.
 
 Deployment
 ----------
-You can deploy your plugins using the CDAP CLI::
+You can deploy your plugins using the CDAP CLI:
 
-  > load artifact <target/plugin.jar> config-file <target/plugin.json>
+    > load artifact <target/plugin.jar> config-file <target/plugin.json>
 
-For example, if your artifact is named 'my-plugins-1.0.0'::
+For example, if your artifact is named 'my-plugins-1.0.0':
 
-  > load artifact target/my-plugins-1.0.0.jar config-file target/my-plugins-1.0.0.json
+    > load artifact target/my-plugins-1.0.0.jar config-file target/my-plugins-1.0.0.json

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-sink-archetype/src/main/resources/archetype-resources/README.md
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-sink-archetype/src/main/resources/archetype-resources/README.md
@@ -1,8 +1,8 @@
 Build
 -----
-To build your plugins::
+To build your plugins:
 
-  mvn clean package -DskipTests
+    mvn clean package -DskipTests
 
 The build will create a .jar and .json file under the ``target`` directory.
 These files can be used to deploy your plugins.
@@ -12,8 +12,10 @@ UI Integration
 The Cask Hydrator UI displays each plugin property as a simple textbox. To customize how the plugin properties
 are displayed in the UI, you can place a configuration file in the ``widgets`` directory.
 The file must be named following a convention of ``[plugin-name]-[plugin-type].json``.
-See [Plugin Widget Configuration](http://docs.cdap.io/cdap/current/en/cdap-apps/hydrator/custom.html#plugin-configuration-json)
+
+See [Plugin Widget Configuration](http://docs.cdap.io/cdap/current/en/hydrator-manual/developing-plugins/packaging-plugins.html#plugin-widget-json)
 for details on the configuration file.
+
 The UI will also display a reference doc for your plugin if you place a file in the ``docs`` directory
 that follows the convention of ``[plugin-name]-[plugin-type].md``.
 
@@ -23,10 +25,10 @@ plugins to CDAP.
 
 Deployment
 ----------
-You can deploy your plugins using the CDAP CLI::
+You can deploy your plugins using the CDAP CLI:
 
-  > load artifact <target/plugin.jar> config-file <target/plugin.json>
+    > load artifact <target/plugin.jar> config-file <target/plugin.json>
 
-For example, if your artifact is named 'my-plugins-1.0.0'::
+For example, if your artifact is named 'my-plugins-1.0.0':
 
-  > load artifact target/my-plugins-1.0.0.jar config-file target/my-plugins-1.0.0.json
+    > load artifact target/my-plugins-1.0.0.jar config-file target/my-plugins-1.0.0.json

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-source-archetype/src/main/resources/archetype-resources/README.md
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-realtime-source-archetype/src/main/resources/archetype-resources/README.md
@@ -1,8 +1,8 @@
 Build
 -----
-To build your plugins::
+To build your plugins:
 
-  mvn clean package -DskipTests
+    mvn clean package -DskipTests
 
 The build will create a .jar and .json file under the ``target`` directory.
 These files can be used to deploy your plugins.
@@ -12,8 +12,10 @@ UI Integration
 The Cask Hydrator UI displays each plugin property as a simple textbox. To customize how the plugin properties
 are displayed in the UI, you can place a configuration file in the ``widgets`` directory.
 The file must be named following a convention of ``[plugin-name]-[plugin-type].json``.
-See [Plugin Widget Configuration](http://docs.cdap.io/cdap/current/en/cdap-apps/hydrator/custom.html#plugin-configuration-json)
+
+See [Plugin Widget Configuration](http://docs.cdap.io/cdap/current/en/hydrator-manual/developing-plugins/packaging-plugins.html#plugin-widget-json)
 for details on the configuration file.
+
 The UI will also display a reference doc for your plugin if you place a file in the ``docs`` directory
 that follows the convention of ``[plugin-name]-[plugin-type].md``.
 
@@ -23,10 +25,10 @@ plugins to CDAP.
 
 Deployment
 ----------
-You can deploy your plugins using the CDAP CLI::
+You can deploy your plugins using the CDAP CLI:
 
-  > load artifact <target/plugin.jar> config-file <target/plugin.json>
+    > load artifact <target/plugin.jar> config-file <target/plugin.json>
 
-For example, if your artifact is named 'my-plugins-1.0.0'::
+For example, if your artifact is named 'my-plugins-1.0.0':
 
-  > load artifact target/my-plugins-1.0.0.jar config-file target/my-plugins-1.0.0.json
+    > load artifact target/my-plugins-1.0.0.jar config-file target/my-plugins-1.0.0.json

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-transform-archetype/src/main/resources/archetype-resources/README.md
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-etl-transform-archetype/src/main/resources/archetype-resources/README.md
@@ -1,8 +1,8 @@
 Build
 -----
-To build your plugins::
+To build your plugins:
 
-  mvn clean package -DskipTests
+    mvn clean package -DskipTests
 
 The build will create a .jar and .json file under the ``target`` directory.
 These files can be used to deploy your plugins.
@@ -12,8 +12,10 @@ UI Integration
 The Cask Hydrator UI displays each plugin property as a simple textbox. To customize how the plugin properties
 are displayed in the UI, you can place a configuration file in the ``widgets`` directory.
 The file must be named following a convention of ``[plugin-name]-[plugin-type].json``.
-See [Plugin Widget Configuration](http://docs.cdap.io/cdap/current/en/cdap-apps/hydrator/custom.html#plugin-configuration-json)
+
+See [Plugin Widget Configuration](http://docs.cdap.io/cdap/current/en/hydrator-manual/developing-plugins/packaging-plugins.html#plugin-widget-json)
 for details on the configuration file.
+
 The UI will also display a reference doc for your plugin if you place a file in the ``docs`` directory
 that follows the convention of ``[plugin-name]-[plugin-type].md``.
 
@@ -23,10 +25,10 @@ plugins to CDAP.
 
 Deployment
 ----------
-You can deploy your plugins using the CDAP CLI::
+You can deploy your plugins using the CDAP CLI:
 
-  > load artifact <target/plugin.jar> config-file <target/plugin.json>
+    > load artifact <target/plugin.jar> config-file <target/plugin.json>
 
-For example, if your artifact is named 'my-plugins-1.0.0'::
+For example, if your artifact is named 'my-plugins-1.0.0':
 
-  > load artifact target/my-plugins-1.0.0.jar config-file target/my-plugins-1.0.0.json
+    > load artifact target/my-plugins-1.0.0.jar config-file target/my-plugins-1.0.0.json

--- a/cdap-docs/admin-manual/source/conf.py
+++ b/cdap-docs/admin-manual/source/conf.py
@@ -12,3 +12,9 @@ sys.path.insert(0, os.path.abspath('../../_common'))
 from common_conf import * 
 
 html_short_title_toc, html_short_title, html_context = set_conf_for_manual()
+
+if release:
+    rst_epilog += """
+.. |literal-Wordcount-release-jar| replace:: ``WordCount-%(release)s.jar``
+
+""" % {'release': release}

--- a/cdap-docs/admin-manual/source/verification.rst
+++ b/cdap-docs/admin-manual/source/verification.rst
@@ -21,7 +21,7 @@ convenience.
 #. Open a web browser to the CDAP UI.
    It is located on port ``9999`` of the box where you installed the CDAP UI service.
 #. On the UI, click the button *Add App*.
-#. Find the pre-built ``WordCount-``\ |literal-release|\ ``.jar`` using the dialog box to navigate to
+#. Find the pre-built |literal-Wordcount-release-jar| using the dialog box to navigate to
    ``CDAP_HOME/examples/WordCount/target/``. 
 #. Once the application is deployed, instructions on running the example can be found at the
    :ref:`WordCount example <examples-word-count>`.

--- a/cdap-docs/developers-manual/source/building-blocks/workers.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/workers.rst
@@ -125,7 +125,7 @@ When uploading events in batch, there are two options: either uploading a ``File
 through a ``StreamBatchWriter``. In batch mode, the content type of the data must be specified. Refer
 to the :ref:`Stream RESTful API <http-restful-api-stream>` for information on the content type specification.
 
-With a ``StreamBatchWriter``, the ``close`` method` needs to be called after all the writes have been performed::
+With a ``StreamBatchWriter``, the ``close`` method needs to be called after all the writes have been performed::
 
   @Override
   public void run() {


### PR DESCRIPTION
Remove extraneous apostrophe.
Fixes formatting and broken link in the archetype Markdown files.
Fixes formatting of an example file version (removes spaces in the middle
that should not have been there.)

Running as [Quick Build 1](http://builds.cask.co/browse/CDAP-DQB82-1)
