### PR TITLE
Make ClientConfig class ThreadSafe, by making it immutable.

### DIFF
--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLITestBase.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLITestBase.java
@@ -41,8 +41,8 @@ public class CLITestBase {
 
   protected static CLIConfig createCLIConfig(URI standaloneUri) throws Exception {
     ConnectionConfig connectionConfig = InstanceURIParser.DEFAULT.parse(standaloneUri.toString());
-    ClientConfig clientConfig = new ClientConfig.Builder().setConnectionConfig(connectionConfig).build();
-    clientConfig.setAllTimeouts(60000);
+    ClientConfig clientConfig =
+      new ClientConfig.Builder().setConnectionConfig(connectionConfig).setAllTimeouts(60000).build();
     return new CLIConfig(clientConfig, System.out, new CsvTableRenderer());
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/CLIConfig.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/CLIConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -64,10 +64,10 @@ public class CLIConfig implements TableRendererConfig {
   private static final int MIN_LINE_WIDTH = 40;
 
   private static final Gson GSON = new Gson();
-  private final ClientConfig clientConfig;
   private final FilePathResolver resolver;
   private final String version;
   private final PrintStream output;
+  private ClientConfig clientConfig;
   private CLIConnectionConfig connectionConfig;
 
   private TableRenderer tableRenderer;
@@ -141,14 +141,14 @@ public class CLIConfig implements TableRendererConfig {
 
   public void setConnectionConfig(@Nullable CLIConnectionConfig connectionConfig) {
     this.connectionConfig = connectionConfig;
-    clientConfig.setConnectionConfig(connectionConfig);
+    this.clientConfig = new ClientConfig.Builder(clientConfig).setConnectionConfig(connectionConfig).build();
     notifyConnectionChanged();
   }
 
   public void tryConnect(CLIConnectionConfig connectionConfig, boolean verifySSLCert,
                          PrintStream output, boolean debug) throws Exception {
     try {
-      clientConfig.setVerifySSLCert(verifySSLCert);
+      clientConfig = new ClientConfig.Builder(clientConfig).setVerifySSLCert(verifySSLCert).build();
       UserAccessToken userToken = acquireAccessToken(clientConfig, connectionConfig, output, debug);
       AccessToken accessToken = null;
       if (userToken != null) {
@@ -158,7 +158,7 @@ public class CLIConfig implements TableRendererConfig {
       }
       checkConnection(clientConfig, connectionConfig, accessToken);
       setConnectionConfig(connectionConfig);
-      clientConfig.setAccessToken(accessToken);
+      clientConfig = new ClientConfig.Builder(clientConfig).setAccessToken(accessToken).build();
       output.printf("Successfully connected to CDAP instance at %s", connectionConfig.getURI().toString());
       output.println();
     } catch (IOException e) {
@@ -169,10 +169,11 @@ public class CLIConfig implements TableRendererConfig {
 
   public void updateAccessToken(PrintStream output) throws IOException {
     UserAccessToken newAccessToken = getNewAccessToken(clientConfig.getConnectionConfig(), output, false);
-    clientConfig.setAccessToken(newAccessToken.getAccessToken());
+    clientConfig = new ClientConfig.Builder(clientConfig).setAccessToken(newAccessToken.getAccessToken()).build();
   }
 
-  private void checkConnection(ClientConfig baseClientConfig, ConnectionConfig connectionInfo, AccessToken accessToken)
+  private void checkConnection(ClientConfig baseClientConfig, ConnectionConfig connectionInfo,
+                               @Nullable AccessToken accessToken)
     throws IOException, UnauthenticatedException, UnauthorizedException {
     ClientConfig clientConfig = new ClientConfig.Builder(baseClientConfig)
       .setConnectionConfig(connectionInfo)

--- a/cdap-client/src/main/java/co/cask/cdap/client/config/ClientConfig.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/config/ClientConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -27,10 +27,12 @@ import com.google.common.base.Suppliers;
 import java.net.MalformedURLException;
 import java.net.URL;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Configuration for the Java client API
  */
+@ThreadSafe
 public class ClientConfig {
 
   private static final boolean DEFAULT_VERIFY_SSL_CERTIFICATE = true;
@@ -45,17 +47,17 @@ public class ClientConfig {
   private static final String DEFAULT_VERSION = Constants.Gateway.API_VERSION_3_TOKEN;
 
   @Nullable
-  private ConnectionConfig connectionConfig;
-  private boolean verifySSLCert;
+  private final ConnectionConfig connectionConfig;
+  private final boolean verifySSLCert;
 
-  private int defaultReadTimeout;
-  private int defaultConnectTimeout;
-  private int uploadReadTimeout;
-  private int uploadConnectTimeout;
+  private final int defaultReadTimeout;
+  private final int defaultConnectTimeout;
+  private final int uploadReadTimeout;
+  private final int uploadConnectTimeout;
 
-  private int unavailableRetryLimit;
-  private String apiVersion;
-  private Supplier<AccessToken> accessToken;
+  private final int unavailableRetryLimit;
+  private final String apiVersion;
+  private final Supplier<AccessToken> accessToken;
 
   private ClientConfig(@Nullable ConnectionConfig connectionConfig,
                        boolean verifySSLCert, int unavailableRetryLimit,
@@ -160,10 +162,6 @@ public class ClientConfig {
     return uploadConnectTimeout;
   }
 
-  public void setConnectionConfig(@Nullable ConnectionConfig connectionConfig) {
-    this.connectionConfig = connectionConfig;
-  }
-
   public ConnectionConfig getConnectionConfig() {
     if (connectionConfig == null) {
       throw new DisconnectedException();
@@ -175,47 +173,12 @@ public class ClientConfig {
     return verifySSLCert;
   }
 
-  public void setVerifySSLCert(boolean verifySSLCert) {
-    this.verifySSLCert = verifySSLCert;
-  }
-
-  public void setDefaultReadTimeout(int defaultReadTimeout) {
-    this.defaultReadTimeout = defaultReadTimeout;
-  }
-
-  public void setDefaultConnectTimeout(int defaultConnectTimeout) {
-    this.defaultConnectTimeout = defaultConnectTimeout;
-  }
-
-  public void setUploadReadTimeout(int uploadReadTimeout) {
-    this.uploadReadTimeout = uploadReadTimeout;
-  }
-
-  public void setUploadConnectTimeout(int uploadConnectTimeout) {
-    this.uploadConnectTimeout = uploadConnectTimeout;
-  }
-
-  public void setUnavailableRetryLimit(int unavailableRetryLimit) {
-    this.unavailableRetryLimit = unavailableRetryLimit;
-  }
-
   public String getApiVersion() {
     return apiVersion;
   }
 
   public int getUnavailableRetryLimit() {
     return unavailableRetryLimit;
-  }
-
-  public void setApiVersion(String apiVersion) {
-    this.apiVersion = apiVersion;
-  }
-
-  public void setAllTimeouts(int timeout) {
-    this.defaultConnectTimeout = timeout;
-    this.defaultReadTimeout = timeout;
-    this.uploadConnectTimeout = timeout;
-    this.uploadReadTimeout = timeout;
   }
 
   @Nullable
@@ -225,14 +188,6 @@ public class ClientConfig {
 
   public Supplier<AccessToken> getAccessTokenSupplier() {
     return accessToken;
-  }
-
-  public void setAccessToken(Supplier<AccessToken> accessToken) {
-    this.accessToken = accessToken;
-  }
-
-  public void setAccessToken(AccessToken accessToken) {
-    this.accessToken = Suppliers.ofInstance(accessToken);
   }
 
   public static Builder builder() {
@@ -297,6 +252,14 @@ public class ClientConfig {
 
     public Builder setDefaultConnectTimeout(int defaultConnectTimeout) {
       this.defaultConnectTimeout = defaultConnectTimeout;
+      return this;
+    }
+
+    public Builder setAllTimeouts(int defaultTimeout) {
+      this.uploadReadTimeout = defaultTimeout;
+      this.uploadConnectTimeout = defaultTimeout;
+      this.defaultReadTimeout = defaultTimeout;
+      this.defaultConnectTimeout = defaultTimeout;
       return this;
     }
 


### PR DESCRIPTION
Make ClientConfig ThreadSafe, by making its fields final.
Change usages of setter methods to use the builder.

Example use case where its useful: https://github.com/caskdata/cask-tracker/pull/71

http://builds.cask.co/browse/CDAP-DUT4826-1
