### PR TITLE
CDAP-6364 Don't initialize LogCallback more than once

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/AbstractChunkedCallback.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/AbstractChunkedCallback.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public abstract class AbstractChunkedCallback implements Callback {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractChunkedCallback.class);
 
+  private final AtomicBoolean initialized = new AtomicBoolean();
   private final AtomicBoolean closed = new AtomicBoolean();
   private final HttpResponder responder;
   private final ByteBuffer chunkBuffer = ByteBuffer.allocate(8 * 1024);
@@ -55,6 +56,10 @@ public abstract class AbstractChunkedCallback implements Callback {
 
   @Override
   public void init() {
+    // if initialized already, then return
+    if (!initialized.compareAndSet(false, true)) {
+      return;
+    }
     chunkResponder = responder.sendChunkStart(HttpResponseStatus.OK, getResponseHeaders());
   }
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandler.java
@@ -123,8 +123,13 @@ public class LogHandler extends AbstractHttpHandler {
       readRange = adjustReadRange(readRange, runRecord, fromTimeSecsParam != -1);
 
       Callback logCallback = getFullLogsCallback(format, responder, fieldsToSuppress, escape);
-      logReader.getLog(loggingContext, readRange.getFromMillis(), readRange.getToMillis(), filter, logCallback);
-      logCallback.close();
+      try {
+        logReader.getLog(loggingContext, readRange.getFromMillis(), readRange.getToMillis(), filter, logCallback);
+      } catch (Exception ex) {
+        LOG.debug("Exception while reading logs for logging context {}", loggingContext, ex);
+      } finally {
+        logCallback.close();
+      }
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
     } catch (IllegalArgumentException e) {
@@ -175,8 +180,13 @@ public class LogHandler extends AbstractHttpHandler {
       LogOffset logOffset = FormattedTextLogEvent.parseLogOffset(fromOffsetStr);
       ReadRange readRange = ReadRange.createFromRange(logOffset);
       readRange = adjustReadRange(readRange, runRecord, true);
-      logReader.getLogNext(loggingContext, readRange, maxEvents, filter, logCallback);
-      logCallback.close();
+      try {
+        logReader.getLogNext(loggingContext, readRange, maxEvents, filter, logCallback);
+      } catch (Exception ex) {
+        LOG.debug("Exception while reading logs for logging context {}", loggingContext, ex);
+      } finally {
+        logCallback.close();
+      }
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
     } catch (IllegalArgumentException e) {
@@ -267,8 +277,13 @@ public class LogHandler extends AbstractHttpHandler {
       LogOffset logOffset = FormattedTextLogEvent.parseLogOffset(fromOffsetStr);
       ReadRange readRange = ReadRange.createToRange(logOffset);
       readRange = adjustReadRange(readRange, runRecord, true);
-      logReader.getLogPrev(loggingContext, readRange, maxEvents, filter, logCallback);
-      logCallback.close();
+      try {
+        logReader.getLogPrev(loggingContext, readRange, maxEvents, filter, logCallback);
+      } catch (Exception ex) {
+        LOG.debug("Exception while reading logs for logging context {}", loggingContext, ex);
+      } finally {
+        logCallback.close();
+      }
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
     } catch (IllegalArgumentException e) {
@@ -296,8 +311,13 @@ public class LogHandler extends AbstractHttpHandler {
       LoggingContext loggingContext = LoggingContextHelper.getLoggingContext(Id.Namespace.SYSTEM.getId(), componentId,
                                                                              serviceId);
       Callback logCallback = getFullLogsCallback(format, responder, suppress, escape);
-      logReader.getLog(loggingContext, timeRange.getFromMillis(), timeRange.getToMillis(), filter, logCallback);
-      logCallback.close();
+      try {
+        logReader.getLog(loggingContext, timeRange.getFromMillis(), timeRange.getToMillis(), filter, logCallback);
+      } catch (Exception ex) {
+        LOG.debug("Exception while reading logs for logging context {}", loggingContext, ex);
+      } finally {
+        logCallback.close();
+      }
     } catch (IllegalArgumentException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
     }
@@ -319,8 +339,13 @@ public class LogHandler extends AbstractHttpHandler {
       Callback logCallback = getNextOrPrevLogsCallback(format, responder, suppress, escape);
       LogOffset logOffset = FormattedTextLogEvent.parseLogOffset(fromOffsetStr);
       ReadRange readRange = ReadRange.createFromRange(logOffset);
-      logReader.getLogNext(loggingContext, readRange, maxEvents, filter, logCallback);
-      logCallback.close();
+      try {
+        logReader.getLogNext(loggingContext, readRange, maxEvents, filter, logCallback);
+      } catch (Exception ex) {
+        LOG.debug("Exception while reading logs for logging context {}", loggingContext, ex);
+      } finally {
+        logCallback.close();
+      }
     } catch (IllegalArgumentException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
     }
@@ -342,8 +367,13 @@ public class LogHandler extends AbstractHttpHandler {
       Callback logCallback = getNextOrPrevLogsCallback(format, responder, suppress, escape);
       LogOffset logOffset = FormattedTextLogEvent.parseLogOffset(fromOffsetStr);
       ReadRange readRange = ReadRange.createToRange(logOffset);
-      logReader.getLogPrev(loggingContext, readRange, maxEvents, filter, logCallback);
-      logCallback.close();
+      try {
+        logReader.getLogPrev(loggingContext, readRange, maxEvents, filter, logCallback);
+      } catch (Exception ex) {
+        LOG.debug("Exception while reading logs for logging context {}", loggingContext, ex);
+      } finally {
+        logCallback.close();
+      }
     } catch (IllegalArgumentException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
     }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/DistributedLogReader.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/DistributedLogReader.java
@@ -55,7 +55,7 @@ public final class DistributedLogReader implements LogReader {
 
   @Override
   public void getLogNext(final LoggingContext loggingContext, final ReadRange readRange, final int maxEvents,
-                              final Filter filter, final Callback callback) {
+                         final Filter filter, final Callback callback) {
     // If latest logs are not requested, try reading from file.
     if (readRange != ReadRange.LATEST) {
       long checkpointTime = getCheckpointTime(loggingContext);


### PR DESCRIPTION
And also close the callback in case of any exception in logReader

JIRA : https://issues.cask.co/browse/CDAP-6364
Build : http://builds.cask.co/browse/CDAP-RUT131-1

Fix tested on a cluster
