### PR TITLE
CDAP-7113 Close log files after some duration.

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/LoggingConfiguration.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/LoggingConfiguration.java
@@ -39,6 +39,7 @@ public final class LoggingConfiguration {
   public static final String LOG_SAVER_EVENT_BUCKET_INTERVAL_MS = "log.saver.event.bucket.interval.ms";
   public static final String LOG_SAVER_MAXIMUM_INMEMORY_EVENT_BUCKETS = "log.saver.event.max.inmemory.buckets";
   public static final String LOG_SAVER_INACTIVE_FILE_INTERVAL_MS = "log.saver.inactive.file.interval.ms";
+  public static final String LOG_SAVER_MAX_FILE_LIFETIME = "log.saver.max.file.lifetime.ms";
   public static final String LOG_SAVER_CHECKPOINT_INTERVAL_MS = "log.saver.checkpoint.interval.ms";
   public static final String LOG_SAVER_TOPIC_WAIT_SLEEP_MS = "log.saver.topic.wait.sleep.ms";
   public static final String LOG_RETENTION_DURATION_DAYS = "log.retention.duration.days";
@@ -59,7 +60,7 @@ public final class LoggingConfiguration {
 
   public static final long DEFAULT_LOG_SAVER_EVENT_BUCKET_INTERVAL_MS = 1 * 1000;
   public static final long DEFAULT_LOG_SAVER_MAXIMUM_INMEMORY_EVENT_BUCKETS = 4;
-  public static final long DEFAULT_LOG_SAVER_INACTIVE_FILE_INTERVAL_MS = 60 * 60 * 1000;
+  public static final long DEFAULT_LOG_SAVER_MAX_FILE_LIFETIME_MS = TimeUnit.HOURS.toMillis(6);
   public static final long DEFAULT_LOG_SAVER_CHECKPOINT_INTERVAL_MS = 60 * 1000;
   public static final long DEFAULT_LOG_RETENTION_DURATION_DAYS = 30;
   public static final long DEFAULT_LOG_SAVER_TOPIC_WAIT_SLEEP_MS = TimeUnit.MILLISECONDS.convert(10, TimeUnit.SECONDS);

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogWriterPlugin.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogWriterPlugin.java
@@ -111,10 +111,16 @@ public class KafkaLogWriterPlugin extends AbstractKafkaLogProcessor {
     Preconditions.checkArgument(checkpointIntervalMs > 0,
                                 "Checkpoint interval is invalid: %s", checkpointIntervalMs);
 
-    long inactiveIntervalMs = cConf.getLong(LoggingConfiguration.LOG_SAVER_INACTIVE_FILE_INTERVAL_MS,
-                                              LoggingConfiguration.DEFAULT_LOG_SAVER_INACTIVE_FILE_INTERVAL_MS);
-    Preconditions.checkArgument(inactiveIntervalMs > 0,
-                                "Inactive interval is invalid: %s", inactiveIntervalMs);
+    long maxFileLifetimeMs = cConf.getLong(LoggingConfiguration.LOG_SAVER_MAX_FILE_LIFETIME,
+                                           LoggingConfiguration.DEFAULT_LOG_SAVER_MAX_FILE_LIFETIME_MS);
+    Preconditions.checkArgument(maxFileLifetimeMs > 0,
+                                "Max file lifetime is invalid: %s", maxFileLifetimeMs);
+
+    if (cConf.get(LoggingConfiguration.LOG_SAVER_INACTIVE_FILE_INTERVAL_MS) != null) {
+      LOG.warn("Parameter '{}' is no longer supported. Instead, use '{}'.",
+               LoggingConfiguration.LOG_SAVER_INACTIVE_FILE_INTERVAL_MS,
+               LoggingConfiguration.LOG_SAVER_MAX_FILE_LIFETIME);
+    }
 
     this.eventBucketIntervalMs = cConf.getLong(LoggingConfiguration.LOG_SAVER_EVENT_BUCKET_INTERVAL_MS,
                                                  LoggingConfiguration.DEFAULT_LOG_SAVER_EVENT_BUCKET_INTERVAL_MS);
@@ -134,13 +140,13 @@ public class KafkaLogWriterPlugin extends AbstractKafkaLogProcessor {
                                 "Topic creation wait sleep is invalid: %s", topicCreationSleepMs);
 
     logCleanupIntervalMins = cConf.getInt(LoggingConfiguration.LOG_CLEANUP_RUN_INTERVAL_MINS,
-                                            LoggingConfiguration.DEFAULT_LOG_CLEANUP_RUN_INTERVAL_MINS);
+                                          LoggingConfiguration.DEFAULT_LOG_CLEANUP_RUN_INTERVAL_MINS);
     Preconditions.checkArgument(logCleanupIntervalMins > 0,
                                 "Log cleanup run interval is invalid: %s", logCleanupIntervalMins);
 
     AvroFileWriter avroFileWriter = new AvroFileWriter(fileMetaDataManager, namespacedLocationFactory, logBaseDir,
                                                        serializer.getAvroSchema(), maxLogFileSizeBytes,
-                                                       syncIntervalBytes, inactiveIntervalMs, impersonator);
+                                                       syncIntervalBytes, maxFileLifetimeMs, impersonator);
 
     checkpointManager = checkpointManagerFactory.create(cConf.get(Constants.Logging.KAFKA_TOPIC),
                                                         CHECKPOINT_ROW_KEY_PREFIX);

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogWriter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogWriter.java
@@ -130,6 +130,8 @@ public class LogWriter implements Runnable {
           it.remove();
         }
 
+        logFileWriter.flush(false);
+
         // Reset backoff after a successful save
         exponentialBackoff.reset();
       } catch (Throwable e) {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/AvroFileWriter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/AvroFileWriter.java
@@ -57,7 +57,7 @@ public final class AvroFileWriter implements Closeable, Flushable {
   private final int syncIntervalBytes;
   private final Map<String, AvroFile> fileMap;
   private final long maxFileSize;
-  private final long inactiveIntervalMs;
+  private final long maxFileLifetimeMs;
   private final Impersonator impersonator;
 
   private final AtomicBoolean closed = new AtomicBoolean(false);
@@ -70,11 +70,11 @@ public final class AvroFileWriter implements Closeable, Flushable {
    * @param schema schema of the Avro data to be written.
    * @param maxFileSize Avro files greater than maxFileSize will get rotated.
    * @param syncIntervalBytes the approximate number of uncompressed bytes to write in each block.
-   * @param inactiveIntervalMs files that have no data written for more than inactiveIntervalMs will be closed.
+   * @param maxFileLifetimeMs files that are older than maxFileLifetimeMs will be closed.
    */
   public AvroFileWriter(FileMetaDataManager fileMetaDataManager, NamespacedLocationFactory namespacedLocationFactory,
                         String logBaseDir, Schema schema, long maxFileSize, int syncIntervalBytes,
-                        long inactiveIntervalMs, Impersonator impersonator) {
+                        long maxFileLifetimeMs, Impersonator impersonator) {
     this.fileMetaDataManager = fileMetaDataManager;
     this.namespacedLocationFactory = namespacedLocationFactory;
     this.logBaseDir = logBaseDir;
@@ -82,7 +82,7 @@ public final class AvroFileWriter implements Closeable, Flushable {
     this.syncIntervalBytes = syncIntervalBytes;
     this.fileMap = Maps.newHashMap();
     this.maxFileSize = maxFileSize;
-    this.inactiveIntervalMs = inactiveIntervalMs;
+    this.maxFileLifetimeMs = maxFileLifetimeMs;
     this.impersonator = impersonator;
   }
 
@@ -155,8 +155,9 @@ public final class AvroFileWriter implements Closeable, Flushable {
       } else {
         avroFile.sync();
 
-        // Close inactive files
-        if (currentTs - avroFile.getLastModifiedTs() > inactiveIntervalMs) {
+        // Close old files
+        long timeSinceFileCreate = currentTs - avroFile.getCreateTime();
+        if (timeSinceFileCreate > maxFileLifetimeMs) {
           avroFile.close();
           it.remove();
         }
@@ -269,7 +270,7 @@ public final class AvroFileWriter implements Closeable, Flushable {
     private final Location location;
     private FSDataOutputStream outputStream;
     private DataFileWriter<GenericRecord> dataFileWriter;
-    private long lastModifiedTs;
+    private long createTime;
     private boolean isOpen = false;
 
     public AvroFile(Location location) {
@@ -288,7 +289,7 @@ public final class AvroFileWriter implements Closeable, Flushable {
         this.dataFileWriter = new DataFileWriter<>(new GenericDatumWriter<GenericRecord>(schema));
         this.dataFileWriter.create(schema, this.outputStream);
         this.dataFileWriter.setSyncInterval(syncIntervalBytes);
-        this.lastModifiedTs = System.currentTimeMillis();
+        this.createTime = System.currentTimeMillis();
       } catch (Exception e) {
         close();
         throw new IOException("Exception while creating file " + location, e);
@@ -307,7 +308,6 @@ public final class AvroFileWriter implements Closeable, Flushable {
     public void append(LogWriteEvent event) throws IOException {
       try {
         dataFileWriter.append(event.getGenericRecord());
-        lastModifiedTs = System.currentTimeMillis();
       } catch (Exception e) {
         close();
         throw new IOException("Exception while appending to file " + location, e);
@@ -323,8 +323,8 @@ public final class AvroFileWriter implements Closeable, Flushable {
       }
     }
 
-    public long getLastModifiedTs() {
-      return lastModifiedTs;
+    public long getCreateTime() {
+      return createTime;
     }
 
     public void flush() throws IOException {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/LogFileWriter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/LogFileWriter.java
@@ -18,6 +18,7 @@ package co.cask.cdap.logging.write;
 
 import java.io.Closeable;
 import java.io.Flushable;
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -30,8 +31,18 @@ public interface LogFileWriter<T extends LogWriteEvent> extends Closeable, Flush
   /**
    * Appends a log event to an appropriate Avro file based on LoggingContext. If the log event does not contain
    * LoggingContext then the event will be dropped.
+   *
    * @param events Log event
    * @throws java.io.IOException
    */
   void append(List<T> events) throws Exception;
+
+  /**
+   * Flushes this stream by writing any buffered output to the underlying
+   * stream.
+   *
+   * @param force if false, will avoid flushing if it has already flushed recently
+   * @throws IOException If an I/O error occurs
+   */
+  void flush(boolean force) throws IOException;
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/SimpleLogFileWriter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/SimpleLogFileWriter.java
@@ -58,21 +58,21 @@ public class SimpleLogFileWriter implements LogFileWriter<LogWriteEvent> {
 
   @Override
   public void flush() throws IOException {
+    flush(true);
+  }
+
+  public void flush(boolean force) throws IOException {
     try {
-      flush(true);
+      long currentTs = System.currentTimeMillis();
+      if (!force && currentTs - lastCheckpointTime < flushIntervalMs) {
+        return;
+      }
+
+      avroFileWriter.flush();
+      lastCheckpointTime = currentTs;
     } catch (Exception e) {
       LOG.error("Got exception: ", e);
       throw new IOException(e);
     }
-  }
-
-  private void flush(boolean force) throws Exception {
-    long currentTs = System.currentTimeMillis();
-    if (!force && currentTs - lastCheckpointTime < flushIntervalMs) {
-      return;
-    }
-
-    avroFileWriter.flush();
-    lastCheckpointTime = currentTs;
   }
 }


### PR DESCRIPTION
Previously, log files are only closed if the file has been inactive for X milliseconds. So, if X is 1 hour, and a single event comes in every 30 minutes, the file can be kept open for days.
Also, once the file has been inactive, it was only being closed when the next event to it came.

Now, have a maximum file lifetime, instead of an inactive file duration, and close it even if no new events come in.

https://issues.cask.co/browse/CDAP-7113
http://builds.cask.co/browse/CDAP-RUT132-1
