### PR TITLE
Feature/hdinsight 3 5

### DIFF
--- a/cdap-distributions/src/hdinsight/cdap-conf.json
+++ b/cdap-distributions/src/hdinsight/cdap-conf.json
@@ -1,9 +1,10 @@
 {
   "cdap": {
     "cdap_site": {
-      "zookeeper.quorum": "{{ZK_QUORUM}}",
+      "explore.enabled": "{{EXPLORE_ENABLED}}",
       "kafka.server.log.dirs": "/var/cdap/kafka-logs",
-      "explore.enabled": "{{EXPLORE_ENABLED}}"
+      "router_bind_port": "11015",
+      "zookeeper.quorum": "{{ZK_QUORUM}}"
     },
     "cdap_env": {
       "cdap_ui_compression_enabled": "false",

--- a/cdap-distributions/src/hdinsight/cdap-conf.json
+++ b/cdap-distributions/src/hdinsight/cdap-conf.json
@@ -2,7 +2,7 @@
   "cdap": {
     "cdap_site": {
       "zookeeper.quorum": "{{ZK_QUORUM}}",
-      "kafka.log.dir": "/var/cdap/kafka-logs",
+      "kafka.server.log.dirs": "/var/cdap/kafka-logs",
       "explore.enabled": "{{EXPLORE_ENABLED}}"
     },
     "cdap_env": {

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -20,11 +20,11 @@
 
 # CDAP config
 # The git branch to clone
-CDAP_BRANCH='release/3.4'
+CDAP_BRANCH='release/3.5'
 # Optional tag to checkout - All released versions of this script should set this
 CDAP_TAG=''
 # The CDAP package version passed to Chef
-CDAP_VERSION='3.4.3-1'
+CDAP_VERSION='3.5.0-1'
 # The version of Chef to install
 CHEF_VERSION='12.10.24'
 # cdap-site.xml configuration parameters

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -78,7 +78,8 @@ source ${__gitdir}/cdap-common/bin/common.sh || die "Cannot source CDAP common s
 __zk_quorum=$(cdap_get_conf 'hbase.zookeeper.quorum' '/etc/hbase/conf/hbase-site.xml') || die "Cannot determine zookeeper quorum"
 
 # Get HDP version, allow for the future addition hdp-select "current" directory
-__hdp_version=$(ls /usr/hdp | grep "^[0-9]*\.") || die "Cannot determine HDP version"
+__hdp_version_str=$(hdp-select status hadoop-client) || die "Cannot run hdp-select to determine HDP version"
+__hdp_version=$(echo ${__hdp_version_str} | cut -d' ' -f3) || die "Cannot determine HDP version from string ${__hdp_version_str}"
 
 # Create chef json configuration
 sed \

--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -22,7 +22,7 @@
 # The git branch to clone
 CDAP_BRANCH='release/3.5'
 # Optional tag to checkout - All released versions of this script should set this
-CDAP_TAG=''
+CDAP_TAG='v3.5.0'
 # The CDAP package version passed to Chef
 CDAP_VERSION='3.5.0-1'
 # The version of Chef to install

--- a/cdap-distributions/src/hdinsight/mainTemplate.json
+++ b/cdap-distributions/src/hdinsight/mainTemplate.json
@@ -66,7 +66,7 @@
       },
       {
        "subDomainSuffix": "api",
-       "destinationPort": 10000
+       "destinationPort": 11015
       }],
       "applicationType": "CustomApplication"
     }

--- a/cdap-distributions/src/hdinsight/mainTemplate.json
+++ b/cdap-distributions/src/hdinsight/mainTemplate.json
@@ -50,12 +50,12 @@
       },
       "installScriptActions": [{
         "name": "[concat('cdap-pageblob-configure-v0','-' ,uniquestring(variables('applicationName')))]",
-        "uri": "https://raw.githubusercontent.com/caskdata/cdap/release/3.4/cdap-distributions/src/hdinsight/pageblob-configure.sh",
+        "uri": "https://raw.githubusercontent.com/caskdata/cdap/release/3.5/cdap-distributions/src/hdinsight/pageblob-configure.sh",
         "roles": ["edgenode"]
       },
       {
         "name": "[concat('cdap-install-v0','-' ,uniquestring(variables('applicationName')))]",
-        "uri": "https://raw.githubusercontent.com/caskdata/cdap/release/3.4/cdap-distributions/src/hdinsight/install.sh",
+        "uri": "https://raw.githubusercontent.com/caskdata/cdap/release/3.5/cdap-distributions/src/hdinsight/install.sh",
         "roles": ["edgenode"]
       }],
       "uninstallScriptActions": [],


### PR DESCRIPTION
updates for HDInsight release using CDAP 3.5.0
- [x] update CDAP version
- [x] use `hdp-select` to determine HDP version (previous `ls` didn't handle multiple versions)
- [x] use future default router port `11015`
- [x] pin checkout to `v3.5.0` tag
