### PR TITLE
Fix Documentation Build

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -270,7 +270,7 @@
     <name>app.program.max.start.seconds</name>
     <value>300</value>
     <description>
-      The maximum number of seconds to wait for a program to start before killing it.
+      The maximum number of seconds to wait for a program to start before killing it
     </description>
   </property>
 
@@ -278,7 +278,7 @@
     <name>app.program.max.stop.seconds</name>
     <value>300</value>
     <description>
-      The maximum number of seconds to wait for a program to stop before killing it.
+      The maximum number of seconds to wait for a program to stop before killing it
     </description>
   </property>
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -250,6 +250,22 @@
   </property>
 
   <property>
+    <name>app.program.max.start.seconds</name>
+    <value>300</value>
+    <description>
+      The maximum number of seconds to wait for a program to start before killing it
+    </description>
+  </property>
+
+  <property>
+    <name>app.program.max.stop.seconds</name>
+    <value>300</value>
+    <description>
+      The maximum number of seconds to wait for a program to stop before killing it
+    </description>
+  </property>
+
+  <property>
     <name>app.program.runid.corrector.interval</name>
     <value>180</value>
     <description>
@@ -263,22 +279,6 @@
     <value>/tmp</value>
     <description>
       Temp directory
-    </description>
-  </property>
-
-  <property>
-    <name>app.program.max.start.seconds</name>
-    <value>300</value>
-    <description>
-      The maximum number of seconds to wait for a program to start before killing it
-    </description>
-  </property>
-
-  <property>
-    <name>app.program.max.stop.seconds</name>
-    <value>300</value>
-    <description>
-      The maximum number of seconds to wait for a program to stop before killing it
     </description>
   </property>
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="c70be42b2e141747b669110d176b6ff4"
+DEFAULT_XML_MD5_HASH="4090188933fb68474f494a53e5385ba8"
 
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -19,7 +19,7 @@
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="c3ec42e3df366d615985a14d2cb482f5"
+DEFAULT_XML_MD5_HASH="c70be42b2e141747b669110d176b6ff4"
 
 DEFAULT_TOOL="../tools/doc-cdap-default.py"
 DEFAULT_RST="cdap-default-table.rst"


### PR DESCRIPTION
Correct the descriptions in the cdap-default.xml (they don't have trailing periods) and adjust the MD5 hash.

Passes as [Quick Build 2](http://builds.cask.co/browse/CDAP-DQB88-2)
