### PR TITLE
[HYDRATOR-374] Move Mock APIs from Hydrator Plugins to CDAP

### DIFF
--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/action/MockActionContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/action/MockActionContext.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.action;
+
+import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.api.security.store.SecureStoreData;
+import co.cask.cdap.etl.api.StageMetrics;
+import co.cask.cdap.etl.api.action.ActionContext;
+import co.cask.cdap.etl.api.action.SettableArguments;
+import co.cask.cdap.proto.id.NamespaceId;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Mock ActionContext for CustomAction tests.
+ */
+public class MockActionContext implements ActionContext {
+
+  private SettableArguments settableArguments;
+
+  public MockActionContext() {
+    this.settableArguments = new MockSettableArguments(new HashMap<String, String>());
+  }
+
+  @Override
+  public long getLogicalStartTime() {
+    return 0L;
+  }
+
+  @Override
+  public SettableArguments getArguments() {
+    return settableArguments;
+  }
+
+  @Override
+  public String getStageName() {
+    return null;
+  }
+
+  @Override
+  public StageMetrics getMetrics() {
+    return null;
+  }
+
+  @Override
+  public PluginProperties getPluginProperties() {
+    return null;
+  }
+
+  @Override
+  public PluginProperties getPluginProperties(String pluginId) {
+    return null;
+  }
+
+  @Override
+  public <T> Class<T> loadPluginClass(String pluginId) {
+    return null;
+  }
+
+  @Override
+  public <T> T newPluginInstance(String pluginId) throws InstantiationException {
+    return null;
+  }
+
+  @Override
+  public String getNamespace() {
+    return NamespaceId.DEFAULT.getNamespace();
+  }
+
+  @Override
+  public Map<String, String> listSecureData(String namespace) {
+    return null;
+  }
+
+  @Override
+  public SecureStoreData getSecureData(String namespace, String name) {
+    return null;
+  }
+
+  @Override
+  public void putSecureData(String namespace, String name, String data, String description,
+                            Map<String, String> properties) {
+    // no-op; unused
+  }
+
+  @Override
+  public void deleteSecureData(String namespace, String name) {
+    // no-op; unused
+  }
+
+  @Override
+  public void execute(TxRunnable runnable) {
+    // no-op; unused
+  }
+
+  /**
+   * SettableArguments class for MockActionContext.
+   */
+  private static class MockSettableArguments implements SettableArguments {
+    private final Map<String, String> options;
+
+    private MockSettableArguments(Map<String, String> arguments) {
+      options = new HashMap<>();
+      for (Map.Entry<String, String> argument : arguments.entrySet()) {
+        options.put(argument.getKey(), argument.getValue());
+      }
+    }
+
+    @Override
+    public boolean has(String name) {
+      return options.containsKey(name);
+    }
+
+    @Override
+    public String get(String name) {
+      return options.get(name);
+    }
+
+    @Override
+    public void set(String name, String value) {
+      options.put(name, value);
+    }
+
+    @Override
+    public Map<String, String> asMap() {
+      return options;
+    }
+
+    @Override
+    public Iterator<Map.Entry<String, String>> iterator() {
+      return options.entrySet().iterator();
+    }
+  }
+}
+

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/common/MockEmitter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/common/MockEmitter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.common;
+
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.InvalidEntry;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Mock implementation of {@link Emitter} for unit tests.
+ *
+ * @param <T> type of object to emit
+ */
+public class MockEmitter<T> implements Emitter<T> {
+  private final List<T> emitted = new ArrayList<>();
+  private final List<InvalidEntry<T>> errors = new ArrayList<>();
+
+  @Override
+  public void emit(T value) {
+    emitted.add(value);
+  }
+
+  @Override
+  public void emitError(InvalidEntry<T> value) {
+    errors.add(value);
+  }
+
+  public List<T> getEmitted() {
+    return emitted;
+  }
+
+  public List<InvalidEntry<T>> getErrors() {
+    return errors;
+  }
+
+  public void clear() {
+    emitted.clear();
+    errors.clear();
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/common/MockLookupProvider.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/common/MockLookupProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.common;
+
+import co.cask.cdap.etl.api.Lookup;
+import co.cask.cdap.etl.api.LookupProvider;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Mock implementation of {@link LookupProvider} used for testing.
+ */
+public class MockLookupProvider implements LookupProvider {
+
+  private final Lookup lookup;
+
+  public MockLookupProvider(Lookup lookup) {
+    this.lookup = lookup;
+  }
+
+  @Override
+  public <T> Lookup<T> provide(String table, @Nullable Map<String, String> arguments) {
+    //noinspection unchecked
+    return lookup;
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/common/MockMetrics.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/common/MockMetrics.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.common;
+
+import co.cask.cdap.api.metrics.Metrics;
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+
+/**
+ * Mock metrics for unit tests.
+ */
+public class MockMetrics implements Metrics {
+  private final Map<String, Long> gauges = Maps.newHashMap();
+  private final Map<String, Integer> counts = Maps.newHashMap();
+
+  @Override
+  public void count(String s, int i) {
+    if (counts.containsKey(s)) {
+      counts.put(s, counts.get(s) + i);
+    } else {
+      counts.put(s, i);
+    }
+  }
+
+  @Override
+  public void gauge(String s, long l) {
+    gauges.put(s, l);
+  }
+
+  public int getCount(String metric) {
+    Integer count = counts.get(metric);
+    return count == null ? 0 : count;
+  }
+
+  public long getGauge(String metric) {
+    Long val = gauges.get(metric);
+    return val == null ? 0 : val;
+  }
+
+  public void clearMetrics() {
+    counts.clear();
+    gauges.clear();
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/common/MockPipelineConfigurer.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/common/MockPipelineConfigurer.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.common;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.data.stream.Stream;
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.api.plugin.PluginSelector;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
+
+import java.util.Collections;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Mock test configurer used to test configure pipeline's validation of input schema and setting of output shcema.
+ */
+public class MockPipelineConfigurer implements PipelineConfigurer {
+  private final Schema inputSchema;
+  Schema outputSchema;
+  private Map<String, Object> plugins;
+
+  /**
+   * Creates a mock pipeline configurer with a map of plugins to use for validation.
+   * @param inputSchema The input schema to use for validation
+   * @param plugins A map from plugin ID strings to plugin objects to use
+   */
+  public MockPipelineConfigurer(Schema inputSchema, Map<String, Object> plugins) {
+    this.inputSchema = inputSchema;
+    this.plugins = plugins;
+  }
+
+  public MockPipelineConfigurer(Schema inputSchema) {
+    this(inputSchema, Collections.<String, Object>emptyMap());
+  }
+
+  @Nullable
+  public Schema getOutputSchema() {
+    return outputSchema;
+  }
+
+  @Override
+  public StageConfigurer getStageConfigurer() {
+    return new StageConfigurer() {
+      @Nullable
+      @Override
+      public Schema getInputSchema() {
+        return inputSchema;
+      }
+
+      @Override
+      public void setOutputSchema(@Nullable Schema schema) {
+        outputSchema = schema;
+      }
+    };
+  }
+
+  @Nullable
+  @Override
+  public <T> T usePlugin(String pluginType, String pluginName, String pluginId, PluginProperties pluginProperties) {
+    return (T) plugins.get(pluginId);
+  }
+
+  @Nullable
+  @Override
+  public <T> T usePlugin(String pluginType, String pluginName, String pluginId,
+                         PluginProperties pluginProperties, PluginSelector pluginSelector) {
+    return (T) plugins.get(pluginId);
+  }
+
+  @Nullable
+  @Override
+  public <T> Class<T> usePluginClass(String pluginType, String pluginName, String pluginId,
+                                     PluginProperties pluginProperties) {
+    return (Class<T>) plugins.get(pluginId).getClass();
+  }
+
+  @Nullable
+  @Override
+  public <T> Class<T> usePluginClass(String pluginType, String pluginName, String pluginId,
+                                     PluginProperties pluginProperties, PluginSelector pluginSelector) {
+    return (Class<T>) plugins.get(pluginId).getClass();
+  }
+
+  @Override
+  public void addStream(Stream stream) {
+
+  }
+
+  @Override
+  public void addStream(String s) {
+
+  }
+
+  @Override
+  public void addDatasetModule(String s, Class<? extends DatasetModule> aClass) {
+
+  }
+
+  @Override
+  public void addDatasetType(Class<? extends Dataset> aClass) {
+
+  }
+
+  @Override
+  public void createDataset(String s, String s1, DatasetProperties datasetProperties) {
+
+  }
+
+  @Override
+  public void createDataset(String s, String s1) {
+
+  }
+
+  @Override
+  public void createDataset(String s, Class<? extends Dataset> aClass, DatasetProperties datasetProperties) {
+
+  }
+
+  @Override
+  public void createDataset(String s, Class<? extends Dataset> aClass) {
+
+  }
+}
+

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/common/MockStageMetrics.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/common/MockStageMetrics.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.common;
+
+import co.cask.cdap.etl.api.StageMetrics;
+
+/**
+ * Mock StageMetrics for unit tests
+ */
+public class MockStageMetrics implements StageMetrics {
+  private final String stageName;
+  private final MockMetrics mockMetrics;
+
+  public MockStageMetrics(String stageName) {
+    this.stageName = stageName;
+    this.mockMetrics = new MockMetrics();
+  }
+
+  @Override
+  public void count(String s, int i) {
+    mockMetrics.count(stageName + "." + s, i);
+  }
+
+  @Override
+  public void gauge(String s, long l) {
+    mockMetrics.gauge(stageName + "." + s, l);
+  }
+
+  @Override
+  public void pipelineCount(String s, int i) {
+    mockMetrics.count(s, i);
+  }
+
+  @Override
+  public void pipelineGauge(String s, long l) {
+    mockMetrics.gauge(s, l);
+  }
+
+  public int getPipelineCount(String s) {
+    return mockMetrics.getCount(s);
+  }
+
+  public long getPipelineGauge(String s) {
+    return mockMetrics.getGauge(s);
+  }
+
+  public int getCount(String s) {
+    return mockMetrics.getCount(stageName + "." + s);
+  }
+
+  public long getGauge(String s) {
+    return mockMetrics.getGauge(stageName + "." + s);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/common/NoopMetrics.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/common/NoopMetrics.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.common;
+
+import co.cask.cdap.etl.api.StageMetrics;
+
+/**
+ * No op metrics implementation for tests.
+ */
+public class NoopMetrics implements StageMetrics {
+
+  public static final StageMetrics INSTANCE = new NoopMetrics();
+
+  @Override
+  public void count(String s, int i) {
+    // no-op
+  }
+
+  @Override
+  public void gauge(String s, long l) {
+    // no-op
+  }
+
+  @Override
+  public void pipelineCount(String metricName, int delta) {
+    // no-op
+  }
+
+  @Override
+  public void pipelineGauge(String metricName, long value) {
+    // no-op
+  }
+}
+

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/realtime/MockRealtimeContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/realtime/MockRealtimeContext.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.realtime;
+
+import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.etl.api.Lookup;
+import co.cask.cdap.etl.api.StageMetrics;
+import co.cask.cdap.etl.api.realtime.RealtimeContext;
+import co.cask.cdap.etl.mock.common.NoopMetrics;
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+
+/**
+ * Mock RealtimeContext for tests.
+ */
+public class MockRealtimeContext implements RealtimeContext {
+  private final PluginProperties pluginProperties;
+
+  public MockRealtimeContext(Map<String, String> properties) {
+    this.pluginProperties = PluginProperties.builder().addAll(properties).build();
+  }
+
+  public MockRealtimeContext() {
+    this(Maps.<String, String>newHashMap());
+  }
+
+  @Override
+  public PluginProperties getPluginProperties() {
+    return pluginProperties;
+  }
+
+  @Override
+  public StageMetrics getMetrics() {
+    return NoopMetrics.INSTANCE;
+  }
+
+  @Override
+  public String getStageName() {
+    return "singleStage";
+  }
+
+  @Override
+  public int getInstanceId() {
+    return 0;
+  }
+
+  @Override
+  public int getInstanceCount() {
+    return 1;
+  }
+
+  @Override
+  public PluginProperties getPluginProperties(String pluginId) {
+    return null;
+  }
+
+  @Override
+  public <T> Class<T> loadPluginClass(String pluginId) {
+    return null;
+  }
+
+  @Override
+  public <T> T newPluginInstance(String pluginId) throws InstantiationException {
+    return null;
+  }
+
+  @Override
+  public <T> Lookup<T> provide(String table, Map<String, String> arguments) {
+    return null;
+  }
+}
+

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/MockTransformContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/MockTransformContext.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.transform;
+
+import co.cask.cdap.api.plugin.PluginProperties;
+import co.cask.cdap.etl.api.Lookup;
+import co.cask.cdap.etl.api.LookupProvider;
+import co.cask.cdap.etl.api.StageMetrics;
+import co.cask.cdap.etl.api.TransformContext;
+import co.cask.cdap.etl.mock.common.MockLookupProvider;
+import co.cask.cdap.etl.mock.common.MockStageMetrics;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Mock context for unit tests
+ */
+public class MockTransformContext implements TransformContext {
+  private final PluginProperties pluginProperties;
+  private final MockStageMetrics metrics;
+  private final LookupProvider lookup;
+  private final String stageName;
+
+  public MockTransformContext() {
+    this("someStage");
+  }
+
+  public MockTransformContext(String stageName) {
+    this(stageName, new HashMap<String, String>());
+  }
+
+  public MockTransformContext(String stageName, Map<String, String> args) {
+    this(stageName, args, new MockLookupProvider(null));
+  }
+
+  public MockTransformContext(String stageName, Map<String, String> args, LookupProvider lookup) {
+    this.pluginProperties = PluginProperties.builder().addAll(args).build();
+    this.lookup = lookup;
+    this.metrics = new MockStageMetrics(stageName);
+    this.stageName = stageName;
+  }
+
+  @Override
+  public PluginProperties getPluginProperties() {
+    return pluginProperties;
+  }
+
+  @Override
+  public PluginProperties getPluginProperties(String pluginId) {
+    return null;
+  }
+
+  @Override
+  public StageMetrics getMetrics() {
+    return metrics;
+  }
+
+  public MockStageMetrics getMockMetrics() {
+    return metrics;
+  }
+
+  @Override
+  public String getStageName() {
+    return stageName;
+  }
+
+  @Override
+  public <T> T newPluginInstance(String pluginId) throws InstantiationException {
+    return null;
+  }
+
+  @Override
+  public <T> Class<T> loadPluginClass(String pluginId) {
+    return null;
+  }
+
+  @Override
+  public <T> Lookup<T> provide(String table, Map<String, String> arguments) {
+    return lookup.provide(table, arguments);
+  }
+}


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/HYDRATOR-374
PR in Hydrator Plugins: https://github.com/caskdata/hydrator-plugins/pull/443

Whenever there is an API change in CDAP, Hydrator Plugins will face compilation errors. This slows down development and leads to bad times in general. Moving the mock APIs used for Hydrator testing to the Hydrator-Test package in CDAP should resolve this issue as API changes leading to compilation errors will be picked up immediately when building CDAP.
