### PR TITLE
[CDAP-7178] check for existence of token before setting Authorization header

### DIFF
--- a/cdap-ui/app/services/file-uploader.js
+++ b/cdap-ui/app/services/file-uploader.js
@@ -46,7 +46,11 @@ angular.module(PKG.name + '.services')
         }
 
         xhr.setRequestHeader('X-Archive-Name', fileObj.file.name);
-        xhr.setRequestHeader('Authorization', 'Bearer ' + myAuth.currentUser.token);
+
+        if (myAuth.currentUser.token) {
+          xhr.setRequestHeader('Authorization', 'Bearer ' + myAuth.currentUser.token);
+        }
+
         xhr.send(fileObj.file);
         cfpLoadingBar.start();
         xhr.onreadystatechange = function () {


### PR DESCRIPTION
Rootcause: File upload in UI is using direct XHR connection, and it strips off Authorization header that is being used by HDInsight gateway. 

Fix: Check for existence of currentUser token before setting Authorization

JIRA: https://issues.cask.co/browse/CDAP-7178
