### PR TITLE
Fix Documentation Build.

### DIFF
--- a/cdap-docs/developers-manual/build.sh
+++ b/cdap-docs/developers-manual/build.sh
@@ -67,11 +67,11 @@ function download_includes() {
 # https://raw.githubusercontent.com/caskdata/cdap-ingest/develop/cdap-file-drop-zone/README.rst
   local ingest_url="${github_url}/cdap-ingest/${ingest_branch}"
 
-  download_readme_file_and_test ${includes_dir} ${ingest_url} c9b6db1741afa823c362237488c2d8f0 cdap-flume
-  download_readme_file_and_test ${includes_dir} ${ingest_url} 08bb5c37085d354834860cb4ca66c121 cdap-stream-clients/java
+  download_readme_file_and_test ${includes_dir} ${ingest_url} cf2d8cac45b4be267adbb0e8ecdc88a4 cdap-flume
+  download_readme_file_and_test ${includes_dir} ${ingest_url} a852e493aff54ffd726368691f248d80 cdap-stream-clients/java
 #   download_readme_file_and_test ${includes_dir} ${ingest_url} 277ded1924cb8d9b52a007f262820002 cdap-stream-clients/javascript
-  download_readme_file_and_test ${includes_dir} ${ingest_url} 3013f72ea3454e43adedda2aed40abc1 cdap-stream-clients/python
-  download_readme_file_and_test ${includes_dir} ${ingest_url} 5fc88ec3a658062775403f5be30afbe9 cdap-stream-clients/ruby
+  download_readme_file_and_test ${includes_dir} ${ingest_url} da242d9be7051417bd5ff73b3dc5edc2 cdap-stream-clients/python
+  download_readme_file_and_test ${includes_dir} ${ingest_url} b7d3fbd2e960c23249f4beadf5cdb967 cdap-stream-clients/ruby
 
   echo_red_bold "Check included example files for changes"
   test_an_include 9e137848822e63101b699af03af7f45e ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java

--- a/cdap-docs/integrations/build.sh
+++ b/cdap-docs/integrations/build.sh
@@ -26,7 +26,7 @@ function download_includes() {
   
   # Download Apache Sentry File
   local github_source="https://raw.githubusercontent.com/caskdata/cdap-security-extn/${GIT_BRANCH_CDAP_SECURITY_EXTN}/cdap-sentry/cdap-sentry-extension/"
-  download_file ${target_includes_dir} ${github_source} README.rst 26f504896ca0d5a995071be9ee5e5706 cdap-sentry-extension-readme.txt
+  download_file ${target_includes_dir} ${github_source} README.rst 526e77d7f3176dc3da0a331209359075 cdap-sentry-extension-readme.txt
 }
 
 run_command ${1}

--- a/cdap-docs/integrations/source/apache-sentry.rst
+++ b/cdap-docs/integrations/source/apache-sentry.rst
@@ -11,7 +11,7 @@ Apache Sentry
 .. _apache-sentry-configuration:
 
 Configuring Apache Sentry for Integration with CDAP
-===================================================
++++++++++++++++++++++++++++++++++++++++++++++++++++
 To use CDAP on a cluster using Apache Sentry for authorization, set this property:
 
 - Add the user ``cdap`` to the Sentry property ``sentry.service.allow.connect``
@@ -31,11 +31,11 @@ We also recommend setting these properties:
 .. _cdap-sentry-authorization-extension:
 
 CDAP Sentry Authorization Extension
-===================================
++++++++++++++++++++++++++++++++++++
 In addition to setting up CDAP to work on a cluster already using Apache Sentry for
 authorization of non-CDAP components, users can also use the CDAP Sentry Authorization
 Extension to enforce authorization on CDAP entities using Apache Sentry.
 
 .. include:: /../target/_includes/cdap-sentry-extension-readme.txt
-    :start-after: ================================================
+    :start-line: 4
     :end-before: Share and Discuss!


### PR DESCRIPTION
Update MD5 hashes.
Changes inclusion of the Apache Sentry documentation to improve levels.
Passes a Quick Build: http://builds.cask.co/browse/CDAP-DQB120-1
Page of interest: [Apache Sentry Integration](http://builds.cask.co/artifact/CDAP-DQB120/shared/build-1/Docs-HTML/4.0.0-SNAPSHOT/en/integrations/apache-sentry.html)
