### PR TITLE
Feature/hdinsights tez client fix

### DIFF
--- a/cdap-distributions/src/hdinsight/install.sh
+++ b/cdap-distributions/src/hdinsight/install.sh
@@ -95,6 +95,9 @@ chef-solo -o 'recipe[ulimit::default],recipe[cdap::fullstack],recipe[cdap::init]
 # Temporary Hack to workaround CDAP-4089
 rm -f /opt/cdap/kafka/lib/log4j.log4j-1.2.14.jar
 
+# Temporary Hack to workaround CDAP-7288
+rm -f /opt/cdap/master/lib/org.apache.tez.tez-api-0.8.4.jar
+
 # Start CDAP Services
 for i in /etc/init.d/cdap-*
 do

--- a/cdap-distributions/src/hdinsight/mainTemplate.json
+++ b/cdap-distributions/src/hdinsight/mainTemplate.json
@@ -50,12 +50,12 @@
       },
       "installScriptActions": [{
         "name": "[concat('cdap-pageblob-configure-v0','-' ,uniquestring(variables('applicationName')))]",
-        "uri": "http://downloads.cask.co/hdinsight/pageblob-configure.sh",
+        "uri": "http://downloads.cask.co/hdinsight/pageblob-configure-3.5.1.sh",
         "roles": ["edgenode"]
       },
       {
         "name": "[concat('cdap-install-v0','-' ,uniquestring(variables('applicationName')))]",
-        "uri": "http://downloads.cask.co/hdinsight/install.sh",
+        "uri": "http://downloads.cask.co/hdinsight/install-3.5.1.sh",
         "roles": ["edgenode"]
       }],
       "uninstallScriptActions": [],


### PR DESCRIPTION
hdinsight fixes:
- [x] workaround [CDAP-7288](https://issues.cask.co/browse/CDAP-7288), introduced in `3.5.1`
- [x] revert to publishing azure packages that refer directly to the versioned install scripts deployed by bamboo.  I feel this is better because 1) we are going to have to test using these versioned urls for major releases regardless, and trying to optimize for patch releases will probably just add confusion, 2) these urls are shown to the user and its useful to have the versions present, and 3) msft recommends having versions in the urls anyway.
