### PR TITLE
[CDAP-7252] - Initial structure for top nav in cdap

### DIFF
--- a/cdap-ui/app/cdap/cdap.js
+++ b/cdap-ui/app/cdap/cdap.js
@@ -24,7 +24,7 @@ require('font-awesome-webpack!./styles/font-awesome.config.js');
 import Management from './components/Management';
 import Dashboard from './components/Dashboard';
 import Home from './components/Home';
-import Header from './components/Header';
+import CdapHeader from './components/CdapHeader';
 import Footer from './components/Footer';
 import SplashScreen from './components/SplashScreen';
 
@@ -40,7 +40,7 @@ class CDAP extends Component {
   render() {
     return (
       <div>
-        <Header />
+        <CdapHeader />
         <SplashScreen />
         <div className="container-fluid">
           {this.props.children}

--- a/cdap-ui/app/cdap/components/AbsLinkTo/index.js
+++ b/cdap-ui/app/cdap/components/AbsLinkTo/index.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, {PropTypes} from 'react';
+
+export default function AbsLinkTo({context, linkLabel, className, children}) {
+  return (
+    <a
+      href={window.getAbsUIUrl(context)}
+      className={className}
+    >
+      {linkLabel ? linkLabel : children}
+    </a>
+  );
+}
+
+AbsLinkTo.propTypes = {
+  context: PropTypes.shape({
+    uiApp: PropTypes.string.isRequired,
+    namespaceId: PropTypes.string,
+    appId: PropTypes.string,
+    entityId: PropTypes.string,
+    entityType: PropTypes.string,
+    runId: PropTypes.string
+  }),
+  linkLabel: PropTypes.string,
+  className: PropTypes.any,
+  children: PropTypes.node
+};

--- a/cdap-ui/app/cdap/components/CaskAppStore/index.js
+++ b/cdap-ui/app/cdap/components/CaskAppStore/index.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import React, {Component} from 'react';
+import Card from './Card';
+export class CaskAppStore extends Component {
+  constructor(props) {
+    super(props);
+  }
+  render() {
+    return (
+      <Card
+        title="Cask App Store"
+      />
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/CdapHeader/index.js
+++ b/cdap-ui/app/cdap/components/CdapHeader/index.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+
+import Header from '../Header';
+
+export default function CdapHeader() {
+  var navbarItemList = [
+    {
+      linkTo: 'home',
+      title: 'Home'
+    },
+    {
+      linkTo: 'dashboard',
+      title: 'Dashboard'
+    },
+    {
+      linkTo: 'management',
+      title: 'Management'
+    }
+  ];
+  return (
+    <Header
+      navbarItemList={navbarItemList}
+    />
+  );
+}

--- a/cdap-ui/app/cdap/components/Header/Header.less
+++ b/cdap-ui/app/cdap/components/Header/Header.less
@@ -20,7 +20,7 @@
 @navbar-brand-bg: #363945;
 @navbar-height: 50px;
 
-CDAP-Header {
+.cask-header {
   .navbar {
     height: @navbar-height;
     background-color: @navbar-bg;

--- a/cdap-ui/app/cdap/components/Header/index.js
+++ b/cdap-ui/app/cdap/components/Header/index.js
@@ -14,31 +14,22 @@
  * the License.
  */
 
-import React, {Component} from 'react';
-import {Link} from 'react-router';
+import React, {Component, PropTypes} from 'react';
+
 require('./Header.less');
+import HeaderBrand from '../HeaderBrand';
+import HeaderNavbarList from '../HeaderNavbarList';
+import HeaderActions from '../HeaderActions';
+import HeaderSidebar from '../HeaderSidebar';
 
 export default class Header extends Component {
   constructor(props) {
     super(props);
     this.props = props;
     this.state = {
-      showSidebar: false
+      showSidebar: false,
+      navbarItemList: this.props.navbarItemList
     };
-  }
-  getAbsUrl(extension) {
-    switch(extension) {
-      case 'hydrator':
-        return window.getAbsUIUrl({
-          uiApp: 'cask-hydrator'
-        });
-      case 'tracker':
-        return window.getAbsUIUrl({
-          uiApp: 'cask-tracker'
-        });
-      default:
-        return window.getAbsUIUrl();
-    }
   }
   sidebarClickNoOp(e) {
     e.stopPropagation();
@@ -50,82 +41,34 @@ export default class Header extends Component {
   }
   render() {
     return (
-      <CDAP-Header>
-        <header className="navbar navbar-fixed-top">
+      <div className="cask-header">
+        <div className="navbar navbar-fixed-top">
           <nav className="navbar cdap">
-            <div className="brand-header">
-              <a className="navbar-brand"
-                 onClick={this.toggleSidebar.bind(this)}>
-                <span className="fa icon-fist"></span>
-              </a>
-              <a href="/" className="menu-item product-title">
-                CDAP
-              </a>
-            </div>
-            <ul className="navbar-list">
-              <li>
-                <Link to="home" activeClassName="active">
-                  Home
-                </Link>
-              </li>
-              <li>
-                <Link to="dashboard" activeClassName="active">
-                  Dashboard
-                </Link>
-              </li>
-              <li>
-                <Link to="management" activeClassName="active">
-                  Managment
-                </Link>
-              </li>
-            </ul>
+            <HeaderBrand
+              title="CDAP"
+              icon="icon-fist"
+              onClickHandler={this.toggleSidebar.bind(this)}
+            />
+            <HeaderNavbarList
+              list={this.state.navbarItemList}
+            />
+            <HeaderActions />
           </nav>
-        </header>
+        </div>
         <div className={this.state.showSidebar ? 'display-container': 'hide'}
              onClick={this.toggleSidebar.bind(this)}>
-          <div className="sidebar" onClick={this.sidebarClickNoOp.bind(this)}>
-            <a href="/"
-               className="brand sidebar-item top">
-              <div className="brand-icon text-center cdap">
-                <span className="icon-fist"></span>
-              </div>
-
-              <div className="product-name">
-                <span>CDAP</span>
-              </div>
-            </a>
-
-            <h5>Extensions:</h5>
-            {
-            /*
-              FIXME: This should be dynamic; based on host, port & other contextual information.
-              Need to build a utility function ASAP
-            */
-            }
-            <a href={this.getAbsUrl('hydrator')}
-               className="brand sidebar-item">
-              <div className="brand-icon text-center hydrator">
-                <span className="icon-hydrator"></span>
-              </div>
-
-              <div className="product-name">
-                <span>Cask Hydrator</span>
-              </div>
-            </a>
-
-            <a href={this.getAbsUrl('tracker')}
-               className="brand sidebar-item">
-              <div className="brand-icon text-center tracker">
-                <span className="icon-tracker"></span>
-              </div>
-
-              <div className="product-name">
-                <span>Cask Tracker</span>
-              </div>
-            </a>
-          </div>
+          <HeaderSidebar
+            onClickHandler={this.sidebarClickNoOp.bind(this)}
+          />
         </div>
-      </CDAP-Header>
+      </div>
     );
   }
 }
+
+Header.propTypes = {
+  navbarItemList: PropTypes.arrayOf(PropTypes.shape({
+    linkTo: PropTypes.string,
+    title: PropTypes.string
+  }))
+};

--- a/cdap-ui/app/cdap/components/HeaderActions/index.js
+++ b/cdap-ui/app/cdap/components/HeaderActions/index.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import React from 'react';
+
+export default function HeaderActions() {
+  return (
+    <ul className="navbar-list pull-right">
+      <div className="navbar-item">
+        <span className="fa fa-search"></span>
+      </div>
+      <div className="navbar-item">
+        <span className="fa fa-bolt"></span>
+      </div>
+      <div className="navbar-item">
+        <span className="fa fa-plus-circle text-success"></span>
+      </div>
+      <div className="navbar-item">
+        <span className="fa fa-cog"></span>
+      </div>
+      <div className="navbar-item namespace-dropdown dropdown">
+        <span> Namespace </span>
+      </div>
+    </ul>
+  );
+}

--- a/cdap-ui/app/cdap/components/HeaderBrand/index.js
+++ b/cdap-ui/app/cdap/components/HeaderBrand/index.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, {PropTypes} from 'react';
+var classNames = require('classnames');
+
+export default function HeaderBrand ({title, icon, onClickHandler}) {
+  return (
+    <div className="brand-header">
+      <a className="navbar-brand"
+         onClick={onClickHandler}>
+        <span className={classNames('fa', icon)}></span>
+      </a>
+      <a href="/" className="menu-item product-title">
+        {title}
+      </a>
+    </div>
+  );
+}
+
+HeaderBrand.propTypes = {
+  title: PropTypes.string,
+  icon: PropTypes.string,
+  onClickHandler: PropTypes.func
+};

--- a/cdap-ui/app/cdap/components/HeaderNavbarList/index.js
+++ b/cdap-ui/app/cdap/components/HeaderNavbarList/index.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import React, {PropTypes} from 'react';
+import {Link} from 'react-router';
+
+export default function HeaderNavbarList({list}) {
+  return (
+    <ul className="navbar-list">
+      {
+        list.map((navbaritem, index) => {
+          return (
+            <li key={index}>
+              <Link
+                to={navbaritem.linkTo}
+                activeClassName="active"
+              >
+                {navbaritem.title}
+              </Link>
+            </li>
+          );
+        })
+      }
+    </ul>
+  );
+}
+
+HeaderNavbarList.propTypes = {
+  list: PropTypes.arrayOf(PropTypes.shape({
+    title: PropTypes.string,
+    linkTo: PropTypes.string
+  }))
+};

--- a/cdap-ui/app/cdap/components/HeaderSidebar/index.js
+++ b/cdap-ui/app/cdap/components/HeaderSidebar/index.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, {PropTypes} from 'react';
+import AbsLinkTo from '../AbsLinkTo';
+
+export default function HeaderSidebar ({onClickHandlerNoOp}) {
+  const getContext = (extension) => {
+    switch(extension) {
+      case 'hydrator':
+        return {
+          uiApp: 'cask-hydrator'
+        };
+      case 'tracker':
+        return {
+          uiApp: 'cask-tracker'
+        };
+      default:
+        return {};
+    }
+  };
+  return (
+    <div className="sidebar" onClick={onClickHandlerNoOp}>
+      <a href="/"
+         className="brand sidebar-item top">
+        <div className="brand-icon text-center cdap">
+          <span className="icon-fist"></span>
+        </div>
+        {/* This will change once we introduce navbar for hydraotr & tracker in react*/}
+        <div className="product-name">
+          <span>CDAP</span>
+        </div>
+      </a>
+      <h5>Extensions:</h5>
+      <AbsLinkTo
+        context={getContext('hydrator')}
+        className="brand sidebar-item"
+      >
+        <div className="brand-icon text-center hydrator">
+          <span className="icon-hydrator"></span>
+        </div>
+
+        <div className="product-name">
+          <span>Cask Hydrator</span>
+        </div>
+      </AbsLinkTo>
+      <AbsLinkTo
+        context={getContext('tracker')}
+        className="brand sidebar-item"
+      >
+        <div className="brand-icon text-center tracker">
+          <span className="icon-tracker"></span>
+        </div>
+
+        <div className="product-name">
+          <span>Cask Tracker</span>
+        </div>
+      </AbsLinkTo>
+    </div>
+  );
+}
+HeaderSidebar.propTypes = {
+  onClickHandlerNoOp: PropTypes.func
+};


### PR DESCRIPTION
- Breaks Top navbar (`<Header />`) in react into individual components - `<HeaderActions />`, `<HeaderBrand />`, `<HeaderNavbarList />`, `<HeaderSidebar />`
- Adds Creates a generic (`<Header />`) component for re-use composed of above mentioned individual components.
- Adds a `<CdapHeader />` as a wrapper around `<Header />` component
- Adds placeholder icons to top navbar for `+` button & other navbuttons from hydrator & tracker.
