### PR TITLE
CDAP-6425 Update FileSetAdmin#Create to throw Exception if base location alread…

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetAdmin.java
@@ -64,6 +64,10 @@ public class FileSetAdmin implements DatasetAdmin, Updatable {
   @Override
   public void create() throws IOException {
     if (!isExternal) {
+      if (exists()) {
+        throw new IOException(String.format(
+          "Base location for file set '%s' at %s already exists", name, baseLocation));
+      }
       baseLocation.mkdirs();
     } else if (!exists()) {
         throw new IOException(String.format(

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/FileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/FileSetTest.java
@@ -63,6 +63,8 @@ public class FileSetTest {
     Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "lookAlikeFileSet");
   private static final Id.DatasetInstance testFileSetInstance5 =
     Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "externalFileSet");
+  private static final Id.DatasetInstance testFileSetInstance6 =
+    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "nonExternalFileSet1");
 
   @Before
   public void before() throws Exception {
@@ -88,6 +90,7 @@ public class FileSetTest {
     deleteInstance(testFileSetInstance3);
     deleteInstance(testFileSetInstance4);
     deleteInstance(testFileSetInstance5);
+    deleteInstance(testFileSetInstance6);
   }
 
   static void deleteInstance(Id.DatasetInstance id) throws Exception {
@@ -224,6 +227,21 @@ public class FileSetTest {
                                    FileSetProperties.builder()
                                      .setBasePath(absolutePath)
                                      .setDataExternal(true)
+                                     .build());
+  }
+
+
+  @Test(expected = IOException.class)
+  public void testNonExternalExistentPath() throws Exception {
+    // Create an instance at a location
+    String absolutePath = tmpFolder.newFolder() + "/some/existing/location";
+    File file = new File(absolutePath);
+    Assert.assertTrue(file.mkdirs());
+    // Try to add another instance of non external fileset at the same location
+    dsFrameworkUtil.createInstance("fileSet", testFileSetInstance6,
+                                   FileSetProperties.builder()
+                                     .setBasePath(absolutePath)
+                                     .setDataExternal(false)
                                      .build());
   }
 

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -424,8 +424,8 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
   @Category(SlowTests.class)
   @Test
   public void testMapperDatasetAccess() throws Exception {
-    addDatasetInstance("keyValueTable", "table1").create();
-    addDatasetInstance("keyValueTable", "table2").create();
+    addDatasetInstance("keyValueTable", "table1");
+    addDatasetInstance("keyValueTable", "table2");
     DataSetManager<KeyValueTable> tableManager = getDataset("table1");
     KeyValueTable inputTable = tableManager.get();
     inputTable.write("hello", "world");
@@ -450,8 +450,8 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     getNamespaceAdmin().create(inputNS);
     getNamespaceAdmin().create(outputNS);
 
-    addDatasetInstance(inputNS.getNamespaceId().toId(), "keyValueTable", "table1").create();
-    addDatasetInstance(outputNS.getNamespaceId().toId(), "keyValueTable", "table2").create();
+    addDatasetInstance(inputNS.getNamespaceId().toId(), "keyValueTable", "table1");
+    addDatasetInstance(outputNS.getNamespaceId().toId(), "keyValueTable", "table2");
     DataSetManager<KeyValueTable> tableManager = getDataset(inputNS.getNamespaceId().toId(), "table1");
     KeyValueTable inputTable = tableManager.get();
     inputTable.write("hello", "world");
@@ -553,8 +553,8 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
   @Category(SlowTests.class)
   @Test
   public void testCustomActionDatasetAccess() throws Exception {
-    addDatasetInstance("keyValueTable", DatasetWithCustomActionApp.CUSTOM_TABLE).create();
-    addDatasetInstance("fileSet", DatasetWithCustomActionApp.CUSTOM_FILESET).create();
+    addDatasetInstance("keyValueTable", DatasetWithCustomActionApp.CUSTOM_TABLE);
+    addDatasetInstance("fileSet", DatasetWithCustomActionApp.CUSTOM_FILESET);
 
     ApplicationManager appManager = deployApplication(DatasetWithCustomActionApp.class);
     ServiceManager serviceManager = appManager.getServiceManager(DatasetWithCustomActionApp.CUSTOM_SERVICE).start();
@@ -1523,14 +1523,14 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
   @Test(timeout = 60000L)
   public void testAppWithExistingDataset() throws Exception {
     deployDatasetModule("my-kv", AppsWithDataset.KeyValueTableDefinition.Module.class);
-    addDatasetInstance("myKeyValueTable", "myTable", DatasetProperties.EMPTY).create();
+    addDatasetInstance("myKeyValueTable", "myTable", DatasetProperties.EMPTY);
     testAppWithDataset(AppsWithDataset.AppWithExisting.class, "MyService");
   }
 
   @Test(timeout = 60000L)
   public void testAppWithExistingDatasetInjectedByAnnotation() throws Exception {
     deployDatasetModule("my-kv", AppsWithDataset.KeyValueTableDefinition.Module.class);
-    addDatasetInstance("myKeyValueTable", "myTable", DatasetProperties.EMPTY).create();
+    addDatasetInstance("myKeyValueTable", "myTable", DatasetProperties.EMPTY);
     testAppWithDataset(AppsWithDataset.AppUsesAnnotation.class, "MyServiceWithUseDataSetAnnotation");
   }
 
@@ -1539,7 +1539,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     // TODO: Although this has nothing to do with this testcase, deploying a dummy app to create the default namespace
     deployApplication(testSpace, DummyApp.class);
     deployDatasetModule(testSpace, "my-kv", AppsWithDataset.KeyValueTableDefinition.Module.class);
-    addDatasetInstance(testSpace, "myKeyValueTable", "myTable", DatasetProperties.EMPTY).create();
+    addDatasetInstance(testSpace, "myKeyValueTable", "myTable", DatasetProperties.EMPTY);
     DataSetManager<AppsWithDataset.KeyValueTableDefinition.KeyValueTable> dataSetManager =
       getDataset(testSpace, "myTable");
     AppsWithDataset.KeyValueTableDefinition.KeyValueTable kvTable = dataSetManager.get();


### PR DESCRIPTION
…y exists for non-external file set

CDAP-6425 FileSetAdmin#create should fail if the directory already exists: https://issues.cask.co/browse/CDAP-6425
Build: http://builds.cask.co/browse/CDAP-DUT4738-1
