### PR TITLE
extend http client read timeout for hdinsight azure page blob storage

### DIFF
--- a/cdap-distributions/src/hdinsight/cdap-conf.json
+++ b/cdap-distributions/src/hdinsight/cdap-conf.json
@@ -3,6 +3,7 @@
     "cdap_site": {
       "dashboard.bind.port": "11011",
       "explore.enabled": "{{EXPLORE_ENABLED}}",
+      "http.client.read.timeout.ms": "120000",
       "kafka.server.log.dirs": "/var/cdap/kafka-logs",
       "router.bind.port": "11015",
       "zookeeper.quorum": "{{ZK_QUORUM}}"


### PR DESCRIPTION
increase http client read timeout for hdinsight azure page blob storage (default 60000)
