### PR TITLE
Update IntelliJ version (fixes VM build)

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -91,7 +91,7 @@
         },
         "idea": {
           "setup_dir": "/opt",
-          "version": "2016.1.3"
+          "version": "2016.2.3"
         },
         "hadoop": {
           "distribution": "hdp",


### PR DESCRIPTION
Jetbrains sometimes removes versions of their software from download availability. This updates to the latest version.
