### PR TITLE
CDAP-6215 Remove deleted partitions from workingset

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/partitioned/ConcurrentPartitionConsumer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/partitioned/ConcurrentPartitionConsumer.java
@@ -47,21 +47,24 @@ public class ConcurrentPartitionConsumer extends AbstractPartitionConsumer {
   public PartitionConsumerResult doConsume(ConsumerWorkingSet workingSet, PartitionAcceptor acceptor) {
     doExpiry(workingSet);
     workingSet.populate(getPartitionedFileSet(), getConfiguration());
-    List<PartitionDetail> toConsume = selectPartitions(acceptor, workingSet.getPartitions());
+    List<PartitionDetail> toConsume = selectPartitions(acceptor, workingSet);
     return new PartitionConsumerResult(toConsume, removeDiscardedPartitions(workingSet));
   }
 
-  private List<PartitionDetail> selectPartitions(PartitionAcceptor acceptor,
-                                                 List<? extends ConsumablePartition> partitions) {
+  private List<PartitionDetail> selectPartitions(PartitionAcceptor acceptor, ConsumerWorkingSet workingSet) {
     long now = System.currentTimeMillis();
     List<PartitionDetail> toConsume = new ArrayList<>();
-    for (ConsumablePartition consumablePartition : partitions) {
+
+    Iterator<ConsumablePartition> iter = workingSet.getPartitions().iterator();
+    while (iter.hasNext()) {
+      ConsumablePartition consumablePartition = iter.next();
       if (ProcessState.AVAILABLE != consumablePartition.getProcessState()) {
         continue;
       }
       PartitionDetail partition = getPartitionedFileSet().getPartition(consumablePartition.getPartitionKey());
       if (partition == null) {
-        // no longer exists
+        // no longer exists, so skip it and remove it from the working set
+        iter.remove();
         continue;
       }
       PartitionAcceptor.Return accept = acceptor.accept(partition);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionConsumerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionConsumerTest.java
@@ -804,6 +804,80 @@ public class PartitionConsumerTest {
     });
   }
 
+  @Test
+  public void testDroppedPartitions() throws Exception {
+    // Tests the case of a partition in the partition consumer working set being dropped from the Partitioned
+    // FileSet (See CDAP-6215)
+    final PartitionedFileSet dataset = dsFrameworkUtil.getInstance(pfsInstance);
+    final TransactionAware txAwareDataset = (TransactionAware) dataset;
+
+    ConsumerConfiguration configuration = ConsumerConfiguration.builder()
+      .setMaxWorkingSetSize(1)
+      // maxRetries needs to be greater than 1, since we fail the partition once
+      .setMaxRetries(2)
+      .build();
+    final PartitionConsumer partitionConsumer = new ConcurrentPartitionConsumer(dataset, new InMemoryStatePersistor(),
+                                                                                configuration);
+
+    final PartitionKey partitionKey1 = generateUniqueKey();
+    final PartitionKey partitionKey2 = generateUniqueKey();
+
+    // Note: These two partitions are added in separate transactions, so that the first can exist in the working set
+    // without the second. Partitions in the same transaction can not be split up (due to their index being the same)
+    dsFrameworkUtil.newInMemoryTransactionExecutor(txAwareDataset).execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        dataset.getPartitionOutput(partitionKey1).addPartition();
+      }
+    });
+
+    dsFrameworkUtil.newInMemoryTransactionExecutor(txAwareDataset).execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        dataset.getPartitionOutput(partitionKey2).addPartition();
+      }
+    });
+
+    dsFrameworkUtil.newInMemoryTransactionExecutor(txAwareDataset).execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+
+        // consuming and aborting the partition numRetries times plus one (for the first attempt) makes it get removed
+        // from the working set
+        List<PartitionDetail> partitionDetails = partitionConsumer.consumePartitions(1).getPartitions();
+        Assert.assertEquals(1, partitionDetails.size());
+        Assert.assertEquals(partitionKey1, partitionDetails.get(0).getPartitionKey());
+
+        // aborting the processing of the partition, to put it back in the working set
+        partitionConsumer.onFinish(partitionDetails, false);
+      }
+    });
+
+    // dropping partitionKey1 from the dataset makes it no longer available for consuming
+
+    dsFrameworkUtil.newInMemoryTransactionExecutor(txAwareDataset).execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        dataset.dropPartition(partitionKey1);
+      }
+    });
+
+    dsFrameworkUtil.newInMemoryTransactionExecutor(txAwareDataset).execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        // first call to consume will drop the partition from the working set, and return nothing, since it was
+        // the only partition in the working set
+        PartitionConsumerResult result = partitionConsumer.consumePartitions(1);
+        Assert.assertEquals(0, result.getPartitions().size());
+        Assert.assertEquals(0, result.getFailedPartitions().size());
+
+        // following calls to consumePartitions will repopulate the working set and return additional partition(s)
+        result = partitionConsumer.consumePartitions(1);
+        Assert.assertEquals(1, result.getPartitions().size());
+        Assert.assertEquals(partitionKey2, result.getPartitions().get(0).getPartitionKey());
+      }
+    });
+  }
 
   /**
    * Custom implementation of {@link ConcurrentPartitionConsumer} that returns only a single partition if it is that


### PR DESCRIPTION
If a partition is dropped from a PartitionedFileSet, it was being skipped, but not removed from the PartitionConsumer working set.

https://issues.cask.co/browse/CDAP-6215
http://builds.cask.co/browse/CDAP-DUT4774-1 (merging disabled, so it wont merge with develop branch)
