### PR TITLE
Fix broken documentation build and re-write description

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1637,10 +1637,12 @@
     <name>security.authorization.admin.users</name>
     <value></value>
     <description>
-      Determines a comma-separated list of users for whom admin privileges are granted on the CDAP instance
-      during CDAP startup, so these users can create namespaces and in-effect bootstrap CDAP on an authorization
-      enabled cluster. Defaults to empty, in which case no users have access to create namespaces. In this scenario, it
-      may be impossible to bootstrap CDAP, so it is recommended that at least one user be provided as the admin user.
+      A comma-separated list of users for whom admin privileges are to be granted on the
+      CDAP instance during CDAP startup, so these these users can create namespaces, and
+      in effect bootstrap CDAP on an authorization-enabled cluster. The default is empty,
+      in which case no users have access to creating namespaces. In that scenario it may
+      be impossible to bootstrap CDAP, so it is recommended that at least one user be
+      provided as the administrative user.
     </description>
   </property>
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="b505ffb17ac2a2dc01c310fc2febf1c5"
+DEFAULT_XML_MD5_HASH="8281fb006fd03cb8b3368418d6b660b8"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
Update message and update hash.

Edits the description for `security.authorization.admin.users` so that the lines are shorter and the writing tighter.

Passed [Quick Build 1](http://builds.cask.co/browse/CDAP-DQB85-1).
