### PR TITLE
HYDRATOR-180 document data streams

### DIFF
--- a/cdap-docs/hydrator-manual/source/_includes/plugins/actions/index.rst
+++ b/cdap-docs/hydrator-manual/source/_includes/plugins/actions/index.rst
@@ -2,7 +2,7 @@
     :author: Cask Data, Inc.
     :copyright: Copyright © 2016 Cask Data, Inc.
 
-.. _cask-hydrator-action-plugins:
+.. _cask-hydrator-plugins-actions:
 
 ==============
 Action Plugins

--- a/cdap-docs/hydrator-manual/source/_includes/plugins/analytics/index.rst
+++ b/cdap-docs/hydrator-manual/source/_includes/plugins/analytics/index.rst
@@ -2,7 +2,7 @@
     :author: Cask Data, Inc.
     :copyright: Copyright © 2016 Cask Data, Inc.
 
-.. _cask-hydrator-analytic-plugins:
+.. _cask-hydrator-plugins-analytics:
 
 ================
 Analytic Plugins

--- a/cdap-docs/hydrator-manual/source/_includes/plugins/sources/index.rst
+++ b/cdap-docs/hydrator-manual/source/_includes/plugins/sources/index.rst
@@ -32,6 +32,16 @@ These plugins work with:
 
 These plugins work with:
 
+  - *Data Pipeline - Realtime* (``cdap-data-streams`` artifact)
+
+.. toctree::
+    :maxdepth: 1
+    :glob:
+    
+    *streamingsource*
+
+These plugins work with:
+
   - *Realtime Pipeline* (``cdap-etl-realtime`` artifact, deprecated as of CDAP 3.5.0)
 
 .. toctree::
@@ -40,12 +50,3 @@ These plugins work with:
 
     *realtime*
 
-These plugins work with:
-
-  - *Data Pipeline - Realtime* (``cdap-data-streams`` artifact)
-
-.. toctree::
-    :maxdepth: 1
-    :glob:
-    
-    *streamingsource*

--- a/cdap-docs/hydrator-manual/source/creating-pipelines.rst
+++ b/cdap-docs/hydrator-manual/source/creating-pipelines.rst
@@ -34,9 +34,6 @@ which are used to create the different kinds of data pipeline applications.
 **Note:** *Two system artifacts,* ``cdap-etl-batch`` *and* ``cdap-etl-realtime``, *have
 been deprecated and replaced by the above artifacts, as of CDAP 3.5.0.*
 
-An additional system artifact (``core-plugins``) provides common resources for the other
-system artifacts, and can be used by developers of custom plugins.
-
 Pipelines can be created using Cask Hydrator's included visual editor (*Cask Hydrator
 Studio*), using command-line tools such the CDAP CLI and ``curl``, or programmatically
 with scripts or Java programs.
@@ -97,7 +94,7 @@ Batch Pipelines
 
 Introduction
 ------------
-Batch pipelines can be scheduled to run periodically, using a cron expression and can read
+Batch pipelines can be scheduled to run periodically using a cron expression, and can read
 data from batch sources using either a MapReduce or Spark job. The batch application then
 performs any (optional) transformations before writing to one or more batch sinks.
 
@@ -109,11 +106,13 @@ Types of Plugins
 ----------------
 Batch pipelines, based on the ``cdap-data-pipeline`` application template, can include these plugins:
 
-- :ref:`Actions <cask-hydrator-action-plugins>`
+- :ref:`Actions <cask-hydrator-plugins-actions>`
 
 - :ref:`Batch Source Plugins <cask-hydrator-plugins-batch-sources>`
 
 - :ref:`Transformation Plugins <cask-hydrator-plugins-transformations>`
+
+- :ref:`Analytics Plugins <cask-hydrator-plugins-analytics>`
 
 - :ref:`Batch Sink Plugins <cask-hydrator-plugins-batch-sinks>`
 
@@ -137,13 +136,14 @@ To use Hydrator Studio to create a batch pipeline:
   template for your pipeline.
 
 - Click the icons in the left-sidebar to select the plugins you would like included in
-  your pipeline. In addition to the :ref:`action plugins <cask-hydrator-action-plugins>`
-  and the :ref:`transform plugins <cask-hydrator-plugins-transformations>`, you can use
+  your pipeline. In addition to the :ref:`action plugins <cask-hydrator-plugins-actions>`,
+  the :ref:`transform plugins <cask-hydrator-plugins-transformations>`, and certain of
+  the :ref:`analytics plugins <cask-hydrator-plugins-analytics>`, you can use
   any of the :ref:`batch source plugins <cask-hydrator-plugins-batch-sources>` or the
   :ref:`batch sink plugins <cask-hydrator-plugins-batch-sinks>`.
 
-- Typically, you will need at a minimum a source, a sink, and any optional transformations
-  that are needed being the source and sink stages.
+- Typically, you will need at a minimum a source, a sink, and any optional transformations or analytics
+  that are required between the source and sink stages.
   
 - Action steps can be added before a source and after a sink. These will be run only at
   the start (before a source) and only at the end if the pipeline successfully completes.
@@ -245,7 +245,7 @@ action to run irregardless of completion, use a :ref:`post-run action
 
 Currently, action plugins are only available when using the ``cdap-data-pipeline``
 application template. Available action plugins are documented in the :ref:`Plugin
-Reference <cask-hydrator-action-plugins>`, with this action available:
+Reference <cask-hydrator-plugins-actions>`, with this action available:
 
 - *SSH Action*, which establishes an SSH connection with a remote machine to execute a
   command on that machine.
@@ -280,21 +280,26 @@ Real-time Pipelines
 
 Introduction
 ------------
-Real-time pipelines are designed to poll sources periodically to fetch data, perform any
-(optional) transformations, and then write to one or more real-time sinks. As they are
-intended to be run continuously, post-run actions are not applicable or available.
+Real-time pipelines are designed to generate micro batches of data at a regular interval, perform any
+(optional) transformations and analytics, and then write to one or more sinks. As they are
+intended to be run continuously, actions and post-run actions are not applicable or available.
+Real-time pipelines do not operate on a record by record basis, but on a micro batch by micro batch basis.
 
 Types of Plugins
 ----------------
-Real-time pipelines, based on the ``cdap-etl-realtime`` application template, can include these plugins:
+Real-time pipelines, based on the ``cdap-data-streams`` application template, can include these plugins:
 
-- :ref:`Actions <cask-hydrator-action-plugins>`
-
-- :ref:`Real-time Sink Source Plugins <cask-hydrator-plugins-real-time-sources>`
+- :ref:`Streaming Source Plugins <cask-hydrator-plugins-real-time-sources>`
 
 - :ref:`Transformation Plugins <cask-hydrator-plugins-transformations>`
 
-- :ref:`Real-time Sink Plugins <cask-hydrator-plugins-real-time-sinks>`
+- :ref:`Analytics Plugins <cask-hydrator-plugins-analytics>`
+
+- :ref:`Batch Sink Plugins <cask-hydrator-plugins-batch-sinks>`
+
+Despite the name, batch sink plugins are not limited to just batch pipelines.
+The real-time pipeline artifact generates micro batches that can then be written to a batch sink.
+
 
 How Does It Work?
 -----------------
@@ -302,11 +307,7 @@ A real-time pipeline is created by taking a "virtual" pipeline (in the form of a
 configuration file) and then creating a "physical" pipeline as a CDAP application with
 appropriate CDAP programs to implement the configuration.
 
-The programs used will depend on the plugins used to build the pipeline. The available
-plugins are determined by those plugins that will work with the *ETL Realtime* (the
-``cdap-etl-realtime`` artifact), as listed above.
-
-The application created will consist of a worker to be run continuously, polling as required.
+The application created will consist of a Spark Streaming program.
 
 Building a Pipeline
 -------------------
@@ -314,23 +315,23 @@ To create a real-time pipeline, you can use either Hydrator Studio or command li
 
 To use Hydrator Studio to create a real-time pipeline:
 
-- Specify *ETL Realtime* (the ``cdap-etl-realtime`` artifact) as the application
+- Specify *Data Pipeline - Realtime* (the ``cdap-data-streams`` artifact) as the application
   template for your pipeline.
 
 - Click the icons in the left-sidebar to select the plugins you would like included in
-  your pipeline. In addition to the :ref:`action plugins <cask-hydrator-action-plugins>`
-  and the :ref:`transform plugins <cask-hydrator-plugins-transformations>`, you can use
-  any of the :ref:`real-time source plugins <cask-hydrator-plugins-real-time-sources>` or the
-  :ref:`real-time sink plugins <cask-hydrator-plugins-real-time-sinks>`.
+  your pipeline. In addition to the :ref:`transform plugins <cask-hydrator-plugins-transformations>`
+  and certain of the :ref:`analytics plugins <cask-hydrator-plugins-analytics>`,
+  you can use any of the :ref:`streaming source plugins <cask-hydrator-plugins-real-time-sources>` or the
+  :ref:`batch sink plugins <cask-hydrator-plugins-batch-sinks>`.
 
-- Typically, you will need at a minimum a source, a sink, and any optional transformations
-  that are needed being the source and sink stages.
+- You will need at a minimum a source, a sink, and any optional transformations or analytics
+  that are needed between the source and sink stages.
   
-- Action steps can be added before a source and after a sink. These will be run only at
-  the start (before a source) and only at the end if the pipeline successfully completes.
-
-- The *Settings* button allows you to specify the number of instances used for workers of
-  the pipeline. The default is one.
+- The *Settings* button allows you to specify the batch interval for your pipeline. The batch interval controls
+  how often your sources will generate a micro batch of data. This must be a number followed
+  by a time unit, with 's' for seconds, 'm' for minutes, and 'h' for hours.
+  For example, '10s' translates to ten seconds. This means the sources will generate a micro batch of data every
+  ten seconds.
 
 - Complete all required information for each stage, and any optional information that your
   particular use requires.

--- a/cdap-docs/hydrator-manual/source/developing-pipelines.rst
+++ b/cdap-docs/hydrator-manual/source/developing-pipelines.rst
@@ -228,7 +228,7 @@ when the run completes, a post-run action send an email indicating that the run 
               "type": "postaction",
               "artifact": {
                 "name": "core-plugins",
-                "version": "1.4.0-SNAPSHOT",
+                "version": "|cask-hydrator-version|",
                 "scope": "SYSTEM"
               },
               "properties": {
@@ -330,8 +330,14 @@ where, in both cases, ``config.json`` is the file that contains the pipeline con
 
 Creating a Real-Time Pipeline
 =============================
+With a Hydrator real-time pipeline, a ``batchInterval`` property is required
+specifying the frequency at which the sources will create new micro batches of data.
+The ``batchInterval`` must be a number followed by a time unit, with 's' for seconds,
+'m' for minutes, and 'h' for hours. For example, a value of '10s' will be interpreted
+as ten seconds. This means that every ten seconds, a new micro batch of data will be generated. 
+
 To create a real-time pipeline that reads from a source such as Twitter and writes to a
-stream after performing a projection transformation, you can use a configuration such as:
+CDAP Table after performing a projection transformation, you can use a configuration such as:
 
 .. container:: highlight
 
@@ -340,21 +346,20 @@ stream after performing a projection transformation, you can use a configuration
     {
       "name": "twitterToStream",
       "artifact": {
-        "name": "cdap-etl-realtime",
+        "name": "cdap-data-streams",
         "version": "|release|",
         "scope": "system"
       },
       "config": {
-        "instances": 1,
-        "postActions": [],
+        "batchInterval": "10s",
         "stages": [
           {
             "name": "twitterSource",
             "plugin": {
               "name": "Twitter",
-              "type": "realtimesource",
+              "type": "streamingsource",
               "artifact": {
-                "name": "core-plugins",
+                "name": "spark-plugins",
                 "version": "|cask-hydrator-version|",
                 "scope": "system"
               },
@@ -384,18 +389,19 @@ stream after performing a projection transformation, you can use a configuration
             }
           },
           {
-            "name": "streamSink",
+            "name": "tableSink",
             "plugin": {
-              "name": "Stream",
-              "type": "realtimesink",
+              "name": "Table",
+              "type": "batchsink",
               "artifact": {
                 "name": "core-plugins",
                 "version": "|cask-hydrator-version|",
                 "scope": "system"
               },              
               "properties": {
-                "name": "twitterStream",
-                "body.field": "tweet"
+                "name": "myTable",
+                "schema": "{\\"type\\":\\"record\\",\\"name\\":\\"etlSchemaBody\\",\\"fields\\":[{\\"name\\":\\"id\\",\\"type\\":\\"long\\"},{\\"name\\":\\"tweet\\",\\"type\\":\\"string\\"},{\\"name\\":\\"retCount\\",\\"type\\":\\"int\\"}]}",
+                "schema.row.field": "id"
               }
             }
           }
@@ -407,27 +413,16 @@ stream after performing a projection transformation, you can use a configuration
           },
           {
             "from": "dropProjector",
-            "to": "streamSink"
+            "to": "tableSink"
           }
         ]
       }
     }
 
-A Hydrator real-time pipeline expects an instance property that will create *N* instances
-of the worker that runs concurrently. In Standalone CDAP mode, this is implemented as
-multiple threads; in Distributed CDAP mode, it will create different YARN containers. The
-number of worker instances of a real-time pipeline should not (in general) be changed
-during runtime. If the number of instances needs to be changed, the worker must first be
-stopped, and then the pipeline configuration can be updated to the new number of instances.
-
-The ``instances`` property value needs to be greater than zero. Note that the ``instance``
-property replaces the ``schedule`` property of a Hydrator batch pipeline.
-
 In the example code above, we will use a *ProjectionTransform* (a type of transform) to
-drop and rename selected columns in the incoming data. A *StreamSink* in the final step
-needs a data field property (``body.field``) that it will use as the content for the data
-to be written.
-
+drop and rename selected columns in the incoming data. A *TableSink* in the final step
+requires a schema property that it will use to set the columns and row field for
+writing the data to a CDAP Table.
 
 Non-linear Executions in Pipelines
 ==================================
@@ -603,7 +598,7 @@ of received records will vary.
               "type": "batchstream",
               "artifact": {
                 "name": "core-plugins",
-                "version": "1.4.0-SNAPSHOT",
+                "version": "|cask-hydrator-version|",
                 "scope": "SYSTEM"
               },
               "properties": {
@@ -630,7 +625,7 @@ of received records will vary.
               "type": "transform",
               "artifact": {
                 "name": "core-plugins",
-                "version": "1.4.0-SNAPSHOT",
+                "version": "|cask-hydrator-version|",
                 "scope": "SYSTEM"
               },
               "properties": {
@@ -663,7 +658,7 @@ of received records will vary.
               "type": "transform",
               "artifact": {
                 "name": "core-plugins",
-                "version": "1.4.0-SNAPSHOT",
+                "version": "|cask-hydrator-version|",
                 "scope": "SYSTEM"
               },
               "properties": {
@@ -692,7 +687,7 @@ of received records will vary.
               "type": "batchsink",
               "artifact": {
                 "name": "core-plugins",
-                "version": "1.4.0-SNAPSHOT",
+                "version": "|cask-hydrator-version|",
                 "scope": "SYSTEM"
               },
               "properties": {
@@ -757,7 +752,7 @@ Sample configuration for using a *Database Source* and a *Database Sink*:
               "type": "batchsource",
               "artifact": {
                 "name": "core-plugins",
-                "version": "1.4.0-SNAPSHOT",
+                "version": "|cask-hydrator-version|",
                 "scope": "SYSTEM"
               },
               "properties": {
@@ -779,7 +774,7 @@ Sample configuration for using a *Database Source* and a *Database Sink*:
               "type": "batchsink",
               "artifact": {
                 "name": "core-plugins",
-                "version": "1.4.0-SNAPSHOT",
+                "version": "|cask-hydrator-version|",
                 "scope": "SYSTEM"
               },
               "properties": {
@@ -816,49 +811,52 @@ creating the source:
     {
       "name": "KafkaPipeline",
       "artifact": {
-        "name": "cdap-etl-realtime",
+        "name": "cdap-data-streams",
         "version": "|version|",
         "scope": "system"
       },
       "config": {
+        "batchInterval": "1s",
         "connections": [
           {
             "from": "kafkaSource",
-            "to": "streamSink"
+            "to": "tableSink"
           }
-        ]
-        "instances": 1,
+        ],
         "stages": [
           {
             "name": "kafkaSource",
             "plugin": {
               "name": "Kafka",
-              "type": "realtimesource",
+              "type": "streamingsource",
               "artifact": {
-                "name": "core-plugins",
-                "version": "1.4.0-SNAPSHOT",
+                "name": "spark-plugins",
+                "version": "|cask-hydrator-version|",
                 "scope": "SYSTEM"
               },
               "properties": {
-                "kafka.partitions": "1",
-                "kafka.topic": "test",
-                "kafka.brokers": "localhost:9092"
+                "referenceName": "purchasesTopic",
+                "brokers": "localhost:9092",
+                "topics": "purchases",
+                "format": "csv",
+                "schema": "{\\"type\\":\\"record\\",\\"name\\":\\"etlSchemaBody\\",\\"fields\\":[{\\"name\\":\\"id\\",\\"type\\":\\"long\\"},{\\"name\\":\\"customer\\",\\"type\\":\\"string\\"},{\\"name\\":\\"item\\",\\"type\\":\\"string\\"}]}"
               }
             }
           },
           {
-            "name": "streamSink",
+            "name": "tableSink",
             "plugin": {
-              "name": "Stream",
-              "type": "realtimesink",
+              "name": "Table",
+              "type": "batchsink",
               "artifact": {
                 "name": "core-plugins",
-                "version": "1.4.0-SNAPSHOT",
-                "scope": "SYSTEM"
-              },
+                "version": "|cask-hydrator-version|",
+                "scope": "system"
+              },              
               "properties": {
-                "name": "myStream",
-                "body.field": "message"
+                "name": "myTable",
+                "schema": "{\\"type\\":\\"record\\",\\"name\\":\\"etlSchemaBody\\",\\"fields\\":[{\\"name\\":\\"id\\",\\"type\\":\\"long\\"},{\\"name\\":\\"customer\\",\\"type\\":\\"string\\"},{\\"name\\":\\"item\\",\\"type\\":\\"string\\"}]}"
+                "schema.row.field": "id"
               }
             }
           }

--- a/cdap-docs/hydrator-manual/source/developing-plugins/index.rst
+++ b/cdap-docs/hydrator-manual/source/developing-plugins/index.rst
@@ -23,10 +23,11 @@ pipelines should refer to the documentation on :ref:`using plugins
 <cask-hydrator-introduction-what-is-a-plugin>`.
 
 CDAP provides for the creation of custom plugins to extend the existing
-``cdap-data-pipeline`` and ``cdap-etl-realtime`` system artifacts.
+``cdap-data-pipeline`` and ``cdap-data-streams`` system artifacts.
 
-**Note:** *The* ``cdap-etl-batch`` *artifact has been deprecated and replaced with the*
-``cdap-data-pipeline``, *as of CDAP 3.5.0.*
+**Note:** *As of CDAP 3.5.0, the* ``cdap-etl-batch`` *artifact has been deprecated and replaced with the*
+``cdap-data-pipeline``, *artifact, and the* ``cdap-etl-realtime`` *artifact has been deprecated and replaced with the*
+``cdap-data-streams``, *artifact.*
 
 Deploying plugins is covered under :ref:`Plugin Management: Plugin Deployment
 <cask-hydrator-plugin-management-deployment>`, for deploying as either a system or user

--- a/cdap-docs/hydrator-manual/source/developing-plugins/plugin-basics.rst
+++ b/cdap-docs/hydrator-manual/source/developing-plugins/plugin-basics.rst
@@ -13,15 +13,22 @@ Plugin Types
 In Cask Hydrator, these plugin types are presently used:
 
 - Action (*action*, restricted to batch pipelines)
-- Batch Source (*batchsource*)
+- Batch Source (*batchsource*, restricted to batch pipelines)
 - Batch Sink (*batchsink*)
-- Real-time Source (*realtimesource*)
-- Real-time Sink (*realtimesink*)
+- Streaming Source (*streamingsource*, restricted to real-time pipelines)
 - Transformation (*transform*)
 - Batch Aggregator (*batchaggregator*)
+- Batch Joiner (*batchjoiner*)
 - Spark Compute (*sparkcompute*)
-- Spark Sink (*sparksink*) 
+- Spark Sink (*sparksink*, restricted to batch pipelines) 
+- Windower (*windower*, restricted to real-time pipelines)
 - Post-run Action (*postaction*, restricted to batch pipelines)
+- Real-time Source (*realtimesource*, deprecated)
+- Real-time Sink (*realtimesink*, deprecated)
+
+In the Cask Hydrator UI, all Batch Aggregator, Batch Joiner, Spark Compute, and Spark Sink
+plugins are grouped under the Analytics section. All Transformation and Windower plugins
+are grouped under the Transforms section. 
 
 .. _cask-hydrator-developing-plugin-basics-maven-archetypes:
 
@@ -30,8 +37,8 @@ Maven Archetypes
 To get started on creating a custom plugin, you can use one of these Maven archetypes to create your project: 
 
 - ``cdap-data-pipeline-plugins-archetype`` (contains batch, Spark plugin, and other types)
-- ``cdap-etl-realtime-source-archetype`` (contains a realtime source)
-- ``cdap-etl-realtime-sink-archetype`` (contains a realtime sink)
+- ``cdap-etl-realtime-source-archetype`` (contains a realtime source, deprecated)
+- ``cdap-etl-realtime-sink-archetype`` (contains a realtime sink, deprecated)
 - ``cdap-etl-transform-archetype`` (contains a transform)
 
 This command will create a project from an archetype:


### PR DESCRIPTION
Updating docs with information about the data streams app.
Replaces some of the documentation on etl-realtime with information
about data-streams. Also adding documentation on the new
StreamingSource and Windower plugin types. Also added a little
blurb at the start of each plugin type section describing what
it is used for.
