### PR TITLE
CDAP-7156 Added a toString method to ResolvingDiscoverable

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/discovery/ResolvingDiscoverable.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/discovery/ResolvingDiscoverable.java
@@ -59,4 +59,9 @@ public class ResolvingDiscoverable implements Discoverable {
     }
     return bindAddress;
   }
+  
+  @Override
+  public String toString() {
+    return getName();
+  }
 }


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-7156 ResolvingDiscoverable does not implement toString()
