### PR TITLE
(CDAP-1491) Added documentation on authorization in the admin manual

### DIFF
--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -215,7 +215,17 @@ locale_dirs = ['_locale/', '../../_common/_locale']
 # returns
 # http://localhost:9999/ns/default/apps/ClicksAndViews/overview/programs
 # use %% to preserve substitution
-cdap_java_source_github_pattern = "https://github.com/caskdata/cdap/blob/%s/%%s" % git_build_vars["GIT_BRANCH_PARENT"]
+GIT_BRANCH_PARENT = 'GIT_BRANCH_PARENT'
+if git_build_vars.has_key(GIT_BRANCH_PARENT):
+    cdap_java_source_github_pattern = "https://github.com/caskdata/cdap/blob/%s/%%s" % git_build_vars[GIT_BRANCH_PARENT]
+else:
+    cdap_java_source_github_pattern = ''
+GIT_BRANCH_CDAP_SECURITY_EXTN = 'GIT_BRANCH_CDAP_SECURITY_EXTN'
+if git_build_vars.has_key(GIT_BRANCH_CDAP_SECURITY_EXTN):
+    cdap_security_extn_github_pattern = "https://github.com/caskdata/cdap-security-extn/blob/%s/%%s" % \
+        git_build_vars[GIT_BRANCH_CDAP_SECURITY_EXTN]
+else:
+    cdap_security_extn_github_pattern = ''
 
 extlinks = {
     'cdap-ui': ('http://localhost:9999/ns/default/%s', None),
@@ -227,7 +237,8 @@ extlinks = {
     'cask-hydrator': ('http://localhost:9999/ns/default/hydrator/%s', None),
     'cask-hydrator-studio': ('http://localhost:9999/ns/default/hydrator/studio/%s', None),
     'cask-hydrator-studio-artifact': ('http://localhost:9999/ns/default/hydrator/studio?artifactType=%s', None),
-    'cdap-java-source-github': (cdap_java_source_github_pattern , None),
+    'cdap-java-source-github': (cdap_java_source_github_pattern, None),
+    'cdap-security-extn-source-github': (cdap_security_extn_github_pattern, None),
     'cask-issue': ('https://issues.cask.co/browse/%s', ''),
 }
 

--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -548,24 +548,11 @@ For Kerberos-enabled Hadoop clusters:
 
 Enabling Sentry
 ---------------
-To use CDAP with Cloudera clusters using Sentry authorization, this property needs to be set:
+To use CDAP with Cloudera clusters using Sentry authorization, refer to the steps at
+:ref:`Apache Sentry Configuration <apache-sentry-configuration>`
 
-- Add the user ``cdap`` to the Sentry property ``sentry.service.allow.connect``
-
-We recommend setting these properties:
-
-- Add the user ``cdap`` to the Sentry property ``sentry.service.admin.group``; this allows
-  the CDAP user to create roles, add roles to users, remove roles, list all roles, etc
-
-- Add the user ``cdap`` to the Hive property ``sentry.metastore.service.users``; this
-  should be set if you want to allow CDAP to bypass Sentry authorization for Hive Metastore
-  queries, such as in the default case where all applications run as ``cdap`` and not
-  individual users
-
-These can be set from within Cloudera Manager by searching for these properties in the
-configuration for each component; in this case, Sentry and Hive.
-
-**Note:** You must restart the cluster and HiveServer2 after setting these values.
+The properties described there can be set from within Cloudera Manager by searching for them in the
+configuration for each component; particularly, Sentry and Hive.
 
 
 .. _cloudera-configuration-highly-available:

--- a/cdap-docs/admin-manual/source/security/authorization.rst
+++ b/cdap-docs/admin-manual/source/security/authorization.rst
@@ -4,23 +4,347 @@
 
 .. _admin-authorization:
 
-=========================
-Configuring Authorization
-=========================
+=============
+Authorization
+=============
+Authorization allows users to enforce fine-grained access control on CDAP entities:
+namespaces, artifacts, applications, programs, datasets, streams, and secure keys. All
+operations on these entities |---| listing, viewing, creating, updating, managing,
+deleting |---| are governed by authorization policies.
 
 .. _security-enabling-authorization:
 
 Enabling Authorization
 ======================
-To enable authorization in :term:`Distributed CDAP <distributed cdap>`, add
-these properties to ``cdap-site.xml``:
+To enable authorization in :term:`Distributed CDAP <distributed cdap>`, add these
+properties to :ref:`cdap-site.xml <appendix-cdap-default-security>`:
 
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
 
-Authorization in CDAP is implemented as extensions
-:ref:`Developers' Manual: Authorization Extensions <authorization-extensions>`.
-In addition to the above properties, an extension may require additional properties to be
-configured. Extension properties, which are also specified in ``cdap-site.xml``, begin
-with the prefix ``security.authorization.extension.config``. Please see the documentation
-on individual extensions such as :ref:`Integrations: Apache Sentry <apache-sentry>` for
-configuring properties specific to that extension
+   * - Parameter
+     - Value
+   * - ``security.authorization.enabled``
+     -  true
+   * - ``security.authorization.extension.extension.jar.path``
+     - Absolute path of the JAR file to be used as the authorization extension. This file
+       must be present on the local file system of the CDAP Master. In an HA environment, it
+       should be present on the local file system of all CDAP Master hosts.
 
+Authorization in CDAP only takes effect once :ref:`perimeter security
+<admin-perimeter-security>` is also enabled by setting ``security.enabled`` to ``true``.
+Additionally, it is recommended that Kerberos be enabled on the cluster by setting
+``kerberos.auth.enabled`` to ``true``.
+
+These additional properties can also be optionally modified to configure authorization:
+
+- ``security.authorization.admin.users``
+- ``security.authorization.cache.enabled``
+- ``security.authorization.cache.refresh.interval.secs``
+- ``security.authorization.cache.ttl.secs``
+
+Please refer to :ref:`cdap-defaults.xml <appendix-cdap-default-security>` for
+documentation on these configuration settings.
+
+Authorization in CDAP is implemented as :ref:`authorization extensions
+<authorization-extensions>`. Apart from the above configuration settings, an extension may
+require additional properties to be configured. Please see the documentation on
+individual extensions for configuring properties specific to that extension:
+
+- :ref:`Integrations: Apache Sentry <apache-sentry>`
+
+:ref:`Security extension properties <appendix-cdap-default-security>`, which are specified
+in ``cdap-site.xml``, begin with the prefix ``security.authorization.extension.config``.
+
+.. _security-cdap-instance:
+
+CDAP Instances
+==============
+The concept of a *CDAP Instance* has been introduced to support authorization policies in
+CDAP. A *CDAP Instance* is uniquely identified by an *instance name*, specified by the
+property ``instance.name`` in the :ref:`cdap-site.xml <appendix-cdap-site.xml>`. Certain
+operations in CDAP (listed in the next section) require privileges on the CDAP instance
+identified by this property. One purpose of introducing this concept is to support, in the
+future, the notion of multiple CDAP instances on which authorization policies are enforced
+using the same authorization backend.
+
+.. _security-authorization-policies:
+
+Authorization Policies
+======================
+Currently, CDAP allows users to enforce authorization for *READ*, *WRITE*, *ADMIN*, and
+*EXECUTE* operations. (This list will be expanded to allow for additional distinctions and
+be made finer-grained in the future.)
+
+In general, this summarizes the authorization policies in CDAP:
+
+- A **create** operation on an entity requires *WRITE* on the entity's parent. For
+  example, creating a namespace requires *WRITE* on the CDAP instance. Deploying an
+  application, artifact, or dataset, or creating a stream requires a *WRITE* on the
+  namespace.
+- A **read** operation (such as reading from a dataset or a stream) on an entity requires
+  *READ* on the entity.
+- A **write** operation (such as writing to a dataset or a stream) on an entity requires
+  *WRITE* on the entity.
+- An **admin** operation (such as setting properties) on an entity requires *ADMIN* on
+  the entity.
+- A **delete** operation on an entity requires *ADMIN* on the entity.
+- A **list** operation (such as listing or searching applications, datasets, streams,
+  artifacts) only returns those entities that the logged-in user has at least one (*READ*,
+  *WRITE*, *ADMIN*, *EXECUTE*) privilege on.
+- A **view** operation on an entity only succeeds if the user has at least one (*READ*,
+  *WRITE*, *ADMIN*, *EXECUTE*) privilege on it.
+
+Additionally:
+
+- Upon successful creation of an entity, the logged-in user receives all privileges
+  (*READ*, *WRITE*, *ADMIN*, and *EXECUTE*) on that entity.
+- Upon successful deletion of an entity, all privileges on that entity for all users are revoked.
+
+CDAP supports hierarchical authorization enforcement, which means that an operation that
+requires a certain privilege on an entity is allowed if the user has the same privilege on
+the entity's parent. For example, reading from a CDAP dataset will succeed even if the
+user does not have specific *READ* privileges on the dataset, but instead has *READ*
+privileges on the namespace in which the dataset exists.
+
+Authorization policies for various CDAP operations are listed in these tables:
+
+.. _security-authorization-policies-namespaces:
+
+Namespaces
+----------
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Operation
+     - Privileges Required
+   * - Create
+     - *WRITE* (on the CDAP instance)
+   * - Update
+     - *ADMIN*
+   * - Delete
+     - *ADMIN*
+   * - List
+     - Only returns those namespaces on which user has at least one of *READ, WRITE, ADMIN,* or *EXECUTE*
+   * - View
+     - At least one of *READ, WRITE, ADMIN,* or *EXECUTE*
+
+.. _security-authorization-policies-artifacts:
+
+Artifacts
+---------
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Operation
+     - Privileges Required
+   * - Add
+     - *WRITE* (on the namespace)
+   * - Add a property
+     - *ADMIN*
+   * - Remove a property
+     - *ADMIN*
+   * - Delete
+     - *ADMIN*
+   * - List
+     - Only returns those artifacts on which user has at least one of *READ*, *WRITE*, *ADMIN*, or *EXECUTE*
+   * - View
+     - At least one of *READ*, *WRITE*, *ADMIN*, or *EXECUTE*
+
+.. _security-authorization-policies-applications:
+
+Applications
+------------
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Operation
+     - Privileges Required
+   * - Add
+     - *WRITE* (on the namespace)
+   * - Delete
+     - *ADMIN*
+   * - List
+     - Only returns those applications on which user has at least one of *READ*, *WRITE*, *ADMIN*, or *EXECUTE*
+   * - View
+     - At least one of *READ*, *WRITE*, *ADMIN*, or *EXECUTE*
+
+.. _security-authorization-policies-programs:
+
+Programs
+--------
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Operation
+     - Privileges Required
+   * - Start, Stop, or Debug
+     - *EXECUTE*
+   * - Set instances
+     - *ADMIN*
+   * - Set runtime arguments
+     - *ADMIN*
+   * - Retrieving status
+     - At least one of *READ*, *WRITE*, *ADMIN*, or *EXECUTE*
+   * - List
+     - Only returns those programs on which user has at least one of *READ*, *WRITE*, *ADMIN*, or *EXECUTE*
+   * - View
+     - At least one of *READ*, *WRITE*, *ADMIN*, or *EXECUTE*
+
+.. _security-authorization-policies-datasets:
+
+Datasets
+--------
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Operation
+     - Privileges Required
+   * - Create
+     - *WRITE* (on the namespace)
+   * - Read
+     - *READ*
+   * - Write
+     - *WRITE*
+   * - Update
+     - *ADMIN*
+   * - Upgrade
+     - *ADMIN*
+   * - Truncate
+     - *ADMIN*
+   * - Drop
+     - *ADMIN*
+   * - List
+     - Only returns those artifacts on which user has at least one of *READ*, *WRITE*, *ADMIN*, or *EXECUTE*
+   * - View
+     - At least one of *READ*, *WRITE*, *ADMIN*, or *EXECUTE*
+
+.. _security-authorization-policies-dataset-modules:
+
+Dataset Modules
+---------------
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Operation
+     - Privileges Required
+   * - Deploy
+     - *WRITE* (on the namespace)
+   * - Delete
+     - *ADMIN*
+   * - Delete-all in the namespace
+     - *ADMIN* (on the namespace)
+   * - List
+     - Only returns those artifacts on which user has at least one of *READ*, *WRITE*, *ADMIN*, or *EXECUTE*
+   * - View
+     - At least one of *READ*, *WRITE*, *ADMIN*, or *EXECUTE*
+
+.. _security-authorization-policies-dataset-types:
+
+Dataset Types
+-------------
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Operation
+     - Privileges Required
+   * - List
+     - Only returns those artifacts on which user has at least one of *READ*, *WRITE*, *ADMIN*, or *EXECUTE*
+   * - View
+     - At least one of *READ*, *WRITE*, *ADMIN*, or *EXECUTE*
+
+.. _security-authorization-policies-secure-keys:
+
+Secure Keys
+-----------
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Operation
+     - Privileges Required
+   * - Create
+     - *WRITE* (on the namespace)
+   * - Delete
+     - *ADMIN*
+   * - List
+     - Only returns those artifacts on which user has at least one of *READ*, *WRITE*, *ADMIN*, or *EXECUTE*
+   * - View
+     - At least one of *READ*, *WRITE*, *ADMIN*, or *EXECUTE*
+
+.. _security-authorization-policies-streams:
+
+Streams
+-------
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Operation
+     - Privileges Required
+   * - Create
+     - *WRITE* (on the namespace)
+   * - Retrieving events
+     - *READ*
+   * - Retrieving properties
+     - At least one of *READ*, *WRITE*, *ADMIN*, or *EXECUTE*
+   * - Sending events to a stream (sync, async, or batch)
+     - *WRITE*
+   * - Drop
+     - *ADMIN*
+   * - Drop-all in the namespace
+     - *ADMIN* (on the namespace)
+   * - Update
+     - *ADMIN*
+   * - Truncate
+     - *ADMIN*
+   * - List
+     - Only returns those artifacts on which user has at least one of *READ*, *WRITE*, *ADMIN*, or *EXECUTE*
+   * - View
+     - At least one of *READ*, *WRITE*, *ADMIN*, or *EXECUTE*
+
+.. _security-bootstrapping-authorization:
+
+Bootstrapping Authorization
+===========================
+
+When CDAP is first started with authorization enabled, no users are granted privileges on
+any CDAP entities. Without any privileges, it can be impossible to bootstrap CDAP (create
+a new namespace or create entities in the *default* namespace) unless an
+external interface (such as `Hue <http://gethue.com/>`__) is used for a supported
+authorization extension (such as :ref:`Integrations: Apache Sentry <apache-sentry>`).
+
+To make this bootstrap process easier, during startup the CDAP Master issues these grants to
+select users:
+
+- The user that runs the CDAP Master is granted *ADMIN* on the CDAP instance, so that the
+  *default* namespace can be created by that user if it does not already exist.
+
+- The user that runs the CDAP Master is granted *READ*, *WRITE*, *ADMIN*, and
+  *EXECUTE* on the system namespace, so operations such as creation of system tables,
+  deployment of system artifacts, and deployment of system dataset modules can be
+  performed by that user.
+
+- Additionally, a comma-separated list of users specified as the
+  ``security.authorization.admin.users`` in ``cdap-site.xml`` is granted *ADMIN*
+  privileges on the CDAP instance and the *default* namespace, so that they have the
+  required privileges to create namespaces and grant other users access to the *default*
+  namespace. It is recommended that this property be set to the list of users that will
+  administer and manage the CDAP installation.

--- a/cdap-docs/admin-manual/source/security/index.rst
+++ b/cdap-docs/admin-manual/source/security/index.rst
@@ -20,10 +20,10 @@ Security
     Secure Storage <secure-storage>
 
 Cask Data Application Platform (CDAP) supports securing clusters using various mechanisms such as
-:ref:`perimeter security <admin-perimeter-security>`,
-:ref:`authorization <admin-authorization>`,
-:ref:`impersonation <admin-impersonation>`, and
-:ref:`secure storage <admin-secure-storage>`.
+:ref:`Perimeter Security <admin-perimeter-security>`,
+:ref:`Authorization <admin-authorization>`,
+:ref:`Impersonation <admin-impersonation>`, and
+:ref:`Secure Storage <admin-secure-storage>`.
 This section covers how to setup these security mechanisms on a secure CDAP instance.
 
 Additional security information, including client APIs, the authentication process,

--- a/cdap-docs/admin-manual/source/security/secure-storage.rst
+++ b/cdap-docs/admin-manual/source/security/secure-storage.rst
@@ -27,9 +27,12 @@ An entry in secure storage consists of:
   Data is stored against the provided key and can be retrieved using the same key.
   Key must be of the :ref:`Alphanumeric Character Set <supported-characters>`, contain *only
   lowercase* characters, and should start with a letter.
+
 - **Data**: The data which is to be stored in a secure and encrypted manner. This could be a passphrase,
   cryptographic key, access token, or any other data that needs to be stored securely.
+
 - **Description**: A description for the secure store entry.
+
 - **Properties**: A string map of properties for the secure storage entry. A ``creationTime`` property is available
   for all secure store entries by default. Additional properties can be supplied by users at the time of creation.
 
@@ -45,18 +48,21 @@ implementation for storing secure keys. This implementation is not available in
 :term:`Distributed CDAP <distributed cdap>` as it stores the secure data in the local file system, and thus is
 not available on all nodes of a distributed cluster.
 
-To use this mode, set:
+To use this mode, set these properties:
 
-- ``security.store.provider`` to ``file`` in ``cdap-site.xml``; and
-- ``security.store.file.password`` to a password (to protect the secure storage file) in ``cdap-security.xml``.
+- In ``cdap-site.xml``, set ``security.store.provider`` to ``file``
+- In ``cdap-security.xml``, set ``security.store.file.password`` to a password (to protect the secure storage file)
 
 .. _admin-secure-storage-kms:
 
-Hadoop Key Management Server (KMS)-backed Secure Storage
---------------------------------------------------------
-`Hadoop KMS-backed <https://hadoop.apache.org/docs/stable/hadoop-kms/index.html>`__ secure storage is available for use
-with :term:`Distributed CDAP <distributed cdap>`. To use this mode, set ``security.store.provider`` to ``kms``
-in ``cdap-site.xml``.
+Hadoop Key Management Server-backed Secure Storage
+--------------------------------------------------
+`Hadoop KMS (Key Management Server)-backed <https://hadoop.apache.org/docs/stable/hadoop-kms/index.html>`__
+secure storage is available for use with :term:`Distributed CDAP <distributed cdap>`.
+
+To use this mode, set this property:
+
+- In ``cdap-site.xml``, set ``security.store.provider`` to ``kms``
 
 For additional information on integration with Hadoop KMS, please refer to
 :ref:`Integrations: Apache Hadoop KMS <apache-hadoop-kms>`.

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/system-custom.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/system-custom.rst
@@ -121,6 +121,8 @@ You can pass other properties, such as for
 :ref:`conflict detection <transaction-system-conflict-detection>` and for
 :ref:`pre-splitting into multiple regions <table-datasets-pre-splitting>`.
 
+.. _custom-datasets-accessing-datasets:
+
 Accessing a Dataset
 -------------------
 Application components can access a custom dataset in the same way as all other datasets:
@@ -132,3 +134,20 @@ A complete application demonstrating the use of a custom dataset is included in 
 :ref:`Purchase Example <examples-purchase>`.
 
 You can also create, drop, and truncate datasets using the :ref:`http-restful-api-dataset`.
+
+.. _custom-datasets-access-annotations:
+
+Annotating Dataset Methods
+--------------------------
+Dataset methods can be annotated with the type of access that they perform on data.
+Annotations help the CDAP runtime to enforce :ref:`authorization <admin-authorization>`,
+as well as track :ref:`lineage <metadata-lineage-lineage>`. Dataset methods (including
+constructors) can be annotated with one of:
+
+- ``@ReadOnly``: Denotes that a method or constructor performs only **read** operations
+- ``@WriteOnly``: Denotes that a method or constructor performs only **write** operations
+- ``@ReadWrite``: Denotes that a method or constructor performs both **read** and **write** operations
+
+Methods in :ref:`System Datasets <system-datasets>` already contain appropriate
+annotations. For :ref:`Custom Datasets <custom-datasets>`, it is the responsibility of the
+developer to appropriately annotate methods.

--- a/cdap-docs/developers-manual/source/building-blocks/metadata-lineage.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/metadata-lineage.rst
@@ -212,12 +212,17 @@ Lineage
 |---| for a specified time range |---| all data access of the entity, and details of where
 that access originated from.
 
-For example: with a stream, writing to a stream may take place from a worker, which
-obtained the data from a combination of a dataset and a stream. The data in those entities
-comes from possibly other entities. The number of levels of the lineage that are
-calculated is set when a request is made to view the lineage of a particular entity.
+For example: with a stream, writing to a stream can take place from a worker, which may
+have obtained the data from a combination of a dataset and a (different) stream. The data
+in those entities can come from (possibly) other entities. The number of levels of the
+lineage that are calculated is set when a request is made to view the lineage of a
+particular entity.
 
 In the case of streams, the lineage includes whether the access was reading or writing to
-the stream. In the case of datasets, in this CDAP version, lineage can only indicate that
-dataset access took place, and does not provide indication if that access was for reading
-or writing. Later versions of CDAP will address this limitation.
+the stream. 
+
+In the case of datasets, lineage can indicate if a dataset access was for reading,
+writing, or both, if the methods in the dataset have appropriate :ref:`annotations
+<custom-datasets-access-annotations>`. If annotations are absent, lineage can only
+indicate that a dataset access took place, and does not provide indication if that access
+was for reading or writing.

--- a/cdap-docs/developers-manual/source/security/authorization-extensions.rst
+++ b/cdap-docs/developers-manual/source/security/authorization-extensions.rst
@@ -8,4 +8,60 @@
 Authorization Extensions
 ========================
 
-Authorization backends in CDAP are implemented as extensions.
+Authorization backends in CDAP are implemented as extensions, and are loaded and executed in their
+own Java classloader. 
+
+The reason for implementing them as extensions is that a variety of existing authorization
+systems can then be plugged into CDAP, and can execute using their own classloader without
+having to worry about conflicts with CDAP's system classloader. Each authorization
+extension is designed to be a fully self-contained JAR file, packaged with the required
+versions of all its dependencies.
+
+This is similar to how CDAP applications are packaged. In fact, users can use the CDAP
+application archetype to write their own authorization extension for CDAP. Having the
+required dependencies loaded from a separate class loader constructed using the provided
+JAR file ensures that there will be no conflicts, even if CDAP itself uses a different
+version of the library than the one that the extension requires.
+
+Writing Your Own Authorization Extension
+----------------------------------------
+CDAP provides an authorization SPI (Service Provider Interface) for users to implement their own authorization
+extensions. To implement an authorization extension:
+
+- Create a Maven project using the CDAP Application Archetype, as described in :ref:`Creating an Application <dev-env>`.
+
+- Implement your authorization extension by extending the ``AbstractAuthorizer`` class.
+
+- This class must be specified as the ``Main-Class`` attribute in the extension JAR's
+  manifest file. This will be done automatically if you specify the ``app.main.class``
+  property to be the fully qualified class name in the ``pom.xml`` of the Maven project
+  generated using the archetype.
+  
+- The class that extends ``AbstractAuthorizer`` must have a default constructor, as that
+  default constructor is the one that will be invoked by CDAP.
+
+- All dependencies of the class must be packaged within the JAR file containing the
+  authorizer class. This is also done automatically by the CDAP Application Archetype.
+
+- The ``AbstractAuthorizer`` class provides lifecycle methods for authorization
+  extensions. Any initialization code should be implemented by overriding the ``initialize``
+  method. Cleanup code should be implemented by overriding the ``destroy`` method.
+
+- The ``initialize`` method provides an ``AuthorizationContext`` object. This object can
+  be used to obtain access to |---| and perform admin operations on |---| CDAP Datasets and Secure
+  Keys.
+
+- If the authorization extension requires configuration parameters, they are provided in
+  the ``AuthorizationContext`` object as a Java ``Properties`` object via the
+  ``getProperties`` method. The ``Properties`` object is populated with configuration
+  parameters from ``cdap-site.xml`` with the prefix ``security.authorization.extension.config``.
+  
+  **Note:** In the ``Properties`` object, these configuration parameters are available
+  with the ``security.authorization.extension.config`` prefix removed. For example:
+  ``security.authorization.extension.config.example.property`` in the ``cdap-site.xml``
+  will be available as ``example.property`` in the ``Properties`` object.
+
+For an example of implementing an authorization extension, please refer to the
+:cdap-security-extn-source-github:`Apache Sentry Authorization Extension
+<cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/main/java/co/cask/cdap/security/authorization/sentry/binding/SentryAuthorizer.java>`
+as well as its documentation at :ref:`Integrations: Apache Sentry <apache-sentry>`.

--- a/cdap-docs/developers-manual/source/security/index.rst
+++ b/cdap-docs/developers-manual/source/security/index.rst
@@ -70,7 +70,6 @@ If the standard authentication mechanisms are not sufficient, you can provide a
 
 .. rubric:: Authorization Extensions
 
-:doc:`Authorization Extensions <authorization-extensions>`
-
-Authorization backends for CDAP are implemented as extensions. Extensions run in their own, isolated classloader
-so that there are no conflicts with the system classloader of the CDAP Master.
+:doc:`Authorization Extensions: <authorization-extensions>` Authorization backends for CDAP
+are implemented as extensions. Extensions run in their own, isolated classloader so that
+there are no conflicts with the system classloader of CDAP Master.

--- a/cdap-docs/integrations/source/apache-sentry.rst
+++ b/cdap-docs/integrations/source/apache-sentry.rst
@@ -8,6 +8,34 @@
 Apache Sentry
 =============
 
+.. _apache-sentry-configuration:
+
+Configuring Apache Sentry for Integration with CDAP
+---------------------------------------------------
+To use CDAP on a cluster using Apache Sentry for authorization, set this property:
+
+- Add the user ``cdap`` to the Sentry property ``sentry.service.allow.connect``
+
+We also recommend setting these properties:
+
+- Add the user ``cdap`` to the Sentry property ``sentry.service.admin.group``; this allows
+  the CDAP user to create roles, add roles to users, remove roles, list all roles, etc.
+
+- Add the user ``cdap`` to the Hive property ``sentry.metastore.service.users``; this
+  should be set if you want to allow CDAP to bypass Sentry authorization for Hive Metastore
+  queries, such as the default case where all applications run as ``cdap`` and not as
+  individual users.
+
+**Note:** You must restart Apache Sentry and HiveServer2 after setting these properties.
+
+.. _cdap-sentry-authorization-extension:
+
+CDAP Sentry Authorization Extension
+-----------------------------------
+
+In addition to setting up CDAP to work on a cluster already using Apache Sentry for
+authorization of non-CDAP components, users can also use the CDAP Sentry Authorization
+Extension to enforce authorization on CDAP entities using Apache Sentry.
 
 .. include:: /../target/_includes/cdap-sentry-extension-readme.txt
     :start-after: ================================================


### PR DESCRIPTION
- Added documentation about authorization policies in CDAP
- Added documentation on implementing an authorization extension to the developers' manual
- Moved the Apache Sentry documentation to the Apache Sentry Integrations page, and added a link to it to the Cloudera page

Build: http://builds.cask.co/browse/CDAP-DQB91

Running Quick Build: http://builds.cask.co/browse/CDAP-DQB91-11
