### PR TITLE
[CDAP-6404][TRACKER-217] After deleting a tag from a entity, search metadata does not work

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
@@ -372,7 +372,11 @@ public class MetadataDataset extends AbstractDataset {
 
     // call remove metadata for tags which will delete all the existing indexes for tags of this targetId
     removeMetadata(targetId, TAGS_KEY);
-    setTags(targetId, Iterables.toArray(existingTags, String.class));
+    //check if tags are all deleted before set Tags, if tags are all deleted, a null value will be set to the targetId,
+    //which will give a NPE later when searchMetadataOnType.
+    if (!existingTags.isEmpty()) {
+      setTags(targetId, Iterables.toArray(existingTags, String.class));
+    }
   }
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
@@ -384,9 +384,12 @@ public class DefaultMetadataStore implements MetadataStore {
     // Score results
     final Map<Id.NamespacedId, Integer> weightedResults = new HashMap<>();
     for (MetadataEntry metadataEntry : results) {
-      Integer score = weightedResults.get(metadataEntry.getTargetId());
-      score = score == null ? 0 : score;
-      weightedResults.put(metadataEntry.getTargetId(), score + 1);
+      //TODO Remove this null check after CDAP-7228 resolved. Since previous CDAP version may have null value.
+      if (metadataEntry != null) {
+        Integer score = weightedResults.get(metadataEntry.getTargetId());
+        score = score == null ? 0 : score;
+        weightedResults.put(metadataEntry.getTargetId(), score + 1);
+      }
     }
 
     // Sort the results by score

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/MetadataStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/MetadataStoreTest.java
@@ -304,11 +304,16 @@ public class MetadataStoreTest {
                                                                  "multiword", multiWordValue);
     Map<String, String> flowSysProps = ImmutableMap.of("sysKey1", "sysValue1");
     Set<String> flowUserTags = ImmutableSet.of("tag1", "tag2");
+    Set<String> streamUserTags = ImmutableSet.of("tag3", "tag4");
     Set<String> flowSysTags = ImmutableSet.of("sysTag1");
     store.setProperties(MetadataScope.USER, flow1, flowUserProps);
     store.setProperties(MetadataScope.SYSTEM, flow1, flowSysProps);
     store.addTags(MetadataScope.USER, flow1, flowUserTags.toArray(new String[flowUserTags.size()]));
     store.addTags(MetadataScope.SYSTEM, flow1, flowSysTags.toArray(new String[flowSysTags.size()]));
+    store.addTags(MetadataScope.USER, stream1, streamUserTags.toArray(new String[streamUserTags.size()]));
+    store.removeTags(MetadataScope.USER, stream1, streamUserTags.toArray(new String[streamUserTags.size()]));
+    store.setProperties(MetadataScope.USER, stream1, flowUserProps);
+    store.removeProperties(MetadataScope.USER, stream1, "key1", "key2", "multiword");
 
     Map<String, String> streamUserProps = ImmutableMap.of("sKey1", "sValue1 sValue2",
                                                                    "Key1", "Value1");
@@ -346,6 +351,9 @@ public class MetadataStoreTest {
                                      expectedFlowMetadata)
     );
     Assert.assertEquals(expected, actual);
+
+    actual = Lists.newArrayList(store.searchMetadata("ns1", "*"));
+    Assert.assertTrue(actual.containsAll(expected));
   }
 
   @AfterClass


### PR DESCRIPTION
There are two jiras for it
https://issues.cask.co/browse/CDAP-6404
https://issues.cask.co/browse/TRACKER-217

After deleting a tag from a  entity, a null exception may come up when searching metadata. This one line code fix it. 

build and test
http://builds.cask.co/browse/CDAP-BUT3515-1
