### PR TITLE
CDAP-7250 Don't have a cache in DefaultUsageRegistry.

### DIFF
--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/registry/UsageRegistryTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/registry/UsageRegistryTest.java
@@ -88,7 +88,8 @@ public class UsageRegistryTest extends UsageDatasetTest {
     registry.register(flow11, datasetInstance1);
     registry.registerAll(ImmutableList.of(flow21, flow22), datasetInstance2);
 
-    // validate that this does not re-register previous usages (through code in wrapped usage dataset)
+    // validate that this does re-register previous usages (DefaultUsageRegistry no longer avoids re-registration)
+    count += 3;
     Assert.assertEquals(count, WrappedUsageDataset.registerCount);
 
     // validate usage


### PR DESCRIPTION
Avoid having a cache in DefaultUsageRegistry.
There's already a cache in RemoteRuntimeUsageRegistry (client side), which is used from program containers).

Otherwise, usage is not recorded after the app is deleted and redeployed (since the cache is not invalidated, since its running in dataset op executor service).

See JIRA for more information: https://issues.cask.co/browse/CDAP-7250
Note: This is the same PR as https://github.com/caskdata/cdap/pull/6708, but reopened against release/3.5 after 3.5.1 has been released. So, it is targeting 3.5.2.

http://builds.cask.co/browse/CDAP-RUT166-3
