### PR TITLE
Bump SDK version in VM build

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -128,7 +128,7 @@
       "json": {
         "cdap": {
           "comment": "DO NOT PUT SNAPHOT IN THE VERSION BELOW, THIS CONTROLS CDAP COOKBOOK CODE",
-          "version": "3.5.0-1",
+          "version": "3.5.1-1",
           "sdk": {
             "comment": "COPY SDK ZIP TO files/cdap-sdk.zip BEFORE RUNNING ME",
             "url": "file:///tmp/cdap-sdk.zip"


### PR DESCRIPTION
VM requires version is set higher than currently released to prevent checksum failures
