### PR TITLE
Deprecated getType() method in subclasses of EntityId to replace with…

### DIFF
--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetTypeId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetTypeId.java
@@ -41,7 +41,15 @@ public class DatasetTypeId extends EntityId implements NamespacedId, ParentedId<
     return namespace;
   }
 
+  /**
+   *  Deprecated as of 3.5; Use {@link #getDatasetType()}
+   */
+  @Deprecated
   public String getType() {
+    return type;
+  }
+
+  public String getDatasetType() {
     return type;
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramId.java
@@ -51,7 +51,15 @@ public class ProgramId extends EntityId implements NamespacedId, ParentedId<Appl
     return application;
   }
 
+  /**
+   *  Deprecated as of 3.5; Use {@link #getProgramType()}
+   */
+  @Deprecated
   public ProgramType getType() {
+    return type;
+  }
+
+  public ProgramType getProgramType() {
     return type;
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramRunId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramRunId.java
@@ -52,7 +52,15 @@ public class ProgramRunId extends EntityId implements NamespacedId, ParentedId<P
     return application;
   }
 
+  /**
+   *  Deprecated as of 3.5; Use {@link #getProgramType()}
+   */
+  @Deprecated
   public ProgramType getType() {
+    return type;
+  }
+
+  public ProgramType getProgramType() {
     return type;
   }
 


### PR DESCRIPTION
… a method with more descriptive name

Issue: https://issues.cask.co/browse/CDAP-7201
