### PR TITLE
Cleanup of Store implementations to use api.Transactional to have dataset access cached

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/store/DefaultNamespaceStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/store/DefaultNamespaceStore.java
@@ -16,8 +16,9 @@
 
 package co.cask.cdap.store;
 
-import co.cask.cdap.api.data.DatasetInstantiationException;
-import co.cask.cdap.api.dataset.DatasetDefinition;
+import co.cask.cdap.api.Transactional;
+import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.table.Table;
@@ -26,17 +27,15 @@ import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
+import co.cask.cdap.data2.transaction.Transactions;
+import co.cask.cdap.data2.transaction.TxCallable;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Supplier;
-import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
-import org.apache.tephra.TransactionAware;
-import org.apache.tephra.TransactionExecutor;
-import org.apache.tephra.TransactionExecutorFactory;
+import org.apache.tephra.TransactionFailureException;
 import org.apache.tephra.TransactionSystemClient;
 
 import java.io.IOException;
@@ -48,123 +47,115 @@ import javax.annotation.Nullable;
  */
 public class DefaultNamespaceStore implements NamespaceStore {
 
-  private static final Id.DatasetInstance APP_META_INSTANCE_ID =
-    Id.DatasetInstance.from(Id.Namespace.SYSTEM, Constants.AppMetaStore.TABLE);
+  private static final DatasetId APP_META_INSTANCE_ID = NamespaceId.SYSTEM.dataset(Constants.AppMetaStore.TABLE);
 
-  private final Supplier<NamespaceMDS> apps;
-  private final Supplier<TransactionExecutor> appsTx;
   private final DatasetFramework dsFramework;
-  private final MultiThreadDatasetCache dsCache;
+  private final Transactional transactional;
 
   @Inject
-  DefaultNamespaceStore(
-    final TransactionExecutorFactory txExecutorFactory,
-    TransactionSystemClient txClient,
-    DatasetFramework framework) {
+  DefaultNamespaceStore(TransactionSystemClient txClient, DatasetFramework framework) {
     this.dsFramework = framework;
-    this.dsCache = new MultiThreadDatasetCache(
-      new SystemDatasetInstantiator(dsFramework), txClient, NamespaceId.SYSTEM, null, null, null);
-    this.apps =
-      new Supplier<NamespaceMDS>() {
-        @Override
-        public NamespaceMDS get() {
-          Table table;
-          try {
-            table = dsCache.getDataset(APP_META_INSTANCE_ID.getId());
-          } catch (DatasetInstantiationException e) {
-            try {
-              DatasetsUtil.getOrCreateDataset(
-                dsFramework, APP_META_INSTANCE_ID, "table",
-                DatasetProperties.EMPTY, DatasetDefinition.NO_ARGUMENTS, null);
-              table = dsCache.getDataset(APP_META_INSTANCE_ID.getId());
-            } catch (DatasetManagementException | IOException e1) {
-              throw Throwables.propagate(e1);
-            }
-          }
-          return new NamespaceMDS(table);
-        }
-      };
-    this.appsTx = new Supplier<TransactionExecutor>() {
-      @Override
-      public TransactionExecutor get() {
-        return txExecutorFactory.createExecutor(ImmutableList.of((TransactionAware) apps.get()));
-      }
-    };
+    this.transactional = Transactions.createTransactional(
+      new MultiThreadDatasetCache(new SystemDatasetInstantiator(dsFramework), txClient,
+                                  NamespaceId.SYSTEM, null, null, null)
+    );
+  }
+
+  private NamespaceMDS getNamespaceMDS(DatasetContext datasetContext) throws IOException, DatasetManagementException {
+    Table table = DatasetsUtil.getOrCreateDataset(datasetContext, dsFramework, APP_META_INSTANCE_ID,
+                                                  Table.class.getName(), DatasetProperties.EMPTY);
+    return new NamespaceMDS(table);
   }
 
   @Override
   @Nullable
   public NamespaceMeta create(final NamespaceMeta metadata) {
     Preconditions.checkArgument(metadata != null, "Namespace metadata cannot be null.");
-    return appsTx.get().executeUnchecked(
-      new TransactionExecutor.Function<NamespaceMDS, NamespaceMeta>() {
+    try {
+      return Transactions.execute(transactional, new TxCallable<NamespaceMeta>() {
         @Override
-        public NamespaceMeta apply(NamespaceMDS mds) throws Exception {
-          Id.Namespace namespace = Id.Namespace.from(metadata.getName());
-          NamespaceMeta existing = mds.get(namespace);
+        public NamespaceMeta call(DatasetContext context) throws Exception {
+          NamespaceMDS mds = getNamespaceMDS(context);
+          NamespaceMeta existing = mds.get(metadata.getNamespaceId().toId());
           if (existing != null) {
             return existing;
           }
           mds.create(metadata);
           return null;
         }
-      }, apps.get());
+      });
+    } catch (TransactionFailureException e) {
+      throw Transactions.propagate(e);
+    }
   }
 
   @Override
   public void update(final NamespaceMeta metadata) {
     Preconditions.checkArgument(metadata != null, "Namespace metadata cannot be null.");
-    appsTx.get().executeUnchecked(
-      new TransactionExecutor.Procedure<NamespaceMDS>() {
+    try {
+      transactional.execute(new TxRunnable() {
         @Override
-        public void apply(NamespaceMDS mds) throws Exception {
-          NamespaceMeta existing = mds.get(Id.Namespace.from(metadata.getName()));
+        public void run(DatasetContext context) throws Exception {
+          NamespaceMDS mds = getNamespaceMDS(context);
+          NamespaceMeta existing = mds.get(metadata.getNamespaceId().toId());
           if (existing != null) {
             mds.create(metadata);
           }
         }
-      }, apps.get());
+      });
+    } catch (TransactionFailureException e) {
+      throw Transactions.propagate(e);
+    }
   }
 
   @Override
   @Nullable
   public NamespaceMeta get(final Id.Namespace id) {
     Preconditions.checkArgument(id != null, "Namespace id cannot be null.");
-    return appsTx.get().executeUnchecked(
-      new TransactionExecutor.Function<NamespaceMDS, NamespaceMeta>() {
+    try {
+      return Transactions.execute(transactional, new TxCallable<NamespaceMeta>() {
         @Override
-        public NamespaceMeta apply(NamespaceMDS mds) throws Exception {
-          return mds.get(id);
+        public NamespaceMeta call(DatasetContext context) throws Exception {
+          return getNamespaceMDS(context).get(id);
         }
-      }, apps.get());
+      });
+    } catch (TransactionFailureException e) {
+      throw Transactions.propagate(e);
+    }
   }
 
   @Override
   @Nullable
   public NamespaceMeta delete(final Id.Namespace id) {
     Preconditions.checkArgument(id != null, "Namespace id cannot be null.");
-    return appsTx.get().executeUnchecked(
-      new TransactionExecutor.Function<NamespaceMDS, NamespaceMeta>() {
+    try {
+      return Transactions.execute(transactional, new TxCallable<NamespaceMeta>() {
         @Override
-        public NamespaceMeta apply(NamespaceMDS mds) throws Exception {
+        public NamespaceMeta call(DatasetContext context) throws Exception {
+          NamespaceMDS mds = getNamespaceMDS(context);
           NamespaceMeta existing = mds.get(id);
           if (existing != null) {
             mds.delete(id);
           }
           return existing;
         }
-      }, apps.get());
+      });
+    } catch (TransactionFailureException e) {
+      throw Transactions.propagate(e);
+    }
   }
 
   @Override
   public List<NamespaceMeta> list() {
-    return appsTx.get().executeUnchecked(
-      new TransactionExecutor.Function<NamespaceMDS, List<NamespaceMeta>>() {
+    try {
+      return Transactions.execute(transactional, new TxCallable<List<NamespaceMeta>>() {
         @Override
-        public List<NamespaceMeta> apply(NamespaceMDS mds) throws Exception {
-          return mds.list();
+        public List<NamespaceMeta> call(DatasetContext context) throws Exception {
+          return getNamespaceMDS(context).list();
         }
-      }, apps.get());
+      });
+    } catch (TransactionFailureException e) {
+      throw Transactions.propagate(e);
+    }
   }
-
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/store/NamespaceMDS.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/store/NamespaceMDS.java
@@ -28,28 +28,28 @@ import javax.annotation.Nullable;
 /**
  * Dataset for namespace metadata
  */
-public class NamespaceMDS extends MetadataStoreDataset {
+final class NamespaceMDS extends MetadataStoreDataset {
 
   private static final String TYPE_NAMESPACE = "namespace";
 
-  public NamespaceMDS(Table table) {
+  NamespaceMDS(Table table) {
     super(table);
   }
 
-  public void create(NamespaceMeta metadata) {
+  void create(NamespaceMeta metadata) {
     write(getNamespaceKey(metadata.getName()), metadata);
   }
 
   @Nullable
-  public NamespaceMeta get(Id.Namespace id) {
+  NamespaceMeta get(Id.Namespace id) {
     return getFirst(getNamespaceKey(id.getId()), NamespaceMeta.class);
   }
 
-  public void delete(Id.Namespace id) {
+  void delete(Id.Namespace id) {
     deleteAll(getNamespaceKey(id.getId()));
   }
 
-  public List<NamespaceMeta> list() {
+  List<NamespaceMeta> list() {
     return list(getNamespaceKey(null), NamespaceMeta.class);
   }
 


### PR DESCRIPTION
- Make DefaultNamespaceStore to use api.Transactional
- Make MDSViewStore use api.Transactional

Cannot modify LineageStore due to circular dependency in Guice. It requires much bigger change in Guice modules.
