### PR TITLE
CDAP-7109 Specify that ds access can be done from Partitioner/Comparator classes.

### DIFF
--- a/cdap-docs/developers-manual/source/building-blocks/mapreduce-programs.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/mapreduce-programs.rst
@@ -135,8 +135,9 @@ MapReduce and Datasets
 
 .. rubric: Reading and Writing to Datasets from a MapReduce program
 
-Both a CDAP ``mapper`` and ``reducer`` can directly read or write to a dataset, using
-one of these options:
+Both a CDAP ``Mapper`` and ``Reducer`` can directly read or write to a dataset, using
+one of the following options. (Note that the second and third options can be used for a
+``Partitioner`` or ``Comparator``, if configured on the MapReduce job.)
 
 #. Inject the dataset into the mapper or reducer that uses it. This method
    is useful if the name of the dataset is constant or known at compile time.
@@ -296,7 +297,7 @@ To write to multiple output datasets from a MapReduce program, begin by adding t
     context.addOutput("catalog");
   }
 
-Then, have the ``mapper`` and/or ``reducer`` implement ``ProgramLifeCycle<MapReduceTaskContext>``.
+Then, have the ``Mapper`` and/or ``Reducer`` implement ``ProgramLifeCycle<MapReduceTaskContext>``.
 This is to obtain access to the ``MapReduceTaskContext`` in their initialization methods and
 to be able to write using the write method of the ``MapReduceTaskContext``::
 

--- a/cdap-docs/developers-manual/source/building-blocks/plugins.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/plugins.rst
@@ -520,7 +520,7 @@ introduce a ``Tokenizer`` interface::
 Now we change our ``WordCountMapper`` to use the plugin framework to instantiate and use a ``Tokenizer``::
 
   public static class WordCountMapper extends Mapper<LongWritable, Text, Text, LongWritable>
-    implements ProgramLifecycle<MapReduceContext> {
+    implements ProgramLifecycle<MapReduceTaskContext> {
     private static final LongWritable ONE = new LongWritable(1);
     private Text word = new Text();
     private Tokenizer tokenizer;
@@ -535,7 +535,7 @@ Now we change our ``WordCountMapper`` to use the plugin framework to instantiate
     }
 
     @Override
-    public void initialize(MapReduceContext context) throws Exception {
+    public void initialize(MapReduceTaskContext context) throws Exception {
       tokenizer = context.newPluginInstance("tokenizerId");
     }
 

--- a/cdap-docs/developers-manual/source/building-blocks/workflows.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/workflows.rst
@@ -298,7 +298,7 @@ To put a value into a token, first obtain access to the token from the workflow 
 and then set a value for a specific key. 
 
 In the case of a MapReduce program, the program's Mapper and Reducer classes need to
-implement ``ProgramLifecycle<MapReduceContext>``. After doing so, they can access the
+implement ``ProgramLifecycle<MapReduceTaskContext>``. After doing so, they can access the
 workflow token in either the ``initialize`` or ``destroy`` methods. To access it in the
 ``map`` or ``reduce`` methods, you would need to cache a reference to the workflow token
 object as a class member in the ``initialize()`` method. This is because the context


### PR DESCRIPTION
CDAP-7109 Specify that ds access can be done from Partitioner/Comparator classes.

https://issues.cask.co/browse/CDAP-7109
Also resolves https://issues.cask.co/browse/CDAP-3544, because it had been mostly resolved before anyways.

Docs quick build: http://builds.cask.co/browse/CDAP-DQB124-1
MapReduce Programs page: http://builds.cask.co/artifact/CDAP-DQB124/shared/build-1/Docs-HTML/3.5.1-SNAPSHOT/en/developers-manual/building-blocks/mapreduce-programs.html
