### PR TITLE
(CDAP-7105) Errors in Spark Java archetype

### DIFF
--- a/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/src/main/java/SparkPageRankApp.java
+++ b/cdap-archetypes/cdap-spark-java-archetype/src/main/resources/archetype-resources/src/main/java/SparkPageRankApp.java
@@ -187,7 +187,8 @@ public class SparkPageRankApp extends AbstractApplication {
 
     @Override
     public void initialize() throws Exception {
-      Job job = getContext().getHadoopJob();
+      MapReduceContext context = getContext();
+      Job job = context.getHadoopJob();
       job.setMapperClass(Emitter.class);
       job.setReducerClass(Counter.class);
       job.setNumReduceTasks(1);


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-7105
Builds: http://builds.cask.co/browse/CDAP-RUT130-1

Installed cdap-spark-java-archetype and cdap-spark-scala-archetype locally and tested using mvn clean package, both builds passed
