### PR TITLE
Quick Doc Fixes

### DIFF
--- a/cdap-docs/_common/_source/index.rst
+++ b/cdap-docs/_common/_source/index.rst
@@ -103,7 +103,7 @@ CDAP extensions provide additional capabilities, such as *Cask Hydrator* and *Ca
 .. _admin-man-i-black: admin-manual/installation/index.html
 
 .. |admin-man-s-black| replace:: `Security:`
-.. _admin-man-s-black: admin-manual/security.html
+.. _admin-man-s-black: admin-manual/security/index.html
 
 .. |admin-man-o-black| replace:: `Operations:`
 .. _admin-man-o-black: admin-manual/operations/index.html

--- a/cdap-docs/admin-manual/source/security.rst
+++ b/cdap-docs/admin-manual/source/security.rst
@@ -1,0 +1,8 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2016 Cask Data, Inc.
+    :http-equiv=refresh: 0; URL=security/index.html
+  
+:orphan:
+
+.. redirect to security/index.rst

--- a/cdap-docs/hydrator-manual/source/_includes/plugins/shared-plugins/core.rst
+++ b/cdap-docs/hydrator-manual/source/_includes/plugins/shared-plugins/core.rst
@@ -14,8 +14,7 @@ A system-supplied validator that offers a set of functions that can be called fr
 
 It is included in a transform by adding its name (``core``) to the ``validators`` field of
 the transform configuration and its functions are referenced by using its JavaScript name
-(``coreValidator``). See an example in the Validator transforms plugin, either for
-`batch <../batch/transforms/validator.html>`__ or `real-time <../realtime/transforms/validator.html>`__.
+(``coreValidator``). See an example in the `Validator transforms plugin <../transforms/validator.html>`__.
 
 .. rubric:: Use Case
 

--- a/cdap-docs/hydrator-manual/source/creating-pipelines.rst
+++ b/cdap-docs/hydrator-manual/source/creating-pipelines.rst
@@ -51,8 +51,10 @@ There are two different methods for creating pipelines:
 
 Using **Hydrator Studio,** the basic operations are:
 
-  1. **Create** a new pipeline, either by starting from a :ref:`blank canvas <cask-hydrator-getting-started-hydrator-studio>`, 
-     starting from a `template <Pipeline Templates>`_, or by `cloning <Cloning>`_ an already-published pipeline.
+  1. **Create** a new pipeline, either by starting from a :ref:`blank canvas 
+     <cask-hydrator-getting-started-hydrator-studio>`, starting from a
+     :ref:`template <cask-hydrator-creating-pipelines-pipeline-templates>`, or by 
+     :ref:`cloning <cask-hydrator-creating-pipelines-cloning>` an already-published pipeline.
 
   #. **Edit** the pipeline in Hydrator Studio, setting appropriate configurations and
      settings.
@@ -505,6 +507,8 @@ Existing pipelines can be used to create new pipelines by:
 - **Cloning** an already-published pipeline and saving the resulting draft with a new name
 - **Exporting** a configuration file, editing it, and then **importing** the revised file
 
+.. _cask-hydrator-creating-pipelines-pipeline-templates:
+
 Pipeline Templates
 ------------------
 A collection of predefined and preconfigured pipelines are available from within Hydrator
@@ -555,6 +559,8 @@ These are the available templates:
 - **ETL Batch** (deprecated as of CDAP 3.5.0; use *Data Pipeline* instead)
 
   - **Stream to HBase:** Periodically ingest from a stream into an HBase table
+
+.. _cask-hydrator-creating-pipelines-cloning:
 
 Cloning
 -------

--- a/cdap-docs/hydrator-manual/source/index.rst
+++ b/cdap-docs/hydrator-manual/source/index.rst
@@ -67,7 +67,7 @@ to enable the building, deploying, and managing of data pipelines.
 .. _developing-pipelines: developing-pipelines.html
 
 .. |developing-plugins| replace:: **Developing Plugins:**
-.. _developing-plugins: developing-plugins.html
+.. _developing-plugins: developing-plugins/index.html
 
 .. |how-hydrator-works| replace:: **How Hydrator Works:**
 .. _how-hydrator-works: how-hydrator-works.html

--- a/cdap-docs/hydrator-manual/source/running-pipelines.rst
+++ b/cdap-docs/hydrator-manual/source/running-pipelines.rst
@@ -162,10 +162,10 @@ configurable error dataset.
 
 These transform plugins support error record handling:
 
-- JavaScript:       `batch <plugins/batch/transforms/javascript.html>`__      or `real-time <plugins/realtime/transforms/javascript.html>`__
-- Python Evaluator: `batch <plugins/batch/transforms/pythonevaluator.html>`__ or `real-time <plugins/realtime/transforms/pythonevaluator.html>`__
-- Validator:        `batch <plugins/batch/transforms/validator.html>`__       or `real-time <plugins/realtime/transforms/validator.html>`__
-- XML Parser:       `batch <plugins/batch/transforms/xmlparser.html>`__       or `real-time <plugins/realtime/transforms/xmlparser.html>`__
+- `JavaScript <plugins/transforms/javascript.html>`__
+- `Python Evaluator <plugins/transforms/pythonevaluator.html>`__
+- `Validator <plugins/transforms/validator.html>`__
+- `XML Parser <plugins/transforms/xmlparser.html>`__
 
 See the :ref:`Core Validator <cask-hydrator-plugins-shared-core-validator>` for examples
 and additional information.

--- a/cdap-docs/hydrator-manual/source/third-party.rst
+++ b/cdap-docs/hydrator-manual/source/third-party.rst
@@ -1,0 +1,8 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2016 Cask Data, Inc.
+    :http-equiv=refresh: 0; URL=plugin-management.html#deploying-third-party-jars
+  
+:orphan:
+
+.. redirect to plugin-management.html Deploying Third-Party JARs

--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -35,17 +35,17 @@ API Changes
 - :cask-issue:`CDAP-5279` - The ``beforeSubmit`` and ``onFinish`` methods of the MapReduce
   and Spark APIs have been deprecated. Changes to the API include:
 
-- 1. ``AbstractMapReduce`` and ``AbstractSpark`` now implement ``ProgramLifeCycle``
+  1. ``AbstractMapReduce`` and ``AbstractSpark`` now implement ``ProgramLifeCycle``
 
-- 2. ``AbstractMapReduce`` and ``AbstractSpark`` now have a ``final
+  2. ``AbstractMapReduce`` and ``AbstractSpark`` now have a ``final
      initialize(context)`` method
 
-- 3. ``AbstractMapReduce`` and ``AbstractSpark`` now have a ``protected initialize()``
+  3. ``AbstractMapReduce`` and ``AbstractSpark`` now have a ``protected initialize()``
      method default implementation of which will call ``beforeSubmit()``
 
-- 4. User programs will override the no-arg initialize method
+  4. User programs will override the no-arg initialize method
 
-- 5. Driver will call both versions of the initialize method
+  5. Driver will call both versions of the initialize method
 
 - :cask-issue:`CDAP-6150` - The ``isSuccessful()`` method of the WorkflowContext is
   replaced by the ``getState()`` method, which returns the state of the workflow.
@@ -156,8 +156,7 @@ New Features
   COBOL Copybook.
 
 - :cask-issue:`HYDRATOR-514` - Added the Excel Reader Source plugin to Cask Hydrator
-  Plugins. This plugin provides the ability to read data from one or more Excel file(s). 
-  New Feature
+  Plugins. This plugin provides the ability to read data from one or more Excel file(s).
 
 - :cask-issue:`HYDRATOR-629` - Adds macros to pipeline plugin configurations. This allows
   users to set macros for plugin properties which can be provided as runtime arguments while
@@ -357,11 +356,13 @@ Improvements
 
 - :cask-issue:`CDAP-6901` - Added a bootstrap step for authorization in CDAP. As part of
   this step:
-- 1. The user that CDAP runs as now receives "admin" privileges on the CDAP instance, as
-  well as "all" privileges on the system namespace.
-- 2. The list of users specified in the parameter ``security.authorization.admin.users``
-  in cdap-site.xml receives "admin" privileges on the CDAP instance so that they can create
-  namespaces.
+
+  1. The user that CDAP runs as now receives "admin" privileges on the CDAP instance, as
+     well as "all" privileges on the system namespace.
+
+  2. The list of users specified in the parameter ``security.authorization.admin.users``
+     in cdap-site.xml receives "admin" privileges on the CDAP instance so that they can
+     create namespaces.
 
 - :cask-issue:`CDAP-6913` - Changed to use ``YarnClient`` instead of the YARN HTTP API to
   fetch node reports.


### PR DESCRIPTION
- Fix broken link in Hydrator manual
- Add a redirect to the security section (`security.html` -> `security/index.html`)
- Fixes formatting in two sub-lists in the 3.5.0 release notes.

Passes [Quick Build 2](http://builds.cask.co/browse/CDAP-DQB92-2)
