### PR TITLE
update hdinsight install script artifact location

### DIFF
--- a/cdap-distributions/src/hdinsight/mainTemplate.json
+++ b/cdap-distributions/src/hdinsight/mainTemplate.json
@@ -50,12 +50,12 @@
       },
       "installScriptActions": [{
         "name": "[concat('cdap-pageblob-configure-v0','-' ,uniquestring(variables('applicationName')))]",
-        "uri": "https://raw.githubusercontent.com/caskdata/cdap/release/3.5/cdap-distributions/src/hdinsight/pageblob-configure.sh",
+        "uri": "http://downloads.cask.co/hdinsight/pageblob-configure.sh",
         "roles": ["edgenode"]
       },
       {
         "name": "[concat('cdap-install-v0','-' ,uniquestring(variables('applicationName')))]",
-        "uri": "https://raw.githubusercontent.com/caskdata/cdap/release/3.5/cdap-distributions/src/hdinsight/install.sh",
+        "uri": "http://downloads.cask.co/hdinsight/install.sh",
         "roles": ["edgenode"]
       }],
       "uninstallScriptActions": [],


### PR DESCRIPTION
This updates the location of the hdinsight install scripts to the "final" locations.  This file is in a package uploaded to azure.

Our `Deploy Artifacts` build deploys these scripts to this location, but with a version appended.  As an extra layer of protection we are manually copying them to their version-less form here.  The idea is we want to be able to replace these scripts as we release cdap without having to upload new packages to Azure.
