### PR TITLE
Fix for Javadoc generation

### DIFF
--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -230,6 +230,9 @@ function set_mvn_environment() {
   if [[ "${OSTYPE}" == "darwin"* ]]; then
     # TODO: hard-coded Java version 1.7
     export JAVA_HOME=$(/usr/libexec/java_home -v 1.7)
+  else
+#     export JAVA_HOME=/usr/lib/jvm/jdk1.7.0_75
+    export JAVA_HOME=/usr/lib/jvm/${JAVA_JDK_VERSION}
   fi
 }
 

--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -232,11 +232,14 @@ function set_mvn_environment() {
     export JAVA_HOME=$(/usr/libexec/java_home -v 1.7)
   else
 #     export JAVA_HOME=/usr/lib/jvm/jdk1.7.0_75
-    if [[ "x${JAVA_JDK_VERSION}" == "x" ]]; then
-      JAVA_JDK_VERSION="jdk1.7.0_75"
+    if [[ "x${JAVA_HOME}" == "x" ]]; then
+      if [[ "x${JAVA_JDK_VERSION}" == "x" ]]; then
+        JAVA_JDK_VERSION="jdk1.7.0_75"
+      fi
+      export JAVA_HOME=/usr/lib/jvm/${JAVA_JDK_VERSION}
     fi
-    export JAVA_HOME=/usr/lib/jvm/${JAVA_JDK_VERSION}
   fi
+  echo "Using JAVA_HOME: ${JAVA_HOME}"
 }
 
 function check_build_rst() {

--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -232,6 +232,9 @@ function set_mvn_environment() {
     export JAVA_HOME=$(/usr/libexec/java_home -v 1.7)
   else
 #     export JAVA_HOME=/usr/lib/jvm/jdk1.7.0_75
+    if [[ "x${JAVA_JDK_VERSION}" == "x" ]]; then
+      JAVA_JDK_VERSION="jdk1.7.0_75"
+    fi
     export JAVA_HOME=/usr/lib/jvm/${JAVA_JDK_VERSION}
   fi
 }

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -262,6 +262,7 @@ function build_javadocs_api() {
   if [ "${DEBUG}" == "${TRUE}" ]; then
     debug_flag="-X"
   fi
+   mvn -version
   local start=`date`
   MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean install -P examples,templates,release -DskipTests -Dgpg.skip=true && ${javadoc_run} -DskipTests -DisOffline=false ${debug_flag}
   echo
@@ -281,6 +282,7 @@ function build_docs_cli() {
     local target_txt=${SCRIPT_PATH}/../cdap-docs-gen/${TARGET}/cdap-docs-cli.txt
     set_version
     set_mvn_environment
+    mvn -version
     mvn package -pl cdap-docs-gen -am -DskipTests
     warnings=$?
     if [ "${warnings}" == "0" ]; then

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -250,18 +250,21 @@ function build_javadocs() {
 
 function build_javadocs_api() {
   local javadoc_type=${1}
+  echo "Building type: ${javadoc_type}"
+  if [ "${javadoc_type}" == "${ALL}" ]; then
+    local javadoc_run="mvn javadoc:aggregate -P release"
+  else
+    local javadoc_run="mvn clean site -P templates"
+  fi
+  if [ "${DEBUG}" == "${TRUE}" ]; then
+    local debug_flag="-X"
+  else
+    local debug_flag=''
+  fi
   set_mvn_environment
   echo "JAVA_HOME: ${JAVA_HOME}"
   echo "JAVA Version:"
   java -version
-  local javadoc_run="mvn javadoc:aggregate -P release"
-  if [ "${javadoc_type}" == "${DOCS}" ]; then
-    javadoc_run="mvn clean site -P templates"
-  fi
-  local debug_flag=''
-  if [ "${DEBUG}" == "${TRUE}" ]; then
-    debug_flag="-X"
-  fi
   echo "Maven Version:"
   mvn -version
   local start=`date`

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -262,7 +262,8 @@ function build_javadocs_api() {
   if [ "${DEBUG}" == "${TRUE}" ]; then
     debug_flag="-X"
   fi
-   mvn -version
+  echo "Maven Version:"
+  mvn -version
   local start=`date`
   MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean install -P examples,templates,release -DskipTests -Dgpg.skip=true && ${javadoc_run} -DskipTests -DisOffline=false ${debug_flag}
   echo

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -268,7 +268,10 @@ function build_javadocs_api() {
   echo "Maven Version:"
   mvn -version
   local start=`date`
-  MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean install -P examples,templates,release -DskipTests -Dgpg.skip=true && ${javadoc_run} -DskipTests -DisOffline=false ${debug_flag}
+  echo "Maven clean install"
+  MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean install -P examples,templates,release -DskipTests -Dgpg.skip=true
+  echo "Maven javadoc_run"
+  MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" ${javadoc_run} -DskipTests -DisOffline=false ${debug_flag}
   echo
   echo "Javadocs Build Start: ${start}"
   echo "                 End: `date`"


### PR DESCRIPTION
This passes at http://builds.cask.co/browse/CDAP-DDB46-5

Output: http://builds.cask.co/artifact/CDAP-DDB46/shared/build-5/Docs-HTML/3.5.0/en/reference-manual/javadocs/index.html

Log file: first part of Javadoc command fails, but the second part succeeds: http://builds.cask.co/browse/CDAP-DDB46-5/log

I _think_ the output is correct, but I need to check. Leaving for another day.
