### PR TITLE
CDAP-5577 Deprecated getEntity() and added the same method with name …

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/audit/AuditPublishTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/audit/AuditPublishTest.java
@@ -133,7 +133,7 @@ public class AuditPublishTest {
           continue;
         }
       }
-      if (entityId.getEntity() == EntityType.ARTIFACT && entityId instanceof ArtifactId) {
+      if (entityId.getEntityType() == EntityType.ARTIFACT && entityId instanceof ArtifactId) {
         ArtifactId artifactId = (ArtifactId) entityId;
         // Version is dynamic for deploys in test cases
         entityId = Ids.namespace(artifactId.getNamespace()).artifact(artifactId.getArtifact(), "1");

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
@@ -85,7 +85,15 @@ public abstract class EntityId implements IdCompatible {
 
   protected abstract Iterable<String> toIdParts();
 
+  /**
+   *  Deprecated method to rename to getEntityType(). Use {@link #getEntityType()}
+   */
+  @Deprecated
   public final EntityType getEntity() {
+    return entity;
+  }
+
+  public final EntityType getEntityType() {
     return entity;
   }
 

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/id/EntityIdTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/id/EntityIdTest.java
@@ -257,7 +257,7 @@ public class EntityIdTest {
   @Ignore
   public void printToString() {
     for (EntityId id : ids) {
-      System.out.println(id.getEntity() + ": " + id.toString());
+      System.out.println(id.getEntityType() + ": " + id.toString());
     }
   }
 
@@ -265,7 +265,7 @@ public class EntityIdTest {
   @Ignore
   public void printToJson() {
     for (EntityId id : ids) {
-      System.out.println(id.getEntity() + ": " + GSON.toJson(id));
+      System.out.println(id.getEntityType() + ": " + GSON.toJson(id));
     }
   }
 


### PR DESCRIPTION
…getEntityType()

https://issues.cask.co/browse/CDAP-5577: EntityId.getEntity() returns EntityType. Rename to getEntityType()

Not sure if this is the right approach but I deprecated the method instead of renaming it as several projects use it. Will rename the usages of the method but don't wanna break anything in the meantime.
Build: http://builds.cask.co/browse/CDAP-DUT4744-1
JIRA to remove the method after two versions: https://issues.cask.co/browse/CDAP-7185
