### PR TITLE
CDAP-2316 Delete metrics upon stream/dataset deletion.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -534,8 +534,6 @@ public class ApplicationLifecycleService extends AbstractIdleService {
     return applicationWithPrograms;
   }
 
-  // deletes without performs checks that no programs are running
-
   /**
    * Delete the specified application without performing checks that its programs are stopped.
    *

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
@@ -20,12 +20,15 @@ import co.cask.cdap.api.Predicate;
 import co.cask.cdap.api.common.HttpErrorStatusProvider;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.metrics.MetricDeleteQuery;
+import co.cask.cdap.api.metrics.MetricStore;
 import co.cask.cdap.common.DatasetAlreadyExistsException;
 import co.cask.cdap.common.DatasetNotFoundException;
 import co.cask.cdap.common.DatasetTypeNotFoundException;
 import co.cask.cdap.common.HandlerException;
 import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.data2.audit.AuditPublisher;
 import co.cask.cdap.data2.audit.AuditPublishers;
@@ -56,6 +59,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
@@ -86,6 +90,7 @@ public class DatasetInstanceService {
   private final AuthorizationEnforcer authorizationEnforcer;
   private final PrivilegesManager privilegesManager;
   private final AuthenticationContext authenticationContext;
+  private final MetricStore metricStore;
 
   private AuditPublisher auditPublisher;
 
@@ -95,7 +100,7 @@ public class DatasetInstanceService {
                                 DatasetOpExecutor opExecutorClient, ExploreFacade exploreFacade,
                                 NamespaceQueryAdmin namespaceQueryAdmin,
                                 AuthorizationEnforcer authorizationEnforcer, PrivilegesManager privilegesManager,
-                                AuthenticationContext authenticationContext) {
+                                AuthenticationContext authenticationContext, MetricStore metricStore) {
     this.opExecutorClient = opExecutorClient;
     this.typeService = typeService;
     this.instanceManager = instanceManager;
@@ -112,6 +117,7 @@ public class DatasetInstanceService {
     this.authorizationEnforcer = authorizationEnforcer;
     this.privilegesManager = privilegesManager;
     this.authenticationContext = authenticationContext;
+    this.metricStore = metricStore;
   }
 
   @VisibleForTesting
@@ -449,12 +455,13 @@ public class DatasetInstanceService {
   private void dropDataset(Id.DatasetInstance instance, DatasetSpecification spec) throws Exception {
     LOG.info("Deleting dataset {}.{}", instance.getNamespaceId(), instance.getId());
 
-    disableExplore(instance);
-
     if (!instanceManager.delete(instance)) {
       throw new DatasetNotFoundException(instance);
     }
     metaCache.invalidate(instance);
+
+    disableExplore(instance);
+    deleteMetrics(instance.toEntityId());
 
     DatasetTypeMeta typeMeta = getTypeInfo(instance.getNamespace(), spec.getType());
     if (typeMeta == null) {
@@ -468,6 +475,15 @@ public class DatasetInstanceService {
     // can clean up. This may result in orphaned privileges, which will be cleaned up by the create API if the same
     // dataset is successfully re-created.
     privilegesManager.revoke(instance.toEntityId());
+  }
+
+  private void deleteMetrics(DatasetId datasetId) throws Exception {
+    long endTs = System.currentTimeMillis() / 1000;
+    Map<String, String> tags = Maps.newHashMap();
+    tags.put(Constants.Metrics.Tag.NAMESPACE, datasetId.getNamespace());
+    tags.put(Constants.Metrics.Tag.DATASET, datasetId.getDataset());
+    MetricDeleteQuery deleteQuery = new MetricDeleteQuery(0, endTs, tags);
+    metricStore.delete(deleteQuery);
   }
 
   private void disableExplore(Id.DatasetInstance datasetInstance) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryQueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryQueueAdmin.java
@@ -69,7 +69,7 @@ public class InMemoryQueueAdmin implements QueueAdmin {
     return new NoopQueueConfigurer();
   }
 
-  // Only used by InMemoryStreadmAdmin
+  // Only used by InMemoryStreamAdmin
   void drop(QueueName queueName) throws Exception {
     queueService.drop(queueName);
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryStreamAdmin.java
@@ -17,6 +17,8 @@
 package co.cask.cdap.data2.transaction.queue.inmemory;
 
 import co.cask.cdap.api.data.stream.StreamSpecification;
+import co.cask.cdap.api.metrics.MetricDeleteQuery;
+import co.cask.cdap.api.metrics.MetricStore;
 import co.cask.cdap.common.StreamNotFoundException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.queue.QueueName;
@@ -36,7 +38,9 @@ import co.cask.cdap.proto.ViewSpecification;
 import co.cask.cdap.proto.audit.AuditPayload;
 import co.cask.cdap.proto.audit.AuditType;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
@@ -55,6 +59,7 @@ public class InMemoryStreamAdmin extends InMemoryQueueAdmin implements StreamAdm
   private final UsageRegistry usageRegistry;
   private final LineageWriter lineageWriter;
   private final MetadataStore metadataStore;
+  private final MetricStore metricStore;
   private final ViewAdmin viewAdmin;
 
   private AuditPublisher auditPublisher;
@@ -65,12 +70,14 @@ public class InMemoryStreamAdmin extends InMemoryQueueAdmin implements StreamAdm
                              LineageWriter lineageWriter,
                              StreamMetaStore streamMetaStore,
                              MetadataStore metadataStore,
+                             MetricStore metricStore,
                              ViewAdmin viewAdmin) {
     super(queueService);
     this.usageRegistry = usageRegistry;
     this.streamMetaStore = streamMetaStore;
     this.lineageWriter = lineageWriter;
     this.metadataStore = metadataStore;
+    this.metricStore = metricStore;
     this.viewAdmin = viewAdmin;
   }
 
@@ -84,6 +91,7 @@ public class InMemoryStreamAdmin extends InMemoryQueueAdmin implements StreamAdm
   public void dropAllInNamespace(Id.Namespace namespace) throws Exception {
     queueService.resetStreamsWithPrefix(QueueName.prefixForNamedspacedStream(namespace.getId()));
     for (StreamSpecification spec : streamMetaStore.listStreams(namespace)) {
+      deleteMetrics(namespace.toEntityId().stream(spec.getName()));
       // Remove metadata for the stream
       metadataStore.removeMetadata(Id.Stream.from(namespace, spec.getName()));
       streamMetaStore.removeStream(Id.Stream.from(namespace, spec.getName()));
@@ -153,9 +161,19 @@ public class InMemoryStreamAdmin extends InMemoryQueueAdmin implements StreamAdm
     Preconditions.checkArgument(exists(streamId), "Stream '%s' does not exist.", streamId);
     // Remove metadata for the stream
     metadataStore.removeMetadata(streamId);
-    drop(QueueName.fromStream(streamId));
     streamMetaStore.removeStream(streamId);
+    deleteMetrics(streamId.toEntityId());
+    drop(QueueName.fromStream(streamId));
     publishAudit(streamId, AuditType.DELETE);
+  }
+
+  private void deleteMetrics(StreamId streamId) throws Exception {
+    long endTs = System.currentTimeMillis() / 1000;
+    Map<String, String> tags = Maps.newHashMap();
+    tags.put(Constants.Metrics.Tag.NAMESPACE, streamId.getNamespace());
+    tags.put(Constants.Metrics.Tag.STREAM, streamId.getStream());
+    MetricDeleteQuery deleteQuery = new MetricDeleteQuery(0, endTs, tags);
+    metricStore.delete(deleteQuery);
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -19,6 +19,7 @@ package co.cask.cdap.data2.datafabric.dataset;
 import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.metrics.MetricStore;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.common.conf.CConfigurationUtil;
 import co.cask.cdap.common.conf.Constants;
@@ -183,7 +184,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
                                                               authenticationContext);
     DatasetInstanceService instanceService = new DatasetInstanceService(
       typeService, instanceManager, opExecutor, exploreFacade, namespaceQueryAdmin, authorizationEnforcer,
-      privilegesManager, authenticationContext);
+      privilegesManager, authenticationContext, injector.getInstance(MetricStore.class));
     instanceService.setAuditPublisher(inMemoryAuditPublisher);
 
     service = new DatasetService(cConf, discoveryService, discoveryServiceClient, metricsCollectionService,

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -18,6 +18,7 @@ package co.cask.cdap.data2.datafabric.dataset.service;
 
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.metrics.MetricStore;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
@@ -236,7 +237,7 @@ public abstract class DatasetServiceTestBase {
 
     instanceService = new DatasetInstanceService(typeService, instanceManager, opExecutor, exploreFacade,
                                                  namespaceQueryAdmin, authEnforcer, privilegesManager,
-                                                 authenticationContext);
+                                                 authenticationContext, injector.getInstance(MetricStore.class));
 
     service = new DatasetService(cConf, discoveryService, discoveryServiceClient, metricsCollectionService,
                                  opExecutor, new HashSet<DatasetMetricsReporter>(), typeService, instanceService);


### PR DESCRIPTION
Delete metrics upon stream/dataset deletion.
Previously, if you deleted a stream and recreated it, the event count metric was not reset.

https://issues.cask.co/browse/CDAP-2316
http://builds.cask.co/browse/CDAP-DUT4776-1
