### PR TITLE
Fix broken documentation build

### DIFF
--- a/cdap-docs/developers-manual/build.sh
+++ b/cdap-docs/developers-manual/build.sh
@@ -58,9 +58,9 @@ function download_includes() {
 # https://raw.githubusercontent.com/caskdata/cdap-clients/develop/cdap-authentication-clients/java/README.rst
   local clients_url="${github_url}/cdap-clients/${clients_branch}"
 
-  download_readme_file_and_test ${includes_dir} ${clients_url} 25b715da9e3f65e93204a9663d19c90b cdap-authentication-clients/java
+  download_readme_file_and_test ${includes_dir} ${clients_url} 9bdc7d9ab874bfb6ec044964d3df804e cdap-authentication-clients/java
 #   download_readme_file_and_test ${includes_dir} ${clients_url} f075935545e48a132d014c6a8d32122a cdap-authentication-clients/javascript
-  download_readme_file_and_test ${includes_dir} ${clients_url} 1f8330e0370b3895c38452f9af72506a cdap-authentication-clients/python
+  download_readme_file_and_test ${includes_dir} ${clients_url} 6f937cbf71ed2312a4893cba27e6145f cdap-authentication-clients/python
 #   download_readme_file_and_test ${includes_dir} ${clients_url} c16bf5ce7c1f0a2a4a680974a848cdd0 cdap-authentication-clients/ruby
   
 # cdap-ingest

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -106,9 +106,7 @@ function download_includes() {
 
   echo_red_bold "Downloading image files from GitHub..."
   download_file $includes $project_img wise_architecture_diagram.png f01e52df149f10702d933d73935d9f29
-  download_file $includes $project_img wise_explore_page.png         5136132e4e3232a216c12e2fe9d1b0c4
-  download_file $includes $project_img wise_flow.png                 4a79853f2b5a0ac45929d0966f7cd7f5
-  download_file $includes $project_img wise_store_page.png           15bcd8dac10ab5d1c643fff7bdecc52d
+  download_file $includes $project_img wise_flow.png                 894828f13019dfbda5de43f514a8a49f
 
   echo_red_bold "Downloading files and any images and re-writing all the image links..."
   guide_rewrite_sed $1 cdap-bi-guide 


### PR DESCRIPTION
Removed references to images no longer used, and updated hashes to files after checking them.

Passed Quick Build 1: http://builds.cask.co/browse/CDAP-DQB111-1
