### PR TITLE
Grant admin users ADMIN on the default namespace so they can manage p…

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1638,11 +1638,13 @@
     <value></value>
     <description>
       A comma-separated list of users for whom admin privileges are to be granted on the
-      CDAP instance during CDAP startup, so these these users can create namespaces, and
-      in effect bootstrap CDAP on an authorization-enabled cluster. The default is empty,
-      in which case no users have access to creating namespaces. In that scenario it may
-      be impossible to bootstrap CDAP, so it is recommended that at least one user be
-      provided as the administrative user.
+      CDAP instance during CDAP startup, so that these users can create namespaces. These
+      users are also granted admin privileges on the default namespace, so that they can
+      manage privileges on the default namespace. This provides a method to bootstrap CDAP on
+      an authorization-enabled cluster. The default is empty, in which case no users have
+      access to creating namespaces or to managing privileges on the default namespace.
+      In that scenario, authorization in CDAP has to be bootstrapped externally using interfaces
+      provided by the configured authorization extension.
     </description>
   </property>
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="8281fb006fd03cb8b3368418d6b660b8"
+DEFAULT_XML_MD5_HASH="c91fc9b8adb20f3bc52a844c2ab5ca60"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizationBootstrapper.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizationBootstrapper.java
@@ -80,9 +80,11 @@ public class AuthorizationBootstrapper {
       // grant ALL on the system namespace, so the system user can create and access tables in the system namespace
       // also required by SystemArtifactsLoader to add system artifacts
       privilegesManager.grant(NamespaceId.SYSTEM, systemUser, EnumSet.allOf(Action.class));
-      // also grant admin privileges on the CDAP instance to the admin users, so they can create namespaces
       for (Principal adminUser : adminUsers) {
+        // grant admin privileges on the CDAP instance to the admin users, so they can create namespaces
         privilegesManager.grant(instanceId, adminUser, Collections.singleton(Action.ADMIN));
+        // also grant admin on the default namespace, so admins can also manage privileges on them
+        privilegesManager.grant(NamespaceId.DEFAULT, adminUser, Collections.singleton(Action.ADMIN));
       }
       LOG.info("Successfully bootstrapped authorization for CDAP instance {}, system user {} and admin users: {}",
                instanceId, systemUser, adminUsers);


### PR DESCRIPTION
…rivileges on the default namespace from within CDAP

Build: http://builds.cask.co/browse/CDAP-RUT129-1

Note: Without this, no users will have access to the default namespace. No one will be able to grant privileges on the default namespace either. Users can still do this via interfaces exposed by extensions (Hue, Ranger UI in future, etc). They can also choose to completely ignore the default namespace, and operate only in custom namespaces. However, this change is necessary for running integration tests, because currently the integration test framework does not support passing in custom namespaces.
