### PR TITLE
CDAP-7031 Fix an incorrect WARN log statement in run record corrector

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/RuntimeStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/RuntimeStore.java
@@ -34,17 +34,6 @@ import javax.annotation.Nullable;
 public interface RuntimeStore {
 
   /**
-   * Compare and set operation that allow to compare and set expected and update status.
-   * Implementation of this method should guarantee that the operation is atomic or in transaction.
-   *
-   * @param id id of the program
-   * @param pid the run id
-   * @param expectedStatus the expected value
-   * @param newStatus the new value
-   */
-  void compareAndSetStatus(ProgramId id, String pid, ProgramRunStatus expectedStatus, ProgramRunStatus newStatus);
-
-  /**
    * Logs start of program run.
    *
    * @param id id of the program

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -77,6 +77,19 @@ public interface Store extends RuntimeStore {
   void setStart(ProgramId id, String pid, long startTime);
 
   /**
+   * Compare and set operation that allow to compare and set expected and update status.
+   * Implementation of this method should guarantee that the operation is atomic or in transaction.
+   *
+   * @param id id of the program
+   * @param pid the run id
+   * @param expectedStatus the expected value
+   * @param newStatus the new value
+   * @return true if successful. False return indicates that
+   * the actual value was not equal to the expected value.
+   */
+  boolean compareAndSetStatus(ProgramId id, String pid, ProgramRunStatus expectedStatus, ProgramRunStatus newStatus);
+
+  /**
    * Fetches run records for particular program. Returns only finished runs.
    * Returned ProgramRunRecords are sorted by their startTime.
    *

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteRuntimeStoreHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/meta/RemoteRuntimeStoreHandler.java
@@ -51,20 +51,6 @@ public class RemoteRuntimeStoreHandler extends AbstractRemoteSystemOpsHandler {
   }
 
   @POST
-  @Path("/compareAndSetStatus")
-  public void compareAndSetStatus(HttpRequest request, HttpResponder responder) throws Exception {
-    Iterator<MethodArgument> arguments = parseArguments(request);
-
-    ProgramId program = deserializeNext(arguments);
-    String pid = deserializeNext(arguments);
-    ProgramRunStatus expectedStatus = deserializeNext(arguments);
-    ProgramRunStatus updateStatus = deserializeNext(arguments);
-    store.compareAndSetStatus(program, pid, expectedStatus, updateStatus);
-
-    responder.sendStatus(HttpResponseStatus.OK);
-  }
-
-  @POST
   @Path("/setStart")
   public void setStart(HttpRequest request, HttpResponder responder) throws Exception {
     Iterator<MethodArgument> arguments = parseArguments(request);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -165,13 +165,13 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public void compareAndSetStatus(final ProgramId id, final String pid, final ProgramRunStatus expectedStatus,
-                                  final ProgramRunStatus newStatus) {
+  public boolean compareAndSetStatus(final ProgramId id, final String pid, final ProgramRunStatus expectedStatus,
+                                     final ProgramRunStatus newStatus) {
     Preconditions.checkArgument(expectedStatus != null, "Expected of program run should be defined");
     Preconditions.checkArgument(newStatus != null, "New state of program run should be defined");
-    txExecute(transactional, new TxRunnable() {
+    return txExecute(transactional, new TxCallable<Boolean>() {
       @Override
-      public void run(DatasetContext context) throws Exception {
+      public Boolean call(DatasetContext context) throws Exception {
         AppMetadataStore mds = getAppMetadataStore(context);
         RunRecordMeta target = mds.getRun(id, pid);
         if (target.getStatus() == expectedStatus) {
@@ -205,7 +205,9 @@ public class DefaultStore implements Store {
             default:
               break;
           }
+          return true;
         }
+        return false;
       }
     });
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeStore.java
@@ -44,12 +44,6 @@ public class RemoteRuntimeStore extends RemoteOpsClient implements RuntimeStore 
   }
 
   @Override
-  public void compareAndSetStatus(ProgramId id, String pid, ProgramRunStatus expectedStatus,
-                                  ProgramRunStatus newStatus) {
-    executeRequest("compareAndSetStatus", id, pid, expectedStatus, newStatus);
-  }
-
-  @Override
   public void setStart(ProgramId id, String pid, long startTime, @Nullable String twillRunId,
                        Map<String, String> runtimeArgs, Map<String, String> systemArgs) {
     executeRequest("setStart", id, pid, startTime, twillRunId, runtimeArgs, systemArgs);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeStoreTest.java
@@ -77,22 +77,12 @@ public class RemoteRuntimeStoreTest extends AppFabricTestBase {
                         store.getRun(flowId, pid));
 
     runtimeStore.setResume(flowId, pid);
-    Assert.assertEquals(initialRunRecord,
-                        store.getRun(flowId, pid));
+    Assert.assertEquals(initialRunRecord, store.getRun(flowId, pid));
 
-    // this should be a no-op, since the status is actually RUNNING, and not SUSPENDED
-    runtimeStore.compareAndSetStatus(flowId, pid, ProgramRunStatus.SUSPENDED, ProgramRunStatus.COMPLETED);
-    Assert.assertEquals(initialRunRecord,
-                        store.getRun(flowId, pid));
-
-    // this call to compareAndSetStatus will correctly mark it as COMPLETED.
-    // we don't do direct equals comparison on the run record objects, because the method internally sets the stopTime
-    runtimeStore.compareAndSetStatus(flowId, pid, ProgramRunStatus.RUNNING, ProgramRunStatus.COMPLETED);
+    runtimeStore.setStop(flowId, pid, stopTime, ProgramRunStatus.COMPLETED);
     RunRecordMeta runRecordMeta = store.getRun(flowId, pid);
-    Assert.assertEquals(initialRunRecord.getStartTs(), runRecordMeta.getStartTs());
-    Assert.assertEquals(initialRunRecord.getPid(), runRecordMeta.getPid());
-    Assert.assertEquals(initialRunRecord.getTwillRunId(), runRecordMeta.getTwillRunId());
-    Assert.assertEquals(ProgramRunStatus.COMPLETED, runRecordMeta.getStatus());
+    RunRecordMeta finalRunRecord = new RunRecordMeta(initialRunRecord, stopTime, ProgramRunStatus.COMPLETED);
+    Assert.assertEquals(finalRunRecord, runRecordMeta);
   }
 
   @Test


### PR DESCRIPTION
Fix an incorrect WARN log statement in run record corrector that could result due to a race condition, by making the Store#compareAndSetStatus method return a boolean instead of void.

Also remove the compareAndSetStatus method from RuntimeStore, because it only needs to be in Store interface.

https://issues.cask.co/browse/CDAP-7031
http://builds.cask.co/browse/CDAP-DUT4824-1
