### PR TITLE
Fix broken documentation build

### DIFF
--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="291d6f832d523dfaeb1e82cce7f8a434"
+DEFAULT_XML_MD5_HASH="8ae0cf53fd007c99e9bf82fd3f2c01b0"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-docs/tools/cdap-default/cdap-default-deprecated.xml
+++ b/cdap-docs/tools/cdap-default/cdap-default-deprecated.xml
@@ -20,6 +20,22 @@
   <!-- Deprecated Properties Configuration -->
 
   <property>
+    <name>app.bind.address</name>
+    <value>0.0.0.0</value>
+    <description>
+      App Fabric service bind address (deprecated: use master.services.bind.address instead)
+    </description>
+  </property>
+
+  <property>
+    <name>dataset.service.bind.address</name>
+    <value>0.0.0.0</value>
+    <description>
+       Dataset service bind address (deprecated: use master.services.bind.address instead)
+    </description>
+  </property>
+ 
+  <property>
     <name>explore.executor.container.instances</name>
     <value>1</value>
     <description>
@@ -152,6 +168,15 @@
     <description>
       Determines if the webapp listening service should be started
       (deprecated)
+    </description>
+  </property>
+
+  <property>
+    <name>security.auth.server.address</name>
+    <value>0.0.0.0</value>
+    <description>
+      CDAP Authentication service bind address
+      (deprecated; use security.auth.server.bind.address instead)
     </description>
   </property>
 


### PR DESCRIPTION
Fixes MD5 hash for cdap-default.xml.
Adds deprecated properties to the deprecated properties list so that
they are documented correctly.

Passes a Quick Build: http://builds.cask.co/browse/CDAP-DQB116-1
