### PR TITLE
CDAP-7222 Rollback namespace create upon a wider range of Throwables.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -175,11 +175,11 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
           return null;
         }
       });
-    } catch (IOException | ExploreException | SQLException e) {
+    } catch (Throwable t) {
       // failed to create namespace in underlying storage so delete the namespace meta stored in the store earlier
       deleteNamespaceMeta(metadata.getNamespaceId());
       privilegesManager.revoke(namespace);
-      throw new NamespaceCannotBeCreatedException(namespace.toId(), e);
+      throw new NamespaceCannotBeCreatedException(namespace.toId(), t);
     }
   }
 


### PR DESCRIPTION
Catch wider range of `Throwable`s so that we delete namespace meta in more error scenarios. For instance, when the configured keytab file doesn't exist.
See JIRA for behavior otherwise.

https://issues.cask.co/browse/CDAP-7222
http://builds.cask.co/browse/CDAP-RUT154-1
