### PR TITLE
Remove Maven deprecation warning about build.directory

### DIFF
--- a/cdap-kafka/pom.xml
+++ b/cdap-kafka/pom.xml
@@ -63,7 +63,7 @@
                 <id>jar-standalone</id>
                 <phase>prepare-package</phase>
                 <configuration combine.self="override">
-                  <outputDirectory>${build.directory}/libexec</outputDirectory>
+                  <outputDirectory>${project.build.directory}/libexec</outputDirectory>
                   <finalName>${project.groupId}.${project.build.finalName}</finalName>
                 </configuration>
                 <goals>
@@ -84,7 +84,7 @@
                   <goal>copy-dependencies</goal>
                 </goals>
                 <configuration combine.self="override">
-                  <outputDirectory>${build.directory}/libexec</outputDirectory>
+                  <outputDirectory>${project.build.directory}/libexec</outputDirectory>
                   <overWriteReleases>false</overWriteReleases>
                   <overWriteSnapshots>false</overWriteSnapshots>
                   <overWriteIfNewer>true</overWriteIfNewer>

--- a/cdap-spark-core/pom.xml
+++ b/cdap-spark-core/pom.xml
@@ -187,7 +187,7 @@
                 <id>jar</id>
                 <phase>prepare-package</phase>
                 <configuration combine.self="override">
-                  <outputDirectory>${build.directory}/libexec</outputDirectory>
+                  <outputDirectory>${project.build.directory}/libexec</outputDirectory>
                   <finalName>${project.groupId}.${project.build.finalName}</finalName>
                 </configuration>
                 <goals>
@@ -209,7 +209,7 @@
                   <goal>copy-dependencies</goal>
                 </goals>
                 <configuration combine.self="override">
-                  <outputDirectory>${build.directory}/libexec</outputDirectory>
+                  <outputDirectory>${project.build.directory}/libexec</outputDirectory>
                   <overWriteReleases>false</overWriteReleases>
                   <overWriteSnapshots>false</overWriteSnapshots>
                   <overWriteIfNewer>true</overWriteIfNewer>
@@ -250,7 +250,7 @@
                       </excludes>
                     </filter>
                   </filters>
-                  <outputFile>${build.directory}/libexec/${project.groupId}.spark-assembly-${spark.version}.jar</outputFile>
+                  <outputFile>${project.build.directory}/libexec/${project.groupId}.spark-assembly-${spark.version}.jar</outputFile>
                   <!-- Needed to merge akka config files -->
                   <transformers>
                     <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">


### PR DESCRIPTION
This removes the Maven deprecation warnings about using `project.build.directory` instead of `build.directory`

Builds:
RAT: http://builds.cask.co/browse/CDAP-DRC4394-1
DUT: http://builds.cask.co/browse/CDAP-DUT4780-1
