### PR TITLE
Removed Id Class Usages from Data Fabric and Related Classes

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/DefaultStreamWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/DefaultStreamWriter.java
@@ -28,6 +28,7 @@ import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
 import co.cask.cdap.data2.registry.RuntimeUsageRegistry;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
@@ -69,7 +70,7 @@ public class DefaultStreamWriter implements StreamWriter {
   /**
    * The owners of this {@link StreamWriter}.
    */
-  private final Iterable<? extends Id> owners;
+  private final Iterable<? extends EntityId> owners;
   private final Id.Run run;
   private final LineageWriter lineageWriter;
   private final AuthenticationContext authenticationContext;
@@ -77,7 +78,7 @@ public class DefaultStreamWriter implements StreamWriter {
 
   @Inject
   public DefaultStreamWriter(@Assisted("run") Id.Run run,
-                             @Assisted("owners") Iterable<? extends Id> owners,
+                             @Assisted("owners") Iterable<? extends EntityId> owners,
                              RuntimeUsageRegistry runtimeUsageRegistry,
                              LineageWriter lineageWriter,
                              DiscoveryServiceClient discoveryServiceClient,
@@ -197,7 +198,7 @@ public class DefaultStreamWriter implements StreamWriter {
   private void registerStream(Id.Stream stream) {
     // prone to being entered multiple times, but OK since usageRegistry.register is not an expensive operation
     if (!isStreamRegistered.containsKey(stream)) {
-      runtimeUsageRegistry.registerAll(owners, stream);
+      runtimeUsageRegistry.registerAll(owners, stream.toEntityId());
       isStreamRegistered.put(stream, true);
     }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/StreamWriterFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/StreamWriterFactory.java
@@ -18,6 +18,7 @@ package co.cask.cdap.app.stream;
 
 import co.cask.cdap.api.data.stream.StreamWriter;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.EntityId;
 import com.google.inject.assistedinject.Assisted;
 
 /**
@@ -29,6 +30,6 @@ public interface StreamWriterFactory {
    * @param run run information
    * @return a {@link StreamWriter} for the specified namespaceId
    */
-  StreamWriter create(@Assisted("run") Id.Run run, @Assisted("owners") Iterable<? extends Id> owners);
+  StreamWriter create(@Assisted("run") Id.Run run, @Assisted("owners") Iterable<? extends EntityId> owners);
 }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/config/DefaultConfigStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/config/DefaultConfigStore.java
@@ -75,7 +75,7 @@ public class DefaultConfigStore implements ConfigStore {
   }
 
   public static void setupDatasets(DatasetFramework dsFramework) throws DatasetManagementException, IOException {
-    dsFramework.addInstance(Table.class.getName(), CONFIG_STORE_DATASET_INSTANCE_ID.toId(), DatasetProperties.EMPTY);
+    dsFramework.addInstance(Table.class.getName(), CONFIG_STORE_DATASET_INSTANCE_ID, DatasetProperties.EMPTY);
   }
 
   private Table getConfigTable(DatasetContext context) throws IOException, DatasetManagementException {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/DatasetServiceStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/DatasetServiceStore.java
@@ -23,9 +23,10 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.kv.NoTxKeyValueTable;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.RestartServiceInstancesStatus;
 import co.cask.cdap.proto.RestartServiceInstancesStatus.RestartStatus;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.DiscreteDomains;
 import com.google.common.collect.ImmutableSet;
@@ -64,8 +65,7 @@ public final class DatasetServiceStore extends AbstractIdleService implements Se
 
   @Override
   protected void startUp() throws Exception {
-    Id.DatasetInstance serviceStoreDatasetInstanceId =
-      Id.DatasetInstance.from(Id.Namespace.SYSTEM, Constants.Service.SERVICE_INSTANCE_TABLE_NAME);
+    DatasetId serviceStoreDatasetInstanceId = NamespaceId.SYSTEM.dataset(Constants.Service.SERVICE_INSTANCE_TABLE_NAME);
     table = DatasetsUtil.getOrCreateDataset(dsFramework, serviceStoreDatasetInstanceId,
                                             NoTxKeyValueTable.class.getName(),
                                             DatasetProperties.EMPTY, null, null);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/UsageHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/UsageHandler.java
@@ -18,8 +18,12 @@ package co.cask.cdap.gateway.handlers;
 
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.registry.UsageRegistry;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpResponder;
 import com.google.inject.Inject;
@@ -49,8 +53,8 @@ public class UsageHandler extends AbstractHttpHandler {
   public void getAppDatasetUsage(HttpRequest request, HttpResponder responder,
                                  @PathParam("namespace-id") String namespaceId,
                                  @PathParam("app-id") String appId) {
-    final Id.Application id = Id.Application.from(namespaceId, appId);
-    Set<? extends Id> ids = registry.getDatasets(id);
+    final ApplicationId id = new ApplicationId(namespaceId, appId);
+    Set<? extends EntityId> ids = registry.getDatasets(id);
     responder.sendJson(HttpResponseStatus.OK, ids);
   }
 
@@ -59,8 +63,8 @@ public class UsageHandler extends AbstractHttpHandler {
   public void getAppStreamUsage(HttpRequest request, HttpResponder responder,
                                 @PathParam("namespace-id") String namespaceId,
                                 @PathParam("app-id") String appId) {
-    final Id.Application id = Id.Application.from(namespaceId, appId);
-    Set<? extends Id> ids = registry.getStreams(id);
+    final ApplicationId id = new ApplicationId(namespaceId, appId);
+    Set<? extends EntityId> ids = registry.getStreams(id);
     responder.sendJson(HttpResponseStatus.OK, ids);
   }
 
@@ -72,8 +76,8 @@ public class UsageHandler extends AbstractHttpHandler {
                                      @PathParam("program-type") String programType,
                                      @PathParam("program-id") String programId) {
     ProgramType type = ProgramType.valueOfCategoryName(programType);
-    final Id.Program id = Id.Program.from(namespaceId, appId, type, programId);
-    Set<? extends Id> ids = registry.getDatasets(id);
+    final ProgramId id = new ProgramId(namespaceId, appId, type, programId);
+    Set<? extends EntityId> ids = registry.getDatasets(id);
     responder.sendJson(HttpResponseStatus.OK, ids);
   }
 
@@ -85,8 +89,8 @@ public class UsageHandler extends AbstractHttpHandler {
                                     @PathParam("program-type") String programType,
                                     @PathParam("program-id") String programId) {
     ProgramType type = ProgramType.valueOfCategoryName(programType);
-    final Id.Program id = Id.Program.from(namespaceId, appId, type, programId);
-    Set<? extends Id> ids = registry.getStreams(id);
+    final ProgramId id = new ProgramId(namespaceId, appId, type, programId);
+    Set<? extends EntityId> ids = registry.getStreams(id);
     responder.sendJson(HttpResponseStatus.OK, ids);
   }
 
@@ -95,8 +99,8 @@ public class UsageHandler extends AbstractHttpHandler {
   public void getStreamProgramUsage(HttpRequest request, HttpResponder responder,
                                 @PathParam("namespace-id") String namespaceId,
                                 @PathParam("stream-id") String streamId) {
-    final Id.Stream id = Id.Stream.from(namespaceId, streamId);
-    Set<? extends Id> ids = registry.getPrograms(id);
+    final StreamId id = new StreamId(namespaceId, streamId);
+    Set<? extends EntityId> ids = registry.getPrograms(id);
     responder.sendJson(HttpResponseStatus.OK, ids);
   }
 
@@ -105,8 +109,8 @@ public class UsageHandler extends AbstractHttpHandler {
   public void getDatasetAppUsage(HttpRequest request, HttpResponder responder,
                                  @PathParam("namespace-id") String namespaceId,
                                  @PathParam("dataset-id") String datasetId) {
-    final Id.DatasetInstance id = Id.DatasetInstance.from(namespaceId, datasetId);
-    Set<? extends Id> ids = registry.getPrograms(id);
+    final DatasetId id = new DatasetId(namespaceId, datasetId);
+    Set<? extends EntityId> ids = registry.getPrograms(id);
     responder.sendJson(HttpResponseStatus.OK, ids);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/WorkflowHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/WorkflowHttpHandler.java
@@ -55,6 +55,7 @@ import co.cask.cdap.proto.codec.ScheduleSpecificationCodec;
 import co.cask.cdap.proto.codec.WorkflowTokenDetailCodec;
 import co.cask.cdap.proto.codec.WorkflowTokenNodeDetailCodec;
 import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.Ids;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.ProgramRunId;
@@ -389,7 +390,7 @@ public class WorkflowHttpHandler extends ProgramLifecycleHttpHandler {
       String mappedDatasetName = localDatasetEntry.getKey() + "." + runId;
       String datasetType = localDatasetEntry.getValue().getTypeName();
       Map<String, String> datasetProperties = localDatasetEntry.getValue().getProperties().getProperties();
-      if (datasetFramework.hasInstance(Id.DatasetInstance.from(namespaceId, mappedDatasetName))) {
+      if (datasetFramework.hasInstance(new DatasetId(namespaceId, mappedDatasetName))) {
         localDatasetSummaries.put(localDatasetEntry.getKey(),
                                   new DatasetSpecificationSummary(mappedDatasetName, datasetType, datasetProperties));
       }
@@ -411,7 +412,7 @@ public class WorkflowHttpHandler extends ProgramLifecycleHttpHandler {
       String mappedDatasetName = localDatasetEntry.getKey() + "." + runId;
       // try best to delete the local datasets.
       try {
-        datasetFramework.deleteInstance(Id.DatasetInstance.from(namespaceId, mappedDatasetName));
+        datasetFramework.deleteInstance(new DatasetId(namespaceId, mappedDatasetName));
       } catch (InstanceNotFoundException e) {
         // Dataset instance is already deleted. so its no-op.
       } catch (Throwable t) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteUsageRegistryHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteUsageRegistryHandler.java
@@ -18,7 +18,9 @@ package co.cask.cdap.gateway.handlers.meta;
 
 import co.cask.cdap.common.internal.remote.MethodArgument;
 import co.cask.cdap.data2.registry.UsageRegistry;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.http.HttpResponder;
 import com.google.inject.Inject;
 import org.jboss.netty.handler.codec.http.HttpRequest;
@@ -46,8 +48,8 @@ public class RemoteUsageRegistryHandler extends AbstractRemoteSystemOpsHandler {
   public void registerDataset(HttpRequest request, HttpResponder responder) throws Exception {
     Iterator<MethodArgument> arguments = parseArguments(request);
 
-    Id.Program programId = deserializeNext(arguments);
-    Id.DatasetInstance datasetInstance = deserializeNext(arguments);
+    ProgramId programId = deserializeNext(arguments);
+    DatasetId datasetInstance = deserializeNext(arguments);
     usageRegistry.register(programId, datasetInstance);
 
     responder.sendStatus(HttpResponseStatus.OK);
@@ -58,8 +60,8 @@ public class RemoteUsageRegistryHandler extends AbstractRemoteSystemOpsHandler {
   public void registerStream(HttpRequest request, HttpResponder responder) throws Exception {
     Iterator<MethodArgument> arguments = parseArguments(request);
 
-    Id.Program programId = deserializeNext(arguments);
-    Id.Stream streamId = deserializeNext(arguments);
+    ProgramId programId = deserializeNext(arguments);
+    StreamId streamId = deserializeNext(arguments);
     usageRegistry.register(programId, streamId);
 
     responder.sendStatus(HttpResponseStatus.OK);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationRegistrationStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationRegistrationStage.java
@@ -29,9 +29,9 @@ import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.pipeline.AbstractStage;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramId;
 import com.google.common.reflect.TypeToken;
 
 import java.net.URI;
@@ -68,45 +68,45 @@ public class ApplicationRegistrationStage extends AbstractStage<ApplicationWithP
     NamespaceId namespaceId = appId.getParent();
 
     for (FlowSpecification flow : appSpec.getFlows().values()) {
-      Id.Program programId = appId.flow(flow.getName()).toId();
+      ProgramId programId = appId.flow(flow.getName());
       for (FlowletConnection connection : flow.getConnections()) {
         if (connection.getSourceType().equals(FlowletConnection.Type.STREAM)) {
-          usageRegistry.register(programId, namespaceId.stream(connection.getSourceName()).toId());
+          usageRegistry.register(programId, namespaceId.stream(connection.getSourceName()));
         }
       }
       for (FlowletDefinition flowlet : flow.getFlowlets().values()) {
         for (String dataset : flowlet.getDatasets()) {
-          usageRegistry.register(programId, namespaceId.dataset(dataset).toId());
+          usageRegistry.register(programId, namespaceId.dataset(dataset));
         }
       }
     }
 
     for (MapReduceSpecification program : appSpec.getMapReduce().values()) {
-      Id.Program programId = appId.mr(program.getName()).toId();
+      ProgramId programId = appId.mr(program.getName());
       for (String dataset : program.getDataSets()) {
         if (!dataset.startsWith(Constants.Stream.URL_PREFIX)) {
-          usageRegistry.register(programId, namespaceId.dataset(dataset).toId());
+          usageRegistry.register(programId, namespaceId.dataset(dataset));
         }
       }
       String inputDatasetName = program.getInputDataSet();
       if (inputDatasetName != null && inputDatasetName.startsWith(Constants.Stream.URL_PREFIX)) {
         StreamBatchReadable stream = new StreamBatchReadable(URI.create(inputDatasetName));
-        usageRegistry.register(programId, namespaceId.stream(stream.getStreamName()).toId());
+        usageRegistry.register(programId, namespaceId.stream(stream.getStreamName()));
       }
     }
 
     for (SparkSpecification sparkSpec : appSpec.getSpark().values()) {
-      Id.Program programId = appId.spark(sparkSpec.getName()).toId();
+      ProgramId programId = appId.spark(sparkSpec.getName());
       for (String dataset : sparkSpec.getDatasets()) {
-        usageRegistry.register(programId, namespaceId.dataset(dataset).toId());
+        usageRegistry.register(programId, namespaceId.dataset(dataset));
       }
     }
 
     for (ServiceSpecification serviceSpecification : appSpec.getServices().values()) {
-      Id.Program programId = appId.service(serviceSpecification.getName()).toId();
+      ProgramId programId = appId.service(serviceSpecification.getName());
       for (HttpServiceHandlerSpecification handlerSpecification : serviceSpecification.getHandlers().values()) {
         for (String dataset : handlerSpecification.getDatasets()) {
-          usageRegistry.register(programId, namespaceId.dataset(dataset).toId());
+          usageRegistry.register(programId, namespaceId.dataset(dataset));
         }
       }
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationVerificationStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/ApplicationVerificationStage.java
@@ -44,13 +44,12 @@ import co.cask.cdap.internal.app.verification.StreamVerification;
 import co.cask.cdap.internal.dataset.DatasetCreationSpec;
 import co.cask.cdap.internal.schedule.StreamSizeSchedule;
 import co.cask.cdap.pipeline.AbstractStage;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.DatasetId;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.reflect.TypeToken;
-import org.apache.hadoop.mapreduce.v2.app.webapp.App;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,7 +116,7 @@ public class ApplicationVerificationStage extends AbstractStage<ApplicationDeplo
         throw new RuntimeException(result.getMessage());
       }
       String dsName = dataSetCreateSpec.getInstanceName();
-      Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(appId.getNamespace(), dsName);
+      DatasetId datasetInstanceId = appId.getParent().dataset(dsName);
       DatasetSpecification existingSpec = dsFramework.getDatasetSpec(datasetInstanceId);
       if (existingSpec != null && !existingSpec.getType().equals(dataSetCreateSpec.getTypeName())) {
         // New app trying to deploy an dataset with same instanceName but different Type than that of existing.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DatasetInstanceCreator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DatasetInstanceCreator.java
@@ -55,10 +55,10 @@ final class DatasetInstanceCreator {
       String instanceName = instanceEntry.getKey();
       DatasetId instanceId = namespaceId.dataset(instanceName);
       DatasetCreationSpec instanceSpec = instanceEntry.getValue();
-      DatasetSpecification existingSpec = datasetFramework.getDatasetSpec(instanceId.toId());
+      DatasetSpecification existingSpec = datasetFramework.getDatasetSpec(instanceId);
       if (existingSpec == null) {
         LOG.info("Adding dataset instance: {}", instanceName);
-        datasetFramework.addInstance(instanceSpec.getTypeName(), instanceId.toId(), instanceSpec.getProperties());
+        datasetFramework.addInstance(instanceSpec.getTypeName(), instanceId, instanceSpec.getProperties());
       } else {
         if (!existingSpec.getType().equals(instanceSpec.getTypeName())) {
           throw new IncompatibleUpdateException(
@@ -67,7 +67,7 @@ final class DatasetInstanceCreator {
         }
         if (allowDatasetUncheckedUpgrade) {
           LOG.info("Updating dataset instance: {}", instanceName);
-          datasetFramework.updateInstance(instanceId.toId(), instanceSpec.getProperties());
+          datasetFramework.updateInstance(instanceId, instanceSpec.getProperties());
         }
       }
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DatasetModulesDeployer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DatasetModulesDeployer.java
@@ -82,7 +82,7 @@ final class DatasetModulesDeployer {
     }
     for (String typeName : implicitModules) {
       DatasetTypeId typeId = namespaceId.datasetType(typeName);
-      DatasetTypeMeta typeMeta = datasetFramework.getTypeInfo(typeId.toId());
+      DatasetTypeMeta typeMeta = datasetFramework.getTypeInfo(typeId);
       if (typeMeta != null) {
         String existingModule = Iterables.getLast(typeMeta.getModules()).getName();
         if (modules.containsKey(existingModule)) {
@@ -114,7 +114,7 @@ final class DatasetModulesDeployer {
           return;
         }
         DatasetTypeId typeId = namespaceId.datasetType(clazz.getName());
-        if (datasetFramework.hasType(typeId.toId()) && !allowDatasetUncheckedUpgrade) {
+        if (datasetFramework.hasType(typeId) && !allowDatasetUncheckedUpgrade) {
           return;
         }
         module = new SingleTypeModule(clazz);
@@ -123,7 +123,7 @@ final class DatasetModulesDeployer {
           "Cannot use class %s to add dataset module: it must be of type DatasetModule or Dataset", clazz.getName()));
       }
       LOG.info("Adding module: {}", clazz.getName());
-      datasetFramework.addModule(moduleId.toId(), module, jarLocation);
+      datasetFramework.addModule(moduleId, module, jarLocation);
     } catch (ModuleConflictException e) {
       LOG.info("Conflict while deploying module {}: {}", moduleName, e.getMessage());
       throw e;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
@@ -122,7 +122,7 @@ public class DeletedProgramHandlerStage extends AbstractStage<ApplicationDeploya
           @Override
           public Void call() throws Exception {
             for (Map.Entry<String, Collection<Long>> entry : streamGroups.asMap().entrySet()) {
-              streamConsumerFactory.dropAll(namespaceId.stream(entry.getKey()).toId(), namespace, entry.getValue());
+              streamConsumerFactory.dropAll(namespaceId.stream(entry.getKey()), namespace, entry.getValue());
             }
             queueAdmin.dropAllForFlow(Id.Flow.from(programId.getApplication(), programId.getEntityName()));
             return null;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/StreamCreator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/pipeline/StreamCreator.java
@@ -47,7 +47,7 @@ final class StreamCreator {
       if (spec.getDescription() != null) {
         props.put(Constants.Stream.DESCRIPTION, spec.getDescription());
       }
-      streamAdmin.create(namespaceId.stream(spec.getName()).toId(), props);
+      streamAdmin.create(namespaceId.stream(spec.getName()), props);
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -31,7 +31,6 @@ import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.security.ImpersonationInfo;
 import co.cask.cdap.common.security.Impersonator;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
-import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceConfig;
 import co.cask.cdap.proto.NamespaceMeta;
@@ -64,7 +63,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.sql.SQLException;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -311,7 +309,7 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
     // Namespace data can be deleted. Revoke all privileges first
     authorizationEnforcer.enforce(namespaceId.toEntityId(), authenticationContext.getPrincipal(), Action.ADMIN);
     try {
-      dsFramework.deleteAllInstances(namespaceId);
+      dsFramework.deleteAllInstances(namespaceId.toEntityId());
     } catch (DatasetManagementException | IOException e) {
       LOG.warn("Error while deleting datasets in namespace {}", namespaceId, e);
       throw new NamespaceCannotBeDeletedException(namespaceId, e);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceResourceDeleter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceResourceDeleter.java
@@ -94,11 +94,11 @@ public class DefaultNamespaceResourceDeleter implements NamespaceResourceDeleter
     // Delete all the schedules
     scheduler.deleteAllSchedules(namespaceId.toId());
     // Delete datasets and modules
-    dsFramework.deleteAllInstances(namespaceId.toId());
-    dsFramework.deleteAllModules(namespaceId.toId());
+    dsFramework.deleteAllInstances(namespaceId);
+    dsFramework.deleteAllModules(namespaceId);
     // Delete queues and streams data
     queueAdmin.dropAllInNamespace(namespaceId.toId());
-    streamAdmin.dropAllInNamespace(namespaceId.toId());
+    streamAdmin.dropAllInNamespace(namespaceId);
     // Delete all meta data
     store.removeAll(namespaceId);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/StreamQueueReader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/queue/StreamQueueReader.java
@@ -68,7 +68,7 @@ public final class StreamQueueReader<T> implements QueueReader<T> {
       throw new IOException(e);
     }
     StreamConsumer consumer = consumerSupplier.get();
-    return new BasicInputDatum<>(QueueName.fromStream(consumer.getStreamId()),
+    return new BasicInputDatum<>(QueueName.fromStream(consumer.getStreamId().toId()),
                                  consumer.poll(batchSize, timeout, timeoutUnit), eventTransform);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -46,8 +46,9 @@ import co.cask.cdap.data2.dataset2.SingleThreadDatasetCache;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.internal.app.program.ProgramTypeMetricTag;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramId;
 import com.google.common.collect.Maps;
 import org.apache.tephra.TransactionSystemClient;
 import org.apache.twill.api.RunId;
@@ -68,7 +69,7 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
   private final Program program;
   private final ProgramOptions programOptions;
   private final RunId runId;
-  private final Iterable<? extends Id> owners;
+  private final Iterable<? extends EntityId> owners;
   private final Map<String, String> runtimeArguments;
   private final Metrics userMetrics;
   private final MetricsContext programMetrics;
@@ -107,7 +108,7 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
     this.programOptions = programOptions;
     this.runId = ProgramRunners.getRunId(programOptions);
     this.discoveryServiceClient = discoveryServiceClient;
-    this.owners = createOwners(program.getId());
+    this.owners = createOwners(program.getId().toEntityId());
     this.programMetrics = createProgramMetrics(program, runId, metricsService, metricsTags);
     this.userMetrics = new ProgramUserMetrics(programMetrics);
 
@@ -133,7 +134,7 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
     this.secureStore = secureStore;
   }
 
-  private Iterable<? extends Id> createOwners(Id.Program programId) {
+  private Iterable<? extends EntityId> createOwners(ProgramId programId) {
     return Collections.singletonList(programId);
   }
 
@@ -162,7 +163,7 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
   /**
    * Returns a list of ID who owns this program context.
    */
-  public Iterable<? extends Id> getOwners() {
+  public Iterable<? extends EntityId> getOwners() {
     return owners;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DataFabricFacade.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DataFabricFacade.java
@@ -20,7 +20,7 @@ import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.data2.queue.ConsumerConfig;
 import co.cask.cdap.data2.queue.QueueClientFactory;
 import co.cask.cdap.data2.transaction.stream.StreamConsumer;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import org.apache.tephra.TransactionContext;
 import org.apache.tephra.TransactionExecutor;
 
@@ -37,5 +37,5 @@ public interface DataFabricFacade extends QueueClientFactory {
 
   TransactionExecutor createTransactionExecutor();
 
-  StreamConsumer createStreamConsumer(Id.Stream streamName, ConsumerConfig consumerConfig) throws IOException;
+  StreamConsumer createStreamConsumer(StreamId streamName, ConsumerConfig consumerConfig) throws IOException;
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DefaultAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DefaultAdmin.java
@@ -23,7 +23,7 @@ import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.InstanceNotFoundException;
 import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
 
 import java.io.IOException;
@@ -44,8 +44,8 @@ public class DefaultAdmin implements Admin {
     this.secureStoreManager = secureStoreManager;
   }
 
-  private Id.DatasetInstance createInstanceId(String name) {
-    return Id.DatasetInstance.from(namespace.getNamespace(), name);
+  private DatasetId createInstanceId(String name) {
+    return namespace.dataset(name);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/LineageWriterDataFabricFacade.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/LineageWriterDataFabricFacade.java
@@ -35,6 +35,7 @@ import co.cask.cdap.data2.transaction.stream.StreamConsumer;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerFactory;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import org.apache.tephra.TransactionAware;
@@ -129,14 +130,14 @@ public final class LineageWriterDataFabricFacade implements DataFabricFacade, Pr
   }
 
   @Override
-  public StreamConsumer createStreamConsumer(Id.Stream streamName, ConsumerConfig consumerConfig) throws IOException {
+  public StreamConsumer createStreamConsumer(StreamId streamName, ConsumerConfig consumerConfig) throws IOException {
     String namespace = String.format("%s.%s", programId.getApplicationId(), programId.getId());
     final StreamConsumer consumer = streamConsumerFactory.create(streamName, namespace, consumerConfig);
 
     datasetCache.addExtraTransactionAware(consumer);
 
     if (programContext.getRun() != null) {
-      lineageWriter.addAccess(programContext.getRun(), streamName.toEntityId(), AccessType.READ,
+      lineageWriter.addAccess(programContext.getRun(), streamName, AccessType.READ,
                               (NamespacedEntityId) programContext.getComponentId());
     }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
@@ -186,7 +186,7 @@ public class ArtifactStore {
    * @param framework framework to add types and datasets to
    */
   public static void setupDatasets(DatasetFramework framework) throws IOException, DatasetManagementException {
-    framework.addInstance(Table.class.getName(), META_ID.toId(), META_PROPERTIES);
+    framework.addInstance(Table.class.getName(), META_ID, META_PROPERTIES);
   }
 
   private Table getMetaTable(DatasetContext context) throws IOException, DatasetManagementException {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -56,6 +56,7 @@ import co.cask.cdap.internal.app.runtime.batch.stream.StreamInputFormatProvider;
 import co.cask.cdap.internal.app.runtime.distributed.LocalizeResource;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
@@ -700,10 +701,10 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
     Type inputValueType = getInputValueType(job.getConfiguration(), StreamEvent.class, mapperTypeToken);
     streamProvider.setDecoderType(inputFormatConfiguration, inputValueType);
 
-    Id.Stream streamId = streamProvider.getStreamId();
+    StreamId streamId = streamProvider.getStreamId().toEntityId();
     try {
-      streamAdmin.register(ImmutableList.of(context.getProgram().getId()), streamId);
-      streamAdmin.addAccess(new Id.Run(context.getProgram().getId(), context.getRunId().getId()),
+      streamAdmin.register(ImmutableList.of(context.getProgram().getId().toEntityId()), streamId);
+      streamAdmin.addAccess(context.getProgram().getId().toEntityId().run(context.getRunId().getId()),
                             streamId, AccessType.READ);
     } catch (Exception e) {
       LOG.warn("Failed to register usage {} -> {}", context.getProgram().getId(), streamId, e);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/stream/StreamInputFormatProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/stream/StreamInputFormatProvider.java
@@ -87,7 +87,7 @@ public class StreamInputFormatProvider implements InputFormatProvider {
   public Map<String, String> getInputFormatConfiguration() {
     Id.Stream streamId = Id.Stream.from(namespaceId, streamBatchReadable.getStreamName());
     try {
-      StreamConfig streamConfig = streamAdmin.getConfig(streamId);
+      StreamConfig streamConfig = streamAdmin.getConfig(streamId.toEntityId());
       Location streamPath = StreamUtils.createGenerationLocation(streamConfig.getLocation(),
                                                                  StreamUtils.getGeneration(streamConfig));
       Configuration hConf = new Configuration();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowUtils.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowUtils.java
@@ -181,7 +181,7 @@ public final class FlowUtils {
           for (ConsumerGroupConfig config : entry.getValue()) {
             configs.put(config.getGroupId(), config.getGroupSize());
           }
-          streamAdmin.configureGroups(entry.getKey().toStreamId(), configs);
+          streamAdmin.configureGroups(entry.getKey().toStreamId().toEntityId(), configs);
         } else {
           groupConfigurers.add(new ConsumerGroupConfigurer(queueAdmin.getQueueConfigurer(entry.getKey()),
                                                            entry.getValue()));
@@ -226,7 +226,7 @@ public final class FlowUtils {
     final List<QueueConfigurer> queueConfigurers = Lists.newArrayList();
     for (QueueName queueName : consumerQueues) {
       if (queueName.isStream()) {
-        streamAdmin.configureInstances(queueName.toStreamId(), groupId, instances);
+        streamAdmin.configureInstances(queueName.toStreamId().toEntityId(), groupId, instances);
       } else {
         queueConfigurers.add(queueAdmin.getQueueConfigurer(queueName));
       }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/ScheduleStoreTableUtil.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/ScheduleStoreTableUtil.java
@@ -22,7 +22,8 @@ import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.table.MetaTableUtil;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.inject.Inject;
 
 import java.io.IOException;
@@ -50,8 +51,7 @@ public class ScheduleStoreTableUtil extends MetaTableUtil {
    * @param datasetFramework framework to add types and datasets to
    */
   public static void setupDatasets(DatasetFramework datasetFramework) throws IOException, DatasetManagementException {
-    Id.DatasetInstance scheduleStoreDatasetInstance =
-      Id.DatasetInstance.from(Id.Namespace.SYSTEM, SCHEDULE_STORE_DATASET_NAME);
+    DatasetId scheduleStoreDatasetInstance = NamespaceId.SYSTEM.dataset(SCHEDULE_STORE_DATASET_NAME);
     datasetFramework.addInstance(Table.class.getName(), scheduleStoreDatasetInstance, DatasetProperties.EMPTY);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/NameMappedDatasetFramework.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/NameMappedDatasetFramework.java
@@ -26,7 +26,8 @@ import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.ForwardingProgramContextAwareDatasetFramework;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.EntityId;
 import com.google.common.base.Function;
 
 import java.io.IOException;
@@ -87,43 +88,43 @@ public class NameMappedDatasetFramework extends ForwardingProgramContextAwareDat
   }
 
   @Override
-  public void addInstance(String datasetTypeName, Id.DatasetInstance datasetInstanceId, DatasetProperties props)
+  public void addInstance(String datasetTypeName, DatasetId datasetInstanceId, DatasetProperties props)
     throws IOException, DatasetManagementException {
     super.addInstance(datasetTypeName, getMappedDatasetInstance(datasetInstanceId), props);
   }
 
   @Override
-  public void updateInstance(Id.DatasetInstance datasetInstanceId, DatasetProperties props)
+  public void updateInstance(DatasetId datasetInstanceId, DatasetProperties props)
     throws DatasetManagementException, IOException {
     super.updateInstance(getMappedDatasetInstance(datasetInstanceId), props);
   }
 
   @Nullable
   @Override
-  public DatasetSpecification getDatasetSpec(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException {
+  public DatasetSpecification getDatasetSpec(DatasetId datasetInstanceId) throws DatasetManagementException {
     return super.getDatasetSpec(getMappedDatasetInstance(datasetInstanceId));
   }
 
   @Override
-  public boolean hasInstance(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException {
+  public boolean hasInstance(DatasetId datasetInstanceId) throws DatasetManagementException {
     return super.hasInstance(getMappedDatasetInstance(datasetInstanceId));
   }
 
   @Override
-  public void deleteInstance(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException, IOException {
+  public void deleteInstance(DatasetId datasetInstanceId) throws DatasetManagementException, IOException {
     super.deleteInstance(getMappedDatasetInstance(datasetInstanceId));
   }
 
   @Nullable
   @Override
-  public <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId, @Nullable ClassLoader classLoader)
+  public <T extends DatasetAdmin> T getAdmin(DatasetId datasetInstanceId, @Nullable ClassLoader classLoader)
     throws DatasetManagementException, IOException {
     return super.getAdmin(getMappedDatasetInstance(datasetInstanceId), classLoader);
   }
 
   @Nullable
   @Override
-  public <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId, @Nullable ClassLoader classLoader,
+  public <T extends DatasetAdmin> T getAdmin(DatasetId datasetInstanceId, @Nullable ClassLoader classLoader,
                                              DatasetClassLoaderProvider classLoaderProvider)
     throws DatasetManagementException, IOException {
     return super.getAdmin(getMappedDatasetInstance(datasetInstanceId), classLoader, classLoaderProvider);
@@ -131,7 +132,7 @@ public class NameMappedDatasetFramework extends ForwardingProgramContextAwareDat
 
   @Nullable
   @Override
-  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
+  public <T extends Dataset> T getDataset(DatasetId datasetInstanceId, @Nullable Map<String, String> arguments,
                                           @Nullable ClassLoader classLoader)
     throws DatasetManagementException, IOException {
     return super.getDataset(getMappedDatasetInstance(datasetInstanceId), arguments, classLoader);
@@ -139,24 +140,23 @@ public class NameMappedDatasetFramework extends ForwardingProgramContextAwareDat
 
   @Nullable
   @Override
-  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
+  public <T extends Dataset> T getDataset(DatasetId datasetInstanceId, @Nullable Map<String, String> arguments,
                                           @Nullable ClassLoader classLoader,
                                           DatasetClassLoaderProvider classLoaderProvider,
-                                          @Nullable Iterable<? extends Id> owners, AccessType accessType)
+                                          @Nullable Iterable<? extends EntityId> owners, AccessType accessType)
     throws DatasetManagementException, IOException {
     return super.getDataset(getMappedDatasetInstance(datasetInstanceId),
                             arguments, classLoader, classLoaderProvider, owners, accessType);
   }
 
   @Override
-  public void writeLineage(Id.DatasetInstance datasetInstanceId, AccessType accessType) {
+  public void writeLineage(DatasetId datasetInstanceId, AccessType accessType) {
     super.writeLineage(getMappedDatasetInstance(datasetInstanceId), accessType);
   }
 
-  private Id.DatasetInstance getMappedDatasetInstance(Id.DatasetInstance datasetInstanceId) {
-    if (datasetNameMapping.containsKey(datasetInstanceId.getId())) {
-      return Id.DatasetInstance.from(datasetInstanceId.getNamespaceId(),
-                                     datasetNameMapping.get(datasetInstanceId.getId()));
+  private DatasetId getMappedDatasetInstance(DatasetId datasetInstanceId) {
+    if (datasetNameMapping.containsKey(datasetInstanceId.getEntityName())) {
+      return datasetInstanceId.getParent().dataset(datasetNameMapping.get(datasetInstanceId.getEntityName()));
     }
     return datasetInstanceId;
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -525,7 +525,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
       DatasetId instanceId = new DatasetId(workflowRunId.getNamespace(), localInstanceName);
       DatasetCreationSpec instanceSpec = workflowSpec.getLocalDatasetSpecs().get(entry.getKey());
       LOG.debug("Adding Workflow local dataset instance: {}", localInstanceName);
-      datasetFramework.addInstance(instanceSpec.getTypeName(), instanceId.toId(),
+      datasetFramework.addInstance(instanceSpec.getTypeName(), instanceId,
                                    addLocalDatasetProperty(instanceSpec.getProperties()));
     }
   }
@@ -542,7 +542,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
       DatasetId instanceId = new DatasetId(workflowRunId.getNamespace(), localInstanceName);
       LOG.debug("Deleting Workflow local dataset instance: {}", localInstanceName);
       try {
-        datasetFramework.deleteInstance(instanceId.toId());
+        datasetFramework.deleteInstance(instanceId);
       } catch (Throwable t) {
         LOG.warn("Failed to delete the Workflow local dataset instance {}", localInstanceName, t);
       }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -67,6 +67,7 @@ import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.Ids;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
@@ -585,8 +586,7 @@ ApplicationLifecycleService extends AbstractIdleService {
         @Override
         public Void call() throws Exception {
           for (Map.Entry<String, Collection<Long>> entry : streamGroups.asMap().entrySet()) {
-            streamConsumerFactory.dropAll(Id.Stream.from(appId.getNamespace(), entry.getKey()),
-                                          namespace, entry.getValue());
+            streamConsumerFactory.dropAll(appId.getParent().stream(entry.getKey()), namespace, entry.getValue());
           }
           queueAdmin.dropAllForFlow(flowId);
           return null;
@@ -600,7 +600,7 @@ ApplicationLifecycleService extends AbstractIdleService {
     store.removeApplication(appId);
 
     try {
-      usageRegistry.unregister(idApplication);
+      usageRegistry.unregister(appId);
     } catch (Exception e) {
       LOG.warn("Failed to unregister usage of app: {}", appId, e);
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -125,8 +125,8 @@ public class DefaultStore implements Store {
    * @param framework framework to add types and datasets to
    */
   public static void setupDatasets(DatasetFramework framework) throws IOException, DatasetManagementException {
-    framework.addInstance(Table.class.getName(), APP_META_INSTANCE_ID.toId(), DatasetProperties.EMPTY);
-    framework.addInstance(Table.class.getName(), WORKFLOW_STATS_INSTANCE_ID.toId(), DatasetProperties.EMPTY);
+    framework.addInstance(Table.class.getName(), APP_META_INSTANCE_ID, DatasetProperties.EMPTY);
+    framework.addInstance(Table.class.getName(), WORKFLOW_STATS_INSTANCE_ID, DatasetProperties.EMPTY);
   }
 
   private AppMetadataStore getAppMetadataStore(DatasetContext datasetContext) throws IOException,
@@ -817,8 +817,8 @@ public class DefaultStore implements Store {
 
   @VisibleForTesting
   void clear() throws Exception {
-    truncate(dsFramework.getAdmin(APP_META_INSTANCE_ID.toId(), null));
-    truncate(dsFramework.getAdmin(WORKFLOW_STATS_INSTANCE_ID.toId(), null));
+    truncate(dsFramework.getAdmin(APP_META_INSTANCE_ID, null));
+    truncate(dsFramework.getAdmin(WORKFLOW_STATS_INSTANCE_ID, null));
   }
 
   private void truncate(DatasetAdmin admin) throws Exception {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeUsageRegistry.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeUsageRegistry.java
@@ -21,7 +21,10 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.internal.remote.RemoteOpsClient;
 import co.cask.cdap.data2.registry.DatasetUsageKey;
 import co.cask.cdap.data2.registry.RuntimeUsageRegistry;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.inject.Inject;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
@@ -42,35 +45,35 @@ public class RemoteRuntimeUsageRegistry extends RemoteOpsClient implements Runti
   }
 
   @Override
-  public void registerAll(Iterable<? extends Id> users, Id.Stream streamId) {
-    for (Id user : users) {
+  public void registerAll(Iterable<? extends EntityId> users, StreamId streamId) {
+    for (EntityId user : users) {
       register(user, streamId);
     }
   }
 
   @Override
-  public void register(Id user, Id.Stream streamId) {
-    if (user instanceof Id.Program) {
-      register((Id.Program) user, streamId);
+  public void register(EntityId user, StreamId streamId) {
+    if (user instanceof ProgramId) {
+      register((ProgramId) user, streamId);
     }
   }
 
   @Override
-  public void registerAll(Iterable<? extends Id> users, Id.DatasetInstance datasetId) {
-    for (Id user : users) {
+  public void registerAll(Iterable<? extends EntityId> users, DatasetId datasetId) {
+    for (EntityId user : users) {
       register(user, datasetId);
     }
   }
 
   @Override
-  public void register(Id user, Id.DatasetInstance datasetId) {
-    if (user instanceof Id.Program) {
-      register((Id.Program) user, datasetId);
+  public void register(EntityId user, DatasetId datasetId) {
+    if (user instanceof ProgramId) {
+      register((ProgramId) user, datasetId);
     }
   }
 
   @Override
-  public void register(Id.Program programId, Id.DatasetInstance datasetInstanceId) {
+  public void register(ProgramId programId, DatasetId datasetInstanceId) {
     if (alreadyRegistered(datasetInstanceId, programId)) {
       return;
     }
@@ -78,11 +81,11 @@ public class RemoteRuntimeUsageRegistry extends RemoteOpsClient implements Runti
   }
 
   @Override
-  public void register(Id.Program programId, Id.Stream streamId) {
+  public void register(ProgramId programId, StreamId streamId) {
     executeRequest("registerStream", programId, streamId);
   }
 
-  private boolean alreadyRegistered(Id.DatasetInstance dataset, Id.Program owner) {
+  private boolean alreadyRegistered(DatasetId dataset, ProgramId owner) {
     return registered.putIfAbsent(new DatasetUsageKey(dataset, owner), true) != null;
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/DefaultId.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/DefaultId.java
@@ -16,8 +16,9 @@
 
 package co.cask.cdap.internal;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.NamespaceId;
 
 /**
  * Default Ids to use in test if you do not want to construct your own.
@@ -25,7 +26,7 @@ import co.cask.cdap.proto.id.ArtifactId;
 public class DefaultId {
   private static final String DEFAULT_APPLICATION_ID = "myapp";
 
-  public static final Id.Namespace NAMESPACE = Id.Namespace.DEFAULT;
-  public static final Id.Application APPLICATION = Id.Application.from(NAMESPACE, DEFAULT_APPLICATION_ID);
-  public static final ArtifactId ARTIFACT = new ArtifactId(NAMESPACE.getId(), "test-artifact", "0.0.0");
+  public static final NamespaceId NAMESPACE = NamespaceId.DEFAULT;
+  public static final ApplicationId APPLICATION = NAMESPACE.app(DEFAULT_APPLICATION_ID);
+  public static final ArtifactId ARTIFACT = NAMESPACE.artifact("test-artifact", "0.0.0");
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/Specifications.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/Specifications.java
@@ -29,7 +29,8 @@ public final class Specifications {
   private Specifications() {}
 
   public static ApplicationSpecification from(Application app) {
-    DefaultAppConfigurer appConfigurer = new DefaultAppConfigurer(DefaultId.NAMESPACE, DefaultId.ARTIFACT.toId(), app);
+    DefaultAppConfigurer appConfigurer = new DefaultAppConfigurer(DefaultId.NAMESPACE.toId(), DefaultId.ARTIFACT.toId(),
+                                                                  app);
     app.configure(appConfigurer, new DefaultApplicationContext());
     return appConfigurer.createSpecification(null);
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/pipeline/ProgramGenerationStageTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/pipeline/ProgramGenerationStageTest.java
@@ -53,7 +53,7 @@ public class ProgramGenerationStageTest {
     LocationFactory lf = new LocalLocationFactory(TEMP_FOLDER.newFolder());
     // have to do this since we are not going through the route of create namespace -> deploy application
     // in real scenarios, the namespace directory would already be created
-    Location namespaceLocation = lf.create(DefaultId.APPLICATION.getNamespaceId());
+    Location namespaceLocation = lf.create(DefaultId.APPLICATION.getNamespace());
     Locations.mkdirsIfNotExists(namespaceLocation);
     LocationFactory jarLf = new LocalLocationFactory(TEMP_FOLDER.newFolder());
     Location appArchive = AppJarHelper.createDeploymentJar(jarLf, ToyApp.class);
@@ -63,7 +63,7 @@ public class ProgramGenerationStageTest {
     ProgramGenerationStage pgmStage = new ProgramGenerationStage(new NoOpAuthorizer(), new AuthenticationTestContext());
     pgmStage.process(new StageContext(Object.class));  // Can do better here - fixed right now to run the test.
     pgmStage.process(new ApplicationDeployable(NamespaceId.DEFAULT.artifact("ToyApp", "1.0"), appArchive,
-                                               DefaultId.APPLICATION.toEntityId(), newSpec, null,
+                                               DefaultId.APPLICATION, newSpec, null,
                                                ApplicationDeployScope.USER));
     Assert.assertTrue(true);
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/queue/SimpleQueueSpecificationGeneratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/queue/SimpleQueueSpecificationGeneratorTest.java
@@ -47,7 +47,7 @@ import java.util.Set;
  */
 public class SimpleQueueSpecificationGeneratorTest {
 
-  private static final String TEST_NAMESPACE_ID = DefaultId.NAMESPACE.getId();
+  private static final String TEST_NAMESPACE_ID = DefaultId.NAMESPACE.getEntityName();
 
   private static Table<QueueSpecificationGenerator.Node, String, Set<QueueSpecification>> table
     = HashBasedTable.create();

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
@@ -39,7 +39,7 @@ import co.cask.cdap.data2.transaction.Transactions;
 import co.cask.cdap.internal.DefaultId;
 import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
 import co.cask.cdap.internal.app.runtime.BasicArguments;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.XSlowTests;
 import com.google.common.base.Charsets;
@@ -148,9 +148,9 @@ public class MapReduceProgramRunnerTest extends MapReduceRunnerTestBase {
 
   @Test
   public void testMapreduceWithDynamicDatasets() throws Exception {
-    Id.DatasetInstance rtInput1 = Id.DatasetInstance.from(DefaultId.NAMESPACE, "rtInput1");
-    Id.DatasetInstance rtInput2 = Id.DatasetInstance.from(DefaultId.NAMESPACE, "rtInput2");
-    Id.DatasetInstance rtOutput1 = Id.DatasetInstance.from(DefaultId.NAMESPACE, "rtOutput1");
+    DatasetId rtInput1 = DefaultId.NAMESPACE.dataset("rtInput1");
+    DatasetId rtInput2 = DefaultId.NAMESPACE.dataset("rtInput2");
+    DatasetId rtOutput1 = DefaultId.NAMESPACE.dataset("rtOutput1");
     // create the datasets here because they are not created by the app
     dsFramework.addInstance("fileSet", rtInput1, FileSetProperties.builder()
       .setBasePath("rtInput1")
@@ -190,7 +190,7 @@ public class MapReduceProgramRunnerTest extends MapReduceRunnerTestBase {
         Integer.MAX_VALUE,
         "system." + Constants.Metrics.Name.Dataset.OP_COUNT,
         AggregationFunction.SUM,
-        ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, DefaultId.NAMESPACE.getId(),
+        ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, DefaultId.NAMESPACE.getNamespace(),
                         Constants.Metrics.Tag.APP, AppWithMapReduceUsingRuntimeDatasets.APP_NAME,
                         Constants.Metrics.Tag.MAPREDUCE, AppWithMapReduceUsingRuntimeDatasets.MR_NAME,
                         Constants.Metrics.Tag.DATASET, "rtt"),

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRunnerTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRunnerTestBase.java
@@ -144,7 +144,7 @@ public class MapReduceRunnerTestBase {
   public void after() throws Exception {
     // cleanup user data (only user datasets)
     for (DatasetSpecificationSummary spec : dsFramework.getInstances(DefaultId.NAMESPACE)) {
-      dsFramework.deleteInstance(Id.DatasetInstance.from(DefaultId.NAMESPACE, spec.getName()));
+      dsFramework.deleteInstance(DefaultId.NAMESPACE.dataset(spec.getName()));
     }
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/entity/EntityExistenceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/entity/EntityExistenceTest.java
@@ -73,7 +73,7 @@ public class EntityExistenceTest {
     artifactRepository.addArtifact(ARTIFACT.toId(), artifactFile);
     AppFabricTestHelper.deployApplication(NAMESPACE.toId(), AllProgramsApp.class, null, cConf);
     StreamAdmin streamAdmin = injector.getInstance(StreamAdmin.class);
-    streamAdmin.createOrUpdateView(VIEW.toId(), new ViewSpecification(new FormatSpecification("csv", null)));
+    streamAdmin.createOrUpdateView(VIEW, new ViewSpecification(new FormatSpecification("csv", null)));
   }
 
   @Test

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunnerTest.java
@@ -39,7 +39,6 @@ import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
 import co.cask.cdap.internal.app.runtime.AbstractListener;
 import co.cask.cdap.internal.app.runtime.BasicArguments;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.SlowTests;
 import com.google.common.base.Supplier;
@@ -137,7 +136,7 @@ public class WorkerProgramRunnerTest {
     }
     // cleanup user data (only user datasets)
     for (DatasetSpecificationSummary spec : dsFramework.getInstances(DefaultId.NAMESPACE)) {
-      dsFramework.deleteInstance(Id.DatasetInstance.from(DefaultId.NAMESPACE, spec.getName()));
+      dsFramework.deleteInstance(DefaultId.NAMESPACE.dataset(spec.getName()));
     }
   }
 
@@ -190,7 +189,7 @@ public class WorkerProgramRunnerTest {
             Integer.MAX_VALUE,
             "system." + Constants.Metrics.Name.Dataset.OP_COUNT,
             AggregationFunction.SUM,
-            ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, DefaultId.NAMESPACE.getId(),
+            ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, DefaultId.NAMESPACE.getEntityName(),
                             Constants.Metrics.Tag.APP, AppWithWorker.NAME,
                             Constants.Metrics.Tag.WORKER, AppWithWorker.WORKER,
                             Constants.Metrics.Tag.DATASET, AppWithWorker.DATASET),

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AuthorizationBootstrapperTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AuthorizationBootstrapperTest.java
@@ -191,7 +191,7 @@ public class AuthorizationBootstrapperTest {
     Assert.assertTrue(systemArtifactLoader.isRunning());
     // ensure that system datasets can be created by the system user
     Dataset systemDataset = DatasetsUtil.getOrCreateDataset(
-      dsFramework, NamespaceId.SYSTEM.dataset("system-dataset").toId(), Table.class.getName(), DatasetProperties.EMPTY,
+      dsFramework, NamespaceId.SYSTEM.dataset("system-dataset"), Table.class.getName(), DatasetProperties.EMPTY,
       Collections.<String, String>emptyMap(), this.getClass().getClassLoader());
     Assert.assertNotNull(systemDataset);
     // as part of bootstrapping, admin users were also granted admin privileges on the CDAP instance, so they can

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
@@ -33,6 +33,8 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceConfig;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -286,8 +288,8 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
     deploy(AppWithStreamSizeSchedule.class, Constants.Gateway.API_VERSION_3_TOKEN, OTHER_NAME);
     deploy(AppForUnrecoverableResetTest.class, Constants.Gateway.API_VERSION_3_TOKEN, OTHER_NAME);
 
-    Id.DatasetInstance myDataset = Id.DatasetInstance.from(NAME, "myds");
-    Id.Stream myStream = Id.Stream.from(OTHER_NAME, "stream");
+    DatasetId myDataset = new DatasetId(NAME, "myds");
+    StreamId myStream = new StreamId(OTHER_NAME, "stream");
 
     Assert.assertTrue(dsFramework.hasInstance(myDataset));
     Assert.assertTrue(streamAdmin.exists(myStream));
@@ -335,7 +337,7 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
     deploy(AppWithServices.class, Constants.Gateway.API_VERSION_3_TOKEN, NAME);
     deploy(AppWithDataset.class, Constants.Gateway.API_VERSION_3_TOKEN, NAME);
 
-    Id.DatasetInstance myDataset = Id.DatasetInstance.from(NAME, "myds");
+    DatasetId myDataset = new DatasetId(NAME, "myds");
 
     Assert.assertTrue(dsFramework.hasInstance(myDataset));
     Id.Program program = Id.Program.from(NAME_ID, "AppWithServices", ProgramType.SERVICE, "NoOpService");

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/DefaultStoreTest.java
@@ -611,7 +611,6 @@ public class DefaultStoreTest {
     store.addApplication(appId, spec);
 
     ProgramId programId = appId.worker(AppWithWorker.WORKER);
-
     int instancesFromSpec = spec.getWorkers().get(AppWithWorker.WORKER).getInstances();
     Assert.assertEquals(1, instancesFromSpec);
     int instances = store.getWorkerInstances(programId);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeUsageRegistryTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeUsageRegistryTest.java
@@ -18,7 +18,11 @@ package co.cask.cdap.internal.app.store.remote;
 
 import co.cask.cdap.data2.registry.UsageRegistry;
 import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.inject.Injector;
@@ -44,9 +48,9 @@ public class RemoteRuntimeUsageRegistryTest extends AppFabricTestBase {
 
   @Test
   public void testSimpleCase() {
-    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, "test_app");
-    Id.Flow flowId1 = Id.Flow.from(appId, "test_flow1");
-    Id.Flow flowId2 = Id.Flow.from(appId, "test_flow2");
+    ApplicationId appId = NamespaceId.DEFAULT.app("test_app");
+    ProgramId flowId1 = appId.flow("test_flow1");
+    ProgramId flowId2 = appId.flow("test_flow2");
 
     // should be no data initially
     Assert.assertEquals(0, usageRegistry.getDatasets(appId).size());
@@ -58,10 +62,10 @@ public class RemoteRuntimeUsageRegistryTest extends AppFabricTestBase {
     Assert.assertEquals(0, usageRegistry.getDatasets(flowId2).size());
     Assert.assertEquals(0, usageRegistry.getStreams(flowId2).size());
 
-    Id.DatasetInstance datasetId1 = Id.DatasetInstance.from(Id.Namespace.DEFAULT, "test_dataset1");
+    DatasetId datasetId1 = NamespaceId.DEFAULT.dataset("test_dataset1");
     runtimeUsageRegistry.register(flowId1, datasetId1);
 
-    ImmutableSet<Id.DatasetInstance> datasetsUsedByFlow1 = ImmutableSet.of(datasetId1);
+    ImmutableSet<DatasetId> datasetsUsedByFlow1 = ImmutableSet.of(datasetId1);
     Assert.assertEquals(datasetsUsedByFlow1, usageRegistry.getDatasets(appId));
     Assert.assertEquals(0, usageRegistry.getStreams(appId).size());
 
@@ -71,14 +75,14 @@ public class RemoteRuntimeUsageRegistryTest extends AppFabricTestBase {
     Assert.assertEquals(0, usageRegistry.getDatasets(flowId2).size());
     Assert.assertEquals(0, usageRegistry.getStreams(flowId2).size());
 
-    Id.DatasetInstance datasetId2 = Id.DatasetInstance.from(Id.Namespace.DEFAULT, "test_dataset2");
-    Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, "test_stream");
+    DatasetId datasetId2 = NamespaceId.DEFAULT.dataset("test_dataset2");
+    StreamId streamId = NamespaceId.DEFAULT.stream("test_stream");
     runtimeUsageRegistry.register(flowId2, datasetId1);
     runtimeUsageRegistry.register(flowId2, datasetId2);
     runtimeUsageRegistry.register(flowId2, streamId);
 
-    ImmutableSet<Id.DatasetInstance> datasetsUsedByFlow2 = ImmutableSet.of(datasetId1, datasetId2);
-    ImmutableSet<Id.Stream> streamsUsedByFlow2 = ImmutableSet.of(streamId);
+    ImmutableSet<DatasetId> datasetsUsedByFlow2 = ImmutableSet.of(datasetId1, datasetId2);
+    ImmutableSet<StreamId> streamsUsedByFlow2 = ImmutableSet.of(streamId);
     Assert.assertEquals(Sets.union(datasetsUsedByFlow1, datasetsUsedByFlow2), usageRegistry.getDatasets(appId));
     Assert.assertEquals(streamsUsedByFlow2, usageRegistry.getStreams(appId));
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/FlowTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/FlowTest.java
@@ -133,7 +133,7 @@ public class FlowTest {
                                                     getInstance(DiscoveryServiceClient.class);
     Discoverable discoverable = discoveryServiceClient.discover(
       String.format("service.%s.%s.%s",
-                    DefaultId.NAMESPACE.getId(), "ArgumentCheckApp", "SimpleService")).iterator().next();
+                    DefaultId.NAMESPACE.getNamespace(), "ArgumentCheckApp", "SimpleService")).iterator().next();
 
     URL url = new URL(String.format("http://%s:%d/v3/namespaces/default/apps/%s/services/%s/methods/%s",
                                     discoverable.getSocketAddress().getHostName(),
@@ -197,7 +197,7 @@ public class FlowTest {
     DiscoveryServiceClient discoveryServiceClient = AppFabricTestHelper.getInjector().
       getInstance(DiscoveryServiceClient.class);
     ServiceDiscovered serviceDiscovered = discoveryServiceClient.discover(
-      String.format("service.%s.%s.%s", DefaultId.NAMESPACE.getId(), "WordCountApp", "WordFrequencyService"));
+      String.format("service.%s.%s.%s", DefaultId.NAMESPACE.getNamespace(), "WordCountApp", "WordFrequencyService"));
     EndpointStrategy endpointStrategy = new RandomEndpointStrategy(serviceDiscovered);
     int trials = 0;
     while (trials++ < 10) {
@@ -362,7 +362,7 @@ public class FlowTest {
 
   private static Map<String, String> metricTagsForQueue(String producer, String queue, String consumer) {
     Map<String, String> tags = Maps.newHashMap();
-    tags.put(Constants.Metrics.Tag.NAMESPACE, DefaultId.NAMESPACE.getId());
+    tags.put(Constants.Metrics.Tag.NAMESPACE, DefaultId.NAMESPACE.getNamespace());
     tags.put(Constants.Metrics.Tag.APP, "PendingMetricTestApp");
     tags.put(Constants.Metrics.Tag.FLOW, "TestPendingFlow");
     if (producer != null) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/OpenCloseDataSetTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/runtime/OpenCloseDataSetTest.java
@@ -94,7 +94,7 @@ public class OpenCloseDataSetTest {
   public static void setup() throws Exception {
     NamespacedLocationFactory namespacedLocationFactory =
       AppFabricTestHelper.getInjector().getInstance(NamespacedLocationFactory.class);
-    namespaceHomeLocation = namespacedLocationFactory.get(DefaultId.NAMESPACE);
+    namespaceHomeLocation = namespacedLocationFactory.get(DefaultId.NAMESPACE.toId());
     NamespaceAdmin namespaceAdmin = AppFabricTestHelper.getInjector().getInstance(NamespaceAdmin.class);
     namespaceAdmin.create(new NamespaceMeta.Builder().setName(DefaultId.NAMESPACE).build());
     Locations.mkdirsIfNotExists(namespaceHomeLocation);
@@ -161,7 +161,7 @@ public class OpenCloseDataSetTest {
       getInstance(DiscoveryServiceClient.class);
 
     Discoverable discoverable = new RandomEndpointStrategy(discoveryServiceClient.discover(
-      String.format("service.%s.%s.%s", DefaultId.NAMESPACE.getId(), "dummy", "DummyService")))
+      String.format("service.%s.%s.%s", DefaultId.NAMESPACE.getEntityName(), "dummy", "DummyService")))
       .pick(5, TimeUnit.SECONDS);
     Assert.assertNotNull(discoverable);
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/stream/store/StreamMetaStoreTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/stream/store/StreamMetaStoreTestBase.java
@@ -20,7 +20,8 @@ import co.cask.cdap.api.data.stream.StreamSpecification;
 import co.cask.cdap.common.AlreadyExistsException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.data.stream.service.StreamMetaStore;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import org.junit.After;
@@ -57,33 +58,33 @@ public abstract class StreamMetaStoreTestBase {
   public void testStreamMetastore() throws Exception {
     StreamMetaStore streamMetaStore = getStreamMetaStore();
 
-    streamMetaStore.addStream(Id.Stream.from("foo", "bar"));
-    Assert.assertTrue(streamMetaStore.streamExists(Id.Stream.from("foo", "bar")));
-    Assert.assertFalse(streamMetaStore.streamExists(Id.Stream.from("foofoo", "bar")));
+    streamMetaStore.addStream(new StreamId("foo", "bar"));
+    Assert.assertTrue(streamMetaStore.streamExists(new StreamId("foo", "bar")));
+    Assert.assertFalse(streamMetaStore.streamExists(new StreamId("foofoo", "bar")));
 
-    streamMetaStore.removeStream(Id.Stream.from("foo", "bar"));
-    Assert.assertFalse(streamMetaStore.streamExists(Id.Stream.from("foo", "bar")));
+    streamMetaStore.removeStream(new StreamId("foo", "bar"));
+    Assert.assertFalse(streamMetaStore.streamExists(new StreamId("foo", "bar")));
 
-    streamMetaStore.addStream(Id.Stream.from("foo1", "bar"));
-    streamMetaStore.addStream(Id.Stream.from("foo2", "bar"));
+    streamMetaStore.addStream(new StreamId("foo1", "bar"));
+    streamMetaStore.addStream(new StreamId("foo2", "bar"));
     Assert.assertEquals(ImmutableList.of(
       new StreamSpecification.Builder().setName("bar").create()),
-                        streamMetaStore.listStreams(Id.Namespace.from("foo1")));
+                        streamMetaStore.listStreams(new NamespaceId("foo1")));
     Assert.assertEquals(
       ImmutableMultimap.builder()
-        .put(Id.Namespace.from("foo1"), new StreamSpecification.Builder().setName("bar").create())
-        .put(Id.Namespace.from("foo2"), new StreamSpecification.Builder().setName("bar").create())
+        .put(new NamespaceId("foo1"), new StreamSpecification.Builder().setName("bar").create())
+        .put(new NamespaceId("foo2"), new StreamSpecification.Builder().setName("bar").create())
         .build(),
       streamMetaStore.listStreams());
 
-    streamMetaStore.removeStream(Id.Stream.from("foo2", "bar"));
-    Assert.assertFalse(streamMetaStore.streamExists(Id.Stream.from("foo2", "bar")));
+    streamMetaStore.removeStream(new StreamId("foo2", "bar"));
+    Assert.assertFalse(streamMetaStore.streamExists(new StreamId("foo2", "bar")));
     Assert.assertEquals(
       ImmutableMultimap.builder()
-        .put(Id.Namespace.from("foo1"), new StreamSpecification.Builder().setName("bar").create())
+        .put(new NamespaceId("foo1"), new StreamSpecification.Builder().setName("bar").create())
         .build(),
       streamMetaStore.listStreams());
 
-    streamMetaStore.removeStream(Id.Stream.from("foo1", "bar"));
+    streamMetaStore.removeStream(new StreamId("foo1", "bar"));
   }
 }

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/UsageHandlerTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/UsageHandlerTestRun.java
@@ -21,9 +21,12 @@ import co.cask.cdap.client.app.AllProgramsApp;
 import co.cask.cdap.client.common.ClientTestBase;
 import co.cask.cdap.client.config.ConnectionConfig;
 import co.cask.cdap.common.utils.Tasks;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramStatus;
-import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.test.XSlowTests;
 import com.google.common.base.Charsets;
 import com.google.common.reflect.TypeToken;
@@ -52,37 +55,37 @@ public class UsageHandlerTestRun extends ClientTestBase {
   private static final Gson GSON = new Gson();
 
   private void deployApp(Class<? extends Application> appCls) throws Exception {
-    new ApplicationClient(getClientConfig()).deploy(Id.Namespace.DEFAULT, createAppJarFile(appCls));
+    new ApplicationClient(getClientConfig()).deploy(NamespaceId.DEFAULT.toId(), createAppJarFile(appCls));
   }
 
-  private void deleteApp(Id.Application appId) throws Exception {
-    new ApplicationClient(getClientConfig()).delete(appId);
+  private void deleteApp(ApplicationId appId) throws Exception {
+    new ApplicationClient(getClientConfig()).delete(appId.toId());
   }
 
-  private void startProgram(Id.Program programId) throws Exception {
-    new ProgramClient(getClientConfig()).start(programId);
+  private void startProgram(ProgramId programId) throws Exception {
+    new ProgramClient(getClientConfig()).start(programId.toId());
   }
 
-  private void stopProgram(Id.Program programId) throws Exception {
-    new ProgramClient(getClientConfig()).stop(programId);
+  private void stopProgram(ProgramId programId) throws Exception {
+    new ProgramClient(getClientConfig()).stop(programId.toId());
   }
 
-  private void waitState(final Id.Program programId, ProgramStatus status) throws Exception {
+  private void waitState(final ProgramId programId, ProgramStatus status) throws Exception {
     final ProgramClient programclient = new ProgramClient(getClientConfig());
     Tasks.waitFor(status, new Callable<ProgramStatus>() {
       @Override
       public ProgramStatus call() throws Exception {
-        return ProgramStatus.valueOf(programclient.getStatus(programId));
+        return ProgramStatus.valueOf(programclient.getStatus(programId.toId()));
       }
     }, 60, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
   }
 
   @Test
   public void testFlowUsage() throws Exception {
-    final Id.Application app = Id.Application.from("default", AllProgramsApp.NAME);
-    final Id.Program program = Id.Program.from(app, ProgramType.FLOW, AllProgramsApp.NoOpFlow.NAME);
-    final Id.Stream stream = Id.Stream.from("default", AllProgramsApp.STREAM_NAME);
-    final Id.DatasetInstance dataset = Id.DatasetInstance.from("default", AllProgramsApp.DATASET_NAME);
+    final ApplicationId app = NamespaceId.DEFAULT.app(AllProgramsApp.NAME);
+    final ProgramId program = app.flow(AllProgramsApp.NoOpFlow.NAME);
+    final StreamId stream = NamespaceId.DEFAULT.stream(AllProgramsApp.STREAM_NAME);
+    final DatasetId dataset = NamespaceId.DEFAULT.dataset(AllProgramsApp.DATASET_NAME);
 
     Assert.assertEquals(0, getAppStreamUsage(app).size());
     Assert.assertEquals(0, getProgramStreamUsage(program).size());
@@ -113,10 +116,10 @@ public class UsageHandlerTestRun extends ClientTestBase {
 
   @Test
   public void testWorkerUsage() throws Exception {
-    final Id.Application app = Id.Application.from("default", AllProgramsApp.NAME);
-    final Id.Program program = Id.Program.from(app, ProgramType.WORKER, AllProgramsApp.NoOpWorker.NAME);
-    final Id.Stream stream = Id.Stream.from("default", AllProgramsApp.STREAM_NAME);
-    final Id.DatasetInstance dataset = Id.DatasetInstance.from("default", AllProgramsApp.DATASET_NAME);
+    final ApplicationId app = NamespaceId.DEFAULT.app(AllProgramsApp.NAME);
+    final ProgramId program = app.worker(AllProgramsApp.NoOpWorker.NAME);
+    final StreamId stream = NamespaceId.DEFAULT.stream(AllProgramsApp.STREAM_NAME);
+    final DatasetId dataset = NamespaceId.DEFAULT.dataset(AllProgramsApp.DATASET_NAME);
 
     Assert.assertEquals(0, getAppStreamUsage(app).size());
     Assert.assertEquals(0, getProgramStreamUsage(program).size());
@@ -154,10 +157,10 @@ public class UsageHandlerTestRun extends ClientTestBase {
 
   @Test
   public void testMapReduceUsage() throws Exception {
-    final Id.Application app = Id.Application.from("default", AllProgramsApp.NAME);
-    final Id.Program program = Id.Program.from(app, ProgramType.MAPREDUCE, AllProgramsApp.NoOpMR.NAME);
-    final Id.Stream stream = Id.Stream.from("default", AllProgramsApp.STREAM_NAME);
-    final Id.DatasetInstance dataset = Id.DatasetInstance.from("default", AllProgramsApp.DATASET_NAME);
+    final ApplicationId app = NamespaceId.DEFAULT.app(AllProgramsApp.NAME);
+    final ProgramId program = app.mr(AllProgramsApp.NoOpMR.NAME);
+    final StreamId stream = NamespaceId.DEFAULT.stream(AllProgramsApp.STREAM_NAME);
+    final DatasetId dataset = NamespaceId.DEFAULT.dataset(AllProgramsApp.DATASET_NAME);
 
     Assert.assertEquals(0, getAppStreamUsage(app).size());
     Assert.assertEquals(0, getProgramStreamUsage(program).size());
@@ -194,10 +197,10 @@ public class UsageHandlerTestRun extends ClientTestBase {
 
   @Test
   public void testSparkUsage() throws Exception {
-    final Id.Application app = Id.Application.from("default", AllProgramsApp.NAME);
-    final Id.Program program = Id.Program.from(app, ProgramType.SPARK, AllProgramsApp.NoOpSpark.NAME);
-    final Id.Stream stream = Id.Stream.from("default", AllProgramsApp.STREAM_NAME);
-    final Id.DatasetInstance dataset = Id.DatasetInstance.from("default", AllProgramsApp.DATASET_NAME);
+    final ApplicationId app = NamespaceId.DEFAULT.app(AllProgramsApp.NAME);
+    final ProgramId program = app.spark(AllProgramsApp.NoOpSpark.NAME);
+    final StreamId stream = NamespaceId.DEFAULT.stream(AllProgramsApp.STREAM_NAME);
+    final DatasetId dataset = NamespaceId.DEFAULT.dataset(AllProgramsApp.DATASET_NAME);
 
     Assert.assertEquals(0, getAppStreamUsage(app).size());
     Assert.assertEquals(0, getProgramStreamUsage(program).size());
@@ -259,9 +262,9 @@ public class UsageHandlerTestRun extends ClientTestBase {
 
   @Test
   public void testServiceUsage() throws Exception {
-    final Id.Application app = Id.Application.from("default", AllProgramsApp.NAME);
-    final Id.Program program = Id.Program.from(app, ProgramType.SERVICE, AllProgramsApp.NoOpService.NAME);
-    final Id.DatasetInstance dataset = Id.DatasetInstance.from("default", AllProgramsApp.DATASET_NAME);
+    final ApplicationId app = NamespaceId.DEFAULT.app(AllProgramsApp.NAME);
+    final ProgramId program = app.service(AllProgramsApp.NoOpService.NAME);
+    final DatasetId dataset = NamespaceId.DEFAULT.dataset(AllProgramsApp.DATASET_NAME);
 
     Assert.assertEquals(0, getAppDatasetUsage(app).size());
     Assert.assertEquals(0, getDatasetProgramUsage(dataset).size());
@@ -297,42 +300,42 @@ public class UsageHandlerTestRun extends ClientTestBase {
     }
   }
 
-  private Set<Id.DatasetInstance> getAppDatasetUsage(Id.Application app) throws Exception {
-    return doGet(String.format("/v3/namespaces/%s/apps/%s/datasets", app.getNamespaceId(), app.getId()),
-                 new TypeToken<Set<Id.DatasetInstance>>() { }.getType());
+  private Set<DatasetId> getAppDatasetUsage(ApplicationId app) throws Exception {
+    return doGet(String.format("/v3/namespaces/%s/apps/%s/datasets", app.getNamespace(), app.getEntityName()),
+                 new TypeToken<Set<DatasetId>>() { }.getType());
   }
 
-  private Set<Id.Stream> getAppStreamUsage(Id.Application app) throws Exception {
-    return doGet(String.format("/v3/namespaces/%s/apps/%s/streams", app.getNamespaceId(), app.getId()),
-                 new TypeToken<Set<Id.Stream>>() { }.getType());
+  private Set<StreamId> getAppStreamUsage(ApplicationId app) throws Exception {
+    return doGet(String.format("/v3/namespaces/%s/apps/%s/streams", app.getNamespace(), app.getEntityName()),
+                 new TypeToken<Set<StreamId>>() { }.getType());
   }
 
-  private Set<Id.DatasetInstance> getProgramDatasetUsage(Id.Program program) throws Exception {
+  private Set<DatasetId> getProgramDatasetUsage(ProgramId program) throws Exception {
     return doGet(String.format("/v3/namespaces/%s/apps/%s/%s/%s/datasets",
-                               program.getNamespaceId(), program.getApplicationId(),
-                               program.getType().getCategoryName(), program.getId()),
-                 new TypeToken<Set<Id.DatasetInstance>>() { }.getType());
+                               program.getNamespace(), program.getApplication(),
+                               program.getType().getCategoryName(), program.getEntityName()),
+                 new TypeToken<Set<DatasetId>>() { }.getType());
   }
 
-  private Set<Id.Stream> getProgramStreamUsage(Id.Program program) throws Exception {
+  private Set<StreamId> getProgramStreamUsage(ProgramId program) throws Exception {
     return doGet(String.format("/v3/namespaces/%s/apps/%s/%s/%s/streams",
-                               program.getNamespaceId(), program.getApplicationId(),
+                               program.getNamespace(), program.getApplication(),
                                program.getType().getCategoryName(),
-                               program.getId()),
-                 new TypeToken<Set<Id.Stream>>() { }.getType());
+                               program.getEntityName()),
+                 new TypeToken<Set<StreamId>>() { }.getType());
   }
 
   // dataset/stream -> program
 
-  private Set<Id.Program> getStreamProgramUsage(Id.Stream stream) throws Exception {
+  private Set<ProgramId> getStreamProgramUsage(StreamId stream) throws Exception {
     return doGet(String.format("/v3/namespaces/%s/streams/%s/programs",
-                               stream.getNamespaceId(), stream.getId()),
-                 new TypeToken<Set<Id.Program>>() { }.getType());
+                               stream.getNamespace(), stream.getEntityName()),
+                 new TypeToken<Set<ProgramId>>() { }.getType());
   }
 
-  private Set<Id.Program> getDatasetProgramUsage(Id.DatasetInstance dataset) throws Exception {
+  private Set<ProgramId> getDatasetProgramUsage(DatasetId dataset) throws Exception {
     return doGet(String.format("/v3/namespaces/%s/data/datasets/%s/programs",
-                               dataset.getNamespaceId(), dataset.getId()),
-                 new TypeToken<Set<Id.Program>>() { }.getType());
+                               dataset.getNamespace(), dataset.getEntityName()),
+                 new TypeToken<Set<ProgramId>>() { }.getType());
   }
 }

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamFileJanitorTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/DFSStreamFileJanitorTest.java
@@ -45,7 +45,7 @@ import co.cask.cdap.data2.transaction.stream.StreamConfig;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationTestModule;
@@ -181,7 +181,7 @@ public class DFSStreamFileJanitorTest extends StreamFileJanitorTestBase {
   }
 
   @Override
-  protected FileWriter<StreamEvent> createWriter(Id.Stream streamId) throws IOException {
+  protected FileWriter<StreamEvent> createWriter(StreamId streamId) throws IOException {
     StreamConfig config = streamAdmin.getConfig(streamId);
     return fileWriterFactory.create(config, StreamUtils.getGeneration(config));
   }

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalStreamFileJanitorTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/LocalStreamFileJanitorTest.java
@@ -41,7 +41,7 @@ import co.cask.cdap.data2.transaction.stream.StreamConfig;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationTestModule;
@@ -150,7 +150,7 @@ public class LocalStreamFileJanitorTest extends StreamFileJanitorTestBase {
   }
 
   @Override
-  protected FileWriter<StreamEvent> createWriter(Id.Stream streamId) throws IOException {
+  protected FileWriter<StreamEvent> createWriter(StreamId streamId) throws IOException {
     StreamConfig config = streamAdmin.getConfig(streamId);
     return fileWriterFactory.create(config, StreamUtils.getGeneration(config));
   }

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/MultiLiveStreamFileReaderTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/MultiLiveStreamFileReaderTestBase.java
@@ -22,7 +22,8 @@ import co.cask.cdap.common.security.Impersonator;
 import co.cask.cdap.common.security.UnsupportedUGIProvider;
 import co.cask.cdap.data.file.FileWriter;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
@@ -57,7 +58,7 @@ public abstract class MultiLiveStreamFileReaderTestBase {
   @Test
   public void testLiveFileReader() throws Exception {
     String streamName = "liveReader";
-    Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, streamName);
+    StreamId streamId = NamespaceId.DEFAULT.stream(streamName);
     Location location = getLocationFactory().create(streamName);
     location.mkdirs();
 
@@ -104,7 +105,7 @@ public abstract class MultiLiveStreamFileReaderTestBase {
   @Test
   public void testMultiFileReader() throws Exception {
     String streamName = "multiReader";
-    Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, streamName);
+    StreamId streamId = NamespaceId.DEFAULT.stream(streamName);
     Location location = getLocationFactory().create(streamName);
     location.mkdirs();
 
@@ -185,7 +186,7 @@ public abstract class MultiLiveStreamFileReaderTestBase {
   @Test
   public void testOffsets() throws Exception {
     String streamName = "offsets";
-    Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, streamName);
+    StreamId streamId = NamespaceId.DEFAULT.stream(streamName);
     Location location = getLocationFactory().create(streamName);
     location.mkdirs();
 
@@ -263,7 +264,7 @@ public abstract class MultiLiveStreamFileReaderTestBase {
 
   private FileWriter<StreamEvent> createWriter(StreamConfig config, String prefix) {
     return new TimePartitionedStreamFileWriter(config.getLocation(), config.getPartitionDuration(),
-                                               prefix, config.getIndexInterval(), config.getStreamId().toEntityId(),
+                                               prefix, config.getIndexInterval(), config.getStreamId(),
                                                impersonator);
   }
 }

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/NoopStreamAdmin.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/NoopStreamAdmin.java
@@ -20,10 +20,13 @@ import co.cask.cdap.api.data.stream.StreamSpecification;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.StreamProperties;
 import co.cask.cdap.proto.ViewSpecification;
+import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.proto.id.StreamId;
+import co.cask.cdap.proto.id.StreamViewId;
 import com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
@@ -38,15 +41,15 @@ import javax.annotation.Nullable;
 public class NoopStreamAdmin implements StreamAdmin {
 
   @Override
-  public void dropAllInNamespace(Id.Namespace namespace) throws Exception {
+  public void dropAllInNamespace(NamespaceId namespace) throws Exception {
   }
 
   @Override
-  public void configureInstances(Id.Stream streamId, long groupId, int instances) throws Exception {
+  public void configureInstances(StreamId streamId, long groupId, int instances) throws Exception {
   }
 
   @Override
-  public void configureGroups(Id.Stream streamId, Map<Long, Integer> groupInfo) throws Exception {
+  public void configureGroups(StreamId streamId, Map<Long, Integer> groupInfo) throws Exception {
   }
 
   @Override
@@ -59,72 +62,72 @@ public class NoopStreamAdmin implements StreamAdmin {
   }
 
   @Override
-  public StreamConfig getConfig(Id.Stream streamId) throws IOException {
+  public StreamConfig getConfig(StreamId streamId) throws IOException {
     throw new IllegalStateException("Stream " + streamId + " not exists.");
   }
 
   @Override
-  public StreamProperties getProperties(Id.Stream streamId) throws IOException {
+  public StreamProperties getProperties(StreamId streamId) throws IOException {
     throw new IllegalStateException("Stream " + streamId + " not exists.");
   }
 
   @Override
-  public void updateConfig(Id.Stream streamId, StreamProperties properties) throws IOException {
+  public void updateConfig(StreamId streamId, StreamProperties properties) throws IOException {
   }
 
   @Override
-  public boolean exists(Id.Stream streamId) throws Exception {
+  public boolean exists(StreamId streamId) throws Exception {
     return false;
   }
 
   @Override
-  public StreamConfig create(Id.Stream streamId) throws Exception {
+  public StreamConfig create(StreamId streamId) throws Exception {
     return null;
   }
 
   @Override
-  public StreamConfig create(Id.Stream streamId, @Nullable Properties props) throws Exception {
+  public StreamConfig create(StreamId streamId, @Nullable Properties props) throws Exception {
     return null;
   }
 
   @Override
-  public void truncate(Id.Stream streamId) throws Exception {
+  public void truncate(StreamId streamId) throws Exception {
   }
 
   @Override
-  public void drop(Id.Stream streamId) throws Exception {
+  public void drop(StreamId streamId) throws Exception {
   }
 
   @Override
-  public boolean createOrUpdateView(Id.Stream.View viewId, ViewSpecification spec) throws Exception {
+  public boolean createOrUpdateView(StreamViewId viewId, ViewSpecification spec) throws Exception {
     return false;
   }
 
   @Override
-  public void deleteView(Id.Stream.View viewId) throws Exception {
+  public void deleteView(StreamViewId viewId) throws Exception {
 
   }
 
   @Override
-  public List<Id.Stream.View> listViews(Id.Stream streamId) {
+  public List<StreamViewId> listViews(StreamId streamId) {
     return null;
   }
 
   @Override
-  public ViewSpecification getView(Id.Stream.View viewId) {
+  public ViewSpecification getView(StreamViewId viewId) {
     return null;
   }
 
   @Override
-  public boolean viewExists(Id.Stream.View viewId) throws Exception {
+  public boolean viewExists(StreamViewId viewId) throws Exception {
     return false;
   }
 
   @Override
-  public void register(Iterable<? extends Id> owners, Id.Stream streamId) {
+  public void register(Iterable<? extends EntityId> owners, StreamId streamId) {
   }
 
   @Override
-  public void addAccess(Id.Run run, Id.Stream streamId, AccessType accessType) {
+  public void addAccess(ProgramRunId run, StreamId streamId, AccessType accessType) {
   }
 }

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamCoordinatorTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamCoordinatorTestBase.java
@@ -19,8 +19,9 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.StreamProperties;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.base.Throwables;
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -55,21 +56,21 @@ public abstract class StreamCoordinatorTestBase {
   protected static void setupNamespaces(NamespacedLocationFactory namespacedLocationFactory) throws IOException {
     // FileStreamAdmin expects namespace directory to exist.
     // Simulate namespace create
-    namespacedLocationFactory.get(Id.Namespace.DEFAULT).mkdirs();
+    namespacedLocationFactory.get(NamespaceId.DEFAULT.toId()).mkdirs();
   }
 
   @Test
   public void testGeneration() throws Exception {
     final StreamAdmin streamAdmin = getStreamAdmin();
     final String streamName = "testGen";
-    final Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, streamName);
+    final StreamId streamId = NamespaceId.DEFAULT.stream(streamName);
     streamAdmin.create(streamId);
 
     StreamCoordinatorClient coordinator = getStreamCoordinator();
     final CountDownLatch genIdChanged = new CountDownLatch(1);
     coordinator.addListener(streamId, new StreamPropertyListener() {
       @Override
-      public void generationChanged(Id.Stream streamId, int generation) {
+      public void generationChanged(StreamId streamId, int generation) {
         if (generation == 10) {
           genIdChanged.countDown();
         }
@@ -102,7 +103,7 @@ public abstract class StreamCoordinatorTestBase {
   public void testConfig() throws Exception {
     final StreamAdmin streamAdmin = getStreamAdmin();
     final String streamName = "testConfig";
-    final Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, streamName);
+    final StreamId streamId = NamespaceId.DEFAULT.stream(streamName);
     streamAdmin.create(streamId);
 
 
@@ -111,12 +112,12 @@ public abstract class StreamCoordinatorTestBase {
     final BlockingDeque<Long> ttls = new LinkedBlockingDeque<>();
     coordinator.addListener(streamId, new StreamPropertyListener() {
       @Override
-      public void thresholdChanged(Id.Stream streamId, int threshold) {
+      public void thresholdChanged(StreamId streamId, int threshold) {
         thresholds.add(threshold);
       }
 
       @Override
-      public void ttlChanged(Id.Stream streamId, long ttl) {
+      public void ttlChanged(StreamId streamId, long ttl) {
         ttls.add(ttl);
       }
     });
@@ -161,7 +162,7 @@ public abstract class StreamCoordinatorTestBase {
 
   @Test
   public void testDeleteStream() throws Exception {
-    final Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, "test");
+    final StreamId streamId = NamespaceId.DEFAULT.stream("test");
 
     StreamAdmin streamAdmin = getStreamAdmin();
     streamAdmin.create(streamId);
@@ -173,7 +174,7 @@ public abstract class StreamCoordinatorTestBase {
     final CountDownLatch latch = new CountDownLatch(1);
     streamCoordinator.addListener(streamId, new StreamPropertyListener() {
       @Override
-      public void deleted(Id.Stream id) {
+      public void deleted(StreamId id) {
         if (id.equals(streamId)) {
           latch.countDown();
         }

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamDataFileTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamDataFileTestBase.java
@@ -26,7 +26,8 @@ import co.cask.cdap.data.file.FileWriter;
 import co.cask.cdap.data.file.ReadFilter;
 import co.cask.cdap.data.file.filter.TTLReadFilter;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.test.SlowTests;
 import com.google.common.base.Charsets;
 import com.google.common.base.Stopwatch;
@@ -687,7 +688,7 @@ public abstract class StreamDataFileTestBase {
   @Test
   public void testLiveStream() throws Exception {
     String streamName = "live";
-    Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, streamName);
+    StreamId streamId = NamespaceId.DEFAULT.stream(streamName);
     final String filePrefix = "prefix";
     long partitionDuration = 5000;    // 5 seconds
     Location location = getLocationFactory().create(streamName);
@@ -995,7 +996,7 @@ public abstract class StreamDataFileTestBase {
 
   private FileWriter<StreamEvent> createWriter(StreamConfig config, String prefix) {
     return new TimePartitionedStreamFileWriter(config.getLocation(), config.getPartitionDuration(),
-                                               prefix, config.getIndexInterval(), config.getStreamId().toEntityId(),
+                                               prefix, config.getIndexInterval(), config.getStreamId(),
                                                impersonator);
   }
 }

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamFileJanitorTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamFileJanitorTestBase.java
@@ -27,8 +27,9 @@ import co.cask.cdap.common.security.UnsupportedUGIProvider;
 import co.cask.cdap.data.file.FileWriter;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.store.NamespaceStore;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
@@ -63,7 +64,7 @@ public abstract class StreamFileJanitorTestBase {
 
   protected abstract CConfiguration getCConfiguration();
 
-  protected abstract FileWriter<StreamEvent> createWriter(Id.Stream streamId) throws IOException;
+  protected abstract FileWriter<StreamEvent> createWriter(StreamId streamId) throws IOException;
 
   private Impersonator impersonator;
 
@@ -72,7 +73,7 @@ public abstract class StreamFileJanitorTestBase {
     // FileStreamAdmin expects namespace directory to exist.
     // Simulate namespace create, since its an inmemory-namespace admin
     getNamespaceAdmin().create(NamespaceMeta.DEFAULT);
-    getNamespacedLocationFactory().get(Id.Namespace.DEFAULT).mkdirs();
+    getNamespacedLocationFactory().get(NamespaceId.DEFAULT.toId()).mkdirs();
     impersonator = new DefaultImpersonator(cConf, new UnsupportedUGIProvider(), null);
   }
 
@@ -80,7 +81,7 @@ public abstract class StreamFileJanitorTestBase {
   public void testCleanupGeneration() throws Exception {
     // Create a stream and performs couple truncate
     String streamName = "testCleanupGeneration";
-    Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, streamName);
+    StreamId streamId = NamespaceId.DEFAULT.stream(streamName);
 
     StreamAdmin streamAdmin = getStreamAdmin();
     streamAdmin.create(streamId);
@@ -118,7 +119,7 @@ public abstract class StreamFileJanitorTestBase {
   public void testCleanupTTL() throws Exception {
     // Create a stream with 5 seconds TTL, partition duration of 2 seconds
     String streamName = "testCleanupTTL";
-    Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, streamName);
+    StreamId streamId = NamespaceId.DEFAULT.stream(streamName);
 
     StreamAdmin streamAdmin = getStreamAdmin();
     StreamFileJanitor janitor = new StreamFileJanitor(getCConfiguration(), getStreamAdmin(),
@@ -160,7 +161,7 @@ public abstract class StreamFileJanitorTestBase {
 
   @Test
   public void testCleanupDeletedStream() throws Exception {
-    Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, "cleanupDelete");
+    StreamId streamId = NamespaceId.DEFAULT.stream("cleanupDelete");
     StreamAdmin streamAdmin = getStreamAdmin();
     StreamFileJanitor janitor = new StreamFileJanitor(getCConfiguration(), streamAdmin, getNamespacedLocationFactory(),
                                                       getNamespaceAdmin(), impersonator);

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamFileTestUtils.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamFileTestUtils.java
@@ -17,7 +17,7 @@ package co.cask.cdap.data.stream;
 
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
@@ -35,8 +35,8 @@ public class StreamFileTestUtils {
   }
 
   public static Location getStreamBaseLocation(NamespacedLocationFactory namespacedLocationFactory,
-                                               Id.Stream streamId) throws IOException {
-    return namespacedLocationFactory.get(streamId.getNamespace()).append(streamId.getId());
+                                               StreamId streamId) throws IOException {
+    return namespacedLocationFactory.get(streamId.getParent().toId()).append(streamId.getEntityName());
   }
 
   public static StreamEvent createEvent(long timestamp, String body) {

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/ConcurrentStreamWriterTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/ConcurrentStreamWriterTestBase.java
@@ -38,6 +38,8 @@ import co.cask.cdap.data.stream.TimestampCloseable;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.base.Charsets;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableMap;
@@ -93,8 +95,8 @@ public abstract class ConcurrentStreamWriterTestBase {
   @Test
   public void testConcurrentWrite() throws Exception {
     final String streamName = "testConcurrentWrite";
-    String namespace = "namespace";
-    Id.Stream streamId = Id.Stream.from(namespace, streamName);
+    NamespaceId namespace = new NamespaceId("namespace");
+    StreamId streamId = namespace.stream(streamName);
     StreamAdmin streamAdmin = new TestStreamAdmin(getNamespacedLocationFactory(), Long.MAX_VALUE, 1000);
     int threads = Runtime.getRuntime().availableProcessors() * 4;
 
@@ -139,8 +141,8 @@ public abstract class ConcurrentStreamWriterTestBase {
   @Test
   public void testConcurrentAppendFile() throws Exception {
     final String streamName = "testConcurrentFile";
-    String namespace = "namespace";
-    Id.Stream streamId = Id.Stream.from(namespace, streamName);
+    NamespaceId namespace = new NamespaceId("namespace");
+    StreamId streamId = namespace.stream(streamName);
     StreamAdmin streamAdmin = new TestStreamAdmin(getNamespacedLocationFactory(), Long.MAX_VALUE, 1000);
     int threads = Runtime.getRuntime().availableProcessors() * 4;
 
@@ -205,7 +207,7 @@ public abstract class ConcurrentStreamWriterTestBase {
     return true;
   }
 
-  private ConcurrentStreamWriter createStreamWriter(Id.Stream streamId, StreamAdmin streamAdmin,
+  private ConcurrentStreamWriter createStreamWriter(StreamId streamId, StreamAdmin streamAdmin,
                                                     int threads, StreamFileWriterFactory writerFactory)
     throws Exception {
     StreamConfig streamConfig = streamAdmin.getConfig(streamId);
@@ -215,7 +217,7 @@ public abstract class ConcurrentStreamWriterTestBase {
                                       writerFactory, threads, new TestMetricsCollectorFactory(), impersonator);
   }
 
-  private Runnable createWriterTask(final Id.Stream streamId,
+  private Runnable createWriterTask(final StreamId streamId,
                                     final ConcurrentStreamWriter streamWriter,
                                     final int threadId, final int msgCount, final int batchSize,
                                     final CountDownLatch startLatch, final CountDownLatch completion) {
@@ -262,7 +264,7 @@ public abstract class ConcurrentStreamWriterTestBase {
     };
   }
 
-  private Runnable createAppendFileTask(final Id.Stream streamId,
+  private Runnable createAppendFileTask(final StreamId streamId,
                                         final ConcurrentStreamWriter streamWriter, final FileInfo fileInfo,
                                         final CountDownLatch startLatch, final CountDownLatch completion) {
     return new Runnable() {
@@ -332,12 +334,12 @@ public abstract class ConcurrentStreamWriterTestBase {
     }
 
     @Override
-    public boolean exists(Id.Stream streamId) throws Exception {
+    public boolean exists(StreamId streamId) throws Exception {
       return true;
     }
 
     @Override
-    public StreamConfig getConfig(Id.Stream streamId) throws IOException {
+    public StreamConfig getConfig(StreamId streamId) throws IOException {
       Location streamLocation = StreamFileTestUtils.getStreamBaseLocation(namespacedLocationFactory, streamId);
       return new StreamConfig(streamId, partitionDuration, indexInterval, Long.MAX_VALUE, streamLocation, null, 1000);
     }
@@ -345,7 +347,7 @@ public abstract class ConcurrentStreamWriterTestBase {
 
   private static final class TestMetricsCollectorFactory implements StreamMetricsCollectorFactory {
     @Override
-    public StreamMetricsCollector createMetricsCollector(Id.Stream streamId) {
+    public StreamMetricsCollector createMetricsCollector(StreamId streamId) {
       return new StreamMetricsCollector() {
         @Override
         public void emitMetrics(long bytesWritten, long eventsWritten) {

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/DFSStreamHeartbeatsTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/DFSStreamHeartbeatsTest.java
@@ -51,7 +51,8 @@ import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModule;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.notifications.service.NotificationService;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationTestModule;
@@ -180,12 +181,12 @@ public class DFSStreamHeartbeatsTest {
     hostname = streamHttpService.getBindAddress().getHostName();
     port = streamHttpService.getBindAddress().getPort();
 
-    Locations.mkdirsIfNotExists(namespacedLocationFactory.get(Id.Namespace.DEFAULT));
+    Locations.mkdirsIfNotExists(namespacedLocationFactory.get(NamespaceId.DEFAULT.toId()));
   }
 
   @AfterClass
   public static void afterClass() throws IOException {
-    Locations.deleteQuietly(namespacedLocationFactory.get(Id.Namespace.DEFAULT), true);
+    Locations.deleteQuietly(namespacedLocationFactory.get(NamespaceId.DEFAULT.toId()), true);
 
     notificationService.startAndWait();
     datasetService.startAndWait();
@@ -207,7 +208,7 @@ public class DFSStreamHeartbeatsTest {
   public void streamPublishesHeartbeatTest() throws Exception {
     final int entries = 10;
     final String streamName = "test_stream";
-    final Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, streamName);
+    final StreamId streamId = NamespaceId.DEFAULT.stream(streamName);
     // Create a new stream.
     streamAdmin.create(streamId);
 
@@ -231,7 +232,7 @@ public class DFSStreamHeartbeatsTest {
     }, Constants.Stream.HEARTBEAT_INTERVAL * 5, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
   }
 
-  private long getStreamSize(Id.Stream streamId, MockHeartbeatPublisher heartbeatPublisher) {
+  private long getStreamSize(StreamId streamId, MockHeartbeatPublisher heartbeatPublisher) {
     StreamWriterHeartbeat heartbeat = heartbeatPublisher.getHeartbeat();
     if (heartbeat == null) {
       return 0L;

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/StreamFileSizeFetcherTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/StreamFileSizeFetcherTest.java
@@ -27,7 +27,8 @@ import co.cask.cdap.data.stream.StreamFileType;
 import co.cask.cdap.data.stream.StreamUtils;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.StreamId;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
@@ -58,7 +59,7 @@ public class StreamFileSizeFetcherTest {
   @Test
   public void testFetchSize() throws Exception {
     final String streamName = "testFetchSize";
-    Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, streamName);
+    StreamId streamId = NamespaceId.DEFAULT.stream(streamName);
     final int nbEvents = 100;
     StreamAdmin streamAdmin = new TestStreamAdmin(namespacedLocationFactory, Long.MAX_VALUE, 1000);
 
@@ -108,12 +109,12 @@ public class StreamFileSizeFetcherTest {
     }
 
     @Override
-    public boolean exists(Id.Stream streamId) throws Exception {
+    public boolean exists(StreamId streamId) throws Exception {
       return true;
     }
 
     @Override
-    public StreamConfig getConfig(Id.Stream streamId) throws IOException {
+    public StreamConfig getConfig(StreamId streamId) throws IOException {
       Location streamLocation = StreamFileTestUtils.getStreamBaseLocation(namespacedLocationFactory, streamId);
       return new StreamConfig(streamId, partitionDuration, indexInterval, Long.MAX_VALUE, streamLocation, null, 1000);
     }

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/audit/AuditPublishersTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/audit/AuditPublishersTest.java
@@ -17,8 +17,11 @@
 package co.cask.cdap.data2.audit;
 
 import co.cask.cdap.data2.metadata.lineage.AccessType;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.audit.AuditMessage;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramId;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -37,8 +40,8 @@ public class AuditPublishersTest {
     String workerName = "dummyWorker";
     String workerName2 = "dummyWorker2";
     InMemoryAuditPublisher auditPublisher = new InMemoryAuditPublisher();
-    Id.Worker workerId = Id.Worker.from(Id.Namespace.DEFAULT, appName, workerName);
-    Id.DatasetInstance datasetId = Id.DatasetInstance.from(Id.Namespace.DEFAULT, datasetName);
+    ProgramId workerId = new ProgramId(NamespaceId.DEFAULT.getNamespace(), appName, ProgramType.WORKER, workerName);
+    DatasetId datasetId = NamespaceId.DEFAULT.dataset(datasetName);
     AuditPublishers.publishAccess(auditPublisher, datasetId, AccessType.READ_WRITE, workerId);
     List<AuditMessage> messages = auditPublisher.popMessages();
     // Since it is a READ_WRITE access, two messages are expected
@@ -55,13 +58,13 @@ public class AuditPublishersTest {
     Assert.assertEquals(1, messages.size());
 
     // Different dataset name, hence a message should be published
-    datasetId = Id.DatasetInstance.from(Id.Namespace.DEFAULT, datasetName2);
+    datasetId = NamespaceId.DEFAULT.dataset(datasetName2);
     AuditPublishers.publishAccess(auditPublisher, datasetId, AccessType.READ_WRITE, workerId);
     messages = auditPublisher.popMessages();
     Assert.assertEquals(2, messages.size());
 
     // Different worker name, hence a message should be published
-    workerId = Id.Worker.from(Id.Namespace.DEFAULT, appName, workerName2);
+    workerId = new ProgramId(NamespaceId.DEFAULT.getNamespace(), appName, ProgramType.WORKER, workerName2);
     AuditPublishers.publishAccess(auditPublisher, datasetId, AccessType.READ_WRITE, workerId);
     messages = auditPublisher.popMessages();
     Assert.assertEquals(2, messages.size());

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableTest.java
@@ -37,7 +37,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTable;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTableTest;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
@@ -132,7 +132,7 @@ public class HBaseMetricsTableTest extends MetricsTableTest {
 
   @Override
   protected MetricsTable getTable(String name) throws Exception {
-    Id.DatasetInstance metricsDatasetInstanceId = Id.DatasetInstance.from(Id.Namespace.SYSTEM, name);
+    DatasetId metricsDatasetInstanceId = NamespaceId.SYSTEM.dataset(name);
     DatasetProperties props = DatasetProperties.builder().add(Table.PROPERTY_READLESS_INCREMENT, "true").build();
     return DatasetsUtil.getOrCreateDataset(dsFramework, metricsDatasetInstanceId,
                                            MetricsTable.class.getName(), props, null, null);

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/StreamAdminTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/StreamAdminTest.java
@@ -29,7 +29,6 @@ import co.cask.cdap.data.stream.StreamFileWriterFactory;
 import co.cask.cdap.data.stream.StreamUtils;
 import co.cask.cdap.data2.audit.InMemoryAuditPublisher;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.StreamProperties;
 import co.cask.cdap.proto.audit.AuditMessage;
@@ -39,6 +38,8 @@ import co.cask.cdap.proto.audit.payload.access.AccessPayload;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
@@ -74,8 +75,8 @@ public abstract class StreamAdminTest {
   private static final Principal USER = new Principal(System.getProperty("user.name"), Principal.PrincipalType.USER);
 
   protected static CConfiguration cConf = CConfiguration.create();
-  protected static final String FOO_NAMESPACE = "fooNamespace";
-  protected static final String OTHER_NAMESPACE = "otherNamespace";
+  protected static final NamespaceId FOO_NAMESPACE = new NamespaceId("fooNamespace");
+  protected static final NamespaceId OTHER_NAMESPACE = new NamespaceId("otherNamespace");
 
   protected abstract StreamAdmin getStreamAdmin();
 
@@ -86,8 +87,8 @@ public abstract class StreamAdminTest {
   protected abstract Authorizer getAuthorizer();
 
   protected static void setupNamespaces(NamespacedLocationFactory namespacedLocationFactory) throws IOException {
-    namespacedLocationFactory.get(Id.Namespace.from(FOO_NAMESPACE)).mkdirs();
-    namespacedLocationFactory.get(Id.Namespace.from(OTHER_NAMESPACE)).mkdirs();
+    namespacedLocationFactory.get(FOO_NAMESPACE.toId()).mkdirs();
+    namespacedLocationFactory.get(OTHER_NAMESPACE.toId()).mkdirs();
   }
 
   @ClassRule
@@ -106,8 +107,8 @@ public abstract class StreamAdminTest {
 
   @Before
   public void beforeTest() throws Exception {
-    revokeAndAssertSuccess(new NamespaceId(FOO_NAMESPACE), USER, EnumSet.allOf(Action.class));
-    revokeAndAssertSuccess(new NamespaceId(OTHER_NAMESPACE), USER, EnumSet.allOf(Action.class));
+    revokeAndAssertSuccess(FOO_NAMESPACE, USER, EnumSet.allOf(Action.class));
+    revokeAndAssertSuccess(OTHER_NAMESPACE, USER, EnumSet.allOf(Action.class));
   }
 
   @Test
@@ -116,8 +117,8 @@ public abstract class StreamAdminTest {
     StreamAdmin streamAdmin = getStreamAdmin();
 
     String streamName = "streamName";
-    Id.Stream streamId = Id.Stream.from(FOO_NAMESPACE, streamName);
-    Id.Stream otherStreamId = Id.Stream.from(OTHER_NAMESPACE, streamName);
+    StreamId streamId = FOO_NAMESPACE.stream(streamName);
+    StreamId otherStreamId = OTHER_NAMESPACE.stream(streamName);
 
     Assert.assertFalse(streamAdmin.exists(streamId));
     Assert.assertFalse(streamAdmin.exists(otherStreamId));
@@ -130,7 +131,7 @@ public abstract class StreamAdminTest {
     }
 
     // grant write access for user to foo_namespace
-    grantAndAssertSuccess(streamId.getNamespace().toEntityId(), USER, ImmutableSet.of(Action.WRITE));
+    grantAndAssertSuccess(streamId.getParent(), USER, ImmutableSet.of(Action.WRITE));
     streamAdmin.create(streamId);
 
     // Even though both streams have the same name, {@code otherStreamId} does not exist because it is in a different
@@ -146,7 +147,7 @@ public abstract class StreamAdminTest {
     }
 
     // grant write access for user to other_namespace
-    grantAndAssertSuccess(otherStreamId.getNamespace().toEntityId(), USER, ImmutableSet.of(Action.WRITE));
+    grantAndAssertSuccess(otherStreamId.getParent(), USER, ImmutableSet.of(Action.WRITE));
     streamAdmin.create(otherStreamId);
     Assert.assertTrue(streamAdmin.exists(otherStreamId));
 
@@ -155,7 +156,7 @@ public abstract class StreamAdminTest {
     Assert.assertFalse(streamAdmin.exists(otherStreamId));
 
     // revoke the permission for the user on the stream in foo_namespace
-    revokeAndAssertSuccess(streamId.toEntityId(), USER, EnumSet.allOf(Action.class));
+    revokeAndAssertSuccess(streamId, USER, EnumSet.allOf(Action.class));
 
     try {
       streamAdmin.drop(streamId);
@@ -165,7 +166,7 @@ public abstract class StreamAdminTest {
     }
 
     // grant WRITE permission to the user but they still should not be able to drop the stream
-    grantAndAssertSuccess(streamId.toEntityId(), USER, ImmutableSet.of(Action.WRITE));
+    grantAndAssertSuccess(streamId, USER, ImmutableSet.of(Action.WRITE));
 
     try {
       streamAdmin.drop(streamId);
@@ -175,7 +176,7 @@ public abstract class StreamAdminTest {
     }
 
     // grant admin access and the user should then be able to drop the stream
-    grantAndAssertSuccess(streamId.toEntityId(), USER, ImmutableSet.of(Action.ADMIN));
+    grantAndAssertSuccess(streamId, USER, ImmutableSet.of(Action.ADMIN));
     streamAdmin.drop(streamId);
     Assert.assertFalse(streamAdmin.exists(streamId));
   }
@@ -183,8 +184,8 @@ public abstract class StreamAdminTest {
   @Test
   public void testConfigAndTruncate() throws Exception {
     StreamAdmin streamAdmin = getStreamAdmin();
-    grantAndAssertSuccess(new NamespaceId(FOO_NAMESPACE), USER, ImmutableSet.of(Action.WRITE));
-    Id.Stream stream = Id.Stream.from(FOO_NAMESPACE, "stream");
+    grantAndAssertSuccess(FOO_NAMESPACE, USER, ImmutableSet.of(Action.WRITE));
+    StreamId stream = FOO_NAMESPACE.stream("stream");
 
     streamAdmin.create(stream);
     Assert.assertTrue(streamAdmin.exists(stream));
@@ -195,8 +196,8 @@ public abstract class StreamAdminTest {
     streamAdmin.getProperties(stream);
 
     // Now revoke access to the user to the stream and to the namespace
-    revokeAndAssertSuccess(new NamespaceId(FOO_NAMESPACE), USER, ImmutableSet.of(Action.WRITE));
-    revokeAndAssertSuccess(stream.toEntityId(), USER, EnumSet.allOf(Action.class));
+    revokeAndAssertSuccess(FOO_NAMESPACE, USER, ImmutableSet.of(Action.WRITE));
+    revokeAndAssertSuccess(stream, USER, EnumSet.allOf(Action.class));
     streamAdmin.getConfig(stream);
 
     try {
@@ -207,7 +208,7 @@ public abstract class StreamAdminTest {
     }
 
     // read action should be enough to get the stream config
-    grantAndAssertSuccess(stream.toEntityId(), USER, ImmutableSet.of(Action.READ));
+    grantAndAssertSuccess(stream, USER, ImmutableSet.of(Action.READ));
     streamAdmin.getConfig(stream);
     StreamProperties properties = streamAdmin.getProperties(stream);
 
@@ -222,7 +223,7 @@ public abstract class StreamAdminTest {
     // to stream will succeed. It is done so that we can check and perform truncate call.
     writeEvent(stream);
 
-    grantAndAssertSuccess(stream.toEntityId(), USER, ImmutableSet.of(Action.WRITE));
+    grantAndAssertSuccess(stream, USER, ImmutableSet.of(Action.WRITE));
     writeEvent(stream);
 
     try {
@@ -246,7 +247,7 @@ public abstract class StreamAdminTest {
       // expdcted
     }
 
-    grantAndAssertSuccess(stream.toEntityId(), USER, ImmutableSet.of(Action.ADMIN));
+    grantAndAssertSuccess(stream, USER, ImmutableSet.of(Action.ADMIN));
     streamAdmin.updateConfig(stream, properties);
     streamAdmin.truncate(stream);
     Assert.assertEquals(0, getStreamSize(stream));
@@ -256,14 +257,14 @@ public abstract class StreamAdminTest {
   @Test
   public void testListStreams() throws Exception {
     StreamAdmin streamAdmin = getStreamAdmin();
-    NamespaceId nsId = new NamespaceId(FOO_NAMESPACE);
+    NamespaceId nsId = FOO_NAMESPACE;
     grantAndAssertSuccess(nsId, USER, EnumSet.allOf(Action.class));
     StreamId s1 = nsId.stream("s1");
     StreamId s2 = nsId.stream("s2");
     List<StreamSpecification> specifications = streamAdmin.listStreams(nsId);
     Assert.assertTrue(specifications.isEmpty());
-    streamAdmin.create(s1.toId());
-    streamAdmin.create(s2.toId());
+    streamAdmin.create(s1);
+    streamAdmin.create(s2);
     specifications = streamAdmin.listStreams(nsId);
     Assert.assertEquals(2, specifications.size());
 
@@ -295,38 +296,38 @@ public abstract class StreamAdminTest {
 
     grantAndAssertSuccess(s1, USER, EnumSet.allOf(Action.class));
     grantAndAssertSuccess(s2, USER, EnumSet.allOf(Action.class));
-    streamAdmin.drop(s1.toId());
-    streamAdmin.drop(s2.toId());
+    streamAdmin.drop(s1);
+    streamAdmin.drop(s2);
   }
 
   @Test
   public void testDropAllInNamespace() throws Exception {
     StreamAdmin streamAdmin = getStreamAdmin();
-    grantAndAssertSuccess(new NamespaceId(FOO_NAMESPACE), USER, ImmutableSet.of(Action.WRITE, Action.ADMIN));
-    grantAndAssertSuccess(new NamespaceId(OTHER_NAMESPACE), USER, ImmutableSet.of(Action.WRITE, Action.ADMIN));
+    grantAndAssertSuccess(FOO_NAMESPACE, USER, ImmutableSet.of(Action.WRITE, Action.ADMIN));
+    grantAndAssertSuccess(OTHER_NAMESPACE, USER, ImmutableSet.of(Action.WRITE, Action.ADMIN));
 
-    Id.Stream otherStream = Id.Stream.from(OTHER_NAMESPACE, "otherStream");
+    StreamId otherStream = OTHER_NAMESPACE.stream("otherStream");
 
-    List<Id.Stream> fooStreams = Lists.newArrayList();
+    List<StreamId> fooStreams = Lists.newArrayList();
     for (int i = 0; i < 4; i++) {
-      fooStreams.add(Id.Stream.from(FOO_NAMESPACE, "stream" + i));
+      fooStreams.add(FOO_NAMESPACE.stream("stream" + i));
     }
 
-    List<Id.Stream> allStreams = Lists.newArrayList();
+    List<StreamId> allStreams = Lists.newArrayList();
     allStreams.addAll(fooStreams);
     allStreams.add(otherStream);
 
-    for (Id.Stream stream : allStreams) {
+    for (StreamId stream : allStreams) {
       streamAdmin.create(stream);
       writeEvent(stream);
       // all of the streams should have data in it after writing to them
       Assert.assertNotEquals(0, getStreamSize(stream));
     }
 
-    streamAdmin.dropAllInNamespace(Id.Namespace.from(FOO_NAMESPACE));
+    streamAdmin.dropAllInNamespace(FOO_NAMESPACE);
 
     // All of the streams within the default namespace should no longer exist
-    for (Id.Stream defaultStream : fooStreams) {
+    for (StreamId defaultStream : fooStreams) {
       Assert.assertFalse(streamAdmin.exists(defaultStream));
     }
     // otherStream isn't in the foo namespace so its data is not deleted in the above call to dropAllInNamespace.
@@ -339,7 +340,7 @@ public abstract class StreamAdminTest {
 
   @Test
   public void testAuditPublish() throws Exception {
-    grantAndAssertSuccess(new NamespaceId(FOO_NAMESPACE), USER, EnumSet.allOf(Action.class));
+    grantAndAssertSuccess(FOO_NAMESPACE, USER, EnumSet.allOf(Action.class));
 
     // clear existing all messages
     getInMemoryAuditPublisher().popMessages();
@@ -347,36 +348,36 @@ public abstract class StreamAdminTest {
     final List<AuditMessage> expectedMessages = new ArrayList<>();
     StreamAdmin streamAdmin = getStreamAdmin();
 
-    Id.Stream stream1 = Id.Stream.from(FOO_NAMESPACE, "stream1");
+    StreamId stream1 = FOO_NAMESPACE.stream("stream1");
     streamAdmin.create(stream1);
-    expectedMessages.add(new AuditMessage(0, stream1.toEntityId(), "", AuditType.CREATE,
+    expectedMessages.add(new AuditMessage(0, stream1, "", AuditType.CREATE,
                                           AuditPayload.EMPTY_PAYLOAD));
 
-    Id.Stream stream2 = Id.Stream.from(FOO_NAMESPACE, "stream2");
+    StreamId stream2 = FOO_NAMESPACE.stream("stream2");
     streamAdmin.create(stream2);
-    expectedMessages.add(new AuditMessage(0, stream2.toEntityId(), "", AuditType.CREATE,
+    expectedMessages.add(new AuditMessage(0, stream2, "", AuditType.CREATE,
                                           AuditPayload.EMPTY_PAYLOAD));
 
     streamAdmin.truncate(stream1);
-    expectedMessages.add(new AuditMessage(0, stream1.toEntityId(), "", AuditType.TRUNCATE,
+    expectedMessages.add(new AuditMessage(0, stream1, "", AuditType.TRUNCATE,
                                           AuditPayload.EMPTY_PAYLOAD));
 
     streamAdmin.updateConfig(stream1, new StreamProperties(100L, new FormatSpecification("f", null), 100));
-    expectedMessages.add(new AuditMessage(0, stream1.toEntityId(), "", AuditType.UPDATE,
+    expectedMessages.add(new AuditMessage(0, stream1, "", AuditType.UPDATE,
                                           AuditPayload.EMPTY_PAYLOAD));
 
-    Id.Run run = new Id.Run(Id.Program.from("ns1", "app", ProgramType.FLOW, "flw"), RunIds.generate().getId());
+    ProgramRunId run = new ProgramId("ns1", "app", ProgramType.FLOW, "flw").run(RunIds.generate().getId());
     streamAdmin.addAccess(run, stream1, AccessType.READ);
-    expectedMessages.add(new AuditMessage(0, stream1.toEntityId(), "", AuditType.ACCESS,
+    expectedMessages.add(new AuditMessage(0, stream1, "", AuditType.ACCESS,
                                           new AccessPayload(co.cask.cdap.proto.audit.payload.access.AccessType.READ,
-                                                            run.toEntityId())));
+                                                            run)));
 
     streamAdmin.drop(stream1);
-    expectedMessages.add(new AuditMessage(0, stream1.toEntityId(), "", AuditType.DELETE,
+    expectedMessages.add(new AuditMessage(0, stream1, "", AuditType.DELETE,
                                           AuditPayload.EMPTY_PAYLOAD));
 
-    streamAdmin.dropAllInNamespace(Id.Namespace.from(FOO_NAMESPACE));
-    expectedMessages.add(new AuditMessage(0, stream2.toEntityId(), "", AuditType.DELETE,
+    streamAdmin.dropAllInNamespace(FOO_NAMESPACE);
+    expectedMessages.add(new AuditMessage(0, stream2, "", AuditType.DELETE,
                                           AuditPayload.EMPTY_PAYLOAD));
 
     // Ignore audit messages for system namespace (creation of system datasets, etc)
@@ -394,7 +395,7 @@ public abstract class StreamAdminTest {
     Assert.assertEquals(expectedMessages, Lists.newArrayList(actualMessages));
   }
 
-  private long getStreamSize(Id.Stream streamId) throws IOException {
+  private long getStreamSize(StreamId streamId) throws IOException {
     StreamAdmin streamAdmin = getStreamAdmin();
     StreamConfig config = streamAdmin.getConfig(streamId);
 
@@ -404,7 +405,7 @@ public abstract class StreamAdminTest {
   }
 
   // simply writes a static string to a stream
-  private void writeEvent(Id.Stream streamId) throws IOException {
+  private void writeEvent(StreamId streamId) throws IOException {
     StreamConfig streamConfig = getStreamAdmin().getConfig(streamId);
     FileWriter<StreamEvent> streamEventFileWriter = getFileWriterFactory().create(streamConfig, 0);
     streamEventFileWriter.append(new StreamEvent(Charsets.UTF_8.encode("EVENT")));

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/StreamConsumerStateTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/StreamConsumerStateTestBase.java
@@ -20,7 +20,8 @@ import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.data.stream.StreamFileOffset;
 import co.cask.cdap.data.stream.StreamFileType;
 import co.cask.cdap.data.stream.StreamUtils;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -41,25 +42,25 @@ public abstract class StreamConsumerStateTestBase {
   protected abstract StreamAdmin getStreamAdmin();
 
   protected static CConfiguration cConf = CConfiguration.create();
-  protected static final Id.Namespace TEST_NAMESPACE = Id.Namespace.from("streamConsumerStateTestNamespace");
-  protected static final Id.Namespace OTHER_NAMESPACE = Id.Namespace.from("otherNamespace");
+  protected static final NamespaceId TEST_NAMESPACE = new NamespaceId("streamConsumerStateTestNamespace");
+  protected static final NamespaceId OTHER_NAMESPACE = new NamespaceId("otherNamespace");
 
   protected static void setupNamespaces(NamespacedLocationFactory namespacedLocationFactory) throws IOException {
-    namespacedLocationFactory.get(TEST_NAMESPACE).mkdirs();
-    namespacedLocationFactory.get(OTHER_NAMESPACE).mkdirs();
+    namespacedLocationFactory.get(TEST_NAMESPACE.toId()).mkdirs();
+    namespacedLocationFactory.get(OTHER_NAMESPACE.toId()).mkdirs();
   }
 
   @Test
   public void testStateExists() throws Exception {
     StreamAdmin streamAdmin = getStreamAdmin();
     String streamName = "testStateExists";
-    Id.Stream streamId = Id.Stream.from(TEST_NAMESPACE, streamName);
+    StreamId streamId = TEST_NAMESPACE.stream(streamName);
     streamAdmin.create(streamId);
 
     StreamConfig config = streamAdmin.getConfig(streamId);
     StreamConsumerStateStore stateStore = createStateStore(config);
 
-    streamAdmin.configureInstances(Id.Stream.from(TEST_NAMESPACE, streamName), 0L, 1);
+    streamAdmin.configureInstances(TEST_NAMESPACE.stream(streamName), 0L, 1);
 
     // Get a consumer state that is configured
     StreamConsumerState state = stateStore.get(0L, 0);
@@ -74,7 +75,7 @@ public abstract class StreamConsumerStateTestBase {
   public void testStore() throws Exception {
     StreamAdmin streamAdmin = getStreamAdmin();
     String streamName = "testStore";
-    Id.Stream streamId = Id.Stream.from(TEST_NAMESPACE, streamName);
+    StreamId streamId = TEST_NAMESPACE.stream(streamName);
 
     streamAdmin.create(streamId);
 
@@ -98,8 +99,8 @@ public abstract class StreamConsumerStateTestBase {
     // StateStoreFactory is capable of storing distinct states for streams with same name but different namespace
     StreamAdmin streamAdmin = getStreamAdmin();
     String streamName = "testNamespacedStore";
-    Id.Stream streamId = Id.Stream.from(TEST_NAMESPACE, streamName);
-    Id.Stream otherStreamId = Id.Stream.from(OTHER_NAMESPACE, streamName);
+    StreamId streamId = TEST_NAMESPACE.stream(streamName);
+    StreamId otherStreamId = OTHER_NAMESPACE.stream(streamName);
 
     streamAdmin.create(streamId);
     streamAdmin.create(otherStreamId);
@@ -132,7 +133,7 @@ public abstract class StreamConsumerStateTestBase {
   public void testMultiStore() throws Exception {
     StreamAdmin streamAdmin = getStreamAdmin();
     String streamName = "testMultiStore";
-    Id.Stream streamId = Id.Stream.from(TEST_NAMESPACE, streamName);
+    StreamId streamId = TEST_NAMESPACE.stream(streamName);
 
     streamAdmin.create(streamId);
 
@@ -158,7 +159,7 @@ public abstract class StreamConsumerStateTestBase {
   public void testRemove() throws Exception {
     StreamAdmin streamAdmin = getStreamAdmin();
     String streamName = "testRemove";
-    Id.Stream streamId = Id.Stream.from(TEST_NAMESPACE, streamName);
+    StreamId streamId = TEST_NAMESPACE.stream(streamName);
 
     streamAdmin.create(streamId);
 
@@ -204,7 +205,7 @@ public abstract class StreamConsumerStateTestBase {
   public void testChangeInstance() throws Exception {
     StreamAdmin streamAdmin = getStreamAdmin();
     String streamName = "testChangeInstance";
-    Id.Stream streamId = Id.Stream.from(TEST_NAMESPACE, streamName);
+    StreamId streamId = TEST_NAMESPACE.stream(streamName);
 
     streamAdmin.create(streamId);
 

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/StreamConsumerTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/StreamConsumerTestBase.java
@@ -25,7 +25,8 @@ import co.cask.cdap.data2.queue.ConsumerConfig;
 import co.cask.cdap.data2.queue.DequeueResult;
 import co.cask.cdap.data2.queue.DequeueStrategy;
 import co.cask.cdap.data2.queue.QueueClientFactory;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.test.SlowTests;
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
@@ -56,8 +57,8 @@ import java.util.concurrent.TimeUnit;
 public abstract class StreamConsumerTestBase {
 
   protected static CConfiguration cConf = CConfiguration.create();
-  protected static final Id.Namespace TEST_NAMESPACE = Id.Namespace.from("streamConsumerTestNamespace");
-  protected static final Id.Namespace OTHER_NAMESPACE = Id.Namespace.from("otherNamespace");
+  protected static final NamespaceId TEST_NAMESPACE = new NamespaceId("streamConsumerTestNamespace");
+  protected static final NamespaceId OTHER_NAMESPACE = new NamespaceId("otherNamespace");
   private static final Comparator<StreamEvent> STREAM_EVENT_COMPARATOR = new Comparator<StreamEvent>() {
     @Override
     public int compare(StreamEvent o1, StreamEvent o2) {
@@ -80,8 +81,8 @@ public abstract class StreamConsumerTestBase {
   protected abstract StreamFileWriterFactory getFileWriterFactory();
 
   protected static void setupNamespaces(NamespacedLocationFactory namespacedLocationFactory) throws IOException {
-    namespacedLocationFactory.get(TEST_NAMESPACE).mkdirs();
-    namespacedLocationFactory.get(OTHER_NAMESPACE).mkdirs();
+    namespacedLocationFactory.get(TEST_NAMESPACE.toId()).mkdirs();
+    namespacedLocationFactory.get(OTHER_NAMESPACE.toId()).mkdirs();
   }
 
   @Test
@@ -89,8 +90,8 @@ public abstract class StreamConsumerTestBase {
     // Test two consumers for two streams with the same name, but in different namespaces. Their consumption should be
     // independent of the other.
     String stream = "testNamespacedStreamConsumers";
-    Id.Stream streamId = Id.Stream.from(TEST_NAMESPACE, stream);
-    Id.Stream otherStreamId = Id.Stream.from(OTHER_NAMESPACE, stream);
+    StreamId streamId = TEST_NAMESPACE.stream(stream);
+    StreamId otherStreamId = OTHER_NAMESPACE.stream(stream);
 
     StreamAdmin streamAdmin = getStreamAdmin();
     streamAdmin.create(streamId);
@@ -163,7 +164,7 @@ public abstract class StreamConsumerTestBase {
   @Test
   public void testFIFORollback() throws Exception {
     String stream = "testFIFORollback";
-    Id.Stream streamId = Id.Stream.from(TEST_NAMESPACE, stream);
+    StreamId streamId = TEST_NAMESPACE.stream(stream);
     StreamAdmin streamAdmin = getStreamAdmin();
     streamAdmin.create(streamId);
     StreamConfig streamConfig = streamAdmin.getConfig(streamId);
@@ -220,7 +221,7 @@ public abstract class StreamConsumerTestBase {
   @Test
   public void testFIFOReconfigure() throws Exception {
     String stream = "testReconfigure";
-    Id.Stream streamId = Id.Stream.from(TEST_NAMESPACE, stream);
+    StreamId streamId = TEST_NAMESPACE.stream(stream);
     StreamAdmin streamAdmin = getStreamAdmin();
     streamAdmin.create(streamId);
     StreamConfig streamConfig = streamAdmin.getConfig(streamId);
@@ -314,7 +315,7 @@ public abstract class StreamConsumerTestBase {
   @Test
   public void testTTL() throws Exception {
     String stream = "testTTL";
-    Id.Stream streamId = Id.Stream.from(TEST_NAMESPACE, stream);
+    StreamId streamId = TEST_NAMESPACE.stream(stream);
     StreamAdmin streamAdmin = getStreamAdmin();
 
     // Create stream with ttl of 1 day
@@ -371,7 +372,7 @@ public abstract class StreamConsumerTestBase {
   @Test
   public void testTTLMultipleEventsWithSameTimestamp() throws Exception {
     String stream = "testTTLMultipleEventsWithSameTimestamp";
-    Id.Stream streamId = Id.Stream.from(TEST_NAMESPACE, stream);
+    StreamId streamId = TEST_NAMESPACE.stream(stream);
     StreamAdmin streamAdmin = getStreamAdmin();
 
     // Create stream with ttl of 1 day
@@ -430,7 +431,7 @@ public abstract class StreamConsumerTestBase {
   @Test
   public void testTTLStartingFile() throws Exception {
     String stream = "testTTLStartingFile";
-    Id.Stream streamId = Id.Stream.from(TEST_NAMESPACE, stream);
+    StreamId streamId = TEST_NAMESPACE.stream(stream);
     StreamAdmin streamAdmin = getStreamAdmin();
 
     // Create stream with ttl of 3 seconds and partition duration of 3 seconds

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseConsumerStateTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseConsumerStateTest.java
@@ -44,7 +44,7 @@ import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationTestModule;
@@ -128,9 +128,9 @@ public class HBaseConsumerStateTest extends StreamConsumerStateTestBase {
 
     tableUtil = injector.getInstance(HBaseTableUtil.class);
     tableUtil.createNamespaceIfNotExists(TEST_HBASE.getHBaseAdmin(),
-                                         tableUtil.getHBaseNamespace(TEST_NAMESPACE.toEntityId()));
+                                         tableUtil.getHBaseNamespace(TEST_NAMESPACE));
     tableUtil.createNamespaceIfNotExists(TEST_HBASE.getHBaseAdmin(),
-                                         tableUtil.getHBaseNamespace(OTHER_NAMESPACE.toEntityId()));
+                                         tableUtil.getHBaseNamespace(OTHER_NAMESPACE));
 
     setupNamespaces(injector.getInstance(NamespacedLocationFactory.class));
   }
@@ -152,9 +152,9 @@ public class HBaseConsumerStateTest extends StreamConsumerStateTestBase {
     }
   }
 
-  private static void deleteNamespace(Id.Namespace namespace) throws IOException {
-    tableUtil.deleteAllInNamespace(TEST_HBASE.getHBaseAdmin(), tableUtil.getHBaseNamespace(namespace.toEntityId()));
-    tableUtil.deleteNamespaceIfExists(TEST_HBASE.getHBaseAdmin(), tableUtil.getHBaseNamespace(namespace.toEntityId()));
+  private static void deleteNamespace(NamespaceId namespace) throws IOException {
+    tableUtil.deleteAllInNamespace(TEST_HBASE.getHBaseAdmin(), tableUtil.getHBaseNamespace(namespace));
+    tableUtil.deleteNamespaceIfExists(TEST_HBASE.getHBaseAdmin(), tableUtil.getHBaseNamespace(namespace));
   }
 
   @Override

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerTest.java
@@ -145,16 +145,16 @@ public class HBaseStreamConsumerTest extends StreamConsumerTestBase {
     tableUtil = injector.getInstance(HBaseTableUtil.class);
     tableUtil.createNamespaceIfNotExists(TEST_HBASE.getHBaseAdmin(), tableUtil.getHBaseNamespace(NamespaceId.SYSTEM));
     tableUtil.createNamespaceIfNotExists(TEST_HBASE.getHBaseAdmin(),
-                                         tableUtil.getHBaseNamespace(TEST_NAMESPACE.toEntityId()));
+                                         tableUtil.getHBaseNamespace(TEST_NAMESPACE));
     tableUtil.createNamespaceIfNotExists(TEST_HBASE.getHBaseAdmin(),
-                                         tableUtil.getHBaseNamespace(OTHER_NAMESPACE.toEntityId()));
+                                         tableUtil.getHBaseNamespace(OTHER_NAMESPACE));
     setupNamespaces(injector.getInstance(NamespacedLocationFactory.class));
   }
 
   @AfterClass
   public static void finish() throws Exception {
-    deleteNamespace(OTHER_NAMESPACE);
-    deleteNamespace(TEST_NAMESPACE);
+    deleteNamespace(OTHER_NAMESPACE.toId());
+    deleteNamespace(TEST_NAMESPACE.toId());
     deleteNamespace(Id.Namespace.SYSTEM);
     txManager.stopAndWait();
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/dataset/SystemDatasetInstantiator.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/dataset/SystemDatasetInstantiator.java
@@ -26,8 +26,8 @@ import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
 import co.cask.cdap.data2.datafabric.dataset.type.DirectoryClassLoaderProvider;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.EntityId;
 import com.google.common.base.Objects;
 
 import java.io.Closeable;
@@ -46,7 +46,7 @@ public class SystemDatasetInstantiator implements Closeable {
   private final DatasetFramework datasetFramework;
   // provides classloaders to use for different dataset modules
   private final DatasetClassLoaderProvider classLoaderProvider;
-  private final Iterable<? extends Id> owners;
+  private final Iterable<? extends EntityId> owners;
   private final ClassLoader parentClassLoader;
 
   /**
@@ -59,14 +59,14 @@ public class SystemDatasetInstantiator implements Closeable {
 
   public SystemDatasetInstantiator(DatasetFramework datasetFramework,
                                    @Nullable ClassLoader classLoader,
-                                   @Nullable Iterable<? extends Id> owners) {
+                                   @Nullable Iterable<? extends EntityId> owners) {
     this(datasetFramework, classLoader, new ConstantClassLoaderProvider(classLoader), owners);
   }
 
   SystemDatasetInstantiator(DatasetFramework datasetFramework,
                             @Nullable ClassLoader parentClassLoader,
                             DatasetClassLoaderProvider classLoaderProvider,
-                            @Nullable Iterable<? extends Id> owners) {
+                            @Nullable Iterable<? extends EntityId> owners) {
     this.owners = owners;
     this.classLoaderProvider = classLoaderProvider;
     this.datasetFramework = datasetFramework;
@@ -76,28 +76,23 @@ public class SystemDatasetInstantiator implements Closeable {
   }
 
   @Nullable
-  public <T extends DatasetAdmin> T getDatasetAdmin(Id.DatasetInstance datasetId) throws DatasetManagementException,
+  public <T extends DatasetAdmin> T getDatasetAdmin(DatasetId datasetId) throws DatasetManagementException,
     IOException {
     return datasetFramework.getAdmin(datasetId, parentClassLoader, classLoaderProvider);
   }
 
-  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetId)
+  public <T extends Dataset> T getDataset(DatasetId datasetId)
     throws DatasetInstantiationException {
     return getDataset(datasetId, DatasetDefinition.NO_ARGUMENTS);
   }
 
   public <T extends Dataset> T getDataset(DatasetId datasetId, Map<String, String> arguments)
     throws DatasetInstantiationException {
-    return getDataset(datasetId.toId(), arguments);
-  }
-
-  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetId, Map<String, String> arguments)
-    throws DatasetInstantiationException {
     return getDataset(datasetId, arguments, AccessType.UNKNOWN);
   }
 
   @SuppressWarnings("unchecked")
-  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetId, Map<String, String> arguments,
+  public <T extends Dataset> T getDataset(DatasetId datasetId, Map<String, String> arguments,
                                           AccessType accessType) throws DatasetInstantiationException {
 
     try {
@@ -112,7 +107,7 @@ public class SystemDatasetInstantiator implements Closeable {
     }
   }
 
-  public void writeLineage(Id.DatasetInstance datasetId, AccessType accessType) {
+  public void writeLineage(DatasetId datasetId, AccessType accessType) {
     datasetFramework.writeLineage(datasetId, accessType);
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/InMemoryStreamFileWriterFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/InMemoryStreamFileWriterFactory.java
@@ -61,7 +61,7 @@ public final class InMemoryStreamFileWriterFactory implements StreamFileWriterFa
 
   @Override
   public FileWriter<StreamEvent> create(StreamConfig config, int generation) throws IOException {
-    final QueueProducer producer = queueClientFactory.createProducer(QueueName.fromStream(config.getStreamId()));
+    final QueueProducer producer = queueClientFactory.createProducer(QueueName.fromStream(config.getStreamId().toId()));
     final List<TransactionAware> txAwares = Lists.newArrayList();
     if (producer instanceof TransactionAware) {
       txAwares.add((TransactionAware) producer);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/LocationStreamFileWriterFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/runtime/LocationStreamFileWriterFactory.java
@@ -59,7 +59,7 @@ public final class LocationStreamFileWriterFactory implements StreamFileWriterFa
     try {
       Preconditions.checkNotNull(config.getLocation(), "Location for stream %s is unknown.", config.getStreamId());
 
-      Location baseLocation = impersonator.doAs(new NamespaceId(config.getStreamId().getNamespaceId()),
+      Location baseLocation = impersonator.doAs(new NamespaceId(config.getStreamId().getNamespace()),
                                                 new Callable<Location>() {
         @Override
         public Location call() throws Exception {
@@ -71,7 +71,7 @@ public final class LocationStreamFileWriterFactory implements StreamFileWriterFa
 
       return new TimePartitionedStreamFileWriter(baseLocation, config.getPartitionDuration(),
                                                  filePrefix, config.getIndexInterval(),
-                                                 config.getStreamId().toEntityId(), impersonator);
+                                                 config.getStreamId(), impersonator);
     } catch (Exception e) {
       Throwables.propagateIfPossible(e, IOException.class);
       throw new IOException(e);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/AbstractStreamCoordinatorClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/AbstractStreamCoordinatorClient.java
@@ -23,7 +23,7 @@ import co.cask.cdap.common.conf.SyncPropertyUpdater;
 import co.cask.cdap.common.io.Codec;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.base.Objects;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -75,20 +75,20 @@ public abstract class AbstractStreamCoordinatorClient extends AbstractIdleServic
   /**
    * Returns a {@link Lock} for performing exclusive operation for the given stream.
    */
-  protected abstract Lock getLock(Id.Stream streamId);
+  protected abstract Lock getLock(StreamId streamId);
 
   /**
    * Gets invoked when a stream of the given name is created.
    */
-  protected abstract void streamCreated(Id.Stream streamId);
+  protected abstract void streamCreated(StreamId streamId);
 
   /**
    * Gets invoked when a stream is deleted.
    */
-  protected abstract void streamDeleted(Id.Stream streamId);
+  protected abstract void streamDeleted(StreamId streamId);
 
   @Override
-  public StreamConfig createStream(Id.Stream streamId, Callable<StreamConfig> action) throws Exception {
+  public StreamConfig createStream(StreamId streamId, Callable<StreamConfig> action) throws Exception {
     Lock lock = getLock(streamId);
     lock.lock();
     try {
@@ -103,7 +103,7 @@ public abstract class AbstractStreamCoordinatorClient extends AbstractIdleServic
   }
 
   @Override
-  public void updateProperties(Id.Stream streamId, Callable<CoordinatorStreamProperties> action) throws Exception {
+  public void updateProperties(StreamId streamId, Callable<CoordinatorStreamProperties> action) throws Exception {
     Lock lock = getLock(streamId);
     lock.lock();
     try {
@@ -114,7 +114,7 @@ public abstract class AbstractStreamCoordinatorClient extends AbstractIdleServic
   }
 
   @Override
-  public void deleteStream(Id.Stream streamId, Runnable action) throws Exception {
+  public void deleteStream(StreamId streamId, Runnable action) throws Exception {
     Lock lock = getLock(streamId);
     lock.lock();
     try {
@@ -128,7 +128,7 @@ public abstract class AbstractStreamCoordinatorClient extends AbstractIdleServic
   }
 
   @Override
-  public <T> T exclusiveAction(Id.Stream streamId, Callable<T> action) throws Exception {
+  public <T> T exclusiveAction(StreamId streamId, Callable<T> action) throws Exception {
     Lock lock = getLock(streamId);
     lock.lock();
     try {
@@ -139,7 +139,7 @@ public abstract class AbstractStreamCoordinatorClient extends AbstractIdleServic
   }
 
   @Override
-  public Cancellable addListener(Id.Stream streamId, StreamPropertyListener listener) {
+  public Cancellable addListener(StreamId streamId, StreamPropertyListener listener) {
     return propertyStore.addChangeListener(streamId.toString(), new StreamPropertyChangeListener(listener));
   }
 
@@ -184,7 +184,7 @@ public abstract class AbstractStreamCoordinatorClient extends AbstractIdleServic
   /**
    * Updates stream properties in the property store.
    */
-  private ListenableFuture<CoordinatorStreamProperties> updateProperties(Id.Stream streamId,
+  private ListenableFuture<CoordinatorStreamProperties> updateProperties(StreamId streamId,
                                                                          final CoordinatorStreamProperties properties) {
     return propertyStore.update(streamId.toString(), new SyncPropertyUpdater<CoordinatorStreamProperties>() {
 
@@ -219,7 +219,7 @@ public abstract class AbstractStreamCoordinatorClient extends AbstractIdleServic
 
     @Override
     public void onChange(String name, CoordinatorStreamProperties properties) {
-      Id.Stream streamId = Id.Stream.fromString(name, Id.Stream.class);
+      StreamId streamId = StreamId.fromString(name);
       if (properties == null) {
         deleted(streamId);
         oldProperties = null;
@@ -253,7 +253,7 @@ public abstract class AbstractStreamCoordinatorClient extends AbstractIdleServic
     }
 
     @Override
-    public void generationChanged(Id.Stream streamId, int generation) {
+    public void generationChanged(StreamId streamId, int generation) {
       try {
         listener.generationChanged(streamId, generation);
       } catch (Throwable t) {
@@ -262,7 +262,7 @@ public abstract class AbstractStreamCoordinatorClient extends AbstractIdleServic
     }
 
     @Override
-    public void ttlChanged(Id.Stream streamId, long ttl) {
+    public void ttlChanged(StreamId streamId, long ttl) {
       try {
         listener.ttlChanged(streamId, ttl);
       } catch (Throwable t) {
@@ -271,7 +271,7 @@ public abstract class AbstractStreamCoordinatorClient extends AbstractIdleServic
     }
 
     @Override
-    public void thresholdChanged(Id.Stream streamId, int threshold) {
+    public void thresholdChanged(StreamId streamId, int threshold) {
       try {
         listener.thresholdChanged(streamId, threshold);
       } catch (Throwable t) {
@@ -280,7 +280,7 @@ public abstract class AbstractStreamCoordinatorClient extends AbstractIdleServic
     }
 
     @Override
-    public void deleted(Id.Stream streamId) {
+    public void deleted(StreamId streamId) {
       try {
         listener.deleted(streamId);
       } catch (Throwable t) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/DistributedStreamCoordinatorClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/DistributedStreamCoordinatorClient.java
@@ -23,7 +23,7 @@ import co.cask.cdap.common.zookeeper.coordination.ResourceCoordinatorClient;
 import co.cask.cdap.common.zookeeper.coordination.ResourceModifier;
 import co.cask.cdap.common.zookeeper.coordination.ResourceRequirement;
 import co.cask.cdap.common.zookeeper.store.ZKPropertyStore;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -73,14 +73,14 @@ public final class DistributedStreamCoordinatorClient extends AbstractStreamCoor
   }
 
   @Override
-  protected Lock getLock(Id.Stream streamId) {
+  protected Lock getLock(StreamId streamId) {
     // It's ok to create new locks every time as it's backed by ZK for distributed lock
     ZKClient lockZKClient = ZKClients.namespace(zkClient, "/" + Constants.Service.STREAMS + "/locks");
     return new ReentrantDistributedLock(lockZKClient, streamId.toString());
   }
 
   @Override
-  protected void streamCreated(final Id.Stream streamId) {
+  protected void streamCreated(final StreamId streamId) {
     resourceCoordinatorClient.modifyRequirement(
       Constants.Service.STREAMS, new ResourceModifier() {
         @Nullable
@@ -110,7 +110,7 @@ public final class DistributedStreamCoordinatorClient extends AbstractStreamCoor
   }
 
   @Override
-  protected void streamDeleted(final Id.Stream streamId) {
+  protected void streamDeleted(final StreamId streamId) {
     resourceCoordinatorClient.modifyRequirement(Constants.Service.STREAMS, new ResourceModifier() {
       @Nullable
       @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/InMemoryStreamCoordinatorClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/InMemoryStreamCoordinatorClient.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data.stream;
 import co.cask.cdap.common.conf.InMemoryPropertyStore;
 import co.cask.cdap.common.conf.PropertyStore;
 import co.cask.cdap.common.io.Codec;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
@@ -56,17 +56,17 @@ public final class InMemoryStreamCoordinatorClient extends AbstractStreamCoordin
   }
 
   @Override
-  protected Lock getLock(Id.Stream streamId) {
+  protected Lock getLock(StreamId streamId) {
     return lock;
   }
 
   @Override
-  protected void streamCreated(Id.Stream streamId) {
+  protected void streamCreated(StreamId streamId) {
     // Nothing to do
   }
 
   @Override
-  protected void streamDeleted(Id.Stream streamId) {
+  protected void streamDeleted(StreamId streamId) {
     // Nothing to do
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamCoordinatorClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamCoordinatorClient.java
@@ -16,7 +16,7 @@
 package co.cask.cdap.data.stream;
 
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.util.concurrent.Service;
 import org.apache.twill.common.Cancellable;
 
@@ -35,7 +35,7 @@ public interface StreamCoordinatorClient extends Service {
    * @param listener listener to get called when there is change in stream properties.
    * @return A {@link Cancellable} to cancel the watch
    */
-  Cancellable addListener(Id.Stream streamId, StreamPropertyListener listener);
+  Cancellable addListener(StreamId streamId, StreamPropertyListener listener);
 
   /**
    * Creates a stream by performing the given action. The execution of the action is protected by a lock
@@ -49,7 +49,7 @@ public interface StreamCoordinatorClient extends Service {
    * @throws Exception if the action throws Exception
    */
   @Nullable
-  StreamConfig createStream(Id.Stream streamId, Callable<StreamConfig> action) throws Exception;
+  StreamConfig createStream(StreamId streamId, Callable<StreamConfig> action) throws Exception;
 
   /**
    * Updates the stream properties by performing the given action. The execution of the action is protected by a lock
@@ -61,7 +61,7 @@ public interface StreamCoordinatorClient extends Service {
    *               about the update properties.
    * @throws Exception if failed to update properties
    */
-  void updateProperties(Id.Stream streamId, Callable<CoordinatorStreamProperties> action) throws Exception;
+  void updateProperties(StreamId streamId, Callable<CoordinatorStreamProperties> action) throws Exception;
 
   /**
    * Deletes a stream by performing the given action. The execution of the action is protected by a lock
@@ -72,7 +72,7 @@ public interface StreamCoordinatorClient extends Service {
    * @param action action to perform.
    * @throws Exception if the action throws Exception
    */
-  void deleteStream(Id.Stream streamId, Runnable action) throws Exception;
+  void deleteStream(StreamId streamId, Runnable action) throws Exception;
 
   /**
    * Performs an action on a stream while holding the lock for the stream.
@@ -81,5 +81,5 @@ public interface StreamCoordinatorClient extends Service {
    * @param action action to perform.
    * @throws Exception if the action throws Exception
    */
-  <T> T exclusiveAction(Id.Stream streamId, Callable<T> action) throws Exception;
+  <T> T exclusiveAction(StreamId streamId, Callable<T> action) throws Exception;
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamExistenceVerifier.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamExistenceVerifier.java
@@ -39,7 +39,7 @@ public class StreamExistenceVerifier implements EntityExistenceVerifier<StreamId
   public void ensureExists(StreamId streamId) throws StreamNotFoundException {
     boolean exists;
     try {
-      exists = streamAdmin.exists(streamId.toId());
+      exists = streamAdmin.exists(streamId);
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamFileJanitor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamFileJanitor.java
@@ -90,8 +90,7 @@ public final class StreamFileJanitor {
       Iterable<Location> streamLocations = StreamUtils.listAllStreams(streamBaseLocation);
 
       for (final Location streamLocation : streamLocations) {
-        Id.Stream streamId = new StreamId(namespace.getNamespaceId().getNamespace(),
-                                          StreamUtils.getStreamNameFromLocation(streamLocation)).toId();
+        StreamId streamId = namespace.getNamespaceId().stream(StreamUtils.getStreamNameFromLocation(streamLocation));
         final AtomicLong ttl = new AtomicLong(0);
         if (isStreamExists(streamId)) {
           ttl.set(streamAdmin.getConfig(streamId).getTTL());
@@ -150,7 +149,7 @@ public final class StreamFileJanitor {
     return (location.isDirectory() && location.getName().indexOf('.') > 0);
   }
 
-  private boolean isStreamExists(Id.Stream streamId) throws IOException {
+  private boolean isStreamExists(StreamId streamId) throws IOException {
     try {
       return streamAdmin.exists(streamId);
     } catch (Exception e) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamLeaderListener.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamLeaderListener.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.data.stream;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 
 import java.util.Set;
 
@@ -31,5 +31,5 @@ public interface StreamLeaderListener {
    *
    * @param streamIds stream Ids of which the current Stream handler became leader
    */
-  void leaderOf(Set<Id.Stream> streamIds);
+  void leaderOf(Set<StreamId> streamIds);
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamPropertyListener.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamPropertyListener.java
@@ -15,7 +15,7 @@
  */
 package co.cask.cdap.data.stream;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 
 /**
  * Listener for changes in stream properties.
@@ -29,7 +29,7 @@ public abstract class StreamPropertyListener {
    * @param streamId Id of the stream
    * @param generation The generation id updated to.
    */
-  public void generationChanged(Id.Stream streamId, int generation) {
+  public void generationChanged(StreamId streamId, int generation) {
     // Default no-op
   }
 
@@ -39,7 +39,7 @@ public abstract class StreamPropertyListener {
    * @param streamId Id of the stream
    * @param ttl TTL of the stream
    */
-  public void ttlChanged(Id.Stream streamId, long ttl) {
+  public void ttlChanged(StreamId streamId, long ttl) {
     // Default no-op
   }
 
@@ -49,7 +49,7 @@ public abstract class StreamPropertyListener {
    * @param streamId Id of the stream
    * @param threshold Notification threshold of the stream
    */
-  public void thresholdChanged(Id.Stream streamId, int threshold) {
+  public void thresholdChanged(StreamId streamId, int threshold) {
     // Default no-op
   }
 
@@ -58,7 +58,7 @@ public abstract class StreamPropertyListener {
    *
    * @param streamId Id of the stream
    */
-  public void deleted(Id.Stream streamId) {
+  public void deleted(StreamId streamId) {
     // Default no-op
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamTailer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamTailer.java
@@ -26,7 +26,8 @@ import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import com.google.common.base.Charsets;
@@ -71,7 +72,7 @@ public class StreamTailer {
     StreamAdmin streamAdmin = injector.getInstance(StreamAdmin.class);
 
     //TODO: get namespace from commandline arguments
-    Id.Stream streamId = Id.Stream.from(Id.Namespace.DEFAULT, streamName);
+    StreamId streamId = NamespaceId.DEFAULT.stream(streamName);
     StreamConfig streamConfig = streamAdmin.getConfig(streamId);
     Location streamLocation = streamConfig.getLocation();
     List<Location> eventFiles = Lists.newArrayList();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamUtils.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamUtils.java
@@ -24,7 +24,8 @@ import co.cask.cdap.data2.transaction.queue.QueueConstants;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
 import co.cask.cdap.data2.util.TableId;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
@@ -303,7 +304,7 @@ public final class StreamUtils {
     return new StreamFileOffset(eventLocation, offset, generation);
   }
 
-  public static StreamConfig ensureExists(StreamAdmin admin, Id.Stream streamId) throws IOException {
+  public static StreamConfig ensureExists(StreamAdmin admin, StreamId streamId) throws IOException {
     try {
       return admin.getConfig(streamId);
     } catch (Exception e) {
@@ -434,10 +435,10 @@ public final class StreamUtils {
    * @param namespace the namespace for which the table is for.
    * @return constructed TableId
    */
-  public static TableId getStateStoreTableId(Id.Namespace namespace) {
+  public static TableId getStateStoreTableId(NamespaceId namespace) {
     String tableName = String.format("%s.%s.state.store",
-                                     Id.Namespace.SYSTEM.getId(), QueueConstants.QueueType.STREAM.toString());
-    return TableId.from(namespace.getId(), tableName);
+                                     NamespaceId.SYSTEM.getNamespace(), QueueConstants.QueueType.STREAM.toString());
+    return TableId.from(namespace.getNamespace(), tableName);
   }
 
   /**

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamViewHttpHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamViewHttpHandler.java
@@ -21,9 +21,10 @@ import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ViewDetail;
 import co.cask.cdap.proto.ViewSpecification;
+import co.cask.cdap.proto.id.StreamId;
+import co.cask.cdap.proto.id.StreamViewId;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpResponder;
 import com.google.common.base.Function;
@@ -72,9 +73,9 @@ public class StreamViewHttpHandler extends AbstractHttpHandler {
                              @PathParam("stream") String stream,
                              @PathParam("view") String view) throws Exception {
 
-    Id.Stream.View viewId;
+    StreamViewId viewId;
     try {
-      viewId = Id.Stream.View.from(namespace, stream, view);
+      viewId = new StreamViewId(namespace, stream, view);
     } catch (IllegalArgumentException e) {
       throw new BadRequestException(e);
     }
@@ -100,7 +101,7 @@ public class StreamViewHttpHandler extends AbstractHttpHandler {
                      @PathParam("stream") String stream,
                      @PathParam("view") String view) throws Exception {
 
-    Id.Stream.View viewId = Id.Stream.View.from(namespace, stream, view);
+    StreamViewId viewId = new StreamViewId(namespace, stream, view);
     admin.deleteView(viewId);
     responder.sendStatus(HttpResponseStatus.OK);
   }
@@ -111,12 +112,12 @@ public class StreamViewHttpHandler extends AbstractHttpHandler {
                    @PathParam("namespace") String namespace,
                    @PathParam("stream") String stream) throws Exception {
 
-    Id.Stream streamId = Id.Stream.from(namespace, stream);
+    StreamId streamId = new StreamId(namespace, stream);
     Collection<String> list = Collections2.transform(
-      admin.listViews(streamId), new Function<Id.Stream.View, String>() {
+      admin.listViews(streamId), new Function<StreamViewId, String>() {
         @Override
-        public String apply(Id.Stream.View input) {
-          return input.getId();
+        public String apply(StreamViewId input) {
+          return input.getEntityName();
         }
       });
     responder.sendJson(HttpResponseStatus.OK, list);
@@ -129,8 +130,8 @@ public class StreamViewHttpHandler extends AbstractHttpHandler {
                   @PathParam("stream") String stream,
                   @PathParam("view") String view) throws Exception {
 
-    Id.Stream.View viewId = Id.Stream.View.from(namespace, stream, view);
-    ViewDetail detail = new ViewDetail(viewId.getId(), admin.getView(viewId));
+    StreamViewId viewId = new StreamViewId(namespace, stream, view);
+    ViewDetail detail = new ViewDetail(viewId.getEntityName(), admin.getView(viewId));
     responder.sendJson(HttpResponseStatus.OK, detail, ViewDetail.class, GSON);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/AbstractStreamService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/AbstractStreamService.java
@@ -23,7 +23,7 @@ import co.cask.cdap.api.metrics.MetricStore;
 import co.cask.cdap.api.metrics.MetricTimeSeries;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data.stream.StreamCoordinatorClient;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -119,13 +119,13 @@ public abstract class AbstractStreamService extends AbstractScheduledService imp
    * @return Size of events ingested by a stream since its creation
    * @throws IOException when getting an error retrieving the metric
    */
-  protected long getStreamEventsSize(Id.Stream streamId) throws IOException {
+  protected long getStreamEventsSize(StreamId streamId) throws IOException {
     MetricDataQuery metricDataQuery = new MetricDataQuery(
       0L, TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()),
       Integer.MAX_VALUE, "system.collect.bytes",
       AggregationFunction.SUM,
-      ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, streamId.getNamespaceId(),
-                      Constants.Metrics.Tag.STREAM, streamId.getId()),
+      ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, streamId.getNamespace(),
+                      Constants.Metrics.Tag.STREAM, streamId.getEntityName()),
       ImmutableList.<String>of()
     );
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/BasicStreamWriterSizeCollector.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/BasicStreamWriterSizeCollector.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.data.stream.service;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class BasicStreamWriterSizeCollector extends AbstractIdleService implements StreamWriterSizeCollector {
   private static final Logger LOG = LoggerFactory.getLogger(BasicStreamWriterSizeCollector.class);
 
-  private final ConcurrentMap<Id.Stream, AtomicLong> streamSizes;
+  private final ConcurrentMap<StreamId, AtomicLong> streamSizes;
   private final List<Cancellable> truncationSubscriptions;
 
   public BasicStreamWriterSizeCollector() {
@@ -56,18 +56,18 @@ public class BasicStreamWriterSizeCollector extends AbstractIdleService implemen
     }
   }
 
-  public Map<Id.Stream, AtomicLong> getStreamSizes() {
+  public Map<StreamId, AtomicLong> getStreamSizes() {
     return ImmutableMap.copyOf(streamSizes);
   }
 
   @Override
-  public long getTotalCollected(Id.Stream streamId) {
+  public long getTotalCollected(StreamId streamId) {
     AtomicLong collected = streamSizes.get(streamId);
     return collected != null ? collected.get() : 0;
   }
 
   @Override
-  public synchronized void received(Id.Stream streamId, long dataSize) {
+  public synchronized void received(StreamId streamId, long dataSize) {
     AtomicLong value = streamSizes.get(streamId);
     if (value == null) {
       value = streamSizes.putIfAbsent(streamId, new AtomicLong(dataSize));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/InMemoryStreamMetaStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/InMemoryStreamMetaStore.java
@@ -17,7 +17,8 @@
 package co.cask.cdap.data.stream.service;
 
 import co.cask.cdap.api.data.stream.StreamSpecification;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.HashMultimap;
@@ -42,38 +43,38 @@ public class InMemoryStreamMetaStore implements StreamMetaStore {
   }
 
   @Override
-  public void addStream(Id.Stream streamId) throws Exception {
-    streams.put(streamId.getNamespaceId(), streamId.getId());
+  public void addStream(StreamId streamId) throws Exception {
+    streams.put(streamId.getNamespace(), streamId.getEntityName());
   }
 
   @Override
-  public void addStream(Id.Stream streamId, @Nullable String description) throws Exception {
+  public void addStream(StreamId streamId, @Nullable String description) throws Exception {
     addStream(streamId);
   }
 
   @Override
-  public StreamSpecification getStream(Id.Stream streamId) throws Exception {
+  public StreamSpecification getStream(StreamId streamId) throws Exception {
     if (!streamExists(streamId)) {
       return null;
     }
-    return new StreamSpecification.Builder().setName(streamId.getId()).create();
+    return new StreamSpecification.Builder().setName(streamId.getEntityName()).create();
   }
 
   @Override
-  public void removeStream(Id.Stream streamId) throws Exception {
-    streams.remove(streamId.getNamespaceId(), streamId.getId());
+  public void removeStream(StreamId streamId) throws Exception {
+    streams.remove(streamId.getNamespace(), streamId.getEntityName());
   }
 
   @Override
-  public boolean streamExists(Id.Stream streamId) throws Exception {
-    return streams.containsEntry(streamId.getNamespaceId(), streamId.getId());
+  public boolean streamExists(StreamId streamId) throws Exception {
+    return streams.containsEntry(streamId.getNamespace(), streamId.getEntityName());
   }
 
   @Override
-  public List<StreamSpecification> listStreams(Id.Namespace namespaceId) throws Exception {
+  public List<StreamSpecification> listStreams(NamespaceId namespaceId) throws Exception {
     ImmutableList.Builder<StreamSpecification> builder = ImmutableList.builder();
     synchronized (streams) {
-      for (String stream : streams.get(namespaceId.getId())) {
+      for (String stream : streams.get(namespaceId.getEntityName())) {
         builder.add(new StreamSpecification.Builder().setName(stream).create());
       }
     }
@@ -81,12 +82,12 @@ public class InMemoryStreamMetaStore implements StreamMetaStore {
   }
 
   @Override
-  public synchronized Multimap<Id.Namespace, StreamSpecification> listStreams() throws Exception {
-    ImmutableMultimap.Builder<Id.Namespace, StreamSpecification> builder = ImmutableMultimap.builder();
+  public synchronized Multimap<NamespaceId, StreamSpecification> listStreams() throws Exception {
+    ImmutableMultimap.Builder<NamespaceId, StreamSpecification> builder = ImmutableMultimap.builder();
     for (String namespaceId : streams.keySet()) {
       synchronized (streams) {
         Collection<String> streamNames = streams.get(namespaceId);
-        builder.putAll(Id.Namespace.from(namespaceId),
+        builder.putAll(new NamespaceId(namespaceId),
                        Collections2.transform(streamNames, new Function<String, StreamSpecification>() {
                          @Nullable
                          @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFetchHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamFetchHandler.java
@@ -32,8 +32,8 @@ import co.cask.cdap.data.stream.StreamUtils;
 import co.cask.cdap.data.stream.TimeRangeReadFilter;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
@@ -124,13 +124,13 @@ public final class StreamFetchHandler extends AbstractHttpHandler {
     long startTime = TimeMathParser.parseTime(start, TimeUnit.MILLISECONDS);
     long endTime = TimeMathParser.parseTime(end, TimeUnit.MILLISECONDS);
 
-    Id.Stream streamId = Id.Stream.from(namespaceId, stream);
+    StreamId streamId = new StreamId(namespaceId, stream);
     if (!verifyGetEventsRequest(streamId, startTime, endTime, limitEvents, responder)) {
       return;
     }
 
     // Make sure the user has READ permission on the stream since getConfig doesn't check for the same.
-    authorizationEnforcer.enforce(streamId.toEntityId(), authenticationContext.getPrincipal(), Action.READ);
+    authorizationEnforcer.enforce(streamId, authenticationContext.getPrincipal(), Action.READ);
     final StreamConfig streamConfig = streamAdmin.getConfig(streamId);
     long now = System.currentTimeMillis();
     startTime = Math.max(startTime, now - streamConfig.getTTL());
@@ -223,7 +223,7 @@ public final class StreamFetchHandler extends AbstractHttpHandler {
   /**
    * Verifies query properties.
    */
-  private boolean verifyGetEventsRequest(Id.Stream streamId, long startTime, long endTime,
+  private boolean verifyGetEventsRequest(StreamId streamId, long startTime, long endTime,
                                          int count, HttpResponder responder) throws Exception {
     if (startTime < 0) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, "Start time must be >= 0");

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamMetaStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamMetaStore.java
@@ -16,7 +16,8 @@
 package co.cask.cdap.data.stream.service;
 
 import co.cask.cdap.api.data.stream.StreamSpecification;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.collect.Multimap;
 
 import java.util.List;
@@ -32,35 +33,35 @@ public interface StreamMetaStore {
   /**
    * Adds a stream to the meta store.
    */
-  void addStream(Id.Stream streamId) throws Exception;
+  void addStream(StreamId streamId) throws Exception;
 
   /**
    * Adds a stream to the meta store (or updates the description of stream, if stream exists).
    */
-  void addStream(Id.Stream streamId, @Nullable String description) throws Exception;
+  void addStream(StreamId streamId, @Nullable String description) throws Exception;
 
   /**
-   * Fetches the {@link StreamSpecification} of the given {@link Id.Stream}.
+   * Fetches the {@link StreamSpecification} of the given {@link StreamId}.
    */
-  StreamSpecification getStream(Id.Stream streamId) throws Exception;
+  StreamSpecification getStream(StreamId streamId) throws Exception;
 
   /**
    * Removes a stream from the meta store.
    */
-  void removeStream(Id.Stream streamId) throws Exception;
+  void removeStream(StreamId streamId) throws Exception;
 
   /**
    * Checks if a stream exists in the meta store.
    */
-  boolean streamExists(Id.Stream streamId) throws Exception;
+  boolean streamExists(StreamId streamId) throws Exception;
 
   /**
    * List all stream specifications stored for the {@code namespaceId}.
    */
-  List<StreamSpecification> listStreams(Id.Namespace namespaceId) throws Exception;
+  List<StreamSpecification> listStreams(NamespaceId namespaceId) throws Exception;
 
   /**
-   * List all stream specifications with their associated {@link Id.Namespace}.
+   * List all stream specifications with their associated {@link NamespaceId}.
    */
-  Multimap<Id.Namespace, StreamSpecification> listStreams() throws Exception;
+  Multimap<NamespaceId, StreamSpecification> listStreams() throws Exception;
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamMetricsCollectorFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamMetricsCollectorFactory.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.data.stream.service;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 
 /**
  * Factory for creating {@link StreamMetricsCollector}s.
@@ -43,5 +43,5 @@ public interface StreamMetricsCollectorFactory {
    * @param streamId stream name to create a collector for
    * @return a {@link StreamMetricsCollector} for the given {@code streamId}
    */
-  StreamMetricsCollector createMetricsCollector(Id.Stream streamId);
+  StreamMetricsCollector createMetricsCollector(StreamId streamId);
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamWriterSizeCollector.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamWriterSizeCollector.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.data.stream.service;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.util.concurrent.Service;
 
 import java.util.Map;
@@ -32,7 +32,7 @@ public interface StreamWriterSizeCollector extends Service {
   /**
    * @return the streamSizes tracked by this StreamWriterSizeCollector.
    */
-  Map<Id.Stream, AtomicLong> getStreamSizes();
+  Map<StreamId, AtomicLong> getStreamSizes();
 
   /**
    * Get the total amount of bytes collected for the stream {@code streamId} so far.
@@ -40,7 +40,7 @@ public interface StreamWriterSizeCollector extends Service {
    * @param streamId stream Id to get the total amount of data collected for
    * @return the total amount of bytes collected for the stream {@code streamId} so far
    */
-  long getTotalCollected(Id.Stream streamId);
+  long getTotalCollected(StreamId streamId);
 
   /**
    * Called to notify this manager that {@code dataSize} bytes of data has been ingested by the stream
@@ -50,5 +50,5 @@ public interface StreamWriterSizeCollector extends Service {
    * @param streamId Id of the stream that ingested data.
    * @param dataSize amount of data ingested in bytes.
    */
-  void received(Id.Stream streamId, long dataSize);
+  void received(StreamId streamId, long dataSize);
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/heartbeat/StreamWriterHeartbeat.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/heartbeat/StreamWriterHeartbeat.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.data.stream.service.heartbeat;
 
 import co.cask.cdap.data.stream.service.DistributedStreamService;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 
@@ -31,9 +31,9 @@ public class StreamWriterHeartbeat {
 
   private final long timestamp;
   private final int instanceId;
-  private final Map<Id.Stream, Long> streamsSizes;
+  private final Map<StreamId, Long> streamsSizes;
 
-  public StreamWriterHeartbeat(long timestamp, int instanceId, Map<Id.Stream, Long> streamsSizes) {
+  public StreamWriterHeartbeat(long timestamp, int instanceId, Map<StreamId, Long> streamsSizes) {
     this.timestamp = timestamp;
     this.instanceId = instanceId;
     this.streamsSizes = ImmutableMap.copyOf(streamsSizes);
@@ -47,7 +47,7 @@ public class StreamWriterHeartbeat {
     return instanceId;
   }
 
-  public Map<Id.Stream, Long> getStreamsSizes() {
+  public Map<StreamId, Long> getStreamsSizes() {
     return streamsSizes;
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/BufferedContentWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/BufferedContentWriter.java
@@ -21,7 +21,7 @@ import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.io.ByteBuffers;
 import co.cask.cdap.data.stream.service.ConcurrentStreamWriter;
 import co.cask.cdap.data.stream.service.MutableStreamEventData;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableMap;
@@ -38,12 +38,12 @@ import java.util.Map;
  */
 final class BufferedContentWriter implements ContentWriter, Iterable<ByteBuffer> {
 
-  private final Id.Stream streamId;
+  private final StreamId streamId;
   private final ConcurrentStreamWriter streamWriter;
   private final Map<String, String> headers;
   private final List<ByteBuffer> bodies;
 
-  BufferedContentWriter(Id.Stream streamId, ConcurrentStreamWriter streamWriter, Map<String, String> headers) {
+  BufferedContentWriter(StreamId streamId, ConcurrentStreamWriter streamWriter, Map<String, String> headers) {
     this.streamId = streamId;
     this.streamWriter = streamWriter;
     this.headers = ImmutableMap.copyOf(headers);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/BufferedContentWriterFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/BufferedContentWriterFactory.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.data.stream.service.upload;
 
 import co.cask.cdap.data.stream.service.ConcurrentStreamWriter;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
@@ -30,11 +30,11 @@ import java.util.Map;
  */
 public final class BufferedContentWriterFactory implements ContentWriterFactory {
 
-  private final Id.Stream streamId;
+  private final StreamId streamId;
   private final ConcurrentStreamWriter streamWriter;
   private final Map<String, String> headers;
 
-  public BufferedContentWriterFactory(Id.Stream streamId, ConcurrentStreamWriter streamWriter,
+  public BufferedContentWriterFactory(StreamId streamId, ConcurrentStreamWriter streamWriter,
                                       Map<String, String> headers) {
     this.streamId = streamId;
     this.streamWriter = streamWriter;
@@ -42,7 +42,7 @@ public final class BufferedContentWriterFactory implements ContentWriterFactory 
   }
 
   @Override
-  public Id.Stream getStream() {
+  public StreamId getStream() {
     return streamId;
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/ContentWriterFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/ContentWriterFactory.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.data.stream.service.upload;
 
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 
 import java.io.IOException;
 import java.util.Map;
@@ -30,7 +30,7 @@ public interface ContentWriterFactory {
   /**
    * Returns the Id of the stream that all {@link ContentWriter} created by this factory will write to.
    */
-  Id.Stream getStream();
+  StreamId getStream();
 
   /**
    * Creates a {@link ContentWriter} with the given set of event headers added to each {@link StreamEvent}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/FileContentWriterFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/FileContentWriterFactory.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data.stream.service.upload;
 
 import co.cask.cdap.data.stream.service.ConcurrentStreamWriter;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import org.apache.twill.filesystem.Location;
@@ -52,7 +52,7 @@ public final class FileContentWriterFactory implements ContentWriterFactory {
   }
 
   @Override
-  public Id.Stream getStream() {
+  public StreamId getStream() {
     return streamConfig.getStreamId();
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/LengthBasedContentWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/LengthBasedContentWriter.java
@@ -50,7 +50,7 @@ final class LengthBasedContentWriter implements ContentWriter {
     this.bufferedContentWriter = (BufferedContentWriter) new BufferedContentWriterFactory(
       streamConfig.getStreamId(), streamWriter, headers).create(ImmutableMap.<String, String>of());
     this.fileContentWriterFactory = new FileContentWriterFactory(streamConfig, streamWriter, headers);
-    this.streamId = streamConfig.getStreamId().toEntityId();
+    this.streamId = streamConfig.getStreamId();
     this.impersonator = impersonator;
     bodySize = 0;
     fileContentWriter = null;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/LengthBasedContentWriterFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/LengthBasedContentWriterFactory.java
@@ -19,7 +19,7 @@ package co.cask.cdap.data.stream.service.upload;
 import co.cask.cdap.common.security.Impersonator;
 import co.cask.cdap.data.stream.service.ConcurrentStreamWriter;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
@@ -48,7 +48,7 @@ public final class LengthBasedContentWriterFactory implements ContentWriterFacto
   }
 
   @Override
-  public Id.Stream getStream() {
+  public StreamId getStream() {
     return streamConfig.getStreamId();
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/TextStreamBodyConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/upload/TextStreamBodyConsumer.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.data.stream.service.upload;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.http.BodyConsumer;
 import co.cask.http.HttpResponder;
 import com.google.common.base.Throwables;
@@ -41,7 +41,7 @@ final class TextStreamBodyConsumer extends BodyConsumer {
 
   private static final Logger LOG = LoggerFactory.getLogger(TextStreamBodyConsumer.class);
 
-  private final Id.Stream streamId;
+  private final StreamId streamId;
   private final ContentWriterFactory contentWriterFactory;
   private ContentWriter contentWriter;
   private boolean failed;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/view/ViewExistenceVerifier.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/view/ViewExistenceVerifier.java
@@ -40,7 +40,7 @@ public class ViewExistenceVerifier implements EntityExistenceVerifier<StreamView
   public void ensureExists(StreamViewId viewId) throws StreamNotFoundException, ViewNotFoundException {
     boolean exists;
     try {
-      exists = streamAdmin.viewExists(viewId.toId());
+      exists = streamAdmin.viewExists(viewId);
     } catch (StreamNotFoundException e) {
       throw e;
     } catch (Exception e) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/view/ViewStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/view/ViewStore.java
@@ -17,9 +17,10 @@
 package co.cask.cdap.data.view;
 
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ViewDetail;
 import co.cask.cdap.proto.ViewSpecification;
+import co.cask.cdap.proto.id.StreamId;
+import co.cask.cdap.proto.id.StreamViewId;
 
 import java.util.List;
 
@@ -34,30 +35,30 @@ public interface ViewStore {
    * @param config the view config
    * @return true if a new view was created
    */
-  boolean createOrUpdate(Id.Stream.View viewId, ViewSpecification config);
+  boolean createOrUpdate(StreamViewId viewId, ViewSpecification config);
 
   /**
    * @param viewId the view
    * @return true if the view exists
    */
-  boolean exists(Id.Stream.View viewId);
+  boolean exists(StreamViewId viewId);
 
   /**
    * Deletes a view.
    *
    * @param viewId the view
    */
-  void delete(Id.Stream.View viewId) throws NotFoundException;
+  void delete(StreamViewId viewId) throws NotFoundException;
 
   /**
    * @param streamId the stream
    * @return list of view IDs for a stream
    */
-  List<Id.Stream.View> list(Id.Stream streamId);
+  List<StreamViewId> list(StreamId streamId);
 
   /**
    * @param viewId the view
    * @return the details of a view
    */
-  ViewDetail get(Id.Stream.View viewId) throws NotFoundException;
+  ViewDetail get(StreamViewId viewId) throws NotFoundException;
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/audit/AuditPublishers.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/audit/AuditPublishers.java
@@ -21,7 +21,6 @@ import co.cask.cdap.proto.audit.AuditPayload;
 import co.cask.cdap.proto.audit.AuditType;
 import co.cask.cdap.proto.audit.payload.access.AccessPayload;
 import co.cask.cdap.proto.id.EntityId;
-import co.cask.cdap.proto.id.EntityIdCompatible;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import org.slf4j.Logger;
@@ -52,8 +51,8 @@ public final class AuditPublishers {
    * @param accessType access type
    * @param accessor the entity accessing entityId
    */
-  public static void publishAccess(@Nullable AuditPublisher publisher, EntityIdCompatible entityId,
-                                   AccessType accessType, EntityIdCompatible accessor) {
+  public static void publishAccess(@Nullable AuditPublisher publisher, EntityId entityId,
+                                   AccessType accessType, EntityId accessor) {
     if (publisher == null) {
       logWarning();
       return;
@@ -70,27 +69,27 @@ public final class AuditPublishers {
 
     switch (accessType) {
       case READ:
-        publisher.publish(entityId.toEntityId(), AuditType.ACCESS,
+        publisher.publish(entityId, AuditType.ACCESS,
                           new AccessPayload(co.cask.cdap.proto.audit.payload.access.AccessType.READ,
-                                            accessor.toEntityId()));
+                                            accessor));
         break;
       case WRITE:
-        publisher.publish(entityId.toEntityId(), AuditType.ACCESS,
+        publisher.publish(entityId, AuditType.ACCESS,
                           new AccessPayload(co.cask.cdap.proto.audit.payload.access.AccessType.WRITE,
-                                            accessor.toEntityId()));
+                                            accessor));
         break;
       case READ_WRITE:
-        publisher.publish(entityId.toEntityId(), AuditType.ACCESS,
+        publisher.publish(entityId, AuditType.ACCESS,
                           new AccessPayload(co.cask.cdap.proto.audit.payload.access.AccessType.READ,
-                                            accessor.toEntityId()));
-        publisher.publish(entityId.toEntityId(), AuditType.ACCESS,
+                                            accessor));
+        publisher.publish(entityId, AuditType.ACCESS,
                           new AccessPayload(co.cask.cdap.proto.audit.payload.access.AccessType.WRITE,
-                                            accessor.toEntityId()));
+                                            accessor));
         break;
       case UNKNOWN:
-        publisher.publish(entityId.toEntityId(), AuditType.ACCESS,
+        publisher.publish(entityId, AuditType.ACCESS,
                           new AccessPayload(co.cask.cdap.proto.audit.payload.access.AccessType.UNKNOWN,
-                                            accessor.toEntityId()));
+                                            accessor));
         break;
     }
   }
@@ -127,21 +126,21 @@ public final class AuditPublishers {
    * Contains the accessed entity info and the access type.
    */
   private static class AccessAuditInfo {
-    private final EntityIdCompatible accessorEntity;
-    private final EntityIdCompatible accessedEntity;
+    private final EntityId accessorEntity;
+    private final EntityId accessedEntity;
     private final AccessType accessType;
 
-    AccessAuditInfo(EntityIdCompatible accessorEntity, EntityIdCompatible accessedEntity, AccessType accessType) {
+    AccessAuditInfo(EntityId accessorEntity, EntityId accessedEntity, AccessType accessType) {
       this.accessorEntity = accessorEntity;
       this.accessedEntity = accessedEntity;
       this.accessType = accessType;
     }
 
-    public EntityIdCompatible getAccessorEntity() {
+    public EntityId getAccessorEntity() {
       return accessorEntity;
     }
 
-    public EntityIdCompatible getAccessedEntity() {
+    public EntityId getAccessedEntity() {
       return accessedEntity;
     }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetMetaTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetMetaTableUtil.java
@@ -23,7 +23,9 @@ import co.cask.cdap.data2.datafabric.dataset.service.mds.DatasetInstanceMDS;
 import co.cask.cdap.data2.datafabric.dataset.service.mds.DatasetTypeMDS;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.SingleTypeModule;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.DatasetModuleId;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.collect.ImmutableMap;
 
 import java.io.IOException;
@@ -36,10 +38,8 @@ public final class DatasetMetaTableUtil {
   public static final String META_TABLE_NAME = "datasets.type";
   public static final String INSTANCE_TABLE_NAME = "datasets.instance";
 
-  public static final Id.DatasetInstance META_TABLE_INSTANCE_ID =
-    Id.DatasetInstance.from(Id.Namespace.SYSTEM, META_TABLE_NAME);
-  public static final Id.DatasetInstance INSTANCE_TABLE_INSTANCE_ID =
-    Id.DatasetInstance.from(Id.Namespace.SYSTEM, INSTANCE_TABLE_NAME);
+  public static final DatasetId META_TABLE_INSTANCE_ID = NamespaceId.SYSTEM.dataset(META_TABLE_NAME);
+  public static final DatasetId INSTANCE_TABLE_INSTANCE_ID = NamespaceId.SYSTEM.dataset(INSTANCE_TABLE_NAME);
 
   /**
    * Adds datasets and types to the given {@link DatasetFramework} used by dataset service mds.
@@ -49,15 +49,13 @@ public final class DatasetMetaTableUtil {
   public static void setupDatasets(DatasetFramework datasetFramework) throws IOException, DatasetManagementException {
     for (Map.Entry<String, ? extends DatasetModule> entry : getModules().entrySet()) {
       // meta tables should be in the system namespace
-      Id.DatasetModule moduleId = Id.DatasetModule.from(Id.Namespace.SYSTEM, entry.getKey());
+      DatasetModuleId moduleId = NamespaceId.SYSTEM.datasetModule(entry.getKey());
       datasetFramework.addModule(moduleId, entry.getValue());
     }
 
-    datasetFramework.addInstance(DatasetTypeMDS.class.getName(), Id.DatasetInstance.from(
-                                   Id.Namespace.SYSTEM, META_TABLE_NAME),
+    datasetFramework.addInstance(DatasetTypeMDS.class.getName(), NamespaceId.SYSTEM.dataset(META_TABLE_NAME),
                                  DatasetProperties.EMPTY);
-    datasetFramework.addInstance(DatasetInstanceMDS.class.getName(), Id.DatasetInstance.from(
-                                   Id.Namespace.SYSTEM, INSTANCE_TABLE_NAME),
+    datasetFramework.addInstance(DatasetInstanceMDS.class.getName(), NamespaceId.SYSTEM.dataset(INSTANCE_TABLE_NAME),
                                  DatasetProperties.EMPTY);
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -34,7 +34,7 @@ import co.cask.cdap.proto.DatasetMeta;
 import co.cask.cdap.proto.DatasetModuleMeta;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.DatasetTypeMeta;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.common.http.HttpMethod;
@@ -119,13 +119,13 @@ class DatasetServiceClient {
   }
 
   @Nullable
-  public DatasetMeta getInstance(String instanceName, @Nullable Iterable<? extends Id> owners)
+  public DatasetMeta getInstance(String instanceName, @Nullable Iterable<? extends EntityId> owners)
     throws DatasetManagementException {
 
     String query = "";
     if (owners != null) {
       Set<String> ownerParams = Sets.newHashSet();
-      for (Id owner : owners) {
+      for (EntityId owner : owners) {
         ownerParams.add("owner=" + owner.toString());
       }
       query = ownerParams.isEmpty() ? "" : "?" + Joiner.on("&").join(ownerParams);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtil.java
@@ -33,8 +33,8 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.file.FileSetDataset;
 import co.cask.cdap.data2.metadata.lineage.LineageDataset;
 import co.cask.cdap.data2.registry.UsageDataset;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import org.slf4j.Logger;
@@ -61,7 +61,7 @@ public final class DatasetsUtil {
    * NOTE: does poor job guarding against races, i.e. only one client for this dataset instance is supported at a time
    */
   public static <T extends Dataset> T getOrCreateDataset(DatasetFramework datasetFramework,
-                                                         Id.DatasetInstance datasetInstanceId, String typeName,
+                                                         DatasetId datasetInstanceId, String typeName,
                                                          DatasetProperties props,
                                                          Map<String, String> arguments,
                                                          ClassLoader cl)
@@ -85,7 +85,7 @@ public final class DatasetsUtil {
     try {
       return datasetContext.getDataset(datasetId.getNamespace(), datasetId.getDataset());
     } catch (DatasetInstantiationException e) {
-      createIfNotExists(datasetFramework, datasetId.toId(), datasetTypename, datasetProperties);
+      createIfNotExists(datasetFramework, datasetId, datasetTypename, datasetProperties);
       return datasetContext.getDataset(datasetId.getNamespace(), datasetId.getDataset());
     }
   }
@@ -94,7 +94,7 @@ public final class DatasetsUtil {
    * Creates instance of the data set if not exists
    */
   public static void createIfNotExists(DatasetFramework datasetFramework,
-                                       Id.DatasetInstance datasetInstanceId, String typeName,
+                                       DatasetId datasetInstanceId, String typeName,
                                        DatasetProperties props) throws DatasetManagementException, IOException {
 
     if (!datasetFramework.hasInstance(datasetInstanceId)) {
@@ -158,11 +158,11 @@ public final class DatasetsUtil {
   }
 
   //TODO: CDAP-4627 - Figure out a better way to identify system datasets in user namespaces
-  public static boolean isUserDataset(Id.DatasetInstance datasetInstanceId) {
-    return !Id.Namespace.SYSTEM.equals(datasetInstanceId.getNamespace()) &&
-      !"system.queue.config".equals(datasetInstanceId.getId()) &&
-      !datasetInstanceId.getId().startsWith("system.sharded.queue") &&
-      !datasetInstanceId.getId().startsWith("system.queue") &&
-      !datasetInstanceId.getId().startsWith("system.stream");
+  public static boolean isUserDataset(DatasetId datasetInstanceId) {
+    return !NamespaceId.SYSTEM.equals(datasetInstanceId.getParent()) &&
+      !"system.queue.config".equals(datasetInstanceId.getEntityName()) &&
+      !datasetInstanceId.getEntityName().startsWith("system.sharded.queue") &&
+      !datasetInstanceId.getEntityName().startsWith("system.queue") &&
+      !datasetInstanceId.getEntityName().startsWith("system.stream");
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/instance/DatasetInstanceManager.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/instance/DatasetInstanceManager.java
@@ -25,7 +25,7 @@ import co.cask.cdap.data2.dataset2.DynamicDatasetCache;
 import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
 import co.cask.cdap.data2.transaction.TransactionExecutorFactory;
 import co.cask.cdap.data2.transaction.TransactionSystemClientService;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
@@ -62,10 +62,10 @@ public class DatasetInstanceManager {
 
   /**
    * Adds dataset instance metadata
-   * @param namespaceId the {@link Id.Namespace} to add the dataset instance to
+   * @param namespaceId the {@link NamespaceId} to add the dataset instance to
    * @param spec {@link DatasetSpecification} of the dataset instance to be added
    */
-  public void add(final Id.Namespace namespaceId, final DatasetSpecification spec) {
+  public void add(final NamespaceId namespaceId, final DatasetSpecification spec) {
     final DatasetInstanceMDS instanceMDS = datasetCache.getDataset(DatasetMetaTableUtil.INSTANCE_TABLE_NAME);
     txExecutorFactory.createExecutor(datasetCache).executeUnchecked(new TransactionExecutor.Subroutine() {
       @Override
@@ -76,11 +76,11 @@ public class DatasetInstanceManager {
   }
 
   /**
-   * @param datasetInstanceId {@link Id.DatasetInstance} of the dataset instance
+   * @param datasetInstanceId {@link DatasetId} of the dataset instance
    * @return dataset instance's {@link DatasetSpecification}
    */
   @Nullable
-  public DatasetSpecification get(final Id.DatasetInstance datasetInstanceId) {
+  public DatasetSpecification get(final DatasetId datasetInstanceId) {
     final DatasetInstanceMDS instanceMDS = datasetCache.getDataset(DatasetMetaTableUtil.INSTANCE_TABLE_NAME);
     return txExecutorFactory.createExecutor(datasetCache).executeUnchecked(new Callable<DatasetSpecification>() {
       @Override
@@ -91,10 +91,10 @@ public class DatasetInstanceManager {
   }
 
   /**
-   * @param namespaceId {@link Id.Namespace} for which dataset instances are required
+   * @param namespaceId {@link NamespaceId} for which dataset instances are required
    * @return collection of {@link DatasetSpecification} of all dataset instances in the given namespace
    */
-  public Collection<DatasetSpecification> getAll(final Id.Namespace namespaceId) {
+  public Collection<DatasetSpecification> getAll(final NamespaceId namespaceId) {
     final DatasetInstanceMDS instanceMDS = datasetCache.getDataset(DatasetMetaTableUtil.INSTANCE_TABLE_NAME);
     return txExecutorFactory.createExecutor(datasetCache)
       .executeUnchecked(new Callable<Collection<DatasetSpecification>>() {
@@ -107,10 +107,10 @@ public class DatasetInstanceManager {
 
   /**
    * Deletes dataset instance
-   * @param datasetInstanceId {@link Id.DatasetInstance} of the instance to delete
+   * @param datasetInstanceId {@link DatasetId} of the instance to delete
    * @return true if deletion succeeded, false otherwise
    */
-  public boolean delete(final Id.DatasetInstance datasetInstanceId) {
+  public boolean delete(final DatasetId datasetInstanceId) {
     final DatasetInstanceMDS instanceMDS = datasetCache.getDataset(DatasetMetaTableUtil.INSTANCE_TABLE_NAME);
     return txExecutorFactory.createExecutor(datasetCache).executeUnchecked(new Callable<Boolean>() {
       @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/ConversionHelpers.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/ConversionHelpers.java
@@ -23,6 +23,10 @@ import co.cask.cdap.data2.transaction.queue.QueueConstants;
 import co.cask.cdap.proto.DatasetInstanceConfiguration;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.DatasetTypeId;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
@@ -45,48 +49,48 @@ class ConversionHelpers {
 
   private static final Gson GSON = new Gson();
 
-  static Id.Namespace toNamespaceId(String namespace) throws BadRequestException {
+  static NamespaceId toNamespaceId(String namespace) throws BadRequestException {
     try {
-      return Id.Namespace.from(namespace);
+      return Id.Namespace.from(namespace).toEntityId();
     } catch (IllegalArgumentException | NullPointerException e) {
       throw new BadRequestException(e.getMessage());
     }
   }
 
-  static Id.DatasetInstance toDatasetInstanceId(String namespace, String name) throws BadRequestException {
+  static DatasetId toDatasetInstanceId(String namespace, String name) throws BadRequestException {
     try {
-      return Id.DatasetInstance.from(namespace, name);
+      return Id.DatasetInstance.from(namespace, name).toEntityId();
     } catch (IllegalArgumentException | NullPointerException e) {
       throw new BadRequestException(e.getMessage());
     }
   }
 
-  static Id.DatasetType toDatasetTypeId(String namespace, String typeName) throws BadRequestException {
+  static DatasetTypeId toDatasetTypeId(String namespace, String typeName) throws BadRequestException {
     try {
-      return Id.DatasetType.from(namespace, typeName);
+      return Id.DatasetType.from(namespace, typeName).toEntityId();
     } catch (IllegalArgumentException | NullPointerException e) {
       throw new BadRequestException(e.getMessage());
     }
   }
 
-  static Id.DatasetType toDatasetTypeId(Id.Namespace namespace, String typeName) throws BadRequestException {
+  static DatasetTypeId toDatasetTypeId(NamespaceId namespace, String typeName) throws BadRequestException {
     try {
-      return Id.DatasetType.from(namespace, typeName);
+      return Id.DatasetType.from(namespace.getNamespace(), typeName).toEntityId();
     } catch (IllegalArgumentException | NullPointerException e) {
       throw new BadRequestException(e.getMessage());
     }
   }
 
-  static List<? extends Id> strings2ProgramIds(List<String> strings) throws BadRequestException {
+  static List<? extends EntityId> strings2ProgramIds(List<String> strings) throws BadRequestException {
     try {
-      return Lists.transform(strings, new Function<String, Id>() {
+      return Lists.transform(strings, new Function<String, EntityId>() {
         @Nullable
         @Override
-        public Id apply(@Nullable String input) {
+        public EntityId apply(@Nullable String input) {
           if (input == null || input.isEmpty()) {
             return null;
           }
-          return Id.fromString(input, Id.Program.class);
+          return Id.fromString(input, Id.Program.class).toEntityId();
         }
       });
     } catch (IllegalArgumentException | NullPointerException e) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceHandler.java
@@ -24,7 +24,6 @@ import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetAdminOpResp
 import co.cask.cdap.internal.guava.reflect.TypeToken;
 import co.cask.cdap.proto.DatasetInstanceConfiguration;
 import co.cask.cdap.proto.DatasetMeta;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpResponder;
@@ -117,7 +116,7 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
   public void getProperties(HttpRequest request, HttpResponder responder,
                             @PathParam("namespace-id") String namespaceId,
                             @PathParam("name") String name) throws Exception {
-    Id.DatasetInstance instance = ConversionHelpers.toDatasetInstanceId(namespaceId, name);
+    DatasetId instance = ConversionHelpers.toDatasetInstanceId(namespaceId, name);
     responder.sendJson(HttpResponseStatus.OK,
                        instanceService.getOriginalProperties(instance),
                        new TypeToken<Map<String, String>>() { }.getType());
@@ -135,7 +134,7 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
   public void update(HttpRequest request, HttpResponder responder,
                      @PathParam("namespace-id") String namespaceId,
                      @PathParam("name") String name) throws Exception {
-    Id.DatasetInstance instance = ConversionHelpers.toDatasetInstanceId(namespaceId, name);
+    DatasetId instance = ConversionHelpers.toDatasetInstanceId(namespaceId, name);
     Map<String, String> properties = ConversionHelpers.getProperties(request);
     instanceService.update(instance, properties);
     responder.sendStatus(HttpResponseStatus.OK);
@@ -152,7 +151,7 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
   @Path("/data/datasets/{name}")
   public void drop(HttpRequest request, HttpResponder responder, @PathParam("namespace-id") String namespaceId,
                    @PathParam("name") String name) throws Exception {
-    Id.DatasetInstance instance = ConversionHelpers.toDatasetInstanceId(namespaceId, name);
+    DatasetId instance = ConversionHelpers.toDatasetInstanceId(namespaceId, name);
     instanceService.drop(instance);
     responder.sendStatus(HttpResponseStatus.OK);
   }
@@ -161,7 +160,7 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
   @Path("/data/datasets")
   public void dropAll(HttpRequest request, HttpResponder responder,
                       @PathParam("namespace-id") String namespaceId) throws Exception {
-    Set<DatasetId> datasets = instanceService.dropAll(ConversionHelpers.toNamespaceId(namespaceId).toEntityId());
+    Set<DatasetId> datasets = instanceService.dropAll(ConversionHelpers.toNamespaceId(namespaceId));
     responder.sendJson(HttpResponseStatus.OK, Collections2.transform(datasets, new Function<DatasetId, String>() {
       @Override
       public String apply(DatasetId datasetId) {
@@ -183,7 +182,7 @@ public class DatasetInstanceHandler extends AbstractHttpHandler {
   public void executeAdmin(HttpRequest request, HttpResponder responder, @PathParam("namespace-id") String namespaceId,
                            @PathParam("name") String name,
                            @PathParam("method") String method) throws Exception {
-    Id.DatasetInstance instance = ConversionHelpers.toDatasetInstanceId(namespaceId, name);
+    DatasetId instance = ConversionHelpers.toDatasetInstanceId(namespaceId, name);
     try {
       DatasetAdminOpResponse response = instanceService.executeAdmin(instance, method);
       responder.sendJson(HttpResponseStatus.OK, response);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetAdminOpHTTPHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetAdminOpHTTPHandler.java
@@ -24,7 +24,8 @@ import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.proto.DatasetTypeMeta;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpResponder;
@@ -67,9 +68,9 @@ public class DatasetAdminOpHTTPHandler extends AbstractHttpHandler {
                      @PathParam("namespace-id") String namespaceId,
                      @PathParam("name") String instanceName) {
     propagateUserId(request);
-    Id.Namespace namespace = Id.Namespace.from(namespaceId);
+    NamespaceId namespace = new NamespaceId(namespaceId);
     try {
-      Id.DatasetInstance instanceId = Id.DatasetInstance.from(namespace, instanceName);
+      DatasetId instanceId = namespace.dataset(instanceName);
       responder.sendJson(HttpResponseStatus.OK,
                          new DatasetAdminOpResponse(datasetAdminService.exists(instanceId), null));
     } catch (NotFoundException e) {
@@ -96,7 +97,7 @@ public class DatasetAdminOpHTTPHandler extends AbstractHttpHandler {
     DatasetTypeMeta typeMeta = params.getTypeMeta();
 
     try {
-      Id.DatasetInstance instanceId = Id.DatasetInstance.from(namespaceId, name);
+      DatasetId instanceId = new DatasetId(namespaceId, name);
       DatasetSpecification spec = datasetAdminService.createOrUpdate(instanceId, typeMeta, props, null);
       responder.sendJson(HttpResponseStatus.OK, spec);
     } catch (BadRequestException e) {
@@ -123,7 +124,7 @@ public class DatasetAdminOpHTTPHandler extends AbstractHttpHandler {
     DatasetTypeMeta typeMeta = params.getTypeMeta();
 
     try {
-      Id.DatasetInstance instanceId = Id.DatasetInstance.from(namespaceId, name);
+      DatasetId instanceId = new DatasetId(namespaceId, name);
       DatasetSpecification spec = datasetAdminService.createOrUpdate(instanceId, typeMeta, props, existing);
       responder.sendJson(HttpResponseStatus.OK, spec);
     } catch (NotFoundException e) {
@@ -153,7 +154,7 @@ public class DatasetAdminOpHTTPHandler extends AbstractHttpHandler {
     DatasetTypeMeta typeMeta = params.getTypeMeta();
 
     try {
-      datasetAdminService.drop(Id.DatasetInstance.from(namespaceId, instanceName), typeMeta, spec);
+      datasetAdminService.drop(new DatasetId(namespaceId, instanceName), typeMeta, spec);
       responder.sendJson(HttpResponseStatus.OK, spec);
     } catch (BadRequestException e) {
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
@@ -167,7 +168,7 @@ public class DatasetAdminOpHTTPHandler extends AbstractHttpHandler {
                        @PathParam("name") String instanceName) {
     propagateUserId(request);
     try {
-      Id.DatasetInstance instanceId = Id.DatasetInstance.from(namespaceId, instanceName);
+      DatasetId instanceId = new DatasetId(namespaceId, instanceName);
       datasetAdminService.truncate(instanceId);
       responder.sendJson(HttpResponseStatus.OK, new DatasetAdminOpResponse(null, null));
     } catch (NotFoundException e) {
@@ -186,7 +187,7 @@ public class DatasetAdminOpHTTPHandler extends AbstractHttpHandler {
                       @PathParam("name") String instanceName) {
     propagateUserId(request);
     try {
-      Id.DatasetInstance instanceId = Id.DatasetInstance.from(namespaceId, instanceName);
+      DatasetId instanceId = new DatasetId(namespaceId, instanceName);
       datasetAdminService.upgrade(instanceId);
       responder.sendJson(HttpResponseStatus.OK, new DatasetAdminOpResponse(null, null));
     } catch (NotFoundException e) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutor.java
@@ -19,7 +19,7 @@ package co.cask.cdap.data2.datafabric.dataset.service.executor;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.proto.DatasetTypeMeta;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import com.google.common.util.concurrent.Service;
 
 import java.io.IOException;
@@ -32,60 +32,60 @@ public interface DatasetOpExecutor extends Service {
   /**
    * Checks for the existence of a dataset instance
    *
-   * @param datasetInstanceId {@link Id.DatasetInstance} of the dataset instance.
+   * @param datasetInstanceId {@link DatasetId} of the dataset instance.
    * @return true if dataset exists
    * @throws IOException
    */
-  boolean exists(Id.DatasetInstance datasetInstanceId) throws Exception;
+  boolean exists(DatasetId datasetInstanceId) throws Exception;
 
   /**
    * Creates a dataset.
    *
-   * @param datasetInstanceId {@link Id.DatasetInstance} of the dataset instance.
+   * @param datasetInstanceId {@link DatasetId} of the dataset instance.
    * @param typeMeta Data set type meta
    * @param props Data set instance properties
    * @throws IOException
    */
-  DatasetSpecification create(Id.DatasetInstance datasetInstanceId, DatasetTypeMeta typeMeta, DatasetProperties props)
+  DatasetSpecification create(DatasetId datasetInstanceId, DatasetTypeMeta typeMeta, DatasetProperties props)
     throws Exception;
 
   /**
    * Creates a dataset.
    *
-   * @param datasetInstanceId {@link Id.DatasetInstance} of the dataset instance.
+   * @param datasetInstanceId {@link DatasetId} of the dataset instance.
    * @param typeMeta dataset type meta
    * @param props dataset instance properties
    * @param existing the existing dataset spec
    * @throws IOException
    */
-  DatasetSpecification update(Id.DatasetInstance datasetInstanceId, DatasetTypeMeta typeMeta,
+  DatasetSpecification update(DatasetId datasetInstanceId, DatasetTypeMeta typeMeta,
                               DatasetProperties props, DatasetSpecification existing) throws Exception;
 
   /**
    * Drops dataset.
    *
    *
-   * @param datasetInstanceId {@link Id.DatasetInstance} of the dataset instance.
+   * @param datasetInstanceId {@link DatasetId} of the dataset instance.
    * @param typeMeta Data set type meta
    * @param spec Data set instance spec
    * @throws IOException
    */
-  void drop(Id.DatasetInstance datasetInstanceId, DatasetTypeMeta typeMeta, DatasetSpecification spec) throws Exception;
+  void drop(DatasetId datasetInstanceId, DatasetTypeMeta typeMeta, DatasetSpecification spec) throws Exception;
 
   /**
    * Deletes all data of the dataset.
    *
-   * @param datasetInstanceId {@link Id.DatasetInstance} of the dataset instance.
+   * @param datasetInstanceId {@link DatasetId} of the dataset instance.
    * @throws IOException
    */
-  void truncate(Id.DatasetInstance datasetInstanceId) throws Exception;
+  void truncate(DatasetId datasetInstanceId) throws Exception;
 
   /**
    * Upgrades dataset.
    *
-   * @param datasetInstanceId {@link Id.DatasetInstance} of the dataset instance.
+   * @param datasetInstanceId {@link DatasetId} of the dataset instance.
    * @throws IOException
    */
-  void upgrade(Id.DatasetInstance datasetInstanceId) throws Exception;
+  void upgrade(DatasetId datasetInstanceId) throws Exception;
 
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/InMemoryDatasetOpExecutor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/InMemoryDatasetOpExecutor.java
@@ -28,7 +28,7 @@ import co.cask.cdap.data2.datafabric.dataset.DatasetType;
 import co.cask.cdap.data2.datafabric.dataset.RemoteDatasetFramework;
 import co.cask.cdap.data2.datafabric.dataset.type.ConstantClassLoaderProvider;
 import co.cask.cdap.proto.DatasetTypeMeta;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.inject.Inject;
 
@@ -47,12 +47,12 @@ public class InMemoryDatasetOpExecutor extends AbstractIdleService implements Da
   }
 
   @Override
-  public boolean exists(Id.DatasetInstance datasetInstanceId) throws Exception {
+  public boolean exists(DatasetId datasetInstanceId) throws Exception {
     return getAdmin(datasetInstanceId).exists();
   }
 
   @Override
-  public DatasetSpecification create(Id.DatasetInstance datasetInstanceId, DatasetTypeMeta typeMeta,
+  public DatasetSpecification create(DatasetId datasetInstanceId, DatasetTypeMeta typeMeta,
                                      DatasetProperties props)
     throws Exception {
 
@@ -62,23 +62,23 @@ public class InMemoryDatasetOpExecutor extends AbstractIdleService implements Da
       throw new IllegalArgumentException("Dataset type cannot be instantiated for provided type meta: " + typeMeta);
     }
 
-    DatasetSpecification spec = type.configure(datasetInstanceId.getId(), props);
-    DatasetAdmin admin = type.getAdmin(DatasetContext.from(datasetInstanceId.getNamespaceId()), spec);
+    DatasetSpecification spec = type.configure(datasetInstanceId.getEntityName(), props);
+    DatasetAdmin admin = type.getAdmin(DatasetContext.from(datasetInstanceId.getNamespace()), spec);
     admin.create();
 
     return spec;
   }
 
   @Override
-  public DatasetSpecification update(Id.DatasetInstance datasetInstanceId, DatasetTypeMeta typeMeta,
+  public DatasetSpecification update(DatasetId datasetInstanceId, DatasetTypeMeta typeMeta,
                                      DatasetProperties props, DatasetSpecification existing) throws Exception {
     DatasetType type = client.getDatasetType(typeMeta, null, new ConstantClassLoaderProvider());
     if (type == null) {
       throw new IllegalArgumentException("Dataset type cannot be instantiated for provided type meta: " + typeMeta);
     }
     try {
-      DatasetSpecification spec = type.reconfigure(datasetInstanceId.getId(), props, existing);
-      DatasetAdmin admin = type.getAdmin(DatasetContext.from(datasetInstanceId.getNamespaceId()), spec);
+      DatasetSpecification spec = type.reconfigure(datasetInstanceId.getEntityName(), props, existing);
+      DatasetAdmin admin = type.getAdmin(DatasetContext.from(datasetInstanceId.getNamespace()), spec);
       if (admin instanceof Updatable) {
         ((Updatable) admin).update(existing);
       } else {
@@ -94,7 +94,7 @@ public class InMemoryDatasetOpExecutor extends AbstractIdleService implements Da
   }
 
   @Override
-  public void drop(Id.DatasetInstance datasetInstanceId, DatasetTypeMeta typeMeta,
+  public void drop(DatasetId datasetInstanceId, DatasetTypeMeta typeMeta,
                    DatasetSpecification spec) throws Exception {
     DatasetType type = client.getDatasetType(typeMeta, null, new ConstantClassLoaderProvider());
 
@@ -102,17 +102,17 @@ public class InMemoryDatasetOpExecutor extends AbstractIdleService implements Da
       throw new IllegalArgumentException("Dataset type cannot be instantiated for provided type meta: " + typeMeta);
     }
 
-    DatasetAdmin admin = type.getAdmin(DatasetContext.from(datasetInstanceId.getNamespaceId()), spec);
+    DatasetAdmin admin = type.getAdmin(DatasetContext.from(datasetInstanceId.getNamespace()), spec);
     admin.drop();
   }
 
   @Override
-  public void truncate(Id.DatasetInstance datasetInstanceId) throws Exception {
+  public void truncate(DatasetId datasetInstanceId) throws Exception {
     getAdmin(datasetInstanceId).truncate();
   }
 
   @Override
-  public void upgrade(Id.DatasetInstance datasetInstanceId) throws Exception {
+  public void upgrade(DatasetId datasetInstanceId) throws Exception {
     getAdmin(datasetInstanceId).upgrade();
   }
 
@@ -126,7 +126,7 @@ public class InMemoryDatasetOpExecutor extends AbstractIdleService implements Da
 
   }
 
-  private DatasetAdmin getAdmin(Id.DatasetInstance datasetInstanceId) throws IOException, DatasetManagementException {
+  private DatasetAdmin getAdmin(DatasetId datasetInstanceId) throws IOException, DatasetManagementException {
     return client.getAdmin(datasetInstanceId, null);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/RemoteDatasetOpExecutor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/executor/RemoteDatasetOpExecutor.java
@@ -29,7 +29,7 @@ import co.cask.cdap.common.http.DefaultHttpRequestConfig;
 import co.cask.cdap.common.service.UncaughtExceptionIdleService;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.proto.DatasetTypeMeta;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequestConfig;
@@ -114,12 +114,12 @@ public abstract class RemoteDatasetOpExecutor extends UncaughtExceptionIdleServi
   }
 
   @Override
-  public boolean exists(Id.DatasetInstance datasetInstanceId) throws Exception {
+  public boolean exists(DatasetId datasetInstanceId) throws Exception {
     return (Boolean) executeAdminOp(datasetInstanceId, "exists", null).getResult();
   }
 
   @Override
-  public DatasetSpecification create(Id.DatasetInstance datasetInstanceId, DatasetTypeMeta typeMeta,
+  public DatasetSpecification create(DatasetId datasetInstanceId, DatasetTypeMeta typeMeta,
                                      DatasetProperties props) throws Exception {
     InternalDatasetCreationParams creationParams = new InternalDatasetCreationParams(typeMeta, props);
     HttpResponse response = doRequest(datasetInstanceId, "create", GSON.toJson(creationParams));
@@ -127,7 +127,7 @@ public abstract class RemoteDatasetOpExecutor extends UncaughtExceptionIdleServi
   }
 
   @Override
-  public DatasetSpecification update(Id.DatasetInstance datasetInstanceId, DatasetTypeMeta typeMeta,
+  public DatasetSpecification update(DatasetId datasetInstanceId, DatasetTypeMeta typeMeta,
                                      DatasetProperties props, DatasetSpecification existing) throws Exception {
     InternalDatasetCreationParams updateParams = new InternalDatasetUpdateParams(typeMeta, existing, props);
     HttpResponse response = doRequest(datasetInstanceId, "update", GSON.toJson(updateParams));
@@ -135,30 +135,30 @@ public abstract class RemoteDatasetOpExecutor extends UncaughtExceptionIdleServi
   }
 
   @Override
-  public void drop(Id.DatasetInstance datasetInstanceId, DatasetTypeMeta typeMeta, DatasetSpecification spec)
+  public void drop(DatasetId datasetInstanceId, DatasetTypeMeta typeMeta, DatasetSpecification spec)
     throws Exception {
     InternalDatasetDropParams dropParams = new InternalDatasetDropParams(typeMeta, spec);
     doRequest(datasetInstanceId, "drop", GSON.toJson(dropParams));
   }
 
   @Override
-  public void truncate(Id.DatasetInstance datasetInstanceId) throws Exception {
+  public void truncate(DatasetId datasetInstanceId) throws Exception {
     executeAdminOp(datasetInstanceId, "truncate", null);
   }
 
   @Override
-  public void upgrade(Id.DatasetInstance datasetInstanceId) throws Exception {
+  public void upgrade(DatasetId datasetInstanceId) throws Exception {
     executeAdminOp(datasetInstanceId, "upgrade", null);
   }
 
   private DatasetAdminOpResponse executeAdminOp(
-    Id.DatasetInstance datasetInstanceId, String opName,
+    DatasetId datasetInstanceId, String opName,
     @Nullable String body) throws IOException, HandlerException, ConflictException {
     HttpResponse httpResponse = doRequest(datasetInstanceId, opName, body);
     return GSON.fromJson(Bytes.toString(httpResponse.getResponseBody()), DatasetAdminOpResponse.class);
   }
 
-  private HttpResponse doRequest(Id.DatasetInstance datasetInstanceId, String opName,
+  private HttpResponse doRequest(DatasetId datasetInstanceId, String opName,
                                  @Nullable String body) throws IOException, ConflictException {
     HttpRequest.Builder builder = HttpRequest.post(resolve(datasetInstanceId, opName));
     if (body != null) {
@@ -173,9 +173,9 @@ public abstract class RemoteDatasetOpExecutor extends UncaughtExceptionIdleServi
     return httpResponse;
   }
 
-  private URL resolve(Id.DatasetInstance datasetInstanceId, String opName) throws MalformedURLException {
-    return resolve(String.format("namespaces/%s/data/datasets/%s/admin/%s", datasetInstanceId.getNamespaceId(),
-                                 datasetInstanceId.getId(), opName));
+  private URL resolve(DatasetId datasetInstanceId, String opName) throws MalformedURLException {
+    return resolve(String.format("namespaces/%s/data/datasets/%s/admin/%s", datasetInstanceId.getNamespace(),
+                                 datasetInstanceId.getEntityName(), opName));
   }
 
   private URL resolve(String path) throws MalformedURLException {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/mds/DatasetInstanceMDS.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/mds/DatasetInstanceMDS.java
@@ -22,7 +22,8 @@ import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
 import co.cask.cdap.data2.dataset2.lib.table.MetadataStoreDataset;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 
@@ -48,24 +49,24 @@ public final class DatasetInstanceMDS extends MetadataStoreDataset {
   }
 
   @Nullable
-  public DatasetSpecification get(Id.DatasetInstance datasetInstanceId) {
-    return get(getInstanceKey(datasetInstanceId.getNamespace(), datasetInstanceId.getId()),
+  public DatasetSpecification get(DatasetId datasetInstanceId) {
+    return get(getInstanceKey(datasetInstanceId.getParent(), datasetInstanceId.getEntityName()),
                DatasetSpecification.class);
   }
 
-  public void write(Id.Namespace namespaceId, DatasetSpecification instanceSpec) {
+  public void write(NamespaceId namespaceId, DatasetSpecification instanceSpec) {
     write(getInstanceKey(namespaceId, instanceSpec.getName()), instanceSpec);
   }
 
-  public boolean delete(Id.DatasetInstance datasetInstanceId) {
+  public boolean delete(DatasetId datasetInstanceId) {
     if (get(datasetInstanceId) == null) {
       return false;
     }
-    deleteAll(getInstanceKey(datasetInstanceId.getNamespace(), datasetInstanceId.getId()));
+    deleteAll(getInstanceKey(datasetInstanceId.getParent(), datasetInstanceId.getEntityName()));
     return true;
   }
 
-  public Collection<DatasetSpecification> getAll(Id.Namespace namespaceId) {
+  public Collection<DatasetSpecification> getAll(NamespaceId namespaceId) {
     Predicate<DatasetSpecification> localDatasetFilter = new Predicate<DatasetSpecification>() {
       @Override
       public boolean apply(@Nullable DatasetSpecification input) {
@@ -79,7 +80,7 @@ public final class DatasetInstanceMDS extends MetadataStoreDataset {
     return instances.values();
   }
 
-  public Collection<DatasetSpecification> getByTypes(Id.Namespace namespaceId, Set<String> typeNames) {
+  public Collection<DatasetSpecification> getByTypes(NamespaceId namespaceId, Set<String> typeNames) {
     List<DatasetSpecification> filtered = Lists.newArrayList();
 
     for (DatasetSpecification spec : getAll(namespaceId)) {
@@ -91,12 +92,12 @@ public final class DatasetInstanceMDS extends MetadataStoreDataset {
     return filtered;
   }
 
-  private MDSKey getInstanceKey(Id.Namespace namespaceId) {
+  private MDSKey getInstanceKey(NamespaceId namespaceId) {
     return getInstanceKey(namespaceId, null);
   }
 
-  private MDSKey getInstanceKey(Id.Namespace namespaceId, @Nullable String instanceName) {
-    MDSKey.Builder builder = new MDSKey.Builder().add(INSTANCE_PREFIX).add(namespaceId.getId());
+  private MDSKey getInstanceKey(NamespaceId namespaceId, @Nullable String instanceName) {
+    MDSKey.Builder builder = new MDSKey.Builder().add(INSTANCE_PREFIX).add(namespaceId.getEntityName());
     if (instanceName != null) {
       builder.add(instanceName);
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetExistenceVerifier.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetExistenceVerifier.java
@@ -37,7 +37,7 @@ public class DatasetExistenceVerifier implements EntityExistenceVerifier<Dataset
   @Override
   public void ensureExists(DatasetId datasetId) throws DatasetNotFoundException {
     try {
-      if (!dsFramework.hasInstance(datasetId.toId())) {
+      if (!dsFramework.hasInstance(datasetId)) {
         throw new DatasetNotFoundException(datasetId.toId());
       }
     } catch (DatasetManagementException e) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetFramework.java
@@ -33,7 +33,11 @@ import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.DatasetTypeMeta;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.DatasetModuleId;
+import co.cask.cdap.proto.id.DatasetTypeId;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.twill.filesystem.Location;
 
@@ -67,7 +71,7 @@ public interface DatasetFramework {
    * Adds dataset types by adding dataset module to the system. Calling this method to add {@link DatasetModule} may
    * result in tracing class dependencies if the {@link DatasetModule} is not a system dataset, which can takes
    * couple seconds for the tracing. If the jar {@link Location} containing the {@link DatasetModule} is known, it's
-   * better to call {@link #addModule(Id.DatasetModule, DatasetModule, Location)} instead.
+   * better to call {@link #addModule(DatasetModuleId, DatasetModule, Location)} instead.
    *
    * @param moduleId dataset module id
    * @param module dataset module
@@ -76,7 +80,7 @@ public interface DatasetFramework {
    * @throws DatasetManagementException in case of problems
    * @throws ServiceUnavailableException when the dataset service is not running
    */
-  void addModule(Id.DatasetModule moduleId, DatasetModule module) throws DatasetManagementException;
+  void addModule(DatasetModuleId moduleId, DatasetModule module) throws DatasetManagementException;
 
   /**
    * Adds dataset types by adding dataset module to the system with a jar location containing all dataset classes
@@ -90,7 +94,7 @@ public interface DatasetFramework {
    * @throws DatasetManagementException in case of problems
    * @throws ServiceUnavailableException when the dataset service is not running
    */
-  void addModule(Id.DatasetModule moduleId, DatasetModule module,
+  void addModule(DatasetModuleId moduleId, DatasetModule module,
                  Location jarLocation) throws DatasetManagementException;
 
   /**
@@ -101,17 +105,17 @@ public interface DatasetFramework {
    * @throws DatasetManagementException
    * @throws ServiceUnavailableException when the dataset service is not running
    */
-  void deleteModule(Id.DatasetModule moduleId) throws DatasetManagementException;
+  void deleteModule(DatasetModuleId moduleId) throws DatasetManagementException;
 
   /**
    * Deletes dataset modules and its types in the specified namespace.
    *
-   * @param namespaceId the {@link Id.Namespace} to delete all modules from.
+   * @param namespaceId the {@link NamespaceId} to delete all modules from.
    * @throws ModuleConflictException when some of modules can't be deleted because of its dependant modules or instances
    * @throws DatasetManagementException
    * @throws ServiceUnavailableException when the dataset service is not running
    */
-  void deleteAllModules(Id.Namespace namespaceId) throws DatasetManagementException;
+  void deleteAllModules(NamespaceId namespaceId) throws DatasetManagementException;
 
   /**
    * Adds information about dataset instance to the system.
@@ -129,7 +133,7 @@ public interface DatasetFramework {
    * @throws DatasetManagementException
    * @throws ServiceUnavailableException when the dataset service is not running
    */
-  void addInstance(String datasetTypeName, Id.DatasetInstance datasetInstanceId, DatasetProperties props)
+  void addInstance(String datasetTypeName, DatasetId datasetInstanceId, DatasetProperties props)
     throws DatasetManagementException, IOException;
 
   /**
@@ -147,7 +151,7 @@ public interface DatasetFramework {
    * @throws DatasetManagementException
    * @throws ServiceUnavailableException when the dataset service is not running
    */
-  void updateInstance(Id.DatasetInstance datasetInstanceId, DatasetProperties props)
+  void updateInstance(DatasetId datasetInstanceId, DatasetProperties props)
     throws DatasetManagementException, IOException;
 
   /**
@@ -156,24 +160,24 @@ public interface DatasetFramework {
    * @param namespaceId the specified namespace id
    * @return a collection of {@link DatasetSpecification}s for all datasets in the specified namespace
    */
-  Collection<DatasetSpecificationSummary> getInstances(Id.Namespace namespaceId) throws DatasetManagementException;
+  Collection<DatasetSpecificationSummary> getInstances(NamespaceId namespaceId) throws DatasetManagementException;
 
   /**
    * Gets the {@link DatasetSpecification} for the specified dataset instance id
    *
-   * @param datasetInstanceId the {@link Id.DatasetInstance} for which the {@link DatasetSpecification} is desired
+   * @param datasetInstanceId the {@link DatasetId} for which the {@link DatasetSpecification} is desired
    * @return {@link DatasetSpecification} of the dataset or {@code null} if dataset not not exist
    */
   @Nullable
-  DatasetSpecification getDatasetSpec(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException;
+  DatasetSpecification getDatasetSpec(DatasetId datasetInstanceId) throws DatasetManagementException;
 
   /**
-   * @param datasetInstanceId the {@link Id.DatasetInstance} to check for existence
+   * @param datasetInstanceId the {@link DatasetId} to check for existence
    * @return true if instance exists, false otherwise
    * @throws DatasetManagementException
    * @throws ServiceUnavailableException when the dataset service is not running
    */
-  boolean hasInstance(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException;
+  boolean hasInstance(DatasetId datasetInstanceId) throws DatasetManagementException;
 
   /**
    * Checks if the specified type exists in the 'system' namespace
@@ -192,7 +196,7 @@ public interface DatasetFramework {
    * @throws ServiceUnavailableException when the dataset service is not running
    */
   @VisibleForTesting
-  boolean hasType(Id.DatasetType datasetTypeId) throws DatasetManagementException;
+  boolean hasType(DatasetTypeId datasetTypeId) throws DatasetManagementException;
 
   /**
    * @return the meta data for a dataset type or null if it does not exist.
@@ -200,7 +204,7 @@ public interface DatasetFramework {
    * @throws ServiceUnavailableException when the dataset service is not running
    */
   @Nullable
-  DatasetTypeMeta getTypeInfo(Id.DatasetType datasetTypeId) throws DatasetManagementException;
+  DatasetTypeMeta getTypeInfo(DatasetTypeId datasetTypeId) throws DatasetManagementException;
 
   /**
    * Truncates a dataset instance.
@@ -211,7 +215,7 @@ public interface DatasetFramework {
    * @throws DatasetManagementException
    * @throws ServiceUnavailableException when the dataset service is not running
    */
-  void truncateInstance(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException, IOException;
+  void truncateInstance(DatasetId datasetInstanceId) throws DatasetManagementException, IOException;
 
   /**
    * Deletes dataset instance from the system.
@@ -223,7 +227,7 @@ public interface DatasetFramework {
    * @throws DatasetManagementException
    * @throws ServiceUnavailableException when the dataset service is not running
    */
-  void deleteInstance(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException, IOException;
+  void deleteInstance(DatasetId datasetInstanceId) throws DatasetManagementException, IOException;
 
   /**
    * Deletes all dataset instances in the specified namespace.
@@ -233,7 +237,7 @@ public interface DatasetFramework {
    * @throws DatasetManagementException
    * @throws ServiceUnavailableException when the dataset service is not running
    */
-  void deleteAllInstances(Id.Namespace namespaceId) throws DatasetManagementException, IOException;
+  void deleteAllInstances(NamespaceId namespaceId) throws DatasetManagementException, IOException;
 
   /**
    * Gets dataset instance admin to be used to perform administrative operations. The given classloader must
@@ -249,7 +253,7 @@ public interface DatasetFramework {
    * @throws ServiceUnavailableException when the dataset service is not running
    */
   @Nullable
-  <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId, @Nullable ClassLoader classLoader)
+  <T extends DatasetAdmin> T getAdmin(DatasetId datasetInstanceId, @Nullable ClassLoader classLoader)
     throws DatasetManagementException, IOException;
 
   /**
@@ -267,7 +271,7 @@ public interface DatasetFramework {
    * @throws ServiceUnavailableException when the dataset service is not running
    */
   @Nullable
-  <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId,
+  <T extends DatasetAdmin> T getAdmin(DatasetId datasetInstanceId,
                                       @Nullable ClassLoader classLoader,
                                       DatasetClassLoaderProvider classLoaderProvider)
     throws DatasetManagementException, IOException;
@@ -285,7 +289,7 @@ public interface DatasetFramework {
    * @throws ServiceUnavailableException when the dataset service is not running
    */
   @Nullable
-  <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
+  <T extends Dataset> T getDataset(DatasetId datasetInstanceId, @Nullable Map<String, String> arguments,
                                    @Nullable ClassLoader classLoader)
     throws DatasetManagementException, IOException;
 
@@ -306,10 +310,10 @@ public interface DatasetFramework {
    * @throws ServiceUnavailableException when the dataset service is not running
    */
   @Nullable
-  <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
+  <T extends Dataset> T getDataset(DatasetId datasetInstanceId, @Nullable Map<String, String> arguments,
                                    @Nullable ClassLoader classLoader,
                                    DatasetClassLoaderProvider classLoaderProvider,
-                                   @Nullable Iterable<? extends Id> owners,
+                                   @Nullable Iterable<? extends EntityId> owners,
                                    AccessType accessType)
     throws DatasetManagementException, IOException;
 
@@ -319,5 +323,5 @@ public interface DatasetFramework {
    * @param datasetInstanceId dataset instance id
    * @param accessType accessType to be recorded
    */
-  void writeLineage(Id.DatasetInstance datasetInstanceId, AccessType accessType);
+  void writeLineage(DatasetId datasetInstanceId, AccessType accessType);
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetNamespace.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DatasetNamespace.java
@@ -16,7 +16,8 @@
 
 package co.cask.cdap.data2.dataset2;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
 
 import javax.annotation.Nullable;
 
@@ -28,59 +29,59 @@ public interface DatasetNamespace {
   /**
    * Namespaces (applies the namespace as a prefix) to the specified dataset instance name
    * Used for dataset instances in the system namespace
-   * Calls #namespace(Id.DatasetInstance.from(Id.Namespace.SYSTEM, datasetInstanceName)
-   * @see #namespace(Id.DatasetInstance)
+   * Calls #namespace(DatasetId.from(NamespaceId.SYSTEM, datasetInstanceName)
+   * @see #namespace(DatasetId)
    *
    * @param datasetInstanceName name of the dataset instance to be namespaced
-   * @return namespaced {@link Id.DatasetInstance} of the dataset
+   * @return namespaced {@link DatasetId} of the dataset
    */
-  Id.DatasetInstance namespace(String datasetInstanceName);
+  DatasetId namespace(String datasetInstanceName);
 
   /**
-   * Namespaces (applies the namespace as a prefix) to the specified {@link Id.DatasetInstance}
+   * Namespaces (applies the namespace as a prefix) to the specified {@link DatasetId}
    * {@code
    * String namespacedInstanceName = datasetInstanceId.getNamespace() + "." + datasetInstanceId.getId();
-   * return Id.DatasetInstance.from(datasetInstanceId.getNamespace(), namespacedInstanceName)
+   * return DatasetId.from(datasetInstanceId.getNamespace(), namespacedInstanceName)
    * }
-   * e.g. If Id.DatasetInstance(default, purchases) is passed, it will return
-   * Id.DatasetInstance(default, cdap.default.purchases)
+   * e.g. If DatasetId(default, purchases) is passed, it will return
+   * DatasetId(default, cdap.default.purchases)
    *
-   * @param datasetInstanceId {@link Id.DatasetInstance} for the dataset instance to be namespaced
-   * @return namespaced {@link Id.DatasetInstance} of the dataset
+   * @param datasetInstanceId {@link DatasetId} for the dataset instance to be namespaced
+   * @return namespaced {@link DatasetId} of the dataset
    */
-  Id.DatasetInstance namespace(Id.DatasetInstance datasetInstanceId);
+  DatasetId namespace(DatasetId datasetInstanceId);
 
   /**
    * Namespaces (applies the namespace as a prefix) to the specified suffix
    * Used for applying namespace to part table names
    *
-   * @param namespaceId the {@link Id.Namespace} to namespace the suffix with
+   * @param namespaceId the {@link NamespaceId} to namespace the suffix with
    * @param suffix the suffix to namespace
    * @return String containing the suffix prefixed with the specified namespace
    */
-  String namespace(Id.Namespace namespaceId, String suffix);
+  String namespace(NamespaceId namespaceId, String suffix);
 
   /**
-   * Returns a new {@link Id.DatasetInstance} with the namespaceId prefix removed from the specified instance name
-   * e.g. if cdap.myspace.myinstance is passed, this will return Id.DatasetInstance(myspace, myinstance)
-   * @see #fromNamespaced(Id.DatasetInstance)
+   * Returns a new {@link DatasetId} with the namespaceId prefix removed from the specified instance name
+   * e.g. if cdap.myspace.myinstance is passed, this will return DatasetId(myspace, myinstance)
+   * @see #fromNamespaced(DatasetId)
    *
    * @param namespaced namespaced name of the dataset
-   * @return original {@link Id.DatasetInstance} of the dataset or null if name is not within this namespace
+   * @return original {@link DatasetId} of the dataset or null if name is not within this namespace
    */
-  Id.DatasetInstance fromNamespaced(String namespaced);
+  DatasetId fromNamespaced(String namespaced);
 
   /**
-   * Returns a new {@link Id.DatasetInstance} with the namespaceId prefix removed from the instance name in the
-   * specified {@link Id.DatasetInstance}
-   * e.g. If Id.DatasetInstance(default, cdap.default.purchases) is passed, this will return
-   * Id.DatasetInstance(default, purchases)
+   * Returns a new {@link DatasetId} with the namespaceId prefix removed from the instance name in the
+   * specified {@link DatasetId}
+   * e.g. If DatasetId(default, cdap.default.purchases) is passed, this will return
+   * DatasetId(default, purchases)
    *
-   * @param datasetInstanceId namespaced {@link Id.DatasetInstance} of the dataset
-   * @return original {@link Id.DatasetInstance} of the dataset or null if name is not within this namespace
+   * @param datasetInstanceId namespaced {@link DatasetId} of the dataset
+   * @return original {@link DatasetId} of the dataset or null if name is not within this namespace
    */
   @Nullable
-  Id.DatasetInstance fromNamespaced(Id.DatasetInstance datasetInstanceId);
+  DatasetId fromNamespaced(DatasetId datasetInstanceId);
 
   /**
    * Checks if the specified namespace contains the specified dataset instance name

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/ForwardingDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/ForwardingDatasetFramework.java
@@ -26,7 +26,11 @@ import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.DatasetTypeMeta;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.DatasetModuleId;
+import co.cask.cdap.proto.id.DatasetTypeId;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.id.NamespaceId;
 import org.apache.twill.filesystem.Location;
 
 import java.io.IOException;
@@ -47,52 +51,52 @@ public class ForwardingDatasetFramework implements DatasetFramework {
   }
 
   @Override
-  public void addModule(Id.DatasetModule moduleId, DatasetModule module) throws DatasetManagementException {
+  public void addModule(DatasetModuleId moduleId, DatasetModule module) throws DatasetManagementException {
     delegate.addModule(moduleId, module);
   }
 
   @Override
-  public void addModule(Id.DatasetModule moduleId, DatasetModule module, Location jarLocation)
+  public void addModule(DatasetModuleId moduleId, DatasetModule module, Location jarLocation)
     throws DatasetManagementException {
     delegate.addModule(moduleId, module, jarLocation);
   }
 
   @Override
-  public void deleteModule(Id.DatasetModule moduleId) throws DatasetManagementException {
+  public void deleteModule(DatasetModuleId moduleId) throws DatasetManagementException {
     delegate.deleteModule(moduleId);
   }
 
   @Override
-  public void deleteAllModules(Id.Namespace namespaceId) throws DatasetManagementException {
+  public void deleteAllModules(NamespaceId namespaceId) throws DatasetManagementException {
     delegate.deleteAllModules(namespaceId);
   }
 
   @Override
-  public void addInstance(String datasetTypeName, Id.DatasetInstance datasetInstanceId, DatasetProperties props)
+  public void addInstance(String datasetTypeName, DatasetId datasetInstanceId, DatasetProperties props)
     throws DatasetManagementException, IOException {
     delegate.addInstance(datasetTypeName, datasetInstanceId, props);
   }
 
   @Override
-  public void updateInstance(Id.DatasetInstance datasetInstanceId, DatasetProperties props)
+  public void updateInstance(DatasetId datasetInstanceId, DatasetProperties props)
     throws DatasetManagementException, IOException {
     delegate.updateInstance(datasetInstanceId, props);
   }
 
   @Override
-  public Collection<DatasetSpecificationSummary> getInstances(Id.Namespace namespaceId)
+  public Collection<DatasetSpecificationSummary> getInstances(NamespaceId namespaceId)
     throws DatasetManagementException {
     return delegate.getInstances(namespaceId);
   }
 
   @Nullable
   @Override
-  public DatasetSpecification getDatasetSpec(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException {
+  public DatasetSpecification getDatasetSpec(DatasetId datasetInstanceId) throws DatasetManagementException {
     return delegate.getDatasetSpec(datasetInstanceId);
   }
 
   @Override
-  public boolean hasInstance(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException {
+  public boolean hasInstance(DatasetId datasetInstanceId) throws DatasetManagementException {
     return delegate.hasInstance(datasetInstanceId);
   }
 
@@ -102,41 +106,41 @@ public class ForwardingDatasetFramework implements DatasetFramework {
   }
 
   @Override
-  public boolean hasType(Id.DatasetType datasetTypeId) throws DatasetManagementException {
+  public boolean hasType(DatasetTypeId datasetTypeId) throws DatasetManagementException {
     return delegate.hasType(datasetTypeId);
   }
 
   @Nullable
   @Override
-  public DatasetTypeMeta getTypeInfo(Id.DatasetType datasetTypeId) throws DatasetManagementException {
+  public DatasetTypeMeta getTypeInfo(DatasetTypeId datasetTypeId) throws DatasetManagementException {
     return delegate.getTypeInfo(datasetTypeId);
   }
 
   @Override
-  public void truncateInstance(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException, IOException {
+  public void truncateInstance(DatasetId datasetInstanceId) throws DatasetManagementException, IOException {
     delegate.truncateInstance(datasetInstanceId);
   }
 
   @Override
-  public void deleteInstance(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException, IOException {
+  public void deleteInstance(DatasetId datasetInstanceId) throws DatasetManagementException, IOException {
     delegate.deleteInstance(datasetInstanceId);
   }
 
   @Override
-  public void deleteAllInstances(Id.Namespace namespaceId) throws DatasetManagementException, IOException {
+  public void deleteAllInstances(NamespaceId namespaceId) throws DatasetManagementException, IOException {
     delegate.deleteAllInstances(namespaceId);
   }
 
   @Nullable
   @Override
-  public <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId, @Nullable ClassLoader classLoader)
+  public <T extends DatasetAdmin> T getAdmin(DatasetId datasetInstanceId, @Nullable ClassLoader classLoader)
     throws DatasetManagementException, IOException {
     return delegate.getAdmin(datasetInstanceId, classLoader);
   }
 
   @Nullable
   @Override
-  public <T extends DatasetAdmin> T getAdmin(Id.DatasetInstance datasetInstanceId, @Nullable ClassLoader classLoader,
+  public <T extends DatasetAdmin> T getAdmin(DatasetId datasetInstanceId, @Nullable ClassLoader classLoader,
                                              DatasetClassLoaderProvider classLoaderProvider)
     throws DatasetManagementException, IOException {
     return delegate.getAdmin(datasetInstanceId, classLoader, classLoaderProvider);
@@ -144,7 +148,7 @@ public class ForwardingDatasetFramework implements DatasetFramework {
 
   @Nullable
   @Override
-  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
+  public <T extends Dataset> T getDataset(DatasetId datasetInstanceId, @Nullable Map<String, String> arguments,
                                           @Nullable ClassLoader classLoader)
     throws DatasetManagementException, IOException {
     return delegate.getDataset(datasetInstanceId, arguments, classLoader);
@@ -152,16 +156,16 @@ public class ForwardingDatasetFramework implements DatasetFramework {
 
   @Nullable
   @Override
-  public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId, @Nullable Map<String, String> arguments,
+  public <T extends Dataset> T getDataset(DatasetId datasetInstanceId, @Nullable Map<String, String> arguments,
                                           @Nullable ClassLoader classLoader,
                                           DatasetClassLoaderProvider classLoaderProvider,
-                                          @Nullable Iterable<? extends Id> owners, AccessType accessType)
+                                          @Nullable Iterable<? extends EntityId> owners, AccessType accessType)
     throws DatasetManagementException, IOException {
     return delegate.getDataset(datasetInstanceId, arguments, classLoader, classLoaderProvider, owners, accessType);
   }
 
   @Override
-  public void writeLineage(Id.DatasetInstance datasetInstanceId, AccessType accessType) {
+  public void writeLineage(DatasetId datasetInstanceId, AccessType accessType) {
     delegate.writeLineage(datasetInstanceId, accessType);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/SingleThreadDatasetCache.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/SingleThreadDatasetCache.java
@@ -23,7 +23,7 @@ import co.cask.cdap.api.dataset.metrics.MeteredDataset;
 import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.CacheBuilder;
@@ -90,7 +90,7 @@ public class SingleThreadDatasetCache extends DynamicDatasetCache {
       @Override
       @ParametersAreNonnullByDefault
       public Dataset load(DatasetCacheKey key) throws Exception {
-        Dataset dataset = instantiator.getDataset(Id.DatasetInstance.from(key.getNamespace(), key.getName()),
+        Dataset dataset = instantiator.getDataset(new DatasetId(key.getNamespace(), key.getName()),
                                                   key.getArguments(), key.getAccessType());
         if (dataset instanceof MeteredDataset && metricsContext != null) {
           ((MeteredDataset) dataset).setMetricsCollector(
@@ -141,7 +141,7 @@ public class SingleThreadDatasetCache extends DynamicDatasetCache {
     @Override
     public Dataset get(DatasetCacheKey key) throws ExecutionException {
       // write lineage information on each get call
-      instantiator.writeLineage(namespaceId.dataset(key.getName()).toId(), key.getAccessType());
+      instantiator.writeLineage(namespaceId.dataset(key.getName()), key.getAccessType());
       return super.get(key);
     }
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/StaticDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/StaticDatasetFramework.java
@@ -19,7 +19,8 @@ package co.cask.cdap.data2.dataset2;
 import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.api.dataset.module.DatasetModule;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetModuleId;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.base.Throwables;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -65,7 +66,7 @@ public class StaticDatasetFramework extends InMemoryDatasetFramework implements 
   }
 
   @Override
-  protected LinkedHashSet<String> getAvailableModuleClasses(final Id.Namespace namespace) {
+  protected LinkedHashSet<String> getAvailableModuleClasses(final NamespaceId namespace) {
     try {
       // It is okay to have an unchecked cast here, as the same line populates the cache for MODULES_CACHE_KEY
       @SuppressWarnings("unchecked")
@@ -82,26 +83,26 @@ public class StaticDatasetFramework extends InMemoryDatasetFramework implements 
   }
 
   @Override
-  public void addModule(Id.DatasetModule moduleId, DatasetModule module) {
+  public void addModule(DatasetModuleId moduleId, DatasetModule module) {
     throw new UnsupportedOperationException("Cannot change modules of "
                                               + StaticDatasetFramework.class.getSimpleName());
   }
 
   @Override
-  public void addModule(Id.DatasetModule moduleId, DatasetModule module,
+  public void addModule(DatasetModuleId moduleId, DatasetModule module,
                         Location jarLocation) throws DatasetManagementException {
     throw new UnsupportedOperationException("Cannot change modules of "
                                               + StaticDatasetFramework.class.getSimpleName());
   }
 
   @Override
-  public void deleteModule(Id.DatasetModule moduleId) {
+  public void deleteModule(DatasetModuleId moduleId) {
     throw new UnsupportedOperationException("Cannot change modules of "
                                               + StaticDatasetFramework.class.getSimpleName());
   }
 
   @Override
-  public void deleteAllModules(Id.Namespace namespaceId) {
+  public void deleteAllModules(NamespaceId namespaceId) {
     throw new UnsupportedOperationException("Cannot change modules of "
                                               + StaticDatasetFramework.class.getSimpleName());
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MetaTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/MetaTableUtil.java
@@ -23,7 +23,8 @@ import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
 
 import java.io.IOException;
 
@@ -39,7 +40,7 @@ public abstract class MetaTableUtil {
   }
 
   public Table getMetaTable() throws IOException, DatasetManagementException {
-    Id.DatasetInstance metaTableInstanceId = Id.DatasetInstance.from(Id.Namespace.SYSTEM, getMetaTableName());
+    DatasetId metaTableInstanceId = NamespaceId.SYSTEM.dataset(getMetaTableName());
     return DatasetsUtil.getOrCreateDataset(dsFramework, metaTableInstanceId, Table.class.getName(),
                                            DatasetProperties.EMPTY, DatasetDefinition.NO_ARGUMENTS, null);
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/lineage/LineageStore.java
@@ -233,7 +233,7 @@ public class LineageStore implements LineageStoreReader, LineageStoreWriter {
   private LineageDataset newLineageDataset() {
     try {
       return DatasetsUtil.getOrCreateDataset(
-        datasetFramework, lineageDatasetId.toId(), LineageDataset.class.getName(),
+        datasetFramework, lineageDatasetId, LineageDataset.class.getName(),
         DatasetProperties.EMPTY, DatasetDefinition.NO_ARGUMENTS, null);
     } catch (Exception e) {
       throw Throwables.propagate(e);
@@ -246,6 +246,6 @@ public class LineageStore implements LineageStoreReader, LineageStoreWriter {
    * @param framework framework to add types and datasets to
    */
   public static void setupDatasets(DatasetFramework framework) throws IOException, DatasetManagementException {
-    framework.addInstance(LineageDataset.class.getName(), LINEAGE_DATASET_ID.toId(), DatasetProperties.EMPTY);
+    framework.addInstance(LineageDataset.class.getName(), LINEAGE_DATASET_ID, DatasetProperties.EMPTY);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
@@ -29,8 +29,9 @@ import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
 import co.cask.cdap.data2.metadata.dataset.MetadataEntry;
 import co.cask.cdap.data2.metadata.indexer.Indexer;
 import co.cask.cdap.data2.transaction.Transactions;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.audit.AuditType;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
@@ -64,10 +65,8 @@ import javax.annotation.Nullable;
  */
 public class DefaultMetadataStore implements MetadataStore {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultMetadataStore.class);
-  private static final Id.DatasetInstance BUSINESS_METADATA_INSTANCE_ID =
-    Id.DatasetInstance.from(Id.Namespace.SYSTEM, "business.metadata");
-  private static final Id.DatasetInstance SYSTEM_METADATA_INSTANCE_ID =
-    Id.DatasetInstance.from(Id.Namespace.SYSTEM, "system.metadata");
+  private static final DatasetId BUSINESS_METADATA_INSTANCE_ID = NamespaceId.SYSTEM.dataset("business.metadata");
+  private static final DatasetId SYSTEM_METADATA_INSTANCE_ID = NamespaceId.SYSTEM.dataset("system.metadata");
   private static final Map<String, String> EMPTY_PROPERTIES = ImmutableMap.of();
   private static final Set<String> EMPTY_TAGS = ImmutableSet.of();
   private static final int BATCH_SIZE = 1000;
@@ -549,7 +548,7 @@ public class DefaultMetadataStore implements MetadataStore {
     }
   }
 
-  private Id.DatasetInstance getMetadataDatasetInstance(MetadataScope scope) {
+  private DatasetId getMetadataDatasetInstance(MetadataScope scope) {
     return MetadataScope.USER == scope ? BUSINESS_METADATA_INSTANCE_ID : SYSTEM_METADATA_INSTANCE_ID;
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/AbstractSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/AbstractSystemMetadataWriter.java
@@ -88,8 +88,7 @@ public abstract class AbstractSystemMetadataWriter implements SystemMetadataWrit
   @Override
   public void write() {
     // Delete existing system metadata before writing new metadata
-    Set<String> existingProperties = metadataStore.getProperties(MetadataScope.SYSTEM,
-                                                                 entityId).keySet();
+    Set<String> existingProperties = metadataStore.getProperties(MetadataScope.SYSTEM, entityId).keySet();
     Sets.SetView<String> removeProperties = Sets.difference(existingProperties, PRESERVE_PROPERTIES);
     if (!removeProperties.isEmpty()) {
       String[] propertiesArray = removeProperties.toArray(new String[removeProperties.size()]);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/DatasetSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/DatasetSystemMetadataWriter.java
@@ -30,7 +30,7 @@ import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
@@ -42,7 +42,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
- * A {@link AbstractSystemMetadataWriter} for a {@link Id.DatasetInstance dataset}.
+ * A {@link AbstractSystemMetadataWriter} for a {@link DatasetId dataset}.
  */
 public class DatasetSystemMetadataWriter extends AbstractSystemMetadataWriter {
   private static final Logger LOG = LoggerFactory.getLogger(DatasetSystemMetadataWriter.class);
@@ -56,7 +56,7 @@ public class DatasetSystemMetadataWriter extends AbstractSystemMetadataWriter {
   static final String FILESET_PARQUET_SCHEMA_OUTPUT_KEY = "parquet.avro.schema";
   static final String FILESET_AVRO_SCHEMA_OUTPUT_KEY = "avro.schema.output.key";
 
-  private final Id.DatasetInstance dsInstance;
+  private final DatasetId dsInstance;
   private final String dsType;
   private final DatasetProperties dsProperties;
   private final Dataset dataset;
@@ -64,18 +64,18 @@ public class DatasetSystemMetadataWriter extends AbstractSystemMetadataWriter {
   private final String description;
 
   public DatasetSystemMetadataWriter(MetadataStore metadataStore,
-                                     Id.DatasetInstance dsInstance, DatasetProperties dsProperties,
+                                     DatasetId dsInstance, DatasetProperties dsProperties,
                                      @Nullable Dataset dataset, @Nullable String dsType,
                                      @Nullable String description) {
     this(metadataStore, dsInstance, dsProperties, -1, dataset, dsType, description);
   }
 
   public DatasetSystemMetadataWriter(MetadataStore metadataStore,
-                                     Id.DatasetInstance dsInstance, DatasetProperties dsProperties,
+                                     DatasetId dsInstance, DatasetProperties dsProperties,
                                      long createTime,
                                      @Nullable Dataset dataset, @Nullable String dsType,
                                      @Nullable String description) {
-    super(metadataStore, dsInstance.toEntityId());
+    super(metadataStore, dsInstance);
     this.dsInstance = dsInstance;
     this.dsType = dsType;
     this.dsProperties = dsProperties;
@@ -109,7 +109,7 @@ public class DatasetSystemMetadataWriter extends AbstractSystemMetadataWriter {
   @Override
   protected String[] getSystemTagsToAdd() {
     List<String> tags = new ArrayList<>();
-    tags.add(dsInstance.getId());
+    tags.add(dsInstance.getEntityName());
     if (dataset instanceof RecordScannable) {
       tags.add(EXPLORE_TAG);
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/StreamSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/StreamSystemMetadataWriter.java
@@ -19,14 +19,14 @@ package co.cask.cdap.data2.metadata.system;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
- * A {@link AbstractSystemMetadataWriter} for a {@link Id.Stream stream}.
+ * A {@link AbstractSystemMetadataWriter} for a {@link StreamId stream}.
  */
 public class StreamSystemMetadataWriter extends AbstractSystemMetadataWriter {
 
@@ -34,14 +34,14 @@ public class StreamSystemMetadataWriter extends AbstractSystemMetadataWriter {
   private final long creationTime;
   private final String description;
 
-  public StreamSystemMetadataWriter(MetadataStore metadataStore, Id.Stream streamId, StreamConfig config,
+  public StreamSystemMetadataWriter(MetadataStore metadataStore, StreamId streamId, StreamConfig config,
                                     @Nullable String description) {
     this(metadataStore, streamId, config, -1, description);
   }
 
-  public StreamSystemMetadataWriter(MetadataStore metadataStore, Id.Stream streamId, StreamConfig config,
+  public StreamSystemMetadataWriter(MetadataStore metadataStore, StreamId streamId, StreamConfig config,
                                     long creationTime, @Nullable String description) {
-    super(metadataStore, streamId.toEntityId());
+    super(metadataStore, streamId);
     this.config = config;
     this.creationTime = creationTime;
     this.description = description;
@@ -63,7 +63,7 @@ public class StreamSystemMetadataWriter extends AbstractSystemMetadataWriter {
   @Override
   protected String[] getSystemTagsToAdd() {
     return new String[] {
-      config.getStreamId().getId(),
+      config.getStreamId().getEntityName(),
       EXPLORE_TAG
     };
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ViewSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/ViewSystemMetadataWriter.java
@@ -22,8 +22,8 @@ import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.data.schema.UnsupportedTypeException;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.format.RecordFormats;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ViewSpecification;
+import co.cask.cdap.proto.id.StreamViewId;
 import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,15 +32,15 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
- * A {@link AbstractSystemMetadataWriter} for an {@link Id.Stream.View view}.
+ * A {@link AbstractSystemMetadataWriter} for an {@link StreamViewId view}.
  */
 public class ViewSystemMetadataWriter extends AbstractSystemMetadataWriter {
   private static final Logger LOG = LoggerFactory.getLogger(ViewSystemMetadataWriter.class);
-  private final Id.Stream.View viewId;
+  private final StreamViewId viewId;
   private final ViewSpecification viewSpec;
 
-  public ViewSystemMetadataWriter(MetadataStore metadataStore, Id.Stream.View viewId, ViewSpecification viewSpec) {
-    super(metadataStore, viewId.toEntityId());
+  public ViewSystemMetadataWriter(MetadataStore metadataStore, StreamViewId viewId, ViewSpecification viewSpec) {
+    super(metadataStore, viewId);
     this.viewId = viewId;
     this.viewSpec = viewSpec;
   }
@@ -54,8 +54,8 @@ public class ViewSystemMetadataWriter extends AbstractSystemMetadataWriter {
   @Override
   protected String[] getSystemTagsToAdd() {
     return new String[] {
-      viewId.getId(),
-      viewId.getStreamId()
+      viewId.getEntityName(),
+      viewId.getStream()
     };
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metrics/HBaseDatasetMetricsReporter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metrics/HBaseDatasetMetricsReporter.java
@@ -27,7 +27,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.AbstractScheduledService;
@@ -119,11 +119,9 @@ public class HBaseDatasetMetricsReporter extends AbstractScheduledService implem
       }
       String tableName = statEntry.getKey().getTableName();
       try {
-        Collection<DatasetSpecificationSummary> instances = dsFramework.getInstances(Id.Namespace.from(cdapNamespace));
+        Collection<DatasetSpecificationSummary> instances = dsFramework.getInstances(new NamespaceId(cdapNamespace));
         for (DatasetSpecificationSummary spec : instances) {
-          dsFramework.getDatasetSpec(Id.DatasetInstance.from(cdapNamespace, spec.getName()));
-          DatasetSpecification specification = dsFramework.getDatasetSpec(Id.DatasetInstance.from(cdapNamespace,
-                                                                                                  spec.getName()));
+          DatasetSpecification specification = dsFramework.getDatasetSpec(new DatasetId(cdapNamespace, spec.getName()));
           if (specification.isParent(tableName)) {
             MetricsContext collector =
               metricsService.getContext(ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, cdapNamespace,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metrics/LevelDBDatasetMetricsReporter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metrics/LevelDBDatasetMetricsReporter.java
@@ -26,7 +26,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.table.leveldb.LevelDBTableService;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.AbstractScheduledService;
@@ -102,10 +102,9 @@ public class LevelDBDatasetMetricsReporter extends AbstractScheduledService impl
       }
       String tableName = statEntry.getKey().getTableName();
 
-      Collection<DatasetSpecificationSummary> instances = dsFramework.getInstances(Id.Namespace.from(namespace));
+      Collection<DatasetSpecificationSummary> instances = dsFramework.getInstances(new NamespaceId(namespace));
       for (DatasetSpecificationSummary spec : instances) {
-        DatasetSpecification specification = dsFramework.getDatasetSpec(Id.DatasetInstance.from(namespace,
-                                                                                                spec.getName()));
+        DatasetSpecification specification = dsFramework.getDatasetSpec(new DatasetId(namespace, spec.getName()));
         if (specification.isParent(tableName)) {
           MetricsContext collector =
             metricsService.getContext(ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, namespace,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/DatasetUsageKey.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/DatasetUsageKey.java
@@ -16,26 +16,27 @@
 
 package co.cask.cdap.data2.registry;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.ProgramId;
 import com.google.common.base.Objects;
 
 /**
  * Key used to keep track of whether a particular usage has been recorded already or not (for UsageRegistry).
  */
 public class DatasetUsageKey {
-  private final Id.DatasetInstance dataset;
-  private final Id.Program owner;
+  private final DatasetId dataset;
+  private final ProgramId owner;
 
-  public DatasetUsageKey(Id.DatasetInstance dataset, Id.Program owner) {
+  public DatasetUsageKey(DatasetId dataset, ProgramId owner) {
     this.dataset = dataset;
     this.owner = owner;
   }
 
-  Id.DatasetInstance getDataset() {
+  DatasetId getDataset() {
     return dataset;
   }
 
-  Id.Program getOwner() {
+  ProgramId getOwner() {
     return owner;
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/NoOpUsageRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/NoOpUsageRegistry.java
@@ -16,7 +16,11 @@
 
 package co.cask.cdap.data2.registry;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
 
 import java.util.Collections;
 import java.util.Set;
@@ -27,53 +31,53 @@ import java.util.Set;
 public class NoOpUsageRegistry implements UsageRegistry {
 
   @Override
-  public void registerAll(final Iterable<? extends Id> users, final Id.Stream streamId) { }
+  public void registerAll(final Iterable<? extends EntityId> users, final StreamId streamId) { }
 
   @Override
-  public void register(Id user, Id.Stream streamId) { }
+  public void register(EntityId user, StreamId streamId) { }
 
   @Override
-  public void registerAll(final Iterable<? extends Id> users, final Id.DatasetInstance datasetId) { }
+  public void registerAll(final Iterable<? extends EntityId> users, final DatasetId datasetId) { }
 
   @Override
-  public void register(Id user, Id.DatasetInstance datasetId) { }
+  public void register(EntityId user, DatasetId datasetId) { }
 
   @Override
-  public void register(final Id.Program programId, final Id.DatasetInstance datasetInstanceId) { }
+  public void register(final ProgramId programId, final DatasetId datasetInstanceId) { }
 
   @Override
-  public void register(final Id.Program programId, final Id.Stream streamId) { }
+  public void register(final ProgramId programId, final StreamId streamId) { }
 
   @Override
-  public void unregister(final Id.Application applicationId) { }
+  public void unregister(final ApplicationId applicationId) { }
 
   @Override
-  public Set<Id.DatasetInstance> getDatasets(final Id.Application id) {
+  public Set<DatasetId> getDatasets(final ApplicationId id) {
     return Collections.emptySet();
   }
 
   @Override
-  public Set<Id.Stream> getStreams(final Id.Application id) {
+  public Set<StreamId> getStreams(final ApplicationId id) {
     return Collections.emptySet();
   }
 
   @Override
-  public Set<Id.DatasetInstance> getDatasets(final Id.Program id) {
+  public Set<DatasetId> getDatasets(final ProgramId id) {
     return Collections.emptySet();
   }
 
   @Override
-  public Set<Id.Stream> getStreams(final Id.Program id) {
+  public Set<StreamId> getStreams(final ProgramId id) {
     return Collections.emptySet();
   }
 
   @Override
-  public Set<Id.Program> getPrograms(final Id.Stream id) {
+  public Set<ProgramId> getPrograms(final StreamId id) {
     return Collections.emptySet();
   }
 
   @Override
-  public Set<Id.Program> getPrograms(final Id.DatasetInstance id) {
+  public Set<ProgramId> getPrograms(final DatasetId id) {
     return Collections.emptySet();
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/RuntimeUsageRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/RuntimeUsageRegistry.java
@@ -16,7 +16,10 @@
 
 package co.cask.cdap.data2.registry;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
 
 /**
  * Store program -> dataset/stream usage information. Differs from UsageRegistry in that UsageRegistry does not have
@@ -30,7 +33,7 @@ public interface RuntimeUsageRegistry {
    * @param users the users of the stream
    * @param streamId the stream
    */
-  void registerAll(final Iterable<? extends Id> users, final Id.Stream streamId);
+  void registerAll(final Iterable<? extends EntityId> users, final StreamId streamId);
 
   /**
    * Register usage of a stream by an id.
@@ -38,7 +41,7 @@ public interface RuntimeUsageRegistry {
    * @param user the user of the stream
    * @param streamId the stream
    */
-  void register(Id user, Id.Stream streamId);
+  void register(EntityId user, StreamId streamId);
 
   /**
    * Registers usage of a stream by multiple ids.
@@ -46,7 +49,7 @@ public interface RuntimeUsageRegistry {
    * @param users the users of the stream
    * @param datasetId the stream
    */
-  void registerAll(final Iterable<? extends Id> users, final Id.DatasetInstance datasetId);
+  void registerAll(final Iterable<? extends EntityId> users, final DatasetId datasetId);
 
   /**
    * Registers usage of a dataset by multiple ids.
@@ -54,7 +57,7 @@ public interface RuntimeUsageRegistry {
    * @param user the user of the dataset
    * @param datasetId the dataset
    */
-  void register(Id user, Id.DatasetInstance datasetId);
+  void register(EntityId user, DatasetId datasetId);
 
   /**
    * Registers usage of a dataset by a program.
@@ -62,7 +65,7 @@ public interface RuntimeUsageRegistry {
    * @param programId program
    * @param datasetInstanceId dataset
    */
-  void register(final Id.Program programId, final Id.DatasetInstance datasetInstanceId);
+  void register(final ProgramId programId, final DatasetId datasetInstanceId);
 
   /**
    * Registers usage of a stream by a program.
@@ -70,5 +73,5 @@ public interface RuntimeUsageRegistry {
    * @param programId program
    * @param streamId  stream
    */
-  void register(final Id.Program programId, final Id.Stream streamId);
+  void register(final ProgramId programId, final StreamId streamId);
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
@@ -16,7 +16,10 @@
 
 package co.cask.cdap.data2.registry;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
 
 import java.util.Set;
 
@@ -30,17 +33,17 @@ public interface UsageRegistry extends RuntimeUsageRegistry {
    *
    * @param applicationId application
    */
-  void unregister(final Id.Application applicationId);
+  void unregister(final ApplicationId applicationId);
 
-  Set<Id.DatasetInstance> getDatasets(final Id.Application id);
+  Set<DatasetId> getDatasets(final ApplicationId id);
 
-  Set<Id.Stream> getStreams(final Id.Application id);
+  Set<StreamId> getStreams(final ApplicationId id);
 
-  Set<Id.DatasetInstance> getDatasets(final Id.Program id);
+  Set<DatasetId> getDatasets(final ProgramId id);
 
-  Set<Id.Stream> getStreams(final Id.Program id);
+  Set<StreamId> getStreams(final ProgramId id);
 
-  Set<Id.Program> getPrograms(final Id.Stream id);
+  Set<ProgramId> getPrograms(final StreamId id);
 
-  Set<Id.Program> getPrograms(final Id.DatasetInstance id);
+  Set<ProgramId> getPrograms(final DatasetId id);
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/keymaker/DatasetKeyMaker.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/keymaker/DatasetKeyMaker.java
@@ -18,17 +18,17 @@ package co.cask.cdap.data2.registry.internal.keymaker;
 
 import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
 import co.cask.cdap.data2.registry.internal.pair.KeyMaker;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 
 /**
- * {@link KeyMaker} for {@link Id.DatasetInstance}.
+ * {@link KeyMaker} for {@link DatasetId}.
  */
-public class DatasetKeyMaker implements KeyMaker<Id.DatasetInstance> {
+public class DatasetKeyMaker implements KeyMaker<DatasetId> {
   @Override
-  public MDSKey getKey(Id.DatasetInstance datasetInstance) {
+  public MDSKey getKey(DatasetId datasetInstance) {
     return new MDSKey.Builder()
-      .add(datasetInstance.getNamespaceId())
-      .add(datasetInstance.getId())
+      .add(datasetInstance.getNamespace())
+      .add(datasetInstance.getEntityName())
       .build();
   }
 
@@ -39,7 +39,7 @@ public class DatasetKeyMaker implements KeyMaker<Id.DatasetInstance> {
   }
 
   @Override
-  public Id.DatasetInstance getElement(MDSKey.Splitter splitter) {
-    return Id.DatasetInstance.from(splitter.getString(), splitter.getString());
+  public DatasetId getElement(MDSKey.Splitter splitter) {
+    return new DatasetId(splitter.getString(), splitter.getString());
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/keymaker/ProgramKeyMaker.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/keymaker/ProgramKeyMaker.java
@@ -18,29 +18,30 @@ package co.cask.cdap.data2.registry.internal.keymaker;
 
 import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
 import co.cask.cdap.data2.registry.internal.pair.KeyMaker;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ProgramId;
 
 /**
- * {@link KeyMaker} for {@link Id.Program}.
+ * {@link KeyMaker} for {@link ProgramId}.
  */
-public class ProgramKeyMaker implements KeyMaker<Id.Program> {
+public class ProgramKeyMaker implements KeyMaker<ProgramId> {
 
-  public static Id.Program getProgramId(Id.Application applicationId) {
+  public static ProgramId getProgramId(ApplicationId applicationId) {
     // Use empty programId to denote applicationId
-    return Id.Program.from(applicationId, ProgramType.FLOW, "");
+    return applicationId.flow("");
   }
 
   @Override
-  public MDSKey getKey(Id.Program programId) {
+  public MDSKey getKey(ProgramId programId) {
     MDSKey.Builder keyBuilder = new MDSKey.Builder()
-      .add(programId.getNamespaceId())
-      .add(programId.getApplicationId());
+      .add(programId.getNamespace())
+      .add(programId.getApplication());
 
     // If programId is empty, this is actually applicationId
-    if (!programId.getId().isEmpty()) {
+    if (!programId.getEntityName().isEmpty()) {
       keyBuilder.add(programId.getType().getCategoryName());
-      keyBuilder.add(programId.getId());
+      keyBuilder.add(programId.getEntityName());
     }
 
     return keyBuilder.build();
@@ -55,8 +56,8 @@ public class ProgramKeyMaker implements KeyMaker<Id.Program> {
   }
 
   @Override
-  public Id.Program getElement(MDSKey.Splitter splitter) {
-    return Id.Program.from(splitter.getString(), splitter.getString(),
+  public ProgramId getElement(MDSKey.Splitter splitter) {
+    return new ProgramId(splitter.getString(), splitter.getString(),
                            ProgramType.valueOfCategoryName(splitter.getString()),
                            splitter.getString());
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/keymaker/StreamKeyMaker.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/keymaker/StreamKeyMaker.java
@@ -18,17 +18,17 @@ package co.cask.cdap.data2.registry.internal.keymaker;
 
 import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
 import co.cask.cdap.data2.registry.internal.pair.KeyMaker;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 
 /**
- * {@link KeyMaker} for {@link Id.Stream}.
+ * {@link KeyMaker} for {@link StreamId}.
  */
-public class StreamKeyMaker implements KeyMaker<Id.Stream> {
+public class StreamKeyMaker implements KeyMaker<StreamId> {
   @Override
-  public MDSKey getKey(Id.Stream streamId) {
+  public MDSKey getKey(StreamId streamId) {
     return new MDSKey.Builder()
-      .add(streamId.getNamespaceId())
-      .add(streamId.getId())
+      .add(streamId.getNamespace())
+      .add(streamId.getEntityName())
       .build();
   }
 
@@ -39,7 +39,7 @@ public class StreamKeyMaker implements KeyMaker<Id.Stream> {
   }
 
   @Override
-  public Id.Stream getElement(MDSKey.Splitter splitter) {
-    return Id.Stream.from(splitter.getString(), splitter.getString());
+  public StreamId getElement(MDSKey.Splitter splitter) {
+    return new StreamId(splitter.getString(), splitter.getString());
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/pair/KeyMaker.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/pair/KeyMaker.java
@@ -18,13 +18,14 @@ package co.cask.cdap.data2.registry.internal.pair;
 
 import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.EntityId;
 
 /**
  * Used to serialize/deserialize {@link Id}s into {@link MDSKey}.
  *
  * @param <T> type of Id.
  */
-public interface KeyMaker<T extends Id> {
+public interface KeyMaker<T extends EntityId> {
   /**
    * Serializes Id as MDSKey.
    *

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/pair/OrderedPair.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/pair/OrderedPair.java
@@ -17,19 +17,19 @@
 package co.cask.cdap.data2.registry.internal.pair;
 
 import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.EntityId;
 import com.google.common.collect.Sets;
 
 import java.util.Set;
 
 /**
- * Represents a mapping between two {@link Id}s - FIRST and SECOND using MDSKey.
+ * Represents a mapping between two {@link EntityId}s - FIRST and SECOND using MDSKey.
  * Uses {@link KeyMaker} to serialize/deserialzie ids into MDSKey.
  *
  * @param <FIRST> type of first element
  * @param <SECOND> type of second element
  */
-public class OrderedPair<FIRST extends Id, SECOND extends Id> {
+public class OrderedPair<FIRST extends EntityId, SECOND extends EntityId> {
   private final KeyMaker<FIRST> keyMaker1;
   private final KeyMaker<SECOND> keyMaker2;
   private final String prefix;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/pair/OrderedPairs.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/pair/OrderedPairs.java
@@ -16,22 +16,22 @@
 
 package co.cask.cdap.data2.registry.internal.pair;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.EntityId;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 
 /**
- * Registry of {@link KeyMaker}s for {@link Id}s.
+ * Registry of {@link KeyMaker}s for {@link EntityId}s.
  */
 public class OrderedPairs {
-  private final Map<String, KeyMaker<? extends Id>> keyMakers;
+  private final Map<String, KeyMaker<? extends EntityId>> keyMakers;
 
-  public OrderedPairs(Map<String, KeyMaker<? extends Id>> keyMakers) {
+  public OrderedPairs(Map<String, KeyMaker<? extends EntityId>> keyMakers) {
     this.keyMakers = ImmutableMap.copyOf(keyMakers);
   }
 
-  public <FIRST extends Id, SECOND extends Id>
+  public <FIRST extends EntityId, SECOND extends EntityId>
   OrderedPair<FIRST, SECOND> get(String first, String second) {
     @SuppressWarnings("unchecked")
     KeyMaker<FIRST> keyMaker1 = (KeyMaker<FIRST>) keyMakers.get(first);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/AbstractStreamFileConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/AbstractStreamFileConsumer.java
@@ -29,7 +29,7 @@ import co.cask.cdap.data2.queue.DequeueResult;
 import co.cask.cdap.data2.queue.DequeueStrategy;
 import co.cask.cdap.data2.transaction.queue.ConsumerEntryState;
 import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.base.Function;
 import com.google.common.base.Objects;
 import com.google.common.base.Stopwatch;
@@ -140,7 +140,7 @@ public abstract class AbstractStreamFileConsumer implements StreamConsumer {
   protected final byte[] stateColumnName;
 
   private final long txTimeoutNano;
-  private final Id.Stream streamName;
+  private final StreamId streamId;
   private final StreamConfig streamConfig;
   private final ConsumerConfig consumerConfig;
   private final StreamConsumerStateStore consumerStateStore;
@@ -181,7 +181,7 @@ public abstract class AbstractStreamFileConsumer implements StreamConsumer {
 
     this.txTimeoutNano = TimeUnit.SECONDS.toNanos(cConf.getInt(TxConstants.Manager.CFG_TX_TIMEOUT,
                                                                TxConstants.Manager.DEFAULT_TX_TIMEOUT));
-    this.streamName = streamConfig.getStreamId();
+    this.streamId = streamConfig.getStreamId();
     this.streamConfig = streamConfig;
     this.consumerConfig = consumerConfig;
     this.consumerStateStore = consumerStateStore;
@@ -210,8 +210,8 @@ public abstract class AbstractStreamFileConsumer implements StreamConsumer {
   protected abstract StateScanner scanStates(byte[] startRow, byte[] endRow) throws IOException;
 
   @Override
-  public final Id.Stream getStreamId() {
-    return streamName;
+  public final StreamId getStreamId() {
+    return streamId;
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/AbstractStreamFileConsumerFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/AbstractStreamFileConsumerFactory.java
@@ -29,6 +29,7 @@ import co.cask.cdap.data2.queue.ConsumerConfig;
 import co.cask.cdap.data2.transaction.queue.QueueConstants;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
@@ -106,7 +107,7 @@ public abstract class AbstractStreamFileConsumerFactory implements StreamConsume
   }
 
   @Override
-  public final StreamConsumer create(Id.Stream streamId, String namespace,
+  public final StreamConsumer create(StreamId streamId, String namespace,
                                      ConsumerConfig consumerConfig) throws IOException {
 
     StreamConfig streamConfig = StreamUtils.ensureExists(streamAdmin, streamId);
@@ -121,7 +122,7 @@ public abstract class AbstractStreamFileConsumerFactory implements StreamConsume
   }
 
   @Override
-  public void dropAll(Id.Stream streamId, String namespace, Iterable<Long> groupIds) throws IOException {
+  public void dropAll(StreamId streamId, String namespace, Iterable<Long> groupIds) throws IOException {
     // Delete the entry table
     dropTable(getTableId(streamId, namespace));
 
@@ -139,9 +140,9 @@ public abstract class AbstractStreamFileConsumerFactory implements StreamConsume
 
   }
 
-  private TableId getTableId(Id.Stream streamId, String namespace) {
-    return TableId.from(streamId.getNamespace().getId(),
-                        String.format("%s.%s.%s", tablePrefix, streamId.getId(), namespace));
+  private TableId getTableId(StreamId streamId, String namespace) {
+    return TableId.from(streamId.getNamespace(),
+                        String.format("%s.%s.%s", tablePrefix, streamId.getEntityName(), namespace));
   }
 
   private MultiLiveStreamFileReader createReader(final StreamConfig streamConfig,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/ForwardingStreamConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/ForwardingStreamConsumer.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data2.transaction.stream;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.data2.queue.ConsumerConfig;
 import co.cask.cdap.data2.queue.DequeueResult;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import org.apache.tephra.Transaction;
 
 import java.io.IOException;
@@ -37,7 +37,7 @@ public abstract class ForwardingStreamConsumer implements StreamConsumer {
   }
 
   @Override
-  public Id.Stream getStreamId() {
+  public StreamId getStreamId() {
     return delegate.getStreamId();
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/QueueToStreamConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/QueueToStreamConsumer.java
@@ -24,7 +24,7 @@ import co.cask.cdap.common.stream.StreamEventDataCodec;
 import co.cask.cdap.data2.queue.ConsumerConfig;
 import co.cask.cdap.data2.queue.DequeueResult;
 import co.cask.cdap.data2.queue.QueueConsumer;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.common.io.ByteBufferInputStream;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
@@ -46,18 +46,18 @@ public final class QueueToStreamConsumer implements StreamConsumer {
 
   private static final StreamEventCodec STREAM_EVENT_CODEC = new StreamEventCodec();
 
-  private final Id.Stream streamId;
+  private final StreamId streamId;
   private final ConsumerConfig consumerConfig;
   private final QueueConsumer consumer;
 
-  public QueueToStreamConsumer(Id.Stream streamId, ConsumerConfig consumerConfig, QueueConsumer consumer) {
+  public QueueToStreamConsumer(StreamId streamId, ConsumerConfig consumerConfig, QueueConsumer consumer) {
     this.streamId = streamId;
     this.consumerConfig = consumerConfig;
     this.consumer = consumer;
   }
 
   @Override
-  public Id.Stream getStreamId() {
+  public StreamId getStreamId() {
     return streamId;
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamAdmin.java
@@ -18,10 +18,13 @@ package co.cask.cdap.data2.transaction.stream;
 
 import co.cask.cdap.api.data.stream.StreamSpecification;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.StreamProperties;
 import co.cask.cdap.proto.ViewSpecification;
+import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramRunId;
+import co.cask.cdap.proto.id.StreamId;
+import co.cask.cdap.proto.id.StreamViewId;
 
 import java.io.IOException;
 import java.util.List;
@@ -37,7 +40,7 @@ public interface StreamAdmin {
   /**
    * Deletes all entries for all streams within a namespace
    */
-  void dropAllInNamespace(Id.Namespace namespace) throws Exception;
+  void dropAllInNamespace(NamespaceId namespace) throws Exception;
 
   /**
    * Sets the number of consumer instances for the given consumer group in a stream.
@@ -45,14 +48,14 @@ public interface StreamAdmin {
    * @param groupId The consumer group to alter.
    * @param instances Number of instances.
    */
-  void configureInstances(Id.Stream streamId, long groupId, int instances) throws Exception;
+  void configureInstances(StreamId streamId, long groupId, int instances) throws Exception;
 
   /**
    * Sets the consumer groups information for the given stream.
    * @param streamId Id of the stream.
    * @param groupInfo A map from groupId to number of instances of each group.
    */
-  void configureGroups(Id.Stream streamId, Map<Long, Integer> groupInfo) throws Exception;
+  void configureGroups(StreamId streamId, Map<Long, Integer> groupInfo) throws Exception;
 
   /**
    * Performs upgrade action for all streams.
@@ -72,7 +75,7 @@ public interface StreamAdmin {
    * @return A {@link StreamConfig} instance.
    * @throws IOException If the stream doesn't exists.
    */
-  StreamConfig getConfig(Id.Stream streamId) throws IOException;
+  StreamConfig getConfig(StreamId streamId) throws IOException;
 
   /**
    * Returns the {@link StreamProperties} of the given stream.
@@ -80,7 +83,7 @@ public interface StreamAdmin {
    * @return {@link StreamProperties} instance.
    * @throws IOException If the stream doesn't exist.
    */
-  StreamProperties getProperties(Id.Stream streamId) throws Exception;
+  StreamProperties getProperties(StreamId streamId) throws Exception;
 
   /**
    * Overwrites existing configuration for the given stream.
@@ -88,14 +91,14 @@ public interface StreamAdmin {
    * @param properties New configuration of the stream.
    * @throws Exception if the update of the stream configuration failed
    */
-  void updateConfig(Id.Stream streamId, StreamProperties properties) throws Exception;
+  void updateConfig(StreamId streamId, StreamProperties properties) throws Exception;
 
   /**
    * @param streamId Id of the stream.
    * @return true if stream with given Id exists, otherwise false
    * @throws Exception if check fails
    */
-  boolean exists(Id.Stream streamId) throws Exception;
+  boolean exists(StreamId streamId) throws Exception;
 
   /**
    * Creates stream if doesn't exist. If stream exists does nothing.
@@ -103,7 +106,7 @@ public interface StreamAdmin {
    * @return The {@link StreamConfig} associated with the new stream
    * @throws Exception if creation fails
    */
-  StreamConfig create(Id.Stream streamId) throws Exception;
+  StreamConfig create(StreamId streamId) throws Exception;
 
   /**
    * Creates stream if doesn't exist. If stream exists, does nothing.
@@ -112,21 +115,21 @@ public interface StreamAdmin {
    * @return The {@link StreamConfig} associated with the new stream
    * @throws Exception if creation fails
    */
-  StreamConfig create(Id.Stream streamId, @Nullable Properties props) throws Exception;
+  StreamConfig create(StreamId streamId, @Nullable Properties props) throws Exception;
 
   /**
    * Wipes out stream data.
    * @param streamId Id of the stream to truncate
    * @throws Exception if cleanup fails
    */
-  void truncate(Id.Stream streamId) throws Exception;
+  void truncate(StreamId streamId) throws Exception;
 
   /**
    * Deletes stream from the system completely.
    * @param streamId Id of the stream to delete
    * @throws Exception if deletion fails
    */
-  void drop(Id.Stream streamId) throws Exception;
+  void drop(StreamId streamId) throws Exception;
 
   /**
    * Creates or updates a stream view.
@@ -135,14 +138,14 @@ public interface StreamAdmin {
    * @param spec specification for the view
    * @return true if a stream view was created
    */
-  boolean createOrUpdateView(Id.Stream.View viewId, ViewSpecification spec) throws Exception;
+  boolean createOrUpdateView(StreamViewId viewId, ViewSpecification spec) throws Exception;
 
   /**
    * Deletes a stream view.
    *
    * @param viewId the view
    */
-  void deleteView(Id.Stream.View viewId) throws Exception;
+  void deleteView(StreamViewId viewId) throws Exception;
 
   /**
    * Lists views associated with a stream.
@@ -150,7 +153,7 @@ public interface StreamAdmin {
    * @param streamId the stream
    * @return the associated views
    */
-  List<Id.Stream.View> listViews(Id.Stream streamId) throws Exception;
+  List<StreamViewId> listViews(StreamId streamId) throws Exception;
 
   /**
    * Gets the details of a stream view.
@@ -158,7 +161,7 @@ public interface StreamAdmin {
    * @param viewId the view
    * @return the details of the view
    */
-  ViewSpecification getView(Id.Stream.View viewId) throws Exception;
+  ViewSpecification getView(StreamViewId viewId) throws Exception;
 
   /**
    * Checks if the view exists
@@ -166,7 +169,7 @@ public interface StreamAdmin {
    * @param viewId the view
    * @return boolean which is true if view exists else false
    */
-  boolean viewExists(Id.Stream.View viewId) throws Exception;
+  boolean viewExists(StreamViewId viewId) throws Exception;
 
   /**
    * Register stream used by program.
@@ -174,7 +177,7 @@ public interface StreamAdmin {
    * @param owners the ids that are using the stream
    * @param streamId the stream being used
    */
-  void register(Iterable<? extends Id> owners, Id.Stream streamId);
+  void register(Iterable<? extends EntityId> owners, StreamId streamId);
 
   /**
    * Record access of stream by a program run for lineage computation.
@@ -183,5 +186,5 @@ public interface StreamAdmin {
    * @param streamId stream being accessed
    * @param accessType type of access
    */
-  void addAccess(Id.Run run, Id.Stream streamId, AccessType accessType);
+  void addAccess(ProgramRunId run, StreamId streamId, AccessType accessType);
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamConfig.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamConfig.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data2.transaction.stream;
 import co.cask.cdap.api.data.format.FormatSpecification;
 import co.cask.cdap.api.data.format.Formats;
 import co.cask.cdap.api.data.schema.Schema;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.base.Objects;
 import org.apache.twill.filesystem.Location;
 
@@ -35,7 +35,7 @@ public final class StreamConfig {
       Schema.recordOf("stringBody", Schema.Field.of("body", Schema.of(Schema.Type.STRING))),
       Collections.<String, String>emptyMap());
 
-  private final transient Id.Stream streamId;
+  private final transient StreamId streamId;
   private final long partitionDuration;
   private final long indexInterval;
   private final long ttl;
@@ -44,7 +44,7 @@ public final class StreamConfig {
 
   private final transient Location location;
 
-  public StreamConfig(Id.Stream streamId, long partitionDuration, long indexInterval, long ttl,
+  public StreamConfig(StreamId streamId, long partitionDuration, long indexInterval, long ttl,
                       Location location, FormatSpecification format, int notificationThresholdMB) {
     this.streamId = streamId;
     this.partitionDuration = partitionDuration;
@@ -58,7 +58,7 @@ public final class StreamConfig {
   /**
    * @return Id of the stream.
    */
-  public Id.Stream getStreamId() {
+  public StreamId getStreamId() {
     return streamId;
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamConsumer.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data2.transaction.stream;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.data2.queue.ConsumerConfig;
 import co.cask.cdap.data2.queue.DequeueResult;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import org.apache.tephra.TransactionAware;
 
 import java.io.Closeable;
@@ -37,7 +37,7 @@ public interface StreamConsumer extends Closeable, TransactionAware {
   /**
    * @return Id of the stream this consumer is consuming.
    */
-  Id.Stream getStreamId();
+  StreamId getStreamId();
 
   /**
    * @return Configuration of this consumer.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamConsumerFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamConsumerFactory.java
@@ -16,7 +16,7 @@
 package co.cask.cdap.data2.transaction.stream;
 
 import co.cask.cdap.data2.queue.ConsumerConfig;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 
 import java.io.IOException;
 
@@ -33,7 +33,7 @@ public interface StreamConsumerFactory {
    * @param consumerConfig consumer configuration.
    * @return a new instance of {@link StreamConsumer}.
    */
-  StreamConsumer create(Id.Stream streamId, String namespace, ConsumerConfig consumerConfig) throws IOException;
+  StreamConsumer create(StreamId streamId, String namespace, ConsumerConfig consumerConfig) throws IOException;
 
   /**
    * Deletes all consumer states for the given namespace and group ids.
@@ -42,5 +42,5 @@ public interface StreamConsumerFactory {
    * @param namespace application namespace for the state table.
    * @param groupIds set of group id that needs to have states cleared.
    */
-  void dropAll(Id.Stream streamId, String namespace, Iterable<Long> groupIds) throws IOException;
+  void dropAll(StreamId streamId, String namespace, Iterable<Long> groupIds) throws IOException;
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamConsumerStateStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamConsumerStateStore.java
@@ -18,7 +18,7 @@ package co.cask.cdap.data2.transaction.stream;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.data.stream.StreamFileOffset;
 import co.cask.cdap.data.stream.StreamUtils;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Maps;
@@ -46,7 +46,7 @@ public abstract class StreamConsumerStateStore implements ConsumerStateStore<Str
                                                                              Iterable<StreamFileOffset>> {
 
   protected final StreamConfig streamConfig;
-  protected final Id.Stream streamId;
+  protected final StreamId streamId;
 
   protected StreamConsumerStateStore(StreamConfig streamConfig) {
     this.streamConfig = streamConfig;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamConsumerStateStoreFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/StreamConsumerStateStoreFactory.java
@@ -15,7 +15,7 @@
  */
 package co.cask.cdap.data2.transaction.stream;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 
 import java.io.IOException;
 
@@ -35,5 +35,5 @@ public interface StreamConsumerStateStoreFactory {
   /**
    * Deletes all consumer state stores.
    */
-  void dropAllInNamespace(Id.Namespace namespace) throws IOException;
+  void dropAllInNamespace(NamespaceId namespace) throws IOException;
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerStateStoreFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerStateStoreFactory.java
@@ -25,7 +25,6 @@ import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStoreFactory;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.NamespaceId;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
@@ -51,7 +50,7 @@ public final class HBaseStreamConsumerStateStoreFactory implements StreamConsume
 
   @Override
   public synchronized StreamConsumerStateStore create(StreamConfig streamConfig) throws IOException {
-    Id.Namespace namespace = streamConfig.getStreamId().getNamespace();
+    NamespaceId namespace = streamConfig.getStreamId().getParent();
     TableId streamStateStoreTableId = StreamUtils.getStateStoreTableId(namespace);
     TableId hbaseTableId = tableUtil.createHTableId(new NamespaceId(streamStateStoreTableId.getNamespace()),
                                                     streamStateStoreTableId.getTableName());
@@ -76,7 +75,7 @@ public final class HBaseStreamConsumerStateStoreFactory implements StreamConsume
   }
 
   @Override
-  public synchronized void dropAllInNamespace(Id.Namespace namespace) throws IOException {
+  public synchronized void dropAllInNamespace(NamespaceId namespace) throws IOException {
     try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
       TableId tableId = StreamUtils.getStateStoreTableId(namespace);
       TableId hbaseTableId = tableUtil.createHTableId(new NamespaceId(tableId.getNamespace()), tableId.getTableName());

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamFileConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamFileConsumer.java
@@ -30,7 +30,7 @@ import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStore;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.hbase.wd.AbstractRowKeyDistributor;
 import co.cask.cdap.hbase.wd.DistributedScanner;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.HTable;
@@ -154,10 +154,10 @@ public final class HBaseStreamFileConsumer extends AbstractStreamFileConsumer {
     };
   }
 
-  private ExecutorService createScanExecutor(Id.Stream streamId) {
+  private ExecutorService createScanExecutor(StreamId streamId) {
     ThreadFactory threadFactory = Threads.newDaemonThreadFactory(String.format("stream-%s-%s-consumer-scanner-",
-                                                   streamId.getNamespaceId(),
-                                                   streamId.getId()));
+                                                                               streamId.getNamespace(),
+                                                                               streamId.getEntityName()));
     ThreadPoolExecutor executor = new ThreadPoolExecutor(1, 20, 60, TimeUnit.SECONDS,
                                                          new SynchronousQueue<Runnable>(), threadFactory);
     executor.allowCoreThreadTimeOut(true);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/inmemory/InMemoryStreamConsumerFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/inmemory/InMemoryStreamConsumerFactory.java
@@ -24,6 +24,7 @@ import co.cask.cdap.data2.transaction.stream.QueueToStreamConsumer;
 import co.cask.cdap.data2.transaction.stream.StreamConsumer;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerFactory;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.inject.Inject;
@@ -46,16 +47,16 @@ public final class InMemoryStreamConsumerFactory implements StreamConsumerFactor
   }
 
   @Override
-  public StreamConsumer create(Id.Stream streamId, String namespace,
+  public StreamConsumer create(StreamId streamId, String namespace,
                                ConsumerConfig consumerConfig) throws IOException {
 
-    QueueName queueName = QueueName.fromStream(streamId);
+    QueueName queueName = QueueName.fromStream(streamId.toId());
     QueueConsumer consumer = queueClientFactory.createConsumer(queueName, consumerConfig, -1);
     return new QueueToStreamConsumer(streamId, consumerConfig, consumer);
   }
 
   @Override
-  public void dropAll(Id.Stream streamId, String namespace, Iterable<Long> groupIds) throws IOException {
+  public void dropAll(StreamId streamId, String namespace, Iterable<Long> groupIds) throws IOException {
     // A bit hacky to assume namespace is formed by appId.flowId. See AbstractDataFabricFacade
     // String namespace = String.format("%s.%s",
     //                                  programId.getApplicationId(),
@@ -68,6 +69,6 @@ public final class InMemoryStreamConsumerFactory implements StreamConsumerFactor
     Preconditions.checkArgument(namespaceParts.hasNext(), invalidNamespaceError);
     String flowId = namespaceParts.next();
 
-    queueService.truncateAllWithPrefix(QueueName.prefixForFlow(Id.Flow.from(streamId.getNamespaceId(), appId, flowId)));
+    queueService.truncateAllWithPrefix(QueueName.prefixForFlow(Id.Flow.from(streamId.getNamespace(), appId, flowId)));
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/inmemory/InMemoryStreamConsumerStateStoreFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/inmemory/InMemoryStreamConsumerStateStoreFactory.java
@@ -25,7 +25,7 @@ import co.cask.cdap.data2.transaction.stream.StreamConfig;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStore;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStoreFactory;
 import co.cask.cdap.data2.util.TableId;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.inject.Inject;
 
 import java.io.IOException;
@@ -43,7 +43,7 @@ public final class InMemoryStreamConsumerStateStoreFactory implements StreamCons
 
   @Override
   public synchronized StreamConsumerStateStore create(StreamConfig streamConfig) throws IOException {
-    Id.Namespace namespace = streamConfig.getStreamId().getNamespace();
+    NamespaceId namespace = streamConfig.getStreamId().getParent();
     TableId tableId = StreamUtils.getStateStoreTableId(namespace);
     InMemoryTableAdmin admin =
       new InMemoryTableAdmin(DatasetContext.from(tableId.getNamespace()), tableId.getTableName(), cConf);
@@ -56,7 +56,7 @@ public final class InMemoryStreamConsumerStateStoreFactory implements StreamCons
   }
 
   @Override
-  public synchronized void dropAllInNamespace(Id.Namespace namespace) throws IOException {
+  public synchronized void dropAllInNamespace(NamespaceId namespace) throws IOException {
     TableId tableId = StreamUtils.getStateStoreTableId(namespace);
     InMemoryTableAdmin admin =
       new InMemoryTableAdmin(DatasetContext.from(tableId.getNamespace()), tableId.getTableName(), cConf);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerStateStoreFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/leveldb/LevelDBStreamConsumerStateStoreFactory.java
@@ -30,7 +30,7 @@ import co.cask.cdap.data2.transaction.stream.StreamConfig;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStore;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStoreFactory;
 import co.cask.cdap.data2.util.TableId;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.inject.Inject;
 
 import java.io.IOException;
@@ -50,7 +50,7 @@ public final class LevelDBStreamConsumerStateStoreFactory implements StreamConsu
 
   @Override
   public synchronized StreamConsumerStateStore create(StreamConfig streamConfig) throws IOException {
-    Id.Namespace namespace = streamConfig.getStreamId().getNamespace();
+    NamespaceId namespace = streamConfig.getStreamId().getParent();
     TableId tableId = StreamUtils.getStateStoreTableId(namespace);
 
     getLevelDBTableAdmin(tableId).create();
@@ -61,7 +61,7 @@ public final class LevelDBStreamConsumerStateStoreFactory implements StreamConsu
   }
 
   @Override
-  public synchronized void dropAllInNamespace(Id.Namespace namespace) throws IOException {
+  public synchronized void dropAllInNamespace(NamespaceId namespace) throws IOException {
     TableId tableId = StreamUtils.getStateStoreTableId(namespace);
     getLevelDBTableAdmin(tableId).drop();
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/CounterTimeseriesTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/CounterTimeseriesTableTest.java
@@ -19,7 +19,7 @@ package co.cask.cdap.api.dataset.lib;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import org.apache.tephra.TransactionExecutor;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -40,8 +40,7 @@ public class CounterTimeseriesTableTest {
   public static DatasetFrameworkTestUtil dsFrameworkUtil = new DatasetFrameworkTestUtil();
 
   private static CounterTimeseriesTable table = null;
-  private static Id.DatasetInstance counterTable =
-    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "counterTable");
+  private static DatasetId counterTable = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("counterTable");
 
   @BeforeClass
   public static void setup() throws Exception {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/DatasetWithArgumentsTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/DatasetWithArgumentsTest.java
@@ -18,7 +18,8 @@ package co.cask.cdap.api.dataset.lib;
 
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.DatasetModuleId;
 import org.apache.tephra.TransactionExecutor;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -35,10 +36,8 @@ public class DatasetWithArgumentsTest {
   @ClassRule
   public static DatasetFrameworkTestUtil dsFrameworkUtil = new DatasetFrameworkTestUtil();
 
-  private static final Id.DatasetModule prefix =
-    Id.DatasetModule.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "prefix");
-  private static final Id.DatasetInstance pret =
-    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "pret");
+  private static final DatasetModuleId prefix = DatasetFrameworkTestUtil.NAMESPACE_ID.datasetModule("prefix");
+  private static final DatasetId pret = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("pret");
 
   @BeforeClass
   public static void beforeClass() throws Exception {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/IndexedObjectStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/IndexedObjectStoreTest.java
@@ -19,7 +19,7 @@ package co.cask.cdap.api.dataset.lib;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import com.google.common.collect.ImmutableList;
 import org.apache.tephra.TransactionExecutor;
 import org.junit.After;
@@ -38,8 +38,7 @@ public class IndexedObjectStoreTest {
   @ClassRule
   public static DatasetFrameworkTestUtil dsFrameworkUtil = new DatasetFrameworkTestUtil();
 
-  private static final Id.DatasetInstance index =
-    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "index");
+  private static final DatasetId index = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("index");
 
   @Before
   public void createDataset() throws Exception {
@@ -200,7 +199,7 @@ public class IndexedObjectStoreTest {
     });
   }
 
-  protected void createIndexedObjectStoreInstance(Id.DatasetInstance datasetInstanceId, Type type) throws Exception {
+  protected void createIndexedObjectStoreInstance(DatasetId datasetInstanceId, Type type) throws Exception {
     dsFrameworkUtil.createInstance("indexedObjectStore", datasetInstanceId,
                                    ObjectStores.objectStoreProperties(type, DatasetProperties.EMPTY));
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/IndexedTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/IndexedTableTest.java
@@ -25,7 +25,7 @@ import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scanner;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import co.cask.cdap.data2.dataset2.TableAssert;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import org.apache.tephra.TransactionExecutor;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -46,8 +46,7 @@ public class IndexedTableTest {
   @ClassRule
   public static DatasetFrameworkTestUtil dsFrameworkUtil = new DatasetFrameworkTestUtil();
 
-  private static final Id.DatasetInstance tabInstance =
-    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "tab");
+  private static final DatasetId tabInstance = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("tab");
 
   private static IndexedTable table;
 
@@ -270,8 +269,7 @@ public class IndexedTableTest {
 
   @Test
   public void testIndexedRangeLookups() throws Exception {
-    Id.DatasetInstance indexRangedLookupDs =
-      Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "rangeLookup");
+    DatasetId indexRangedLookupDs = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("rangeLookup");
     dsFrameworkUtil.createInstance("indexedTable", indexRangedLookupDs, DatasetProperties.builder()
       .add(IndexedTable.INDEX_COLUMNS_CONF_KEY, idxColString)
       .build());
@@ -353,7 +351,7 @@ public class IndexedTableTest {
     final byte[] x = { 'x' };
     final byte[] y = { 'y' };
     final byte[] z = { 'z' };
-    Id.DatasetInstance delimTabInstance = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "delimtab");
+    DatasetId delimTabInstance = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("delimtab");
     dsFrameworkUtil.createInstance("indexedTable", delimTabInstance, DatasetProperties.builder()
       .add(IndexedTable.INDEX_COLUMNS_CONF_KEY, Bytes.toString(a) + "," + Bytes.toString(ab))
       .build());
@@ -427,8 +425,8 @@ public class IndexedTableTest {
 
   @Test
   public void testMultipleIndexedColumns() throws Exception {
-    Id.DatasetInstance multiColumnTabInstance =
-      Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "multicolumntab");
+    DatasetId multiColumnTabInstance =
+      DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("multicolumntab");
     dsFrameworkUtil.createInstance("indexedTable", multiColumnTabInstance, DatasetProperties.builder()
       .add(IndexedTable.INDEX_COLUMNS_CONF_KEY, "idx1,idx2,idx3")
       .build());
@@ -623,7 +621,7 @@ public class IndexedTableTest {
    */
   @Test
   public void testIndexKeyDelimiterHandling() throws Exception {
-    Id.DatasetInstance delimTabInstance = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "delimtab");
+    DatasetId delimTabInstance = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("delimtab");
     dsFrameworkUtil.createInstance("indexedTable", delimTabInstance, DatasetProperties.builder()
       .add(IndexedTable.INDEX_COLUMNS_CONF_KEY, idxColString)
       .build());
@@ -679,7 +677,7 @@ public class IndexedTableTest {
 
   @Test
   public void testIncrementIndexing() throws Exception {
-    Id.DatasetInstance incrTabInstance = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "incrtab");
+    DatasetId incrTabInstance = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("incrtab");
     dsFrameworkUtil.createInstance("indexedTable", incrTabInstance, DatasetProperties.builder()
       .add(IndexedTable.INDEX_COLUMNS_CONF_KEY, "idx1,idx2,idx3")
       .build());

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/KeyValueTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/KeyValueTableTest.java
@@ -21,7 +21,7 @@ import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.data.batch.SplitReader;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import com.google.common.collect.Sets;
 import org.apache.tephra.TransactionExecutor;
 import org.apache.tephra.TransactionFailureException;
@@ -51,8 +51,7 @@ public class KeyValueTableTest {
   static final byte[] VAL2 = Bytes.toBytes("VAL2");
   static final byte[] VAL3 = Bytes.toBytes("VAL3");
 
-  private static final Id.DatasetInstance testInstance =
-    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "test");
+  private static final DatasetId testInstance = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("test");
 
   private static KeyValueTable kvTable;
 
@@ -187,8 +186,8 @@ public class KeyValueTableTest {
 
   @Test
   public void testTransactionAcrossTables() throws Exception {
-    Id.DatasetInstance t1 = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "t1");
-    Id.DatasetInstance t2 = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "t2");
+    DatasetId t1 = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("t1");
+    DatasetId t2 = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("t2");
     dsFrameworkUtil.createInstance("keyValueTable", t1, DatasetProperties.EMPTY);
     dsFrameworkUtil.createInstance("keyValueTable", t2, DatasetProperties.EMPTY);
 
@@ -253,7 +252,7 @@ public class KeyValueTableTest {
 
   @Test
   public void testScanning() throws Exception {
-    Id.DatasetInstance tScan = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "tScan");
+    DatasetId tScan = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("tScan");
     dsFrameworkUtil.createInstance("keyValueTable", tScan, DatasetProperties.EMPTY);
 
     final KeyValueTable t = dsFrameworkUtil.getInstance(tScan);
@@ -311,7 +310,7 @@ public class KeyValueTableTest {
 
   @Test
   public void testBatchReads() throws Exception {
-    Id.DatasetInstance tBatch = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "tBatch");
+    DatasetId tBatch = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("tBatch");
     dsFrameworkUtil.createInstance("keyValueTable", tBatch, DatasetProperties.EMPTY);
 
     final KeyValueTable t = dsFrameworkUtil.getInstance(tBatch);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/ReflectionTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/ReflectionTableTest.java
@@ -28,7 +28,7 @@ import co.cask.cdap.internal.io.ReflectionPutWriter;
 import co.cask.cdap.internal.io.ReflectionRowReader;
 import co.cask.cdap.internal.io.ReflectionRowRecordReader;
 import co.cask.cdap.internal.io.ReflectionSchemaGenerator;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import com.google.common.base.Objects;
 import com.google.common.reflect.TypeToken;
 import org.apache.tephra.TransactionAware;
@@ -47,8 +47,7 @@ public class ReflectionTableTest {
   @ClassRule
   public static DatasetFrameworkTestUtil dsFrameworkUtil = new DatasetFrameworkTestUtil();
 
-  private static final Id.DatasetInstance users =
-    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "users");
+  private static final DatasetId users = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("users");
   private static final User SAMUEL = new User(
     "Samuel L.", "Jackson",
     123,

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/TimeseriesTableScannerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/TimeseriesTableScannerTest.java
@@ -19,7 +19,7 @@ package co.cask.cdap.api.dataset.lib;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -48,8 +48,7 @@ public class TimeseriesTableScannerTest {
   @ClassRule
   public static DatasetFrameworkTestUtil dsFrameworkUtil = new DatasetFrameworkTestUtil();
 
-  private static final Id.DatasetInstance facts =
-    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "facts");
+  private static final DatasetId facts = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("facts");
   private static final byte[] ALL_KEY = Bytes.toBytes("a");
   private static final String SRC_TAG = "src";
   private static final String DST_TAG = "dst";

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/TimeseriesTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/api/dataset/lib/TimeseriesTableTest.java
@@ -19,7 +19,7 @@ package co.cask.cdap.api.dataset.lib;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import org.apache.tephra.TransactionExecutor;
 import org.apache.tephra.TransactionFailureException;
 import org.junit.AfterClass;
@@ -41,8 +41,7 @@ public class TimeseriesTableTest {
   @ClassRule
   public static DatasetFrameworkTestUtil dsFrameworkUtil = new DatasetFrameworkTestUtil();
 
-  private static final Id.DatasetInstance metricsTableInstance =
-    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "metricsTable");
+  private static final DatasetId metricsTableInstance = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("metricsTable");
   private static TimeseriesTable table;
 
   @BeforeClass

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/stream/StreamUtilsTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/stream/StreamUtilsTest.java
@@ -17,7 +17,7 @@
 package co.cask.cdap.data.stream;
 
 import co.cask.cdap.data2.util.TableId;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.StreamId;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
@@ -47,21 +47,21 @@ public class StreamUtilsTest {
     LocationFactory locationFactory = new LocalLocationFactory();
     String path = "/cdap/namespaces/default/streams/fooStream";
     Location streamBaseLocation = locationFactory.create(path);
-    Id.Stream expectedId = Id.Stream.from("default", "fooStream");
+    StreamId expectedId = NamespaceId.DEFAULT.stream("fooStream");
     Assert.assertEquals(expectedId, new StreamId("default",
-                                                 StreamUtils.getStreamNameFromLocation(streamBaseLocation)).toId());
+                                                 StreamUtils.getStreamNameFromLocation(streamBaseLocation)));
 
 
     path = "/customLocation/streams/otherstream";
     streamBaseLocation = locationFactory.create(path);
-    expectedId = Id.Stream.from("othernamespace", "otherstream");
+    expectedId = new StreamId("othernamespace", "otherstream");
     Assert.assertEquals(expectedId, new StreamId("othernamespace",
-                                                 StreamUtils.getStreamNameFromLocation(streamBaseLocation)).toId());
+                                                 StreamUtils.getStreamNameFromLocation(streamBaseLocation)));
   }
 
   @Test
   public void testGetStateStoreTableId() {
-    Id.Namespace namespace = Id.Namespace.from("foonamespace");
+    NamespaceId namespace = new NamespaceId("foonamespace");
     TableId expected = TableId.from("foonamespace", "system.stream.state.store");
     Assert.assertEquals(expected, StreamUtils.getStateStoreTableId(namespace));
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/stream/service/upload/StreamBodyConsumerTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/stream/service/upload/StreamBodyConsumerTestBase.java
@@ -16,7 +16,7 @@
 
 package co.cask.cdap.data.stream.service.upload;
 
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.common.io.ByteBufferInputStream;
 import co.cask.http.AbstractHttpResponder;
 import co.cask.http.BodyConsumer;
@@ -69,8 +69,8 @@ public abstract class StreamBodyConsumerTestBase {
     final TestContentWriter contentWriter = new TestContentWriter();
     BodyConsumer bodyConsumer = createBodyConsumer(new ContentWriterFactory() {
       @Override
-      public Id.Stream getStream() {
-        return Id.Stream.from("test_namespace", "test-stream");
+      public StreamId getStream() {
+        return new StreamId("test_namespace", "test-stream");
       }
 
       @Override

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/view/ViewStoreTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/view/ViewStoreTestBase.java
@@ -19,8 +19,9 @@ package co.cask.cdap.data.view;
 import co.cask.cdap.api.data.format.FormatSpecification;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.internal.io.SQLSchemaParser;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ViewSpecification;
+import co.cask.cdap.proto.id.StreamId;
+import co.cask.cdap.proto.id.StreamViewId;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
@@ -39,10 +40,10 @@ public abstract class ViewStoreTestBase {
   public void testExploreViewStore() throws Exception {
     ViewStore store = getExploreViewStore();
 
-    Id.Stream stream = Id.Stream.from("foo", "s");
-    Id.Stream.View view1 = Id.Stream.View.from(stream, "bar1");
-    Id.Stream.View view2 = Id.Stream.View.from(stream, "bar2");
-    Id.Stream.View view3 = Id.Stream.View.from(stream, "bar3");
+    StreamId stream = new StreamId("foo", "s");
+    StreamViewId view1 = stream.view("bar1");
+    StreamViewId view2 = stream.view("bar2");
+    StreamViewId view3 = stream.view("bar3");
 
     Assert.assertFalse(store.exists(view1));
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtilTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/DatasetsUtilTest.java
@@ -35,7 +35,7 @@ import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import co.cask.cdap.data2.dataset2.TestObject;
 import co.cask.cdap.data2.metadata.lineage.LineageDataset;
 import co.cask.cdap.data2.registry.UsageDataset;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -84,7 +84,7 @@ public class DatasetsUtilTest extends DatasetServiceTestBase {
 
   private void testFix(String type, DatasetProperties props) {
     DatasetDefinition def = DatasetFrameworkTestUtil.getDatasetDefinition(
-      inMemoryDatasetFramework, Id.Namespace.DEFAULT, type);
+      inMemoryDatasetFramework, NamespaceId.DEFAULT, type);
     Assert.assertNotNull(def);
     DatasetSpecification spec = def.configure("nn", props);
     Map<String, String> originalProperties = DatasetsUtil.fixOriginalProperties(spec).getOriginalProperties();

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -58,8 +58,8 @@ import co.cask.cdap.data2.transaction.TransactionExecutorFactory;
 import co.cask.cdap.data2.transaction.TransactionSystemClientService;
 import co.cask.cdap.explore.client.DiscoveryExploreClient;
 import co.cask.cdap.explore.client.ExploreFacade;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationTestModule;
@@ -197,7 +197,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
     Preconditions.checkNotNull(endpointStrategy.pick(5, TimeUnit.SECONDS),
                                "%s service is not up after 5 seconds", service);
 
-    createNamespace(Id.Namespace.SYSTEM);
+    createNamespace(NamespaceId.SYSTEM);
     createNamespace(NAMESPACE_ID);
   }
 
@@ -209,37 +209,37 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
     DatasetFramework framework = getFramework();
     // Adding module to system namespace should fail
     try {
-      framework.addModule(Id.DatasetModule.from(Id.Namespace.SYSTEM, "keyValue"),
+      framework.addModule(NamespaceId.SYSTEM.datasetModule("keyValue"),
                           new SingleTypeModule(SimpleKVTable.class));
       Assert.fail("Should not be able to add a module to system namespace");
     } catch (DatasetManagementException e) {
       // expected
     }
     try {
-      framework.deleteModule(Id.DatasetModule.from(Id.Namespace.SYSTEM, "orderedTable-memory"));
+      framework.deleteModule(NamespaceId.SYSTEM.datasetModule("orderedTable-memory"));
       Assert.fail("Should not be able to delete a default module.");
     } catch (DatasetManagementException e) {
       // expected
     }
     try {
-      framework.deleteAllModules(Id.Namespace.SYSTEM);
+      framework.deleteAllModules(NamespaceId.SYSTEM);
       Assert.fail("Should not be able to delete modules from system namespace");
     } catch (DatasetManagementException e) {
       // expected
     }
   }
 
-  private void createNamespace (Id.Namespace namespaceId) throws Exception {
+  private void createNamespace (NamespaceId namespaceId) throws Exception {
     // since the namespace admin here is an in memory one we need to create the location explicitly
-    namespacedLocationFactory.get(namespaceId).mkdirs();
+    namespacedLocationFactory.get(namespaceId.toId()).mkdirs();
     // the framework.delete looks up namespace config through namespaceadmin add the meta there too.
     namespaceAdmin.create(new NamespaceMeta.Builder().setName(namespaceId).build());
   }
 
-  private void deleteNamespace (Id.Namespace namespaceId) throws Exception {
+  private void deleteNamespace (NamespaceId namespaceId) throws Exception {
     // since the namespace admin here is an in memory one we need to delete the location explicitly
-    namespacedLocationFactory.get(namespaceId).delete(true);
-    namespaceAdmin.delete(namespaceId);
+    namespacedLocationFactory.get(namespaceId.toId()).delete(true);
+    namespaceAdmin.delete(namespaceId.toId());
   }
 
   @After
@@ -247,7 +247,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
     // since we stored namespace meta through admin so that framework.delete can lookup namespaceconfig clean the
     // meta from there too
     deleteNamespace(NAMESPACE_ID);
-    deleteNamespace(Id.Namespace.SYSTEM);
+    deleteNamespace(NamespaceId.SYSTEM);
     Futures.getUnchecked(Services.chainStop(service, opExecutorService, txManager));
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
@@ -30,7 +30,9 @@ import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data.runtime.TransactionExecutorModule;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.DatasetModuleId;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.base.Preconditions;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -52,8 +54,8 @@ import java.util.Collection;
 import java.util.Map;
 
 public final class DatasetFrameworkTestUtil extends ExternalResource {
-  public static final Id.Namespace NAMESPACE_ID = Id.Namespace.from("myspace");
-  public static final Id.Namespace NAMESPACE2_ID = Id.Namespace.from("myspace2");
+  public static final NamespaceId NAMESPACE_ID = new NamespaceId("myspace");
+  public static final NamespaceId NAMESPACE2_ID = new NamespaceId("myspace2");
 
   private Injector injector;
   private CConfiguration cConf;
@@ -115,39 +117,39 @@ public final class DatasetFrameworkTestUtil extends ExternalResource {
     return framework;
   }
 
-  public void addModule(Id.DatasetModule moduleId, DatasetModule module) throws DatasetManagementException {
+  public void addModule(DatasetModuleId moduleId, DatasetModule module) throws DatasetManagementException {
     framework.addModule(moduleId, module);
   }
 
-  public void deleteModule(Id.DatasetModule moduleId) throws DatasetManagementException {
+  public void deleteModule(DatasetModuleId moduleId) throws DatasetManagementException {
     framework.deleteModule(moduleId);
   }
 
-  public void createInstance(String type, Id.DatasetInstance datasetInstanceId, DatasetProperties properties)
+  public void createInstance(String type, DatasetId datasetInstanceId, DatasetProperties properties)
     throws IOException, DatasetManagementException {
     framework.addInstance(type, datasetInstanceId, properties);
   }
 
-  public void deleteInstance(Id.DatasetInstance datasetInstanceId)
+  public void deleteInstance(DatasetId datasetInstanceId)
     throws IOException, DatasetManagementException {
     framework.deleteInstance(datasetInstanceId);
   }
 
-  public <T extends Dataset> T getInstance(Id.DatasetInstance datasetInstanceId)
+  public <T extends Dataset> T getInstance(DatasetId datasetInstanceId)
     throws DatasetManagementException, IOException {
     return getInstance(datasetInstanceId, DatasetDefinition.NO_ARGUMENTS);
   }
 
-  public <T extends Dataset> T getInstance(Id.DatasetInstance datasetInstanceId, Map<String, String> arguments)
+  public <T extends Dataset> T getInstance(DatasetId datasetInstanceId, Map<String, String> arguments)
     throws DatasetManagementException, IOException {
     return framework.getDataset(datasetInstanceId, arguments, null);
   }
 
-  public DatasetSpecification getSpec(Id.DatasetInstance datasetInstanceId) throws DatasetManagementException {
+  public DatasetSpecification getSpec(DatasetId datasetInstanceId) throws DatasetManagementException {
     return framework.getDatasetSpec(datasetInstanceId);
   }
 
-  public Collection<DatasetSpecificationSummary> list(Id.Namespace namespace) throws DatasetManagementException {
+  public Collection<DatasetSpecificationSummary> list(NamespaceId namespace) throws DatasetManagementException {
     return framework.getInstances(namespace);
   }
 
@@ -186,7 +188,7 @@ public final class DatasetFrameworkTestUtil extends ExternalResource {
 
   // helper to make this method accessible to DatasetsUtilTest
   public static DatasetDefinition getDatasetDefinition(InMemoryDatasetFramework framework,
-                                                       Id.Namespace namespace, String type) {
+                                                       NamespaceId namespace, String type) {
     return framework.getDefinitionForType(namespace, type);
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/InMemoryDatasetFrameworkTest.java
@@ -30,7 +30,7 @@ public class InMemoryDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
     InMemoryDatasetFramework framework = new InMemoryDatasetFramework(registryFactory, DEFAULT_MODULES);
     framework.setAuditPublisher(inMemoryAuditPublisher);
     try {
-      namespacedLocationFactory.get(NAMESPACE_ID).mkdirs();
+      namespacedLocationFactory.get(NAMESPACE_ID.toId()).mkdirs();
     } catch (IOException e) {
       throw new DatasetManagementException(e.getMessage());
     }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/cache/DynamicDatasetCacheTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/cache/DynamicDatasetCacheTest.java
@@ -24,7 +24,6 @@ import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import co.cask.cdap.data2.dataset2.DynamicDatasetCache;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.data2.transaction.Transactions;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
@@ -63,10 +62,8 @@ public abstract class DynamicDatasetCacheTest {
   private static final Map<String, String> C_ARGUMENTS = ImmutableMap.of("key", "c", "value", "c");
   private static final Map<String, String> X_ARGUMENTS = ImmutableMap.of("value", "x");
 
-  protected static final Id.Namespace NAMESPACE = DatasetFrameworkTestUtil.NAMESPACE_ID;
-  protected static final Id.Namespace NAMESPACE2 = DatasetFrameworkTestUtil.NAMESPACE2_ID;
-  protected static final NamespaceId NAMESPACE_ID = new NamespaceId(NAMESPACE.getId());
-  protected static final NamespaceId NAMESPACE2_ID = new NamespaceId(NAMESPACE2.getId());
+  protected static final NamespaceId NAMESPACE = DatasetFrameworkTestUtil.NAMESPACE_ID;
+  protected static final NamespaceId NAMESPACE2 = DatasetFrameworkTestUtil.NAMESPACE2_ID;
   protected static DatasetFramework dsFramework;
   protected static TransactionSystemClient txClient;
   protected DynamicDatasetCache cache;
@@ -74,25 +71,25 @@ public abstract class DynamicDatasetCacheTest {
   @BeforeClass
   public static void init() throws DatasetManagementException, IOException {
     dsFramework = dsFrameworkUtil.getFramework();
-    dsFramework.addModule(Id.DatasetModule.from(NAMESPACE, "testDataset"), new TestDatasetModule());
-    dsFramework.addModule(Id.DatasetModule.from(NAMESPACE2, "testDataset"), new TestDatasetModule());
+    dsFramework.addModule(NAMESPACE.datasetModule("testDataset"), new TestDatasetModule());
+    dsFramework.addModule(NAMESPACE2.datasetModule("testDataset"), new TestDatasetModule());
     txClient = new InMemoryTxSystemClient(dsFrameworkUtil.getTxManager());
-    dsFrameworkUtil.createInstance("testDataset", Id.DatasetInstance.from(NAMESPACE, "a"), DatasetProperties.EMPTY);
-    dsFrameworkUtil.createInstance("testDataset", Id.DatasetInstance.from(NAMESPACE, "b"), DatasetProperties.EMPTY);
-    dsFrameworkUtil.createInstance("testDataset", Id.DatasetInstance.from(NAMESPACE, "c"), DatasetProperties.EMPTY);
-    dsFrameworkUtil.createInstance("testDataset", Id.DatasetInstance.from(NAMESPACE2, "a2"), DatasetProperties.EMPTY);
-    dsFrameworkUtil.createInstance("testDataset", Id.DatasetInstance.from(NAMESPACE2, "c2"), DatasetProperties.EMPTY);
+    dsFrameworkUtil.createInstance("testDataset", NAMESPACE.dataset("a"), DatasetProperties.EMPTY);
+    dsFrameworkUtil.createInstance("testDataset", NAMESPACE.dataset("b"), DatasetProperties.EMPTY);
+    dsFrameworkUtil.createInstance("testDataset", NAMESPACE.dataset("c"), DatasetProperties.EMPTY);
+    dsFrameworkUtil.createInstance("testDataset", NAMESPACE2.dataset("a2"), DatasetProperties.EMPTY);
+    dsFrameworkUtil.createInstance("testDataset", NAMESPACE2.dataset("c2"), DatasetProperties.EMPTY);
   }
 
   @AfterClass
   public static void tearDown() throws IOException, DatasetManagementException {
-    dsFrameworkUtil.deleteInstance(Id.DatasetInstance.from(NAMESPACE, "a"));
-    dsFrameworkUtil.deleteInstance(Id.DatasetInstance.from(NAMESPACE, "b"));
-    dsFrameworkUtil.deleteInstance(Id.DatasetInstance.from(NAMESPACE, "c"));
-    dsFrameworkUtil.deleteInstance(Id.DatasetInstance.from(NAMESPACE2, "a2"));
-    dsFrameworkUtil.deleteInstance(Id.DatasetInstance.from(NAMESPACE2, "c2"));
-    dsFrameworkUtil.deleteModule(Id.DatasetModule.from(NAMESPACE, "testDataset"));
-    dsFrameworkUtil.deleteModule(Id.DatasetModule.from(NAMESPACE2, "testDataset"));
+    dsFrameworkUtil.deleteInstance(NAMESPACE.dataset("a"));
+    dsFrameworkUtil.deleteInstance(NAMESPACE.dataset("b"));
+    dsFrameworkUtil.deleteInstance(NAMESPACE.dataset("c"));
+    dsFrameworkUtil.deleteInstance(NAMESPACE2.dataset("a2"));
+    dsFrameworkUtil.deleteInstance(NAMESPACE2.dataset("c2"));
+    dsFrameworkUtil.deleteModule(NAMESPACE.datasetModule("testDataset"));
+    dsFrameworkUtil.deleteModule(NAMESPACE2.datasetModule("testDataset"));
   }
 
   @Before
@@ -134,9 +131,9 @@ public abstract class DynamicDatasetCacheTest {
     Assert.assertSame(b1, b2);
 
     // Test this for cross namespace access
-    TestDataset an2 = cache.getDataset(NAMESPACE2.getId(), "a2");
-    TestDataset a1n2 = cache.getDataset(NAMESPACE2.getId(), "a2");
-    TestDataset a2n2 = cache.getDataset(NAMESPACE2.getId(), "a2", A_ARGUMENTS);
+    TestDataset an2 = cache.getDataset(NAMESPACE2.getEntityName(), "a2");
+    TestDataset a1n2 = cache.getDataset(NAMESPACE2.getEntityName(), "a2");
+    TestDataset a2n2 = cache.getDataset(NAMESPACE2.getEntityName(), "a2", A_ARGUMENTS);
     Assert.assertSame(an2, a1n2);
     Assert.assertSame(an2, a2n2);
     Assert.assertNotSame(a, an2);
@@ -171,7 +168,7 @@ public abstract class DynamicDatasetCacheTest {
     Assert.assertEquals(a.getCurrentTransaction(), c.getCurrentTransaction());
 
     // another dataset from different namespace
-    TestDataset cn2 = cache.getDataset(NAMESPACE2.getId(), "c2", C_ARGUMENTS);
+    TestDataset cn2 = cache.getDataset(NAMESPACE2.getEntityName(), "c2", C_ARGUMENTS);
     Assert.assertEquals(an2.getCurrentTransaction(), cn2.getCurrentTransaction());
 
     // validate runtime arguments of c and c2
@@ -203,7 +200,7 @@ public abstract class DynamicDatasetCacheTest {
     // get b and c again, validate that they are the same
     TestDataset b3 = cache.getDataset("b", B_ARGUMENTS);
     TestDataset c1 = cache.getDataset("c", C_ARGUMENTS);
-    TestDataset c1n2 = cache.getDataset(NAMESPACE2.getId(), "c2", C_ARGUMENTS);
+    TestDataset c1n2 = cache.getDataset(NAMESPACE2.getEntityName(), "c2", C_ARGUMENTS);
     Assert.assertSame(b3, b);
     Assert.assertSame(c1, c);
     Assert.assertSame(c1n2, cn2);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/cache/MultiThreadDatasetCacheTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/cache/MultiThreadDatasetCacheTest.java
@@ -35,7 +35,7 @@ public class MultiThreadDatasetCacheTest extends DynamicDatasetCacheTest {
   protected DynamicDatasetCache createCache(SystemDatasetInstantiator instantiator,
                                             Map<String, String> arguments,
                                             Map<String, Map<String, String>> staticDatasets) {
-    return new MultiThreadDatasetCache(instantiator, txClient, NAMESPACE_ID, arguments, null, staticDatasets);
+    return new MultiThreadDatasetCache(instantiator, txClient, NAMESPACE, arguments, null, staticDatasets);
   }
 
   @Test

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/cache/SingleThreadDatasetCacheTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/cache/SingleThreadDatasetCacheTest.java
@@ -32,7 +32,7 @@ public class SingleThreadDatasetCacheTest extends DynamicDatasetCacheTest {
   protected DynamicDatasetCache createCache(SystemDatasetInstantiator instantiator,
                                             Map<String, String> arguments,
                                             Map<String, Map<String, String>> staticDatasets) {
-    return new SingleThreadDatasetCache(instantiator, txClient, NAMESPACE_ID, arguments, null, staticDatasets);
+    return new SingleThreadDatasetCache(instantiator, txClient, NAMESPACE, arguments, null, staticDatasets);
   }
 
   @Test

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/FileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/FileSetTest.java
@@ -25,7 +25,8 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import co.cask.cdap.data2.dataset2.lib.file.FileSetDataset;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.collect.Maps;
 import org.apache.tephra.TransactionFailureException;
 import org.apache.twill.filesystem.Location;
@@ -52,19 +53,18 @@ public class FileSetTest {
 
   static FileSet fileSet1;
   static FileSet fileSet2;
-  private static final Id.Namespace OTHER_NAMESPACE = Id.Namespace.from("yourspace");
-  private static final Id.DatasetInstance testFileSetInstance1 =
-    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "testFileSet");
-  private static final Id.DatasetInstance testFileSetInstance2 =
-    Id.DatasetInstance.from(OTHER_NAMESPACE, "testFileSet");
-  private static final Id.DatasetInstance testFileSetInstance3 =
-    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "absoluteFileSet");
-  private static final Id.DatasetInstance testFileSetInstance4 =
-    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "lookAlikeFileSet");
-  private static final Id.DatasetInstance testFileSetInstance5 =
-    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "externalFileSet");
-  private static final Id.DatasetInstance testFileSetInstance6 =
-    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "nonExternalFileSet1");
+  private static final NamespaceId OTHER_NAMESPACE = new NamespaceId("yourspace");
+  private static final DatasetId testFileSetInstance1 =
+    DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("testFileSet");
+  private static final DatasetId testFileSetInstance2 = OTHER_NAMESPACE.dataset("testFileSet");
+  private static final DatasetId testFileSetInstance3 =
+    DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("absoluteFileSet");
+  private static final DatasetId testFileSetInstance4 =
+    DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("lookAlikeFileSet");
+  private static final DatasetId testFileSetInstance5 =
+    DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("externalFileSet");
+  private static final DatasetId testFileSetInstance6 =
+    DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("nonExternalFileSet1");
 
   @Before
   public void before() throws Exception {
@@ -93,7 +93,7 @@ public class FileSetTest {
     deleteInstance(testFileSetInstance6);
   }
 
-  static void deleteInstance(Id.DatasetInstance id) throws Exception {
+  static void deleteInstance(DatasetId id) throws Exception {
     if (dsFrameworkUtil.getInstance(id) != null) {
       dsFrameworkUtil.deleteInstance(id);
     }
@@ -107,8 +107,8 @@ public class FileSetTest {
     Location fileSet2NsDir = Locations.getParent(Locations.getParent(Locations.getParent(fileSet2Output)));
     Assert.assertNotNull(fileSet1NsDir);
     Assert.assertNotNull(fileSet2NsDir);
-    Assert.assertEquals(fileSet1NsDir.getName(), DatasetFrameworkTestUtil.NAMESPACE_ID.getId());
-    Assert.assertEquals(fileSet2NsDir.getName(), OTHER_NAMESPACE.getId());
+    Assert.assertEquals(fileSet1NsDir.getName(), DatasetFrameworkTestUtil.NAMESPACE_ID.getNamespace());
+    Assert.assertEquals(fileSet2NsDir.getName(), OTHER_NAMESPACE.getNamespace());
 
     Assert.assertNotEquals(fileSet1.getInputLocations().get(0).toURI().getPath(),
                            fileSet2.getInputLocations().get(0).toURI().getPath());
@@ -156,7 +156,7 @@ public class FileSetTest {
   public void testAbsolutePathInsideCDAP() throws IOException, DatasetManagementException {
     String absolutePath = dsFrameworkUtil.getConfiguration().get(Constants.CFG_LOCAL_DATA_DIR).concat("/hello");
     dsFrameworkUtil.createInstance("fileSet",
-                                   Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "badFileSet"),
+                                   DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("badFileSet"),
                                    FileSetProperties.builder().setBasePath(absolutePath).build());
   }
 
@@ -166,7 +166,7 @@ public class FileSetTest {
     String absolutePath = dsFrameworkUtil.getConfiguration()
       .get(Constants.CFG_LOCAL_DATA_DIR).replace("/", "//").concat("/hello");
     dsFrameworkUtil.createInstance("fileSet",
-                                   Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "badFileSet"),
+                                   DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("badFileSet"),
                                    FileSetProperties.builder().setBasePath(absolutePath).build());
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/cube/CubeDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/cube/CubeDatasetTest.java
@@ -26,7 +26,7 @@ import co.cask.cdap.api.dataset.lib.cube.CubeQuery;
 import co.cask.cdap.api.dataset.lib.cube.DimensionValue;
 import co.cask.cdap.api.dataset.lib.cube.TimeSeries;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -64,7 +64,7 @@ public class CubeDatasetTest extends AbstractCubeTest {
   private Cube getCubeInternal(String name, int[] resolutions,
                                   Map<String, ? extends Aggregation> aggregations) throws Exception {
     DatasetProperties props = configureProperties(resolutions, aggregations);
-    Id.DatasetInstance id = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, name);
+    DatasetId id = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset(name);
     if (dsFrameworkUtil.getInstance(id) == null) {
       dsFrameworkUtil.createInstance(Cube.class.getName(), id, props);
     }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/cube/MetricsTableOnTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/cube/MetricsTableOnTableTest.java
@@ -23,7 +23,7 @@ import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import co.cask.cdap.data2.dataset2.lib.table.FuzzyRowFilter;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTable;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTableTest;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import org.apache.tephra.TransactionAware;
 import org.apache.tephra.TransactionExecutor;
 import org.junit.ClassRule;
@@ -44,7 +44,7 @@ public class MetricsTableOnTableTest extends MetricsTableTest {
 
   @Override
   protected MetricsTable getTable(String name) throws Exception {
-    Id.DatasetInstance id = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, name);
+    DatasetId id = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset(name);
     if (dsFrameworkUtil.getInstance(id) == null) {
       dsFrameworkUtil.createInstance(Table.class.getName(), id, DatasetProperties.EMPTY);
     }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionConsumerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionConsumerTest.java
@@ -34,7 +34,7 @@ import co.cask.cdap.api.dataset.lib.partitioned.PartitionConsumerResult;
 import co.cask.cdap.api.dataset.lib.partitioned.ProcessState;
 import co.cask.cdap.api.dataset.lib.partitioned.StatePersistor;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -75,10 +75,8 @@ public class PartitionConsumerTest {
     .addLongField("l")
     .build();
 
-  private static final Id.DatasetInstance pfsInstance =
-    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "pfs");
-  private static final Id.DatasetInstance pfsExternalInstance =
-    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "ext");
+  private static final DatasetId pfsInstance = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("pfs");
+  private static final DatasetId pfsExternalInstance = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("ext");
   private static Location pfsBaseLocation;
 
   @Before

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
@@ -30,7 +30,7 @@ import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
 import co.cask.cdap.api.dataset.lib.Partitioning;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.test.SlowTests;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -97,10 +97,8 @@ public class PartitionedFileSetTest {
     .addStringField("s", "x")
     .build();
 
-  private static final Id.DatasetInstance pfsInstance =
-    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "pfs");
-  private static final Id.DatasetInstance pfsExternalInstance =
-    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "ext");
+  private static final DatasetId pfsInstance = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("pfs");
+  private static final DatasetId pfsExternalInstance = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("ext");
   private static Location pfsBaseLocation;
 
   private InMemoryTxSystemClient txClient;
@@ -160,7 +158,7 @@ public class PartitionedFileSetTest {
       pfs.addMetadata(key, "metaKey", "metaValue");
       Assert.fail("Expected not to find key: " + key);
     } catch (PartitionNotFoundException e) {
-      Assert.assertEquals(pfsInstance.getId(), e.getPartitionedFileSetName());
+      Assert.assertEquals(pfsInstance.getEntityName(), e.getPartitionedFileSetName());
       Assert.assertEquals(key, e.getPartitionKey());
     }
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetTest.java
@@ -26,7 +26,7 @@ import co.cask.cdap.api.dataset.lib.TimePartitionDetail;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSetArguments;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -64,8 +64,7 @@ public class TimePartitionedFileSetTest {
   static final long HOUR = TimeUnit.HOURS.toMillis(1);
   static final long MAX = Long.MAX_VALUE;
 
-  private static final Id.DatasetInstance TPFS_INSTANCE =
-    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "tpfs");
+  private static final DatasetId TPFS_INSTANCE = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("tpfs");
 
   @Before
   public void before() throws Exception {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/MetadataStoreDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/MetadataStoreDatasetTest.java
@@ -20,7 +20,7 @@ import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
@@ -39,7 +39,7 @@ public class MetadataStoreDatasetTest {
 
   @Test
   public void testList() throws Exception {
-    Id.DatasetInstance storeTable = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "testList");
+    DatasetId storeTable = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("testList");
     dsFrameworkUtil.createInstance(Table.class.getName(), storeTable, DatasetProperties.EMPTY);
 
     Table table = dsFrameworkUtil.getInstance(storeTable);
@@ -88,7 +88,7 @@ public class MetadataStoreDatasetTest {
 
   @Test
   public void testScan() throws Exception {
-    Id.DatasetInstance storeTable = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "testScan");
+    DatasetId storeTable = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("testScan");
     dsFrameworkUtil.createInstance(Table.class.getName(), storeTable, DatasetProperties.EMPTY);
 
     Table table = dsFrameworkUtil.getInstance(storeTable);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/ObjectMappedTableDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/ObjectMappedTableDatasetTest.java
@@ -25,7 +25,7 @@ import co.cask.cdap.api.dataset.lib.ObjectMappedTable;
 import co.cask.cdap.api.dataset.lib.ObjectMappedTableProperties;
 import co.cask.cdap.api.dataset.table.Scan;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -43,8 +43,7 @@ public class ObjectMappedTableDatasetTest {
   @ClassRule
   public static DatasetFrameworkTestUtil dsFrameworkUtil = new DatasetFrameworkTestUtil();
 
-  private static final Id.DatasetInstance RECORDS_ID =
-    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "records");
+  private static final DatasetId RECORDS_ID = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("records");
 
   @Test
   public void testGetPutDelete() throws Exception {
@@ -185,14 +184,14 @@ public class ObjectMappedTableDatasetTest {
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidTypeFails() throws Exception {
     dsFrameworkUtil.createInstance(ObjectMappedTable.class.getName(),
-                                   Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "custom"),
+                                   DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("custom"),
                                    ObjectMappedTableProperties.builder().setType(Custom.class).build());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testRowKeyConflict() throws Exception {
     dsFrameworkUtil.createInstance(ObjectMappedTable.class.getName(),
-                                   Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "record"),
+                                   DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("record"),
                                    ObjectMappedTableProperties.builder()
                                      .setType(Record.class)
                                      .setRowKeyExploreName("intfield")

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/ObjectStoreDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/ObjectStoreDatasetTest.java
@@ -32,7 +32,8 @@ import co.cask.cdap.common.utils.ImmutablePair;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import co.cask.cdap.internal.io.ReflectionSchemaGenerator;
 import co.cask.cdap.internal.io.TypeRepresentation;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.DatasetModuleId;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
@@ -66,8 +67,8 @@ public class ObjectStoreDatasetTest {
 
   private static final byte[] a = { 'a' };
 
-  private static final Id.DatasetModule integerStore = 
-    Id.DatasetModule.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "integerStore");
+  private static final DatasetModuleId integerStore =
+    DatasetFrameworkTestUtil.NAMESPACE_ID.datasetModule("integerStore");
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -79,13 +80,13 @@ public class ObjectStoreDatasetTest {
     dsFrameworkUtil.deleteModule(integerStore);
   }
 
-  private void addIntegerStoreInstance(Id.DatasetInstance datasetInstanceId) throws Exception {
+  private void addIntegerStoreInstance(DatasetId datasetInstanceId) throws Exception {
     dsFrameworkUtil.createInstance("integerStore", datasetInstanceId, DatasetProperties.EMPTY);
   }
 
   @Test
   public void testStringStore() throws Exception {
-    Id.DatasetInstance strings = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "strings");
+    DatasetId strings = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("strings");
     createObjectStoreInstance(strings, String.class);
     
     ObjectStoreDataset<String> stringStore = dsFrameworkUtil.getInstance(strings);
@@ -101,7 +102,7 @@ public class ObjectStoreDatasetTest {
 
   @Test
   public void testPairStore() throws Exception {
-    Id.DatasetInstance pairs = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "pairs");
+    DatasetId pairs = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("pairs");
     createObjectStoreInstance(pairs, new TypeToken<ImmutablePair<Integer, String>>() { }.getType());
 
     ObjectStoreDataset<ImmutablePair<Integer, String>> pairStore = dsFrameworkUtil.getInstance(pairs);
@@ -117,7 +118,7 @@ public class ObjectStoreDatasetTest {
 
   @Test
   public void testCustomStore() throws Exception {
-    Id.DatasetInstance customs = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "customs");
+    DatasetId customs = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("customs");
     createObjectStoreInstance(customs, new TypeToken<Custom>() { }.getType());
 
     ObjectStoreDataset<Custom> customStore = dsFrameworkUtil.getInstance(customs);
@@ -137,7 +138,7 @@ public class ObjectStoreDatasetTest {
 
   @Test
   public void testInnerStore() throws Exception {
-    Id.DatasetInstance inners = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "inners");
+    DatasetId inners = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("inners");
     createObjectStoreInstance(inners, new TypeToken<CustomWithInner.Inner<Integer>>() { }.getType());
 
     ObjectStoreDataset<CustomWithInner.Inner<Integer>> innerStore = dsFrameworkUtil.getInstance(inners);
@@ -153,7 +154,7 @@ public class ObjectStoreDatasetTest {
 
   @Test
   public void testInstantiateWrongClass() throws Exception {
-    Id.DatasetInstance pairs = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "pairs");
+    DatasetId pairs = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("pairs");
     createObjectStoreInstance(pairs, new TypeToken<ImmutablePair<Integer, String>>() { }.getType());
 
     // note: due to type erasure, this succeeds
@@ -214,7 +215,7 @@ public class ObjectStoreDatasetTest {
 
   @Test
   public void testWithCustomClassLoader() throws Exception {
-    Id.DatasetInstance kv = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "kv");
+    DatasetId kv = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("kv");
     // create a dummy class loader that records the name of the class it loaded
     final AtomicReference<String> lastClassLoaded = new AtomicReference<>(null);
     ClassLoader loader = new ClassLoader() {
@@ -248,7 +249,7 @@ public class ObjectStoreDatasetTest {
 
   @Test
   public void testBatchCustomList() throws Exception {
-    Id.DatasetInstance customlist = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "customlist");
+    DatasetId customlist = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("customlist");
     createObjectStoreInstance(customlist, new TypeToken<List<Custom>>() { }.getType());
 
     final ObjectStoreDataset<List<Custom>> customStore = dsFrameworkUtil.getInstance(customlist);
@@ -307,7 +308,7 @@ public class ObjectStoreDatasetTest {
 
   @Test
   public void testBatchReads() throws Exception {
-    Id.DatasetInstance batch = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "batch");
+    DatasetId batch = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("batch");
     createObjectStoreInstance(batch, String.class);
 
     final ObjectStoreDataset<String> t = dsFrameworkUtil.getInstance(batch);
@@ -359,7 +360,7 @@ public class ObjectStoreDatasetTest {
 
   @Test
   public void testScanObjectStore() throws Exception {
-    Id.DatasetInstance scan = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "scan");
+    DatasetId scan = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("scan");
     createObjectStoreInstance(scan, String.class);
 
     final ObjectStoreDataset<String> t = dsFrameworkUtil.getInstance(scan);
@@ -436,7 +437,7 @@ public class ObjectStoreDatasetTest {
 
   @Test
   public void testSubclass() throws Exception {
-    Id.DatasetInstance intsInstance = Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "ints");
+    DatasetId intsInstance = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("ints");
     addIntegerStoreInstance(intsInstance);
 
     IntegerStore ints = dsFrameworkUtil.getInstance(intsInstance);
@@ -450,7 +451,7 @@ public class ObjectStoreDatasetTest {
     dsFrameworkUtil.deleteInstance(intsInstance);
   }
 
-  private void createObjectStoreInstance(Id.DatasetInstance datasetInstanceId, Type type) throws Exception {
+  private void createObjectStoreInstance(DatasetId datasetInstanceId, Type type) throws Exception {
     dsFrameworkUtil.createInstance("objectStore", datasetInstanceId, 
                                    ObjectStores.objectStoreProperties(type, DatasetProperties.EMPTY));
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryMetricsTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryMetricsTableTest.java
@@ -31,7 +31,8 @@ import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
 import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTable;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTableTest;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.PrivateModule;
@@ -71,7 +72,7 @@ public class InMemoryMetricsTableTest extends MetricsTableTest {
 
   @Override
   protected MetricsTable getTable(String name) throws Exception {
-    Id.DatasetInstance metricsDatasetInstanceId = Id.DatasetInstance.from(Id.Namespace.SYSTEM, name);
+    DatasetId metricsDatasetInstanceId = NamespaceId.SYSTEM.dataset(name);
     return DatasetsUtil.getOrCreateDataset(dsFramework, metricsDatasetInstanceId, MetricsTable.class.getName(),
                                            DatasetProperties.EMPTY, null, null);
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBMetricsTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBMetricsTableTest.java
@@ -30,7 +30,8 @@ import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTable;
 import co.cask.cdap.data2.dataset2.lib.table.MetricsTableTest;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationTestModule;
@@ -71,7 +72,7 @@ public class LevelDBMetricsTableTest extends MetricsTableTest {
 
   @Override
   protected MetricsTable getTable(String name) throws Exception {
-    Id.DatasetInstance metricsDatasetInstanceId = Id.DatasetInstance.from(Id.Namespace.SYSTEM, name);
+    DatasetId metricsDatasetInstanceId = NamespaceId.SYSTEM.dataset(name);
     return DatasetsUtil.getOrCreateDataset(dsFramework, metricsDatasetInstanceId, MetricsTable.class.getName(),
                                            DatasetProperties.EMPTY, null, null);
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
@@ -55,8 +55,7 @@ public class MetadataDatasetTest {
   @ClassRule
   public static DatasetFrameworkTestUtil dsFrameworkUtil = new DatasetFrameworkTestUtil();
 
-  private static final Id.DatasetInstance datasetInstance =
-    Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "meta");
+  private static final DatasetId datasetInstance = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("meta");
 
   private MetadataDataset dataset;
 
@@ -567,7 +566,7 @@ public class MetadataDatasetTest {
   @Test
   public void testHistory() throws Exception {
     MetadataDataset dataset =
-      getDataset(Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "testHistory"));
+      getDataset(DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("testHistory"));
 
     doTestHistory(dataset, flow1, "f_");
     doTestHistory(dataset, app1, "a_");
@@ -578,7 +577,7 @@ public class MetadataDatasetTest {
   @Test
   public void testIndexRebuilding() throws Exception {
     MetadataDataset dataset =
-      getDataset(Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "testIndexRebuilding"));
+      getDataset(DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("testIndexRebuilding"));
     dataset.setProperty(flow1, "flowKey", "flowValue", new ReversingIndexer());
     dataset.setProperty(dataset1, "datasetKey", "datasetValue", new ReversingIndexer());
     String namespaceId = flow1.getNamespace();
@@ -625,7 +624,7 @@ public class MetadataDatasetTest {
   @Test
   public void testIndexDeletion() throws Exception {
     MetadataDataset dataset =
-      getDataset(Id.DatasetInstance.from(DatasetFrameworkTestUtil.NAMESPACE_ID, "testIndexRebuilding"));
+      getDataset(DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("testIndexRebuilding"));
     dataset.setProperty(flow1, "flowKey", "flowValue");
     dataset.setProperty(dataset1, "datasetKey", "datasetValue");
     String namespaceId = flow1.getNamespace();
@@ -821,7 +820,7 @@ public class MetadataDatasetTest {
     return iterable.iterator().next();
   }
 
-  private static MetadataDataset getDataset(Id.DatasetInstance instance) throws Exception {
+  private static MetadataDataset getDataset(DatasetId instance) throws Exception {
     return DatasetsUtil.getOrCreateDataset(dsFrameworkUtil.getFramework(), instance,
                                            MetadataDataset.class.getName(),
                                            DatasetProperties.EMPTY, null, null);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/lineage/LineageDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/lineage/LineageDatasetTest.java
@@ -167,8 +167,8 @@ public class LineageDatasetTest {
   }
 
   private static LineageDataset getLineageDataset(String instanceId) throws Exception {
-    DatasetId id = DatasetFrameworkTestUtil.NAMESPACE_ID.toEntityId().dataset(instanceId);
-    return DatasetsUtil.getOrCreateDataset(dsFrameworkUtil.getFramework(), id.toId(),
+    DatasetId id = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset(instanceId);
+    return DatasetsUtil.getOrCreateDataset(dsFrameworkUtil.getFramework(), id,
                                            LineageDataset.class.getName(), DatasetProperties.EMPTY, null, null);
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/system/AbstractSystemMetadataWriterTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/system/AbstractSystemMetadataWriterTest.java
@@ -90,7 +90,7 @@ public class AbstractSystemMetadataWriterTest {
   public void testMetadataOverwrite() throws Exception {
     DatasetId dsInstance = new DatasetId("ns1", "ds1");
     DatasetSystemMetadataWriter datasetSystemMetadataWriter =
-      new DatasetSystemMetadataWriter(store, dsInstance.toId(),
+      new DatasetSystemMetadataWriter(store, dsInstance,
                                       DatasetProperties.builder()
                                         .add(Table.PROPERTY_TTL, "100")
                                         .build(),
@@ -107,8 +107,7 @@ public class AbstractSystemMetadataWriterTest {
 
     // Now remove TTL, and add dsType
     datasetSystemMetadataWriter =
-      new DatasetSystemMetadataWriter(store, dsInstance.toId(),
-                                      DatasetProperties.EMPTY, null, "dsType", "description2");
+      new DatasetSystemMetadataWriter(store, dsInstance, DatasetProperties.EMPTY, null, "dsType", "description2");
     datasetSystemMetadataWriter.write();
 
     expected =

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/system/DatasetSystemMetadataWriterTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/system/DatasetSystemMetadataWriterTest.java
@@ -19,7 +19,7 @@ package co.cask.cdap.data2.metadata.system;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.data2.metadata.store.NoOpMetadataStore;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -74,7 +74,7 @@ public class DatasetSystemMetadataWriterTest {
 
   private void assertDatasetSchema(String expected, DatasetProperties properties) {
     DatasetSystemMetadataWriter metadataWriter =
-      new DatasetSystemMetadataWriter(new NoOpMetadataStore(), Id.DatasetInstance.from("ns1", "avro1"),
+      new DatasetSystemMetadataWriter(new NoOpMetadataStore(), new DatasetId("ns1", "avro1"),
                                       properties, null, null, null);
     Assert.assertEquals(expected, metadataWriter.getSchemaToAdd());
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/system/ViewSystemMetadataWriterTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/system/ViewSystemMetadataWriterTest.java
@@ -58,7 +58,7 @@ public class ViewSystemMetadataWriterTest {
     FormatSpecification formatSpec = new FormatSpecification(format, schema);
     ViewSpecification viewSpec = new ViewSpecification(formatSpec);
     NoOpMetadataStore metadataStore = new NoOpMetadataStore();
-    ViewSystemMetadataWriter writer = new ViewSystemMetadataWriter(metadataStore, viewId.toId(), viewSpec);
+    ViewSystemMetadataWriter writer = new ViewSystemMetadataWriter(metadataStore, viewId, viewSpec);
     return writer.getSchemaToAdd();
   }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/registry/UsageRegistryTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/registry/UsageRegistryTest.java
@@ -20,7 +20,10 @@ import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.metrics.MetricsCollector;
 import co.cask.cdap.data2.dataset2.ForwardingDatasetFramework;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.apache.tephra.Transaction;
@@ -51,7 +54,7 @@ public class UsageRegistryTest extends UsageDatasetTest {
       }, new ForwardingDatasetFramework(dsFrameworkUtil.getFramework()) {
       @Nullable
       @Override
-      public <T extends Dataset> T getDataset(Id.DatasetInstance datasetInstanceId,
+      public <T extends Dataset> T getDataset(DatasetId datasetInstanceId,
                                               @Nullable Map<String, String> arguments,
                                               @Nullable ClassLoader classLoader)
         throws DatasetManagementException, IOException {
@@ -103,7 +106,7 @@ public class UsageRegistryTest extends UsageDatasetTest {
     Assert.assertEquals(ImmutableSet.of(flow12, flow21, flow22), registry.getPrograms(stream1));
 
     // unregister app
-    registry.unregister(flow11.getApplication());
+    registry.unregister(flow11.getParent());
 
     // validate usage for that app is gone
     Assert.assertEquals(ImmutableSet.of(), registry.getDatasets(flow11));
@@ -151,49 +154,49 @@ public class UsageRegistryTest extends UsageDatasetTest {
     }
 
     @Override
-    public void register(Id.Program programId, Id.DatasetInstance datasetInstanceId) {
+    public void register(ProgramId programId, DatasetId datasetInstanceId) {
       registerCount++;
       uds.register(programId, datasetInstanceId);
     }
 
     @Override
-    public void register(Id.Program programId, Id.Stream streamId) {
+    public void register(ProgramId programId, StreamId streamId) {
       registerCount++;
       uds.register(programId, streamId);
     }
 
     @Override
-    public void unregister(Id.Application applicationId) {
+    public void unregister(ApplicationId applicationId) {
       uds.unregister(applicationId);
     }
 
     @Override
-    public Set<Id.DatasetInstance> getDatasets(Id.Program programId) {
+    public Set<DatasetId> getDatasets(ProgramId programId) {
       return uds.getDatasets(programId);
     }
 
     @Override
-    public Set<Id.DatasetInstance> getDatasets(Id.Application applicationId) {
+    public Set<DatasetId> getDatasets(ApplicationId applicationId) {
       return uds.getDatasets(applicationId);
     }
 
     @Override
-    public Set<Id.Stream> getStreams(Id.Program programId) {
+    public Set<StreamId> getStreams(ProgramId programId) {
       return uds.getStreams(programId);
     }
 
     @Override
-    public Set<Id.Stream> getStreams(Id.Application applicationId) {
+    public Set<StreamId> getStreams(ApplicationId applicationId) {
       return uds.getStreams(applicationId);
     }
 
     @Override
-    public Set<Id.Program> getPrograms(Id.DatasetInstance datasetInstanceId) {
+    public Set<ProgramId> getPrograms(DatasetId datasetInstanceId) {
       return uds.getPrograms(datasetInstanceId);
     }
 
     @Override
-    public Set<Id.Program> getPrograms(Id.Stream streamId) {
+    public Set<ProgramId> getPrograms(StreamId streamId) {
       return uds.getPrograms(streamId);
     }
 

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorHttpHandler.java
@@ -124,7 +124,7 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
     StreamId streamId = new StreamId(namespace, streamName);
     try {
       // throws io exception if there is no stream
-      streamAdmin.getConfig(streamId.toId());
+      streamAdmin.getConfig(streamId);
     } catch (IOException e) {
       LOG.debug("Could not find stream {} to disable explore on.", streamName, e);
       responder.sendString(HttpResponseStatus.NOT_FOUND, "Could not find stream " + streamName);
@@ -162,7 +162,7 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
     DatasetId datasetId = new DatasetId(namespace, datasetName);
     DatasetSpecification datasetSpec;
     try {
-      datasetSpec = datasetFramework.getDatasetSpec(datasetId.toId());
+      datasetSpec = datasetFramework.getDatasetSpec(datasetId);
       if (datasetSpec == null) {
         responder.sendString(HttpResponseStatus.NOT_FOUND, "Cannot load dataset " + datasetId);
         return;
@@ -283,7 +283,7 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
     propagateUserId(request);
     Dataset dataset;
     try (SystemDatasetInstantiator datasetInstantiator = datasetInstantiatorFactory.create()) {
-      dataset = datasetInstantiator.getDataset(datasetId.toId());
+      dataset = datasetInstantiator.getDataset(datasetId);
 
       if (dataset == null) {
         responder.sendString(HttpResponseStatus.NOT_FOUND, "Cannot load dataset " + datasetId);
@@ -350,7 +350,7 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
     propagateUserId(request);
     Dataset dataset;
     try (SystemDatasetInstantiator datasetInstantiator = datasetInstantiatorFactory.create()) {
-      dataset = datasetInstantiator.getDataset(datasetId.toId());
+      dataset = datasetInstantiator.getDataset(datasetId);
       if (dataset == null) {
         responder.sendString(HttpResponseStatus.NOT_FOUND, "Cannot load dataset " + datasetId);
         return;

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreTableManager.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreTableManager.java
@@ -181,7 +181,7 @@ public class ExploreTableManager {
     Dataset dataset = null;
     String createStatement;
     try (SystemDatasetInstantiator datasetInstantiator = datasetInstantiatorFactory.create()) {
-      dataset = datasetInstantiator.getDataset(datasetId.toId());
+      dataset = datasetInstantiator.getDataset(datasetId);
       if (dataset == null) {
         throw new DatasetNotFoundException(datasetId.toId());
       }
@@ -233,7 +233,7 @@ public class ExploreTableManager {
     Dataset dataset = null;
     List<String> alterStatements;
     try (SystemDatasetInstantiator datasetInstantiator = datasetInstantiatorFactory.create()) {
-      dataset = datasetInstantiator.getDataset(datasetId.toId());
+      dataset = datasetInstantiator.getDataset(datasetId);
       if (dataset == null) {
         throw new DatasetNotFoundException(datasetId.toId());
       }
@@ -282,7 +282,7 @@ public class ExploreTableManager {
     Dataset dataset = null;
     String deleteStatement;
     try (SystemDatasetInstantiator datasetInstantiator = datasetInstantiatorFactory.create()) {
-      dataset = datasetInstantiator.getDataset(datasetId.toId());
+      dataset = datasetInstantiator.getDataset(datasetId);
       if (dataset == null) {
         throw new DatasetNotFoundException(datasetId.toId());
       }

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/context/ContextManager.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/context/ContextManager.java
@@ -221,11 +221,11 @@ public class ContextManager {
     }
 
     public StreamConfig getStreamConfig(Id.Stream streamId) throws IOException {
-      return streamAdmin.getConfig(streamId);
+      return streamAdmin.getConfig(streamId.toEntityId());
     }
 
     public DatasetSpecification getDatasetSpec(Id.DatasetInstance datasetId) throws DatasetManagementException {
-      return datasetFramework.getDatasetSpec(datasetId);
+      return datasetFramework.getDatasetSpec(datasetId.toEntityId());
     }
 
     @Nullable

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetAccessor.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetAccessor.java
@@ -66,7 +66,7 @@ public class DatasetAccessor implements Closeable {
 
   public void initialize() throws IOException, DatasetManagementException,
     DatasetNotFoundException, ClassNotFoundException {
-    dataset = datasetInstantiator.getDataset(datasetId);
+    dataset = datasetInstantiator.getDataset(datasetId.toEntityId());
     if (dataset instanceof TransactionAware) {
       ((TransactionAware) dataset).startTx(transaction);
     }

--- a/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetSerDe.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/datasets/DatasetSerDe.java
@@ -129,7 +129,7 @@ public class DatasetSerDe implements SerDe {
       // conf is null if this is a query that writes to a dataset
       ClassLoader parentClassLoader = conf == null ? null : conf.getClassLoader();
       try (SystemDatasetInstantiator datasetInstantiator = hiveContext.createDatasetInstantiator(parentClassLoader)) {
-        Dataset dataset = datasetInstantiator.getDataset(datasetId);
+        Dataset dataset = datasetInstantiator.getDataset(datasetId.toEntityId());
         if (dataset == null) {
           throw new SerDeException("Could not find dataset " + datasetId);
         }

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
@@ -48,8 +48,10 @@ import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.notifications.feeds.NotificationFeedManager;
 import co.cask.cdap.notifications.feeds.service.NoOpNotificationFeedManager;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.DatasetModuleId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationTestModule;
@@ -74,7 +76,7 @@ import java.util.List;
  * Test deployment behavior when explore module is disabled.
  */
 public class ExploreDisabledTest {
-  private static final Id.Namespace namespaceId = Id.Namespace.from("myspace");
+  private static final NamespaceId namespaceId = new NamespaceId("myspace");
 
   private static TransactionManager transactionManager;
   private static DatasetFramework datasetFramework;
@@ -107,14 +109,14 @@ public class ExploreDisabledTest {
     namespaceAdmin.create(namespaceMeta);
     // This happens when you create a namespace via REST APIs. However, since we do not start AppFabricServer in
     // Explore tests, simulating that scenario by explicitly calling DatasetFramework APIs.
-    namespacedLocationFactory.get(namespaceId).mkdirs();
+    namespacedLocationFactory.get(namespaceId.toId()).mkdirs();
     exploreClient.addNamespace(namespaceMeta);
   }
 
   @AfterClass
   public static void stop() throws Exception {
-    exploreClient.removeNamespace(namespaceId);
-    namespaceAdmin.delete(namespaceId);
+    exploreClient.removeNamespace(namespaceId.toId());
+    namespaceAdmin.delete(namespaceId.toId());
     exploreClient.close();
     datasetService.stopAndWait();
     dsOpExecutor.stopAndWait();
@@ -125,8 +127,8 @@ public class ExploreDisabledTest {
   public void testDeployRecordScannable() throws Exception {
     // Try to deploy a dataset that is not record scannable, when explore is enabled.
     // This should be processed with no exception being thrown
-    Id.DatasetModule module1 = Id.DatasetModule.from(namespaceId, "module1");
-    Id.DatasetInstance instance1 = Id.DatasetInstance.from(namespaceId, "table1");
+    DatasetModuleId module1 = new DatasetModuleId(namespaceId.getNamespace(), "module1");
+    DatasetId instance1 = namespaceId.dataset("table1");
     datasetFramework.addModule(module1, new KeyStructValueTableDefinition.KeyStructValueTableModule());
 
     // Performing admin operations to create dataset instance
@@ -168,8 +170,8 @@ public class ExploreDisabledTest {
   public void testDeployNotRecordScannable() throws Exception {
     // Try to deploy a dataset that is not record scannable, when explore is enabled.
     // This should be processed with no exceptionbeing thrown
-    Id.DatasetModule module2 = Id.DatasetModule.from(namespaceId, "module2");
-    Id.DatasetInstance instance2 = Id.DatasetInstance.from(namespaceId, "table1");
+    DatasetModuleId module2 = namespaceId.datasetModule("module2");
+    DatasetId instance2 = namespaceId.dataset("table1");
     datasetFramework.addModule(module2, new NotRecordScannableTableDefinition.NotRecordScannableTableModule());
 
     // Performing admin operations to create dataset instance

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreExtensiveSchemaTableTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreExtensiveSchemaTableTestRun.java
@@ -20,9 +20,9 @@ import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.explore.service.datasets.ExtensiveSchemaTableDefinition;
 import co.cask.cdap.proto.ColumnDesc;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.proto.TableInfo;
+import co.cask.cdap.proto.id.DatasetModuleId;
 import co.cask.cdap.test.SlowTests;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -45,7 +45,7 @@ public class ExploreExtensiveSchemaTableTestRun extends BaseHiveExploreServiceTe
   @ClassRule
   public static TemporaryFolder tmpFolder = new TemporaryFolder();
 
-  private static final Id.DatasetModule extensiveSchema = Id.DatasetModule.from(NAMESPACE_ID, "extensiveSchema");
+  private static final DatasetModuleId extensiveSchema = NAMESPACE_ID.datasetModule("extensiveSchema");
 
   @BeforeClass
   public static void start() throws Exception {
@@ -272,6 +272,6 @@ public class ExploreExtensiveSchemaTableTestRun extends BaseHiveExploreServiceTe
                                                                   null),
                                          new TableInfo.ColumnInfo("date", "bigint", null)
                                          ),
-                        exploreService.getTableInfo(NAMESPACE_ID.getId(), MY_TABLE_NAME).getSchema());
+                        exploreService.getTableInfo(NAMESPACE_ID.getNamespace(), MY_TABLE_NAME).getSchema());
   }
 }

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreMetadataTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreMetadataTestRun.java
@@ -20,8 +20,8 @@ import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.explore.client.ExploreExecutionResult;
 import co.cask.cdap.explore.service.datasets.KeyStructValueTableDefinition;
 import co.cask.cdap.proto.ColumnDesc;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.QueryResult;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.test.SlowTests;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -45,10 +45,9 @@ public class ExploreMetadataTestRun extends BaseHiveExploreServiceTest {
   @ClassRule
   public static TemporaryFolder tmpFolder = new TemporaryFolder();
 
-  private static final Id.DatasetInstance otherTable = Id.DatasetInstance.from(NAMESPACE_ID, "other_table");
+  private static final DatasetId otherTable = NAMESPACE_ID.dataset("other_table");
   private static final String otherTableName = getDatasetHiveName(otherTable);
-  private static final Id.DatasetInstance namespacedOtherTable =
-    Id.DatasetInstance.from(OTHER_NAMESPACE_ID, "other_table");
+  private static final DatasetId namespacedOtherTable = OTHER_NAMESPACE_ID.dataset("other_table");
   private static final String namespacedOtherTableName = getDatasetHiveName(namespacedOtherTable);
 
   @BeforeClass
@@ -120,7 +119,7 @@ public class ExploreMetadataTestRun extends BaseHiveExploreServiceTest {
     );
 
     // Pattern on database
-    future = getExploreClient().tables(null, OTHER_NAMESPACE_ID.getId(), "%", null);
+    future = getExploreClient().tables(null, OTHER_NAMESPACE_ID.getNamespace(), "%", null);
     assertStatementResult(future, true,
                           Lists.newArrayList(
                             new ColumnDesc("TABLE_CAT", "STRING", 1, "Catalog name. NULL if not applicable."),
@@ -164,7 +163,7 @@ public class ExploreMetadataTestRun extends BaseHiveExploreServiceTest {
                                              new QueryResult(Lists.<Object>newArrayList(DEFAULT_DATABASE, "")))
     );
 
-    future = getExploreClient().schemas(null, NAMESPACE_ID.getId());
+    future = getExploreClient().schemas(null, NAMESPACE_ID.getNamespace());
     assertStatementResult(future, true,
                           Lists.newArrayList(
                             new ColumnDesc("TABLE_SCHEM", "STRING", 1, "Schema name."),
@@ -173,7 +172,7 @@ public class ExploreMetadataTestRun extends BaseHiveExploreServiceTest {
                           Lists.newArrayList(new QueryResult(Lists.<Object>newArrayList(NAMESPACE_DATABASE, "")))
     );
 
-    future = getExploreClient().schemas(null, OTHER_NAMESPACE_ID.getId());
+    future = getExploreClient().schemas(null, OTHER_NAMESPACE_ID.getNamespace());
     assertStatementResult(future, true,
                           Lists.newArrayList(
                             new ColumnDesc("TABLE_SCHEM", "STRING", 1, "Schema name."),
@@ -355,7 +354,7 @@ public class ExploreMetadataTestRun extends BaseHiveExploreServiceTest {
                           expectedColumnDescs, expectedColumns);
 
     // Get all columns in a namespace
-    future = getExploreClient().columns(null, OTHER_NAMESPACE_ID.getId(), "%", "%");
+    future = getExploreClient().columns(null, OTHER_NAMESPACE_ID.getNamespace(), "%", "%");
     assertStatementResult(future, true,
                           expectedColumnDescs,
                           getExpectedColumns(OTHER_NAMESPACE_DATABASE)

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreObjectMappedTableTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreObjectMappedTableTestRun.java
@@ -142,7 +142,7 @@ public class HiveExploreObjectMappedTableTestRun extends BaseHiveExploreServiceT
       new ColumnDesc(MY_TABLE_NAME + ".longfield", "BIGINT", 6, null),
       new ColumnDesc(MY_TABLE_NAME + ".stringfield", "STRING", 7, null)
     );
-    ExploreExecutionResult results = exploreClient.submit(NAMESPACE_ID, "select * from " + MY_TABLE_NAME).get();
+    ExploreExecutionResult results = exploreClient.submit(NAMESPACE_ID.toId(), "select * from " + MY_TABLE_NAME).get();
     // check schema
     Assert.assertEquals(expectedSchema, results.getResultSchema());
     List<Object> columns = results.next().getColumns();

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceFileSetTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceFileSetTestRun.java
@@ -30,8 +30,8 @@ import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.explore.client.ExploreExecutionResult;
 import co.cask.cdap.proto.ColumnDesc;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.QueryResult;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.test.SlowTests;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
@@ -88,7 +88,7 @@ public class HiveExploreServiceFileSetTestRun extends BaseHiveExploreServiceTest
 
   @Test
   public void testOrcFileset() throws Exception {
-    final Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(NAMESPACE_ID, "orcfiles");
+    final DatasetId datasetInstanceId = NAMESPACE_ID.dataset("orcfiles");
     final String tableName = getDatasetHiveName(datasetInstanceId);
 
     // create a time partitioned file set
@@ -108,7 +108,7 @@ public class HiveExploreServiceFileSetTestRun extends BaseHiveExploreServiceTest
     // insert data into the table
 
     ExploreExecutionResult result = exploreClient.submit(
-      NAMESPACE_ID, String.format("insert into table %s values (1, 'samuel'), (2, 'dwayne')", tableName)).get();
+      NAMESPACE_ID.toId(), String.format("insert into table %s values (1, 'samuel'), (2, 'dwayne')", tableName)).get();
     result.close();
 
     // verify that we can query the key-values in the file with Hive
@@ -131,7 +131,7 @@ public class HiveExploreServiceFileSetTestRun extends BaseHiveExploreServiceTest
 
   @Test
   public void testCreateAddDrop() throws Exception {
-    final Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(NAMESPACE_ID, "files");
+    final DatasetId datasetInstanceId = NAMESPACE_ID.dataset("files");
     final String tableName = getDatasetHiveName(datasetInstanceId);
 
     // create a time partitioned file set
@@ -188,7 +188,7 @@ public class HiveExploreServiceFileSetTestRun extends BaseHiveExploreServiceTest
 
   @Test
   public void testPartitionedFileSet() throws Exception {
-    final Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(NAMESPACE_ID, "parted");
+    final DatasetId datasetInstanceId = NAMESPACE_ID.dataset("parted");
     final String tableName = getDatasetHiveName(datasetInstanceId);
 
     // create a time partitioned file set
@@ -325,7 +325,7 @@ public class HiveExploreServiceFileSetTestRun extends BaseHiveExploreServiceTest
 
   // this tests mainly the support for different text formats. Other features (partitioning etc.) are tested above.
   private void testPartitionedTextFile(String name, String format, String delim, String fileDelim) throws Exception {
-    final Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(NAMESPACE_ID, name);
+    final DatasetId datasetInstanceId = NAMESPACE_ID.dataset(name);
     final String tableName = getDatasetHiveName(datasetInstanceId);
     // create a time partitioned file set
     PartitionedFileSetProperties.Builder builder = (PartitionedFileSetProperties.Builder)
@@ -387,7 +387,7 @@ public class HiveExploreServiceFileSetTestRun extends BaseHiveExploreServiceTest
 
   @Test
   public void testPartitionedAvroSchemaUpdate() throws Exception {
-    final Id.DatasetInstance datasetId = Id.DatasetInstance.from(NAMESPACE_ID, "avroupd");
+    final DatasetId datasetId = NAMESPACE_ID.dataset("avroupd");
     final String tableName = getDatasetHiveName(datasetId);
 
     // create a time partitioned file set
@@ -442,7 +442,7 @@ public class HiveExploreServiceFileSetTestRun extends BaseHiveExploreServiceTest
 
   @Test
   public void testPartitionedTextSchemaUpdate() throws Exception {
-    final Id.DatasetInstance datasetId = Id.DatasetInstance.from(NAMESPACE_ID, "txtschemaupd");
+    final DatasetId datasetId = NAMESPACE_ID.dataset("txtschemaupd");
     final String tableName = getDatasetHiveName(datasetId);
 
     // create a time partitioned file set
@@ -504,7 +504,7 @@ public class HiveExploreServiceFileSetTestRun extends BaseHiveExploreServiceTest
 
   @Test
     public void testPartitionedTextFileUpdate() throws Exception {
-    final Id.DatasetInstance datasetId = Id.DatasetInstance.from(NAMESPACE_ID, "txtupd");
+    final DatasetId datasetId = NAMESPACE_ID.dataset("txtupd");
     final String tableName = getDatasetHiveName(datasetId);
 
     // create a time partitioned file set
@@ -606,7 +606,7 @@ public class HiveExploreServiceFileSetTestRun extends BaseHiveExploreServiceTest
 
   @Test
   public void testTimePartitionedFileSet() throws Exception {
-    final Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(NAMESPACE_ID, "parts");
+    final DatasetId datasetInstanceId = NAMESPACE_ID.dataset("parts");
     final String tableName = getDatasetHiveName(datasetInstanceId);
 
     // create a time partitioned file set

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceInvalidateTxTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceInvalidateTxTest.java
@@ -54,7 +54,7 @@ public class HiveExploreServiceInvalidateTxTest extends BaseHiveExploreServiceTe
     // check that BaseHiveExploreService invalidates read-write transaction that failed
     Assert.assertEquals(0, transactionManager.getCurrentState().getInvalid().size());
     try {
-      waitForCompletionStatus(exploreService.execute(NAMESPACE_ID, "select * from dataset_nonexistent"),
+      waitForCompletionStatus(exploreService.execute(NAMESPACE_ID.toId(), "select * from dataset_nonexistent"),
                               5, TimeUnit.SECONDS, 10);
       Assert.fail("Expected HiveSQLException");
     } catch (HiveSQLException e) {

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceStopTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceStopTest.java
@@ -54,7 +54,7 @@ public class HiveExploreServiceStopTest extends BaseHiveExploreServiceTest {
     ExploreService exploreService = injector.getInstance(ExploreService.class);
     Set<Long> beforeTxns = transactionManager.getCurrentState().getInProgress().keySet();
 
-    exploreService.execute(NAMESPACE_ID, "show tables");
+    exploreService.execute(NAMESPACE_ID.toId(), "show tables");
 
     Set<Long> queryTxns = Sets.difference(transactionManager.getCurrentState().getInProgress().keySet(), beforeTxns);
     Assert.assertFalse(queryTxns.isEmpty());

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTimeoutTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTimeoutTest.java
@@ -111,7 +111,7 @@ public class HiveExploreServiceTimeoutTest extends BaseHiveExploreServiceTest {
   public void testTimeoutRunning() throws Exception {
     Set<Long> beforeTxns = transactionManager.getCurrentState().getInProgress().keySet();
 
-    QueryHandle handle = exploreService.execute(NAMESPACE_ID, "select key, value from " + MY_TABLE_NAME);
+    QueryHandle handle = exploreService.execute(NAMESPACE_ID.toId(), "select key, value from " + MY_TABLE_NAME);
 
     Set<Long> queryTxns = Sets.difference(transactionManager.getCurrentState().getInProgress().keySet(), beforeTxns);
     Assert.assertFalse(queryTxns.isEmpty());
@@ -138,7 +138,7 @@ public class HiveExploreServiceTimeoutTest extends BaseHiveExploreServiceTest {
   public void testTimeoutFetchAllResults() throws Exception {
     Set<Long> beforeTxns = transactionManager.getCurrentState().getInProgress().keySet();
 
-    QueryHandle handle = exploreService.execute(NAMESPACE_ID, "select key, value from " + MY_TABLE_NAME);
+    QueryHandle handle = exploreService.execute(NAMESPACE_ID.toId(), "select key, value from " + MY_TABLE_NAME);
 
     Set<Long> queryTxns = Sets.difference(transactionManager.getCurrentState().getInProgress().keySet(), beforeTxns);
     Assert.assertFalse(queryTxns.isEmpty());
@@ -183,7 +183,7 @@ public class HiveExploreServiceTimeoutTest extends BaseHiveExploreServiceTest {
   public void testTimeoutNoResults() throws Exception {
     Set<Long> beforeTxns = transactionManager.getCurrentState().getInProgress().keySet();
 
-    QueryHandle handle = exploreService.execute(NAMESPACE_ID, "drop table if exists not_existing_table_name");
+    QueryHandle handle = exploreService.execute(NAMESPACE_ID.toId(), "drop table if exists not_existing_table_name");
 
     Set<Long> queryTxns = Sets.difference(transactionManager.getCurrentState().getInProgress().keySet(), beforeTxns);
     Assert.assertFalse(queryTxns.isEmpty());
@@ -222,7 +222,7 @@ public class HiveExploreServiceTimeoutTest extends BaseHiveExploreServiceTest {
 
   @Test
   public void testCloseQuery() throws Exception {
-    QueryHandle handle = exploreService.execute(NAMESPACE_ID, "drop table if exists not_existing_table_name");
+    QueryHandle handle = exploreService.execute(NAMESPACE_ID.toId(), "drop table if exists not_existing_table_name");
     exploreService.close(handle);
     try {
       exploreService.getStatus(handle);

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DataMigration.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DataMigration.java
@@ -36,6 +36,7 @@ import co.cask.cdap.metrics.store.DefaultMetricDatasetFactory;
 import co.cask.cdap.metrics.store.upgrade.DataMigrationException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
@@ -223,11 +224,11 @@ public class DataMigration {
     DatasetFramework datasetFramework =
       new InMemoryDatasetFramework(registryFactory);
     // TODO: this doesn't sound right. find out why its needed.
-    datasetFramework.addModule(Id.DatasetModule.from(Id.Namespace.SYSTEM, "table"), new HBaseTableModule());
-    datasetFramework.addModule(Id.DatasetModule.from(Id.Namespace.SYSTEM, "metricsTable"),
+    datasetFramework.addModule(NamespaceId.SYSTEM.datasetModule("table"), new HBaseTableModule());
+    datasetFramework.addModule(NamespaceId.SYSTEM.datasetModule("metricsTable"),
                                new HBaseMetricsTableModule());
-    datasetFramework.addModule(Id.DatasetModule.from(Id.Namespace.SYSTEM, "core"), new CoreDatasetsModule());
-    datasetFramework.addModule(Id.DatasetModule.from(Id.Namespace.SYSTEM, "fileSet"), new FileSetModule());
+    datasetFramework.addModule(NamespaceId.SYSTEM.datasetModule("core"), new CoreDatasetsModule());
+    datasetFramework.addModule(NamespaceId.SYSTEM.datasetModule("fileSet"), new FileSetModule());
     return datasetFramework;
   }
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetServiceManager.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetServiceManager.java
@@ -50,7 +50,7 @@ import co.cask.cdap.metrics.store.DefaultMetricStore;
 import co.cask.cdap.metrics.store.MetricDatasetFactory;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.guice.SecureStoreModules;
@@ -111,7 +111,7 @@ public class DatasetServiceManager extends AbstractIdleService {
       @Override
       public Boolean call() throws Exception {
         try {
-          getDSFramework().getInstances(Id.Namespace.DEFAULT);
+          getDSFramework().getInstances(NamespaceId.DEFAULT);
           return true;
         } catch (ServiceUnavailableException sue) {
           return false;

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
@@ -29,6 +29,7 @@ import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.data2.util.hbase.HTableNameConverterFactory;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HTableDescriptor;
@@ -79,9 +80,9 @@ public class DatasetUpgrader extends AbstractUpgrader {
   }
 
   private void upgradeSystemDatasets() throws Exception {
-    for (DatasetSpecificationSummary spec : dsFramework.getInstances(Id.Namespace.SYSTEM)) {
+    for (DatasetSpecificationSummary spec : dsFramework.getInstances(NamespaceId.SYSTEM)) {
       LOG.info("Upgrading dataset in system namespace: {}, spec: {}", spec.getName(), spec.toString());
-      DatasetAdmin admin = dsFramework.getAdmin(Id.DatasetInstance.from(Id.Namespace.SYSTEM, spec.getName()), null);
+      DatasetAdmin admin = dsFramework.getAdmin(NamespaceId.SYSTEM.dataset(spec.getName()), null);
       // we know admin is not null, since we are looping over existing datasets
       //noinspection ConstantConditions
       admin.upgrade();

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemover.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemover.java
@@ -63,7 +63,7 @@ final class DeletedDatasetMetadataRemover {
                                  MetadataSearchTargetType.DATASET, Id.DatasetInstance.class.getSimpleName(),
                                  entityId.getClass().getName());
         DatasetId datasetInstance = (DatasetId) entityId;
-        if (!dsFramework.hasInstance(datasetInstance.toId())) {
+        if (!dsFramework.hasInstance(datasetInstance)) {
           metadataStore.removeMetadata(datasetInstance);
           removedDatasets.add(datasetInstance.toId());
         }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/StreamStateStoreUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/StreamStateStoreUpgrader.java
@@ -54,7 +54,7 @@ public class StreamStateStoreUpgrader extends AbstractQueueUpgrader {
     return Lists.transform(namespaceQueryAdmin.list(), new Function<NamespaceMeta, TableId>() {
       @Override
       public TableId apply(NamespaceMeta input) {
-        return StreamUtils.getStateStoreTableId(Id.Namespace.from(input.getName()));
+        return StreamUtils.getStateStoreTableId(input.getNamespaceId());
       }
     });
   }

--- a/cdap-master/src/test/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemoverTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemoverTest.java
@@ -84,10 +84,10 @@ public class DeletedDatasetMetadataRemoverTest {
     DatasetId ds1 = NamespaceId.DEFAULT.dataset("ds1");
     DatasetId ds2 = NamespaceId.DEFAULT.dataset("ds2");
     DatasetId ds3 = NamespaceId.DEFAULT.dataset("ds3");
-    DS_FRAMEWORK_TEST_UTIL.createInstance("table", ds1.toId(), DatasetProperties.EMPTY);
-    DS_FRAMEWORK_TEST_UTIL.createInstance("table", ds2.toId(), DatasetProperties.EMPTY);
-    DS_FRAMEWORK_TEST_UTIL.createInstance("table", ds3.toId(), DatasetProperties.EMPTY);
-    Assert.assertEquals(3, DS_FRAMEWORK_TEST_UTIL.list(NamespaceId.DEFAULT.toId()).size());
+    DS_FRAMEWORK_TEST_UTIL.createInstance("table", ds1, DatasetProperties.EMPTY);
+    DS_FRAMEWORK_TEST_UTIL.createInstance("table", ds2, DatasetProperties.EMPTY);
+    DS_FRAMEWORK_TEST_UTIL.createInstance("table", ds3, DatasetProperties.EMPTY);
+    Assert.assertEquals(3, DS_FRAMEWORK_TEST_UTIL.list(NamespaceId.DEFAULT).size());
     metadataStore.addTags(MetadataScope.USER, ds1, "ds1Tag1", "ds1Tag2");
     metadataStore.setProperties(MetadataScope.USER, ds2, Collections.singletonMap("ds2Key", "ds2Value"));
     metadataStore.addTags(MetadataScope.USER, ds3, "ds3Tag1", "ds3Tag2");
@@ -98,7 +98,7 @@ public class DeletedDatasetMetadataRemoverTest {
   }
 
   private void verifyMetadataRemoval(DatasetId dsId) throws IOException, DatasetManagementException {
-    DS_FRAMEWORK_TEST_UTIL.deleteInstance(dsId.toId());
+    DS_FRAMEWORK_TEST_UTIL.deleteInstance(dsId);
     assertNonEmptyMetadata(dsId);
     metadataRemover.remove();
     assertEmptyMetadata(dsId);

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceMeta.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceMeta.java
@@ -81,6 +81,11 @@ public final class NamespaceMeta {
       }
     }
 
+    public Builder setName(NamespaceId id) {
+      this.name = id.getNamespace();
+      return this;
+    }
+
     public Builder setName(Id.Namespace id) {
       this.name = id.getId();
       return this;

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamId.java
@@ -15,6 +15,7 @@
  */
 package co.cask.cdap.proto.id;
 
+import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.element.EntityType;
 
@@ -29,6 +30,7 @@ import java.util.Objects;
 public class StreamId extends NamespacedEntityId implements ParentedId<NamespaceId> {
   private final String stream;
   private transient Integer hashCode;
+  private transient byte[] idBytes;
 
   public StreamId(String namespace, String stream) {
     super(namespace, EntityType.STREAM);
@@ -90,5 +92,12 @@ public class StreamId extends NamespacedEntityId implements ParentedId<Namespace
 
   public StreamViewId view(String view) {
     return new StreamViewId(namespace, stream, view);
+  }
+
+  public byte[] toBytes() {
+    if (idBytes == null) {
+      idBytes = Bytes.toBytes(toString());
+    }
+    return idBytes;
   }
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -48,6 +48,8 @@ import co.cask.cdap.proto.artifact.ArtifactRange;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.DatasetModuleId;
 import co.cask.cdap.proto.id.Ids;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.internal.ApplicationManagerFactory;
@@ -344,7 +346,7 @@ public class UnitTestManager implements TestManager {
   public final void deployDatasetModule(Id.Namespace namespace,
                                         String moduleName, Class<? extends DatasetModule> datasetModule)
     throws Exception {
-    datasetFramework.addModule(Id.DatasetModule.from(namespace, moduleName), datasetModule.newInstance());
+    datasetFramework.addModule(new DatasetModuleId(namespace.getId(), moduleName), datasetModule.newInstance());
   }
 
   @Beta
@@ -352,7 +354,7 @@ public class UnitTestManager implements TestManager {
   public final <T extends DatasetAdmin> T addDatasetInstance(Id.Namespace namespace,
                                                              String datasetTypeName, String datasetInstanceName,
                                                              DatasetProperties props) throws Exception {
-    Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(namespace, datasetInstanceName);
+    DatasetId datasetInstanceId = new DatasetId(namespace.getId(), datasetInstanceName);
     datasetFramework.addInstance(datasetTypeName, datasetInstanceId, props);
     return datasetFramework.getAdmin(datasetInstanceId, null);
   }
@@ -368,7 +370,7 @@ public class UnitTestManager implements TestManager {
   @Beta
   @Override
   public final void deleteDatasetInstance(NamespaceId namespaceId, String datasetInstanceName) throws Exception {
-    Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(namespaceId.toId(), datasetInstanceName);
+    DatasetId datasetInstanceId = namespaceId.dataset(datasetInstanceName);
     datasetFramework.deleteInstance(datasetInstanceId);
   }
 
@@ -381,7 +383,7 @@ public class UnitTestManager implements TestManager {
   @Beta
   @Override
   public final <T> DataSetManager<T> getDataset(Id.Namespace namespace, String datasetInstanceName) throws Exception {
-    Id.DatasetInstance datasetInstanceId = Id.DatasetInstance.from(namespace, datasetInstanceName);
+    DatasetId datasetInstanceId = new DatasetId(namespace.getId(), datasetInstanceName);
     @SuppressWarnings("unchecked")
     final T dataSet = datasetFramework.getDataset(datasetInstanceId, new HashMap<String, String>(), null);
     try {

--- a/cdap-unit-test/src/test/java/co/cask/cdap/spark/SparkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/spark/SparkTestRun.java
@@ -276,7 +276,7 @@ public class SparkTestRun extends TestFrameworkTestBase {
             Integer.MAX_VALUE,
             "system." + Constants.Metrics.Name.Dataset.OP_COUNT,
             AggregationFunction.SUM,
-            ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, DefaultId.NAMESPACE.getId(),
+            ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, DefaultId.NAMESPACE.getNamespace(),
                             Constants.Metrics.Tag.APP, SparkAppUsingObjectStore.class.getSimpleName(),
                             Constants.Metrics.Tag.SPARK, CharCountProgram.class.getSimpleName(),
                             Constants.Metrics.Tag.DATASET, "totals"),

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -487,7 +487,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
           readCountName, AggregationFunction.SUM,
           writeCountName, AggregationFunction.SUM
         ),
-        ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, DefaultId.NAMESPACE.getId(),
+        ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, DefaultId.NAMESPACE.getNamespace(),
                         Constants.Metrics.Tag.APP, appClass.getSimpleName(),
                         Constants.Metrics.Tag.MAPREDUCE, DatasetWithMRApp.MAPREDUCE_PROGRAM),
         ImmutableList.<String>of()

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogSaverTableUtil.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/LogSaverTableUtil.java
@@ -23,7 +23,8 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.table.MetaTableUtil;
 import co.cask.cdap.logging.LoggingConfiguration;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.inject.Inject;
 
 import java.io.IOException;
@@ -50,7 +51,7 @@ public class LogSaverTableUtil extends MetaTableUtil {
    * @param datasetFramework framework to add types and datasets to
    */
   public static void setupDatasets(DatasetFramework datasetFramework) throws IOException, DatasetManagementException {
-    Id.DatasetInstance logMetaDatasetInstance = Id.DatasetInstance.from(Id.Namespace.SYSTEM, TABLE_NAME);
+    DatasetId logMetaDatasetInstance = NamespaceId.SYSTEM.dataset(TABLE_NAME);
     datasetFramework.addInstance(Table.class.getName(), logMetaDatasetInstance, DatasetProperties.EMPTY);
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricDatasetFactory.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/DefaultMetricDatasetFactory.java
@@ -32,7 +32,8 @@ import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.metrics.process.KafkaConsumerMetaTable;
 import co.cask.cdap.metrics.store.upgrade.DataMigrationException;
 import co.cask.cdap.metrics.store.upgrade.MetricsDataMigrator;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Throwables;
@@ -117,7 +118,7 @@ public class DefaultMetricDatasetFactory implements MetricDatasetFactory {
   private MetricsTable getOrCreateMetricsTable(String tableName, DatasetProperties props) {
     MetricsTable table = null;
     // metrics tables are in the system namespace
-    Id.DatasetInstance metricsDatasetInstanceId = Id.DatasetInstance.from(Id.Namespace.SYSTEM, tableName);
+    DatasetId metricsDatasetInstanceId = NamespaceId.SYSTEM.dataset(tableName);
     while (table == null) {
       try {
         table = DatasetsUtil.getOrCreateDataset(dsFramework, metricsDatasetInstanceId,


### PR DESCRIPTION
Phasing usages of the deprecated `Id` class out of data fabric.
