### PR TITLE
Removed Id Usages From Several (Smaller?) Packages

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -42,6 +42,7 @@ import co.cask.cdap.internal.app.services.ApplicationLifecycleService;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.http.BodyConsumer;
 import co.cask.http.HttpResponder;
@@ -391,13 +392,13 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   private ProgramTerminator createProgramTerminator() {
     return new ProgramTerminator() {
       @Override
-      public void stop(Id.Program programId) throws Exception {
+      public void stop(ProgramId programId) throws Exception {
         switch (programId.getType()) {
           case FLOW:
             stopProgramIfRunning(programId);
             break;
           case WORKFLOW:
-            scheduler.deleteSchedules(programId, SchedulableProgramType.WORKFLOW);
+            scheduler.deleteSchedules(programId.toId(), SchedulableProgramType.WORKFLOW);
             break;
           case MAPREDUCE:
             //no-op
@@ -413,7 +414,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     };
   }
 
-  private void stopProgramIfRunning(Id.Program programId) throws InterruptedException, ExecutionException {
+  private void stopProgramIfRunning(ProgramId programId) throws InterruptedException, ExecutionException {
     ProgramRuntimeService.RuntimeInfo programRunInfo = findRuntimeInfo(programId, runtimeService);
     if (programRunInfo != null) {
       ProgramController controller = programRunInfo.getController();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/util/AbstractAppFabricHttpHandler.java
@@ -25,6 +25,7 @@ import co.cask.cdap.proto.Instances;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.codec.EntityIdTypeAdapter;
 import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.id.ProgramId;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpResponder;
 import com.google.common.base.Charsets;
@@ -120,13 +121,13 @@ public abstract class AbstractAppFabricHttpHandler extends AbstractHttpHandler {
     }
   }
 
-  protected ProgramRuntimeService.RuntimeInfo findRuntimeInfo(Id.Program programId,
+  protected ProgramRuntimeService.RuntimeInfo findRuntimeInfo(ProgramId programId,
                                                               ProgramRuntimeService runtimeService) {
     Collection<ProgramRuntimeService.RuntimeInfo> runtimeInfos = runtimeService.list(programId.getType()).values();
     Preconditions.checkNotNull(runtimeInfos, UserMessages.getMessage(UserErrors.RUNTIME_INFO_NOT_FOUND), programId);
 
     for (ProgramRuntimeService.RuntimeInfo info : runtimeInfos) {
-      if (programId.equals(info.getProgramId())) {
+      if (programId.equals(info.getProgramId().toEntityId())) {
         return info;
       }
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/ProgramTerminator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/ProgramTerminator.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.internal.app.deploy;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.ProgramId;
 
 /**
  * Interface that is responsible to stopping programs. Used while stop programs that are being deleted during
@@ -29,6 +29,6 @@ public interface ProgramTerminator {
    *
    * @param programId  Program id.
    */
-  void stop(Id.Program programId) throws Exception;
+  void stop(ProgramId programId) throws Exception;
 
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
@@ -57,6 +57,7 @@ import co.cask.cdap.internal.guice.AppFabricTestModule;
 import co.cask.cdap.notifications.service.NotificationService;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.security.authorization.AuthorizationBootstrapper;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
 import com.google.common.base.Supplier;
@@ -141,7 +142,7 @@ public class AppFabricTestHelper {
 
     return factory.create(new ProgramTerminator() {
       @Override
-      public void stop(Id.Program programId) throws Exception {
+      public void stop(ProgramId programId) throws Exception {
         //No-op
       }
     });

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
@@ -24,6 +24,7 @@ import co.cask.cdap.internal.app.deploy.ProgramTerminator;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.ProgramId;
 import com.google.common.io.Files;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
@@ -63,7 +64,7 @@ public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
       applicationLifecycleService.deployAppAndArtifact(Id.Namespace.DEFAULT, "appName", artifactId, appJarFile, null,
         new ProgramTerminator() {
           @Override
-          public void stop(Id.Program programId) throws Exception {
+          public void stop(ProgramId programId) throws Exception {
             // no-op
           }
         });

--- a/cdap-examples/DataCleansing/src/test/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduceTest.java
+++ b/cdap-examples/DataCleansing/src/test/java/co/cask/cdap/examples/datacleansing/DataCleansingMapReduceTest.java
@@ -24,7 +24,7 @@ import co.cask.cdap.api.dataset.lib.cube.TimeValue;
 import co.cask.cdap.api.metrics.MetricDataQuery;
 import co.cask.cdap.api.metrics.MetricTimeSeries;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.MapReduceManager;
@@ -230,7 +230,7 @@ public class DataCleansingMapReduceTest extends TestBase {
   private long getValidityMetrics(boolean invalid) throws Exception {
     String metric = "user.records." + (invalid ? "invalid" : "valid");
 
-    Map<String, String> tags = ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, Id.Namespace.DEFAULT.getId(),
+    Map<String, String> tags = ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, NamespaceId.DEFAULT.getNamespace(),
                                                Constants.Metrics.Tag.APP, DataCleansing.NAME,
                                                Constants.Metrics.Tag.MAPREDUCE, DataCleansingMapReduce.NAME);
     MetricDataQuery metricQuery = new MetricDataQuery(0, Integer.MAX_VALUE, Integer.MAX_VALUE, metric,

--- a/cdap-examples/WikipediaPipeline/src/test/java/co/cask/cdap/examples/wikipedia/WikipediaPipelineAppTest.java
+++ b/cdap-examples/WikipediaPipeline/src/test/java/co/cask/cdap/examples/wikipedia/WikipediaPipelineAppTest.java
@@ -16,17 +16,18 @@
 
 package co.cask.cdap.examples.wikipedia;
 
-import co.cask.cdap.api.artifact.ArtifactVersion;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.utils.Tasks;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.WorkflowTokenNodeDetail;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.StreamManager;
 import co.cask.cdap.test.TestBase;
@@ -54,10 +55,8 @@ public class WikipediaPipelineAppTest extends TestBase {
   @ClassRule
   public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
 
-  private static final Id.Artifact ARTIFACT_ID =
-    Id.Artifact.from(Id.Namespace.DEFAULT, "WikipediaPipelineArtifact", new ArtifactVersion("1.0"));
-  private static final Id.Application APP_ID =
-    Id.Application.from(Id.Namespace.DEFAULT, WikipediaPipelineApp.class.getSimpleName());
+  private static final ArtifactId ARTIFACT_ID = NamespaceId.DEFAULT.artifact("WikipediaPipelineArtifact", "1.0");
+  private static final ApplicationId APP_ID = NamespaceId.DEFAULT.app(WikipediaPipelineApp.class.getSimpleName());
   private static final ArtifactSummary ARTIFACT_SUMMARY = new ArtifactSummary("WikipediaPipelineArtifact", "1.0");
 
   @BeforeClass
@@ -70,7 +69,7 @@ public class WikipediaPipelineAppTest extends TestBase {
   public void test() throws Exception {
     WikipediaPipelineApp.WikipediaAppConfig appConfig = new WikipediaPipelineApp.WikipediaAppConfig();
     AppRequest<WikipediaPipelineApp.WikipediaAppConfig> appRequest = new AppRequest<>(ARTIFACT_SUMMARY, appConfig);
-    ApplicationManager appManager = deployApplication(APP_ID, appRequest);
+    ApplicationManager appManager = deployApplication(APP_ID.toId(), appRequest);
     // Setup input streams with test data
     createTestData();
 
@@ -84,7 +83,7 @@ public class WikipediaPipelineAppTest extends TestBase {
     // Test K-Means
     appConfig = new WikipediaPipelineApp.WikipediaAppConfig("kmeans");
     appRequest = new AppRequest<>(ARTIFACT_SUMMARY, appConfig);
-    appManager = deployApplication(APP_ID, appRequest);
+    appManager = deployApplication(APP_ID.toId(), appRequest);
     workflowManager = appManager.getWorkflowManager(WikipediaPipelineWorkflow.NAME);
     testWorkflow(workflowManager, appConfig, 1);
   }

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreDriver.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreDriver.java
@@ -20,7 +20,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.utils.ProjectInfo;
 import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.explore.client.FixedAddressExploreClient;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,7 +63,7 @@ public class ExploreDriver implements Driver {
     ExploreConnectionParams params = ExploreConnectionParams.parseConnectionUrl(url);
 
     String authToken = getString(params, ExploreConnectionParams.Info.EXPLORE_AUTH_TOKEN, null);
-    String namespace = getString(params, ExploreConnectionParams.Info.NAMESPACE, Id.Namespace.DEFAULT.getId());
+    String namespace = getString(params, ExploreConnectionParams.Info.NAMESPACE, NamespaceId.DEFAULT.getNamespace());
     boolean sslEnabled = getBoolean(params, ExploreConnectionParams.Info.SSL_ENABLED, false);
     boolean verifySSLCert = getBoolean(params, ExploreConnectionParams.Info.VERIFY_SSL_CERT, true);
 

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreStatement.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreStatement.java
@@ -19,7 +19,7 @@ package co.cask.cdap.explore.jdbc;
 import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.explore.client.ExploreExecutionResult;
 import co.cask.cdap.explore.service.HandleNotFoundException;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.slf4j.Logger;
@@ -69,12 +69,12 @@ public class ExploreStatement implements Statement {
 
   private Connection connection;
   private ExploreClient exploreClient;
-  private final Id.Namespace namespace;
+  private final NamespaceId namespace;
 
   ExploreStatement(Connection connection, ExploreClient exploreClient, String namespace) {
     this.connection = connection;
     this.exploreClient = exploreClient;
-    this.namespace = Id.Namespace.from(namespace);
+    this.namespace = new NamespaceId(namespace);
   }
 
   @Override
@@ -103,7 +103,7 @@ public class ExploreStatement implements Statement {
       resultSet = null;
     }
 
-    futureResults = exploreClient.submit(namespace, sql);
+    futureResults = exploreClient.submit(namespace.toId(), sql);
     try {
       resultSet = new ExploreResultSet(futureResults.get(), this, maxRows);
       // NOTE: Javadoc states: "returns false if the first result is an update count or there is no result"

--- a/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreResultSetTest.java
+++ b/cdap-explore-jdbc/src/test/java/co/cask/cdap/explore/jdbc/ExploreResultSetTest.java
@@ -19,8 +19,8 @@ package co.cask.cdap.explore.jdbc;
 import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.explore.client.MockExploreClient;
 import co.cask.cdap.proto.ColumnDesc;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.QueryResult;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -80,7 +80,7 @@ public class ExploreResultSetTest {
         ))
     );
 
-    ResultSet resultSet = new ExploreResultSet(exploreClient.submit(Id.Namespace.from(ns), "mock_query").get(),
+    ResultSet resultSet = new ExploreResultSet(exploreClient.submit(new NamespaceId(ns).toId(), "mock_query").get(),
                                                new ExploreStatement(null, exploreClient, ns), 0);
     Assert.assertTrue(resultSet.next());
     Assert.assertEquals(resultSet.getObject(1), resultSet.getObject("column1"));
@@ -121,7 +121,7 @@ public class ExploreResultSetTest {
         ))
     );
 
-    ResultSet resultSet = new ExploreResultSet(exploreClient.submit(Id.Namespace.from(ns), "mock_query").get(),
+    ResultSet resultSet = new ExploreResultSet(exploreClient.submit(new NamespaceId(ns).toId(), "mock_query").get(),
                                                new ExploreStatement(null, exploreClient, ns), 0);
     Assert.assertTrue(resultSet.next());
     Assert.assertEquals(1, resultSet.findColumn("column1"));

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/increment/hbase96/IncrementSummingScannerTest.java
@@ -25,7 +25,7 @@ import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
 import co.cask.cdap.data2.util.hbase.MockRegionServerServices;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -77,7 +77,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testIncrementScanning() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "TestIncrementSummingScanner");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "TestIncrementSummingScanner");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     HRegion region = createRegion(tableId, familyBytes);
@@ -217,7 +217,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testFlushAndCompact() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "TestFlushAndCompact");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "TestFlushAndCompact");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     HRegion region = createRegion(tableId, familyBytes);
@@ -310,7 +310,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testMultiColumnFlushAndCompact() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "testMultiColumnFlushAndCompact");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "testMultiColumnFlushAndCompact");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     byte[] columnBytes2 = Bytes.toBytes("c2");
@@ -377,7 +377,8 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testIncrementScanningWithBatchAndUVB() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "TestIncrementSummingScannerWithUpperVisibilityBound");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(),
+                                   "TestIncrementSummingScannerWithUpperVisibilityBound");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     HRegion region = createRegion(tableId, familyBytes);

--- a/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/util/hbase/HBase96TableUtilTest.java
+++ b/cdap-hbase-compat-0.96/src/test/java/co/cask/cdap/data2/util/hbase/HBase96TableUtilTest.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data2.util.hbase;
 
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.util.TableId;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.XSlowTests;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -49,7 +49,7 @@ public class HBase96TableUtilTest extends AbstractHBaseTableUtilTest {
   protected String getTableNameAsString(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "TableId should not be null.");
     String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
-    if (Id.Namespace.DEFAULT.getId().equals(tableId.getNamespace())) {
+    if (NamespaceId.DEFAULT.getNamespace().equals(tableId.getNamespace())) {
       return nameConverter.toHBaseTableName(tablePrefix, tableId);
     }
     return Joiner.on(':').join(tableId.getNamespace(), nameConverter.toHBaseTableName(tablePrefix, tableId));

--- a/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-0.98/src/test/java/co/cask/cdap/data2/increment/hbase98/IncrementSummingScannerTest.java
@@ -25,7 +25,7 @@ import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
 import co.cask.cdap.data2.util.hbase.MockRegionServerServices;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -78,7 +78,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testIncrementScanning() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "TestIncrementSummingScanner");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "TestIncrementSummingScanner");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     HRegion region = createRegion(tableId, familyBytes);
@@ -218,7 +218,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testFlushAndCompact() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "TestFlushAndCompact");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "TestFlushAndCompact");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     HRegion region = createRegion(tableId, familyBytes);
@@ -311,7 +311,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testMultiColumnFlushAndCompact() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "testMultiColumnFlushAndCompact");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "testMultiColumnFlushAndCompact");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     byte[] columnBytes2 = Bytes.toBytes("c2");
@@ -378,7 +378,8 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testIncrementScanningWithBatchAndUVB() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "TestIncrementSummingScannerWithUpperVisibilityBound");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(),
+                                   "TestIncrementSummingScannerWithUpperVisibilityBound");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     HRegion region = createRegion(tableId, familyBytes);

--- a/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementSummingScannerTest.java
@@ -24,7 +24,7 @@ import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -80,7 +80,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testIncrementScanning() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "TestIncrementSummingScanner");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "TestIncrementSummingScanner");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     HRegion region = createRegion(tableId, familyBytes);
@@ -220,7 +220,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testFlushAndCompact() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "TestFlushAndCompact");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "TestFlushAndCompact");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     HRegion region = createRegion(tableId, familyBytes);
@@ -313,7 +313,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testMultiColumnFlushAndCompact() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "testMultiColumnFlushAndCompact");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "testMultiColumnFlushAndCompact");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     byte[] columnBytes2 = Bytes.toBytes("c2");
@@ -380,7 +380,8 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testIncrementScanningWithBatchAndUVB() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "TestIncrementSummingScannerWithUpperVisibilityBound");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(),
+                                   "TestIncrementSummingScannerWithUpperVisibilityBound");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     HRegion region = createRegion(tableId, familyBytes);

--- a/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableUtilTest.java
+++ b/cdap-hbase-compat-1.0-cdh/src/test/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableUtilTest.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data2.util.hbase;
 
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.util.TableId;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.XSlowTests;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -49,7 +49,7 @@ public class HBase10CDHTableUtilTest extends AbstractHBaseTableUtilTest {
   protected String getTableNameAsString(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "TableId should not be null.");
     String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
-    if (Id.Namespace.DEFAULT.getId().equals(tableId.getNamespace())) {
+    if (NamespaceId.DEFAULT.getNamespace().equals(tableId.getNamespace())) {
       return nameConverter.toHBaseTableName(tablePrefix, tableId);
     }
     return Joiner.on(':').join(tableId.getNamespace(), nameConverter.toHBaseTableName(tablePrefix, tableId));

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/test/java/co/cask/cdap/data2/increment/hbase10cdh550/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/test/java/co/cask/cdap/data2/increment/hbase10cdh550/IncrementSummingScannerTest.java
@@ -24,7 +24,7 @@ import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -81,7 +81,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testIncrementScanning() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "TestIncrementSummingScanner");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "TestIncrementSummingScanner");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     HRegion region = createRegion(tableId, familyBytes);
@@ -221,7 +221,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testFlushAndCompact() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "TestFlushAndCompact");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "TestFlushAndCompact");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     HRegion region = createRegion(tableId, familyBytes);
@@ -314,7 +314,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testMultiColumnFlushAndCompact() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "testMultiColumnFlushAndCompact");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "testMultiColumnFlushAndCompact");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     byte[] columnBytes2 = Bytes.toBytes("c2");
@@ -381,7 +381,8 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testIncrementScanningWithBatchAndUVB() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "TestIncrementSummingScannerWithUpperVisibilityBound");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(),
+                                   "TestIncrementSummingScannerWithUpperVisibilityBound");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     HRegion region = createRegion(tableId, familyBytes);

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/test/java/co/cask/cdap/data2/util/hbase/HBase10CDH550TableUtilTest.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/test/java/co/cask/cdap/data2/util/hbase/HBase10CDH550TableUtilTest.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data2.util.hbase;
 
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.util.TableId;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.XSlowTests;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -49,7 +49,7 @@ public class HBase10CDH550TableUtilTest extends AbstractHBaseTableUtilTest {
   protected String getTableNameAsString(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "TableId should not be null.");
     String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
-    if (Id.Namespace.DEFAULT.getId().equals(tableId.getNamespace())) {
+    if (NamespaceId.DEFAULT.getNamespace().equals(tableId.getNamespace())) {
       return nameConverter.toHBaseTableName(tablePrefix, tableId);
     }
     return Joiner.on(':').join(tableId.getNamespace(), nameConverter.toHBaseTableName(tablePrefix, tableId));

--- a/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/increment/hbase10/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/increment/hbase10/IncrementSummingScannerTest.java
@@ -24,7 +24,7 @@ import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -80,7 +80,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testIncrementScanning() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "TestIncrementSummingScanner");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "TestIncrementSummingScanner");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     HRegion region = createRegion(tableId, familyBytes);
@@ -220,7 +220,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testFlushAndCompact() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "TestFlushAndCompact");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "TestFlushAndCompact");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     HRegion region = createRegion(tableId, familyBytes);
@@ -313,7 +313,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testMultiColumnFlushAndCompact() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "testMultiColumnFlushAndCompact");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "testMultiColumnFlushAndCompact");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     byte[] columnBytes2 = Bytes.toBytes("c2");
@@ -380,7 +380,8 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testIncrementScanningWithBatchAndUVB() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "TestIncrementSummingScannerWithUpperVisibilityBound");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(),
+                                   "TestIncrementSummingScannerWithUpperVisibilityBound");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     HRegion region = createRegion(tableId, familyBytes);

--- a/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/util/hbase/HBase10TableUtilTest.java
+++ b/cdap-hbase-compat-1.0/src/test/java/co/cask/cdap/data2/util/hbase/HBase10TableUtilTest.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data2.util.hbase;
 
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.util.TableId;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.XSlowTests;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -49,7 +49,7 @@ public class HBase10TableUtilTest extends AbstractHBaseTableUtilTest {
   protected String getTableNameAsString(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "TableId should not be null.");
     String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
-    if (Id.Namespace.DEFAULT.getId().equals(tableId.getNamespace())) {
+    if (NamespaceId.DEFAULT.getNamespace().equals(tableId.getNamespace())) {
       return nameConverter.toHBaseTableName(tablePrefix, tableId);
     }
     return Joiner.on(':').join(tableId.getNamespace(), nameConverter.toHBaseTableName(tablePrefix, tableId));

--- a/cdap-hbase-compat-1.1/src/test/java/co/cask/cdap/data2/increment/hbase11/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-1.1/src/test/java/co/cask/cdap/data2/increment/hbase11/IncrementSummingScannerTest.java
@@ -24,7 +24,7 @@ import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -81,7 +81,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testIncrementScanning() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "TestIncrementSummingScanner");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "TestIncrementSummingScanner");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     HRegion region = createRegion(tableId, familyBytes);
@@ -221,7 +221,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testFlushAndCompact() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "TestFlushAndCompact");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "TestFlushAndCompact");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     HRegion region = createRegion(tableId, familyBytes);
@@ -314,7 +314,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testWithBatchLimit() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "testWithBatchLimit");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "testWithBatchLimit");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c2");
 
@@ -376,7 +376,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testMultiColumnFlushAndCompact() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "testMultiColumnFlushAndCompact");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "testMultiColumnFlushAndCompact");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     byte[] columnBytes2 = Bytes.toBytes("c2");
@@ -443,7 +443,8 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testIncrementScanningWithBatchAndUVB() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "TestIncrementSummingScannerWithUpperVisibilityBound");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(),
+                                   "TestIncrementSummingScannerWithUpperVisibilityBound");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     HRegion region = createRegion(tableId, familyBytes);

--- a/cdap-hbase-compat-1.1/src/test/java/co/cask/cdap/data2/util/hbase/HBase11TableUtilTest.java
+++ b/cdap-hbase-compat-1.1/src/test/java/co/cask/cdap/data2/util/hbase/HBase11TableUtilTest.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data2.util.hbase;
 
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.util.TableId;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.XSlowTests;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -49,7 +49,7 @@ public class HBase11TableUtilTest extends AbstractHBaseTableUtilTest {
   protected String getTableNameAsString(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "TableId should not be null.");
     String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
-    if (Id.Namespace.DEFAULT.getId().equals(tableId.getNamespace())) {
+    if (NamespaceId.DEFAULT.getNamespace().equals(tableId.getNamespace())) {
       return nameConverter.toHBaseTableName(tablePrefix, tableId);
     }
     return Joiner.on(':').join(tableId.getNamespace(), nameConverter.toHBaseTableName(tablePrefix, tableId));

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/test/java/co/cask/cdap/data2/increment/hbase12cdh570/IncrementSummingScannerTest.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/test/java/co/cask/cdap/data2/increment/hbase12cdh570/IncrementSummingScannerTest.java
@@ -24,7 +24,7 @@ import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -81,7 +81,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testIncrementScanning() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "TestIncrementSummingScanner");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "TestIncrementSummingScanner");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     HRegion region = createRegion(tableId, familyBytes);
@@ -221,7 +221,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testFlushAndCompact() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "TestFlushAndCompact");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "TestFlushAndCompact");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     HRegion region = createRegion(tableId, familyBytes);
@@ -314,7 +314,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testWithBatchLimit() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "testWithBatchLimit");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "testWithBatchLimit");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c2");
 
@@ -376,7 +376,7 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testMultiColumnFlushAndCompact() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "testMultiColumnFlushAndCompact");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(), "testMultiColumnFlushAndCompact");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     byte[] columnBytes2 = Bytes.toBytes("c2");
@@ -443,7 +443,8 @@ public class IncrementSummingScannerTest {
 
   @Test
   public void testIncrementScanningWithBatchAndUVB() throws Exception {
-    TableId tableId = TableId.from(Id.Namespace.DEFAULT.getId(), "TestIncrementSummingScannerWithUpperVisibilityBound");
+    TableId tableId = TableId.from(NamespaceId.DEFAULT.getNamespace(),
+                                   "TestIncrementSummingScannerWithUpperVisibilityBound");
     byte[] familyBytes = Bytes.toBytes("f");
     byte[] columnBytes = Bytes.toBytes("c");
     HRegion region = createRegion(tableId, familyBytes);

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/test/java/co/cask/cdap/data2/util/hbase/HBase12CDH570TableUtilTest.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/test/java/co/cask/cdap/data2/util/hbase/HBase12CDH570TableUtilTest.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data2.util.hbase;
 
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.util.TableId;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.XSlowTests;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -49,7 +49,7 @@ public class HBase12CDH570TableUtilTest extends AbstractHBaseTableUtilTest {
   protected String getTableNameAsString(TableId tableId) {
     Preconditions.checkArgument(tableId != null, "TableId should not be null.");
     String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
-    if (Id.Namespace.DEFAULT.getId().equals(tableId.getNamespace())) {
+    if (NamespaceId.DEFAULT.getNamespace().equals(tableId.getNamespace())) {
       return nameConverter.toHBaseTableName(tablePrefix, tableId);
     }
     return Joiner.on(':').join(tableId.getNamespace(), nameConverter.toHBaseTableName(tablePrefix, tableId));

--- a/cdap-kms/src/main/java/co/cask/cdap/security/store/KMSSecureStore.java
+++ b/cdap-kms/src/main/java/co/cask/cdap/security/store/KMSSecureStore.java
@@ -24,7 +24,7 @@ import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.security.DelegationTokensUpdater;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.SecureKeyId;
 import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
@@ -235,9 +235,9 @@ public class KMSSecureStore implements SecureStore, SecureStoreManager, Delegati
   }
 
   private void checkNamespaceExists(String namespace) throws Exception {
-    Id.Namespace namespaceId = new Id.Namespace(namespace);
-    if (!namespaceQueryAdmin.exists(namespaceId)) {
-      throw new NamespaceNotFoundException(namespaceId);
+    NamespaceId namespaceId = new NamespaceId(namespace);
+    if (!namespaceQueryAdmin.exists(namespaceId.toId())) {
+      throw new NamespaceNotFoundException(namespaceId.toId());
     }
   }
 

--- a/cdap-security/src/main/java/co/cask/cdap/security/store/FileSecureStore.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/store/FileSecureStore.java
@@ -27,7 +27,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.conf.SConfiguration;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.SecureKeyId;
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
@@ -50,10 +50,8 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
-import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -244,9 +242,9 @@ public class FileSecureStore implements SecureStore, SecureStoreManager {
   }
 
   private void checkNamespaceExists(String namespace) throws Exception {
-    Id.Namespace namespaceId = new Id.Namespace(namespace);
-    if (!namespaceQueryAdmin.exists(namespaceId)) {
-      throw new NamespaceNotFoundException(namespaceId);
+    NamespaceId namespaceId = new NamespaceId(namespace);
+    if (!namespaceQueryAdmin.exists(namespaceId.toId())) {
+      throw new NamespaceNotFoundException(namespaceId.toId());
     }
   }
 

--- a/cdap-security/src/test/java/co/cask/cdap/security/store/FileSecureStoreTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/store/FileSecureStoreTest.java
@@ -25,7 +25,6 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.conf.SConfiguration;
 import co.cask.cdap.common.namespace.InMemoryNamespaceClient;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.io.Charsets;
@@ -76,11 +75,11 @@ public class FileSecureStoreTest {
     sConf.set(Constants.Security.Store.FILE_PASSWORD, "secret");
     InMemoryNamespaceClient namespaceClient = new InMemoryNamespaceClient();
     NamespaceMeta namespaceMeta = new NamespaceMeta.Builder()
-      .setName(new Id.Namespace(NAMESPACE1))
+      .setName(NAMESPACE1)
       .build();
     namespaceClient.create(namespaceMeta);
     namespaceMeta = new NamespaceMeta.Builder()
-      .setName(new Id.Namespace(NAMESPACE2))
+      .setName(NAMESPACE2)
       .build();
     namespaceClient.create(namespaceMeta);
     FileSecureStore fileSecureStore = new FileSecureStore(conf, sConf, namespaceClient);

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRunner.java
@@ -280,14 +280,15 @@ final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
           // Service was killed
           runStatus = ProgramController.State.KILLED.getRunStatus();
         }
-        runtimeStore.setStop(programId, runId.getId(), TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()),
-                             runStatus);
+        runtimeStore.setStop(programId, runId.getId(),
+                             TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()), runStatus);
       }
 
       @Override
       public void failed(Service.State from, @Nullable Throwable failure) {
         closeAll(closeables);
-        runtimeStore.setStop(programId, runId.getId(), TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()),
+        runtimeStore.setStop(programId, runId.getId(),
+                             TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()),
                              ProgramController.State.ERROR.getRunStatus(), new BasicThrowable(failure));
       }
     };

--- a/cdap-standalone/src/test/java/co/cask/cdap/StandaloneTester.java
+++ b/cdap-standalone/src/test/java/co/cask/cdap/StandaloneTester.java
@@ -22,8 +22,9 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.artifact.ArtifactRange;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.rules.ExternalResource;
@@ -128,8 +129,8 @@ public class StandaloneTester extends ExternalResource {
                                 @Nullable Set<ArtifactRange> parentArtifacts) throws Exception {
     ArtifactRepository artifactRepository = standaloneMain.getInjector().getInstance(ArtifactRepository.class);
 
-    Id.Artifact artifactId = new Id.Artifact(Id.Namespace.SYSTEM, name, version);
-    artifactRepository.addArtifact(artifactId, artifactFile, parentArtifacts);
+    ArtifactId artifactId = NamespaceId.SYSTEM.artifact(name, version.getVersion());
+    artifactRepository.addArtifact(artifactId.toId(), artifactFile, parentArtifacts);
   }
 
   private String getLocalHostname() {


### PR DESCRIPTION
Phasing out deprecated Id usages in the following packages (each had only a few usages):
- `WikipediaPipeline`
- `DataCleansing`
- `cdap-standalone`
- `cdap-spark-core`
- `cdap-security`
- `cdap-kms`
- `cdap-hbase-compat-1.2-cdh5.7.0`
- `cdap-hbase-compat-1.1`
- `cdap-hbase-compat-1.0-cdh5.5.0`
- `cdap-hbase-compat-1.0-cdh5.5.0`
- `cdap-hbase-compat-1.0`
- `cdap-hbase-compat-0.98`
- `cdap-hbase-compat-0.96`
- `cdap-explore-jdbc`
