### PR TITLE
CDAP-7268 CDAP-7269 REST Endpoint to store/retrieve config in RouteStore

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -54,6 +54,7 @@ import co.cask.cdap.gateway.handlers.NamespaceHttpHandler;
 import co.cask.cdap.gateway.handlers.NotificationFeedHttpHandler;
 import co.cask.cdap.gateway.handlers.PreferencesHttpHandler;
 import co.cask.cdap.gateway.handlers.ProgramLifecycleHttpHandler;
+import co.cask.cdap.gateway.handlers.RouteConfigHttpHandler;
 import co.cask.cdap.gateway.handlers.SecureStoreHandler;
 import co.cask.cdap.gateway.handlers.TransactionHttpHandler;
 import co.cask.cdap.gateway.handlers.UsageHandler;
@@ -97,6 +98,9 @@ import co.cask.cdap.logging.run.LogSaverStatusServiceManager;
 import co.cask.cdap.metrics.runtime.MetricsProcessorStatusServiceManager;
 import co.cask.cdap.metrics.runtime.MetricsServiceManager;
 import co.cask.cdap.pipeline.PipelineFactory;
+import co.cask.cdap.route.store.LocalRouteStore;
+import co.cask.cdap.route.store.RouteStore;
+import co.cask.cdap.route.store.ZKRouteStore;
 import co.cask.cdap.security.DefaultUGIProvider;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.http.HttpHandler;
@@ -153,7 +157,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                bind(MRJobInfoFetcher.class).to(LocalMRJobInfoFetcher.class);
                                bind(StorageProviderNamespaceAdmin.class).to(LocalStorageProviderNamespaceAdmin.class);
                                bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
-
+                               bind(RouteStore.class).to(LocalRouteStore.class).in(Scopes.SINGLETON);
                                addInMemoryBindings(binder());
 
                                Multibinder<String> servicesNamesBinder =
@@ -189,7 +193,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                bind(MRJobInfoFetcher.class).to(LocalMRJobInfoFetcher.class);
                                bind(StorageProviderNamespaceAdmin.class).to(LocalStorageProviderNamespaceAdmin.class);
                                bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
-
+                               bind(RouteStore.class).to(LocalRouteStore.class).in(Scopes.SINGLETON);
                                addInMemoryBindings(binder());
 
                                Multibinder<String> servicesNamesBinder =
@@ -246,7 +250,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                bind(StorageProviderNamespaceAdmin.class)
                                  .to(DistributedStorageProviderNamespaceAdmin.class);
                                bind(UGIProvider.class).to(DefaultUGIProvider.class);
-
+                               bind(RouteStore.class).to(ZKRouteStore.class).in(Scopes.SINGLETON);
                                MapBinder<String, MasterServiceManager> mapBinder = MapBinder.newMapBinder(
                                  binder(), String.class, MasterServiceManager.class);
                                mapBinder.addBinding(Constants.Service.LOGSAVER)
@@ -350,6 +354,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       handlerBinder.addBinding().to(AuthorizationHandler.class);
       handlerBinder.addBinding().to(SecureStoreHandler.class);
       handlerBinder.addBinding().to(RemotePrivilegesHandler.class);
+      handlerBinder.addBinding().to(RouteConfigHttpHandler.class);
 
       for (Class<? extends HttpHandler> handlerClass : handlerClasses) {
         handlerBinder.addBinding().to(handlerClass);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/config/DefaultConfigStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/config/DefaultConfigStore.java
@@ -25,7 +25,6 @@ import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scanner;
 import co.cask.cdap.api.dataset.table.Table;
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
@@ -64,7 +63,7 @@ public class DefaultConfigStore implements ConfigStore {
   private final Transactional transactional;
 
   @Inject
-  public DefaultConfigStore(CConfiguration cConf, DatasetFramework datasetFramework, TransactionSystemClient txClient) {
+  public DefaultConfigStore(DatasetFramework datasetFramework, TransactionSystemClient txClient) {
     this.datasetFramework = datasetFramework;
     this.transactional = Transactions.createTransactionalWithRetry(
       Transactions.createTransactional(new MultiThreadDatasetCache(

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/RouteConfigHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/RouteConfigHttpHandler.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.handlers;
+
+import co.cask.cdap.api.service.ServiceSpecification;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
+import co.cask.cdap.internal.app.services.ProgramLifecycleService;
+import co.cask.cdap.proto.id.Ids;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.route.store.RouteConfig;
+import co.cask.cdap.route.store.RouteStore;
+import co.cask.http.HttpResponder;
+import com.google.gson.reflect.TypeToken;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.Map;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * HttpHandler to store, retrieve and delete {@link RouteConfig} for configuring routing requests to User Services.
+ */
+@Singleton
+@Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}/apps/{app-id}/services/{service-id}")
+public class RouteConfigHttpHandler extends AbstractAppFabricHttpHandler {
+  private static final Type ROUTE_CONFIG_TYPE = new TypeToken<Map<String, Integer>>() { }.getType();
+  private final ProgramLifecycleService lifecycleService;
+  private final RouteStore routeStore;
+
+  @Inject
+  RouteConfigHttpHandler(ProgramLifecycleService lifecycleService, RouteStore routeStore) {
+    this.lifecycleService = lifecycleService;
+    this.routeStore = routeStore;
+  }
+
+  @GET
+  @Path("/routeconfig")
+  public void getRouteConfig(HttpRequest request, HttpResponder responder,
+                             @PathParam("namespace-id") String namespaceId,
+                             @PathParam("app-id") String appId,
+                             @PathParam("service-id") String serviceId) throws Exception {
+    ProgramId programId = Ids.namespace(namespaceId).app(appId).service(serviceId);
+    ServiceSpecification spec = (ServiceSpecification) lifecycleService.getProgramSpecification(programId);
+    if (spec == null) {
+      responder.sendStatus(HttpResponseStatus.NOT_FOUND);
+      return;
+    }
+
+    RouteConfig routeConfig = routeStore.fetch(programId);
+    if (routeConfig == null) {
+      responder.sendJson(HttpResponseStatus.OK, Collections.emptyMap());
+      return;
+    }
+    responder.sendJson(HttpResponseStatus.OK, routeConfig.getRoutes());
+  }
+
+  @PUT
+  @Path("/routeconfig")
+  public void storeRouteConfig(HttpRequest request, HttpResponder responder,
+                               @PathParam("namespace-id") String namespaceId,
+                               @PathParam("app-id") String appId,
+                               @PathParam("service-id") String serviceId) throws Exception {
+    ProgramId programId = Ids.namespace(namespaceId).app(appId).service(serviceId);
+    ServiceSpecification spec = (ServiceSpecification) lifecycleService.getProgramSpecification(programId);
+    if (spec == null) {
+      responder.sendStatus(HttpResponseStatus.NOT_FOUND);
+      return;
+    }
+    Map<String, Integer> routes = parseBody(request, ROUTE_CONFIG_TYPE);
+    routeStore.store(programId, new RouteConfig(routes));
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  @DELETE
+  @Path("/routeconfig")
+  public void deleteRouteConfig(HttpRequest request, HttpResponder responder,
+                                @PathParam("namespace-id") String namespaceId,
+                                @PathParam("app-id") String appId,
+                                @PathParam("service-id") String serviceId) throws Exception {
+    ProgramId programId = Ids.namespace(namespaceId).app(appId).service(serviceId);
+    ServiceSpecification spec = (ServiceSpecification) lifecycleService.getProgramSpecification(programId);
+    if (spec == null) {
+      responder.sendStatus(HttpResponseStatus.NOT_FOUND);
+      return;
+    }
+    routeStore.delete(programId);
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
@@ -32,6 +32,7 @@ import co.cask.cdap.internal.app.runtime.plugin.PluginService;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
 import co.cask.cdap.notifications.service.NotificationService;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.route.store.RouteStore;
 import co.cask.cdap.security.authorization.PrivilegesFetcherProxyService;
 import co.cask.http.HandlerHook;
 import co.cask.http.HttpHandler;
@@ -77,6 +78,7 @@ public class AppFabricServer extends AbstractIdleService {
   private final SystemArtifactLoader systemArtifactLoader;
   private final PluginService pluginService;
   private final PrivilegesFetcherProxyService privilegesFetcherProxyService;
+  private final RouteStore routeStore;
 
   private NettyHttpService httpService;
   private Set<HttpHandler> handlers;
@@ -101,7 +103,8 @@ public class AppFabricServer extends AbstractIdleService {
                          DefaultNamespaceEnsurer defaultNamespaceEnsurer,
                          SystemArtifactLoader systemArtifactLoader,
                          PluginService pluginService,
-                         PrivilegesFetcherProxyService privilegesFetcherProxyService) {
+                         PrivilegesFetcherProxyService privilegesFetcherProxyService,
+                         RouteStore routeStore) {
     this.hostname = hostname;
     this.discoveryService = discoveryService;
     this.schedulerService = schedulerService;
@@ -119,6 +122,7 @@ public class AppFabricServer extends AbstractIdleService {
     this.systemArtifactLoader = systemArtifactLoader;
     this.pluginService = pluginService;
     this.privilegesFetcherProxyService = privilegesFetcherProxyService;
+    this.routeStore = routeStore;
   }
 
   /**
@@ -216,6 +220,7 @@ public class AppFabricServer extends AbstractIdleService {
 
   @Override
   protected void shutDown() throws Exception {
+    routeStore.close();
     defaultNamespaceEnsurer.stopAndWait();
     httpService.stopAndWait();
     programRuntimeService.stopAndWait();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceHttpServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceHttpServer.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.internal.app.services;
 
+import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.security.store.SecureStore;
@@ -235,7 +236,9 @@ public class ServiceHttpServer extends AbstractIdleService {
     // announce the twill runnable
     InetSocketAddress bindAddress = service.getBindAddress();
     int port = bindAddress.getPort();
-    cancelDiscovery = serviceAnnouncer.announce(ServiceDiscoverable.getName(programId), port);
+    // Announce the service with its version as the payload
+    cancelDiscovery = serviceAnnouncer.announce(ServiceDiscoverable.getName(programId), port,
+                                                Bytes.toBytes(programId.getVersion()));
     LOG.info("Announced HTTP Service for Service {} at {}", programId, bindAddress);
 
     // Create a Timer thread to periodically collect handler that are no longer in used and call destroy on it

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/StandaloneAppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/StandaloneAppFabricServer.java
@@ -28,6 +28,7 @@ import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
 import co.cask.cdap.internal.app.runtime.plugin.PluginService;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
 import co.cask.cdap.notifications.service.NotificationService;
+import co.cask.cdap.route.store.RouteStore;
 import co.cask.cdap.security.authorization.PrivilegesFetcherProxyService;
 import co.cask.http.HttpHandler;
 import com.google.inject.Inject;
@@ -66,11 +67,12 @@ public class StandaloneAppFabricServer extends AppFabricServer {
                                    MetricStore metricStore,
                                    SystemArtifactLoader systemArtifactLoader,
                                    PluginService pluginService,
-                                   PrivilegesFetcherProxyService privilegesFetcherProxyService) {
+                                   PrivilegesFetcherProxyService privilegesFetcherProxyService,
+                                   RouteStore routeStore) {
     super(configuration, discoveryService, schedulerService, notificationService, hostname, handlers,
           metricsCollectionService, programRuntimeService, applicationLifecycleService,
           programLifecycleService, streamCoordinatorClient, servicesNames, handlerHookNames, defaultNamespaceEnsurer,
-          systemArtifactLoader, pluginService, privilegesFetcherProxyService);
+          systemArtifactLoader, pluginService, privilegesFetcherProxyService, routeStore);
     this.metricStore = metricStore;
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/route/store/LocalRouteStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/route/store/LocalRouteStore.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.route.store;
+
+import co.cask.cdap.api.Transactional;
+import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetManagementException;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.common.service.ServiceDiscoverable;
+import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
+import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
+import co.cask.cdap.data2.transaction.Transactions;
+import co.cask.cdap.data2.transaction.TxCallable;
+import co.cask.cdap.internal.guava.reflect.TypeToken;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramId;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import org.apache.tephra.RetryStrategies;
+import org.apache.tephra.TransactionFailureException;
+import org.apache.tephra.TransactionSystemClient;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/**
+ * RouteStore where the routes are stored in a table for persistence. This is intended for use in SDK mode
+ * where performance is not a big issue but we still need persistence of configuration routes across restarts.
+ */
+public class LocalRouteStore implements RouteStore  {
+  private static final Gson GSON = new Gson();
+  private static final Type MAP_STRING_INTEGER_TYPE = new TypeToken<Map<String, Integer>>() { }.getType();
+  private static final DatasetId ROUTE_STORE_DATASET_INSTANCE_ID = NamespaceId.SYSTEM.dataset("routestore");
+
+  private final DatasetFramework datasetFramework;
+  private final Transactional transactional;
+
+  @Inject
+  public LocalRouteStore(DatasetFramework datasetFramework, TransactionSystemClient txClient) {
+    this.datasetFramework = datasetFramework;
+    this.transactional = Transactions.createTransactionalWithRetry(
+      Transactions.createTransactional(new MultiThreadDatasetCache(
+        new SystemDatasetInstantiator(datasetFramework), txClient,
+        NamespaceId.SYSTEM, ImmutableMap.<String, String>of(), null, null)), RetryStrategies.retryOnConflict(20, 100));
+  }
+
+  private KeyValueTable getRouteTable(DatasetContext context) throws IOException, DatasetManagementException {
+    return DatasetsUtil.getOrCreateDataset(context, datasetFramework, ROUTE_STORE_DATASET_INSTANCE_ID,
+                                           KeyValueTable.class.getName(), DatasetProperties.EMPTY);
+  }
+
+  @Override
+  public void store(final ProgramId serviceId, final RouteConfig routeConfig) {
+    try {
+      transactional.execute(new TxRunnable() {
+        @Override
+        public void run(DatasetContext context) throws Exception {
+          getRouteTable(context).write(ServiceDiscoverable.getName(serviceId), GSON.toJson(routeConfig.getRoutes()));
+        }
+      });
+    } catch (TransactionFailureException ex) {
+      throw Transactions.propagate(ex);
+    }
+  }
+
+  @Override
+  public void delete(final ProgramId serviceId) throws NotFoundException {
+    try {
+      transactional.execute(new TxRunnable() {
+        @Override
+        public void run(DatasetContext context) throws Exception {
+          byte[] key = Bytes.toBytes(ServiceDiscoverable.getName(serviceId));
+          KeyValueTable kvTable = getRouteTable(context);
+          if (kvTable.read(key) == null) {
+            throw new NotFoundException(String.format("Route Config for Service %s was not found.", serviceId));
+          }
+          kvTable.delete(key);
+        }
+      });
+    } catch (TransactionFailureException e) {
+      throw Transactions.propagate(e, NotFoundException.class);
+    }
+  }
+
+  @Override
+  public RouteConfig fetch(final ProgramId serviceId) throws NotFoundException {
+    try {
+      return Transactions.execute(transactional, new TxCallable<RouteConfig>() {
+        @Override
+        public RouteConfig call(DatasetContext context) throws Exception {
+          byte[] value = getRouteTable(context).read(ServiceDiscoverable.getName(serviceId));
+          if (value == null) {
+            throw new NotFoundException(String.format("Route Config for Service %s was not found.", serviceId));
+          }
+
+          Map<String, Integer> routeConfigs = GSON.fromJson(Bytes.toString(value), MAP_STRING_INTEGER_TYPE);
+          return new RouteConfig(routeConfigs);
+        }
+      });
+    } catch (TransactionFailureException e) {
+      throw Transactions.propagate(e, NotFoundException.class);
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    // nothing to close
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/route/store/RouteConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/route/store/RouteConfig.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.route.store;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+/**
+ * Route Configuration.
+ */
+public class RouteConfig {
+  private final Map<String, Integer> routes;
+
+  public RouteConfig(Map<String, Integer> routes) {
+    int percentageSum = 0;
+    Preconditions.checkNotNull(routes);
+    for (Integer percent : routes.values()) {
+      percentageSum += percent;
+    }
+    Preconditions.checkArgument(percentageSum == 100, "Route Percentage needs to add upto 100.");
+    this.routes = ImmutableMap.copyOf(routes);
+  }
+
+  public Map<String, Integer> getRoutes() {
+    return routes;
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/route/store/RouteStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/route/store/RouteStore.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.route.store;
+
+import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.proto.id.ProgramId;
+
+/**
+ * Provides the ability to store and retrieve user service routing configuration.
+ */
+public interface RouteStore extends AutoCloseable {
+
+  /**
+   * Store a {@link RouteConfig} for a given {@link ProgramId}. If a {@link RouteConfig} already exists,
+   * it is overwritten.
+   *
+   * @param serviceId Id of the User Service
+   * @param routeConfig {@link RouteConfig}
+   */
+  void store(ProgramId serviceId, RouteConfig routeConfig);
+
+  /**
+   * Delete any {@link RouteConfig} for a given {@link ProgramId}. If a {@link RouteConfig} doesn't exist,
+   * {@link NotFoundException} is thrown.
+   *
+   * @param serviceId Id of the User Service
+   */
+  void delete(ProgramId serviceId) throws NotFoundException;
+
+
+  /**
+   * Get the {@link RouteConfig} for a given {@link ProgramId}. If a {@link RouteConfig} doesn't exist,
+   * {@link NotFoundException} is thrown.
+   *
+   * @param serviceId Id of the User Service
+   * @return {@link RouteConfig}
+   */
+  RouteConfig fetch(ProgramId serviceId) throws NotFoundException;
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/route/store/ZKRouteStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/route/store/ZKRouteStore.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.route.store;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.common.io.Codec;
+import co.cask.cdap.common.service.ServiceDiscoverable;
+import co.cask.cdap.common.zookeeper.ZKExtOperations;
+import co.cask.cdap.internal.guava.reflect.TypeToken;
+import co.cask.cdap.proto.id.ProgramId;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import org.apache.twill.zookeeper.NodeData;
+import org.apache.twill.zookeeper.OperationFuture;
+import org.apache.twill.zookeeper.ZKClient;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * RouteStore where the routes are stored in a ZK persistent node. This is intended for use in distributed mode.
+ */
+public class ZKRouteStore implements RouteStore {
+  private static final Logger LOG = LoggerFactory.getLogger(ZKRouteStore.class);
+  private static final Gson GSON = new Gson();
+  private static final Type MAP_STRING_INTEGER_TYPE = new TypeToken<Map<String, Integer>>() { }.getType();
+  private static final int ZK_TIMEOUT_SECS = 5;
+
+  private final ZKClient zkClient;
+  private final ConcurrentMap<ProgramId, SettableFuture<RouteConfig>> routeConfigMap;
+
+  @Inject
+  public ZKRouteStore(ZKClient zkClient) {
+    this.zkClient = zkClient;
+    this.routeConfigMap = Maps.newConcurrentMap();
+  }
+
+  @Override
+  public void store(final ProgramId serviceId, final RouteConfig routeConfig) {
+    Supplier<RouteConfig> supplier = Suppliers.ofInstance(routeConfig);
+    Future<RouteConfig> future = ZKExtOperations.createOrSet(zkClient, getZKPath(serviceId), supplier,
+                                                             ROUTE_CONFIG_CODEC, 10);
+    try {
+      future.get(ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+    } catch (ExecutionException | InterruptedException | TimeoutException ex) {
+      throw Throwables.propagate(ex);
+    }
+  }
+
+  @Override
+  public void delete(final ProgramId serviceId) throws NotFoundException {
+    OperationFuture<String> future = zkClient.delete(getZKPath(serviceId));
+    try {
+      future.get(ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+    } catch (ExecutionException | InterruptedException | TimeoutException ex) {
+      if (ex.getCause() instanceof KeeperException.NoNodeException) {
+        throw new NotFoundException(String.format("Route Config for Service %s was not found.", serviceId));
+      }
+      throw Throwables.propagate(ex);
+    }
+  }
+
+  @Override
+  public RouteConfig fetch(final ProgramId serviceId) throws NotFoundException {
+    SettableFuture<RouteConfig> settableFuture = SettableFuture.create();
+    Future<RouteConfig> future = routeConfigMap.putIfAbsent(serviceId, settableFuture);
+    if (future == null) {
+      future = getAndWatchData(serviceId, settableFuture, new ZKRouteWatcher(serviceId));
+    }
+    return getConfig(serviceId, future);
+  }
+
+  private RouteConfig getConfig(ProgramId serviceId, Future<RouteConfig> future) throws NotFoundException {
+    try {
+      return future.get(ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      if (e.getCause() instanceof KeeperException.NoNodeException) {
+        throw new NotFoundException(String.format("Route Config for Service %s was not found.", serviceId));
+      }
+      throw Throwables.propagate(e);
+    }
+  }
+
+  private static String getZKPath(ProgramId serviceId) {
+    return String.format("/routestore/%s", ServiceDiscoverable.getName(serviceId));
+  }
+
+  static final Codec<RouteConfig> ROUTE_CONFIG_CODEC = new Codec<RouteConfig>() {
+
+    @Override
+    public byte[] encode(RouteConfig object) throws IOException {
+      return Bytes.toBytes(GSON.toJson(object.getRoutes()));
+    }
+
+    @Override
+    public RouteConfig decode(byte[] data) throws IOException {
+      Map<String, Integer> routes = GSON.fromJson(Bytes.toString(data), MAP_STRING_INTEGER_TYPE);
+      return new RouteConfig(routes);
+    }
+  };
+
+  private Future<RouteConfig> getAndWatchData(final ProgramId serviceId,
+                                              final SettableFuture<RouteConfig> settableFuture,
+                                              final Watcher watcher) {
+    OperationFuture<NodeData> future = zkClient.getData(getZKPath(serviceId), watcher);
+    Futures.addCallback(future, new FutureCallback<NodeData>() {
+      @Override
+      public void onSuccess(NodeData result) {
+        try {
+          RouteConfig route = ROUTE_CONFIG_CODEC.decode(result.getData());
+          settableFuture.set(route);
+          routeConfigMap.put(serviceId, settableFuture);
+        } catch (Exception ex) {
+          LOG.debug("Unable to deserialize the config for service {}. Got data {}", serviceId, result.getData());
+          // Need to remove the future from the map since later calls will continue to use this future and will think
+          // that there is an exception
+          routeConfigMap.remove(serviceId);
+          settableFuture.setException(ex);
+        }
+      }
+
+      @Override
+      public void onFailure(Throwable t) {
+        routeConfigMap.remove(serviceId);
+        settableFuture.setException(t);
+      }
+    });
+    return settableFuture;
+  }
+
+  @Override
+  public void close() throws Exception {
+    // Clear the map, so that any active watches will expire.
+    routeConfigMap.clear();
+  }
+
+  private class ZKRouteWatcher implements Watcher {
+    private final ProgramId serviceId;
+
+    ZKRouteWatcher(ProgramId serviceId) {
+      this.serviceId = serviceId;
+    }
+
+    @Override
+    public void process(WatchedEvent event) {
+      // If service name doesn't exist in the map, then don't re-watch it.
+      if (!routeConfigMap.containsKey(serviceId)) {
+        return;
+      }
+
+      if (event.getType() == Event.EventType.NodeDeleted) {
+        // Remove the mapping from cache
+        routeConfigMap.remove(serviceId);
+        return;
+      }
+
+      // Create a new settable future, since we don't want to set the existing future again
+      getAndWatchData(serviceId, SettableFuture.<RouteConfig>create(), this);
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/RouteConfigHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/RouteConfigHttpHandlerTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.services.http.handlers;
+
+import co.cask.cdap.WordCountApp;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.gateway.handlers.RouteConfigHttpHandler;
+import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonObject;
+import org.apache.http.HttpResponse;
+import org.apache.http.util.EntityUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+/**
+ * Tests for {@link RouteConfigHttpHandler}.
+ */
+public class RouteConfigHttpHandlerTest extends AppFabricTestBase {
+
+  private static final String WORDCOUNT_APP_NAME = "WordCountApp";
+  private static final String WORDCOUNT_SERVICE_NAME = "WordFrequencyService";
+
+  @Test
+  public void testRouteStore() throws Exception {
+    // deploy, check the status
+    HttpResponse response = deploy(WordCountApp.class, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE1);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+
+    Map<String, Integer> routes = ImmutableMap.<String, Integer>builder().put("v1", 30).put("v2", 70).build();
+    String routeAPI = getVersionedAPIPath(
+      String.format("apps/%s/services/%s/routeconfig", WORDCOUNT_APP_NAME, WORDCOUNT_SERVICE_NAME),
+      Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE1);
+    doPut(routeAPI, GSON.toJson(routes));
+    String getResult = EntityUtils.toString(doGet(routeAPI).getEntity());
+    JsonObject jsonObject = GSON.fromJson(getResult, JsonObject.class);
+    Assert.assertNotNull(jsonObject);
+    Assert.assertEquals(30, jsonObject.get("v1").getAsInt());
+    Assert.assertEquals(70, jsonObject.get("v2").getAsInt());
+    doDelete(routeAPI);
+    Assert.assertEquals(404, doGet(routeAPI).getStatusLine().getStatusCode());
+    Assert.assertEquals(404, doDelete(routeAPI).getStatusLine().getStatusCode());
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/route/store/LocalRouteStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/route/store/LocalRouteStoreTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.route.store;
+
+import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.internal.app.services.http.AppFabricTestBase;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ProgramId;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Route Configuration Store Test.
+ */
+public class LocalRouteStoreTest extends AppFabricTestBase {
+
+  @Test
+  public void testRouteStorage() throws Exception {
+    RouteStore routeStore = getInjector().getInstance(RouteStore.class);
+    ApplicationId appId = new ApplicationId("n1", "a1");
+    ProgramId service1 = appId.service("s1");
+    RouteConfig routeConfig = new RouteConfig(ImmutableMap.of("v1", 100));
+    routeStore.store(service1, routeConfig);
+    Assert.assertEquals(routeConfig.getRoutes(), routeStore.fetch(service1).getRoutes());
+    routeStore.delete(service1);
+
+    try {
+      routeStore.fetch(service1);
+      Assert.fail("Config should have been deleted and thus a NotFoundException must have been thrown.");
+    } catch (NotFoundException e) {
+      // expected
+    }
+
+    try {
+      routeStore.delete(service1);
+      Assert.fail("Config should have been deleted and thus a NotFoundException must have been thrown.");
+    } catch (NotFoundException e) {
+      // expected
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/route/store/RouteConfigTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/route/store/RouteConfigTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.route.store;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Test to verify Route Config.
+ */
+public class RouteConfigTest {
+
+  @Test
+  public void testValidRouteConfig() {
+    Map<String, Integer> configDist = ImmutableMap.<String, Integer>builder()
+      .put("v1", 20).put("v2", 30).put("v3", 50).build();
+    RouteConfig config = new RouteConfig(configDist);
+    Assert.assertEquals(configDist, config.getRoutes());
+    configDist = ImmutableMap.<String, Integer>builder().put("v2", 100).build();
+    config = new RouteConfig(configDist);
+    Assert.assertEquals(configDist, config.getRoutes());
+  }
+
+  @Test
+  public void testInvalidRouteConfig() {
+    Map<String, Integer> configDist = ImmutableMap.<String, Integer>builder().put("v1", 20).put("v2", 50).build();
+    try {
+      RouteConfig config = new RouteConfig(configDist);
+      Assert.fail("RouteConfig creation should have failed since the values didn't add up to 100.");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    try {
+      RouteConfig config = new RouteConfig(Collections.<String, Integer>emptyMap());
+      Assert.fail("RouteConfig creation should have failed since the values didn't add up to 100.");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/route/store/ZKRouteStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/route/store/ZKRouteStoreTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.route.store;
+
+import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.guice.ConfigModule;
+import co.cask.cdap.common.guice.ZKClientModule;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ProgramId;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.twill.internal.zookeeper.InMemoryZKServer;
+import org.apache.twill.zookeeper.ZKClientService;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Tests for {@link ZKRouteStore}.
+ */
+public class ZKRouteStoreTest {
+
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+  private static InMemoryZKServer zkServer;
+  private static Injector injector;
+  private static ZKClientService zkClientService;
+
+  @BeforeClass
+  public static void init() throws IOException {
+    zkServer = InMemoryZKServer.builder().setDataDir(TMP_FOLDER.newFolder()).build();
+    zkServer.startAndWait();
+
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.Zookeeper.QUORUM, zkServer.getConnectionStr());
+
+    injector = Guice.createInjector(new ConfigModule(cConf),
+                                    new ZKClientModule());
+    zkClientService = injector.getInstance(ZKClientService.class);
+    zkClientService.startAndWait();
+  }
+
+  @AfterClass
+  public static void finish() throws Exception {
+    zkClientService.stopAndWait();
+    zkServer.stopAndWait();
+  }
+
+  @Test
+  public void testStore() throws Exception {
+    ApplicationId appId = new ApplicationId("n1", "a1");
+    ProgramId s1 = appId.service("s1");
+    Map<String, Integer> routeMap = ImmutableMap.<String, Integer>builder().put("v1", 30).put("v2", 70).build();
+    try (RouteStore routeStore = new ZKRouteStore(zkClientService)) {
+      routeStore.store(s1, new RouteConfig(routeMap));
+      Assert.assertEquals(routeMap, routeStore.fetch(s1).getRoutes());
+      routeStore.delete(s1);
+      try {
+        routeStore.fetch(s1);
+        Assert.fail("Fetch should have thrown a NotFoundException since the config was deleted.");
+      } catch (NotFoundException ex) {
+        // expected since the config was deleted
+      }
+    }
+  }
+}


### PR DESCRIPTION
JIRAs:
https://issues.cask.co/browse/CDAP-7268
https://issues.cask.co/browse/CDAP-7269
https://issues.cask.co/browse/CDAP-7272

Build:
http://builds.cask.co/browse/CDAP-RUT171

Summary:
i) Introduce RouteStore interface which provides methods to store, retrieve, delete route configurations for user services
ii) LocalRouteStore -> stores the routes in a KVTable. 
iii) ZKRouteStore -> stores the routes in ZK
iv) Changes to ProgramLifecycleHttpHandler to add three endpoints to get/put/delete routes.
v) Routes have to be a map of string to integers and the values should add up to 100.
