### PR TITLE
(CDAP-7107) Propagate user-id from ExploreClient -> ExploreService ->…

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
@@ -199,7 +199,7 @@ public class DatasetInstanceService {
    * @param instance the id of the dataset
    * @return The original properties as stored in the dataset's spec, or if they are not available, a best effort
    *   to derive the original properties from the top-level properties of the spec
-   * @throws UnauthorizedException if permimeter security and authorization are enabled, and the current user does not
+   * @throws UnauthorizedException if perimeter security and authorization are enabled, and the current user does not
    *   have any privileges on the #instance
    */
   Map<String, String> getOriginalProperties(Id.DatasetInstance instance) throws Exception {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/LocalDatasetOpExecutor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/LocalDatasetOpExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,8 @@
 package co.cask.cdap.data2.datafabric.dataset.service.executor;
 
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.security.spi.authentication.AuthenticationContext;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.slf4j.Logger;
@@ -31,10 +33,12 @@ public class LocalDatasetOpExecutor extends RemoteDatasetOpExecutor {
   private final DatasetOpExecutorService executorServer;
 
   @Inject
+  @VisibleForTesting
   public LocalDatasetOpExecutor(CConfiguration cConf,
                                 DiscoveryServiceClient discoveryClient,
-                                DatasetOpExecutorService executorServer) {
-    super(cConf, discoveryClient);
+                                DatasetOpExecutorService executorServer,
+                                AuthenticationContext authenticationContext) {
+    super(cConf, discoveryClient, authenticationContext);
     this.executorServer = executorServer;
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/YarnDatasetOpExecutor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/YarnDatasetOpExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,7 @@
 package co.cask.cdap.data2.datafabric.dataset.service.executor;
 
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import com.google.inject.Inject;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
@@ -30,8 +31,9 @@ import org.apache.twill.discovery.DiscoveryServiceClient;
 public class YarnDatasetOpExecutor extends RemoteDatasetOpExecutor {
 
   @Inject
-  public YarnDatasetOpExecutor(CConfiguration cConf, DiscoveryServiceClient discoveryClient) {
-    super(cConf, discoveryClient);
+  YarnDatasetOpExecutor(CConfiguration cConf, DiscoveryServiceClient discoveryClient,
+                        AuthenticationContext authenticationContext) {
+    super(cConf, discoveryClient, authenticationContext);
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -163,7 +163,8 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
 
     InMemoryDatasetFramework mdsFramework = new InMemoryDatasetFramework(registryFactory, modules);
 
-    ExploreFacade exploreFacade = new ExploreFacade(new DiscoveryExploreClient(cConf, discoveryServiceClient), cConf);
+    DiscoveryExploreClient exploreClient = new DiscoveryExploreClient(discoveryServiceClient, authenticationContext);
+    ExploreFacade exploreFacade = new ExploreFacade(exploreClient, cConf);
     TransactionExecutorFactory txExecutorFactory = new DynamicTransactionExecutorFactory(txSystemClient);
     AuthorizationEnforcer authorizationEnforcer = injector.getInstance(AuthorizationEnforcer.class);
 
@@ -177,7 +178,8 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
                                                             authenticationContext, cConf, impersonator,
                                                             txSystemClientService, mdsFramework, txExecutorFactory,
                                                             DEFAULT_MODULES);
-    DatasetOpExecutor opExecutor = new LocalDatasetOpExecutor(cConf, discoveryServiceClient, opExecutorService);
+    DatasetOpExecutor opExecutor = new LocalDatasetOpExecutor(cConf, discoveryServiceClient, opExecutorService,
+                                                              authenticationContext);
     DatasetInstanceService instanceService = new DatasetInstanceService(
       typeService, instanceManager, opExecutor, exploreFacade, namespaceQueryAdmin, authorizationEnforcer,
       privilegesManager, authenticationContext);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -216,7 +216,8 @@ public abstract class DatasetServiceTestBase {
     registryFactory = injector.getInstance(DatasetDefinitionRegistryFactory.class);
     inMemoryDatasetFramework = new InMemoryDatasetFramework(registryFactory, modules);
 
-    ExploreFacade exploreFacade = new ExploreFacade(new DiscoveryExploreClient(cConf, discoveryServiceClient), cConf);
+    DiscoveryExploreClient exploreClient = new DiscoveryExploreClient(discoveryServiceClient, authenticationContext);
+    ExploreFacade exploreFacade = new ExploreFacade(exploreClient, cConf);
     namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
     namespaceAdmin.create(NamespaceMeta.DEFAULT);
     NamespaceQueryAdmin namespaceQueryAdmin = injector.getInstance(NamespaceQueryAdmin.class);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/PartitionCorrectorTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/PartitionCorrectorTestRun.java
@@ -111,6 +111,4 @@ public class PartitionCorrectorTestRun extends TestFrameworkTestBase {
     output.addPartition();
     tpfsManager.flush();
   }
-
-
 }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/security/PartitionTestApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/security/PartitionTestApp.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security;
+
+import co.cask.cdap.api.annotation.UseDataSet;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.lib.PartitionDetail;
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.api.dataset.lib.PartitionOutput;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
+import co.cask.cdap.api.dataset.lib.Partitioning;
+import co.cask.cdap.api.service.AbstractService;
+import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
+import co.cask.cdap.api.service.http.HttpServiceRequest;
+import co.cask.cdap.api.service.http.HttpServiceResponder;
+import com.google.common.base.Charsets;
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
+import org.apache.twill.filesystem.Location;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * App to test partition creation/deletion from programs
+ */
+public class PartitionTestApp extends AbstractApplication {
+  public static final String PFS_NAME = "pfs";
+  public static final String PFS_SERVICE_NAME = "PartitionService";
+
+  @Override
+  public void configure() {
+    addService(new PartitionService());
+    // Create a partitioned file set, configure it to work with MapReduce and with Explore
+    createDataset("pfs", PartitionedFileSet.class, PartitionedFileSetProperties.builder()
+      // Properties for partitioning
+      .setPartitioning(Partitioning.builder().addStringField("partition").addIntField("sub-partition").build())
+      // Properties for file set
+      .setInputFormat(TextInputFormat.class)
+      .setOutputFormat(TextOutputFormat.class)
+      .setOutputProperty(TextOutputFormat.SEPERATOR, ",")
+      // Properties for Explore (to create a partitioned Hive table)
+      .setEnableExploreOnCreate(true)
+      .setExploreFormat("csv")
+      .setExploreSchema("f1 STRING, f2 INT")
+      .setDescription("App for testing authorization in partitioned filesets.")
+      .build());
+  }
+
+  public static class PartitionService extends AbstractService {
+
+    @Override
+    protected void configure() {
+      addHandler(new PartitionHandler());
+    }
+
+    public static class PartitionHandler extends AbstractHttpServiceHandler {
+      @SuppressWarnings("unused")
+      @UseDataSet("pfs")
+      private PartitionedFileSet pfs;
+
+      @POST
+      @Path("partitions/{partition}/subpartitions/{sub-partition}")
+      public void create(HttpServiceRequest request, HttpServiceResponder responder,
+                         @PathParam("partition") String partition, @PathParam("sub-partition") int subPartition) {
+        PartitionKey key = PartitionKey.builder()
+          .addStringField("partition", partition)
+          .addIntField("sub-partition", subPartition)
+          .build();
+
+        if (pfs.getPartition(key) != null) {
+          responder.sendString(409, "Partition exists.", Charsets.UTF_8);
+          return;
+        }
+
+        final PartitionOutput output = pfs.getPartitionOutput(key);
+        try {
+          final Location partitionDir = output.getLocation();
+          if (!partitionDir.mkdirs()) {
+            responder.sendString(409, "Partition exists.", Charsets.UTF_8);
+            return;
+          }
+
+          final Location location = partitionDir.append("file");
+          byte[] content = Bytes.toBytes(request.getContent());
+          if (content == null) {
+            responder.sendString(400, "No content", Charsets.UTF_8);
+            return;
+          }
+          Files.write(Paths.get(location.toURI()), content);
+        } catch (IOException e) {
+          responder.sendError(400, String.format("Unable to write path '%s'. Reason: '%s'",
+                                                 output.getRelativePath(), e.getMessage()));
+          return;
+        }
+
+        output.addPartition();
+        responder.sendString(200, "Successfully added partition", Charsets.UTF_8);
+      }
+
+      @GET
+      @Path("partitions/{partition}/subpartitions/{sub-partition}")
+      public void read(HttpServiceRequest request, HttpServiceResponder responder,
+                       @PathParam("partition") String partition, @PathParam("sub-partition") int subPartition) {
+        PartitionDetail partitionDetail = pfs.getPartition(PartitionKey.builder()
+                                                             .addStringField("partition", partition)
+                                                             .addIntField("sub-partition", subPartition)
+                                                             .build());
+        if (partitionDetail == null) {
+          responder.sendString(404, "Partition not found.", Charsets.UTF_8);
+          return;
+        }
+
+        try {
+          responder.send(200, partitionDetail.getLocation().append("file"), "text/plain");
+        } catch (IOException e) {
+          responder.sendError(400, String.format("Unable to read path '%s'", partitionDetail.getRelativePath()));
+        }
+      }
+
+      @DELETE
+      @Path("partitions/{partition}/subpartitions/{sub-partition}")
+      public void drop(HttpServiceRequest request, HttpServiceResponder responder,
+                         @PathParam("partition") String partition, @PathParam("sub-partition") int subPartition) {
+
+        PartitionKey key = PartitionKey.builder()
+          .addStringField("partition", partition)
+          .addIntField("sub-partition", subPartition)
+          .build();
+
+        if (pfs.getPartition(key) == null) {
+          responder.sendString(404, "Partition not found.", Charsets.UTF_8);
+          return;
+        }
+
+        pfs.dropPartition(key);
+
+        responder.sendString(200, "Successfully dropped partition", Charsets.UTF_8);
+      }
+    }
+  }
+}


### PR DESCRIPTION
… DatasetService while instantiating datasets in Explore service.
- Similarly propagate user-id from RemoteDatasetOpExecutor -> DatasetOpExecutorService.
- Add a unit test for testing authorization while adding/dropping/retrieving partitions of a partitioned fileset from a program (Service).
- Fix DefaultNamespaceAdmin to grant privileges on the user executing programs even if kerberos is disabled.

Jira: [CDAP-7107](https://issues.cask.co/browse/CDAP-7107)
Build: http://builds.cask.co/browse/CDAP-RUT123

Pending one final test on cluster, but it seems like `release/3.5` is broken right now.
