### PR TITLE
Removed Id Usages from Lineage Classes

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/DefaultStreamWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/DefaultStreamWriter.java
@@ -202,6 +202,6 @@ public class DefaultStreamWriter implements StreamWriter {
     }
 
     // Lineage writer handles duplicate accesses internally
-    lineageWriter.addAccess(run, stream, AccessType.WRITE);
+    lineageWriter.addAccess(run.toEntityId(), stream.toEntityId(), AccessType.WRITE);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteLineageWriterHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteLineageWriterHandler.java
@@ -19,7 +19,10 @@ package co.cask.cdap.gateway.handlers.meta;
 import co.cask.cdap.common.internal.remote.MethodArgument;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.http.HttpResponder;
 import com.google.inject.Inject;
 import org.jboss.netty.handler.codec.http.HttpRequest;
@@ -47,10 +50,10 @@ public class RemoteLineageWriterHandler extends AbstractRemoteSystemOpsHandler {
   public void addDatasetAccess(HttpRequest request, HttpResponder responder) throws Exception {
     Iterator<MethodArgument> arguments = parseArguments(request);
 
-    Id.Run run = deserializeNext(arguments);
-    Id.DatasetInstance datasetInstance = deserializeNext(arguments);
+    ProgramRunId run = deserializeNext(arguments);
+    DatasetId datasetInstance = deserializeNext(arguments);
     AccessType accessType = deserializeNext(arguments);
-    Id.NamespacedId component = deserializeNext(arguments);
+    NamespacedEntityId component = deserializeNext(arguments);
     lineageWriter.addAccess(run, datasetInstance, accessType, component);
 
     responder.sendStatus(HttpResponseStatus.OK);
@@ -61,10 +64,10 @@ public class RemoteLineageWriterHandler extends AbstractRemoteSystemOpsHandler {
   public void addStreamAccess(HttpRequest request, HttpResponder responder) throws Exception {
     Iterator<MethodArgument> arguments = parseArguments(request);
 
-    Id.Run run = deserializeNext(arguments);
-    Id.Stream stream = deserializeNext(arguments);
+    ProgramRunId run = deserializeNext(arguments);
+    StreamId stream = deserializeNext(arguments);
     AccessType accessType = deserializeNext(arguments);
-    Id.NamespacedId component = deserializeNext(arguments);
+    NamespacedEntityId component = deserializeNext(arguments);
     lineageWriter.addAccess(run, stream, accessType, component);
 
     responder.sendStatus(HttpResponseStatus.OK);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/LineageWriterDataFabricFacade.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/LineageWriterDataFabricFacade.java
@@ -34,6 +34,7 @@ import co.cask.cdap.data2.transaction.stream.ForwardingStreamConsumer;
 import co.cask.cdap.data2.transaction.stream.StreamConsumer;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerFactory;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import org.apache.tephra.TransactionAware;
@@ -73,7 +74,7 @@ public final class LineageWriterDataFabricFacade implements DataFabricFacade, Pr
 
   @Override
   public void initContext(Id.Run run) {
-    programContext.initContext(run);
+    programContext.initContext(run.toEntityId());
     if (queueClientFactory instanceof ProgramContextAware) {
       ((ProgramContextAware) queueClientFactory).initContext(run);
     }
@@ -81,7 +82,7 @@ public final class LineageWriterDataFabricFacade implements DataFabricFacade, Pr
 
   @Override
   public void initContext(Id.Run run, Id.NamespacedId componentId) {
-    programContext.initContext(run, componentId);
+    programContext.initContext(run.toEntityId(), (NamespacedEntityId) componentId.toEntityId());
     if (queueClientFactory instanceof ProgramContextAware) {
       ((ProgramContextAware) queueClientFactory).initContext(run, componentId);
     }
@@ -135,7 +136,8 @@ public final class LineageWriterDataFabricFacade implements DataFabricFacade, Pr
     datasetCache.addExtraTransactionAware(consumer);
 
     if (programContext.getRun() != null) {
-      lineageWriter.addAccess(programContext.getRun(), streamName, AccessType.READ, programContext.getComponentId());
+      lineageWriter.addAccess(programContext.getRun(), streamName.toEntityId(), AccessType.READ,
+                              (NamespacedEntityId) programContext.getComponentId());
     }
 
     return new ForwardingStreamConsumer(consumer) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteLineageWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteLineageWriter.java
@@ -22,7 +22,10 @@ import co.cask.cdap.common.internal.remote.RemoteOpsClient;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.data2.metadata.writer.BasicLineageWriter;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.inject.Inject;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
@@ -44,14 +47,14 @@ public class RemoteLineageWriter extends RemoteOpsClient implements LineageWrite
   }
 
   @Override
-  public void addAccess(Id.Run run, Id.DatasetInstance datasetInstance, AccessType accessType) {
+  public void addAccess(ProgramRunId run, DatasetId datasetInstance, AccessType accessType) {
     // delegates on client side; so corresponding method is not required to be implemented on server side
     addAccess(run, datasetInstance, accessType, null);
   }
 
   @Override
-  public void addAccess(Id.Run run, Id.DatasetInstance datasetInstance, AccessType accessType,
-                        @Nullable Id.NamespacedId component) {
+  public void addAccess(ProgramRunId run, DatasetId datasetInstance, AccessType accessType,
+                        @Nullable NamespacedEntityId component) {
     if (alreadyRegistered(run, datasetInstance, accessType, component)) {
       return;
     }
@@ -59,21 +62,22 @@ public class RemoteLineageWriter extends RemoteOpsClient implements LineageWrite
   }
 
   @Override
-  public void addAccess(Id.Run run, Id.Stream stream, AccessType accessType) {
+  public void addAccess(ProgramRunId run, StreamId stream, AccessType accessType) {
     // delegates on client side; so corresponding method is not required to be implemented on server side
     addAccess(run, stream, accessType, null);
   }
 
   @Override
-  public void addAccess(Id.Run run, Id.Stream stream, AccessType accessType, @Nullable Id.NamespacedId component) {
+  public void addAccess(ProgramRunId run, StreamId stream, AccessType accessType,
+                        @Nullable NamespacedEntityId component) {
     if (alreadyRegistered(run, stream, accessType, component)) {
       return;
     }
     executeRequest("addStreamAccess", run, stream, accessType, component);
   }
 
-  private boolean alreadyRegistered(Id.Run run, Id.NamespacedId data, AccessType accessType,
-                                    @Nullable Id.NamespacedId component) {
+  private boolean alreadyRegistered(ProgramRunId run, NamespacedEntityId data, AccessType accessType,
+                                    @Nullable NamespacedEntityId component) {
     return registered.putIfAbsent(new BasicLineageWriter.DataAccessKey(run, data, accessType, component), true) != null;
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/LineageHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/LineageHandler.java
@@ -25,7 +25,10 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.codec.NamespacedEntityIdCodec;
 import co.cask.cdap.proto.codec.NamespacedIdCodec;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.lineage.CollapseType;
 import co.cask.cdap.proto.metadata.lineage.LineageRecord;
@@ -82,7 +85,7 @@ public class LineageHandler extends AbstractHttpHandler {
     checkLevels(levels);
     TimeRange range = parseRange(startStr, endStr);
 
-    Id.DatasetInstance datasetInstance = Id.DatasetInstance.from(namespaceId, datasetId);
+    DatasetId datasetInstance = new DatasetId(namespaceId, datasetId);
     Lineage lineage = lineageAdmin.computeLineage(datasetInstance, range.getStart(), range.getEnd(), levels);
     responder.sendJson(HttpResponseStatus.OK,
                        LineageSerializer.toLineageRecord(TimeUnit.MILLISECONDS.toSeconds(range.getStart()),
@@ -104,7 +107,7 @@ public class LineageHandler extends AbstractHttpHandler {
     checkLevels(levels);
     TimeRange range = parseRange(startStr, endStr);
 
-    Id.Stream streamId = Id.Stream.from(namespaceId, stream);
+    StreamId streamId = new StreamId(namespaceId, stream);
     Lineage lineage = lineageAdmin.computeLineage(streamId, range.getStart(), range.getEnd(), levels);
     responder.sendJson(HttpResponseStatus.OK,
                        LineageSerializer.toLineageRecord(TimeUnit.MILLISECONDS.toSeconds(range.getStart()),
@@ -121,9 +124,8 @@ public class LineageHandler extends AbstractHttpHandler {
                                 @PathParam("program-type") String programType,
                                 @PathParam("program-id") String programId,
                                 @PathParam("run-id") String runId) throws Exception {
-    Id.Run run = new Id.Run(
-      Id.Program.from(namespaceId, appId, ProgramType.valueOfCategoryName(programType), programId),
-      runId);
+    ProgramRunId run = new ProgramRunId(namespaceId, appId, ProgramType.valueOfCategoryName(programType), programId,
+                                        runId);
     responder.sendJson(HttpResponseStatus.OK, lineageAdmin.getMetadataForRun(run), SET_METADATA_RECORD_TYPE, GSON);
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemoteLineageWriterTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemoteLineageWriterTest.java
@@ -67,24 +67,24 @@ public class RemoteLineageWriterTest extends AppFabricTestBase {
     Set<Relation> expectedRelations = new HashSet<>();
 
     // test null serialization
-    remoteLineageWriter.addAccess(runId.toId(), datasetId.toId(), AccessType.READ, null);
+    remoteLineageWriter.addAccess(runId, datasetId, AccessType.READ, null);
     expectedRelations.add(new Relation(datasetId, flowId, AccessType.READ, twillRunId));
 
-    Assert.assertEquals(ImmutableSet.of(flowId, datasetId), lineageStore.getEntitiesForRun(runId.toId()));
+    Assert.assertEquals(ImmutableSet.of(flowId, datasetId), lineageStore.getEntitiesForRun(runId));
 
     Assert.assertEquals(expectedRelations,
-                        lineageStore.getRelations(flowId.toId(), now, now + 1, Predicates.<Relation>alwaysTrue()));
+                        lineageStore.getRelations(flowId, now, now + 1, Predicates.<Relation>alwaysTrue()));
 
-    remoteLineageWriter.addAccess(runId.toId(), streamId.toId(), AccessType.READ);
+    remoteLineageWriter.addAccess(runId, streamId, AccessType.READ);
     expectedRelations.add(new Relation(streamId, flowId, AccessType.READ, twillRunId));
 
     Assert.assertEquals(expectedRelations,
-                        lineageStore.getRelations(flowId.toId(), now, now + 1, Predicates.<Relation>alwaysTrue()));
+                        lineageStore.getRelations(flowId, now, now + 1, Predicates.<Relation>alwaysTrue()));
 
-    remoteLineageWriter.addAccess(runId.toId(), streamId.toId(), AccessType.WRITE);
+    remoteLineageWriter.addAccess(runId, streamId, AccessType.WRITE);
     expectedRelations.add(new Relation(streamId, flowId, AccessType.WRITE, twillRunId));
 
     Assert.assertEquals(expectedRelations,
-                        lineageStore.getRelations(flowId.toId(), now, now + 1, Predicates.<Relation>alwaysTrue()));
+                        lineageStore.getRelations(flowId, now, now + 1, Predicates.<Relation>alwaysTrue()));
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageAdminTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/LineageAdminTest.java
@@ -27,7 +27,6 @@ import co.cask.cdap.data2.metadata.lineage.LineageStore;
 import co.cask.cdap.data2.metadata.lineage.Relation;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.EntityId;
@@ -35,6 +34,7 @@ import co.cask.cdap.proto.id.FlowletId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
@@ -68,20 +68,20 @@ public class LineageAdminTest extends AppFabricTestBase {
   // Define programs and runs
   private final ProgramId program1 = new ProgramId("default", "app1", ProgramType.FLOW, "flow1");
   private final FlowletId flowlet1 = program1.flowlet("flowlet1");
-  private final Id.Run run1 = new Id.Run(program1.toId(), RunIds.generate(10000).getId());
+  private final ProgramRunId run1 = program1.run(RunIds.generate(10000).getId());
 
   private final ProgramId program2 = new ProgramId("default", "app2", ProgramType.FLOW, "flow2");
   private final FlowletId flowlet2 = program2.flowlet("flowlet2");
-  private final Id.Run run2 = new Id.Run(program2.toId(), RunIds.generate(900).getId());
+  private final ProgramRunId run2 = program2.run(RunIds.generate(900).getId());
 
   private final ProgramId program3 = new ProgramId("default", "app3", ProgramType.WORKER, "worker3");
-  private final Id.Run run3 = new Id.Run(program3.toId(), RunIds.generate(800).getId());
+  private final ProgramRunId run3 = program3.run(RunIds.generate(800).getId());
 
   private final ProgramId program4 = new ProgramId("default", "app4", ProgramType.SERVICE, "service4");
-  private final Id.Run run4 = new Id.Run(program4.toId(), RunIds.generate(800).getId());
+  private final ProgramRunId run4 = program4.run(RunIds.generate(800).getId());
 
   private final ProgramId program5 = new ProgramId("default", "app5", ProgramType.SERVICE, "service5");
-  private final Id.Run run5 = new Id.Run(program5.toId(), RunIds.generate(700).getId());
+  private final ProgramRunId run5 = program5.run(RunIds.generate(700).getId());
 
   @After
   public void cleanup() throws Exception {
@@ -93,7 +93,7 @@ public class LineageAdminTest extends AppFabricTestBase {
     // Lineage for D3 -> P2 -> D2 -> P1 -> D1
 
     LineageStore lineageStore = new LineageStore(getTxExecFactory(), getDatasetFramework(),
-                                                 Id.DatasetInstance.from("default", "testSimpleLineage"));
+                                                 NamespaceId.DEFAULT.dataset("testSimpleLineage"));
     Store store = getInjector().getInstance(Store.class);
     MetadataStore metadataStore = getInjector().getInstance(MetadataStore.class);
     LineageAdmin lineageAdmin = new LineageAdmin(lineageStore, store, metadataStore, new NoOpEntityExistenceVerifier());
@@ -125,20 +125,20 @@ public class LineageAdminTest extends AppFabricTestBase {
 
     // Add accesses for D3 -> P2 -> D2 -> P1 -> D1 <-> P3
     // We need to use current time here as metadata store stores access time using current time
-    Id.Run run1 = new Id.Run(program1.toId(), RunIds.generate(System.currentTimeMillis()).getId());
-    Id.Run run2 = new Id.Run(program2.toId(), RunIds.generate(System.currentTimeMillis()).getId());
-    Id.Run run3 = new Id.Run(program3.toId(), RunIds.generate(System.currentTimeMillis()).getId());
+    ProgramRunId run1 = program1.run(RunIds.generate(System.currentTimeMillis()).getId());
+    ProgramRunId run2 = program2.run(RunIds.generate(System.currentTimeMillis()).getId());
+    ProgramRunId run3 = program3.run(RunIds.generate(System.currentTimeMillis()).getId());
 
     addRuns(store, run1, run2, run3);
     // It is okay to use current time here since access time is ignore during assertions
-    lineageStore.addAccess(run1, dataset1.toId(), AccessType.UNKNOWN, System.currentTimeMillis(), flowlet1.toId());
-    lineageStore.addAccess(run1, dataset1.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet1.toId());
-    lineageStore.addAccess(run1, dataset2.toId(), AccessType.READ, System.currentTimeMillis(), flowlet1.toId());
+    lineageStore.addAccess(run1, dataset1, AccessType.UNKNOWN, System.currentTimeMillis(), flowlet1);
+    lineageStore.addAccess(run1, dataset1, AccessType.WRITE, System.currentTimeMillis(), flowlet1);
+    lineageStore.addAccess(run1, dataset2, AccessType.READ, System.currentTimeMillis(), flowlet1);
 
-    lineageStore.addAccess(run2, dataset2.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet2.toId());
-    lineageStore.addAccess(run2, dataset3.toId(), AccessType.READ, System.currentTimeMillis(), flowlet2.toId());
+    lineageStore.addAccess(run2, dataset2, AccessType.WRITE, System.currentTimeMillis(), flowlet2);
+    lineageStore.addAccess(run2, dataset3, AccessType.READ, System.currentTimeMillis(), flowlet2);
 
-    lineageStore.addAccess(run3, dataset1.toId(), AccessType.UNKNOWN, System.currentTimeMillis());
+    lineageStore.addAccess(run3, dataset1, AccessType.UNKNOWN, System.currentTimeMillis());
 
     // The UNKNOWN access type will get filtered out if there is READ/WRITE. It will be preserved if it is the
     // only access type
@@ -154,14 +154,14 @@ public class LineageAdminTest extends AppFabricTestBase {
 
     // Lineage for D1
     Assert.assertEquals(expectedLineage,
-                        lineageAdmin.computeLineage(dataset1.toId(), 500, System.currentTimeMillis() + 10000, 100));
+                        lineageAdmin.computeLineage(dataset1, 500, System.currentTimeMillis() + 10000, 100));
 
     // Lineage for D2
     Assert.assertEquals(expectedLineage,
-                        lineageAdmin.computeLineage(dataset2.toId(), 500, System.currentTimeMillis() + 10000, 100));
+                        lineageAdmin.computeLineage(dataset2, 500, System.currentTimeMillis() + 10000, 100));
 
     // Lineage for D1 for one level should be D2 -> P1 -> D1 <-> P3
-    Lineage oneLevelLineage = lineageAdmin.computeLineage(dataset1.toId(), 500, System.currentTimeMillis() + 10000, 1);
+    Lineage oneLevelLineage = lineageAdmin.computeLineage(dataset1, 500, System.currentTimeMillis() + 10000, 1);
 
     Assert.assertEquals(
       ImmutableSet.of(
@@ -178,11 +178,10 @@ public class LineageAdminTest extends AppFabricTestBase {
     // Assert that in a different namespace both lineage and metadata should be empty
     NamespaceId customNamespace = new NamespaceId("custom_namespace");
     DatasetId customDataset1 = customNamespace.dataset(dataset1.getEntityName());
-    Id.Run customRun1 =
-      new Id.Run(new ProgramId(customNamespace.getNamespace(), program1.getApplication(), program1.getType(),
-                               program1.getEntityName()).toId(), run1.getId());
+    ProgramRunId customRun1 = customNamespace.app(program1.getApplication()).program(program1.getType(),
+                               program1.getEntityName()).run(run1.getEntityName());
     Assert.assertEquals(new Lineage(ImmutableSet.<Relation>of()),
-                        lineageAdmin.computeLineage(customDataset1.toId(), 500,
+                        lineageAdmin.computeLineage(customDataset1, 500,
                                                     System.currentTimeMillis() + 10000, 100));
     Assert.assertEquals(ImmutableSet.<MetadataRecord>of(), lineageAdmin.getMetadataForRun(customRun1));
   }
@@ -196,7 +195,7 @@ public class LineageAdminTest extends AppFabricTestBase {
     //
 
     LineageStore lineageStore = new LineageStore(getTxExecFactory(), getDatasetFramework(),
-                                                 new DatasetId("default", "testSimpleLoopLineage").toId());
+                                                 NamespaceId.DEFAULT.dataset("testSimpleLoopLineage"));
     Store store = getInjector().getInstance(Store.class);
     MetadataStore metadataStore = getInjector().getInstance(MetadataStore.class);
     LineageAdmin lineageAdmin = new LineageAdmin(lineageStore, store, metadataStore, new NoOpEntityExistenceVerifier());
@@ -205,15 +204,15 @@ public class LineageAdminTest extends AppFabricTestBase {
     // Add access
     addRuns(store, run1, run2, run3, run4, run5);
     // It is okay to use current time here since access time is ignore during assertions
-    lineageStore.addAccess(run1, dataset1.toId(), AccessType.READ, System.currentTimeMillis(), flowlet1.toId());
-    lineageStore.addAccess(run1, dataset2.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet1.toId());
+    lineageStore.addAccess(run1, dataset1, AccessType.READ, System.currentTimeMillis(), flowlet1);
+    lineageStore.addAccess(run1, dataset2, AccessType.WRITE, System.currentTimeMillis(), flowlet1);
 
-    lineageStore.addAccess(run2, dataset2.toId(), AccessType.READ, System.currentTimeMillis(), flowlet2.toId());
-    lineageStore.addAccess(run2, dataset1.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet2.toId());
-    lineageStore.addAccess(run2, dataset3.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet2.toId());
+    lineageStore.addAccess(run2, dataset2, AccessType.READ, System.currentTimeMillis(), flowlet2);
+    lineageStore.addAccess(run2, dataset1, AccessType.WRITE, System.currentTimeMillis(), flowlet2);
+    lineageStore.addAccess(run2, dataset3, AccessType.WRITE, System.currentTimeMillis(), flowlet2);
 
-    lineageStore.addAccess(run3, dataset3.toId(), AccessType.READ, System.currentTimeMillis());
-    lineageStore.addAccess(run3, dataset4.toId(), AccessType.WRITE, System.currentTimeMillis());
+    lineageStore.addAccess(run3, dataset3, AccessType.READ, System.currentTimeMillis());
+    lineageStore.addAccess(run3, dataset4, AccessType.WRITE, System.currentTimeMillis());
 
     Lineage expectedLineage = new Lineage(
       ImmutableSet.of(
@@ -228,17 +227,17 @@ public class LineageAdminTest extends AppFabricTestBase {
     );
 
     // Lineage for D1
-    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset1.toId(), 500, 20000, 100));
+    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset1, 500, 20000, 100));
 
     // Lineage for D2
-    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset2.toId(), 500, 20000, 100));
+    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset2, 500, 20000, 100));
 
     // Lineage for D1 for one level D1 -> P1 -> D2 -> P2 -> D3
     //                              |                 |
     //                              |                 V
     //                              |<-----------------
     //
-    Lineage oneLevelLineage = lineageAdmin.computeLineage(dataset1.toId(), 500, 20000, 1);
+    Lineage oneLevelLineage = lineageAdmin.computeLineage(dataset1, 500, 20000, 1);
 
     Assert.assertEquals(
       ImmutableSet.of(
@@ -258,7 +257,7 @@ public class LineageAdminTest extends AppFabricTestBase {
     // D1 <-> P1
     //
     LineageStore lineageStore = new LineageStore(getTxExecFactory(), getDatasetFramework(),
-                                                 NamespaceId.DEFAULT.dataset("testDirectCycle").toId());
+                                                 NamespaceId.DEFAULT.dataset("testDirectCycle"));
     Store store = getInjector().getInstance(Store.class);
     MetadataStore metadataStore = getInjector().getInstance(MetadataStore.class);
     LineageAdmin lineageAdmin = new LineageAdmin(lineageStore, store, metadataStore, new NoOpEntityExistenceVerifier());
@@ -266,8 +265,8 @@ public class LineageAdminTest extends AppFabricTestBase {
     // Add accesses
     addRuns(store, run1, run2, run3, run4, run5);
     // It is okay to use current time here since access time is ignore during assertions
-    lineageStore.addAccess(run1, dataset1.toId(), AccessType.READ, System.currentTimeMillis(), flowlet1.toId());
-    lineageStore.addAccess(run1, dataset1.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet1.toId());
+    lineageStore.addAccess(run1, dataset1, AccessType.READ, System.currentTimeMillis(), flowlet1);
+    lineageStore.addAccess(run1, dataset1, AccessType.WRITE, System.currentTimeMillis(), flowlet1);
 
     Lineage expectedLineage = new Lineage(
       ImmutableSet.of(
@@ -276,7 +275,7 @@ public class LineageAdminTest extends AppFabricTestBase {
         )
     );
 
-    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset1.toId(), 500, 20000, 100));
+    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset1, 500, 20000, 100));
   }
 
   @Test
@@ -288,7 +287,7 @@ public class LineageAdminTest extends AppFabricTestBase {
     // D1 <- P1 (run2)
     //
     LineageStore lineageStore = new LineageStore(getTxExecFactory(), getDatasetFramework(),
-                                                 NamespaceId.DEFAULT.dataset("testDirectCycleTwoRuns").toId());
+                                                 NamespaceId.DEFAULT.dataset("testDirectCycleTwoRuns"));
     Store store = getInjector().getInstance(Store.class);
     MetadataStore metadataStore = getInjector().getInstance(MetadataStore.class);
     LineageAdmin lineageAdmin = new LineageAdmin(lineageStore, store, metadataStore, new NoOpEntityExistenceVerifier());
@@ -296,10 +295,11 @@ public class LineageAdminTest extends AppFabricTestBase {
     // Add accesses
     addRuns(store, run1, run2, run3, run4, run5);
     // It is okay to use current time here since access time is ignore during assertions
-    lineageStore.addAccess(run1, dataset1.toId(), AccessType.READ, System.currentTimeMillis(), flowlet1.toId());
+    lineageStore.addAccess(run1, dataset1, AccessType.READ, System.currentTimeMillis(), flowlet1);
     // Write is in a different run
-    lineageStore.addAccess(new Id.Run(run1.getProgram(), run2.getId()), dataset1.toId(), AccessType.WRITE,
-                           System.currentTimeMillis(), flowlet1.toId());
+    lineageStore.addAccess(new ProgramRunId(run1.getNamespace(), run1.getApplication(), run1.getParent().getType(),
+                                            run1.getProgram(), run2.getEntityName()), dataset1, AccessType.WRITE,
+                           System.currentTimeMillis(), flowlet1);
 
     Lineage expectedLineage = new Lineage(
       ImmutableSet.of(
@@ -308,7 +308,7 @@ public class LineageAdminTest extends AppFabricTestBase {
       )
     );
 
-    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset1.toId(), 500, 20000, 100));
+    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset1, 500, 20000, 100));
   }
 
   @Test
@@ -324,7 +324,7 @@ public class LineageAdminTest extends AppFabricTestBase {
     // S1 -->|     ---------------> P4 -> D7
 
     LineageStore lineageStore = new LineageStore(getTxExecFactory(), getDatasetFramework(),
-                                                 NamespaceId.DEFAULT.dataset("testBranchLineage").toId());
+                                                 NamespaceId.DEFAULT.dataset("testBranchLineage"));
     Store store = getInjector().getInstance(Store.class);
     MetadataStore metadataStore = getInjector().getInstance(MetadataStore.class);
     LineageAdmin lineageAdmin = new LineageAdmin(lineageStore, store, metadataStore, new NoOpEntityExistenceVerifier());
@@ -332,21 +332,21 @@ public class LineageAdminTest extends AppFabricTestBase {
     // Add accesses
     addRuns(store, run1, run2, run3, run4, run5);
     // It is okay to use current time here since access time is ignore during assertions
-    lineageStore.addAccess(run1, stream1.toId(), AccessType.READ, System.currentTimeMillis(), flowlet1.toId());
-    lineageStore.addAccess(run1, dataset1.toId(), AccessType.READ, System.currentTimeMillis(), flowlet1.toId());
-    lineageStore.addAccess(run1, dataset2.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet1.toId());
-    lineageStore.addAccess(run1, dataset4.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet1.toId());
+    lineageStore.addAccess(run1, stream1, AccessType.READ, System.currentTimeMillis(), flowlet1);
+    lineageStore.addAccess(run1, dataset1, AccessType.READ, System.currentTimeMillis(), flowlet1);
+    lineageStore.addAccess(run1, dataset2, AccessType.WRITE, System.currentTimeMillis(), flowlet1);
+    lineageStore.addAccess(run1, dataset4, AccessType.WRITE, System.currentTimeMillis(), flowlet1);
 
-    lineageStore.addAccess(run2, dataset2.toId(), AccessType.READ, System.currentTimeMillis(), flowlet2.toId());
-    lineageStore.addAccess(run2, dataset3.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet2.toId());
-    lineageStore.addAccess(run2, dataset5.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet2.toId());
+    lineageStore.addAccess(run2, dataset2, AccessType.READ, System.currentTimeMillis(), flowlet2);
+    lineageStore.addAccess(run2, dataset3, AccessType.WRITE, System.currentTimeMillis(), flowlet2);
+    lineageStore.addAccess(run2, dataset5, AccessType.WRITE, System.currentTimeMillis(), flowlet2);
 
-    lineageStore.addAccess(run3, dataset5.toId(), AccessType.READ, System.currentTimeMillis());
-    lineageStore.addAccess(run3, dataset6.toId(), AccessType.WRITE, System.currentTimeMillis());
+    lineageStore.addAccess(run3, dataset5, AccessType.READ, System.currentTimeMillis());
+    lineageStore.addAccess(run3, dataset6, AccessType.WRITE, System.currentTimeMillis());
 
-    lineageStore.addAccess(run4, dataset2.toId(), AccessType.READ, System.currentTimeMillis());
-    lineageStore.addAccess(run4, dataset3.toId(), AccessType.READ, System.currentTimeMillis());
-    lineageStore.addAccess(run4, dataset7.toId(), AccessType.WRITE, System.currentTimeMillis());
+    lineageStore.addAccess(run4, dataset2, AccessType.READ, System.currentTimeMillis());
+    lineageStore.addAccess(run4, dataset3, AccessType.READ, System.currentTimeMillis());
+    lineageStore.addAccess(run4, dataset7, AccessType.WRITE, System.currentTimeMillis());
 
     Lineage expectedLineage = new Lineage(
       ImmutableSet.of(
@@ -369,11 +369,11 @@ public class LineageAdminTest extends AppFabricTestBase {
     );
 
     // Lineage for D7
-    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset7.toId(), 500, 20000, 100));
+    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset7, 500, 20000, 100));
     // Lineage for D6
-    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset6.toId(), 500, 20000, 100));
+    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset6, 500, 20000, 100));
     // Lineage for D3
-    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset3.toId(), 500, 20000, 100));
+    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset3, 500, 20000, 100));
   }
 
   @Test
@@ -392,7 +392,7 @@ public class LineageAdminTest extends AppFabricTestBase {
     // S1 -->|     ---------------> P4 -> D7
 
     LineageStore lineageStore = new LineageStore(getTxExecFactory(), getDatasetFramework(),
-                                                 NamespaceId.DEFAULT.dataset("testBranchLoopLineage").toId());
+                                                 NamespaceId.DEFAULT.dataset("testBranchLoopLineage"));
     Store store = getInjector().getInstance(Store.class);
     MetadataStore metadataStore = getInjector().getInstance(MetadataStore.class);
     LineageAdmin lineageAdmin = new LineageAdmin(lineageStore, store, metadataStore, new NoOpEntityExistenceVerifier());
@@ -400,25 +400,25 @@ public class LineageAdminTest extends AppFabricTestBase {
     // Add accesses
     addRuns(store, run1, run2, run3, run4, run5);
     // It is okay to use current time here since access time is ignore during assertions
-    lineageStore.addAccess(run1, stream1.toId(), AccessType.READ, System.currentTimeMillis(), flowlet1.toId());
-    lineageStore.addAccess(run1, dataset1.toId(), AccessType.READ, System.currentTimeMillis(), flowlet1.toId());
-    lineageStore.addAccess(run1, dataset2.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet1.toId());
-    lineageStore.addAccess(run1, dataset4.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet1.toId());
+    lineageStore.addAccess(run1, stream1, AccessType.READ, System.currentTimeMillis(), flowlet1);
+    lineageStore.addAccess(run1, dataset1, AccessType.READ, System.currentTimeMillis(), flowlet1);
+    lineageStore.addAccess(run1, dataset2, AccessType.WRITE, System.currentTimeMillis(), flowlet1);
+    lineageStore.addAccess(run1, dataset4, AccessType.WRITE, System.currentTimeMillis(), flowlet1);
 
-    lineageStore.addAccess(run2, dataset2.toId(), AccessType.READ, System.currentTimeMillis(), flowlet2.toId());
-    lineageStore.addAccess(run2, dataset3.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet2.toId());
-    lineageStore.addAccess(run2, dataset5.toId(), AccessType.WRITE, System.currentTimeMillis(), flowlet2.toId());
+    lineageStore.addAccess(run2, dataset2, AccessType.READ, System.currentTimeMillis(), flowlet2);
+    lineageStore.addAccess(run2, dataset3, AccessType.WRITE, System.currentTimeMillis(), flowlet2);
+    lineageStore.addAccess(run2, dataset5, AccessType.WRITE, System.currentTimeMillis(), flowlet2);
 
-    lineageStore.addAccess(run3, dataset5.toId(), AccessType.READ, System.currentTimeMillis());
-    lineageStore.addAccess(run3, dataset6.toId(), AccessType.WRITE, System.currentTimeMillis());
+    lineageStore.addAccess(run3, dataset5, AccessType.READ, System.currentTimeMillis());
+    lineageStore.addAccess(run3, dataset6, AccessType.WRITE, System.currentTimeMillis());
 
-    lineageStore.addAccess(run4, dataset2.toId(), AccessType.READ, System.currentTimeMillis());
-    lineageStore.addAccess(run4, dataset3.toId(), AccessType.READ, System.currentTimeMillis());
-    lineageStore.addAccess(run4, dataset7.toId(), AccessType.WRITE, System.currentTimeMillis());
+    lineageStore.addAccess(run4, dataset2, AccessType.READ, System.currentTimeMillis());
+    lineageStore.addAccess(run4, dataset3, AccessType.READ, System.currentTimeMillis());
+    lineageStore.addAccess(run4, dataset7, AccessType.WRITE, System.currentTimeMillis());
 
-    lineageStore.addAccess(run5, dataset3.toId(), AccessType.READ, System.currentTimeMillis());
-    lineageStore.addAccess(run5, dataset6.toId(), AccessType.READ, System.currentTimeMillis());
-    lineageStore.addAccess(run5, dataset1.toId(), AccessType.WRITE, System.currentTimeMillis());
+    lineageStore.addAccess(run5, dataset3, AccessType.READ, System.currentTimeMillis());
+    lineageStore.addAccess(run5, dataset6, AccessType.READ, System.currentTimeMillis());
+    lineageStore.addAccess(run5, dataset1, AccessType.WRITE, System.currentTimeMillis());
 
     Lineage expectedLineage = new Lineage(
       ImmutableSet.of(
@@ -445,20 +445,20 @@ public class LineageAdminTest extends AppFabricTestBase {
     );
 
     // Lineage for D1
-    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset1.toId(), 500, 20000, 100));
+    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset1, 500, 20000, 100));
     // Lineage for D5
-    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset5.toId(), 500, 20000, 100));
+    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset5, 500, 20000, 100));
     // Lineage for D7
-    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset7.toId(), 500, 20000, 100));
+    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(dataset7, 500, 20000, 100));
     // Lineage for S1
-    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(stream1.toId(), 500, 20000, 100));
+    Assert.assertEquals(expectedLineage, lineageAdmin.computeLineage(stream1, 500, 20000, 100));
 
     // Lineage for D5 for one level
     //                   -> D5 -> P3 -> D6
     //                   |
     //                   |
     //             D2 -> P2 -> D3
-    Lineage oneLevelLineage = lineageAdmin.computeLineage(dataset5.toId(), 500, 20000, 1);
+    Lineage oneLevelLineage = lineageAdmin.computeLineage(dataset5, 500, 20000, 1);
 
     Assert.assertEquals(
       ImmutableSet.of(
@@ -482,7 +482,7 @@ public class LineageAdminTest extends AppFabricTestBase {
     //       |
     // S1 -->|
 
-    oneLevelLineage = lineageAdmin.computeLineage(stream1.toId(), 500, 20000, 1);
+    oneLevelLineage = lineageAdmin.computeLineage(stream1, 500, 20000, 1);
     Assert.assertEquals(
       ImmutableSet.of(
         new Relation(stream1, program1, AccessType.READ, twillRunId(run1), toSet(flowlet1)),
@@ -518,9 +518,10 @@ public class LineageAdminTest extends AppFabricTestBase {
     Assert.assertEquals(101, scanRange.getEnd());
   }
 
-  private void addRuns(Store store, Id.Run... runs) {
-    for (Id.Run run : runs) {
-      store.setStart(run.getProgram(), run.getId(), RunIds.getTime(RunIds.fromString(run.getId()), TimeUnit.SECONDS));
+  private void addRuns(Store store, ProgramRunId... runs) {
+    for (ProgramRunId run : runs) {
+      store.setStart(run.getParent().toId(), run.getEntityName(), RunIds.getTime(
+        RunIds.fromString(run.getEntityName()), TimeUnit.SECONDS));
     }
   }
 
@@ -537,8 +538,8 @@ public class LineageAdminTest extends AppFabricTestBase {
     return Collections.emptySet();
   }
 
-  private RunId twillRunId(Id.Run run) {
-    return RunIds.fromString(run.getId());
+  private RunId twillRunId(ProgramRunId run) {
+    return RunIds.fromString(run.getEntityName());
   }
 
   private TransactionExecutorFactory getTxExecFactory() {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageStoreReader.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageStoreReader.java
@@ -16,8 +16,11 @@
 
 package co.cask.cdap.data2.metadata.lineage;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.base.Predicate;
 
 import java.util.Set;
@@ -31,7 +34,7 @@ public interface LineageStoreReader {
   /**
    * @return a set of entities (program and data it accesses) associated with a program run.
    */
-  Set<NamespacedEntityId> getEntitiesForRun(Id.Run run);
+  Set<NamespacedEntityId> getEntitiesForRun(ProgramRunId run);
 
   /**
    * Fetch program-dataset access information for a dataset for a given period.
@@ -42,7 +45,7 @@ public interface LineageStoreReader {
    * @param filter filter to be applied on result set
    * @return program-dataset access information
    */
-  Set<Relation> getRelations(Id.DatasetInstance datasetInstance, long start, long end,
+  Set<Relation> getRelations(DatasetId datasetInstance, long start, long end,
                              Predicate<Relation> filter);
 
   /**
@@ -54,7 +57,7 @@ public interface LineageStoreReader {
    * @param filter filter to be applied on result set
    * @return program-stream access information
    */
-  Set<Relation> getRelations(Id.Stream stream, long start, long end,
+  Set<Relation> getRelations(StreamId stream, long start, long end,
                              Predicate<Relation> filter);
 
   /**
@@ -66,6 +69,6 @@ public interface LineageStoreReader {
    * @param filter filter to be applied on result set
    * @return program-dataset access information
    */
-  Set<Relation> getRelations(Id.Program program, long start, long end,
+  Set<Relation> getRelations(ProgramId program, long start, long end,
                              Predicate<Relation> filter);
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageStoreWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageStoreWriter.java
@@ -16,7 +16,10 @@
 
 package co.cask.cdap.data2.metadata.lineage;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.proto.id.StreamId;
 
 import javax.annotation.Nullable;
 
@@ -34,7 +37,7 @@ public interface LineageStoreWriter {
    * @param accessType access type
    * @param accessTimeMillis time of access
    */
-  void addAccess(Id.Run run, Id.DatasetInstance datasetInstance, AccessType accessType, long accessTimeMillis);
+  void addAccess(ProgramRunId run, DatasetId datasetInstance, AccessType accessType, long accessTimeMillis);
 
   /**
    * Add a program-dataset access.
@@ -45,9 +48,9 @@ public interface LineageStoreWriter {
    * @param accessTimeMillis time of access
    * @param component program component such as flowlet id, etc.
    */
-  void addAccess(Id.Run run, Id.DatasetInstance datasetInstance,
+  void addAccess(ProgramRunId run, DatasetId datasetInstance,
                  AccessType accessType, long accessTimeMillis,
-                 @Nullable Id.NamespacedId component);
+                 @Nullable NamespacedEntityId component);
 
   /**
    * Add a program-stream access.
@@ -57,7 +60,7 @@ public interface LineageStoreWriter {
    * @param accessType access type
    * @param accessTimeMillis time of access
    */
-  void addAccess(Id.Run run, Id.Stream stream, AccessType accessType, long accessTimeMillis);
+  void addAccess(ProgramRunId run, StreamId stream, AccessType accessType, long accessTimeMillis);
 
   /**
    * Add a program-stream access.
@@ -68,7 +71,7 @@ public interface LineageStoreWriter {
    * @param accessTimeMillis time of access
    * @param component program component such as flowlet id, etc.
    */
-  void addAccess(Id.Run run, Id.Stream stream,
+  void addAccess(ProgramRunId run, StreamId stream,
                  AccessType accessType, long accessTimeMillis,
-                 @Nullable Id.NamespacedId component);
+                 @Nullable NamespacedEntityId component);
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/BasicLineageWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/BasicLineageWriter.java
@@ -19,7 +19,10 @@ package co.cask.cdap.data2.metadata.writer;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.data2.metadata.lineage.LineageStore;
 import co.cask.cdap.data2.metadata.lineage.LineageStoreWriter;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,13 +48,13 @@ public class BasicLineageWriter implements LineageWriter {
   }
 
   @Override
-  public void addAccess(Id.Run run, Id.DatasetInstance datasetInstance, AccessType accessType) {
+  public void addAccess(ProgramRunId run, DatasetId datasetInstance, AccessType accessType) {
     addAccess(run, datasetInstance, accessType, null);
   }
 
   @Override
-  public void addAccess(Id.Run run, Id.DatasetInstance datasetInstance, AccessType accessType,
-                        @Nullable Id.NamespacedId component) {
+  public void addAccess(ProgramRunId run, DatasetId datasetInstance, AccessType accessType,
+                        @Nullable NamespacedEntityId component) {
     if (alreadyRegistered(run, datasetInstance, accessType, component)) {
       return;
     }
@@ -63,12 +66,13 @@ public class BasicLineageWriter implements LineageWriter {
   }
 
   @Override
-  public void addAccess(Id.Run run, Id.Stream stream, AccessType accessType) {
+  public void addAccess(ProgramRunId run, StreamId stream, AccessType accessType) {
     addAccess(run, stream, accessType, null);
   }
 
   @Override
-  public void addAccess(Id.Run run, Id.Stream stream, AccessType accessType, @Nullable Id.NamespacedId component) {
+  public void addAccess(ProgramRunId run, StreamId stream, AccessType accessType,
+                        @Nullable NamespacedEntityId component) {
     if (alreadyRegistered(run, stream, accessType, component)) {
       return;
     }
@@ -79,8 +83,8 @@ public class BasicLineageWriter implements LineageWriter {
     lineageStoreWriter.addAccess(run, stream, accessType, accessTime, component);
   }
 
-  private boolean alreadyRegistered(Id.Run run, Id.NamespacedId data, AccessType accessType,
-                                    @Nullable Id.NamespacedId component) {
+  private boolean alreadyRegistered(ProgramRunId run, NamespacedEntityId data, AccessType accessType,
+                                    @Nullable NamespacedEntityId component) {
     return registered.putIfAbsent(new DataAccessKey(run, data, accessType, component), true) != null;
   }
 
@@ -88,12 +92,13 @@ public class BasicLineageWriter implements LineageWriter {
    * Key used to keep track of whether a particular access has been recorded already or not (for lineage).
    */
   public static final class DataAccessKey {
-    private final Id.Run run;
-    private final Id.NamespacedId data;
+    private final ProgramRunId run;
+    private final NamespacedEntityId data;
     private final AccessType accessType;
-    private final Id.NamespacedId component;
+    private final NamespacedEntityId component;
 
-    public DataAccessKey(Id.Run run, Id.NamespacedId data, AccessType accessType, @Nullable Id.NamespacedId component) {
+    public DataAccessKey(ProgramRunId run, NamespacedEntityId data, AccessType accessType, 
+                         @Nullable NamespacedEntityId component) {
       this.run = run;
       this.data = data;
       this.accessType = accessType;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriter.java
@@ -17,7 +17,10 @@
 package co.cask.cdap.data2.metadata.writer;
 
 import co.cask.cdap.data2.metadata.lineage.AccessType;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.proto.id.StreamId;
 
 import javax.annotation.Nullable;
 
@@ -32,7 +35,7 @@ public interface LineageWriter {
    * @param datasetInstance dataset accessed by the program
    * @param accessType access type
    */
-  void addAccess(Id.Run run, Id.DatasetInstance datasetInstance, AccessType accessType);
+  void addAccess(ProgramRunId run, DatasetId datasetInstance, AccessType accessType);
 
   /**
    * Add a program-dataset access.
@@ -42,8 +45,8 @@ public interface LineageWriter {
    * @param accessType access type
    * @param component program component such as flowlet id, etc.
    */
-  void addAccess(Id.Run run, Id.DatasetInstance datasetInstance,
-                 AccessType accessType, @Nullable Id.NamespacedId component);
+  void addAccess(ProgramRunId run, DatasetId datasetInstance,
+                 AccessType accessType, @Nullable NamespacedEntityId component);
 
   /**
    * Add a program-stream access.
@@ -52,7 +55,7 @@ public interface LineageWriter {
    * @param stream stream accessed by the program
    * @param accessType access type
    */
-  void addAccess(Id.Run run, Id.Stream stream, AccessType accessType);
+  void addAccess(ProgramRunId run, StreamId stream, AccessType accessType);
 
   /**
    * Add a program-stream access.
@@ -62,6 +65,6 @@ public interface LineageWriter {
    * @param accessType access type
    * @param component program component such as flowlet id, etc.
    */
-  void addAccess(Id.Run run, Id.Stream stream,
-                 AccessType accessType, @Nullable Id.NamespacedId component);
+  void addAccess(ProgramRunId run, StreamId stream,
+                 AccessType accessType, @Nullable NamespacedEntityId component);
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/NoOpLineageWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/NoOpLineageWriter.java
@@ -17,7 +17,10 @@
 package co.cask.cdap.data2.metadata.writer;
 
 import co.cask.cdap.data2.metadata.lineage.AccessType;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.proto.id.StreamId;
 
 import javax.annotation.Nullable;
 
@@ -26,23 +29,24 @@ import javax.annotation.Nullable;
  */
 public class NoOpLineageWriter implements LineageWriter {
   @Override
-  public void addAccess(Id.Run run, Id.DatasetInstance datasetInstance, AccessType accessType) {
+  public void addAccess(ProgramRunId run, DatasetId datasetInstance, AccessType accessType) {
     // no-op
   }
 
   @Override
-  public void addAccess(Id.Run run, Id.DatasetInstance datasetInstance, AccessType accessType,
-                        @Nullable Id.NamespacedId component) {
+  public void addAccess(ProgramRunId run, DatasetId datasetInstance, AccessType accessType,
+                        @Nullable NamespacedEntityId component) {
     // no-op
   }
 
   @Override
-  public void addAccess(Id.Run run, Id.Stream stream, AccessType accessType) {
+  public void addAccess(ProgramRunId run, StreamId stream, AccessType accessType) {
     // no-op
   }
 
   @Override
-  public void addAccess(Id.Run run, Id.Stream stream, AccessType accessType, @Nullable Id.NamespacedId component) {
+  public void addAccess(ProgramRunId run, StreamId stream, AccessType accessType,
+                        @Nullable NamespacedEntityId component) {
     // no-op
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/ProgramContext.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/ProgramContext.java
@@ -16,7 +16,8 @@
 
 package co.cask.cdap.data2.metadata.writer;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.id.ProgramRunId;
 
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
@@ -25,25 +26,25 @@ import javax.annotation.Nullable;
  * Helper classs to store program context for lineage writing.
  */
 public class ProgramContext {
-  private final AtomicReference<Id.Run> runRef = new AtomicReference<>();
-  private final AtomicReference<Id.NamespacedId> componentIdRef = new AtomicReference<>();
+  private final AtomicReference<ProgramRunId> runRef = new AtomicReference<>();
+  private final AtomicReference<NamespacedEntityId> componentIdRef = new AtomicReference<>();
 
-  public void initContext(Id.Run run) {
+  public void initContext(ProgramRunId run) {
     runRef.set(run);
   }
 
-  public void initContext(Id.Run run, Id.NamespacedId componentId) {
+  public void initContext(ProgramRunId run, NamespacedEntityId componentId) {
     runRef.set(run);
     componentIdRef.set(componentId);
   }
 
   @Nullable
-  public Id.Run getRun() {
+  public ProgramRunId getRun() {
     return runRef.get();
   }
 
   @Nullable
-  public Id.NamespacedId getComponentId() {
+  public NamespacedEntityId getComponentId() {
     return componentIdRef.get();
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/inmemory/InMemoryStreamAdmin.java
@@ -198,7 +198,7 @@ public class InMemoryStreamAdmin extends InMemoryQueueAdmin implements StreamAdm
 
   @Override
   public void addAccess(Id.Run run, Id.Stream streamId, AccessType accessType) {
-    lineageWriter.addAccess(run, streamId, accessType);
+    lineageWriter.addAccess(run.toEntityId(), streamId.toEntityId(), accessType);
     AuditPublishers.publishAccess(auditPublisher, streamId, accessType, run);
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
@@ -582,7 +582,7 @@ public class FileStreamAdmin implements StreamAdmin {
 
   @Override
   public void addAccess(Id.Run run, Id.Stream streamId, AccessType accessType) {
-    lineageWriter.addAccess(run, streamId, accessType);
+    lineageWriter.addAccess(run.toEntityId(), streamId.toEntityId(), accessType);
     AuditPublishers.publishAccess(auditPublisher, streamId, accessType, run);
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/writer/BasicLineageWriterTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/writer/BasicLineageWriterTest.java
@@ -71,8 +71,8 @@ public class BasicLineageWriterTest {
     // Tag stream
     metadataStore.addTags(MetadataScope.USER, stream, "stag1", "stag2");
     // Write access for run1
-    lineageWriter.addAccess(run1.toId(), stream.toId(), AccessType.READ);
-    Assert.assertEquals(ImmutableSet.of(program, stream), lineageStore.getEntitiesForRun(run1.toId()));
+    lineageWriter.addAccess(run1, stream, AccessType.READ);
+    Assert.assertEquals(ImmutableSet.of(program, stream), lineageStore.getEntitiesForRun(run1));
 
     // Record time to verify duplicate writes.
     long beforeSecondTag = System.currentTimeMillis();
@@ -82,14 +82,14 @@ public class BasicLineageWriterTest {
     // Add another tag to stream
     metadataStore.addTags(MetadataScope.USER, stream, "stag3");
     // Write access for run1 again
-    lineageWriter.addAccess(run1.toId(), stream.toId(), AccessType.READ);
+    lineageWriter.addAccess(run1, stream, AccessType.READ);
     // The write should be no-op, and access time for run1 should not be updated
-    Assert.assertTrue(lineageStore.getAccessTimesForRun(run1.toId()).get(0) < beforeSecondTag);
+    Assert.assertTrue(lineageStore.getAccessTimesForRun(run1).get(0) < beforeSecondTag);
 
     // However, you can write access for another run
-    lineageWriter.addAccess(run2.toId(), stream.toId(), AccessType.READ);
+    lineageWriter.addAccess(run2, stream, AccessType.READ);
     // Assert new access time is written
-    Assert.assertTrue(lineageStore.getAccessTimesForRun(run2.toId()).get(0) >= beforeSecondTag);
+    Assert.assertTrue(lineageStore.getAccessTimesForRun(run2).get(0) >= beforeSecondTag);
   }
 
   private static Injector getInjector() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramRunId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramRunId.java
@@ -56,7 +56,7 @@ public class ProgramRunId extends NamespacedEntityId implements ParentedId<Progr
 
   @Override
   public String getEntityName() {
-    return getProgram();
+    return run;
   }
 
   public String getRun() {


### PR DESCRIPTION
Phasing deprecated `Id` class usages out of lineage-related classes.
