### PR TITLE
Remove Id Class From MetadataAdmin and Some Related Classes

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
@@ -130,7 +130,7 @@ public class DeletedProgramHandlerStage extends AbstractStage<ApplicationDeploya
       }
 
       // Remove metadata for the deleted program
-      metadataStore.removeMetadata(programId);
+      metadataStore.removeMetadata(programId.toEntityId());
     }
     if (!deletedFlows.isEmpty()) {
       deleteMetrics(appSpec.getApplicationId(), deletedFlows);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/SystemMetadataWriterStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/SystemMetadataWriterStage.java
@@ -45,7 +45,7 @@ public class SystemMetadataWriterStage extends AbstractStage<ApplicationWithProg
     // add system metadata for apps
     ApplicationId appId = input.getApplicationId();
     ApplicationSpecification appSpec = input.getSpecification();
-    SystemMetadataWriter appSystemMetadataWriter = new AppSystemMetadataWriter(metadataStore, appId.toId(), appSpec);
+    SystemMetadataWriter appSystemMetadataWriter = new AppSystemMetadataWriter(metadataStore, appId, appSpec);
     appSystemMetadataWriter.write();
 
     // add system metadata for programs

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
@@ -480,7 +480,7 @@ public class ArtifactRepository {
       ArtifactInfo artifactInfo = new ArtifactInfo(descriptor.getArtifactId(), artifactDetail.getMeta().getClasses(),
                                                    artifactDetail.getMeta().getProperties());
       // add system metadata for artifacts
-      writeSystemMetadata(artifactId, artifactInfo);
+      writeSystemMetadata(artifactId.toEntityId(), artifactInfo);
       return artifactDetail;
     } finally {
       Closeables.closeQuietly(parentClassLoader);
@@ -727,7 +727,7 @@ public class ArtifactRepository {
     // delete the artifact first and then privileges. Not the other way to avoid orphan artifact
     // which does not have any privilege if the artifact delete from store fails. see CDAP-6648
     artifactStore.delete(artifactId);
-    metadataStore.removeMetadata(artifactId);
+    metadataStore.removeMetadata(artifactId.toEntityId());
     // revoke all privileges on the artifact
     privilegesManager.revoke(artifactId.toEntityId());
   }
@@ -916,7 +916,7 @@ public class ArtifactRepository {
     }
   }
 
-  private void writeSystemMetadata(Id.Artifact artifactId, ArtifactInfo artifactInfo) {
+  private void writeSystemMetadata(co.cask.cdap.proto.id.ArtifactId artifactId, ArtifactInfo artifactInfo) {
     // add system metadata for artifacts
     ArtifactSystemMetadataWriter writer = new ArtifactSystemMetadataWriter(metadataStore, artifactId, artifactInfo);
     writer.write();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -616,13 +616,13 @@ public class ApplicationLifecycleService extends AbstractIdleService {
    */
   private void deleteAppMetadata(Id.Application appId, ApplicationSpecification appSpec) {
     // Remove metadata for the Application itself.
-    metadataStore.removeMetadata(appId);
+    metadataStore.removeMetadata(appId.toEntityId());
 
     // Remove metadata for the programs of the Application
     // TODO: Need to remove this we support prefix search of metadata type.
     // See https://issues.cask.co/browse/CDAP-3669
     for (ProgramId programId : getAllPrograms(appId.toEntityId(), appSpec)) {
-      metadataStore.removeMetadata(programId.toId());
+      metadataStore.removeMetadata(programId);
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
@@ -24,8 +24,8 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.entity.EntityExistenceVerifier;
 import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
@@ -77,84 +77,87 @@ public class DefaultMetadataAdmin implements MetadataAdmin {
   }
 
   @Override
-  public void addProperties(Id.NamespacedId entityId, Map<String, String> properties)
+  public void addProperties(NamespacedEntityId namespacedEntityId, Map<String, String> properties)
     throws NotFoundException, InvalidMetadataException {
-    entityExistenceVerifier.ensureExists(entityId.toEntityId());
-    validateProperties(entityId, properties);
-    metadataStore.setProperties(MetadataScope.USER, entityId, properties);
+    entityExistenceVerifier.ensureExists(namespacedEntityId);
+    validateProperties(namespacedEntityId, properties);
+    metadataStore.setProperties(MetadataScope.USER, namespacedEntityId, properties);
   }
 
   @Override
-  public void addTags(Id.NamespacedId entityId, String... tags) throws NotFoundException, InvalidMetadataException {
-    entityExistenceVerifier.ensureExists(entityId.toEntityId());
-    validateTags(entityId, tags);
-    metadataStore.addTags(MetadataScope.USER, entityId, tags);
+  public void addTags(NamespacedEntityId namespacedEntityId, String... tags)
+    throws NotFoundException, InvalidMetadataException {
+    entityExistenceVerifier.ensureExists(namespacedEntityId);
+    validateTags(namespacedEntityId, tags);
+    metadataStore.addTags(MetadataScope.USER, namespacedEntityId, tags);
   }
 
   @Override
-  public Set<MetadataRecord> getMetadata(Id.NamespacedId entityId) throws NotFoundException {
-    entityExistenceVerifier.ensureExists(entityId.toEntityId());
-    return metadataStore.getMetadata(entityId);
+  public Set<MetadataRecord> getMetadata(NamespacedEntityId namespacedEntityId) throws NotFoundException {
+    entityExistenceVerifier.ensureExists(namespacedEntityId);
+    return metadataStore.getMetadata(namespacedEntityId);
   }
 
   @Override
-  public Set<MetadataRecord> getMetadata(MetadataScope scope, Id.NamespacedId entityId) throws NotFoundException {
-    entityExistenceVerifier.ensureExists(entityId.toEntityId());
-    return ImmutableSet.of(metadataStore.getMetadata(scope, entityId));
+  public Set<MetadataRecord> getMetadata(MetadataScope scope, NamespacedEntityId namespacedEntityId)
+    throws NotFoundException {
+    entityExistenceVerifier.ensureExists(namespacedEntityId);
+    return ImmutableSet.of(metadataStore.getMetadata(scope, namespacedEntityId));
   }
 
   @Override
-  public Map<String, String> getProperties(Id.NamespacedId entityId) throws NotFoundException {
-    entityExistenceVerifier.ensureExists(entityId.toEntityId());
-    return metadataStore.getProperties(entityId);
+  public Map<String, String> getProperties(NamespacedEntityId namespacedEntityId) throws NotFoundException {
+    entityExistenceVerifier.ensureExists(namespacedEntityId);
+    return metadataStore.getProperties(namespacedEntityId);
   }
 
   @Override
-  public Map<String, String> getProperties(MetadataScope scope, Id.NamespacedId entityId) throws NotFoundException {
-    entityExistenceVerifier.ensureExists(entityId.toEntityId());
-    return metadataStore.getProperties(scope, entityId);
+  public Map<String, String> getProperties(MetadataScope scope, NamespacedEntityId namespacedEntityId)
+    throws NotFoundException {
+    entityExistenceVerifier.ensureExists(namespacedEntityId);
+    return metadataStore.getProperties(scope, namespacedEntityId);
   }
 
   @Override
-  public Set<String> getTags(Id.NamespacedId entityId) throws NotFoundException {
-    entityExistenceVerifier.ensureExists(entityId.toEntityId());
-    return metadataStore.getTags(entityId);
+  public Set<String> getTags(NamespacedEntityId namespacedEntityId) throws NotFoundException {
+    entityExistenceVerifier.ensureExists(namespacedEntityId);
+    return metadataStore.getTags(namespacedEntityId);
   }
 
   @Override
-  public Set<String> getTags(MetadataScope scope, Id.NamespacedId entityId) throws NotFoundException {
-    entityExistenceVerifier.ensureExists(entityId.toEntityId());
-    return metadataStore.getTags(scope, entityId);
+  public Set<String> getTags(MetadataScope scope, NamespacedEntityId namespacedEntityId) throws NotFoundException {
+    entityExistenceVerifier.ensureExists(namespacedEntityId);
+    return metadataStore.getTags(scope, namespacedEntityId);
   }
 
   @Override
-  public void removeMetadata(Id.NamespacedId entityId) throws NotFoundException {
-    entityExistenceVerifier.ensureExists(entityId.toEntityId());
-    metadataStore.removeMetadata(MetadataScope.USER, entityId);
+  public void removeMetadata(NamespacedEntityId namespacedEntityId) throws NotFoundException {
+    entityExistenceVerifier.ensureExists(namespacedEntityId);
+    metadataStore.removeMetadata(MetadataScope.USER, namespacedEntityId);
   }
 
   @Override
-  public void removeProperties(Id.NamespacedId entityId) throws NotFoundException {
-    entityExistenceVerifier.ensureExists(entityId.toEntityId());
-    metadataStore.removeProperties(MetadataScope.USER, entityId);
+  public void removeProperties(NamespacedEntityId namespacedEntityId) throws NotFoundException {
+    entityExistenceVerifier.ensureExists(namespacedEntityId);
+    metadataStore.removeProperties(MetadataScope.USER, namespacedEntityId);
   }
 
   @Override
-  public void removeProperties(Id.NamespacedId entityId, String... keys) throws NotFoundException {
-    entityExistenceVerifier.ensureExists(entityId.toEntityId());
-    metadataStore.removeProperties(MetadataScope.USER, entityId, keys);
+  public void removeProperties(NamespacedEntityId namespacedEntityId, String... keys) throws NotFoundException {
+    entityExistenceVerifier.ensureExists(namespacedEntityId);
+    metadataStore.removeProperties(MetadataScope.USER, namespacedEntityId, keys);
   }
 
   @Override
-  public void removeTags(Id.NamespacedId entityId) throws NotFoundException {
-    entityExistenceVerifier.ensureExists(entityId.toEntityId());
-    metadataStore.removeTags(MetadataScope.USER, entityId);
+  public void removeTags(NamespacedEntityId namespacedEntityId) throws NotFoundException {
+    entityExistenceVerifier.ensureExists(namespacedEntityId);
+    metadataStore.removeTags(MetadataScope.USER, namespacedEntityId);
   }
 
   @Override
-  public void removeTags(Id.NamespacedId entityId, String... tags) throws NotFoundException {
-    entityExistenceVerifier.ensureExists(entityId.toEntityId());
-    metadataStore.removeTags(MetadataScope.USER, entityId, tags);
+  public void removeTags(NamespacedEntityId namespacedEntityId, String... tags) throws NotFoundException {
+    entityExistenceVerifier.ensureExists(namespacedEntityId);
+    metadataStore.removeTags(MetadataScope.USER, namespacedEntityId, tags);
   }
 
   @Override
@@ -184,7 +187,7 @@ public class DefaultMetadataAdmin implements MetadataAdmin {
       Iterables.filter(results, new com.google.common.base.Predicate<MetadataSearchResultRecord>() {
         @Override
         public boolean apply(MetadataSearchResultRecord metadataSearchResultRecord) {
-          return filter.apply(metadataSearchResultRecord.getEntityId().toEntityId());
+          return filter.apply(metadataSearchResultRecord.getEntityId());
         }
       })
     );
@@ -192,62 +195,65 @@ public class DefaultMetadataAdmin implements MetadataAdmin {
 
   // Helper methods to validate the metadata entries.
 
-  private void validateProperties(Id.NamespacedId entityId,
+  private void validateProperties(NamespacedEntityId namespacedEntityId,
                                   Map<String, String> properties) throws InvalidMetadataException {
     for (Map.Entry<String, String> entry : properties.entrySet()) {
       // validate key
-      validateKeyAndTagsFormat(entityId, entry.getKey());
-      validateTagReservedKey(entityId, entry.getKey());
-      validateLength(entityId, entry.getKey());
+      validateKeyAndTagsFormat(namespacedEntityId, entry.getKey());
+      validateTagReservedKey(namespacedEntityId, entry.getKey());
+      validateLength(namespacedEntityId, entry.getKey());
 
       // validate value
-      validateValueFormat(entityId, entry.getValue());
-      validateLength(entityId, entry.getValue());
+      validateValueFormat(namespacedEntityId, entry.getValue());
+      validateLength(namespacedEntityId, entry.getValue());
     }
   }
 
-  private void validateTags(Id.NamespacedId entityId, String... tags) throws InvalidMetadataException {
+  private void validateTags(NamespacedEntityId namespacedEntityId, String... tags) throws InvalidMetadataException {
     for (String tag : tags) {
-      validateKeyAndTagsFormat(entityId, tag);
-      validateLength(entityId, tag);
+      validateKeyAndTagsFormat(namespacedEntityId, tag);
+      validateLength(namespacedEntityId, tag);
     }
   }
 
   /**
    * Validate that the key is not reserved {@link MetadataDataset#TAGS_KEY}.
    */
-  private void validateTagReservedKey(Id.NamespacedId entityId, String key) throws InvalidMetadataException {
+  private void validateTagReservedKey(NamespacedEntityId namespacedEntityId, String key)
+    throws InvalidMetadataException {
     if (MetadataDataset.TAGS_KEY.equals(key.toLowerCase())) {
-      throw new InvalidMetadataException(entityId,
-                                  "Could not set metadata with reserved key " + MetadataDataset.TAGS_KEY);
+      throw new InvalidMetadataException(namespacedEntityId,
+                                         "Could not set metadata with reserved key " + MetadataDataset.TAGS_KEY);
     }
   }
 
   /**
    * Validate the key matches the {@link #KEY_AND_TAG_MATCHER} character test.
    */
-  private void validateKeyAndTagsFormat(Id.NamespacedId entityId, String keyword) throws InvalidMetadataException {
+  private void validateKeyAndTagsFormat(NamespacedEntityId namespacedEntityId, String keyword)
+    throws InvalidMetadataException {
     if (!KEY_AND_TAG_MATCHER.matchesAllOf(keyword)) {
-      throw new InvalidMetadataException(entityId, "Illegal format for the value : " + keyword);
+      throw new InvalidMetadataException(namespacedEntityId, "Illegal format for the value : " + keyword);
     }
   }
 
   /**
    * Validate the value of a property matches the {@link #VALUE_MATCHER} character test.
    */
-  private void validateValueFormat(Id.NamespacedId entityId, String keyword) throws InvalidMetadataException {
+  private void validateValueFormat(NamespacedEntityId namespacedEntityId, String keyword)
+    throws InvalidMetadataException {
     if (!VALUE_MATCHER.matchesAllOf(keyword)) {
-      throw new InvalidMetadataException(entityId, "Illegal format for the value : " + keyword);
+      throw new InvalidMetadataException(namespacedEntityId, "Illegal format for the value : " + keyword);
     }
   }
 
   /**
    * Validate that the key length does not exceed the configured limit.
    */
-  private void validateLength(Id.NamespacedId entityId, String keyword) throws InvalidMetadataException {
+  private void validateLength(NamespacedEntityId namespacedEntityId, String keyword) throws InvalidMetadataException {
     // check for max char per value
     if (keyword.length() > cConf.getInt(Constants.Metadata.MAX_CHARS_ALLOWED)) {
-      throw new InvalidMetadataException(entityId, "Metadata " + keyword + " should not exceed maximum of " +
+      throw new InvalidMetadataException(namespacedEntityId, "Metadata " + keyword + " should not exceed maximum of " +
         cConf.get(Constants.Metadata.MAX_CHARS_ALLOWED) + " characters.");
     }
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/LineageHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/LineageHandler.java
@@ -23,7 +23,9 @@ import co.cask.cdap.data2.metadata.lineage.Lineage;
 import co.cask.cdap.data2.metadata.lineage.LineageSerializer;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.codec.NamespacedEntityIdCodec;
 import co.cask.cdap.proto.codec.NamespacedIdCodec;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.lineage.CollapseType;
 import co.cask.cdap.proto.metadata.lineage.LineageRecord;
@@ -56,6 +58,7 @@ import javax.ws.rs.QueryParam;
 public class LineageHandler extends AbstractHttpHandler {
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(Id.NamespacedId.class, new NamespacedIdCodec())
+    .registerTypeAdapter(NamespacedEntityId.class, new NamespacedEntityIdCodec())
     .create();
   private static final Type SET_METADATA_RECORD_TYPE = new TypeToken<Set<MetadataRecord>>() { }.getType();
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
@@ -18,7 +18,7 @@ package co.cask.cdap.metadata;
 
 import co.cask.cdap.common.InvalidMetadataException;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
@@ -37,117 +37,119 @@ import java.util.Set;
 public interface MetadataAdmin {
 
   /**
-   * Adds the specified {@link Map} to the metadata of the specified {@link Id.NamespacedId entityId}.
+   * Adds the specified {@link Map} to the metadata of the specified {@link NamespacedEntityId namespacedEntityId}.
    * Existing keys are updated with new values, newer keys are appended to the metadata. This API only supports adding
    * properties in {@link MetadataScope#USER}.
    *
    * @throws NotFoundException if the specified entity was not found
    * @throws InvalidMetadataException if some of the properties violate metadata validation rules
    */
-  void addProperties(Id.NamespacedId entityId, Map<String, String> properties)
+  void addProperties(NamespacedEntityId namespacedEntityId, Map<String, String> properties)
     throws NotFoundException, InvalidMetadataException;
 
   /**
-   * Adds the specified tags to specified {@link Id.NamespacedId}. This API only supports adding tags in
+   * Adds the specified tags to specified {@link NamespacedEntityId}. This API only supports adding tags in
    * {@link MetadataScope#USER}.
    *
    * @throws NotFoundException if the specified entity was not found
    * @throws InvalidMetadataException if some of the properties violate metadata validation rules
    */
-  void addTags(Id.NamespacedId entityId, String... tags) throws NotFoundException, InvalidMetadataException;
+  void addTags(NamespacedEntityId namespacedEntityId, String... tags)
+    throws NotFoundException, InvalidMetadataException;
 
   /**
    * Returns a set of {@link MetadataRecord} representing all metadata (including properties and tags) for the specified
-   * {@link Id.NamespacedId} in both {@link MetadataScope#USER} and {@link MetadataScope#SYSTEM}.
+   * {@link NamespacedEntityId} in both {@link MetadataScope#USER} and {@link MetadataScope#SYSTEM}.
    *
    * @throws NotFoundException if the specified entity was not found
    */
-  Set<MetadataRecord> getMetadata(Id.NamespacedId entityId) throws NotFoundException;
+  Set<MetadataRecord> getMetadata(NamespacedEntityId namespacedEntityId) throws NotFoundException;
 
   /**
    * Returns a set of {@link MetadataRecord} representing all metadata (including properties and tags) for the specified
-   * {@link Id.NamespacedId} in the specified {@link MetadataScope}.
+   * {@link NamespacedEntityId} in the specified {@link MetadataScope}.
    *
    * @throws NotFoundException if the specified entity was not found
    */
   // TODO: Should this return a single metadata record instead or is a set of one record ok?
-  Set<MetadataRecord> getMetadata(MetadataScope scope, Id.NamespacedId entityId) throws NotFoundException;
+  Set<MetadataRecord> getMetadata(MetadataScope scope, NamespacedEntityId namespacedEntityId) throws NotFoundException;
 
   /**
-   * @return a {@link Map} representing the metadata of the specified {@link Id.NamespacedId} in both
+   * @return a {@link Map} representing the metadata of the specified {@link NamespacedEntityId} in both
    * {@link MetadataScope#USER} and {@link MetadataScope#SYSTEM}
    * @throws NotFoundException if the specified entity was not found
    */
   // TODO: This should perhaps return a Map<MetadataScope, Map<String, String>>
-  Map<String, String> getProperties(Id.NamespacedId entityId) throws NotFoundException;
+  Map<String, String> getProperties(NamespacedEntityId namespacedEntityId) throws NotFoundException;
 
   /**
-   * @return a {@link Map} representing the metadata of the specified {@link Id.NamespacedId} in the specified
+   * @return a {@link Map} representing the metadata of the specified {@link NamespacedEntityId} in the specified
    * {@link MetadataScope}
    * @throws NotFoundException if the specified entity was not found
    */
-  Map<String, String> getProperties(MetadataScope scope, Id.NamespacedId entityId) throws NotFoundException;
+  Map<String, String> getProperties(MetadataScope scope, NamespacedEntityId namespacedEntityId)
+    throws NotFoundException;
 
   /**
-   * @return all the tags for the specified {@link Id.NamespacedId} in both {@link MetadataScope#USER} and
+   * @return all the tags for the specified {@link NamespacedEntityId} in both {@link MetadataScope#USER} and
    * {@link MetadataScope#SYSTEM}
    * @throws NotFoundException if the specified entity was not found
    */
   // TODO: This should perhaps return a Map<MetadataScope, Set<String>>
-  Set<String> getTags(Id.NamespacedId entityId) throws NotFoundException;
+  Set<String> getTags(NamespacedEntityId namespacedEntityId) throws NotFoundException;
 
   /**
-   * @return all the tags for the specified {@link Id.NamespacedId} in the specified {@link MetadataScope}
+   * @return all the tags for the specified {@link NamespacedEntityId} in the specified {@link MetadataScope}
    * @throws NotFoundException if the specified entity was not found
    */
-  Set<String> getTags(MetadataScope scope, Id.NamespacedId entityId) throws NotFoundException;
+  Set<String> getTags(MetadataScope scope, NamespacedEntityId namespacedEntityId) throws NotFoundException;
 
   /**
-   * Removes all the metadata (including properties and tags) for the specified {@link Id.NamespacedId}. This
+   * Removes all the metadata (including properties and tags) for the specified {@link NamespacedEntityId}. This
    * API only supports removing metadata in {@link MetadataScope#USER}.
    *
-   * @param entityId the {@link Id.NamespacedId} to remove metadata for
+   * @param namespacedEntityId the {@link NamespacedEntityId} to remove metadata for
    * @throws NotFoundException if the specified entity was not found
    */
-  void removeMetadata(Id.NamespacedId entityId) throws NotFoundException;
+  void removeMetadata(NamespacedEntityId namespacedEntityId) throws NotFoundException;
 
   /**
-   * Removes all properties from the metadata of the specified {@link Id.NamespacedId}. This API only supports
+   * Removes all properties from the metadata of the specified {@link NamespacedEntityId}. This API only supports
    * removing properties in {@link MetadataScope#USER}.
    *
-   * @param entityId the {@link Id.NamespacedId} to remove properties for
+   * @param namespacedEntityId the {@link NamespacedEntityId} to remove properties for
    * @throws NotFoundException if the specified entity was not found
    */
-  void removeProperties(Id.NamespacedId entityId) throws NotFoundException;
+  void removeProperties(NamespacedEntityId namespacedEntityId) throws NotFoundException;
 
   /**
-   * Removes the specified keys from the metadata properties of the specified {@link Id.NamespacedId}. This API only
+   * Removes the specified keys from the metadata properties of the specified {@link NamespacedEntityId}. This API only
    * supports removing properties in {@link MetadataScope#USER}.
    *
-   * @param entityId the {@link Id.NamespacedId} to remove the specified properties for
+   * @param namespacedEntityId the {@link NamespacedEntityId} to remove the specified properties for
    * @param keys the metadata property keys to remove
    * @throws NotFoundException if the specified entity was not found
    */
-  void removeProperties(Id.NamespacedId entityId, String... keys) throws NotFoundException;
+  void removeProperties(NamespacedEntityId namespacedEntityId, String... keys) throws NotFoundException;
 
   /**
-   * Removes all tags from the specified {@link Id.NamespacedId}. This API only supports removing tags in
+   * Removes all tags from the specified {@link NamespacedEntityId}. This API only supports removing tags in
    * {@link MetadataScope#USER}.
    *
-   * @param entityId the {@link Id.NamespacedId} to remove tags for
+   * @param namespacedEntityId the {@link NamespacedEntityId} to remove tags for
    * @throws NotFoundException if the specified entity was not found
    */
-  void removeTags(Id.NamespacedId entityId) throws NotFoundException;
+  void removeTags(NamespacedEntityId namespacedEntityId) throws NotFoundException;
 
   /**
-   * Removes the specified tags from the specified {@link Id.NamespacedId}. This API only supports removing tags in
+   * Removes the specified tags from the specified {@link NamespacedEntityId}. This API only supports removing tags in
    * {@link MetadataScope#USER}.
    *
-   * @param entityId the {@link Id.NamespacedId} to remove the specified tags for
+   * @param namespacedEntityId the {@link NamespacedEntityId} to remove the specified tags for
    * @param tags the tags to remove
    * @throws NotFoundException if the specified entity was not found
    */
-  void removeTags(Id.NamespacedId entityId, String ... tags) throws NotFoundException;
+  void removeTags(NamespacedEntityId namespacedEntityId, String ... tags) throws NotFoundException;
 
   /**
    * Executes a search for CDAP entities in the specified namespace with the specified search query and

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
@@ -21,7 +21,15 @@ import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.codec.NamespacedEntityIdCodec;
 import co.cask.cdap.proto.codec.NamespacedIdCodec;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
+import co.cask.cdap.proto.id.StreamViewId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
@@ -64,6 +72,7 @@ import javax.ws.rs.QueryParam;
 public class MetadataHttpHandler extends AbstractHttpHandler {
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(Id.NamespacedId.class, new NamespacedIdCodec())
+    .registerTypeAdapter(NamespacedEntityId.class, new NamespacedEntityIdCodec())
     .create();
   private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
   private static final Type LIST_STRING_TYPE = new TypeToken<List<String>>() { }.getType();
@@ -92,7 +101,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                              @PathParam("namespace-id") String namespaceId,
                              @PathParam("app-id") String appId,
                              @QueryParam("scope") String scope) throws NotFoundException, BadRequestException {
-    Id.Application app = Id.Application.from(namespaceId, appId);
+    ApplicationId app = new ApplicationId(namespaceId, appId);
     responder.sendJson(HttpResponseStatus.OK, getMetadata(app, scope), SET_METADATA_RECORD_TYPE, GSON);
   }
 
@@ -104,8 +113,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                  @PathParam("program-type") String programType,
                                  @PathParam("program-id") String programId,
                                  @QueryParam("scope") String scope) throws NotFoundException, BadRequestException {
-    Id.Program program = Id.Program.from(Id.Application.from(namespaceId, appId),
-                                         ProgramType.valueOfCategoryName(programType), programId);
+    ProgramId program = new ProgramId(namespaceId, appId, ProgramType.valueOfCategoryName(programType), programId);
     responder.sendJson(HttpResponseStatus.OK, getMetadata(program, scope), SET_METADATA_RECORD_TYPE, GSON);
   }
 
@@ -116,7 +124,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                   @PathParam("artifact-name") String artifactName,
                                   @PathParam("artifact-version") String artifactVersionStr,
                                   @QueryParam("scope") String scope) throws NotFoundException, BadRequestException {
-    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.from(namespaceId), artifactName, artifactVersionStr);
+    ArtifactId artifactId = new ArtifactId(namespaceId, artifactName, artifactVersionStr);
     responder.sendJson(HttpResponseStatus.OK, getMetadata(artifactId, scope), SET_METADATA_RECORD_TYPE, GSON);
   }
 
@@ -126,7 +134,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                  @PathParam("namespace-id") String namespaceId,
                                  @PathParam("dataset-id") String datasetId,
                                  @QueryParam("scope") String scope) throws NotFoundException, BadRequestException {
-    Id.DatasetInstance datasetInstance = Id.DatasetInstance.from(namespaceId, datasetId);
+    DatasetId datasetInstance = new DatasetId(namespaceId, datasetId);
     responder.sendJson(HttpResponseStatus.OK, getMetadata(datasetInstance, scope), SET_METADATA_RECORD_TYPE, GSON);
   }
 
@@ -136,7 +144,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                 @PathParam("namespace-id") String namespaceId,
                                 @PathParam("stream-id") String streamId,
                                 @QueryParam("scope") String scope) throws NotFoundException, BadRequestException {
-    Id.Stream stream = Id.Stream.from(namespaceId, streamId);
+    StreamId stream = new StreamId(namespaceId, streamId);
     responder.sendJson(HttpResponseStatus.OK, getMetadata(stream, scope), SET_METADATA_RECORD_TYPE, GSON);
   }
 
@@ -147,7 +155,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                               @PathParam("stream-id") String streamId,
                               @PathParam("view-id") String viewId,
                               @QueryParam("scope") String scope) throws NotFoundException, BadRequestException {
-    Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
+    StreamViewId view = new StreamViewId(namespaceId, streamId, viewId);
     responder.sendJson(HttpResponseStatus.OK, getMetadata(view, scope), SET_METADATA_RECORD_TYPE, GSON);
   }
 
@@ -157,7 +165,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                @PathParam("namespace-id") String namespaceId,
                                @PathParam("app-id") String appId,
                                @QueryParam("scope") String scope) throws NotFoundException, BadRequestException {
-    Id.Application app = Id.Application.from(namespaceId, appId);
+    ApplicationId app = new ApplicationId(namespaceId, appId);
     responder.sendJson(HttpResponseStatus.OK, getProperties(app, scope));
   }
 
@@ -168,7 +176,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                     @PathParam("artifact-name") String artifactName,
                                     @PathParam("artifact-version") String artifactVersionStr,
                                     @QueryParam("scope") String scope) throws NotFoundException, BadRequestException {
-    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.from(namespaceId), artifactName, artifactVersionStr);
+    ArtifactId artifactId = new ArtifactId(namespaceId, artifactName, artifactVersionStr);
     responder.sendJson(HttpResponseStatus.OK, getProperties(artifactId, scope));
   }
 
@@ -180,8 +188,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                    @PathParam("program-type") String programType,
                                    @PathParam("program-id") String programId,
                                    @QueryParam("scope") String scope) throws NotFoundException, BadRequestException {
-    Id.Program program = Id.Program.from(Id.Application.from(namespaceId, appId),
-                                         ProgramType.valueOfCategoryName(programType), programId);
+    ProgramId program = new ProgramId(namespaceId, appId, ProgramType.valueOfCategoryName(programType), programId);
     responder.sendJson(HttpResponseStatus.OK, getProperties(program, scope));
   }
 
@@ -191,7 +198,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                    @PathParam("namespace-id") String namespaceId,
                                    @PathParam("dataset-id") String datasetId,
                                    @QueryParam("scope") String scope) throws NotFoundException, BadRequestException {
-    Id.DatasetInstance datasetInstance = Id.DatasetInstance.from(namespaceId, datasetId);
+    DatasetId datasetInstance = new DatasetId(namespaceId, datasetId);
     responder.sendJson(HttpResponseStatus.OK, getProperties(datasetInstance, scope));
   }
 
@@ -201,7 +208,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                   @PathParam("namespace-id") String namespaceId,
                                   @PathParam("stream-id") String streamId,
                                   @QueryParam("scope") String scope) throws NotFoundException, BadRequestException {
-    Id.Stream stream = Id.Stream.from(namespaceId, streamId);
+    StreamId stream = new StreamId(namespaceId, streamId);
     responder.sendJson(HttpResponseStatus.OK, getProperties(stream, scope));
   }
 
@@ -212,7 +219,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                 @PathParam("stream-id") String streamId,
                                 @PathParam("view-id") String viewId,
                                 @QueryParam("scope") String scope) throws NotFoundException, BadRequestException {
-    Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
+    StreamViewId view = new StreamViewId(namespaceId, streamId, viewId);
     responder.sendJson(HttpResponseStatus.OK, getProperties(view, scope));
   }
 
@@ -221,7 +228,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   public void addAppProperties(HttpRequest request, HttpResponder responder,
                                @PathParam("namespace-id") String namespaceId,
                                @PathParam("app-id") String appId) throws BadRequestException, NotFoundException {
-    Id.Application app = Id.Application.from(namespaceId, appId);
+    ApplicationId app = new ApplicationId(namespaceId, appId);
     metadataAdmin.addProperties(app, readMetadata(request));
     responder.sendString(HttpResponseStatus.OK, "Metadata added successfully to " + app);
   }
@@ -233,7 +240,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                     @PathParam("artifact-name") String artifactName,
                                     @PathParam("artifact-version") String artifactVersionStr)
     throws BadRequestException, NotFoundException {
-    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.from(namespaceId), artifactName, artifactVersionStr);
+    ArtifactId artifactId = new ArtifactId(namespaceId, artifactName, artifactVersionStr);
     metadataAdmin.addProperties(artifactId, readMetadata(request));
     responder.sendString(HttpResponseStatus.OK, "Metadata added successfully to " + artifactId);
   }
@@ -246,8 +253,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                    @PathParam("program-type") String programType,
                                    @PathParam("program-id") String programId)
     throws BadRequestException, NotFoundException {
-    Id.Program program = Id.Program.from(Id.Application.from(namespaceId, appId),
-                                         ProgramType.valueOfCategoryName(programType), programId);
+    ProgramId program = new ProgramId(namespaceId, appId, ProgramType.valueOfCategoryName(programType), programId);
     metadataAdmin.addProperties(program, readMetadata(request));
     responder.sendString(HttpResponseStatus.OK, "Metadata added successfully to " + program);
   }
@@ -258,7 +264,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                    @PathParam("namespace-id") String namespaceId,
                                    @PathParam("dataset-id") String datasetId)
     throws BadRequestException, NotFoundException {
-    Id.DatasetInstance dataset = Id.DatasetInstance.from(namespaceId, datasetId);
+    DatasetId dataset = new DatasetId(namespaceId, datasetId);
     metadataAdmin.addProperties(dataset, readMetadata(request));
     responder.sendString(HttpResponseStatus.OK, "Metadata added successfully to " + dataset);
   }
@@ -269,7 +275,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                   @PathParam("namespace-id") String namespaceId,
                                   @PathParam("stream-id") String streamId)
     throws BadRequestException, NotFoundException {
-    Id.Stream stream = Id.Stream.from(namespaceId, streamId);
+    StreamId stream = new StreamId(namespaceId, streamId);
     metadataAdmin.addProperties(stream, readMetadata(request));
     responder.sendString(HttpResponseStatus.OK, "Metadata added successfully to " + stream);
   }
@@ -280,7 +286,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                   @PathParam("namespace-id") String namespaceId,
                                   @PathParam("stream-id") String streamId,
                                   @PathParam("view-id") String viewId) throws NotFoundException, BadRequestException {
-    Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
+    StreamViewId view = new StreamViewId(namespaceId, streamId, viewId);
     metadataAdmin.addProperties(view, readMetadata(request));
     responder.sendString(HttpResponseStatus.OK, "Metadata added successfully to " + view);
   }
@@ -290,7 +296,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   public void removeAppMetadata(HttpRequest request, HttpResponder responder,
                                 @PathParam("namespace-id") String namespaceId,
                                 @PathParam("app-id") String appId) throws NotFoundException {
-    Id.Application app = Id.Application.from(namespaceId, appId);
+    ApplicationId app = new ApplicationId(namespaceId, appId);
     metadataAdmin.removeMetadata(app);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Metadata for app %s deleted successfully.", app));
@@ -302,7 +308,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                     @PathParam("namespace-id") String namespaceId,
                                     @PathParam("artifact-name") String artifactName,
                                     @PathParam("artifact-version") String artifactVersionStr) throws NotFoundException {
-    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.from(namespaceId), artifactName, artifactVersionStr);
+    ArtifactId artifactId = new ArtifactId(namespaceId, artifactName, artifactVersionStr);
     metadataAdmin.removeMetadata(artifactId);
     responder.sendJson(HttpResponseStatus.OK,
                        String.format("Metadata for artifact %s deleted successfully.", artifactId));
@@ -315,8 +321,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                     @PathParam("app-id") String appId,
                                     @PathParam("program-type") String programType,
                                     @PathParam("program-id") String programId) throws NotFoundException {
-    Id.Program program = Id.Program.from(Id.Application.from(namespaceId, appId),
-                                         ProgramType.valueOfCategoryName(programType), programId);
+    ProgramId program = new ProgramId(namespaceId, appId, ProgramType.valueOfCategoryName(programType), programId);
     metadataAdmin.removeMetadata(program);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Metadata for program %s deleted successfully.", program));
@@ -327,7 +332,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   public void removeDatasetMetadata(HttpRequest request, HttpResponder responder,
                                     @PathParam("namespace-id") String namespaceId,
                                     @PathParam("dataset-id") String datasetId) throws NotFoundException {
-    Id.DatasetInstance dataset = Id.DatasetInstance.from(namespaceId, datasetId);
+    DatasetId dataset = new DatasetId(namespaceId, datasetId);
     metadataAdmin.removeMetadata(dataset);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Metadata for dataset %s deleted successfully.", dataset));
@@ -338,7 +343,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   public void removeStreamMetadata(HttpRequest request, HttpResponder responder,
                                    @PathParam("namespace-id") String namespaceId,
                                    @PathParam("stream-id") String streamId) throws NotFoundException {
-    Id.Stream stream = Id.Stream.from(namespaceId, streamId);
+    StreamId stream = new StreamId(namespaceId, streamId);
     metadataAdmin.removeMetadata(stream);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Metadata for stream %s deleted successfully.", stream));
@@ -350,7 +355,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                    @PathParam("namespace-id") String namespaceId,
                                    @PathParam("stream-id") String streamId,
                                    @PathParam("view-id") String viewId) throws NotFoundException {
-    Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
+    StreamViewId view = new StreamViewId(namespaceId, streamId, viewId);
     metadataAdmin.removeMetadata(view);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Metadata for view %s deleted successfully.", view));
@@ -361,7 +366,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   public void removeAppProperties(HttpRequest request, HttpResponder responder,
                                   @PathParam("namespace-id") String namespaceId,
                                   @PathParam("app-id") String appId) throws NotFoundException {
-    Id.Application app = Id.Application.from(namespaceId, appId);
+    ApplicationId app = new ApplicationId(namespaceId, appId);
     metadataAdmin.removeProperties(app);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Metadata properties for app %s deleted successfully.", app));
@@ -373,7 +378,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                 @PathParam("namespace-id") String namespaceId,
                                 @PathParam("app-id") String appId,
                                 @PathParam("property") String property) throws NotFoundException {
-    Id.Application app = Id.Application.from(namespaceId, appId);
+    ApplicationId app = new ApplicationId(namespaceId, appId);
     metadataAdmin.removeProperties(app, property);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Metadata property %s for app %s deleted successfully.", property, app));
@@ -386,7 +391,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                        @PathParam("artifact-name") String artifactName,
                                        @PathParam("artifact-version") String artifactVersionStr)
     throws NotFoundException {
-    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.from(namespaceId), artifactName, artifactVersionStr);
+    ArtifactId artifactId = new ArtifactId(namespaceId, artifactName, artifactVersionStr);
     metadataAdmin.removeProperties(artifactId);
     responder.sendJson(HttpResponseStatus.OK,
                        String.format("Metadata properties for artifact %s deleted successfully.", artifactId));
@@ -400,7 +405,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                      @PathParam("artifact-name") String artifactName,
                                      @PathParam("artifact-version") String artifactVersionStr,
                                      @PathParam("property") String property) throws NotFoundException {
-    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.from(namespaceId), artifactName, artifactVersionStr);
+    ArtifactId artifactId = new ArtifactId(namespaceId, artifactName, artifactVersionStr);
     metadataAdmin.removeProperties(artifactId, property);
     responder.sendJson(HttpResponseStatus.OK,
                        String.format("Metadata property %s for  artifact %s deleted successfully.",
@@ -414,8 +419,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                       @PathParam("app-id") String appId,
                                       @PathParam("program-type") String programType,
                                       @PathParam("program-id") String programId) throws NotFoundException {
-    Id.Program program = Id.Program.from(Id.Application.from(namespaceId, appId),
-                                         ProgramType.valueOfCategoryName(programType), programId);
+    ProgramId program = new ProgramId(namespaceId, appId, ProgramType.valueOfCategoryName(programType), programId);
     metadataAdmin.removeProperties(program);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Metadata properties for program %s deleted successfully.", program));
@@ -429,8 +433,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                     @PathParam("program-type") String programType,
                                     @PathParam("program-id") String programId,
                                     @PathParam("property") String property) throws NotFoundException {
-    Id.Program program = Id.Program.from(Id.Application.from(namespaceId, appId),
-                                         ProgramType.valueOfCategoryName(programType), programId);
+    ProgramId program = new ProgramId(namespaceId, appId, ProgramType.valueOfCategoryName(programType), programId);
     metadataAdmin.removeProperties(program, property);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Metadata property %s for program %s deleted successfully.", property, program));
@@ -441,7 +444,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   public void removeDatasetProperties(HttpRequest request, HttpResponder responder,
                                       @PathParam("namespace-id") String namespaceId,
                                       @PathParam("dataset-id") String datasetId) throws NotFoundException {
-    Id.DatasetInstance dataset = Id.DatasetInstance.from(namespaceId, datasetId);
+    DatasetId dataset = new DatasetId(namespaceId, datasetId);
     metadataAdmin.removeProperties(dataset);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Metadata properties for dataset %s deleted successfully.", dataset));
@@ -453,7 +456,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                     @PathParam("namespace-id") String namespaceId,
                                     @PathParam("dataset-id") String datasetId,
                                     @PathParam("property") String property) throws NotFoundException {
-    Id.DatasetInstance dataset = Id.DatasetInstance.from(namespaceId, datasetId);
+    DatasetId dataset = new DatasetId(namespaceId, datasetId);
     metadataAdmin.removeProperties(dataset, property);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Metadata property %s for dataset %s deleted successfully.", property, dataset));
@@ -464,7 +467,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   public void removeStreamProperties(HttpRequest request, HttpResponder responder,
                                      @PathParam("namespace-id") String namespaceId,
                                      @PathParam("stream-id") String streamId) throws NotFoundException {
-    Id.Stream stream = Id.Stream.from(namespaceId, streamId);
+    StreamId stream = new StreamId(namespaceId, streamId);
     metadataAdmin.removeProperties(stream);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Metadata properties for stream %s deleted successfully.", stream));
@@ -476,7 +479,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                       @PathParam("namespace-id") String namespaceId,
                                       @PathParam("stream-id") String streamId,
                                       @PathParam("view-id") String viewId) throws NotFoundException {
-    Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
+    StreamViewId view = new StreamViewId(namespaceId, streamId, viewId);
     metadataAdmin.removeProperties(view);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Metadata properties for view %s deleted successfully.", view));
@@ -488,7 +491,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                    @PathParam("namespace-id") String namespaceId,
                                    @PathParam("stream-id") String streamId,
                                    @PathParam("property") String property) throws NotFoundException {
-    Id.Stream stream = Id.Stream.from(namespaceId, streamId);
+    StreamId stream = new StreamId(namespaceId, streamId);
     metadataAdmin.removeProperties(stream, property);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Metadata property %s for stream %s deleted successfully.", property, stream));
@@ -501,7 +504,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                  @PathParam("stream-id") String streamId,
                                  @PathParam("view-id") String viewId,
                                  @PathParam("property") String property) throws NotFoundException {
-    Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
+    StreamViewId view = new StreamViewId(namespaceId, streamId, viewId);
     metadataAdmin.removeProperties(view, property);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Metadata property %s for view %s deleted successfully.", property, view));
@@ -512,7 +515,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   public void addAppTags(HttpRequest request, HttpResponder responder,
                          @PathParam("namespace-id") String namespaceId,
                          @PathParam("app-id") String appId) throws BadRequestException, NotFoundException {
-    Id.Application app = Id.Application.from(namespaceId, appId);
+    ApplicationId app = new ApplicationId(namespaceId, appId);
     metadataAdmin.addTags(app, readArray(request));
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Added tags to application %s successfully.", app));
@@ -525,7 +528,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                               @PathParam("artifact-name") String artifactName,
                               @PathParam("artifact-version") String artifactVersionStr)
     throws BadRequestException, NotFoundException {
-    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.from(namespaceId), artifactName, artifactVersionStr);
+    ArtifactId artifactId = new ArtifactId(namespaceId, artifactName, artifactVersionStr);
     metadataAdmin.addTags(artifactId, readArray(request));
     responder.sendJson(HttpResponseStatus.OK,
                        String.format("Added tags to artifact %s successfully.", artifactId));
@@ -538,8 +541,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                              @PathParam("app-id") String appId,
                              @PathParam("program-type") String programType,
                              @PathParam("program-id") String programId) throws BadRequestException, NotFoundException {
-    Id.Program program = Id.Program.from(Id.Application.from(namespaceId, appId),
-                                         ProgramType.valueOfCategoryName(programType), programId);
+    ProgramId program = new ProgramId(namespaceId, appId, ProgramType.valueOfCategoryName(programType), programId);
     metadataAdmin.addTags(program, readArray(request));
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Added tags to program %s successfully.", program));
@@ -550,7 +552,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   public void addDatasetTags(HttpRequest request, HttpResponder responder,
                             @PathParam("namespace-id") String namespaceId,
                             @PathParam("dataset-id") String datasetId) throws BadRequestException, NotFoundException {
-    Id.DatasetInstance dataset = Id.DatasetInstance.from(namespaceId, datasetId);
+    DatasetId dataset = new DatasetId(namespaceId, datasetId);
     metadataAdmin.addTags(dataset, readArray(request));
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Added tags to dataset %s successfully.", dataset));
@@ -561,7 +563,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   public void addStreamTags(HttpRequest request, HttpResponder responder,
                             @PathParam("namespace-id") String namespaceId,
                             @PathParam("stream-id") String streamId) throws BadRequestException, NotFoundException {
-    Id.Stream stream = Id.Stream.from(namespaceId, streamId);
+    StreamId stream = new StreamId(namespaceId, streamId);
     metadataAdmin.addTags(stream, readArray(request));
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Added tags to stream %s successfully.", stream));
@@ -573,7 +575,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                             @PathParam("namespace-id") String namespaceId,
                             @PathParam("stream-id") String streamId,
                             @PathParam("view-id") String viewId) throws NotFoundException, BadRequestException {
-    Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
+    StreamViewId view = new StreamViewId(namespaceId, streamId, viewId);
     metadataAdmin.addTags(view, readArray(request));
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Added tags to view %s successfully", view));
@@ -585,7 +587,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                          @PathParam("namespace-id") String namespaceId,
                          @PathParam("app-id") String appId,
                          @QueryParam("scope") String scope) throws NotFoundException, BadRequestException {
-    Id.Application app = Id.Application.from(namespaceId, appId);
+    ApplicationId app = new ApplicationId(namespaceId, appId);
     responder.sendJson(HttpResponseStatus.OK, getTags(app, scope));
   }
 
@@ -597,7 +599,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                               @PathParam("artifact-version") String artifactVersionStr,
                               @QueryParam("scope") String scope)
     throws BadRequestException, NotFoundException {
-    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.from(namespaceId), artifactName, artifactVersionStr);
+    ArtifactId artifactId = new ArtifactId(namespaceId, artifactName, artifactVersionStr);
     responder.sendJson(HttpResponseStatus.OK, getTags(artifactId, scope));
   }
 
@@ -609,8 +611,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                              @PathParam("program-type") String programType,
                              @PathParam("program-id") String programId,
                              @QueryParam("scope") String scope) throws NotFoundException, BadRequestException {
-    Id.Program program = Id.Program.from(Id.Application.from(namespaceId, appId),
-                                         ProgramType.valueOfCategoryName(programType), programId);
+    ProgramId program = new ProgramId(namespaceId, appId, ProgramType.valueOfCategoryName(programType), programId);
     responder.sendJson(HttpResponseStatus.OK, getTags(program, scope));
   }
 
@@ -620,7 +621,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                              @PathParam("namespace-id") String namespaceId,
                              @PathParam("dataset-id") String datasetId,
                              @QueryParam("scope") String scope) throws NotFoundException, BadRequestException {
-    Id.DatasetInstance dataset = Id.DatasetInstance.from(namespaceId, datasetId);
+    DatasetId dataset = new DatasetId(namespaceId, datasetId);
     responder.sendJson(HttpResponseStatus.OK, getTags(dataset, scope));
   }
 
@@ -630,7 +631,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                             @PathParam("namespace-id") String namespaceId,
                             @PathParam("stream-id") String streamId,
                             @QueryParam("scope") String scope) throws NotFoundException, BadRequestException {
-    Id.Stream stream = Id.Stream.from(namespaceId, streamId);
+    StreamId stream = new StreamId(namespaceId, streamId);
     responder.sendJson(HttpResponseStatus.OK, getTags(stream, scope));
   }
 
@@ -641,7 +642,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                           @PathParam("stream-id") String streamId,
                           @PathParam("view-id") String viewId,
                           @QueryParam("scope") String scope) throws NotFoundException, BadRequestException {
-    Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
+    StreamViewId view = new StreamViewId(namespaceId, streamId, viewId);
     responder.sendJson(HttpResponseStatus.OK, getTags(view, scope));
   }
 
@@ -650,7 +651,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   public void removeAppTags(HttpRequest request, HttpResponder responder,
                             @PathParam("namespace-id") String namespaceId,
                             @PathParam("app-id") String appId) throws NotFoundException {
-    Id.Application app = Id.Application.from(namespaceId, appId);
+    ApplicationId app = new ApplicationId(namespaceId, appId);
     metadataAdmin.removeTags(app);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Tags for app %s deleted successfully.", app));
@@ -662,7 +663,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                            @PathParam("namespace-id") String namespaceId,
                            @PathParam("app-id") String appId,
                            @PathParam("tag") String tag) throws NotFoundException {
-    Id.Application app = Id.Application.from(namespaceId, appId);
+    ApplicationId app = new ApplicationId(namespaceId, appId);
     metadataAdmin.removeTags(app, tag);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Tag %s for app %s deleted successfully.", tag, app));
@@ -674,7 +675,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                  @PathParam("namespace-id") String namespaceId,
                                  @PathParam("artifact-name") String artifactName,
                                  @PathParam("artifact-version") String artifactVersionStr) throws NotFoundException {
-    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.from(namespaceId), artifactName, artifactVersionStr);
+    ArtifactId artifactId = new ArtifactId(namespaceId, artifactName, artifactVersionStr);
     metadataAdmin.removeTags(artifactId);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Tags for artifact %s deleted successfully.", artifactId));
@@ -687,7 +688,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                 @PathParam("artifact-name") String artifactName,
                                 @PathParam("artifact-version") String artifactVersionStr,
                                 @PathParam("tag") String tag) throws NotFoundException {
-    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.from(namespaceId), artifactName, artifactVersionStr);
+    ArtifactId artifactId = new ArtifactId(namespaceId, artifactName, artifactVersionStr);
     metadataAdmin.removeTags(artifactId, tag);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Tags %s for artifact %s deleted successfully.", tag, artifactId));
@@ -700,8 +701,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                 @PathParam("app-id") String appId,
                                 @PathParam("program-type") String programType,
                                 @PathParam("program-id") String programId) throws NotFoundException {
-    Id.Program program = Id.Program.from(Id.Application.from(namespaceId, appId),
-                                         ProgramType.valueOfCategoryName(programType), programId);
+    ProgramId program = new ProgramId(namespaceId, appId, ProgramType.valueOfCategoryName(programType), programId);
     metadataAdmin.removeTags(program);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Tags for program %s deleted successfully.", program));
@@ -715,8 +715,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                @PathParam("program-type") String programType,
                                @PathParam("program-id") String programId,
                                @PathParam("tag") String tag) throws NotFoundException {
-    Id.Program program = Id.Program.from(Id.Application.from(namespaceId, appId),
-                                         ProgramType.valueOfCategoryName(programType), programId);
+    ProgramId program = new ProgramId(namespaceId, appId, ProgramType.valueOfCategoryName(programType), programId);
     metadataAdmin.removeTags(program, tag);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Tag %s for program %s deleted successfully.", tag, program));
@@ -727,7 +726,8 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   public void removeDatasetTags(HttpRequest request, HttpResponder responder,
                                 @PathParam("namespace-id") String namespaceId,
                                 @PathParam("dataset-id") String datasetId) throws NotFoundException {
-    Id.DatasetInstance dataset = Id.DatasetInstance.from(namespaceId, datasetId);
+    DatasetId dataset = new DatasetId(namespaceId, datasetId);
+    
     metadataAdmin.removeTags(dataset);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Tags for dataset %s deleted successfully.", dataset));
@@ -739,7 +739,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                @PathParam("namespace-id") String namespaceId,
                                @PathParam("dataset-id") String datasetId,
                                @PathParam("tag") String tag) throws NotFoundException {
-    Id.DatasetInstance dataset = Id.DatasetInstance.from(namespaceId, datasetId);
+    DatasetId dataset = new DatasetId(namespaceId, datasetId);
     metadataAdmin.removeTags(dataset, tag);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Tag %s for dataset %s deleted successfully.", tag, dataset));
@@ -750,7 +750,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   public void removeStreamTags(HttpRequest request, HttpResponder responder,
                                @PathParam("namespace-id") String namespaceId,
                                @PathParam("stream-id") String streamId) throws NotFoundException {
-    Id.Stream stream = Id.Stream.from(namespaceId, streamId);
+    StreamId stream = new StreamId(namespaceId, streamId);
     metadataAdmin.removeTags(stream);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Tags for stream %s deleted successfully.", stream));
@@ -762,7 +762,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                                @PathParam("namespace-id") String namespaceId,
                                @PathParam("stream-id") String streamId,
                                @PathParam("view-id") String viewId) throws NotFoundException {
-    Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
+    StreamViewId view = new StreamViewId(namespaceId, streamId, viewId);
     metadataAdmin.removeTags(view);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Tags for view %s deleted successfully.", view));
@@ -774,7 +774,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                               @PathParam("namespace-id") String namespaceId,
                               @PathParam("stream-id") String streamId,
                               @PathParam("tag") String tag) throws NotFoundException {
-    Id.Stream stream = Id.Stream.from(namespaceId, streamId);
+    StreamId stream = new StreamId(namespaceId, streamId);
     metadataAdmin.removeTags(stream, tag);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Tag %s for stream %s deleted successfully.", tag, stream));
@@ -787,7 +787,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                               @PathParam("stream-id") String streamId,
                               @PathParam("view-id") String viewId,
                               @PathParam("tag") String tag) throws NotFoundException {
-    Id.Stream.View view = Id.Stream.View.from(namespaceId, streamId, viewId);
+    StreamViewId view = new StreamViewId(namespaceId, streamId, viewId);
     metadataAdmin.removeTags(view, tag);
     responder.sendString(HttpResponseStatus.OK,
                          String.format("Tag %s for view %s deleted successfully.", tag, view));
@@ -851,21 +851,25 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
     responder.sendJson(HttpResponseStatus.OK, results, SET_METADATA_SEARCH_RESULT_TYPE, GSON);
   }
 
-  private Set<MetadataRecord> getMetadata(Id.NamespacedId entityId,
+  private Set<MetadataRecord> getMetadata(NamespacedEntityId namespacedEntityId,
                                           @Nullable String scope) throws NotFoundException, BadRequestException {
-    return  (scope == null) ? metadataAdmin.getMetadata(entityId) :
-      metadataAdmin.getMetadata(validateScope(scope), entityId);
+    return  (scope == null) ?
+      metadataAdmin.getMetadata(namespacedEntityId) :
+      metadataAdmin.getMetadata(validateScope(scope), namespacedEntityId);
   }
 
-  private Map<String, String> getProperties(Id.NamespacedId entityId,
+  private Map<String, String> getProperties(NamespacedEntityId namespacedEntityId,
                                             @Nullable String scope) throws NotFoundException, BadRequestException {
-    return  (scope == null) ? metadataAdmin.getProperties(entityId) :
-      metadataAdmin.getProperties(validateScope(scope), entityId);
+    return  (scope == null) ?
+      metadataAdmin.getProperties(namespacedEntityId) :
+      metadataAdmin.getProperties(validateScope(scope), namespacedEntityId);
   }
 
-  private Set<String> getTags(Id.NamespacedId entityId,
+  private Set<String> getTags(NamespacedEntityId namespacedEntityId,
                               @Nullable String scope) throws NotFoundException, BadRequestException {
-    return  (scope == null) ? metadataAdmin.getTags(entityId) : metadataAdmin.getTags(validateScope(scope), entityId);
+    return  (scope == null) ?
+      metadataAdmin.getTags(namespacedEntityId) :
+      metadataAdmin.getTags(validateScope(scope), namespacedEntityId);
   }
 
   private MetadataScope validateScope(String scope) throws BadRequestException {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/pipeline/SystemMetadataWriterStageTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/pipeline/SystemMetadataWriterStageTest.java
@@ -77,7 +77,7 @@ public class SystemMetadataWriterStageTest {
     systemMetadataWriterStage.process(appWithPrograms);
 
     // verify that the workflow is not tagged with the fork node name
-    Set<String> workflowSystemTags = metadataStore.getTags(MetadataScope.SYSTEM, appId.workflow(workflowName).toId());
+    Set<String> workflowSystemTags = metadataStore.getTags(MetadataScope.SYSTEM, appId.workflow(workflowName));
     Sets.SetView<String> intersection = Sets.intersection(workflowSystemTags, getWorkflowForkNodes(workflowSpec));
     Assert.assertTrue("Workflows should not be tagged with fork node names, but found the following fork nodes " +
                         "in the workflow's system tags: " + intersection, intersection.isEmpty());

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
@@ -146,10 +146,10 @@ public class ArtifactRepositoryTest {
 
   @Test
   public void testDeletingArtifact() throws Exception {
-    MetadataRecord record = metadataStore.getMetadata(MetadataScope.SYSTEM, APP_ARTIFACT_ID);
+    MetadataRecord record = metadataStore.getMetadata(MetadataScope.SYSTEM, APP_ARTIFACT_ID.toEntityId());
     Assert.assertEquals(1, record.getTags().size());
     artifactRepository.deleteArtifact(APP_ARTIFACT_ID);
-    record = metadataStore.getMetadata(MetadataScope.SYSTEM, APP_ARTIFACT_ID);
+    record = metadataStore.getMetadata(MetadataScope.SYSTEM, APP_ARTIFACT_ID.toEntityId());
     Assert.assertEquals(0, record.getTags().size());
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ArtifactHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ArtifactHttpHandlerTest.java
@@ -220,7 +220,8 @@ public class ArtifactHttpHandlerTest extends AppFabricTestBase {
 
     Set<MetadataRecord> metadataRecords = metadataClient.getMetadata(wordcountId1, MetadataScope.USER);
     Assert.assertEquals(1, metadataRecords.size());
-    Assert.assertEquals(new MetadataRecord(wordcountId1, MetadataScope.USER), metadataRecords.iterator().next());
+    Assert.assertEquals(new MetadataRecord(wordcountId1.toEntityId(), MetadataScope.USER),
+                        metadataRecords.iterator().next());
     // delete artifact
     deleteArtifact(wordcountId1, true, null, 200);
     try {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemoteLineageWriterTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemoteLineageWriterTest.java
@@ -68,21 +68,21 @@ public class RemoteLineageWriterTest extends AppFabricTestBase {
 
     // test null serialization
     remoteLineageWriter.addAccess(runId.toId(), datasetId.toId(), AccessType.READ, null);
-    expectedRelations.add(new Relation(datasetId.toId(), flowId.toId(), AccessType.READ, twillRunId));
+    expectedRelations.add(new Relation(datasetId, flowId, AccessType.READ, twillRunId));
 
-    Assert.assertEquals(ImmutableSet.of(flowId.toId(), datasetId.toId()), lineageStore.getEntitiesForRun(runId.toId()));
+    Assert.assertEquals(ImmutableSet.of(flowId, datasetId), lineageStore.getEntitiesForRun(runId.toId()));
 
     Assert.assertEquals(expectedRelations,
                         lineageStore.getRelations(flowId.toId(), now, now + 1, Predicates.<Relation>alwaysTrue()));
 
     remoteLineageWriter.addAccess(runId.toId(), streamId.toId(), AccessType.READ);
-    expectedRelations.add(new Relation(streamId.toId(), flowId.toId(), AccessType.READ, twillRunId));
+    expectedRelations.add(new Relation(streamId, flowId, AccessType.READ, twillRunId));
 
     Assert.assertEquals(expectedRelations,
                         lineageStore.getRelations(flowId.toId(), now, now + 1, Predicates.<Relation>alwaysTrue()));
 
     remoteLineageWriter.addAccess(runId.toId(), streamId.toId(), AccessType.WRITE);
-    expectedRelations.add(new Relation(streamId.toId(), flowId.toId(), AccessType.WRITE, twillRunId));
+    expectedRelations.add(new Relation(streamId, flowId, AccessType.WRITE, twillRunId));
 
     Assert.assertEquals(expectedRelations,
                         lineageStore.getRelations(flowId.toId(), now, now + 1, Predicates.<Relation>alwaysTrue()));

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/audit/AuditPublishTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/audit/AuditPublishTest.java
@@ -33,7 +33,7 @@ import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.Ids;
 import co.cask.cdap.proto.id.NamespaceId;
-import co.cask.cdap.proto.id.NamespacedId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -127,8 +127,8 @@ public class AuditPublishTest {
     Multimap<AuditType, EntityId> actualAuditEntities = HashMultimap.create();
     for (AuditMessage message : publishedMessages) {
       EntityId entityId = message.getEntityId();
-      if (entityId instanceof NamespacedId) {
-        if (((NamespacedId) entityId).getNamespace().equals(NamespaceId.SYSTEM.getNamespace())) {
+      if (entityId instanceof NamespacedEntityId) {
+        if (((NamespacedEntityId) entityId).getNamespace().equals(NamespaceId.SYSTEM.getNamespace())) {
           // Ignore system audit messages
           continue;
         }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageAdminTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageAdminTest.java
@@ -29,8 +29,13 @@ import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.id.FlowletId;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import com.google.common.collect.ImmutableMap;
@@ -51,34 +56,32 @@ import java.util.concurrent.TimeUnit;
  */
 public class LineageAdminTest extends AppFabricTestBase {
   // Define data
-  private final Id.Stream stream1 = Id.Stream.from("default", "stream1");
-  private final Id.DatasetInstance dataset1 = Id.DatasetInstance.from("default", "dataset1");
-  private final Id.DatasetInstance dataset2 = Id.DatasetInstance.from("default", "dataset2");
-  private final Id.DatasetInstance dataset3 = Id.DatasetInstance.from("default", "dataset3");
-  private final Id.DatasetInstance dataset4 = Id.DatasetInstance.from("default", "dataset4");
-  private final Id.DatasetInstance dataset5 = Id.DatasetInstance.from("default", "dataset5");
-  private final Id.DatasetInstance dataset6 = Id.DatasetInstance.from("default", "dataset6");
-  private final Id.DatasetInstance dataset7 = Id.DatasetInstance.from("default", "dataset7");
+  private final StreamId stream1 = new StreamId("default", "stream1");
+  private final DatasetId dataset1 = new DatasetId("default", "dataset1");
+  private final DatasetId dataset2 = new DatasetId("default", "dataset2");
+  private final DatasetId dataset3 = new DatasetId("default", "dataset3");
+  private final DatasetId dataset4 = new DatasetId("default", "dataset4");
+  private final DatasetId dataset5 = new DatasetId("default", "dataset5");
+  private final DatasetId dataset6 = new DatasetId("default", "dataset6");
+  private final DatasetId dataset7 = new DatasetId("default", "dataset7");
 
   // Define programs and runs
-  private final Id.Program program1 = Id.Program.from("default", "app1", ProgramType.FLOW, "flow1");
-  private final Id.Flow.Flowlet flowlet1 =
-    Id.Flow.Flowlet.from(program1.getApplication(), program1.getId(), "flowlet1");
-  private final Id.Run run1 = new Id.Run(program1, RunIds.generate(10000).getId());
+  private final ProgramId program1 = new ProgramId("default", "app1", ProgramType.FLOW, "flow1");
+  private final FlowletId flowlet1 = program1.flowlet("flowlet1");
+  private final Id.Run run1 = new Id.Run(program1.toId(), RunIds.generate(10000).getId());
 
-  private final Id.Program program2 = Id.Program.from("default", "app2", ProgramType.FLOW, "flow2");
-  private final Id.Flow.Flowlet flowlet2 =
-    Id.Flow.Flowlet.from(program2.getApplication(), program2.getId(), "flowlet2");
-  private final Id.Run run2 = new Id.Run(program2, RunIds.generate(900).getId());
+  private final ProgramId program2 = new ProgramId("default", "app2", ProgramType.FLOW, "flow2");
+  private final FlowletId flowlet2 = program2.flowlet("flowlet2");
+  private final Id.Run run2 = new Id.Run(program2.toId(), RunIds.generate(900).getId());
 
-  private final Id.Program program3 = Id.Worker.from("default", "app3", ProgramType.WORKER, "worker3");
-  private final Id.Run run3 = new Id.Run(program3, RunIds.generate(800).getId());
+  private final ProgramId program3 = new ProgramId("default", "app3", ProgramType.WORKER, "worker3");
+  private final Id.Run run3 = new Id.Run(program3.toId(), RunIds.generate(800).getId());
 
-  private final Id.Program program4 = Id.Program.from("default", "app4", ProgramType.SERVICE, "service4");
-  private final Id.Run run4 = new Id.Run(program4, RunIds.generate(800).getId());
+  private final ProgramId program4 = new ProgramId("default", "app4", ProgramType.SERVICE, "service4");
+  private final Id.Run run4 = new Id.Run(program4.toId(), RunIds.generate(800).getId());
 
-  private final Id.Program program5 = Id.Program.from("default", "app5", ProgramType.SERVICE, "service5");
-  private final Id.Run run5 = new Id.Run(program5, RunIds.generate(700).getId());
+  private final ProgramId program5 = new ProgramId("default", "app5", ProgramType.SERVICE, "service5");
+  private final Id.Run run5 = new Id.Run(program5.toId(), RunIds.generate(700).getId());
 
   @After
   public void cleanup() throws Exception {
@@ -96,7 +99,7 @@ public class LineageAdminTest extends AppFabricTestBase {
     LineageAdmin lineageAdmin = new LineageAdmin(lineageStore, store, metadataStore, new NoOpEntityExistenceVerifier());
 
     // Define metadata
-    MetadataRecord run1AppMeta = new MetadataRecord(program1.getApplication(), MetadataScope.USER,
+    MetadataRecord run1AppMeta = new MetadataRecord(program1.getParent(), MetadataScope.USER,
                                                     toMap("pk1", "pk1"), toSet("pt1"));
     MetadataRecord run1ProgramMeta = new MetadataRecord(program1, MetadataScope.USER,
                                                         toMap("pk1", "pk1"), toSet("pt1"));
@@ -106,9 +109,9 @@ public class LineageAdminTest extends AppFabricTestBase {
                                                       toMap("dk2", "dk2"), toSet("dt2"));
 
     // Add metadata
-    metadataStore.setProperties(MetadataScope.USER, program1.getApplication(), run1AppMeta.getProperties());
+    metadataStore.setProperties(MetadataScope.USER, program1.getParent(), run1AppMeta.getProperties());
     //noinspection ToArrayCallWithZeroLengthArrayArgument
-    metadataStore.addTags(MetadataScope.USER, program1.getApplication(), run1AppMeta.getTags().toArray(new String[0]));
+    metadataStore.addTags(MetadataScope.USER, program1.getParent(), run1AppMeta.getTags().toArray(new String[0]));
     metadataStore.setProperties(MetadataScope.USER, program1, run1ProgramMeta.getProperties());
     //noinspection ToArrayCallWithZeroLengthArrayArgument
     metadataStore.addTags(MetadataScope.USER, program1, run1ProgramMeta.getTags().toArray(new String[0]));
@@ -122,20 +125,20 @@ public class LineageAdminTest extends AppFabricTestBase {
 
     // Add accesses for D3 -> P2 -> D2 -> P1 -> D1 <-> P3
     // We need to use current time here as metadata store stores access time using current time
-    Id.Run run1 = new Id.Run(program1, RunIds.generate(System.currentTimeMillis()).getId());
-    Id.Run run2 = new Id.Run(program2, RunIds.generate(System.currentTimeMillis()).getId());
-    Id.Run run3 = new Id.Run(program3, RunIds.generate(System.currentTimeMillis()).getId());
+    Id.Run run1 = new Id.Run(program1.toId(), RunIds.generate(System.currentTimeMillis()).getId());
+    Id.Run run2 = new Id.Run(program2.toId(), RunIds.generate(System.currentTimeMillis()).getId());
+    Id.Run run3 = new Id.Run(program3.toId(), RunIds.generate(System.currentTimeMillis()).getId());
 
     addRuns(store, run1, run2, run3);
     // It is okay to use current time here since access time is ignore during assertions
-    lineageStore.addAccess(run1, dataset1, AccessType.UNKNOWN, System.currentTimeMillis(), flowlet1);
-    lineageStore.addAccess(run1, dataset1, AccessType.WRITE, System.currentTimeMillis(), flowlet1);
-    lineageStore.addAccess(run1, dataset2, AccessType.READ, System.currentTimeMillis(), flowlet1);
+    lineageStore.addAccess(run1, dataset1.toId(), AccessType.UNKNOWN, System.currentTimeMillis(), flowlet1.toId());
+    lineageStore.addAccess(run1, dataset1.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet1.toId());
+    lineageStore.addAccess(run1, dataset2.toId(), AccessType.READ, System.currentTimeMillis(), flowlet1.toId());
 
-    lineageStore.addAccess(run2, dataset2, AccessType.WRITE, System.currentTimeMillis(), flowlet2);
-    lineageStore.addAccess(run2, dataset3, AccessType.READ, System.currentTimeMillis(), flowlet2);
+    lineageStore.addAccess(run2, dataset2.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet2.toId());
+    lineageStore.addAccess(run2, dataset3.toId(), AccessType.READ, System.currentTimeMillis(), flowlet2.toId());
 
-    lineageStore.addAccess(run3, dataset1, AccessType.UNKNOWN, System.currentTimeMillis());
+    lineageStore.addAccess(run3, dataset1.toId(), AccessType.UNKNOWN, System.currentTimeMillis());
 
     // The UNKNOWN access type will get filtered out if there is READ/WRITE. It will be preserved if it is the
     // only access type
@@ -151,14 +154,14 @@ public class LineageAdminTest extends AppFabricTestBase {
 
     // Lineage for D1
     Assert.assertEquals(expectedLineage,
-                        lineageAdmin.computeLineage(dataset1, 500, System.currentTimeMillis() + 10000, 100));
+                        lineageAdmin.computeLineage(dataset1.toId(), 500, System.currentTimeMillis() + 10000, 100));
 
     // Lineage for D2
     Assert.assertEquals(expectedLineage,
-                        lineageAdmin.computeLineage(dataset2, 500, System.currentTimeMillis() + 10000, 100));
+                        lineageAdmin.computeLineage(dataset2.toId(), 500, System.currentTimeMillis() + 10000, 100));
 
     // Lineage for D1 for one level should be D2 -> P1 -> D1 <-> P3
-    Lineage oneLevelLineage = lineageAdmin.computeLineage(dataset1, 500, System.currentTimeMillis() + 10000, 1);
+    Lineage oneLevelLineage = lineageAdmin.computeLineage(dataset1.toId(), 500, System.currentTimeMillis() + 10000, 1);
 
     Assert.assertEquals(
       ImmutableSet.of(
@@ -173,13 +176,14 @@ public class LineageAdminTest extends AppFabricTestBase {
                         lineageAdmin.getMetadataForRun(run1));
 
     // Assert that in a different namespace both lineage and metadata should be empty
-    Id.Namespace customNamespace = Id.Namespace.from("custom_namespace");
-    Id.DatasetInstance customDataset1 = Id.DatasetInstance.from(customNamespace, dataset1.getId());
+    NamespaceId customNamespace = new NamespaceId("custom_namespace");
+    DatasetId customDataset1 = customNamespace.dataset(dataset1.getEntityName());
     Id.Run customRun1 =
-      new Id.Run(Id.Program.from(customNamespace, program1.getApplicationId(), program1.getType(), program1.getId()),
-                 run1.getId());
+      new Id.Run(new ProgramId(customNamespace.getNamespace(), program1.getApplication(), program1.getType(),
+                               program1.getEntityName()).toId(), run1.getId());
     Assert.assertEquals(new Lineage(ImmutableSet.<Relation>of()),
-                        lineageAdmin.computeLineage(customDataset1, 500, System.currentTimeMillis() + 10000, 100));
+                        lineageAdmin.computeLineage(customDataset1.toId(), 500,
+                                                    System.currentTimeMillis() + 10000, 100));
     Assert.assertEquals(ImmutableSet.<MetadataRecord>of(), lineageAdmin.getMetadataForRun(customRun1));
   }
 
@@ -192,7 +196,7 @@ public class LineageAdminTest extends AppFabricTestBase {
     //
 
     LineageStore lineageStore = new LineageStore(getTxExecFactory(), getDatasetFramework(),
-                                                 Id.DatasetInstance.from("default", "testSimpleLoopLineage"));
+                                                 new DatasetId("default", "testSimpleLoopLineage").toId());
     Store store = getInjector().getInstance(Store.class);
     MetadataStore metadataStore = getInjector().getInstance(MetadataStore.class);
     LineageAdmin lineageAdmin = new LineageAdmin(lineageStore, store, metadataStore, new NoOpEntityExistenceVerifier());
@@ -201,15 +205,15 @@ public class LineageAdminTest extends AppFabricTestBase {
     // Add access
     addRuns(store, run1, run2, run3, run4, run5);
     // It is okay to use current time here since access time is ignore during assertions
-    lineageStore.addAccess(run1, dataset1, AccessType.READ, System.currentTimeMillis(), flowlet1);
-    lineageStore.addAccess(run1, dataset2, AccessType.WRITE, System.currentTimeMillis(), flowlet1);
+    lineageStore.addAccess(run1, dataset1.toId(), AccessType.READ, System.currentTimeMillis(), flowlet1.toId());
+    lineageStore.addAccess(run1, dataset2.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet1.toId());
 
-    lineageStore.addAccess(run2, dataset2, AccessType.READ, System.currentTimeMillis(), flowlet2);
-    lineageStore.addAccess(run2, dataset1, AccessType.WRITE, System.currentTimeMillis(), flowlet2);
-    lineageStore.addAccess(run2, dataset3, AccessType.WRITE, System.currentTimeMillis(), flowlet2);
+    lineageStore.addAccess(run2, dataset2.toId(), AccessType.READ, System.currentTimeMillis(), flowlet2.toId());
+    lineageStore.addAccess(run2, dataset1.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet2.toId());
+    lineageStore.addAccess(run2, dataset3.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet2.toId());
 
-    lineageStore.addAccess(run3, dataset3, AccessType.READ, System.currentTimeMillis());
-    lineageStore.addAccess(run3, dataset4, AccessType.WRITE, System.currentTimeMillis());
+    lineageStore.addAccess(run3, dataset3.toId(), AccessType.READ, System.currentTimeMillis());
+    lineageStore.addAccess(run3, dataset4.toId(), AccessType.WRITE, System.currentTimeMillis());
 
     Lineage expectedLineage = new Lineage(
       ImmutableSet.of(
@@ -224,17 +228,17 @@ public class LineageAdminTest extends AppFabricTestBase {
     );
 
     // Lineage for D1
-    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset1, 500, 20000, 100));
+    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset1.toId(), 500, 20000, 100));
 
     // Lineage for D2
-    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset2, 500, 20000, 100));
+    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset2.toId(), 500, 20000, 100));
 
     // Lineage for D1 for one level D1 -> P1 -> D2 -> P2 -> D3
     //                              |                 |
     //                              |                 V
     //                              |<-----------------
     //
-    Lineage oneLevelLineage = lineageAdmin.computeLineage(dataset1, 500, 20000, 1);
+    Lineage oneLevelLineage = lineageAdmin.computeLineage(dataset1.toId(), 500, 20000, 1);
 
     Assert.assertEquals(
       ImmutableSet.of(
@@ -254,7 +258,7 @@ public class LineageAdminTest extends AppFabricTestBase {
     // D1 <-> P1
     //
     LineageStore lineageStore = new LineageStore(getTxExecFactory(), getDatasetFramework(),
-                                                 Id.DatasetInstance.from("default", "testDirectCycle"));
+                                                 NamespaceId.DEFAULT.dataset("testDirectCycle").toId());
     Store store = getInjector().getInstance(Store.class);
     MetadataStore metadataStore = getInjector().getInstance(MetadataStore.class);
     LineageAdmin lineageAdmin = new LineageAdmin(lineageStore, store, metadataStore, new NoOpEntityExistenceVerifier());
@@ -262,8 +266,8 @@ public class LineageAdminTest extends AppFabricTestBase {
     // Add accesses
     addRuns(store, run1, run2, run3, run4, run5);
     // It is okay to use current time here since access time is ignore during assertions
-    lineageStore.addAccess(run1, dataset1, AccessType.READ, System.currentTimeMillis(), flowlet1);
-    lineageStore.addAccess(run1, dataset1, AccessType.WRITE, System.currentTimeMillis(), flowlet1);
+    lineageStore.addAccess(run1, dataset1.toId(), AccessType.READ, System.currentTimeMillis(), flowlet1.toId());
+    lineageStore.addAccess(run1, dataset1.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet1.toId());
 
     Lineage expectedLineage = new Lineage(
       ImmutableSet.of(
@@ -272,7 +276,7 @@ public class LineageAdminTest extends AppFabricTestBase {
         )
     );
 
-    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset1, 500, 20000, 100));
+    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset1.toId(), 500, 20000, 100));
   }
 
   @Test
@@ -284,7 +288,7 @@ public class LineageAdminTest extends AppFabricTestBase {
     // D1 <- P1 (run2)
     //
     LineageStore lineageStore = new LineageStore(getTxExecFactory(), getDatasetFramework(),
-                                                 Id.DatasetInstance.from("default", "testDirectCycleTwoRuns"));
+                                                 NamespaceId.DEFAULT.dataset("testDirectCycleTwoRuns").toId());
     Store store = getInjector().getInstance(Store.class);
     MetadataStore metadataStore = getInjector().getInstance(MetadataStore.class);
     LineageAdmin lineageAdmin = new LineageAdmin(lineageStore, store, metadataStore, new NoOpEntityExistenceVerifier());
@@ -292,10 +296,10 @@ public class LineageAdminTest extends AppFabricTestBase {
     // Add accesses
     addRuns(store, run1, run2, run3, run4, run5);
     // It is okay to use current time here since access time is ignore during assertions
-    lineageStore.addAccess(run1, dataset1, AccessType.READ, System.currentTimeMillis(), flowlet1);
+    lineageStore.addAccess(run1, dataset1.toId(), AccessType.READ, System.currentTimeMillis(), flowlet1.toId());
     // Write is in a different run
-    lineageStore.addAccess(new Id.Run(run1.getProgram(), run2.getId()), dataset1, AccessType.WRITE,
-                           System.currentTimeMillis(), flowlet1);
+    lineageStore.addAccess(new Id.Run(run1.getProgram(), run2.getId()), dataset1.toId(), AccessType.WRITE,
+                           System.currentTimeMillis(), flowlet1.toId());
 
     Lineage expectedLineage = new Lineage(
       ImmutableSet.of(
@@ -304,7 +308,7 @@ public class LineageAdminTest extends AppFabricTestBase {
       )
     );
 
-    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset1, 500, 20000, 100));
+    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset1.toId(), 500, 20000, 100));
   }
 
   @Test
@@ -320,7 +324,7 @@ public class LineageAdminTest extends AppFabricTestBase {
     // S1 -->|     ---------------> P4 -> D7
 
     LineageStore lineageStore = new LineageStore(getTxExecFactory(), getDatasetFramework(),
-                                                 Id.DatasetInstance.from("default", "testBranchLineage"));
+                                                 NamespaceId.DEFAULT.dataset("testBranchLineage").toId());
     Store store = getInjector().getInstance(Store.class);
     MetadataStore metadataStore = getInjector().getInstance(MetadataStore.class);
     LineageAdmin lineageAdmin = new LineageAdmin(lineageStore, store, metadataStore, new NoOpEntityExistenceVerifier());
@@ -328,21 +332,21 @@ public class LineageAdminTest extends AppFabricTestBase {
     // Add accesses
     addRuns(store, run1, run2, run3, run4, run5);
     // It is okay to use current time here since access time is ignore during assertions
-    lineageStore.addAccess(run1, stream1, AccessType.READ, System.currentTimeMillis(), flowlet1);
-    lineageStore.addAccess(run1, dataset1, AccessType.READ, System.currentTimeMillis(), flowlet1);
-    lineageStore.addAccess(run1, dataset2, AccessType.WRITE, System.currentTimeMillis(), flowlet1);
-    lineageStore.addAccess(run1, dataset4, AccessType.WRITE, System.currentTimeMillis(), flowlet1);
+    lineageStore.addAccess(run1, stream1.toId(), AccessType.READ, System.currentTimeMillis(), flowlet1.toId());
+    lineageStore.addAccess(run1, dataset1.toId(), AccessType.READ, System.currentTimeMillis(), flowlet1.toId());
+    lineageStore.addAccess(run1, dataset2.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet1.toId());
+    lineageStore.addAccess(run1, dataset4.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet1.toId());
 
-    lineageStore.addAccess(run2, dataset2, AccessType.READ, System.currentTimeMillis(), flowlet2);
-    lineageStore.addAccess(run2, dataset3, AccessType.WRITE, System.currentTimeMillis(), flowlet2);
-    lineageStore.addAccess(run2, dataset5, AccessType.WRITE, System.currentTimeMillis(), flowlet2);
+    lineageStore.addAccess(run2, dataset2.toId(), AccessType.READ, System.currentTimeMillis(), flowlet2.toId());
+    lineageStore.addAccess(run2, dataset3.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet2.toId());
+    lineageStore.addAccess(run2, dataset5.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet2.toId());
 
-    lineageStore.addAccess(run3, dataset5, AccessType.READ, System.currentTimeMillis());
-    lineageStore.addAccess(run3, dataset6, AccessType.WRITE, System.currentTimeMillis());
+    lineageStore.addAccess(run3, dataset5.toId(), AccessType.READ, System.currentTimeMillis());
+    lineageStore.addAccess(run3, dataset6.toId(), AccessType.WRITE, System.currentTimeMillis());
 
-    lineageStore.addAccess(run4, dataset2, AccessType.READ, System.currentTimeMillis());
-    lineageStore.addAccess(run4, dataset3, AccessType.READ, System.currentTimeMillis());
-    lineageStore.addAccess(run4, dataset7, AccessType.WRITE, System.currentTimeMillis());
+    lineageStore.addAccess(run4, dataset2.toId(), AccessType.READ, System.currentTimeMillis());
+    lineageStore.addAccess(run4, dataset3.toId(), AccessType.READ, System.currentTimeMillis());
+    lineageStore.addAccess(run4, dataset7.toId(), AccessType.WRITE, System.currentTimeMillis());
 
     Lineage expectedLineage = new Lineage(
       ImmutableSet.of(
@@ -365,11 +369,11 @@ public class LineageAdminTest extends AppFabricTestBase {
     );
 
     // Lineage for D7
-    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset7, 500, 20000, 100));
+    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset7.toId(), 500, 20000, 100));
     // Lineage for D6
-    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset6, 500, 20000, 100));
+    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset6.toId(), 500, 20000, 100));
     // Lineage for D3
-    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset3, 500, 20000, 100));
+    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset3.toId(), 500, 20000, 100));
   }
 
   @Test
@@ -388,7 +392,7 @@ public class LineageAdminTest extends AppFabricTestBase {
     // S1 -->|     ---------------> P4 -> D7
 
     LineageStore lineageStore = new LineageStore(getTxExecFactory(), getDatasetFramework(),
-                                                 Id.DatasetInstance.from("default", "testBranchLoopLineage"));
+                                                 NamespaceId.DEFAULT.dataset("testBranchLoopLineage").toId());
     Store store = getInjector().getInstance(Store.class);
     MetadataStore metadataStore = getInjector().getInstance(MetadataStore.class);
     LineageAdmin lineageAdmin = new LineageAdmin(lineageStore, store, metadataStore, new NoOpEntityExistenceVerifier());
@@ -396,25 +400,25 @@ public class LineageAdminTest extends AppFabricTestBase {
     // Add accesses
     addRuns(store, run1, run2, run3, run4, run5);
     // It is okay to use current time here since access time is ignore during assertions
-    lineageStore.addAccess(run1, stream1, AccessType.READ, System.currentTimeMillis(), flowlet1);
-    lineageStore.addAccess(run1, dataset1, AccessType.READ, System.currentTimeMillis(), flowlet1);
-    lineageStore.addAccess(run1, dataset2, AccessType.WRITE, System.currentTimeMillis(), flowlet1);
-    lineageStore.addAccess(run1, dataset4, AccessType.WRITE, System.currentTimeMillis(), flowlet1);
+    lineageStore.addAccess(run1, stream1.toId(), AccessType.READ, System.currentTimeMillis(), flowlet1.toId());
+    lineageStore.addAccess(run1, dataset1.toId(), AccessType.READ, System.currentTimeMillis(), flowlet1.toId());
+    lineageStore.addAccess(run1, dataset2.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet1.toId());
+    lineageStore.addAccess(run1, dataset4.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet1.toId());
 
-    lineageStore.addAccess(run2, dataset2, AccessType.READ, System.currentTimeMillis(), flowlet2);
-    lineageStore.addAccess(run2, dataset3, AccessType.WRITE, System.currentTimeMillis(), flowlet2);
-    lineageStore.addAccess(run2, dataset5, AccessType.WRITE, System.currentTimeMillis(), flowlet2);
+    lineageStore.addAccess(run2, dataset2.toId(), AccessType.READ, System.currentTimeMillis(), flowlet2.toId());
+    lineageStore.addAccess(run2, dataset3.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet2.toId());
+    lineageStore.addAccess(run2, dataset5.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet2.toId());
 
-    lineageStore.addAccess(run3, dataset5, AccessType.READ, System.currentTimeMillis());
-    lineageStore.addAccess(run3, dataset6, AccessType.WRITE, System.currentTimeMillis());
+    lineageStore.addAccess(run3, dataset5.toId(), AccessType.READ, System.currentTimeMillis());
+    lineageStore.addAccess(run3, dataset6.toId(), AccessType.WRITE, System.currentTimeMillis());
 
-    lineageStore.addAccess(run4, dataset2, AccessType.READ, System.currentTimeMillis());
-    lineageStore.addAccess(run4, dataset3, AccessType.READ, System.currentTimeMillis());
-    lineageStore.addAccess(run4, dataset7, AccessType.WRITE, System.currentTimeMillis());
+    lineageStore.addAccess(run4, dataset2.toId(), AccessType.READ, System.currentTimeMillis());
+    lineageStore.addAccess(run4, dataset3.toId(), AccessType.READ, System.currentTimeMillis());
+    lineageStore.addAccess(run4, dataset7.toId(), AccessType.WRITE, System.currentTimeMillis());
 
-    lineageStore.addAccess(run5, dataset3, AccessType.READ, System.currentTimeMillis());
-    lineageStore.addAccess(run5, dataset6, AccessType.READ, System.currentTimeMillis());
-    lineageStore.addAccess(run5, dataset1, AccessType.WRITE, System.currentTimeMillis());
+    lineageStore.addAccess(run5, dataset3.toId(), AccessType.READ, System.currentTimeMillis());
+    lineageStore.addAccess(run5, dataset6.toId(), AccessType.READ, System.currentTimeMillis());
+    lineageStore.addAccess(run5, dataset1.toId(), AccessType.WRITE, System.currentTimeMillis());
 
     Lineage expectedLineage = new Lineage(
       ImmutableSet.of(
@@ -441,20 +445,20 @@ public class LineageAdminTest extends AppFabricTestBase {
     );
 
     // Lineage for D1
-    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset1, 500, 20000, 100));
+    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset1.toId(), 500, 20000, 100));
     // Lineage for D5
-    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset5, 500, 20000, 100));
+    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset5.toId(), 500, 20000, 100));
     // Lineage for D7
-    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset7, 500, 20000, 100));
+    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset7.toId(), 500, 20000, 100));
     // Lineage for S1
-    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(stream1, 500, 20000, 100));
+    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(stream1.toId(), 500, 20000, 100));
 
     // Lineage for D5 for one level
     //                   -> D5 -> P3 -> D6
     //                   |
     //                   |
     //             D2 -> P2 -> D3
-    Lineage oneLevelLineage = lineageAdmin.computeLineage(dataset5, 500, 20000, 1);
+    Lineage oneLevelLineage = lineageAdmin.computeLineage(dataset5.toId(), 500, 20000, 1);
 
     Assert.assertEquals(
       ImmutableSet.of(
@@ -478,7 +482,7 @@ public class LineageAdminTest extends AppFabricTestBase {
     //       |
     // S1 -->|
 
-    oneLevelLineage = lineageAdmin.computeLineage(stream1, 500, 20000, 1);
+    oneLevelLineage = lineageAdmin.computeLineage(stream1.toId(), 500, 20000, 1);
     Assert.assertEquals(
       ImmutableSet.of(
         new Relation(stream1, program1, AccessType.READ, twillRunId(run1), toSet(flowlet1)),
@@ -529,7 +533,7 @@ public class LineageAdminTest extends AppFabricTestBase {
     return ImmutableMap.of(key, value);
   }
 
-  private static Set<Id.NamespacedId> emptySet() {
+  private static Set<NamespacedEntityId> emptySet() {
     return Collections.emptySet();
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageCollapserTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageCollapserTest.java
@@ -20,7 +20,10 @@ import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.data2.metadata.lineage.CollapsedRelation;
 import co.cask.cdap.data2.metadata.lineage.LineageCollapser;
 import co.cask.cdap.data2.metadata.lineage.Relation;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.metadata.lineage.CollapseType;
 import com.google.common.collect.ImmutableSet;
 import org.apache.twill.api.RunId;
@@ -33,20 +36,20 @@ import java.util.Set;
  * Test {@link LineageCollapser}.
  */
 public class LineageCollapserTest {
-  private final Id.DatasetInstance data1 = Id.DatasetInstance.from("n1", "d1");
-  private final Id.DatasetInstance data2 = Id.DatasetInstance.from("n1", "d2");
+  private final DatasetId data1 = new DatasetId("n1", "d1");
+  private final DatasetId data2 = new DatasetId("n1", "d2");
 
-  private final Id.Flow flow1 = Id.Flow.from("n1", "app1", "flow1");
-  private final Id.Flow flow2 = Id.Flow.from("n1", "app2", "flow1");
+  private final ProgramId flow1 = new ProgramId("n1", "app1", ProgramType.FLOW, "flow1");
+  private final ProgramId flow2 = new ProgramId("n1", "app2", ProgramType.FLOW, "flow1");
   
   private final RunId runId1 = new TestRunId("r1");
   private final RunId runId2 = new TestRunId("r2");
   private final RunId runId3 = new TestRunId("r3");
 
-  private final Id.NamespacedId flowlet11 = Id.Flow.Flowlet.from(flow1, "flowlet1");
-  private final Id.NamespacedId flowlet12 = Id.Flow.Flowlet.from(flow1, "flowlet2");
-  private final Id.NamespacedId flowlet21 = Id.Flow.Flowlet.from(flow2, "flowlet1");
-  private final Id.NamespacedId flowlet22 = Id.Flow.Flowlet.from(flow2, "flowlet2");
+  private final NamespacedEntityId flowlet11 = flow1.flowlet("flowlet1");
+  private final NamespacedEntityId flowlet12 = flow1.flowlet("flowlet2");
+  private final NamespacedEntityId flowlet21 = flow2.flowlet("flowlet1");
+  private final NamespacedEntityId flowlet22 = flow2.flowlet("flowlet2");
 
   @Test
   public void testCollapseAccess() throws Exception {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataCommand.java
@@ -64,7 +64,7 @@ public class GetMetadataCommand extends AbstractCommand {
           @Override
           public List<String> apply(MetadataRecord record) {
             return Lists.newArrayList(
-              record.getEntityId().toEntityId().toString(),
+              record.getEntityId().toString(),
               Joiner.on("\n").join(record.getTags()),
               Joiner.on("\n").withKeyValueSeparator(":").join(record.getProperties()),
               record.getScope().name());

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataTestBase.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataTestBase.java
@@ -18,9 +18,15 @@ package co.cask.cdap.client;
 
 import co.cask.cdap.client.common.ClientTestBase;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.ArtifactRange;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.proto.id.StreamId;
+import co.cask.cdap.proto.id.StreamViewId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
@@ -69,20 +75,20 @@ public abstract class MetadataTestBase extends ClientTestBase {
     datasetClient = new DatasetClient(getClientConfig());
   }
 
-  protected void addAppArtifact(Id.Artifact artifactId, Class<?> cls) throws Exception {
-    artifactClient.add(artifactId, null, Files.newInputStreamSupplier(createAppJarFile(cls)));
+  protected void addAppArtifact(ArtifactId artifactId, Class<?> cls) throws Exception {
+    artifactClient.add(artifactId.toId(), null, Files.newInputStreamSupplier(createAppJarFile(cls)));
   }
 
-  protected void addPluginArtifact(Id.Artifact artifactId, Class<?> cls, Manifest manifest,
+  protected void addPluginArtifact(ArtifactId artifactId, Class<?> cls, Manifest manifest,
                                    @Nullable Set<ArtifactRange> parents) throws Exception {
-    artifactClient.add(artifactId, parents, Files.newInputStreamSupplier(createArtifactJarFile(cls, manifest)));
+    artifactClient.add(artifactId.toId(), parents, Files.newInputStreamSupplier(createArtifactJarFile(cls, manifest)));
   }
 
-  protected void addProperties(Id.Application app, @Nullable Map<String, String> properties) throws Exception {
-    metadataClient.addProperties(app, properties);
+  protected void addProperties(ApplicationId app, @Nullable Map<String, String> properties) throws Exception {
+    metadataClient.addProperties(app.toId(), properties);
   }
 
-  protected void addProperties(final Id.Application app, @Nullable final Map<String, String> properties,
+  protected void addProperties(final ApplicationId app, @Nullable final Map<String, String> properties,
                                Class<? extends Exception> expectedExceptionClass) throws IOException {
     expectException(new Callable<Void>() {
       @Override
@@ -93,11 +99,11 @@ public abstract class MetadataTestBase extends ClientTestBase {
     }, expectedExceptionClass);
   }
 
-  protected void addProperties(Id.Artifact artifact, @Nullable Map<String, String> properties) throws Exception {
-    metadataClient.addProperties(artifact, properties);
+  protected void addProperties(ArtifactId artifact, @Nullable Map<String, String> properties) throws Exception {
+    metadataClient.addProperties(artifact.toId(), properties);
   }
 
-  protected void addProperties(final Id.Artifact artifact, @Nullable final Map<String, String> properties,
+  protected void addProperties(final ArtifactId artifact, @Nullable final Map<String, String> properties,
                                Class<? extends Exception> expectedExceptionClass) throws IOException {
     expectException(new Callable<Void>() {
       @Override
@@ -108,11 +114,11 @@ public abstract class MetadataTestBase extends ClientTestBase {
     }, expectedExceptionClass);
   }
 
-  protected void addProperties(Id.Program program, @Nullable Map<String, String> properties) throws Exception {
-    metadataClient.addProperties(program, properties);
+  protected void addProperties(ProgramId program, @Nullable Map<String, String> properties) throws Exception {
+    metadataClient.addProperties(program.toId(), properties);
   }
 
-  protected void addProperties(final Id.Program program, @Nullable final Map<String, String> properties,
+  protected void addProperties(final ProgramId program, @Nullable final Map<String, String> properties,
                                Class<? extends Exception> expectedExceptionClass) throws IOException {
     expectException(new Callable<Void>() {
       @Override
@@ -123,11 +129,11 @@ public abstract class MetadataTestBase extends ClientTestBase {
     }, expectedExceptionClass);
   }
 
-  protected void addProperties(Id.DatasetInstance dataset, @Nullable Map<String, String> properties) throws Exception {
-    metadataClient.addProperties(dataset, properties);
+  protected void addProperties(DatasetId dataset, @Nullable Map<String, String> properties) throws Exception {
+    metadataClient.addProperties(dataset.toId(), properties);
   }
 
-  protected void addProperties(final Id.DatasetInstance dataset, @Nullable final Map<String, String> properties,
+  protected void addProperties(final DatasetId dataset, @Nullable final Map<String, String> properties,
                                Class<? extends Exception> expectedExceptionClass) throws IOException {
     expectException(new Callable<Void>() {
       @Override
@@ -138,17 +144,17 @@ public abstract class MetadataTestBase extends ClientTestBase {
     }, expectedExceptionClass);
   }
 
-  protected void addProperties(Id.Stream stream, @Nullable Map<String, String> properties)
+  protected void addProperties(StreamId stream, @Nullable Map<String, String> properties)
     throws Exception {
-    metadataClient.addProperties(stream, properties);
+    metadataClient.addProperties(stream.toId(), properties);
   }
 
-  protected void addProperties(Id.Stream.View view, @Nullable Map<String, String> properties)
+  protected void addProperties(StreamViewId view, @Nullable Map<String, String> properties)
     throws Exception {
-    metadataClient.addProperties(view, properties);
+    metadataClient.addProperties(view.toId(), properties);
   }
 
-  protected void addProperties(final Id.Stream stream, @Nullable final Map<String, String> properties,
+  protected void addProperties(final StreamId stream, @Nullable final Map<String, String> properties,
                                Class<? extends Exception> expectedExceptionClass) throws IOException {
     expectException(new Callable<Void>() {
       @Override
@@ -159,7 +165,7 @@ public abstract class MetadataTestBase extends ClientTestBase {
     }, expectedExceptionClass);
   }
 
-  protected void addProperties(final Id.Stream.View view, @Nullable final Map<String, String> properties,
+  protected void addProperties(final StreamViewId view, @Nullable final Map<String, String> properties,
                                Class<? extends Exception> expectedExceptionClass) throws IOException {
     expectException(new Callable<Void>() {
       @Override
@@ -170,80 +176,80 @@ public abstract class MetadataTestBase extends ClientTestBase {
     }, expectedExceptionClass);
   }
 
-  protected Set<MetadataRecord> getMetadata(Id.Application app) throws Exception {
+  protected Set<MetadataRecord> getMetadata(ApplicationId app) throws Exception {
     return getMetadata(app, null);
   }
 
-  protected Set<MetadataRecord> getMetadata(Id.Artifact artifact) throws Exception {
+  protected Set<MetadataRecord> getMetadata(ArtifactId artifact) throws Exception {
     return getMetadata(artifact, null);
   }
 
-  protected Set<MetadataRecord> getMetadata(Id.Program program) throws Exception {
+  protected Set<MetadataRecord> getMetadata(ProgramId program) throws Exception {
     return getMetadata(program, null);
   }
 
-  protected Set<MetadataRecord> getMetadata(Id.DatasetInstance dataset) throws Exception {
+  protected Set<MetadataRecord> getMetadata(DatasetId dataset) throws Exception {
     return getMetadata(dataset, null);
   }
 
-  protected Set<MetadataRecord> getMetadata(Id.Stream stream) throws Exception {
+  protected Set<MetadataRecord> getMetadata(StreamId stream) throws Exception {
     return getMetadata(stream, null);
   }
 
-  protected Set<MetadataRecord> getMetadata(Id.Stream.View view) throws Exception {
+  protected Set<MetadataRecord> getMetadata(StreamViewId view) throws Exception {
     return getMetadata(view, null);
   }
 
-  protected Set<MetadataRecord> getMetadata(Id.Application app, @Nullable MetadataScope scope) throws Exception {
-    return metadataClient.getMetadata(app, scope);
+  protected Set<MetadataRecord> getMetadata(ApplicationId app, @Nullable MetadataScope scope) throws Exception {
+    return metadataClient.getMetadata(app.toId(), scope);
   }
 
-  protected Set<MetadataRecord> getMetadata(Id.Artifact artifact, @Nullable MetadataScope scope) throws Exception {
-    return metadataClient.getMetadata(artifact, scope);
+  protected Set<MetadataRecord> getMetadata(ArtifactId artifact, @Nullable MetadataScope scope) throws Exception {
+    return metadataClient.getMetadata(artifact.toId(), scope);
   }
 
-  protected Set<MetadataRecord> getMetadata(Id.Program program, @Nullable MetadataScope scope) throws Exception {
-    return metadataClient.getMetadata(program, scope);
+  protected Set<MetadataRecord> getMetadata(ProgramId program, @Nullable MetadataScope scope) throws Exception {
+    return metadataClient.getMetadata(program.toId(), scope);
   }
 
-  protected Set<MetadataRecord> getMetadata(Id.DatasetInstance dataset,
+  protected Set<MetadataRecord> getMetadata(DatasetId dataset,
                                             @Nullable MetadataScope scope) throws Exception {
-    return metadataClient.getMetadata(dataset, scope);
+    return metadataClient.getMetadata(dataset.toId(), scope);
   }
 
-  protected Set<MetadataRecord> getMetadata(Id.Stream stream, @Nullable MetadataScope scope) throws Exception {
-    return metadataClient.getMetadata(stream, scope);
+  protected Set<MetadataRecord> getMetadata(StreamId stream, @Nullable MetadataScope scope) throws Exception {
+    return metadataClient.getMetadata(stream.toId(), scope);
   }
 
-  protected Set<MetadataRecord> getMetadata(Id.Stream.View view, @Nullable MetadataScope scope) throws Exception {
-    return metadataClient.getMetadata(view, scope);
+  protected Set<MetadataRecord> getMetadata(StreamViewId view, @Nullable MetadataScope scope) throws Exception {
+    return metadataClient.getMetadata(view.toId(), scope);
   }
 
-  protected Map<String, String> getProperties(Id.Application app, MetadataScope scope) throws Exception {
+  protected Map<String, String> getProperties(ApplicationId app, MetadataScope scope) throws Exception {
     return Iterators.getOnlyElement(getMetadata(app, scope).iterator()).getProperties();
   }
 
-  protected Map<String, String> getProperties(Id.Artifact artifact, MetadataScope scope) throws Exception {
+  protected Map<String, String> getProperties(ArtifactId artifact, MetadataScope scope) throws Exception {
     return Iterators.getOnlyElement(getMetadata(artifact, scope).iterator()).getProperties();
   }
 
-  protected Map<String, String> getProperties(Id.Program program, MetadataScope scope) throws Exception {
+  protected Map<String, String> getProperties(ProgramId program, MetadataScope scope) throws Exception {
     return Iterators.getOnlyElement(getMetadata(program, scope).iterator()).getProperties();
   }
 
-  protected Map<String, String> getProperties(Id.DatasetInstance dataset, MetadataScope scope) throws Exception {
+  protected Map<String, String> getProperties(DatasetId dataset, MetadataScope scope) throws Exception {
     return Iterators.getOnlyElement(getMetadata(dataset, scope).iterator()).getProperties();
   }
 
-  protected Map<String, String> getProperties(Id.Stream stream, MetadataScope scope) throws Exception {
+  protected Map<String, String> getProperties(StreamId stream, MetadataScope scope) throws Exception {
     return Iterators.getOnlyElement(getMetadata(stream, scope).iterator()).getProperties();
   }
 
-  protected Map<String, String> getProperties(Id.Stream.View view, MetadataScope scope) throws Exception {
+  protected Map<String, String> getProperties(StreamViewId view, MetadataScope scope) throws Exception {
     return Iterators.getOnlyElement(getMetadata(view, scope).iterator()).getProperties();
   }
 
-  protected void getPropertiesFromInvalidEntity(Id.Application app) throws Exception {
+  protected void getPropertiesFromInvalidEntity(ApplicationId app) throws Exception {
     try {
       getProperties(app, MetadataScope.USER);
       Assert.fail("Expected not to be able to get properties from invalid entity: " + app);
@@ -252,7 +258,7 @@ public abstract class MetadataTestBase extends ClientTestBase {
     }
   }
 
-  protected void getPropertiesFromInvalidEntity(Id.Program program) throws Exception {
+  protected void getPropertiesFromInvalidEntity(ProgramId program) throws Exception {
     try {
       getProperties(program, MetadataScope.USER);
       Assert.fail("Expected not to be able to get properties from invalid entity: " + program);
@@ -261,7 +267,7 @@ public abstract class MetadataTestBase extends ClientTestBase {
     }
   }
 
-  protected void getPropertiesFromInvalidEntity(Id.DatasetInstance dataset) throws Exception {
+  protected void getPropertiesFromInvalidEntity(DatasetId dataset) throws Exception {
     try {
       getProperties(dataset, MetadataScope.USER);
       Assert.fail("Expected not to be able to get properties from invalid entity: " + dataset);
@@ -270,7 +276,7 @@ public abstract class MetadataTestBase extends ClientTestBase {
     }
   }
 
-  protected void getPropertiesFromInvalidEntity(Id.Stream stream) throws Exception {
+  protected void getPropertiesFromInvalidEntity(StreamId stream) throws Exception {
     try {
       getProperties(stream, MetadataScope.USER);
       Assert.fail("Expected not to be able to get properties from invalid entity: " + stream);
@@ -278,7 +284,7 @@ public abstract class MetadataTestBase extends ClientTestBase {
       // expected
     }
   }
-  protected void getPropertiesFromInvalidEntity(Id.Stream.View view) throws Exception {
+  protected void getPropertiesFromInvalidEntity(StreamViewId view) throws Exception {
     try {
       getProperties(view, MetadataScope.USER);
       Assert.fail("Expected not to be able to get properties from invalid entity: " + view);
@@ -287,83 +293,83 @@ public abstract class MetadataTestBase extends ClientTestBase {
     }
   }
 
-  protected void removeMetadata(Id.Application app) throws Exception {
-    metadataClient.removeMetadata(app);
+  protected void removeMetadata(ApplicationId app) throws Exception {
+    metadataClient.removeMetadata(app.toId());
   }
 
-  protected void removeMetadata(Id.Artifact artifact) throws Exception {
-    metadataClient.removeMetadata(artifact);
+  protected void removeMetadata(ArtifactId artifact) throws Exception {
+    metadataClient.removeMetadata(artifact.toId());
   }
 
-  protected void removeMetadata(Id.Program program) throws Exception {
-    metadataClient.removeMetadata(program);
+  protected void removeMetadata(ProgramId program) throws Exception {
+    metadataClient.removeMetadata(program.toId());
   }
 
-  protected void removeMetadata(Id.DatasetInstance dataset) throws Exception {
-    metadataClient.removeMetadata(dataset);
+  protected void removeMetadata(DatasetId dataset) throws Exception {
+    metadataClient.removeMetadata(dataset.toId());
   }
 
-  protected void removeMetadata(Id.Stream stream) throws Exception {
-    metadataClient.removeMetadata(stream);
+  protected void removeMetadata(StreamId stream) throws Exception {
+    metadataClient.removeMetadata(stream.toId());
   }
 
-  protected void removeMetadata(Id.Stream.View view) throws Exception {
-    metadataClient.removeMetadata(view);
+  protected void removeMetadata(StreamViewId view) throws Exception {
+    metadataClient.removeMetadata(view.toId());
   }
 
-  protected void removeProperties(Id.Application app) throws Exception {
-    metadataClient.removeProperties(app);
+  protected void removeProperties(ApplicationId app) throws Exception {
+    metadataClient.removeProperties(app.toId());
   }
 
-  private void removeProperty(Id.Application app, String propertyToRemove) throws Exception {
-    metadataClient.removeProperty(app, propertyToRemove);
+  private void removeProperty(ApplicationId app, String propertyToRemove) throws Exception {
+    metadataClient.removeProperty(app.toId(), propertyToRemove);
   }
 
-  protected void removeProperties(Id.Artifact artifact) throws Exception {
-    metadataClient.removeProperties(artifact);
+  protected void removeProperties(ArtifactId artifact) throws Exception {
+    metadataClient.removeProperties(artifact.toId());
   }
 
-  private void removeProperty(Id.Artifact artifact, String propertyToRemove) throws Exception {
-    metadataClient.removeProperty(artifact, propertyToRemove);
+  private void removeProperty(ArtifactId artifact, String propertyToRemove) throws Exception {
+    metadataClient.removeProperty(artifact.toId(), propertyToRemove);
   }
 
-  protected void removeProperties(Id.Program program) throws Exception {
-    metadataClient.removeProperties(program);
+  protected void removeProperties(ProgramId program) throws Exception {
+    metadataClient.removeProperties(program.toId());
   }
 
-  protected void removeProperty(Id.Program program, String propertyToRemove) throws Exception {
-    metadataClient.removeProperty(program, propertyToRemove);
+  protected void removeProperty(ProgramId program, String propertyToRemove) throws Exception {
+    metadataClient.removeProperty(program.toId(), propertyToRemove);
   }
 
-  protected void removeProperties(Id.DatasetInstance dataset) throws Exception {
-    metadataClient.removeProperties(dataset);
+  protected void removeProperties(DatasetId dataset) throws Exception {
+    metadataClient.removeProperties(dataset.toId());
   }
 
-  protected void removeProperty(Id.DatasetInstance dataset, String propertyToRemove) throws Exception {
-    metadataClient.removeProperty(dataset, propertyToRemove);
+  protected void removeProperty(DatasetId dataset, String propertyToRemove) throws Exception {
+    metadataClient.removeProperty(dataset.toId(), propertyToRemove);
   }
 
-  protected void removeProperties(Id.Stream stream) throws Exception {
-    metadataClient.removeProperties(stream);
+  protected void removeProperties(StreamId stream) throws Exception {
+    metadataClient.removeProperties(stream.toId());
   }
 
-  protected void removeProperties(Id.Stream.View view) throws Exception {
-    metadataClient.removeProperties(view);
+  protected void removeProperties(StreamViewId view) throws Exception {
+    metadataClient.removeProperties(view.toId());
   }
 
-  protected void removeProperty(Id.Stream stream, String propertyToRemove) throws Exception {
-    metadataClient.removeProperty(stream, propertyToRemove);
+  protected void removeProperty(StreamId stream, String propertyToRemove) throws Exception {
+    metadataClient.removeProperty(stream.toId(), propertyToRemove);
   }
 
-  protected void removeProperty(Id.Stream.View view, String propertyToRemove) throws Exception {
-    metadataClient.removeProperty(view, propertyToRemove);
+  protected void removeProperty(StreamViewId view, String propertyToRemove) throws Exception {
+    metadataClient.removeProperty(view.toId(), propertyToRemove);
   }
 
-  protected void addTags(Id.Application app, @Nullable Set<String> tags) throws Exception {
-    metadataClient.addTags(app, tags);
+  protected void addTags(ApplicationId app, @Nullable Set<String> tags) throws Exception {
+    metadataClient.addTags(app.toId(), tags);
   }
 
-  protected void addTags(final Id.Application app, @Nullable final Set<String> tags,
+  protected void addTags(final ApplicationId app, @Nullable final Set<String> tags,
                          Class<? extends Exception> expectedExceptionClass) throws IOException {
     expectException(new Callable<Void>() {
       @Override
@@ -374,11 +380,11 @@ public abstract class MetadataTestBase extends ClientTestBase {
     }, expectedExceptionClass);
   }
 
-  protected void addTags(Id.Artifact artifact, @Nullable Set<String> tags) throws Exception {
-    metadataClient.addTags(artifact, tags);
+  protected void addTags(ArtifactId artifact, @Nullable Set<String> tags) throws Exception {
+    metadataClient.addTags(artifact.toId(), tags);
   }
 
-  protected void addTags(final Id.Artifact artifact, @Nullable final Set<String> tags,
+  protected void addTags(final ArtifactId artifact, @Nullable final Set<String> tags,
                          Class<? extends Exception> expectedExceptionClass) throws IOException {
     expectException(new Callable<Void>() {
       @Override
@@ -389,12 +395,12 @@ public abstract class MetadataTestBase extends ClientTestBase {
     }, expectedExceptionClass);
   }
 
-  protected void addTags(Id.Program program, @Nullable Set<String> tags)
+  protected void addTags(ProgramId program, @Nullable Set<String> tags)
     throws Exception {
-    metadataClient.addTags(program, tags);
+    metadataClient.addTags(program.toId(), tags);
   }
 
-  protected void addTags(final Id.Program program, @Nullable final Set<String> tags,
+  protected void addTags(final ProgramId program, @Nullable final Set<String> tags,
                          Class<? extends Exception> expectedExceptionClass) throws IOException {
     expectException(new Callable<Void>() {
       @Override
@@ -405,11 +411,11 @@ public abstract class MetadataTestBase extends ClientTestBase {
     }, expectedExceptionClass);
   }
 
-  protected void addTags(Id.DatasetInstance dataset, @Nullable Set<String> tags) throws Exception {
-    metadataClient.addTags(dataset, tags);
+  protected void addTags(DatasetId dataset, @Nullable Set<String> tags) throws Exception {
+    metadataClient.addTags(dataset.toId(), tags);
   }
 
-  protected void addTags(final Id.DatasetInstance dataset, @Nullable final Set<String> tags,
+  protected void addTags(final DatasetId dataset, @Nullable final Set<String> tags,
                          Class<? extends Exception> expectedExceptionClass) throws IOException {
     expectException(new Callable<Void>() {
       @Override
@@ -420,15 +426,15 @@ public abstract class MetadataTestBase extends ClientTestBase {
     }, expectedExceptionClass);
   }
 
-  protected void addTags(Id.Stream stream, @Nullable Set<String> tags) throws Exception {
-    metadataClient.addTags(stream, tags);
+  protected void addTags(StreamId stream, @Nullable Set<String> tags) throws Exception {
+    metadataClient.addTags(stream.toId(), tags);
   }
 
-  protected void addTags(Id.Stream.View view, @Nullable Set<String> tags) throws Exception {
-    metadataClient.addTags(view, tags);
+  protected void addTags(StreamViewId view, @Nullable Set<String> tags) throws Exception {
+    metadataClient.addTags(view.toId(), tags);
   }
 
-  protected void addTags(final Id.Stream stream, @Nullable final Set<String> tags,
+  protected void addTags(final StreamId stream, @Nullable final Set<String> tags,
                          Class<? extends Exception> expectedExceptionClass) throws IOException {
     expectException(new Callable<Void>() {
       @Override
@@ -439,7 +445,7 @@ public abstract class MetadataTestBase extends ClientTestBase {
     }, expectedExceptionClass);
   }
 
-  protected void addTags(final Id.Stream.View view, @Nullable final Set<String> tags,
+  protected void addTags(final StreamViewId view, @Nullable final Set<String> tags,
                          Class<? extends Exception> expectedExceptionClass) throws IOException {
     expectException(new Callable<Void>() {
       @Override
@@ -450,92 +456,92 @@ public abstract class MetadataTestBase extends ClientTestBase {
     }, expectedExceptionClass);
   }
 
-  protected Set<MetadataSearchResultRecord> searchMetadata(Id.Namespace namespaceId, String query,
+  protected Set<MetadataSearchResultRecord> searchMetadata(NamespaceId namespaceId, String query,
                                                            Set<MetadataSearchTargetType> targets)
     throws Exception {
-    return metadataClient.searchMetadata(namespaceId, query, targets);
+    return metadataClient.searchMetadata(namespaceId.toId(), query, targets);
   }
 
-  protected Set<String> getTags(Id.Application app, MetadataScope scope) throws Exception {
+  protected Set<String> getTags(ApplicationId app, MetadataScope scope) throws Exception {
     return Iterators.getOnlyElement(getMetadata(app, scope).iterator()).getTags();
   }
 
-  protected Set<String> getTags(Id.Artifact artifact, MetadataScope scope) throws Exception {
+  protected Set<String> getTags(ArtifactId artifact, MetadataScope scope) throws Exception {
     return Iterators.getOnlyElement(getMetadata(artifact, scope).iterator()).getTags();
   }
 
-  protected Set<String> getTags(Id.Program program, MetadataScope scope) throws Exception {
+  protected Set<String> getTags(ProgramId program, MetadataScope scope) throws Exception {
     return Iterators.getOnlyElement(getMetadata(program, scope).iterator()).getTags();
   }
 
-  protected Set<String> getTags(Id.DatasetInstance dataset, MetadataScope scope) throws Exception {
+  protected Set<String> getTags(DatasetId dataset, MetadataScope scope) throws Exception {
     return Iterators.getOnlyElement(getMetadata(dataset, scope).iterator()).getTags();
   }
 
-  protected Set<String> getTags(Id.Stream stream, MetadataScope scope) throws Exception {
+  protected Set<String> getTags(StreamId stream, MetadataScope scope) throws Exception {
     return Iterators.getOnlyElement(getMetadata(stream, scope).iterator()).getTags();
   }
 
-  protected Set<String> getTags(Id.Stream.View view, MetadataScope scope) throws Exception {
+  protected Set<String> getTags(StreamViewId view, MetadataScope scope) throws Exception {
     return Iterators.getOnlyElement(getMetadata(view, scope).iterator()).getTags();
   }
 
-  protected void removeTags(Id.Application app) throws Exception {
-    metadataClient.removeTags(app);
+  protected void removeTags(ApplicationId app) throws Exception {
+    metadataClient.removeTags(app.toId());
   }
 
-  protected void removeTag(Id.Application app, String tagToRemove) throws Exception {
-    metadataClient.removeTag(app, tagToRemove);
+  protected void removeTag(ApplicationId app, String tagToRemove) throws Exception {
+    metadataClient.removeTag(app.toId(), tagToRemove);
   }
 
-  protected void removeTags(Id.Artifact artifact) throws Exception {
-    metadataClient.removeTags(artifact);
+  protected void removeTags(ArtifactId artifact) throws Exception {
+    metadataClient.removeTags(artifact.toId());
   }
 
-  protected void removeTag(Id.Artifact artifact, String tagToRemove) throws Exception {
-    metadataClient.removeTag(artifact, tagToRemove);
+  protected void removeTag(ArtifactId artifact, String tagToRemove) throws Exception {
+    metadataClient.removeTag(artifact.toId(), tagToRemove);
   }
 
-  protected void removeTags(Id.Program program) throws Exception {
-    metadataClient.removeTags(program);
+  protected void removeTags(ProgramId program) throws Exception {
+    metadataClient.removeTags(program.toId());
   }
 
-  private void removeTag(Id.Program program, String tagToRemove) throws Exception {
-    metadataClient.removeTag(program, tagToRemove);
+  private void removeTag(ProgramId program, String tagToRemove) throws Exception {
+    metadataClient.removeTag(program.toId(), tagToRemove);
   }
 
-  protected void removeTags(Id.DatasetInstance dataset) throws Exception {
-    metadataClient.removeTags(dataset);
+  protected void removeTags(DatasetId dataset) throws Exception {
+    metadataClient.removeTags(dataset.toId());
   }
 
-  protected void removeTag(Id.DatasetInstance dataset, String tagToRemove) throws Exception {
-    metadataClient.removeTag(dataset, tagToRemove);
+  protected void removeTag(DatasetId dataset, String tagToRemove) throws Exception {
+    metadataClient.removeTag(dataset.toId(), tagToRemove);
   }
 
-  protected void removeTags(Id.Stream stream) throws Exception {
-    metadataClient.removeTags(stream);
+  protected void removeTags(StreamId stream) throws Exception {
+    metadataClient.removeTags(stream.toId());
   }
 
-  protected void removeTags(Id.Stream.View view) throws Exception {
-    metadataClient.removeTags(view);
+  protected void removeTags(StreamViewId view) throws Exception {
+    metadataClient.removeTags(view.toId());
   }
 
-  protected void removeTag(Id.Stream stream, String tagToRemove) throws Exception {
-    metadataClient.removeTag(stream, tagToRemove);
+  protected void removeTag(StreamId stream, String tagToRemove) throws Exception {
+    metadataClient.removeTag(stream.toId(), tagToRemove);
   }
 
-  protected void removeTag(Id.Stream.View view, String tagToRemove) throws Exception {
-    metadataClient.removeTag(view, tagToRemove);
+  protected void removeTag(StreamViewId view, String tagToRemove) throws Exception {
+    metadataClient.removeTag(view.toId(), tagToRemove);
   }
 
   // expect an exception during fetching of lineage
-  protected void fetchLineage(Id.DatasetInstance datasetInstance, long start, long end, int levels,
+  protected void fetchLineage(DatasetId datasetInstance, long start, long end, int levels,
                               Class<? extends Exception> expectedExceptionClass) throws Exception {
     fetchLineage(datasetInstance, Long.toString(start), Long.toString(end), levels, expectedExceptionClass);
   }
 
   // expect an exception during fetching of lineage
-  protected void fetchLineage(final Id.DatasetInstance datasetInstance, final String start, final String end,
+  protected void fetchLineage(final DatasetId datasetInstance, final String start, final String end,
                               final int levels, Class<? extends Exception> expectedExceptionClass) throws Exception {
     expectException(new Callable<Void>() {
       @Override
@@ -546,39 +552,39 @@ public abstract class MetadataTestBase extends ClientTestBase {
     }, expectedExceptionClass);
   }
 
-  protected LineageRecord fetchLineage(Id.DatasetInstance datasetInstance, long start, long end,
+  protected LineageRecord fetchLineage(DatasetId datasetInstance, long start, long end,
                                        int levels) throws Exception {
-    return lineageClient.getLineage(datasetInstance, start, end, levels);
+    return lineageClient.getLineage(datasetInstance.toId(), start, end, levels);
   }
 
-  protected LineageRecord fetchLineage(Id.DatasetInstance datasetInstance, long start, long end,
+  protected LineageRecord fetchLineage(DatasetId datasetInstance, long start, long end,
                                        Set<CollapseType> collapseTypes, int levels) throws Exception {
-    return lineageClient.getLineage(datasetInstance, start, end, collapseTypes, levels);
+    return lineageClient.getLineage(datasetInstance.toId(), start, end, collapseTypes, levels);
   }
 
-  protected LineageRecord fetchLineage(Id.DatasetInstance datasetInstance, String start, String end,
+  protected LineageRecord fetchLineage(DatasetId datasetInstance, String start, String end,
                                        int levels) throws Exception {
-    return lineageClient.getLineage(datasetInstance, start, end, levels);
+    return lineageClient.getLineage(datasetInstance.toId(), start, end, levels);
   }
 
-  protected LineageRecord fetchLineage(Id.Stream stream, long start, long end, int levels) throws Exception {
-    return lineageClient.getLineage(stream, start, end, levels);
+  protected LineageRecord fetchLineage(StreamId stream, long start, long end, int levels) throws Exception {
+    return lineageClient.getLineage(stream.toId(), start, end, levels);
   }
 
-  protected LineageRecord fetchLineage(Id.Stream stream, String start, String end, int levels) throws Exception {
-    return lineageClient.getLineage(stream, start, end, levels);
+  protected LineageRecord fetchLineage(StreamId stream, String start, String end, int levels) throws Exception {
+    return lineageClient.getLineage(stream.toId(), start, end, levels);
   }
 
-  protected LineageRecord fetchLineage(Id.Stream stream, long start, long end, Set<CollapseType> collapseTypes,
+  protected LineageRecord fetchLineage(StreamId stream, long start, long end, Set<CollapseType> collapseTypes,
                                        int levels) throws Exception {
-    return lineageClient.getLineage(stream, start, end, collapseTypes, levels);
+    return lineageClient.getLineage(stream.toId(), start, end, collapseTypes, levels);
   }
 
-  protected Set<MetadataRecord> fetchRunMetadata(Id.Run run) throws Exception {
-    return metadataClient.getMetadata(run);
+  protected Set<MetadataRecord> fetchRunMetadata(ProgramRunId run) throws Exception {
+    return metadataClient.getMetadata(run.toId());
   }
 
-  protected void assertRunMetadataNotFound(Id.Run run) throws Exception {
+  protected void assertRunMetadataNotFound(ProgramRunId run) throws Exception {
     try {
       fetchRunMetadata(run);
       Assert.fail("Excepted not to fetch Metadata for a nonexistent Run.");

--- a/cdap-client/src/main/java/co/cask/cdap/client/LineageClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/LineageClient.java
@@ -22,7 +22,9 @@ import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.codec.NamespacedEntityIdCodec;
 import co.cask.cdap.proto.codec.NamespacedIdCodec;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.lineage.CollapseType;
 import co.cask.cdap.proto.metadata.lineage.LineageRecord;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
@@ -46,7 +48,9 @@ import javax.inject.Inject;
 public class LineageClient {
 
   private static final Gson GSON = new GsonBuilder()
-    .registerTypeAdapter(Id.NamespacedId.class, new NamespacedIdCodec()).create();
+    .registerTypeAdapter(Id.NamespacedId.class, new NamespacedIdCodec())
+    .registerTypeAdapter(NamespacedEntityId.class, new NamespacedEntityIdCodec())
+    .create();
 
   private final RESTClient restClient;
   private final ClientConfig config;

--- a/cdap-common/src/main/java/co/cask/cdap/common/InvalidMetadataException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/InvalidMetadataException.java
@@ -15,21 +15,21 @@
  */
 package co.cask.cdap.common;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 
 /**
  * Base exception for Metadata validation.
  */
 public class InvalidMetadataException extends BadRequestException {
 
-  private final Id.NamespacedId targetId;
+  private final NamespacedEntityId targetId;
 
-  public InvalidMetadataException(Id.NamespacedId targetId, String message) {
+  public InvalidMetadataException(NamespacedEntityId targetId, String message) {
     super("Unable to set metadata for " + targetId + " with error: " + message);
     this.targetId = targetId;
   }
 
-  public Id.NamespacedId getTargetId() {
+  public NamespacedEntityId getTargetId() {
     return targetId;
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/metadata/AbstractMetadataClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/metadata/AbstractMetadataClient.java
@@ -20,7 +20,9 @@ import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.codec.NamespacedEntityIdCodec;
 import co.cask.cdap.proto.codec.NamespacedIdCodec;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
@@ -52,7 +54,9 @@ public abstract class AbstractMetadataClient {
   private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
   private static final Type SET_STRING_TYPE = new TypeToken<Set<String>>() { }.getType();
   private static final Gson GSON = new GsonBuilder()
-    .registerTypeAdapter(Id.NamespacedId.class, new NamespacedIdCodec()).create();
+    .registerTypeAdapter(Id.NamespacedId.class, new NamespacedIdCodec())
+    .registerTypeAdapter(NamespacedEntityId.class, new NamespacedEntityIdCodec())
+    .create();
 
   /**
    * Executes an HTTP request.

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/StreamAdminTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/StreamAdminTest.java
@@ -38,7 +38,7 @@ import co.cask.cdap.proto.audit.AuditType;
 import co.cask.cdap.proto.audit.payload.access.AccessPayload;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.NamespaceId;
-import co.cask.cdap.proto.id.NamespacedId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
@@ -386,8 +386,8 @@ public abstract class StreamAdminTest {
                        new Predicate<AuditMessage>() {
                          @Override
                          public boolean apply(AuditMessage input) {
-                           return !(input.getEntityId() instanceof NamespacedId &&
-                             ((NamespacedId) input.getEntityId()).getNamespace().equals(systemNs));
+                           return !(input.getEntityId() instanceof NamespacedEntityId &&
+                             ((NamespacedEntityId) input.getEntityId()).getNamespace().equals(systemNs));
                          }
                        });
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/view/ViewAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/view/ViewAdmin.java
@@ -74,7 +74,7 @@ public class ViewAdmin {
     ViewSpecification spec = store.get(viewId);
     explore.disableExploreStream(viewId.getStream(), spec.getTableName());
     store.delete(viewId);
-    metadataStore.removeMetadata(viewId);
+    metadataStore.removeMetadata(viewId.toEntityId());
   }
 
   public List<Id.Stream.View> list(Id.Stream streamId) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/audit/AuditPublishers.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/audit/AuditPublishers.java
@@ -20,6 +20,7 @@ import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.proto.audit.AuditPayload;
 import co.cask.cdap.proto.audit.AuditType;
 import co.cask.cdap.proto.audit.payload.access.AccessPayload;
+import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.EntityIdCompatible;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -102,14 +103,14 @@ public final class AuditPublishers {
    * @param auditType audit type
    * @param auditPayload audit payload
    */
-  public static void publishAudit(@Nullable AuditPublisher publisher, EntityIdCompatible entityId,
+  public static void publishAudit(@Nullable AuditPublisher publisher, EntityId entityId,
                                   AuditType auditType, AuditPayload auditPayload) {
     if (publisher == null) {
       logWarning();
       return;
     }
 
-    publisher.publish(entityId.toEntityId(), auditType, auditPayload);
+    publisher.publish(entityId, auditType, auditPayload);
   }
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
@@ -530,7 +530,7 @@ public class DatasetInstanceService {
 
   private void publishAudit(Id.DatasetInstance datasetInstance, AuditType auditType) {
     // TODO: Add properties to Audit Payload (CDAP-5220)
-    AuditPublishers.publishAudit(auditPublisher, datasetInstance, auditType, AuditPayload.EMPTY_PAYLOAD);
+    AuditPublishers.publishAudit(auditPublisher, datasetInstance.toEntityId(), auditType, AuditPayload.EMPTY_PAYLOAD);
   }
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetAdminService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetAdminService.java
@@ -219,7 +219,7 @@ public class DatasetAdminService {
     }
 
     // Remove metadata for the dataset
-    metadataStore.removeMetadata(datasetInstanceId);
+    metadataStore.removeMetadata(datasetInstanceId.toEntityId());
   }
 
   public void truncate(Id.DatasetInstance datasetInstanceId) throws Exception {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFramework.java
@@ -563,6 +563,6 @@ public class InMemoryDatasetFramework implements DatasetFramework {
       auditType != AuditType.ACCESS) {
       return;
     }
-    AuditPublishers.publishAudit(auditPublisher, datasetInstance, auditType, AuditPayload.EMPTY_PAYLOAD);
+    AuditPublishers.publishAudit(auditPublisher, datasetInstance.toEntityId(), auditType, AuditPayload.EMPTY_PAYLOAD);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsHistoryKey.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsHistoryKey.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data2.metadata.dataset;
 
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 
 /**
  * Key used to store metadata history.
@@ -26,7 +26,7 @@ import co.cask.cdap.proto.Id;
 public class MdsHistoryKey {
   private static final byte[] ROW_PREFIX = {'h'};
 
-  public static MDSKey getMdsKey(Id.NamespacedId targetId, long time) {
+  public static MDSKey getMdsKey(NamespacedEntityId targetId, long time) {
     MDSKey.Builder builder = new MDSKey.Builder();
     builder.add(ROW_PREFIX);
     KeyHelper.addTargetIdToKey(builder, targetId);
@@ -34,11 +34,11 @@ public class MdsHistoryKey {
     return builder.build();
   }
 
-  public static MDSKey getMdsScanStartKey(Id.NamespacedId targetId, long time) {
+  public static MDSKey getMdsScanStartKey(NamespacedEntityId targetId, long time) {
     return getMdsKey(targetId, time);
   }
 
-  public static MDSKey getMdsScanEndKey(Id.NamespacedId targetId) {
+  public static MDSKey getMdsScanEndKey(NamespacedEntityId targetId) {
     MDSKey.Builder builder = new MDSKey.Builder();
     builder.add(ROW_PREFIX);
     KeyHelper.addTargetIdToKey(builder, targetId);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsKey.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MdsKey.java
@@ -17,9 +17,14 @@
 package co.cask.cdap.data2.metadata.dataset;
 
 import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
+import co.cask.cdap.proto.id.StreamViewId;
 
-import java.util.Arrays;
 import javax.annotation.Nullable;
 
 /**
@@ -43,26 +48,26 @@ final class MdsKey {
     keySplitter.skipString();
 
     // Skip targetId
-    if (type.equals(Id.Program.class.getSimpleName())) {
+    if (type.equals(KeyHelper.TYPE_MAP.get(ProgramId.class))) {
       keySplitter.skipString();
       keySplitter.skipString();
       keySplitter.skipString();
       keySplitter.skipString();
-    } else if (type.equals(Id.Application.class.getSimpleName())) {
+    } else if (type.equals(KeyHelper.TYPE_MAP.get(ApplicationId.class))) {
       keySplitter.skipString();
       keySplitter.skipString();
-    } else if (type.equals(Id.DatasetInstance.class.getSimpleName())) {
+    } else if (type.equals(KeyHelper.TYPE_MAP.get(DatasetId.class))) {
       keySplitter.skipString();
       keySplitter.skipString();
-    } else if (type.equals(Id.Stream.class.getSimpleName())) {
+    } else if (type.equals(KeyHelper.TYPE_MAP.get(StreamId.class))) {
       keySplitter.skipString();
       keySplitter.skipString();
-    } else if (type.equals(Id.Stream.View.class.getSimpleName())) {
+    } else if (type.equals(KeyHelper.TYPE_MAP.get(StreamViewId.class))) {
       // skip namespace, stream, view
       keySplitter.skipString();
       keySplitter.skipString();
       keySplitter.skipString();
-    } else if (type.equals(Id.Artifact.class.getSimpleName())) {
+    } else if (type.equals(KeyHelper.TYPE_MAP.get(ArtifactId.class))) {
       // skip namespace, name, version
       keySplitter.skipString();
       keySplitter.skipString();
@@ -86,7 +91,7 @@ final class MdsKey {
    * Creates a key for metadata value row in the format:
    * [{@link #VALUE_ROW_PREFIX}][targetType][targetId][key] for value index rows
    */
-  static MDSKey getMDSValueKey(Id.NamespacedId targetId, @Nullable String key) {
+  static MDSKey getMDSValueKey(NamespacedEntityId targetId, @Nullable String key) {
     MDSKey.Builder builder = getMDSKeyPrefix(targetId, VALUE_ROW_PREFIX);
     if (key != null) {
       builder.add(key);
@@ -98,7 +103,7 @@ final class MdsKey {
    * Creates a key for metadata index row in the format:
    * [{@link #INDEX_ROW_PREFIX}][targetType][targetId][key][index] for value index rows
    */
-  static MDSKey getMDSIndexKey(Id.NamespacedId targetId, String key, @Nullable String index) {
+  static MDSKey getMDSIndexKey(NamespacedEntityId targetId, String key, @Nullable String index) {
     MDSKey.Builder builder = getMDSKeyPrefix(targetId, INDEX_ROW_PREFIX);
     builder.add(key);
     if (index != null) {
@@ -107,7 +112,7 @@ final class MdsKey {
     return builder.build();
   }
 
-  static Id.NamespacedId getNamespacedIdFromKey(String type, byte[] rowKey) {
+  static NamespacedEntityId getNamespacedIdFromKey(String type, byte[] rowKey) {
     MDSKey.Splitter keySplitter = new MDSKey(rowKey).split();
 
     // The rowkey is
@@ -142,7 +147,7 @@ final class MdsKey {
     return key.getKey();
   }
 
-  private static MDSKey.Builder getMDSKeyPrefix(Id.NamespacedId targetId, byte[] rowPrefix) {
+  private static MDSKey.Builder getMDSKeyPrefix(NamespacedEntityId targetId, byte[] rowPrefix) {
     String targetType = KeyHelper.getTargetType(targetId);
     MDSKey.Builder builder = new MDSKey.Builder();
     builder.add(rowPrefix);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/Metadata.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/Metadata.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.data2.metadata.dataset;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
@@ -25,28 +25,28 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * Represents the complete metadata of a {@link Id.NamespacedId} including its properties and tags.
+ * Represents the complete metadata of a {@link NamespacedEntityId} including its properties and tags.
  */
 public class Metadata {
-  private final Id.NamespacedId entityId;
+  private final NamespacedEntityId namespacedEntityId;
   private final Map<String, String> properties;
   private final Set<String> tags;
 
   /**
    * Returns an empty {@link Metadata}
    */
-  public Metadata(Id.NamespacedId entityId) {
-    this(entityId, ImmutableMap.<String, String>of(), ImmutableSet.<String>of());
+  public Metadata(NamespacedEntityId namespacedEntityId) {
+    this(namespacedEntityId, ImmutableMap.<String, String>of(), ImmutableSet.<String>of());
   }
 
-  public Metadata(Id.NamespacedId entityId, Map<String, String> properties, Set<String> tags) {
-    this.entityId = entityId;
+  public Metadata(NamespacedEntityId namespacedEntityId, Map<String, String> properties, Set<String> tags) {
+    this.namespacedEntityId = namespacedEntityId;
     this.properties = properties;
     this.tags = tags;
   }
 
-  public Id.NamespacedId getEntityId() {
-    return entityId;
+  public NamespacedEntityId getEntityId() {
+    return namespacedEntityId;
   }
 
   public Map<String, String> getProperties() {
@@ -68,20 +68,20 @@ public class Metadata {
 
     Metadata that = (Metadata) o;
 
-    return Objects.equals(entityId, that.entityId) &&
+    return Objects.equals(namespacedEntityId, that.namespacedEntityId) &&
       Objects.equals(properties, that.properties) &&
       Objects.equals(tags, that.tags);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(entityId, properties, tags);
+    return Objects.hash(namespacedEntityId, properties, tags);
   }
 
   @Override
   public String toString() {
     return "Metadata{" +
-      "entityId=" + entityId +
+      "namespacedEntityId=" + namespacedEntityId +
       ", properties=" + properties +
       ", tags=" + tags +
       '}';

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataEntry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataEntry.java
@@ -15,7 +15,7 @@
  */
 package co.cask.cdap.data2.metadata.dataset;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 
 import java.util.Objects;
 import javax.annotation.Nullable;
@@ -24,17 +24,17 @@ import javax.annotation.Nullable;
  * Represents a single Metadata entry for a CDAP Entity.
  */
 public class MetadataEntry {
-  private final Id.NamespacedId targetId;
+  private final NamespacedEntityId targetId;
   private final String key;
   private final String value;
   private final String schema;
 
-  public MetadataEntry(Id.NamespacedId targetId, String key, String value) {
+  public MetadataEntry(NamespacedEntityId targetId, String key, String value) {
     this(targetId, key, value, null);
   }
 
   //TODO: Remove this constructor when it is finalized that schema need not be stored separately
-  public MetadataEntry(Id.NamespacedId targetId, String key, String value,
+  public MetadataEntry(NamespacedEntityId targetId, String key, String value,
                        @Nullable String schema) {
     this.targetId = targetId;
     this.key = key;
@@ -42,7 +42,7 @@ public class MetadataEntry {
     this.schema = schema;
   }
 
-  public Id.NamespacedId  getTargetId() {
+  public NamespacedEntityId getTargetId() {
     return targetId;
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/CollapsedRelation.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/CollapsedRelation.java
@@ -17,10 +17,17 @@
 package co.cask.cdap.data2.metadata.lineage;
 
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.metadata.lineage.CollapseType;
+import com.google.common.base.Function;
+import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableSet;
 import org.apache.twill.api.RunId;
 
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -28,14 +35,14 @@ import java.util.Set;
  * A {@link Relation} collapsed based on {@link CollapseType}.
  */
 public class CollapsedRelation {
-  private final Id.NamespacedId data;
-  private final Id.Program program;
+  private final NamespacedEntityId data;
+  private final ProgramId program;
   private final Set<AccessType> access;
   private final Set<RunId> runs;
-  private final Set<Id.NamespacedId> components;
+  private final Set<NamespacedEntityId> components;
 
-  public CollapsedRelation(Id.DatasetInstance dataset, Id.Program program, Set<AccessType> access, Set<RunId> runs,
-                           Set<Id.NamespacedId> components) {
+  public CollapsedRelation(DatasetId dataset, ProgramId program, Set<AccessType> access, Set<RunId> runs,
+                           Set<NamespacedEntityId> components) {
     this.data = dataset;
     this.program = program;
     this.access = ImmutableSet.copyOf(access);
@@ -43,8 +50,8 @@ public class CollapsedRelation {
     this.components = ImmutableSet.copyOf(components);
   }
 
-  public CollapsedRelation(Id.Stream stream, Id.Program program, Set<AccessType> access, Set<RunId> runs,
-                           Set<Id.NamespacedId> components) {
+  public CollapsedRelation(StreamId stream, ProgramId program, Set<AccessType> access, Set<RunId> runs,
+                           Set<NamespacedEntityId> components) {
     this.data = stream;
     this.program = program;
     this.access = ImmutableSet.copyOf(access);
@@ -52,11 +59,11 @@ public class CollapsedRelation {
     this.components = ImmutableSet.copyOf(components);
   }
 
-  public Id.NamespacedId getData() {
+  public NamespacedEntityId getData() {
     return data;
   }
 
-  public Id.Program getProgram() {
+  public ProgramId getProgram() {
     return program;
   }
 
@@ -68,8 +75,21 @@ public class CollapsedRelation {
     return runs;
   }
 
-  public Set<Id.NamespacedId> getComponents() {
+  public Set<NamespacedEntityId> getComponents() {
     return components;
+  }
+
+  /**
+   * Temporary fix while phasing out usages of the {@link Id} class.
+   */
+  public Set<Id.NamespacedId> getIdComponents() {
+    Set<NamespacedEntityId> components = getComponents();
+    return new HashSet<>(Collections2.transform(components, new Function<NamespacedEntityId, Id.NamespacedId>() {
+      @Override
+      public Id.NamespacedId apply(NamespacedEntityId namespacedEntityId) {
+        return (Id.NamespacedId) namespacedEntityId.toId();
+      }
+    }));
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageDataset.java
@@ -25,6 +25,7 @@ import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
@@ -146,8 +147,8 @@ public class LineageDataset extends AbstractDataset {
   /**
    * @return a set of entities (program and data it accesses) associated with a program run.
    */
-  public Set<Id.NamespacedId> getEntitiesForRun(Id.Run run) {
-    ImmutableSet.Builder<Id.NamespacedId> recordBuilder = ImmutableSet.builder();
+  public Set<NamespacedEntityId> getEntitiesForRun(Id.Run run) {
+    ImmutableSet.Builder<NamespacedEntityId> recordBuilder = ImmutableSet.builder();
     byte[] startKey = getRunScanStartKey(run);
     try (Scanner scanner = accessRegistryTable.scan(startKey, Bytes.stopKeyForPrefix(startKey))) {
       Row row;
@@ -157,8 +158,8 @@ public class LineageDataset extends AbstractDataset {
         }
         RowKey rowKey = parseRow(row);
         if (run.getId().equals(rowKey.getRunId().getId())) {
-          recordBuilder.add(rowKey.getProgram());
-          recordBuilder.add(rowKey.getData());
+          recordBuilder.add(rowKey.getProgram().toEntityId());
+          recordBuilder.add((NamespacedEntityId) rowKey.getData().toEntityId());
         }
       }
     }
@@ -506,18 +507,22 @@ public class LineageDataset extends AbstractDataset {
     LOG.trace("Got component {}", component);
 
     if (stream == null) {
-      return new Relation(datasetInstance,
-                          program,
+      return new Relation(datasetInstance.toEntityId(),
+                          program.toEntityId(),
                           accessType,
                           runId,
-                          component == null ? ImmutableSet.<Id.NamespacedId>of() : ImmutableSet.of(component));
+                          component == null ?
+                            ImmutableSet.<NamespacedEntityId>of() :
+                            ImmutableSet.of((NamespacedEntityId) component.toEntityId()));
     }
 
-    return new Relation(stream,
-                        program,
+    return new Relation(stream.toEntityId(),
+                        program.toEntityId(),
                         accessType,
                         runId,
-                        component == null ? ImmutableSet.<Id.NamespacedId>of() : ImmutableSet.of(component));
+                        component == null ?
+                          ImmutableSet.<NamespacedEntityId>of() :
+                          ImmutableSet.of((NamespacedEntityId) component.toEntityId()));
   }
 
   private static final class RowKey {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageSerializer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageSerializer.java
@@ -73,15 +73,15 @@ public final class LineageSerializer {
     Set<CollapsedRelation> collapsedRelations =
       LineageCollapser.collapseRelations(lineage.getRelations(), collapseTypes);
     for (CollapsedRelation relation : collapsedRelations) {
-      String dataKey = makeDataKey(relation.getData());
-      String programKey = makeProgramKey(relation.getProgram());
+      String dataKey = makeDataKey((Id.NamespacedId) relation.getData().toId());
+      String programKey = makeProgramKey(relation.getProgram().toId());
       RelationRecord relationRecord = new RelationRecord(dataKey, programKey,
                                                          convertAccessType(relation.getAccess()),
                                                          convertRuns(relation.getRuns()),
-                                                         convertComponents(relation.getComponents()));
+                                                         convertComponents(relation.getIdComponents()));
       relationBuilder.add(relationRecord);
-      programBuilder.put(programKey, new ProgramRecord(relation.getProgram()));
-      dataBuilder.put(dataKey, new DataRecord(relation.getData()));
+      programBuilder.put(programKey, new ProgramRecord(relation.getProgram().toId()));
+      dataBuilder.put(dataKey, new DataRecord((Id.NamespacedId) relation.getData().toId()));
     }
     return new LineageRecord(start, end, relationBuilder, programBuilder, dataBuilder);
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageStore.java
@@ -23,6 +23,7 @@ import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.Transactions;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
@@ -131,10 +132,10 @@ public class LineageStore implements LineageStoreReader, LineageStoreWriter {
    * @return a set of entities (program and data it accesses) associated with a program run.
    */
   @Override
-  public Set<Id.NamespacedId> getEntitiesForRun(final Id.Run run) {
-    return execute(new TransactionExecutor.Function<LineageDataset, Set<Id.NamespacedId>>() {
+  public Set<NamespacedEntityId> getEntitiesForRun(final Id.Run run) {
+    return execute(new TransactionExecutor.Function<LineageDataset, Set<NamespacedEntityId>>() {
       @Override
-      public Set<Id.NamespacedId> apply(LineageDataset input) throws Exception {
+      public Set<NamespacedEntityId> apply(LineageDataset input) throws Exception {
         return input.getEntitiesForRun(run);
       }
     });

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageStoreReader.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageStoreReader.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data2.metadata.lineage;
 
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 import com.google.common.base.Predicate;
 
 import java.util.Set;
@@ -30,7 +31,7 @@ public interface LineageStoreReader {
   /**
    * @return a set of entities (program and data it accesses) associated with a program run.
    */
-  Set<Id.NamespacedId> getEntitiesForRun(Id.Run run);
+  Set<NamespacedEntityId> getEntitiesForRun(Id.Run run);
 
   /**
    * Fetch program-dataset access information for a dataset for a given period.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/Relation.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/Relation.java
@@ -17,10 +17,17 @@
 package co.cask.cdap.data2.metadata.lineage;
 
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
+import com.google.common.base.Function;
+import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableSet;
 import org.apache.twill.api.RunId;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -28,18 +35,18 @@ import java.util.Set;
  * Represents a Dataset access by a Program.
  */
 public class Relation {
-  private final Id.NamespacedId data;
-  private final Id.Program program;
+  private final NamespacedEntityId data;
+  private final ProgramId program;
   private final AccessType access;
   private final RunId run;
-  private final Set<Id.NamespacedId> components;
+  private final Set<NamespacedEntityId> components;
 
-  public Relation(Id.DatasetInstance data, Id.Program program, AccessType access, RunId run) {
-    this(data, program, access, run, Collections.<Id.NamespacedId>emptySet());
+  public Relation(DatasetId data, ProgramId program, AccessType access, RunId run) {
+    this(data, program, access, run, Collections.<NamespacedEntityId>emptySet());
   }
 
-  public Relation(Id.DatasetInstance data, Id.Program program, AccessType access, RunId run,
-                  Set<? extends Id.NamespacedId> components) {
+  public Relation(DatasetId data, ProgramId program, AccessType access, RunId run,
+                  Set<? extends NamespacedEntityId> components) {
     this.data = data;
     this.program = program;
     this.access = access;
@@ -47,12 +54,12 @@ public class Relation {
     this.components = ImmutableSet.copyOf(components);
   }
 
-  public Relation(Id.Stream stream, Id.Program program, AccessType access, RunId run) {
-    this(stream, program, access, run, Collections.<Id.NamespacedId>emptySet());
+  public Relation(StreamId stream, ProgramId program, AccessType access, RunId run) {
+    this(stream, program, access, run, Collections.<NamespacedEntityId>emptySet());
   }
 
-  public Relation(Id.Stream stream, Id.Program program, AccessType access, RunId run,
-                  Set<? extends Id.NamespacedId> components) {
+  public Relation(StreamId stream, ProgramId program, AccessType access, RunId run,
+                  Set<? extends NamespacedEntityId> components) {
     this.data = stream;
     this.program = program;
     this.access = access;
@@ -60,11 +67,11 @@ public class Relation {
     this.components = ImmutableSet.copyOf(components);
   }
 
-  public Id.NamespacedId getData() {
+  public NamespacedEntityId getData() {
     return data;
   }
 
-  public Id.Program getProgram() {
+  public ProgramId getProgram() {
     return program;
   }
 
@@ -76,8 +83,21 @@ public class Relation {
     return run;
   }
 
-  public Set<Id.NamespacedId> getComponents() {
+  public Set<NamespacedEntityId> getComponents() {
     return components;
+  }
+
+  /**
+   * Temporary fix while phasing out {@link Id} class.
+   */
+  public Set<Id.NamespacedId> getIdComponents() {
+    Set<NamespacedEntityId> components = getComponents();
+    return new HashSet<>(Collections2.transform(components, new Function<NamespacedEntityId, Id.NamespacedId>() {
+      @Override
+      public Id.NamespacedId apply(NamespacedEntityId namespaceEntityId) {
+        return (Id.NamespacedId) namespaceEntityId.toId();
+      }
+    }));
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data2.metadata.store;
 
 import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
 import co.cask.cdap.data2.metadata.indexer.Indexer;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
 /**
  * Defines operations on {@link MetadataDataset} for both system and user metadata.
  *
- * Operations supported for a specified {@link Id.NamespacedId}:
+ * Operations supported for a specified {@link NamespacedEntityId}:
  * <ul>
  *   <li>Adding new metadata: Supported for a single scope.</li>
  *   <li>Retrieving metadata: Supported for a specified scope as well as across both scopes.</li>
@@ -41,125 +41,125 @@ import javax.annotation.Nullable;
 public interface MetadataStore {
 
   /**
-   * Adds/updates properties for the specified {@link Id.NamespacedId} in the specified {@link MetadataScope}.
+   * Adds/updates properties for the specified {@link NamespacedEntityId} in the specified {@link MetadataScope}.
    *
    * @param scope the {@link MetadataScope} to add/update the properties in
-   * @param entityId the {@link Id.NamespacedId} to add the properties to
+   * @param namespacedEntityId the {@link NamespacedEntityId} to add the properties to
    * @param properties the properties to add/update
    */
-  void setProperties(MetadataScope scope, Id.NamespacedId entityId, Map<String, String> properties);
+  void setProperties(MetadataScope scope, NamespacedEntityId namespacedEntityId, Map<String, String> properties);
 
   /**
-   * Adds/updates properties for the specified {@link Id.NamespacedId} in the specified {@link MetadataScope}.
+   * Adds/updates properties for the specified {@link NamespacedEntityId} in the specified {@link MetadataScope}.
    *
    * @param scope the {@link MetadataScope} to add/update the properties in
-   * @param entityId the {@link Id.NamespacedId} to add the properties to
+   * @param namespacedEntityId the {@link NamespacedEntityId} to add the properties to
    * @param properties the properties to add/update
    * @param indexer {@link Indexer} to use for creating indexes
    */
-  void setProperties(MetadataScope scope, Id.NamespacedId entityId, Map<String, String> properties,
+  void setProperties(MetadataScope scope, NamespacedEntityId namespacedEntityId, Map<String, String> properties,
                      @Nullable Indexer indexer);
 
 
   /**
-   * Adds tags for the specified {@link Id.NamespacedId} in the specified {@link MetadataScope}.
+   * Adds tags for the specified {@link NamespacedEntityId} in the specified {@link MetadataScope}.
    *
    * @param scope the {@link MetadataScope} to add the tags in
-   * @param entityId the {@link Id.NamespacedId} to add the tags to
+   * @param namespacedEntityId the {@link NamespacedEntityId} to add the tags to
    * @param tagsToAdd the tags to add
    */
-  void addTags(MetadataScope scope, Id.NamespacedId entityId, String... tagsToAdd);
+  void addTags(MetadataScope scope, NamespacedEntityId namespacedEntityId, String... tagsToAdd);
 
   /**
    * @return a set of {@link MetadataRecord} representing all the metadata (including properties and tags) for the
-   * specified {@link Id.NamespacedId} in both {@link MetadataScope#USER} and {@link MetadataScope#SYSTEM}.
+   * specified {@link NamespacedEntityId} in both {@link MetadataScope#USER} and {@link MetadataScope#SYSTEM}.
    */
-  Set<MetadataRecord> getMetadata(Id.NamespacedId entityId);
+  Set<MetadataRecord> getMetadata(NamespacedEntityId namespacedEntityId);
 
   /**
    * @return a {@link MetadataRecord} representing all the metadata (including properties and tags) for the specified
-   * {@link Id.NamespacedId} in the specified {@link MetadataScope}.
+   * {@link NamespacedEntityId} in the specified {@link MetadataScope}.
    */
-  MetadataRecord getMetadata(MetadataScope scope, Id.NamespacedId entityId);
+  MetadataRecord getMetadata(MetadataScope scope, NamespacedEntityId namespacedEntityId);
 
   /**
    * @return a set of {@link MetadataRecord}s representing all the metadata (including properties and tags)
-   * for the specified set of {@link Id.NamespacedId}s in the specified {@link MetadataScope}.
+   * for the specified set of {@link NamespacedEntityId}s in the specified {@link MetadataScope}.
    */
-  Set<MetadataRecord> getMetadata(MetadataScope scope, Set<Id.NamespacedId> entityIds);
+  Set<MetadataRecord> getMetadata(MetadataScope scope, Set<NamespacedEntityId> namespacedEntityIds);
 
   /**
-   * @return the properties for the specified {@link Id.NamespacedId} in both {@link MetadataScope#USER} and
+   * @return the properties for the specified {@link NamespacedEntityId} in both {@link MetadataScope#USER} and
    * {@link MetadataScope#SYSTEM}
    */
-  Map<String, String> getProperties(Id.NamespacedId entityId);
+  Map<String, String> getProperties(NamespacedEntityId namespacedEntityId);
 
   /**
-   * @return the properties for the specified {@link Id.NamespacedId} in the specified {@link MetadataScope}
+   * @return the properties for the specified {@link NamespacedEntityId} in the specified {@link MetadataScope}
    */
-  Map<String, String> getProperties(MetadataScope scope, Id.NamespacedId entityId);
+  Map<String, String> getProperties(MetadataScope scope, NamespacedEntityId namespacedEntityId);
 
   /**
-   * @return the tags for the specified {@link Id.NamespacedId} in both {@link MetadataScope#USER} and
+   * @return the tags for the specified {@link NamespacedEntityId} in both {@link MetadataScope#USER} and
    * {@link MetadataScope#SYSTEM}
    */
-  Set<String> getTags(Id.NamespacedId entityId);
+  Set<String> getTags(NamespacedEntityId namespacedEntityId);
 
   /**
-   * @return the tags for the specified {@link Id.NamespacedId} in the specified {@link MetadataScope}
+   * @return the tags for the specified {@link NamespacedEntityId} in the specified {@link MetadataScope}
    */
-  Set<String> getTags(MetadataScope scope, Id.NamespacedId entityId);
+  Set<String> getTags(MetadataScope scope, NamespacedEntityId namespacedEntityId);
 
   /**
-   * Removes all metadata (including properties and tags) for the specified {@link Id.NamespacedId} in both
+   * Removes all metadata (including properties and tags) for the specified {@link NamespacedEntityId} in both
    * {@link MetadataScope#USER} and {@link MetadataScope#SYSTEM}.
    *
-   * @param entityId the {@link Id.NamespacedId} to remove all metadata for
+   * @param namespacedEntityId the {@link NamespacedEntityId} to remove all metadata for
    */
-  void removeMetadata(Id.NamespacedId entityId);
+  void removeMetadata(NamespacedEntityId namespacedEntityId);
 
   /**
-   * Removes all metadata (including properties and tags) for the specified {@link Id.NamespacedId} in the specified
+   * Removes all metadata (including properties and tags) for the specified {@link NamespacedEntityId} in the specified
    * {@link MetadataScope}.
    *
    * @param scope the {@link MetadataScope}
-   * @param entityId the {@link Id.NamespacedId} to remove all metadata for
+   * @param namespacedEntityId the {@link NamespacedEntityId} to remove all metadata for
    */
-  void removeMetadata(MetadataScope scope, Id.NamespacedId entityId);
+  void removeMetadata(MetadataScope scope, NamespacedEntityId namespacedEntityId);
 
   /**
-   * Removes all properties for the specified {@link Id.NamespacedId} in the specified {@link MetadataScope}.
+   * Removes all properties for the specified {@link NamespacedEntityId} in the specified {@link MetadataScope}.
    *
    * @param scope the {@link MetadataScope}
-   * @param entityId the {@link Id.NamespacedId} to remove all properties for
+   * @param namespacedEntityId the {@link NamespacedEntityId} to remove all properties for
    */
-  void removeProperties(MetadataScope scope, Id.NamespacedId entityId);
+  void removeProperties(MetadataScope scope, NamespacedEntityId namespacedEntityId);
 
   /**
-   * Removes the specified properties of the {@link Id.NamespacedId} in the specified {@link MetadataScope}.
+   * Removes the specified properties of the {@link NamespacedEntityId} in the specified {@link MetadataScope}.
    *
    * @param scope the {@link MetadataScope}
-   * @param entityId the {@link Id.NamespacedId} to remove the specified keys for
+   * @param namespacedEntityId the {@link NamespacedEntityId} to remove the specified keys for
    * @param keys the keys to remove
    */
-  void removeProperties(MetadataScope scope, Id.NamespacedId entityId, String... keys);
+  void removeProperties(MetadataScope scope, NamespacedEntityId namespacedEntityId, String... keys);
 
   /**
-   * Removes tags of the {@link Id.NamespacedId} in the specified {@link MetadataScope}.
+   * Removes tags of the {@link NamespacedEntityId} in the specified {@link MetadataScope}.
    *
    * @param scope the {@link MetadataScope}
-   * @param entityId the {@link Id.NamespacedId} to remove all tags for
+   * @param namespacedEntityId the {@link NamespacedEntityId} to remove all tags for
    */
-  void removeTags(MetadataScope scope, Id.NamespacedId entityId);
+  void removeTags(MetadataScope scope, NamespacedEntityId namespacedEntityId);
 
   /**
-   * Removes the specified tags from the {@link Id.NamespacedId} in the specified {@link MetadataScope}.
+   * Removes the specified tags from the {@link NamespacedEntityId} in the specified {@link MetadataScope}.
    *
    * @param scope the {@link MetadataScope}
-   * @param entityId the {@link Id.NamespacedId} to remove the specified tags for
+   * @param namespacedEntityId the {@link NamespacedEntityId} to remove the specified tags for
    * @param tagsToRemove the tags to remove
    */
-  void removeTags(MetadataScope scope, Id.NamespacedId entityId, String ... tagsToRemove);
+  void removeTags(MetadataScope scope, NamespacedEntityId namespacedEntityId, String ... tagsToRemove);
 
   /**
    * Search the Metadata Dataset in both {@link MetadataScope#USER} and {@link MetadataScope#SYSTEM}.
@@ -201,22 +201,23 @@ public interface MetadataStore {
    * Returns the snapshot of the metadata for entities on or before the given time in both {@link MetadataScope#USER}
    * and {@link MetadataScope#SYSTEM}.
    *
-   * @param entityIds entity ids
+   * @param namespacedEntityIds entity ids
    * @param timeMillis time in milliseconds
    * @return the snapshot of the metadata for entities on or before the given time
    */
-  Set<MetadataRecord> getSnapshotBeforeTime(Set<Id.NamespacedId> entityIds, long timeMillis);
+  Set<MetadataRecord> getSnapshotBeforeTime(Set<NamespacedEntityId> namespacedEntityIds, long timeMillis);
 
   /**
    * Returns the snapshot of the metadata for entities on or before the given time in the specified
    * {@link MetadataScope}.
    *
    * @param scope the {@link MetadataScope} to get the snapshot in
-   * @param entityIds entity ids
+   * @param namespacedEntityIds entity ids
    * @param timeMillis time in milliseconds
    * @return the snapshot of the metadata for entities on or before the given time
    */
-  Set<MetadataRecord> getSnapshotBeforeTime(MetadataScope scope,  Set<Id.NamespacedId> entityIds, long timeMillis);
+  Set<MetadataRecord> getSnapshotBeforeTime(MetadataScope scope, Set<NamespacedEntityId> namespacedEntityIds,
+                                            long timeMillis);
 
   /**
    * Rebuild stale metadata indexes.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
@@ -16,7 +16,7 @@
 package co.cask.cdap.data2.metadata.store;
 
 import co.cask.cdap.data2.metadata.indexer.Indexer;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
@@ -33,84 +33,85 @@ import java.util.Set;
 public class NoOpMetadataStore implements MetadataStore {
 
   @Override
-  public void setProperties(MetadataScope scope, Id.NamespacedId entityId, Map<String, String> properties) {
+  public void setProperties(MetadataScope scope, NamespacedEntityId namespacedEntityId,
+                            Map<String, String> properties) {
     // NO-OP
   }
 
   @Override
-  public void setProperties(MetadataScope scope, Id.NamespacedId entityId, Map<String, String> properties,
+  public void setProperties(MetadataScope scope, NamespacedEntityId namespacedEntityId, Map<String, String> properties,
                             Indexer indexer) {
     // NO-OP
   }
 
   @Override
-  public void addTags(MetadataScope scope, Id.NamespacedId entityId, String... tagsToAdd) {
+  public void addTags(MetadataScope scope, NamespacedEntityId namespacedEntityId, String... tagsToAdd) {
     // NO-OP
   }
 
   @Override
-  public Set<MetadataRecord> getMetadata(Id.NamespacedId entityId) {
-    return ImmutableSet.of(new MetadataRecord(entityId, MetadataScope.USER),
-                           new MetadataRecord(entityId, MetadataScope.SYSTEM));
+  public Set<MetadataRecord> getMetadata(NamespacedEntityId namespacedEntityId) {
+    return ImmutableSet.of(new MetadataRecord(namespacedEntityId, MetadataScope.USER),
+                           new MetadataRecord(namespacedEntityId, MetadataScope.SYSTEM));
   }
 
   @Override
-  public MetadataRecord getMetadata(MetadataScope scope, Id.NamespacedId entityId) {
-    return new MetadataRecord(entityId, scope);
+  public MetadataRecord getMetadata(MetadataScope scope, NamespacedEntityId namespacedEntityId) {
+    return new MetadataRecord(namespacedEntityId, scope);
   }
 
   @Override
-  public Set<MetadataRecord> getMetadata(MetadataScope scope, Set<Id.NamespacedId> entityIds) {
+  public Set<MetadataRecord> getMetadata(MetadataScope scope, Set<NamespacedEntityId> namespacedEntityIds) {
     return Collections.emptySet();
   }
 
   @Override
-  public Map<String, String> getProperties(Id.NamespacedId entityId) {
+  public Map<String, String> getProperties(NamespacedEntityId namespacedEntityId) {
     return Collections.emptyMap();
   }
 
   @Override
-  public Map<String, String> getProperties(MetadataScope scope, Id.NamespacedId entityId) {
+  public Map<String, String> getProperties(MetadataScope scope, NamespacedEntityId namespacedEntityId) {
     return Collections.emptyMap();
   }
 
   @Override
-  public Set<String> getTags(Id.NamespacedId entityId) {
+  public Set<String> getTags(NamespacedEntityId namespacedEntityId) {
     return Collections.emptySet();
   }
 
   @Override
-  public Set<String> getTags(MetadataScope scope, Id.NamespacedId entityId) {
+  public Set<String> getTags(MetadataScope scope, NamespacedEntityId namespacedEntityId) {
     return Collections.emptySet();
   }
 
   @Override
-  public void removeMetadata(Id.NamespacedId entityId) {
+  public void removeMetadata(NamespacedEntityId namespacedEntityId) {
     // NO-OP
   }
 
   @Override
-  public void removeMetadata(MetadataScope scope, Id.NamespacedId entityId) {
+  public void removeMetadata(MetadataScope scope, NamespacedEntityId namespacedEntityId) {
     // NO-OP
   }
 
   @Override
-  public void removeProperties(MetadataScope scope, Id.NamespacedId entityId) {
+  public void removeProperties(MetadataScope scope, NamespacedEntityId namespacedEntityId) {
     // NO-OP
   }
 
   @Override
-  public void removeProperties(MetadataScope scope, Id.NamespacedId entityId, String... keys) {
+  public void removeProperties(MetadataScope scope, NamespacedEntityId namespacedEntityId, String... keys) {
     // NO-OP
   }
 
   @Override
-  public void removeTags(MetadataScope scope, Id.NamespacedId entityId) {
+  public void removeTags(MetadataScope scope, NamespacedEntityId namespacedEntityId) {
     // NO-OP
   }
 
   @Override
-  public void removeTags(MetadataScope scope, Id.NamespacedId entityId, String... tagsToRemove) {
+  public void removeTags(MetadataScope scope, NamespacedEntityId namespacedEntityId, String... tagsToRemove) {
     // NO-OP
   }
 
@@ -137,19 +138,19 @@ public class NoOpMetadataStore implements MetadataStore {
   }
 
   @Override
-  public Set<MetadataRecord> getSnapshotBeforeTime(Set<Id.NamespacedId> entityIds, long timeMillis) {
+  public Set<MetadataRecord> getSnapshotBeforeTime(Set<NamespacedEntityId> namespacedEntityIds, long timeMillis) {
     return ImmutableSet.<MetadataRecord>builder()
-      .addAll(getSnapshotBeforeTime(MetadataScope.USER, entityIds, timeMillis))
-      .addAll(getSnapshotBeforeTime(MetadataScope.SYSTEM, entityIds, timeMillis))
+      .addAll(getSnapshotBeforeTime(MetadataScope.USER, namespacedEntityIds, timeMillis))
+      .addAll(getSnapshotBeforeTime(MetadataScope.SYSTEM, namespacedEntityIds, timeMillis))
       .build();
   }
 
   @Override
-  public Set<MetadataRecord> getSnapshotBeforeTime(MetadataScope scope, Set<Id.NamespacedId> entityIds,
+  public Set<MetadataRecord> getSnapshotBeforeTime(MetadataScope scope, Set<NamespacedEntityId> namespacedEntityIds,
                                                    long timeMillis) {
     ImmutableSet.Builder<MetadataRecord> builder = ImmutableSet.builder();
-    for (Id.NamespacedId entityId : entityIds) {
-      builder.add(new MetadataRecord(entityId, scope));
+    for (NamespacedEntityId namespacedEntityId : namespacedEntityIds) {
+      builder.add(new MetadataRecord(namespacedEntityId, scope));
     }
     return builder.build();
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/AbstractSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/AbstractSystemMetadataWriter.java
@@ -21,6 +21,7 @@ import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
 import co.cask.cdap.data2.metadata.indexer.SchemaIndexer;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
@@ -50,9 +51,9 @@ public abstract class AbstractSystemMetadataWriter implements SystemMetadataWrit
   protected static final Set<String> PRESERVE_PROPERTIES = ImmutableSet.of(CREATION_TIME, DESCRIPTION);
 
   private final MetadataStore metadataStore;
-  private final Id.NamespacedId entityId;
+  private final NamespacedEntityId entityId;
 
-  public AbstractSystemMetadataWriter(MetadataStore metadataStore, Id.NamespacedId entityId) {
+  public AbstractSystemMetadataWriter(MetadataStore metadataStore, NamespacedEntityId entityId) {
     this.metadataStore = metadataStore;
     this.entityId = entityId;
   }
@@ -87,7 +88,8 @@ public abstract class AbstractSystemMetadataWriter implements SystemMetadataWrit
   @Override
   public void write() {
     // Delete existing system metadata before writing new metadata
-    Set<String> existingProperties = metadataStore.getProperties(MetadataScope.SYSTEM, entityId).keySet();
+    Set<String> existingProperties = metadataStore.getProperties(MetadataScope.SYSTEM,
+                                                                 entityId).keySet();
     Sets.SetView<String> removeProperties = Sets.difference(existingProperties, PRESERVE_PROPERTIES);
     if (!removeProperties.isEmpty()) {
       String[] propertiesArray = removeProperties.toArray(new String[removeProperties.size()]);
@@ -106,9 +108,8 @@ public abstract class AbstractSystemMetadataWriter implements SystemMetadataWrit
     }
     // if there is schema property then set that while providing schema indexer
     if (!Strings.isNullOrEmpty(getSchemaToAdd())) {
-      metadataStore.setProperties(MetadataScope.SYSTEM, entityId, ImmutableMap.of(SCHEMA_FIELD_PROPERTY_PREFIX,
-                                                                                  getSchemaToAdd()),
-                                  new SchemaIndexer());
+      metadataStore.setProperties(MetadataScope.SYSTEM, entityId,
+                                  ImmutableMap.of(SCHEMA_FIELD_PROPERTY_PREFIX, getSchemaToAdd()), new SchemaIndexer());
     }
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/AppSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/AppSystemMetadataWriter.java
@@ -26,6 +26,7 @@ import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ApplicationId;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.HashSet;
@@ -39,7 +40,7 @@ public class AppSystemMetadataWriter extends AbstractSystemMetadataWriter {
 
   private final ApplicationSpecification appSpec;
 
-  public AppSystemMetadataWriter(MetadataStore metadataStore, Id.Application entityId,
+  public AppSystemMetadataWriter(MetadataStore metadataStore, ApplicationId entityId,
                                  ApplicationSpecification appSpec) {
     super(metadataStore, entityId);
     this.appSpec = appSpec;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ArtifactSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ArtifactSystemMetadataWriter.java
@@ -21,6 +21,7 @@ import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.ArtifactClasses;
 import co.cask.cdap.proto.artifact.ArtifactInfo;
+import co.cask.cdap.proto.id.ArtifactId;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
@@ -32,7 +33,7 @@ public class ArtifactSystemMetadataWriter extends AbstractSystemMetadataWriter {
 
   private final ArtifactInfo artifactInfo;
 
-  public ArtifactSystemMetadataWriter(MetadataStore metadataStore, Id.Artifact artifactId,
+  public ArtifactSystemMetadataWriter(MetadataStore metadataStore, ArtifactId artifactId,
                                       ArtifactInfo artifactInfo) {
     super(metadataStore, artifactId);
     this.artifactInfo = artifactInfo;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/DatasetSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/DatasetSystemMetadataWriter.java
@@ -75,7 +75,7 @@ public class DatasetSystemMetadataWriter extends AbstractSystemMetadataWriter {
                                      long createTime,
                                      @Nullable Dataset dataset, @Nullable String dsType,
                                      @Nullable String description) {
-    super(metadataStore, dsInstance);
+    super(metadataStore, dsInstance.toEntityId());
     this.dsInstance = dsInstance;
     this.dsType = dsType;
     this.dsProperties = dsProperties;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ProgramSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ProgramSystemMetadataWriter.java
@@ -42,7 +42,7 @@ public class ProgramSystemMetadataWriter extends AbstractSystemMetadataWriter {
 
   public ProgramSystemMetadataWriter(MetadataStore metadataStore, ProgramId programId,
                                      ProgramSpecification programSpec) {
-    super(metadataStore, programId.toId());
+    super(metadataStore, programId);
     this.programId = programId;
     this.programSpec = programSpec;
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/StreamSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/StreamSystemMetadataWriter.java
@@ -41,7 +41,7 @@ public class StreamSystemMetadataWriter extends AbstractSystemMetadataWriter {
 
   public StreamSystemMetadataWriter(MetadataStore metadataStore, Id.Stream streamId, StreamConfig config,
                                     long creationTime, @Nullable String description) {
-    super(metadataStore, streamId);
+    super(metadataStore, streamId.toEntityId());
     this.config = config;
     this.creationTime = creationTime;
     this.description = description;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ViewSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ViewSystemMetadataWriter.java
@@ -40,7 +40,7 @@ public class ViewSystemMetadataWriter extends AbstractSystemMetadataWriter {
   private final ViewSpecification viewSpec;
 
   public ViewSystemMetadataWriter(MetadataStore metadataStore, Id.Stream.View viewId, ViewSpecification viewSpec) {
-    super(metadataStore, viewId);
+    super(metadataStore, viewId.toEntityId());
     this.viewId = viewId;
     this.viewSpec = viewSpec;
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryStreamAdmin.java
@@ -36,6 +36,7 @@ import co.cask.cdap.proto.ViewSpecification;
 import co.cask.cdap.proto.audit.AuditPayload;
 import co.cask.cdap.proto.audit.AuditType;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -85,7 +86,7 @@ public class InMemoryStreamAdmin extends InMemoryQueueAdmin implements StreamAdm
     queueService.resetStreamsWithPrefix(QueueName.prefixForNamedspacedStream(namespace.getId()));
     for (StreamSpecification spec : streamMetaStore.listStreams(namespace)) {
       // Remove metadata for the stream
-      metadataStore.removeMetadata(Id.Stream.from(namespace, spec.getName()));
+      metadataStore.removeMetadata(new StreamId(namespace.getId(), spec.getName()));
       streamMetaStore.removeStream(Id.Stream.from(namespace, spec.getName()));
     }
   }
@@ -152,7 +153,7 @@ public class InMemoryStreamAdmin extends InMemoryQueueAdmin implements StreamAdm
   public void drop(Id.Stream streamId) throws Exception {
     Preconditions.checkArgument(exists(streamId), "Stream '%s' does not exist.", streamId);
     // Remove metadata for the stream
-    metadataStore.removeMetadata(streamId);
+    metadataStore.removeMetadata(streamId.toEntityId());
     drop(QueueName.fromStream(streamId));
     streamMetaStore.removeStream(streamId);
     publishAudit(streamId, AuditType.DELETE);
@@ -202,6 +203,6 @@ public class InMemoryStreamAdmin extends InMemoryQueueAdmin implements StreamAdm
   }
 
   private void publishAudit(Id.Stream stream, AuditType auditType) {
-    AuditPublishers.publishAudit(auditPublisher, stream, auditType, AuditPayload.EMPTY_PAYLOAD);
+    AuditPublishers.publishAudit(auditPublisher, stream.toEntityId(), auditType, AuditPayload.EMPTY_PAYLOAD);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
@@ -667,7 +667,7 @@ public class FileStreamAdmin implements StreamAdmin {
           });
 
           streamMetaStore.removeStream(streamId);
-          metadataStore.removeMetadata(streamId);
+          metadataStore.removeMetadata(streamId.toEntityId());
           // revoke all privileges on the stream
           privilegesManager.revoke(streamId.toEntityId());
           publishAudit(streamId, AuditType.DELETE);
@@ -795,7 +795,7 @@ public class FileStreamAdmin implements StreamAdmin {
   }
 
   private void publishAudit(Id.Stream stream, AuditType auditType) {
-    AuditPublishers.publishAudit(auditPublisher, stream, auditType, AuditPayload.EMPTY_PAYLOAD);
+    AuditPublishers.publishAudit(auditPublisher, stream.toEntityId(), auditType, AuditPayload.EMPTY_PAYLOAD);
   }
 
   private <T extends EntityId> void ensureAccess(T entityId, Action action) throws Exception {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
@@ -15,15 +15,19 @@
  */
 package co.cask.cdap.data2.metadata.dataset;
 
-import co.cask.cdap.api.artifact.ArtifactId;
-import co.cask.cdap.api.artifact.ArtifactScope;
-import co.cask.cdap.api.artifact.ArtifactVersion;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import co.cask.cdap.data2.metadata.indexer.Indexer;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
+import co.cask.cdap.proto.id.StreamViewId;
 import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -56,14 +60,15 @@ public class MetadataDatasetTest {
 
   private MetadataDataset dataset;
 
-  private final Id.Application app1 = Id.Application.from("ns1", "app1");
-  private final Id.Application appNs2 = Id.Application.from("ns2", "app1");
+  private final ApplicationId app1 = new ApplicationId("ns1", "app1");
+  private final ApplicationId appNs2 = new ApplicationId("ns2", "app1");
   // Have to use Id.Program for comparison here because the MetadataDataset APIs return Id.Program.
-  private final Id.Program flow1 = Id.Program.from("ns1", "app1", ProgramType.FLOW, "flow1");
-  private final Id.DatasetInstance dataset1 = Id.DatasetInstance.from("ns1", "ds1");
-  private final Id.Stream stream1 = Id.Stream.from("ns1", "s1");
-  private final Id.Stream.View view1 = Id.Stream.View.from(stream1, "v1");
-  private final Id.Artifact artifact1 = Id.Artifact.from(Id.Namespace.from("ns1"), "a1", "1.0.0");
+  private final ProgramId flow1 = new ProgramId("ns1", "app1", ProgramType.FLOW, "flow1");
+  private final DatasetId dataset1 = new DatasetId("ns1", "ds1");
+  private final StreamId stream1 = new StreamId("ns1", "s1");
+  private final StreamViewId view1 = new StreamViewId(stream1.getNamespace(), stream1.getStream(), "v1");
+  private final co.cask.cdap.proto.id.ArtifactId artifact1 =
+    new co.cask.cdap.proto.id.ArtifactId("ns1", "a1", "1.0.0");
 
   @Before
   public void before() throws Exception {
@@ -380,7 +385,7 @@ public class MetadataDatasetTest {
     // Test wrong ns
     List<MetadataEntry> results2  =
       dataset.search("ns12", "key1" + MetadataDataset.KEYVALUE_SEPARATOR + "value1",
-                               ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+                     ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
     Assert.assertTrue(results2.isEmpty());
 
     // Test multi word query
@@ -401,9 +406,10 @@ public class MetadataDatasetTest {
   @Test
   public void testSearchIncludesSystemEntities() {
     // Use the same artifact in two different namespaces - system and ns2
-    Id.Artifact sysArtifact = Id.Artifact.from(
-      Id.Namespace.SYSTEM, new ArtifactId("artifact", new ArtifactVersion("1.0"), ArtifactScope.SYSTEM));
-    Id.Artifact ns2Artifact = Id.Artifact.from(Id.Namespace.from("ns2"), "artifact", "1.0");
+    co.cask.cdap.proto.id.ArtifactId sysArtifact = new co.cask.cdap.proto.id.ArtifactId(
+      NamespaceId.SYSTEM.getNamespace(), "artifact", "1.0");
+    co.cask.cdap.proto.id.ArtifactId ns2Artifact = new co.cask.cdap.proto.id.ArtifactId(
+      "ns2", "artifact", "1.0");
     String multiWordKey = "multiword";
     String multiWordValue = "aV1 av2 ,  -  ,  av3 - av4_av5 av6";
     dataset.setProperty(flow1, multiWordKey, multiWordValue);
@@ -451,11 +457,11 @@ public class MetadataDatasetTest {
     dataset.addTags(flow1, "tag1", "tag2");
 
     Assert.assertEquals(ImmutableList.of(new MetadataEntry(flow1, "key1", "value1")),
-                        dataset.search(flow1.getNamespaceId(), "value1", ImmutableSet.<MetadataSearchTargetType>of()));
+                        dataset.search(flow1.getNamespace(), "value1", ImmutableSet.<MetadataSearchTargetType>of()));
     Assert.assertEquals(ImmutableList.of(new MetadataEntry(flow1, "key2", "value2")),
-                        dataset.search(flow1.getNamespaceId(), "value2", ImmutableSet.<MetadataSearchTargetType>of()));
+                        dataset.search(flow1.getNamespace(), "value2", ImmutableSet.<MetadataSearchTargetType>of()));
     Assert.assertEquals(ImmutableList.of(new MetadataEntry(flow1, MetadataDataset.TAGS_KEY, "tag1,tag2")),
-                        dataset.search(flow1.getNamespaceId(), "tag2", ImmutableSet.<MetadataSearchTargetType>of()));
+                        dataset.search(flow1.getNamespace(), "tag2", ImmutableSet.<MetadataSearchTargetType>of()));
     // Update key1
     dataset.setProperty(flow1, "key1", "value3");
     dataset.removeProperties(flow1, "key2");
@@ -463,43 +469,43 @@ public class MetadataDatasetTest {
 
     // Searching for value1 should be empty
     Assert.assertEquals(ImmutableList.of(),
-                        dataset.search(flow1.getNamespaceId(), "value1", ImmutableSet.<MetadataSearchTargetType>of()));
+                        dataset.search(flow1.getNamespace(), "value1", ImmutableSet.<MetadataSearchTargetType>of()));
     // Instead key1 has value value3 now
     Assert.assertEquals(ImmutableList.of(new MetadataEntry(flow1, "key1", "value3")),
-                        dataset.search(flow1.getNamespaceId(), "value3", ImmutableSet.<MetadataSearchTargetType>of()));
+                        dataset.search(flow1.getNamespace(), "value3", ImmutableSet.<MetadataSearchTargetType>of()));
     // key2 was deleted
     Assert.assertEquals(ImmutableList.of(),
-                        dataset.search(flow1.getNamespaceId(), "value2", ImmutableSet.<MetadataSearchTargetType>of()));
+                        dataset.search(flow1.getNamespace(), "value2", ImmutableSet.<MetadataSearchTargetType>of()));
     // tag2 was deleted
     Assert.assertEquals(ImmutableList.of(),
-                        dataset.search(flow1.getNamespaceId(), "tag2", ImmutableSet.<MetadataSearchTargetType>of()));
+                        dataset.search(flow1.getNamespace(), "tag2", ImmutableSet.<MetadataSearchTargetType>of()));
     Assert.assertEquals(ImmutableList.of(new MetadataEntry(flow1, MetadataDataset.TAGS_KEY, "tag1")),
-                        dataset.search(flow1.getNamespaceId(), "tag1", ImmutableSet.<MetadataSearchTargetType>of()));
+                        dataset.search(flow1.getNamespace(), "tag1", ImmutableSet.<MetadataSearchTargetType>of()));
   }
 
   @Test
   public void testMultiGet() throws Exception {
-    Map<Id.NamespacedId, Metadata> allMetadata = new HashMap<>();
+    Map<NamespacedEntityId, Metadata> allMetadata = new HashMap<>();
     allMetadata.put(flow1, new Metadata(flow1,
                                         ImmutableMap.of("key1", "value1", "key2", "value2"),
                                         ImmutableSet.of("tag1", "tag2", "tag3")));
     allMetadata.put(dataset1, new Metadata(dataset1,
-                                 ImmutableMap.of("key10", "value10", "key11", "value11"),
-                                 ImmutableSet.<String>of()));
+                                           ImmutableMap.of("key10", "value10", "key11", "value11"),
+                                           ImmutableSet.<String>of()));
     allMetadata.put(app1, new Metadata(app1,
-                                 ImmutableMap.of("key20", "value20", "key21", "value21"),
-                                 ImmutableSet.<String>of()));
+                                       ImmutableMap.of("key20", "value20", "key21", "value21"),
+                                       ImmutableSet.<String>of()));
     allMetadata.put(stream1, new Metadata(stream1,
-                                 ImmutableMap.of("key30", "value30", "key31", "value31", "key32", "value32"),
-                                 ImmutableSet.<String>of()));
+                                          ImmutableMap.of("key30", "value30", "key31", "value31", "key32", "value32"),
+                                          ImmutableSet.<String>of()));
     allMetadata.put(artifact1, new Metadata(artifact1,
-                                 ImmutableMap.of("key40", "value41"),
-                                 ImmutableSet.<String>of()));
+                                            ImmutableMap.of("key40", "value41"),
+                                            ImmutableSet.<String>of()));
     allMetadata.put(view1, new Metadata(view1,
-                                 ImmutableMap.of("key50", "value50", "key51", "value51"),
-                                 ImmutableSet.of("tag51")));
+                                        ImmutableMap.of("key50", "value50", "key51", "value51"),
+                                        ImmutableSet.of("tag51")));
 
-    for (Map.Entry<Id.NamespacedId, Metadata> entry : allMetadata.entrySet()) {
+    for (Map.Entry<NamespacedEntityId, Metadata> entry : allMetadata.entrySet()) {
       Metadata metadata = entry.getValue();
       for (Map.Entry<String, String> props : metadata.getProperties().entrySet()) {
         dataset.setProperty(metadata.getEntityId(), props.getKey(), props.getValue());
@@ -530,7 +536,7 @@ public class MetadataDatasetTest {
     Assert.assertEquals(expected, dataset.getMetadata(ImmutableSet.of(artifact1)));
 
     expected = ImmutableSet.of();
-    Assert.assertEquals(expected, dataset.getMetadata(ImmutableSet.<Id.NamespacedId>of()));
+    Assert.assertEquals(expected, dataset.getMetadata(ImmutableSet.<NamespacedEntityId>of()));
   }
 
   @Test
@@ -575,7 +581,7 @@ public class MetadataDatasetTest {
       getDataset(Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "testIndexRebuilding"));
     dataset.setProperty(flow1, "flowKey", "flowValue", new ReversingIndexer());
     dataset.setProperty(dataset1, "datasetKey", "datasetValue", new ReversingIndexer());
-    String namespaceId = flow1.getNamespaceId();
+    String namespaceId = flow1.getNamespace();
     Set<MetadataSearchTargetType> targetTypes = Collections.singleton(MetadataSearchTargetType.ALL);
     List<MetadataEntry> searchResults = dataset.search(namespaceId, "flowValue", targetTypes);
     Assert.assertTrue(searchResults.isEmpty());
@@ -622,7 +628,7 @@ public class MetadataDatasetTest {
       getDataset(Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "testIndexRebuilding"));
     dataset.setProperty(flow1, "flowKey", "flowValue");
     dataset.setProperty(dataset1, "datasetKey", "datasetValue");
-    String namespaceId = flow1.getNamespaceId();
+    String namespaceId = flow1.getNamespace();
     Set<MetadataSearchTargetType> targetTypes = Collections.singleton(MetadataSearchTargetType.ALL);
     MetadataEntry expectedFlowEntry = new MetadataEntry(flow1, "flowKey", "flowValue");
     MetadataEntry expectedDatasetEntry = new MetadataEntry(dataset1, "datasetKey", "datasetValue");
@@ -642,7 +648,7 @@ public class MetadataDatasetTest {
     Assert.assertEquals(0, dataset.deleteAllIndexes(1));
   }
 
-  private void doTestHistory(MetadataDataset dataset, Id.NamespacedId targetId, String prefix)
+  private void doTestHistory(MetadataDataset dataset, NamespacedEntityId targetId, String prefix)
     throws Exception {
     // Metadata change history keyed by time in millis the change was made
     Map<Long, Metadata> expected = new HashMap<>();
@@ -677,7 +683,7 @@ public class MetadataDatasetTest {
     dataset.addTags(targetId, prefix + "t3");
     // Save the complete metadata record at this point
     completeRecord = new Metadata(targetId, toProps(prefix, "k1", "v1", "k2", "v2"),
-                                              toTags(prefix, "t1", "t2", "t3"));
+                                  toTags(prefix, "t1", "t2", "t3"));
     time = System.currentTimeMillis();
     expected.put(time, completeRecord);
     // Assert the history record with the change
@@ -693,7 +699,7 @@ public class MetadataDatasetTest {
     dataset.addTags(targetId, prefix + "t4");
     // Save the complete metadata record at this point
     completeRecord = new Metadata(targetId, toProps(prefix, "k1", "v1", "k2", "v2", "k3", "v3"),
-                                        toTags(prefix, "t1", "t2", "t3", "t4"));
+                                  toTags(prefix, "t1", "t2", "t3", "t4"));
     time = System.currentTimeMillis();
     expected.put(time, completeRecord);
     // Assert the history record with the change
@@ -709,7 +715,7 @@ public class MetadataDatasetTest {
     dataset.addTags(targetId, prefix + "t3");
     // Save the complete metadata record at this point
     completeRecord = new Metadata(targetId, toProps(prefix, "k1", "v1", "k2", "v2", "k3", "v3"),
-                                        toTags(prefix, "t1", "t2", "t3", "t4"));
+                                  toTags(prefix, "t1", "t2", "t3", "t4"));
     time = System.currentTimeMillis();
     expected.put(time, completeRecord);
     // Assert the history record with the change
@@ -726,7 +732,7 @@ public class MetadataDatasetTest {
     dataset.removeTags(targetId, prefix + "t2");
     // Save the complete metadata record at this point
     completeRecord = new Metadata(targetId, toProps(prefix, "k1", "v1", "k3", "v3"),
-                                        toTags(prefix, "t1", "t3"));
+                                  toTags(prefix, "t1", "t3"));
     time = System.currentTimeMillis();
     expected.put(time, completeRecord);
     // Assert the history record with the change
@@ -757,7 +763,7 @@ public class MetadataDatasetTest {
     dataset.addTags(targetId, prefix + "t2");
     // Save the complete metadata record at this point
     completeRecord = new Metadata(targetId, toProps(prefix, "k2", "v2"),
-                                        toTags(prefix, "t2"));
+                                  toTags(prefix, "t2"));
     time = System.currentTimeMillis();
     expected.put(time, completeRecord);
     // Assert the history record with the change

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/indexer/SchemaIndexerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/indexer/SchemaIndexerTest.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data2.metadata.indexer;
 
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.data2.metadata.dataset.MetadataEntry;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Test;
@@ -36,7 +36,7 @@ public class SchemaIndexerTest {
     Schema simpleSchema = Schema.of(Schema.Type.INT);
     Set<String> expected = Collections.emptySet();
     SchemaIndexer indexer = new SchemaIndexer();
-    Id.DatasetInstance datasetInstance = Id.DatasetInstance.from("ns1", "ds1");
+    DatasetId datasetInstance = new DatasetId("ns1", "ds1");
     Set<String> actual = indexer.getIndexes(new MetadataEntry(datasetInstance, "schema", simpleSchema.toString()));
     Assert.assertEquals(expected, actual);
   }
@@ -53,7 +53,7 @@ public class SchemaIndexerTest {
                                                                             Schema.of(Schema.Type.DOUBLE))));
     Set<String> expected = ImmutableSet.of("record1", "record1:RECORD", "x", "x:STRING", "y", "y:ARRAY", "z", "z:MAP");
     SchemaIndexer indexer = new SchemaIndexer();
-    Id.DatasetInstance datasetInstance = Id.DatasetInstance.from("ns1", "ds1");
+    DatasetId datasetInstance = new DatasetId("ns1", "ds1");
     Set<String> actual = indexer.getIndexes(new MetadataEntry(datasetInstance, "schema", simpleSchema.toString()));
     Assert.assertEquals(expected, actual);
   }
@@ -93,7 +93,7 @@ public class SchemaIndexerTest {
                                            "y", "y:ARRAY", "z", "z:MAP", "record22", "record22:RECORD", "a", "a:MAP",
                                            "i", "i:INT", "j", "j:UNION", "record1", "record1:RECORD");
     SchemaIndexer indexer = new SchemaIndexer();
-    Id.DatasetInstance datasetInstance = Id.DatasetInstance.from("ns1", "ds1");
+    DatasetId datasetInstance = new DatasetId("ns1", "ds1");
     Set<String> actual = indexer.getIndexes(new MetadataEntry(datasetInstance, "schema",
                                                               superComplexSchema.toString()));
     Assert.assertEquals(expected, actual);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/lineage/LineageDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/lineage/LineageDatasetTest.java
@@ -22,6 +22,9 @@ import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -45,25 +48,26 @@ public class LineageDatasetTest {
     Assert.assertNotNull(lineageDataset);
 
     RunId runId = RunIds.generate(10000);
-    Id.DatasetInstance datasetInstance = Id.DatasetInstance.from("default", "dataset1");
-    Id.Program program = Id.Program.from("default", "app1", ProgramType.FLOW, "flow1");
-    Id.Flow.Flowlet flowlet = Id.Flow.Flowlet.from(program.getApplication(), program.getId(), "flowlet1");
-    Id.Run run = new Id.Run(program, runId.getId());
+    DatasetId datasetInstance = new DatasetId("default", "dataset1");
+    ProgramId program = new ProgramId("default", "app1", ProgramType.FLOW, "flow1");
+    Id.Flow.Flowlet flowlet = Id.Flow.Flowlet.from(program.toId().getApplication(), program.getEntityName(),
+                                                   "flowlet1");
+    Id.Run run = new Id.Run(program.toId(), runId.getId());
 
     long accessTimeMillis = System.currentTimeMillis();
     lineageDataset.addAccess(run,
-                             datasetInstance, AccessType.READ, accessTimeMillis,
+                             datasetInstance.toId(), AccessType.READ, accessTimeMillis,
                              flowlet);
 
     Relation expected = new Relation(datasetInstance, program, AccessType.READ,
-                                     runId, ImmutableSet.of(flowlet));
+                                     runId, ImmutableSet.of(flowlet.toEntityId()));
 
-    Set<Relation> relations = lineageDataset.getRelations(datasetInstance, 0, 100000,
+    Set<Relation> relations = lineageDataset.getRelations(datasetInstance.toId(), 0, 100000,
                                                           Predicates.<Relation>alwaysTrue());
     Assert.assertEquals(1, relations.size());
     Assert.assertEquals(expected, relations.iterator().next());
 
-    Assert.assertEquals(toSet(datasetInstance, program), lineageDataset.getEntitiesForRun(run));
+    Assert.assertEquals(toSet(program, datasetInstance), lineageDataset.getEntitiesForRun(run));
     Assert.assertEquals(ImmutableList.of(accessTimeMillis), lineageDataset.getAccessTimesForRun(run));
   }
 
@@ -77,41 +81,42 @@ public class LineageDatasetTest {
     RunId runId3 = RunIds.generate(30000);
     RunId runId4 = RunIds.generate(40000);
 
-    Id.DatasetInstance datasetInstance1 = Id.DatasetInstance.from("default", "dataset1");
-    Id.DatasetInstance datasetInstance2 = Id.DatasetInstance.from("default", "dataset2");
+    DatasetId datasetInstance1 = new DatasetId("default", "dataset1");
+    DatasetId datasetInstance2 = new DatasetId("default", "dataset2");
 
-    Id.Stream stream1 = Id.Stream.from("default", "stream1");
-    Id.Stream stream2 = Id.Stream.from("default", "stream2");
+    StreamId stream1 = new StreamId("default", "stream1");
+    StreamId stream2 = new StreamId("default", "stream2");
 
-    Id.Program program1 = Id.Program.from("default", "app1", ProgramType.FLOW, "flow1");
-    Id.Flow.Flowlet flowlet1 = Id.Flow.Flowlet.from(program1.getApplication(), program1.getId(), "flowlet1");
-    Id.Program program2 = Id.Program.from("default", "app2", ProgramType.WORKER, "worker2");
-    Id.Program program3 = Id.Program.from("default", "app3", ProgramType.SERVICE, "service3");
+    ProgramId program1 = new ProgramId("default", "app1", ProgramType.FLOW, "flow1");
+    Id.Flow.Flowlet flowlet1 = Id.Flow.Flowlet.from(program1.toId().getApplication(), program1.getEntityName(),
+                                                    "flowlet1");
+    ProgramId program2 = new ProgramId("default", "app2", ProgramType.WORKER, "worker2");
+    ProgramId program3 = new ProgramId("default", "app3", ProgramType.SERVICE, "service3");
 
-    Id.Run run11 = new Id.Run(program1, runId1.getId());
-    Id.Run run22 = new Id.Run(program2, runId2.getId());
-    Id.Run run23 = new Id.Run(program2, runId3.getId());
-    Id.Run run34 = new Id.Run(program3, runId4.getId());
+    Id.Run run11 = new Id.Run(program1.toId(), runId1.getId());
+    Id.Run run22 = new Id.Run(program2.toId(), runId2.getId());
+    Id.Run run23 = new Id.Run(program2.toId(), runId3.getId());
+    Id.Run run34 = new Id.Run(program3.toId(), runId4.getId());
 
     long now = System.currentTimeMillis();
     //noinspection UnnecessaryLocalVariable
     long run11Data1AccessTime = now;
-    lineageDataset.addAccess(run11, datasetInstance1, AccessType.READ, run11Data1AccessTime, flowlet1);
+    lineageDataset.addAccess(run11, datasetInstance1.toId(), AccessType.READ, run11Data1AccessTime, flowlet1);
     long run22Data2AccessTime = now + 1;
-    lineageDataset.addAccess(run22, datasetInstance2, AccessType.WRITE, run22Data2AccessTime);
+    lineageDataset.addAccess(run22, datasetInstance2.toId(), AccessType.WRITE, run22Data2AccessTime);
     long run22Stream1AccessTime = now + 2;
-    lineageDataset.addAccess(run22, stream1, AccessType.READ, run22Stream1AccessTime);
+    lineageDataset.addAccess(run22, stream1.toId(), AccessType.READ, run22Stream1AccessTime);
     long run23Stream2AccessTime = now + 1;
-    lineageDataset.addAccess(run23, stream2, AccessType.READ, run23Stream2AccessTime);
+    lineageDataset.addAccess(run23, stream2.toId(), AccessType.READ, run23Stream2AccessTime);
     long run23Data2AccessTime = now + 3;
-    lineageDataset.addAccess(run23, datasetInstance2, AccessType.WRITE, run23Data2AccessTime);
-    lineageDataset.addAccess(run34, datasetInstance2, AccessType.READ_WRITE, System.currentTimeMillis());
-    lineageDataset.addAccess(run34, stream2, AccessType.UNKNOWN, System.currentTimeMillis());
+    lineageDataset.addAccess(run23, datasetInstance2.toId(), AccessType.WRITE, run23Data2AccessTime);
+    lineageDataset.addAccess(run34, datasetInstance2.toId(), AccessType.READ_WRITE, System.currentTimeMillis());
+    lineageDataset.addAccess(run34, stream2.toId(), AccessType.UNKNOWN, System.currentTimeMillis());
 
     Assert.assertEquals(
       ImmutableSet.of(new Relation(datasetInstance1, program1, AccessType.READ, runId1,
-                                   ImmutableSet.of(flowlet1))),
-      lineageDataset.getRelations(datasetInstance1, 0, 100000, Predicates.<Relation>alwaysTrue())
+                                   ImmutableSet.of(flowlet1.toEntityId()))),
+      lineageDataset.getRelations(datasetInstance1.toId(), 0, 100000, Predicates.<Relation>alwaysTrue())
     );
 
     Assert.assertEquals(
@@ -119,18 +124,18 @@ public class LineageDatasetTest {
                       new Relation(datasetInstance2, program2, AccessType.WRITE, runId3),
                       new Relation(datasetInstance2, program3, AccessType.READ_WRITE, runId4)
       ),
-      lineageDataset.getRelations(datasetInstance2, 0, 100000, Predicates.<Relation>alwaysTrue())
+      lineageDataset.getRelations(datasetInstance2.toId(), 0, 100000, Predicates.<Relation>alwaysTrue())
     );
 
     Assert.assertEquals(
       ImmutableSet.of(new Relation(stream1, program2, AccessType.READ, runId2)),
-      lineageDataset.getRelations(stream1, 0, 100000, Predicates.<Relation>alwaysTrue())
+      lineageDataset.getRelations(stream1.toId(), 0, 100000, Predicates.<Relation>alwaysTrue())
     );
 
     Assert.assertEquals(
       ImmutableSet.of(new Relation(stream2, program2, AccessType.READ, runId3),
                       new Relation(stream2, program3, AccessType.UNKNOWN, runId4)),
-      lineageDataset.getRelations(stream2, 0, 100000, Predicates.<Relation>alwaysTrue())
+      lineageDataset.getRelations(stream2.toId(), 0, 100000, Predicates.<Relation>alwaysTrue())
     );
 
     Assert.assertEquals(
@@ -139,7 +144,7 @@ public class LineageDatasetTest {
                       new Relation(datasetInstance2, program2, AccessType.WRITE, runId3),
                       new Relation(stream2, program2, AccessType.READ, runId3)
       ),
-      lineageDataset.getRelations(program2, 0, 100000, Predicates.<Relation>alwaysTrue())
+      lineageDataset.getRelations(program2.toId(), 0, 100000, Predicates.<Relation>alwaysTrue())
     );
 
     // Reduced time range
@@ -147,7 +152,7 @@ public class LineageDatasetTest {
       ImmutableSet.of(new Relation(datasetInstance2, program2, AccessType.WRITE, runId2),
                       new Relation(datasetInstance2, program2, AccessType.WRITE, runId3)
       ),
-      lineageDataset.getRelations(datasetInstance2, 0, 35000, Predicates.<Relation>alwaysTrue())
+      lineageDataset.getRelations(datasetInstance2.toId(), 0, 35000, Predicates.<Relation>alwaysTrue())
     );
 
     Assert.assertEquals(toSet(program1, datasetInstance1), lineageDataset.getEntitiesForRun(run11));

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/MetadataStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/MetadataStoreTest.java
@@ -25,7 +25,6 @@ import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data2.audit.AuditModule;
 import co.cask.cdap.data2.audit.InMemoryAuditPublisher;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.audit.AuditMessage;
 import co.cask.cdap.proto.audit.AuditType;
@@ -33,7 +32,7 @@ import co.cask.cdap.proto.audit.payload.metadata.MetadataPayload;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
-import co.cask.cdap.proto.id.NamespacedId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.metadata.Metadata;
@@ -221,9 +220,9 @@ public class MetadataStoreTest {
     List<AuditMessage> actualAuditMessages = new ArrayList<>();
     for (AuditMessage auditMessage : auditPublisher.popMessages()) {
       // Ignore system audit messages
-      if (auditMessage.getEntityId() instanceof NamespacedId) {
+      if (auditMessage.getEntityId() instanceof NamespacedEntityId) {
         String systemNs = NamespaceId.SYSTEM.getNamespace();
-        if (!((NamespacedId) auditMessage.getEntityId()).getNamespace().equals(systemNs)) {
+        if (!((NamespacedEntityId) auditMessage.getEntityId()).getNamespace().equals(systemNs)) {
           actualAuditMessages.add(auditMessage);
         }
       }
@@ -251,9 +250,9 @@ public class MetadataStoreTest {
 
   @Test
   public void testSearchWeight() throws Exception {
-    Id.Program flow1 = Id.Program.from("ns1", "app1", ProgramType.FLOW, "flow1");
-    Id.Stream stream1 = Id.Stream.from("ns1", "s1");
-    Id.DatasetInstance dataset1 = Id.DatasetInstance.from("ns1", "ds1");
+    ProgramId flow1 = new ProgramId("ns1", "app1", ProgramType.FLOW, "flow1");
+    StreamId stream1 = new StreamId("ns1", "s1");
+    DatasetId dataset1 = new DatasetId("ns1", "ds1");
 
     // Add metadata
     String multiWordValue = "aV1 av2 ,  -  ,  av3 - av4_av5 av6";
@@ -312,16 +311,16 @@ public class MetadataStoreTest {
   }
 
   private void generateMetadataUpdates() {
-    store.addTags(MetadataScope.USER, dataset.toId(), datasetTags.iterator().next());
-    store.setProperties(MetadataScope.USER, app.toId(), appProperties);
-    store.addTags(MetadataScope.USER, app.toId(), appTags.iterator().next());
-    store.setProperties(MetadataScope.USER, stream.toId(), streamProperties);
-    store.setProperties(MetadataScope.USER, stream.toId(), streamProperties);
-    store.setProperties(MetadataScope.USER, stream.toId(), updatedStreamProperties);
-    store.addTags(MetadataScope.USER, flow.toId(), flowTags.iterator().next());
-    store.removeTags(MetadataScope.USER, flow.toId());
-    store.removeTags(MetadataScope.USER, dataset.toId(), datasetTags.iterator().next());
-    store.removeProperties(MetadataScope.USER, stream.toId());
-    store.removeMetadata(MetadataScope.USER, app.toId());
+    store.addTags(MetadataScope.USER, dataset, datasetTags.iterator().next());
+    store.setProperties(MetadataScope.USER, app, appProperties);
+    store.addTags(MetadataScope.USER, app, appTags.iterator().next());
+    store.setProperties(MetadataScope.USER, stream, streamProperties);
+    store.setProperties(MetadataScope.USER, stream, streamProperties);
+    store.setProperties(MetadataScope.USER, stream, updatedStreamProperties);
+    store.addTags(MetadataScope.USER, flow, flowTags.iterator().next());
+    store.removeTags(MetadataScope.USER, flow);
+    store.removeTags(MetadataScope.USER, dataset, datasetTags.iterator().next());
+    store.removeProperties(MetadataScope.USER, stream);
+    store.removeMetadata(MetadataScope.USER, app);
   }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/system/AbstractSystemMetadataWriterTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/system/AbstractSystemMetadataWriterTest.java
@@ -26,7 +26,7 @@ import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data2.metadata.store.DefaultMetadataStore;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
@@ -88,9 +88,9 @@ public class AbstractSystemMetadataWriterTest {
 
   @Test
   public void testMetadataOverwrite() throws Exception {
-    Id.DatasetInstance dsInstance = Id.DatasetInstance.from("ns1", "ds1");
+    DatasetId dsInstance = new DatasetId("ns1", "ds1");
     DatasetSystemMetadataWriter datasetSystemMetadataWriter =
-      new DatasetSystemMetadataWriter(store, dsInstance,
+      new DatasetSystemMetadataWriter(store, dsInstance.toId(),
                                       DatasetProperties.builder()
                                         .add(Table.PROPERTY_TTL, "100")
                                         .build(),
@@ -102,12 +102,13 @@ public class AbstractSystemMetadataWriterTest {
                          ImmutableMap.of(AbstractSystemMetadataWriter.DESCRIPTION, "description1",
                                          AbstractSystemMetadataWriter.CREATION_TIME, String.valueOf(123456L),
                                          AbstractSystemMetadataWriter.TTL_KEY, "100"),
-                         ImmutableSet.of(dsInstance.getId()));
+                         ImmutableSet.of(dsInstance.getDataset()));
     Assert.assertEquals(expected, store.getMetadata(MetadataScope.SYSTEM, dsInstance));
 
     // Now remove TTL, and add dsType
     datasetSystemMetadataWriter =
-      new DatasetSystemMetadataWriter(store, dsInstance, DatasetProperties.EMPTY, null, "dsType", "description2");
+      new DatasetSystemMetadataWriter(store, dsInstance.toId(),
+                                      DatasetProperties.EMPTY, null, "dsType", "description2");
     datasetSystemMetadataWriter.write();
 
     expected =
@@ -115,7 +116,7 @@ public class AbstractSystemMetadataWriterTest {
                          ImmutableMap.of(AbstractSystemMetadataWriter.DESCRIPTION, "description2",
                                          AbstractSystemMetadataWriter.CREATION_TIME, String.valueOf(123456L),
                                          DatasetSystemMetadataWriter.TYPE, "dsType"),
-                         ImmutableSet.of(dsInstance.getId()));
+                         ImmutableSet.of(dsInstance.getDataset()));
     Assert.assertEquals(expected, store.getMetadata(MetadataScope.SYSTEM, dsInstance));
 
     store.removeMetadata(dsInstance);

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemover.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemover.java
@@ -21,6 +21,8 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
 import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.cdap.store.NamespaceStore;
@@ -55,15 +57,15 @@ final class DeletedDatasetMetadataRemover {
         metadataStore.searchMetadataOnType(namespaceMeta.getName(), "*",
                                            ImmutableSet.of(MetadataSearchTargetType.DATASET));
       for (MetadataSearchResultRecord searchResult : searchResults) {
-        Id.NamespacedId entityId = searchResult.getEntityId();
-        Preconditions.checkState(entityId instanceof Id.DatasetInstance,
+        NamespacedEntityId entityId = searchResult.getEntityId();
+        Preconditions.checkState(entityId instanceof DatasetId,
                                  "Since search was filtered for %s, expected result to be a %s, but got a %s",
                                  MetadataSearchTargetType.DATASET, Id.DatasetInstance.class.getSimpleName(),
                                  entityId.getClass().getName());
-        Id.DatasetInstance datasetInstance = (Id.DatasetInstance) entityId;
-        if (!dsFramework.hasInstance(datasetInstance)) {
+        DatasetId datasetInstance = (DatasetId) entityId;
+        if (!dsFramework.hasInstance(datasetInstance.toId())) {
           metadataStore.removeMetadata(datasetInstance);
-          removedDatasets.add(datasetInstance);
+          removedDatasets.add(datasetInstance.toId());
         }
       }
     }

--- a/cdap-master/src/test/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemoverTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemoverTest.java
@@ -88,9 +88,9 @@ public class DeletedDatasetMetadataRemoverTest {
     DS_FRAMEWORK_TEST_UTIL.createInstance("table", ds2.toId(), DatasetProperties.EMPTY);
     DS_FRAMEWORK_TEST_UTIL.createInstance("table", ds3.toId(), DatasetProperties.EMPTY);
     Assert.assertEquals(3, DS_FRAMEWORK_TEST_UTIL.list(NamespaceId.DEFAULT.toId()).size());
-    metadataStore.addTags(MetadataScope.USER, ds1.toId(), "ds1Tag1", "ds1Tag2");
-    metadataStore.setProperties(MetadataScope.USER, ds2.toId(), Collections.singletonMap("ds2Key", "ds2Value"));
-    metadataStore.addTags(MetadataScope.USER, ds3.toId(), "ds3Tag1", "ds3Tag2");
+    metadataStore.addTags(MetadataScope.USER, ds1, "ds1Tag1", "ds1Tag2");
+    metadataStore.setProperties(MetadataScope.USER, ds2, Collections.singletonMap("ds2Key", "ds2Value"));
+    metadataStore.addTags(MetadataScope.USER, ds3, "ds3Tag1", "ds3Tag2");
 
     verifyMetadataRemoval(ds1);
     verifyMetadataRemoval(ds2);
@@ -105,12 +105,12 @@ public class DeletedDatasetMetadataRemoverTest {
   }
 
   private void assertNonEmptyMetadata(DatasetId dsId) {
-    MetadataRecord metadata = metadataStore.getMetadata(MetadataScope.USER, dsId.toId());
+    MetadataRecord metadata = metadataStore.getMetadata(MetadataScope.USER, dsId);
     Assert.assertTrue(!metadata.getProperties().isEmpty() || !metadata.getTags().isEmpty());
   }
 
   private void assertEmptyMetadata(DatasetId dsId) {
-    MetadataRecord metadata = metadataStore.getMetadata(MetadataScope.USER, dsId.toId());
+    MetadataRecord metadata = metadataStore.getMetadata(MetadataScope.USER, dsId);
     Assert.assertTrue(metadata.getProperties().isEmpty() && metadata.getTags().isEmpty());
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Id.java
@@ -28,6 +28,7 @@ import co.cask.cdap.proto.id.EntityIdCompatible;
 import co.cask.cdap.proto.id.FlowletId;
 import co.cask.cdap.proto.id.FlowletQueueId;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.id.NotificationFeedId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.ProgramRunId;
@@ -116,7 +117,7 @@ public abstract class Id implements EntityIdCompatible {
   /**
    * Indicates that the ID belongs to a namespace.
    *
-   * @deprecated As of 3.3.0, use {@link co.cask.cdap.proto.id.NamespacedId}.
+   * @deprecated As of 3.3.0, use {@link NamespacedEntityId}.
    */
   @Deprecated
   public abstract static class NamespacedId extends Id {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/NamespacedEntityIdCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/NamespacedEntityIdCodec.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto.codec;
+
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+
+import java.lang.reflect.Type;
+
+/**
+ * Codec for {@link co.cask.cdap.proto.id.NamespacedEntityId}. Currently only supports
+ * {@link co.cask.cdap.proto.id.ApplicationId}, {@link co.cask.cdap.proto.id.ArtifactId},
+ * {@link co.cask.cdap.proto.id.ProgramId}, {@link co.cask.cdap.proto.id.DatasetId},
+ * {@link co.cask.cdap.proto.id.StreamId} and {@link co.cask.cdap.proto.id.StreamViewId}.
+ *
+ * Currently just delegates to {@link NamespacedEntityIdCodec} while phasing out {@link Id} usages.
+ */
+public class NamespacedEntityIdCodec extends AbstractSpecificationCodec<NamespacedEntityId> {
+
+  private NamespacedIdCodec namespacedIdCodec;
+
+  public NamespacedEntityIdCodec() {
+    this.namespacedIdCodec = new NamespacedIdCodec();
+  }
+
+  @Override
+  public JsonElement serialize(NamespacedEntityId src, Type typeOfSrc, JsonSerializationContext context) {
+    return namespacedIdCodec.serialize((Id.NamespacedId) src.toId(), typeOfSrc, context);
+  }
+
+  @Override
+  public NamespacedEntityId deserialize(JsonElement json, Type typeOfT,
+                                     JsonDeserializationContext context) throws JsonParseException {
+    return (NamespacedEntityId) namespacedIdCodec.deserialize(json, typeOfT, context).toEntityId();
+  }
+
+}

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ApplicationId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ApplicationId.java
@@ -27,19 +27,13 @@ import java.util.Objects;
 /**
  * Uniquely identifies an application.
  */
-public class ApplicationId extends EntityId implements NamespacedId, ParentedId<NamespaceId> {
-  private final String namespace;
+public class ApplicationId extends NamespacedEntityId implements ParentedId<NamespaceId> {
   private final String application;
   private transient Integer hashCode;
 
   public ApplicationId(String namespace, String application) {
-    super(EntityType.APPLICATION);
-    this.namespace = namespace;
+    super(namespace, EntityType.APPLICATION);
     this.application = application;
-  }
-
-  public String getNamespace() {
-    return namespace;
   }
 
   public String getApplication() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ArtifactId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ArtifactId.java
@@ -26,15 +26,13 @@ import java.util.Objects;
 /**
  * Uniquely identifies an artifact.
  */
-public class ArtifactId extends EntityId implements NamespacedId, ParentedId<NamespaceId> {
-  private final String namespace;
+public class ArtifactId extends NamespacedEntityId implements ParentedId<NamespaceId> {
   private final String artifact;
   private final String version;
   private transient Integer hashCode;
 
   public ArtifactId(String namespace, String artifact, String version) {
-    super(EntityType.ARTIFACT);
-    this.namespace = namespace;
+    super(namespace, EntityType.ARTIFACT);
     this.artifact = artifact;
     this.version = version;
   }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetId.java
@@ -26,17 +26,15 @@ import java.util.Objects;
 /**
  * Uniquely identifies a dataset.
  */
-public class DatasetId extends EntityId implements NamespacedId, ParentedId<NamespaceId> {
+public class DatasetId extends NamespacedEntityId implements ParentedId<NamespaceId> {
 
-  private final String namespace;
   private final String dataset;
   private transient Integer hashCode;
   private final transient NamespaceId namespaceId;
 
   public DatasetId(String namespace, String dataset) {
-    super(EntityType.DATASET);
+    super(namespace, EntityType.DATASET);
 
-    this.namespace = namespace;
     // Preconstruct the parent since it will get used many times for authorization for each dataset op.
     this.namespaceId = new NamespaceId(namespace);
     this.dataset = dataset;
@@ -46,10 +44,6 @@ public class DatasetId extends EntityId implements NamespacedId, ParentedId<Name
         String.format("Invalid characters found in dataset instance Id %s. Allowed characters are letters, numbers, " +
                         "and _, -, ., or $.", dataset));
     }
-  }
-
-  public String getNamespace() {
-    return namespace;
   }
 
   public String getDataset() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetModuleId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetModuleId.java
@@ -26,19 +26,13 @@ import java.util.Objects;
 /**
  * Uniquely identifies a dataset module.
  */
-public class DatasetModuleId extends EntityId implements NamespacedId, ParentedId<NamespaceId> {
-  private final String namespace;
+public class DatasetModuleId extends NamespacedEntityId implements ParentedId<NamespaceId> {
   private final String module;
   private transient Integer hashCode;
 
   public DatasetModuleId(String namespace, String module) {
-    super(EntityType.DATASET_MODULE);
-    this.namespace = namespace;
+    super(namespace, EntityType.DATASET_MODULE);
     this.module = module;
-  }
-
-  public String getNamespace() {
-    return namespace;
   }
 
   public String getModule() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetTypeId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetTypeId.java
@@ -26,19 +26,13 @@ import java.util.Objects;
 /**
  * Uniquely identifies a dataset type.
  */
-public class DatasetTypeId extends EntityId implements NamespacedId, ParentedId<NamespaceId> {
-  private final String namespace;
+public class DatasetTypeId extends NamespacedEntityId implements ParentedId<NamespaceId> {
   private final String type;
   private transient Integer hashCode;
 
   public DatasetTypeId(String namespace, String type) {
-    super(EntityType.DATASET_TYPE);
-    this.namespace = namespace;
+    super(namespace, EntityType.DATASET_TYPE);
     this.type = type;
-  }
-
-  public String getNamespace() {
-    return namespace;
   }
 
   public String getType() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
@@ -34,7 +34,7 @@ import javax.annotation.Nullable;
  *     <li>
  *       Implement interfaces
  *       <ol>
- *         <li>{@link NamespacedId} if the new ID belongs to a namespace</li>
+ *         <li>{@link NamespacedEntityId} if the new ID belongs to a namespace</li>
  *         <li>{@link ParentedId} if the new ID has a parent ID</li>
  *       </ol>
  *     </li>

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/FlowletId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/FlowletId.java
@@ -27,16 +27,14 @@ import java.util.Objects;
 /**
  * Uniquely identifies a flowlet.
  */
-public class FlowletId extends EntityId implements NamespacedId, ParentedId<ProgramId> {
-  private final String namespace;
+public class FlowletId extends NamespacedEntityId implements ParentedId<ProgramId> {
   private final String application;
   private final String flow;
   private final String flowlet;
   private transient Integer hashCode;
 
   public FlowletId(String namespace, String application, String flow, String flowlet) {
-    super(EntityType.FLOWLET);
-    this.namespace = namespace;
+    super(namespace, EntityType.FLOWLET);
     this.application = application;
     this.flow = flow;
     this.flowlet = flowlet;
@@ -62,11 +60,6 @@ public class FlowletId extends EntityId implements NamespacedId, ParentedId<Prog
   @Override
   public ProgramId getParent() {
     return new ProgramId(namespace, application, ProgramType.FLOW, flow);
-  }
-
-  @Override
-  public String getNamespace() {
-    return namespace;
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/FlowletQueueId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/FlowletQueueId.java
@@ -26,8 +26,7 @@ import java.util.Objects;
 /**
  * Uniquely identifies a flowlet queue.
  */
-public class FlowletQueueId extends EntityId implements NamespacedId, ParentedId<FlowletId> {
-  private final String namespace;
+public class FlowletQueueId extends NamespacedEntityId implements ParentedId<FlowletId> {
   private final String application;
   private final String flow;
   private final String flowlet;
@@ -35,8 +34,7 @@ public class FlowletQueueId extends EntityId implements NamespacedId, ParentedId
   private transient Integer hashCode;
 
   public FlowletQueueId(String namespace, String application, String flow, String flowlet, String queue) {
-    super(EntityType.FLOWLET_QUEUE);
-    this.namespace = namespace;
+    super(namespace, EntityType.FLOWLET_QUEUE);
     this.application = application;
     this.flow = flow;
     this.flowlet = flowlet;
@@ -76,11 +74,6 @@ public class FlowletQueueId extends EntityId implements NamespacedId, ParentedId
       next(iterator, "namespace"), next(iterator, "application"),
       next(iterator, "flow"), next(iterator, "flowlet"),
       nextAndEnd(iterator, "queue"));
-  }
-
-  @Override
-  public String getNamespace() {
-    return namespace;
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/NamespaceId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/NamespaceId.java
@@ -26,22 +26,16 @@ import java.util.Objects;
 /**
  * Uniquely identifies a namespace.
  */
-public class NamespaceId extends EntityId implements NamespacedId {
+public class NamespaceId extends NamespacedEntityId {
 
   public static final NamespaceId DEFAULT = new NamespaceId("default");
   public static final NamespaceId SYSTEM = new NamespaceId("system");
   public static final NamespaceId CDAP = new NamespaceId("cdap");
 
-  private final String namespace;
   private transient Integer hashCode;
 
   public NamespaceId(String namespace) {
-    super(EntityType.NAMESPACE);
-    this.namespace = namespace;
-  }
-
-  public String getNamespace() {
-    return namespace;
+    super(namespace, EntityType.NAMESPACE);
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/NamespacedEntityId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/NamespacedEntityId.java
@@ -15,9 +15,21 @@
  */
 package co.cask.cdap.proto.id;
 
+import co.cask.cdap.proto.element.EntityType;
+
 /**
  * An {@link EntityId} which belongs to a namespace.
  */
-public interface NamespacedId {
-  String getNamespace();
+public abstract class NamespacedEntityId extends EntityId {
+
+  protected final String namespace;
+
+  protected NamespacedEntityId(String namespace, EntityType entity) {
+    super(entity);
+    this.namespace = namespace;
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/NotificationFeedId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/NotificationFeedId.java
@@ -27,21 +27,15 @@ import java.util.Objects;
  * Uniquely identifies a notification feed.
  */
 // TODO: toString() must be namespace.category.feed for backwards compatibility with Id.NotificationFeed
-public class NotificationFeedId extends EntityId implements NamespacedId, ParentedId<NamespaceId> {
-  private final String namespace;
+public class NotificationFeedId extends NamespacedEntityId implements ParentedId<NamespaceId> {
   private final String category;
   private final String feed;
   private transient Integer hashCode;
 
   public NotificationFeedId(String namespace, String category, String feed) {
-    super(EntityType.NOTIFICATION_FEED);
-    this.namespace = namespace;
+    super(namespace, EntityType.NOTIFICATION_FEED);
     this.category = category;
     this.feed = feed;
-  }
-
-  public String getNamespace() {
-    return namespace;
   }
 
   public String getCategory() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramId.java
@@ -28,23 +28,21 @@ import java.util.Objects;
 /**
  * Uniquely identifies a program.
  */
-public class ProgramId extends EntityId implements NamespacedId, ParentedId<ApplicationId> {
-  private final String namespace;
+public class ProgramId extends NamespacedEntityId implements ParentedId<ApplicationId> {
   private final String application;
   private final ProgramType type;
   private final String program;
   private transient Integer hashCode;
 
   public ProgramId(String namespace, String application, ProgramType type, String program) {
-    super(EntityType.PROGRAM);
-    this.namespace = namespace;
+    super(namespace, EntityType.PROGRAM);
     this.application = application;
     this.type = type;
     this.program = program;
   }
 
-  public String getNamespace() {
-    return namespace;
+  public ProgramId(String namespace, String application, String type, String program) {
+    this(namespace, application, ProgramType.valueOf(type), program);
   }
 
   public String getApplication() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramRunId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramRunId.java
@@ -27,8 +27,7 @@ import java.util.Objects;
 /**
  * Uniquely identifies a program run.
  */
-public class ProgramRunId extends EntityId implements NamespacedId, ParentedId<ProgramId> {
-  private final String namespace;
+public class ProgramRunId extends NamespacedEntityId implements ParentedId<ProgramId> {
   private final String application;
   private final ProgramType type;
   private final String program;
@@ -36,16 +35,11 @@ public class ProgramRunId extends EntityId implements NamespacedId, ParentedId<P
   private transient Integer hashCode;
 
   public ProgramRunId(String namespace, String application, ProgramType type, String program, String run) {
-    super(EntityType.PROGRAM_RUN);
-    this.namespace = namespace;
+    super(namespace, EntityType.PROGRAM_RUN);
     this.application = application;
     this.type = type;
     this.program = program;
     this.run = run;
-  }
-
-  public String getNamespace() {
-    return namespace;
   }
 
   public String getApplication() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ScheduleId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ScheduleId.java
@@ -26,21 +26,15 @@ import java.util.Objects;
 /**
  * Uniquely identifies a schedule.
  */
-public class ScheduleId extends EntityId implements NamespacedId, ParentedId<ApplicationId> {
-  private final String namespace;
+public class ScheduleId extends NamespacedEntityId implements ParentedId<ApplicationId> {
   private final String application;
   private final String schedule;
   private transient Integer hashCode;
 
   public ScheduleId(String namespace, String application, String schedule) {
-    super(EntityType.SCHEDULE);
-    this.namespace = namespace;
+    super(namespace, EntityType.SCHEDULE);
     this.application = application;
     this.schedule = schedule;
-  }
-
-  public String getNamespace() {
-    return namespace;
   }
 
   public String getApplication() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/SecureKeyId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/SecureKeyId.java
@@ -28,28 +28,21 @@ import java.util.regex.Pattern;
 /**
  * Uniquely identifies a Secure store key.
  */
-public class SecureKeyId extends EntityId implements NamespacedId, ParentedId<NamespaceId> {
+public class SecureKeyId extends NamespacedEntityId implements ParentedId<NamespaceId> {
   // KMS only supports lower case keys.
   private static final Pattern secureKeyNamePattern = Pattern.compile("[a-z0-9_-]+");
 
-  private final String namespace;
   private final String name;
   private transient Integer hashCode;
 
   public SecureKeyId(String namespace, String name) {
-    super(EntityType.SECUREKEY);
+    super(namespace, EntityType.SECUREKEY);
     if (!isValidSecureKey(name)) {
       throw new IllegalArgumentException(String.format("Improperly formatted secure key name '%s'." +
                                                          " The name can contain lower case alphabets," +
                                                          " numbers, _, and -", name));
     }
-    this.namespace = namespace;
     this.name = name;
-  }
-
-  @Override
-  public String getNamespace() {
-    return namespace;
   }
 
   @Override

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamId.java
@@ -26,19 +26,13 @@ import java.util.Objects;
 /**
  * Uniquely identifies a stream.
  */
-public class StreamId extends EntityId implements NamespacedId, ParentedId<NamespaceId> {
-  private final String namespace;
+public class StreamId extends NamespacedEntityId implements ParentedId<NamespaceId> {
   private final String stream;
   private transient Integer hashCode;
 
   public StreamId(String namespace, String stream) {
-    super(EntityType.STREAM);
-    this.namespace = namespace;
+    super(namespace, EntityType.STREAM);
     this.stream = stream;
-  }
-
-  public String getNamespace() {
-    return namespace;
   }
 
   public String getStream() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamViewId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamViewId.java
@@ -26,21 +26,15 @@ import java.util.Objects;
 /**
  * Uniquely identifies a stream view.
  */
-public class StreamViewId extends EntityId implements NamespacedId, ParentedId<StreamId> {
-  private final String namespace;
+public class StreamViewId extends NamespacedEntityId implements ParentedId<StreamId> {
   private final String stream;
   private final String view;
   private transient Integer hashCode;
 
   public StreamViewId(String namespace, String stream, String view) {
-    super(EntityType.STREAM_VIEW);
-    this.namespace = namespace;
+    super(namespace, EntityType.STREAM_VIEW);
     this.stream = stream;
     this.view = view;
-  }
-
-  public String getNamespace() {
-    return namespace;
   }
 
   public String getStream() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataRecord.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataRecord.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.proto.metadata;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 
 import java.util.Collections;
 import java.util.Map;
@@ -24,12 +24,12 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * Represents the complete metadata of a {@link Id.NamespacedId} including its properties, tags in a given
+ * Represents the complete metadata of a {@link NamespacedEntityId} including its properties, tags in a given
  * {@link MetadataScope}
  */
 @Deprecated
 public class MetadataRecord {
-  private final Id.NamespacedId entityId;
+  private final NamespacedEntityId entityId;
   private final MetadataScope scope;
   private final Map<String, String> properties;
   private final Set<String> tags;
@@ -37,7 +37,7 @@ public class MetadataRecord {
   /**
    * Returns an empty {@link MetadataRecord} in the specified {@link MetadataScope}.
    */
-  public MetadataRecord(Id.NamespacedId entityId, MetadataScope scope) {
+  public MetadataRecord(NamespacedEntityId entityId, MetadataScope scope) {
     this(entityId, scope, Collections.<String, String>emptyMap(), Collections.<String>emptySet());
   }
 
@@ -48,7 +48,7 @@ public class MetadataRecord {
     this(other.getEntityId(), other.getScope(), other.getProperties(), other.getTags());
   }
 
-  public MetadataRecord(Id.NamespacedId entityId, MetadataScope scope, Map<String, String> properties,
+  public MetadataRecord(NamespacedEntityId entityId, MetadataScope scope, Map<String, String> properties,
                         Set<String> tags) {
     this.entityId = entityId;
     this.scope = scope;
@@ -56,7 +56,7 @@ public class MetadataRecord {
     this.tags = tags;
   }
 
-  public Id.NamespacedId getEntityId() {
+  public NamespacedEntityId getEntityId() {
     return entityId;
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataSearchResultRecord.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataSearchResultRecord.java
@@ -16,7 +16,7 @@
 package co.cask.cdap.proto.metadata;
 
 import co.cask.cdap.api.annotation.Beta;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 
 import java.util.Collections;
 import java.util.Map;
@@ -27,20 +27,20 @@ import java.util.Objects;
  */
 @Beta
 public class MetadataSearchResultRecord {
-  private final Id.NamespacedId entityId;
+  private final NamespacedEntityId entityId;
   private final Map<MetadataScope, Metadata> metadata;
 
-  public MetadataSearchResultRecord(Id.NamespacedId entityId) {
+  public MetadataSearchResultRecord(NamespacedEntityId entityId) {
     this.entityId = entityId;
     this.metadata = Collections.emptyMap();
   }
 
-  public MetadataSearchResultRecord(Id.NamespacedId entityId, Map<MetadataScope, Metadata> metadata) {
+  public MetadataSearchResultRecord(NamespacedEntityId entityId, Map<MetadataScope, Metadata> metadata) {
     this.entityId = entityId;
     this.metadata = metadata;
   }
 
-  public Id.NamespacedId getEntityId() {
+  public NamespacedEntityId getEntityId() {
     return entityId;
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataSearchTargetType.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataSearchTargetType.java
@@ -49,4 +49,8 @@ public enum MetadataSearchTargetType {
     }
     throw new IllegalArgumentException(String.format("No enum constant for serialized form: %s", value));
   }
+
+  public String getSerializedForm() {
+    return serializedForm;
+  }
 }

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/audit/AuditMessageTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/audit/AuditMessageTest.java
@@ -27,9 +27,11 @@ import co.cask.cdap.proto.metadata.Metadata;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -46,6 +48,8 @@ public class AuditMessageTest {
     .registerTypeAdapter(EntityId.class, new EntityIdTypeAdapter())
     .create();
 
+  private static final Type MAP_TYPE = new TypeToken<Map<String, Object>>() { }.getType();
+
   @Test
   public void testCreateMessage() throws Exception {
     String dsCreateJson =
@@ -53,7 +57,7 @@ public class AuditMessageTest {
         "\"user\":\"user1\",\"type\":\"CREATE\",\"payload\":{}}";
     AuditMessage dsCreate = new AuditMessage(1000L, Ids.namespace("ns1").dataset("ds1"), "user1",
                                              AuditType.CREATE, AuditPayload.EMPTY_PAYLOAD);
-    Assert.assertEquals(dsCreateJson, GSON.toJson(dsCreate));
+    Assert.assertEquals(jsonToMap(dsCreateJson), jsonToMap(GSON.toJson(dsCreate)));
     Assert.assertEquals(dsCreate, GSON.fromJson(dsCreateJson, AuditMessage.class));
   }
 
@@ -67,7 +71,8 @@ public class AuditMessageTest {
     AuditMessage flowAccess =
       new AuditMessage(2000L, Ids.namespace("ns1").stream("stream1"), "user1", AuditType.ACCESS,
                        new AccessPayload(AccessType.WRITE, Ids.namespace("ns1").app("app1").flow("flow1").run("run1")));
-    Assert.assertEquals(flowAccessJson, GSON.toJson(flowAccess));
+
+    Assert.assertEquals(jsonToMap(flowAccessJson), jsonToMap(GSON.toJson(flowAccess)));
     Assert.assertEquals(flowAccess, GSON.fromJson(flowAccessJson, AuditMessage.class));
 
     String exploreAccessJson =
@@ -77,7 +82,8 @@ public class AuditMessageTest {
     AuditMessage exploreAccess =
       new AuditMessage(2500L, Ids.namespace("ns1").dataset("ds1"), "user1", AuditType.ACCESS,
                        new AccessPayload(AccessType.UNKNOWN, Ids.systemService("explore")));
-    Assert.assertEquals(exploreAccessJson, GSON.toJson(exploreAccess));
+
+    Assert.assertEquals(jsonToMap(exploreAccessJson), jsonToMap(GSON.toJson(exploreAccess)));
     Assert.assertEquals(exploreAccess, GSON.fromJson(exploreAccessJson, AuditMessage.class));
   }
 
@@ -100,10 +106,10 @@ public class AuditMessageTest {
     userTags.add("ut2");
     Map<MetadataScope, Metadata> previous = new LinkedHashMap<>();
     previous.put(MetadataScope.USER, new Metadata(Collections.unmodifiableMap(userProperties),
-                                                             Collections.unmodifiableSet(userTags)));
+                                                  Collections.unmodifiableSet(userTags)));
     previous.put(MetadataScope.SYSTEM, new Metadata(Collections.unmodifiableMap(systemProperties),
-                                                               Collections.unmodifiableSet(
-                                                                 new LinkedHashSet<String>())));
+                                                    Collections.unmodifiableSet(
+                                                      new LinkedHashSet<String>())));
     Map<String, String> sysPropertiesAdded = new HashMap<>();
     sysPropertiesAdded.put("sk", "sv");
     Set<String> systemTagsAdded = new LinkedHashSet<>();
@@ -111,18 +117,22 @@ public class AuditMessageTest {
     systemTagsAdded.add("t2");
     Map<MetadataScope, Metadata> additions = new HashMap<>();
     additions.put(MetadataScope.SYSTEM, new Metadata(Collections.unmodifiableMap(sysPropertiesAdded),
-                                                                Collections.unmodifiableSet(systemTagsAdded)));
+                                                     Collections.unmodifiableSet(systemTagsAdded)));
     Map<String, String> userPropertiesDeleted = new HashMap<>();
     userPropertiesDeleted.put("uk", "uv");
     Set<String> userTagsDeleted = new LinkedHashSet<>();
     userTagsDeleted.add("ut1");
     Map<MetadataScope, Metadata> deletions = new HashMap<>();
     deletions.put(MetadataScope.USER, new Metadata(Collections.unmodifiableMap(userPropertiesDeleted),
-                                                              Collections.unmodifiableSet(userTagsDeleted)));
+                                                   Collections.unmodifiableSet(userTagsDeleted)));
     AuditMessage metadataChange =
       new AuditMessage(3000L, Ids.namespace("ns1").app("app1"), "user1", AuditType.METADATA_CHANGE,
                        new MetadataPayload(previous, additions, deletions));
-    Assert.assertEquals(metadataJson, GSON.toJson(metadataChange));
+    Assert.assertEquals(jsonToMap(metadataJson), jsonToMap(GSON.toJson(metadataChange)));
     Assert.assertEquals(metadataChange, GSON.fromJson(metadataJson, AuditMessage.class));
+  }
+
+  private Map<String, Object> jsonToMap(String json) {
+    return GSON.fromJson(json, MAP_TYPE);
   }
 }

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/codec/NamespacedIdCodecTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/codec/NamespacedIdCodecTest.java
@@ -18,6 +18,7 @@ package co.cask.cdap.proto.codec;
 
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import com.google.gson.Gson;
@@ -36,6 +37,7 @@ import java.util.Set;
 public class NamespacedIdCodecTest {
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(Id.NamespacedId.class, new NamespacedIdCodec())
+    .registerTypeAdapter(NamespacedEntityId.class, new NamespacedEntityIdCodec())
     .create();
 
   private final Id.Namespace ns = Id.Namespace.from("ns");
@@ -85,43 +87,43 @@ public class NamespacedIdCodecTest {
     tags.add("tag1");
     tags.add("t1");
     // verify with Id.Application
-    MetadataRecord appRecord = new MetadataRecord(app, MetadataScope.USER, properties, tags);
+    MetadataRecord appRecord = new MetadataRecord(app.toEntityId(), MetadataScope.USER, properties, tags);
     String appRecordJson = GSON.toJson(appRecord);
     Assert.assertEquals(appRecord, GSON.fromJson(appRecordJson, MetadataRecord.class));
     // verify with Id.Program
-    MetadataRecord programRecord = new MetadataRecord(program, MetadataScope.USER, properties, tags);
+    MetadataRecord programRecord = new MetadataRecord(program.toEntityId(), MetadataScope.USER, properties, tags);
     String programRecordJson = GSON.toJson(programRecord);
     Assert.assertEquals(programRecord, GSON.fromJson(programRecordJson, MetadataRecord.class));
     // verify with Id.Flow
-    MetadataRecord flowRecord = new MetadataRecord(flow, MetadataScope.USER, properties, tags);
+    MetadataRecord flowRecord = new MetadataRecord(flow.toEntityId(), MetadataScope.USER, properties, tags);
     String flowRecordJson = GSON.toJson(flowRecord);
     Assert.assertEquals(flowRecord, GSON.fromJson(flowRecordJson, MetadataRecord.class));
     // verify with Id.Flow.Flowlet
-    MetadataRecord flowletRecord = new MetadataRecord(flowlet, MetadataScope.USER, properties, tags);
+    MetadataRecord flowletRecord = new MetadataRecord(flowlet.toEntityId(), MetadataScope.USER, properties, tags);
     String flowletRecordJson = GSON.toJson(flowletRecord);
     Assert.assertEquals(flowletRecord, GSON.fromJson(flowletRecordJson, MetadataRecord.class));
     // verify with Id.Service
-    MetadataRecord serviceRecord = new MetadataRecord(service, MetadataScope.USER, properties, tags);
+    MetadataRecord serviceRecord = new MetadataRecord(service.toEntityId(), MetadataScope.USER, properties, tags);
     String serviceRecordJson = GSON.toJson(serviceRecord);
     Assert.assertEquals(serviceRecord, GSON.fromJson(serviceRecordJson, MetadataRecord.class));
     // verify with Id.Schedule
-    MetadataRecord scheduleRecord = new MetadataRecord(schedule, MetadataScope.USER, properties, tags);
+    MetadataRecord scheduleRecord = new MetadataRecord(schedule.toEntityId(), MetadataScope.USER, properties, tags);
     String scheduleRecordJson = GSON.toJson(scheduleRecord);
     Assert.assertEquals(scheduleRecord, GSON.fromJson(scheduleRecordJson, MetadataRecord.class));
     // verify with Id.Worker
-    MetadataRecord workerRecord = new MetadataRecord(worker, MetadataScope.USER, properties, tags);
+    MetadataRecord workerRecord = new MetadataRecord(worker.toEntityId(), MetadataScope.USER, properties, tags);
     String workerRecordJson = GSON.toJson(workerRecord);
     Assert.assertEquals(workerRecord, GSON.fromJson(workerRecordJson, MetadataRecord.class));
     // verify with Id.Workflow
-    MetadataRecord workflowRecord = new MetadataRecord(workflow, MetadataScope.USER, properties, tags);
+    MetadataRecord workflowRecord = new MetadataRecord(workflow.toEntityId(), MetadataScope.USER, properties, tags);
     String workflowRecordJson = GSON.toJson(workflowRecord);
     Assert.assertEquals(workflowRecord, GSON.fromJson(workflowRecordJson, MetadataRecord.class));
     // verify with Id.DatasetInstance
-    MetadataRecord datasetRecord = new MetadataRecord(dataset, MetadataScope.USER, properties, tags);
+    MetadataRecord datasetRecord = new MetadataRecord(dataset.toEntityId(), MetadataScope.USER, properties, tags);
     String datasetRecordJson = GSON.toJson(datasetRecord);
     Assert.assertEquals(datasetRecord, GSON.fromJson(datasetRecordJson, MetadataRecord.class));
     // verify with Id.Stream
-    MetadataRecord streamRecord = new MetadataRecord(stream, MetadataScope.USER, properties, tags);
+    MetadataRecord streamRecord = new MetadataRecord(stream.toEntityId(), MetadataScope.USER, properties, tags);
     String streamRecordJson = GSON.toJson(streamRecord);
     Assert.assertEquals(streamRecord, GSON.fromJson(streamRecordJson, MetadataRecord.class));
   }

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/id/EntityIdTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/id/EntityIdTest.java
@@ -21,10 +21,12 @@ import co.cask.cdap.proto.codec.EntityIdTypeAdapter;
 import co.cask.cdap.proto.codec.IdTypeAdapter;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -39,6 +41,8 @@ public class EntityIdTest {
     .registerTypeAdapter(Id.class, new IdTypeAdapter())
     .registerTypeAdapter(EntityId.class, new EntityIdTypeAdapter())
     .create();
+
+  private static final Type MAP_TYPE = new TypeToken<Map<String, Object>>() { }.getType();
 
   private static final List<EntityId> ids = new ArrayList<>();
   static {
@@ -228,7 +232,7 @@ public class EntityIdTest {
     }
 
     for (Map.Entry<? extends EntityId, String> toJsonEntry : idsToJson.entrySet()) {
-      Assert.assertEquals(toJsonEntry.getValue(), GSON.toJson(toJsonEntry.getKey()));
+      Assert.assertEquals(jsonToMap(toJsonEntry.getValue()), jsonToMap(GSON.toJson(toJsonEntry.getKey())));
     }
   }
 
@@ -269,4 +273,7 @@ public class EntityIdTest {
     }
   }
 
+  private Map<String, Object> jsonToMap(String json) {
+    return GSON.fromJson(json, MAP_TYPE);
+  }
 }


### PR DESCRIPTION
Beginning to phase the `Id` class out of Metadata related classes.
