### PR TITLE
CDAP-1491 Add a note about all REST APIs returning FORBIDDEN

### DIFF
--- a/cdap-docs/reference-manual/source/http-restful-api/base-url.txt
+++ b/cdap-docs/reference-manual/source/http-restful-api/base-url.txt
@@ -2,3 +2,5 @@
 All methods or endpoints described in this API have a base URL (typically
 ``http://<host>:10000`` or ``https://<host>:10443``) that precedes the resource
 identifier, as described in the :ref:`RESTful API Conventions <http-restful-api-conventions-base-url>`.
+These methods return a status code, as listed in the :ref:`RESTful API  Status Codes
+<http-restful-api-status-codes>`.

--- a/cdap-docs/reference-manual/source/http-restful-api/introduction.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/introduction.rst
@@ -126,14 +126,13 @@ Status Codes
      - The request had a combination of parameters that is not recognized
    * - ``401``
      - ``Unauthorized``
-     - The request did not contain an authentication token; requests can fail due to a
-       lack of authorization, as described in the section below on
-       :ref:`http-restful-api-working-with-cdap-security`.
+     - The request did not contain an authentication token; see the section below on
+       :ref:`http-restful-api-working-with-cdap-security`
    * - ``403``
      - ``Forbidden``
      - The request was authenticated but the client does not have permission; requests can
        fail due to a lack of privilege, as described in the section below on
-       :ref:`http-restful-api-working-with-cdap-security`.
+       :ref:`http-restful-api-working-with-cdap-security`
    * - ``404``
      - ``Not Found``
      - The request did not address any of the known URIs
@@ -150,7 +149,7 @@ Status Codes
      - ``Not Implemented``
      - A request contained a query that is not supported by this API
 
-**Notes:** These returned status codes are not necessarily included in the descriptions of
+**Note:** These returned status codes are not necessarily included in the descriptions of
 the APIs, but a request may return any of these.
 
 Converting from V2 APIs

--- a/cdap-docs/reference-manual/source/http-restful-api/introduction.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/introduction.rst
@@ -126,10 +126,14 @@ Status Codes
      - The request had a combination of parameters that is not recognized
    * - ``401``
      - ``Unauthorized``
-     - The request did not contain an authentication token
+     - The request did not contain an authentication token; requests can fail due to a
+       lack of authorization, as described in the section below on
+       :ref:`http-restful-api-working-with-cdap-security`.
    * - ``403``
      - ``Forbidden``
-     - The request was authenticated but the client does not have permission
+     - The request was authenticated but the client does not have permission; requests can
+       fail due to a lack of privilege, as described in the section below on
+       :ref:`http-restful-api-working-with-cdap-security`.
    * - ``404``
      - ``Not Found``
      - The request did not address any of the known URIs
@@ -146,12 +150,8 @@ Status Codes
      - ``Not Implemented``
      - A request contained a query that is not supported by this API
 
-**Notes** 
-
-- These returned status codes are not necessarily included in the descriptions of the APIs,
-  but a request may return any of these.
-- Requests can fail due to a lack of authorization or privilege, as described in the
-  section below on :ref:`http-restful-api-working-with-cdap-security`.
+**Notes:** These returned status codes are not necessarily included in the descriptions of
+the APIs, but a request may return any of these.
 
 Converting from V2 APIs
 =======================
@@ -172,18 +172,18 @@ addition of namespaces.
 
 Working with CDAP Security
 ==========================
-When working with a CDAP cluster with **security enabled** (``security.enabled=true`` in
-``cdap-site.xml``), all calls to the HTTP RESTful APIs must be authenticated. Clients must
-first obtain an access token from the authentication server (see the :ref:`Client
-Authentication <client-authentication>` section of the :ref:`developers:developer-index`).
-In order to authenticate, all client requests must supply this access token in the
-``Authorization`` header of the request::
+- When working with a CDAP cluster with **security enabled** (``security.enabled=true`` in
+  ``cdap-site.xml``), all calls to the HTTP RESTful APIs must be authenticated. Clients must
+  first obtain an access token from the authentication server (see the :ref:`Client
+  Authentication <client-authentication>` section of the :ref:`developers:developer-index`).
+  In order to authenticate, all client requests must supply this access token in the
+  ``Authorization`` header of the request::
 
-   Authorization: Bearer <token>
+    Authorization: Bearer <token>
 
-For CDAP-issued access tokens, the authentication scheme must always be ``Bearer``.
+  For CDAP-issued access tokens, the authentication scheme must always be ``Bearer``.
 
-When working with a CDAP cluster with **authorization enabled**
-(``security.authorization.enabled=true`` in ``cdap-site.xml``), all calls to the HTTP
-RESTful APIs must be authorized. Clients must be privileged, following the polices
-described in :ref:`security-authorization-policies`.
+- When working with a CDAP cluster with **authorization enabled**
+  (``security.authorization.enabled=true`` in ``cdap-site.xml``), all calls to the HTTP
+  RESTful APIs must be authorized. Clients must be privileged, following the polices
+  described in :ref:`security-authorization-policies`.

--- a/cdap-docs/reference-manual/source/http-restful-api/introduction.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/introduction.rst
@@ -146,9 +146,12 @@ Status Codes
      - ``Not Implemented``
      - A request contained a query that is not supported by this API
 
-**Note:** These returned status codes are not necessarily included in the descriptions of the APIs,
-but a request may return any of these.
+**Notes** 
 
+- These returned status codes are not necessarily included in the descriptions of the APIs,
+  but a request may return any of these.
+- Requests can fail due to a lack of authorization or privilege, as described in the
+  section below on :ref:`http-restful-api-working-with-cdap-security`.
 
 Converting from V2 APIs
 =======================
@@ -165,10 +168,11 @@ can be replaced with::
 However, you will need to test your code, as many APIs have changed as a result of the 
 addition of namespaces.
 
+.. _http-restful-api-working-with-cdap-security:
 
 Working with CDAP Security
 ==========================
-When working with a CDAP cluster with security enabled (``security.enabled=true`` in
+When working with a CDAP cluster with **security enabled** (``security.enabled=true`` in
 ``cdap-site.xml``), all calls to the HTTP RESTful APIs must be authenticated. Clients must
 first obtain an access token from the authentication server (see the :ref:`Client
 Authentication <client-authentication>` section of the :ref:`developers:developer-index`).
@@ -178,3 +182,8 @@ In order to authenticate, all client requests must supply this access token in t
    Authorization: Bearer <token>
 
 For CDAP-issued access tokens, the authentication scheme must always be ``Bearer``.
+
+When working with a CDAP cluster with **authorization enabled**
+(``security.authorization.enabled=true`` in ``cdap-site.xml``), all calls to the HTTP
+RESTful APIs must be authorized. Clients must be privileged, following the polices
+described in :ref:`security-authorization-policies`.


### PR DESCRIPTION
Adding links and references about policies.

Running as Quick Build: http://builds.cask.co/browse/CDAP-DQB106-3
Build fails, but unrelated to this PR.

Pages of interest: to be completed:
- [HTTP RESTful API: Introduction: Status Codes](http://builds.cask.co/artifact/CDAP-DQB106/shared/build-3/Docs-HTML/3.5.0/en/reference-manual/http-restful-api/introduction.html#status-codes)
- [HTTP RESTful API: Introduction: Working With Security](http://builds.cask.co/artifact/CDAP-DQB106/shared/build-3/Docs-HTML/3.5.0/en/reference-manual/http-restful-api/introduction.html#working-with-cdap-security)
- [HTTP RESTful API: Artifacts](http://builds.cask.co/artifact/CDAP-DQB106/shared/build-3/Docs-HTML/3.5.0/en/reference-manual/http-restful-api/artifact.html)
