### PR TITLE
CDAP-6364 Don't initialize logCallback more than once

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/ChunkedLogReaderCallback.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/ChunkedLogReaderCallback.java
@@ -38,6 +38,7 @@ import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -53,6 +54,7 @@ class ChunkedLogReaderCallback implements Callback {
   private final PatternLayout patternLayout;
   private final boolean escape;
   private final AtomicInteger count = new AtomicInteger();
+  private final AtomicBoolean initialized = new AtomicBoolean();
   private ChunkResponder chunkResponder;
 
   ChunkedLogReaderCallback(HttpResponder responder, String logPattern, boolean escape) {
@@ -70,6 +72,10 @@ class ChunkedLogReaderCallback implements Callback {
 
   @Override
   public void init() {
+    // if initialized already, then return
+    if (!initialized.compareAndSet(false, true)) {
+      return;
+    }
     patternLayout.start();
     chunkResponder = responder.sendChunkStart(HttpResponseStatus.OK,
                                               ImmutableMultimap.of(HttpHeaders.Names.CONTENT_TYPE,

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogHandler.java
@@ -116,8 +116,13 @@ public class LogHandler extends AbstractHttpHandler {
       readRange = adjustReadRange(readRange, runRecord, fromTimeSecsParam != -1);
 
       ChunkedLogReaderCallback logCallback = new ChunkedLogReaderCallback(responder, logPattern, escape);
-      logReader.getLog(loggingContext, readRange.getFromMillis(), readRange.getToMillis(), filter, logCallback);
-      logCallback.close();
+      try {
+        logReader.getLog(loggingContext, readRange.getFromMillis(), readRange.getToMillis(), filter, logCallback);
+      } catch (Exception ex) {
+        LOG.debug("Exception while reading logs for logging context {}", loggingContext, ex);
+      } finally {
+        logCallback.close();
+      }
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
     } catch (IllegalArgumentException e) {
@@ -167,8 +172,13 @@ public class LogHandler extends AbstractHttpHandler {
       LogOffset logOffset = FormattedLogEvent.parseLogOffset(fromOffsetStr);
       ReadRange readRange = ReadRange.createFromRange(logOffset);
       readRange = adjustReadRange(readRange, runRecord, true);
-      logReader.getLogNext(loggingContext, readRange, maxEvents, filter, logCallback);
-      logCallback.close();
+      try {
+        logReader.getLogNext(loggingContext, readRange, maxEvents, filter, logCallback);
+      } catch (Exception ex) {
+        LOG.debug("Exception while reading logs for logging context {}", loggingContext, ex);
+      } finally {
+        logCallback.close();
+      }
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
     } catch (IllegalArgumentException e) {
@@ -256,9 +266,13 @@ public class LogHandler extends AbstractHttpHandler {
       LogOffset logOffset = FormattedLogEvent.parseLogOffset(fromOffsetStr);
       ReadRange readRange = ReadRange.createToRange(logOffset);
       readRange = adjustReadRange(readRange, runRecord, true);
-      logReader.getLogPrev(loggingContext, readRange,
-                           maxEvents, filter, logCallback);
-      logCallback.close();
+      try {
+        logReader.getLogPrev(loggingContext, readRange, maxEvents, filter, logCallback);
+      } catch (Exception ex) {
+        LOG.debug("Exception while reading logs for logging context {}", loggingContext, ex);
+      } finally {
+        logCallback.close();
+      }
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
     } catch (IllegalArgumentException e) {
@@ -284,8 +298,13 @@ public class LogHandler extends AbstractHttpHandler {
       LoggingContext loggingContext = LoggingContextHelper.getLoggingContext(Id.Namespace.SYSTEM.getId(), componentId,
                                                                              serviceId);
       ChunkedLogReaderCallback logCallback = new ChunkedLogReaderCallback(responder, logPattern, escape);
-      logReader.getLog(loggingContext, timeRange.getFromMillis(), timeRange.getToMillis(), filter, logCallback);
-      logCallback.close();
+      try {
+        logReader.getLog(loggingContext, timeRange.getFromMillis(), timeRange.getToMillis(), filter, logCallback);
+      } catch (Exception ex) {
+        LOG.debug("Exception while reading logs for logging context {}", loggingContext, ex);
+      } finally {
+        logCallback.close();
+      }
     } catch (IllegalArgumentException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
     }
@@ -306,9 +325,13 @@ public class LogHandler extends AbstractHttpHandler {
       LogReaderCallback logCallback = new LogReaderCallback(responder, logPattern, escape);
       LogOffset logOffset = FormattedLogEvent.parseLogOffset(fromOffsetStr);
       ReadRange readRange = ReadRange.createFromRange(logOffset);
-      logReader.getLogNext(loggingContext, readRange,
-                           maxEvents, filter, logCallback);
-      logCallback.close();
+      try {
+        logReader.getLogNext(loggingContext, readRange, maxEvents, filter, logCallback);
+      } catch (Exception ex) {
+        LOG.debug("Exception while reading logs for logging context {}", loggingContext, ex);
+      } finally {
+        logCallback.close();
+      }
     } catch (IllegalArgumentException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
     }
@@ -329,9 +352,13 @@ public class LogHandler extends AbstractHttpHandler {
       LogReaderCallback logCallback = new LogReaderCallback(responder, logPattern, escape);
       LogOffset logOffset = FormattedLogEvent.parseLogOffset(fromOffsetStr);
       ReadRange readRange = ReadRange.createToRange(logOffset);
-      logReader.getLogPrev(loggingContext, readRange,
-                           maxEvents, filter, logCallback);
-      logCallback.close();
+      try {
+        logReader.getLogPrev(loggingContext, readRange, maxEvents, filter, logCallback);
+      } catch (Exception ex) {
+        LOG.debug("Exception while reading logs for logging context {}", loggingContext, ex);
+      } finally {
+        logCallback.close();
+      }
     } catch (IllegalArgumentException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
     }


### PR DESCRIPTION
Also close logCallback in a finally clause 

Similar to PR https://github.com/caskdata/cdap/pull/6516

JIRA : https://issues.cask.co/browse/CDAP-6364
Build : http://builds.cask.co/browse/CDAP-RUT134-1
