### PR TITLE
Add Entity Name Validation to EntityId Classes

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/verification/AbstractVerifier.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/verification/AbstractVerifier.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.app.verification;
 
 import co.cask.cdap.error.Err;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.EntityId;
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/verification/FlowVerification.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/verification/FlowVerification.java
@@ -25,7 +25,6 @@ import co.cask.cdap.app.queue.QueueSpecificationGenerator;
 import co.cask.cdap.app.verification.VerifyResult;
 import co.cask.cdap.error.Err;
 import co.cask.cdap.internal.app.queue.SimpleQueueSpecificationGenerator;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.EntityId;
 import com.google.common.collect.HashMultimap;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/ConversionHelpers.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/ConversionHelpers.java
@@ -22,11 +22,11 @@ import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.transaction.queue.QueueConstants;
 import co.cask.cdap.proto.DatasetInstanceConfiguration;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.DatasetTypeId;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramId;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
@@ -44,14 +44,13 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
-//TODO: CDAP-5411 Cannot use EntityId in this class until EntityId classes do name validation
 class ConversionHelpers {
 
   private static final Gson GSON = new Gson();
 
   static NamespaceId toNamespaceId(String namespace) throws BadRequestException {
     try {
-      return Id.Namespace.from(namespace).toEntityId();
+      return new NamespaceId(namespace);
     } catch (IllegalArgumentException | NullPointerException e) {
       throw new BadRequestException(e.getMessage());
     }
@@ -59,7 +58,7 @@ class ConversionHelpers {
 
   static DatasetId toDatasetInstanceId(String namespace, String name) throws BadRequestException {
     try {
-      return Id.DatasetInstance.from(namespace, name).toEntityId();
+      return new DatasetId(namespace, name);
     } catch (IllegalArgumentException | NullPointerException e) {
       throw new BadRequestException(e.getMessage());
     }
@@ -67,7 +66,7 @@ class ConversionHelpers {
 
   static DatasetTypeId toDatasetTypeId(String namespace, String typeName) throws BadRequestException {
     try {
-      return Id.DatasetType.from(namespace, typeName).toEntityId();
+      return new DatasetTypeId(namespace, typeName);
     } catch (IllegalArgumentException | NullPointerException e) {
       throw new BadRequestException(e.getMessage());
     }
@@ -75,7 +74,7 @@ class ConversionHelpers {
 
   static DatasetTypeId toDatasetTypeId(NamespaceId namespace, String typeName) throws BadRequestException {
     try {
-      return Id.DatasetType.from(namespace.getNamespace(), typeName).toEntityId();
+      return new DatasetTypeId(namespace.getNamespace(), typeName);
     } catch (IllegalArgumentException | NullPointerException e) {
       throw new BadRequestException(e.getMessage());
     }
@@ -90,7 +89,7 @@ class ConversionHelpers {
           if (input == null || input.isEmpty()) {
             return null;
           }
-          return Id.fromString(input, Id.Program.class).toEntityId();
+          return ProgramId.fromString(input);
         }
       });
     } catch (IllegalArgumentException | NullPointerException e) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/keymaker/ProgramKeyMaker.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/internal/keymaker/ProgramKeyMaker.java
@@ -27,6 +27,10 @@ import co.cask.cdap.proto.id.ProgramId;
  */
 public class ProgramKeyMaker implements KeyMaker<ProgramId> {
 
+  /**
+   * Creates a {@link ProgramId} with no program name. This allows matching
+   * for all datasets associated with an Application as opposed to a single program.
+   */
   public static ProgramId getProgramId(ApplicationId applicationId) {
     // Use empty programId to denote applicationId
     return applicationId.flow("");

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ApplicationId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ApplicationId.java
@@ -38,6 +38,13 @@ public class ApplicationId extends NamespacedEntityId implements ParentedId<Name
 
   public ApplicationId(String namespace, String application, String version) {
     super(namespace, EntityType.APPLICATION);
+    if (application == null) {
+      throw new NullPointerException("Application ID cannot be null.");
+    }
+    if (version == null) {
+      throw new NullPointerException("Version cannot be null.");
+    }
+    ensureValidId("application", application);
     this.application = application;
     this.version = version;
   }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ArtifactId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ArtifactId.java
@@ -33,6 +33,13 @@ public class ArtifactId extends NamespacedEntityId implements ParentedId<Namespa
 
   public ArtifactId(String namespace, String artifact, String version) {
     super(namespace, EntityType.ARTIFACT);
+    if (artifact == null) {
+      throw new NullPointerException("Artifact ID cannot be null.");
+    }
+    if (version == null) {
+      throw new NullPointerException("Version cannot be null.");
+    }
+    ensureValidId("artifact", artifact);
     this.artifact = artifact;
     this.version = version;
   }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetId.java
@@ -34,16 +34,13 @@ public class DatasetId extends NamespacedEntityId implements ParentedId<Namespac
 
   public DatasetId(String namespace, String dataset) {
     super(namespace, EntityType.DATASET);
-
+    if (dataset == null) {
+      throw new NullPointerException("Dataset ID cannot be null.");
+    }
+    ensureValidDatasetId("dataset", dataset);
     // Preconstruct the parent since it will get used many times for authorization for each dataset op.
     this.namespaceId = new NamespaceId(namespace);
     this.dataset = dataset;
-
-    if (!isValidDatasetId(dataset)) {
-      throw new IllegalArgumentException(
-        String.format("Invalid characters found in dataset instance Id %s. Allowed characters are letters, numbers, " +
-                        "and _, -, ., or $.", dataset));
-    }
   }
 
   public String getDataset() {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetModuleId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetModuleId.java
@@ -32,6 +32,10 @@ public class DatasetModuleId extends NamespacedEntityId implements ParentedId<Na
 
   public DatasetModuleId(String namespace, String module) {
     super(namespace, EntityType.DATASET_MODULE);
+    if (module == null) {
+      throw new NullPointerException("Module ID cannot be null.");
+    }
+    ensureValidDatasetId("dataset module", module);
     this.module = module;
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetTypeId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/DatasetTypeId.java
@@ -32,6 +32,10 @@ public class DatasetTypeId extends NamespacedEntityId implements ParentedId<Name
 
   public DatasetTypeId(String namespace, String type) {
     super(namespace, EntityType.DATASET_TYPE);
+    if (type == null) {
+      throw new NullPointerException("Type cannot be null.");
+    }
+    ensureValidDatasetId("dataset type", type);
     this.type = type;
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/EntityId.java
@@ -67,19 +67,49 @@ public abstract class EntityId implements IdCompatible {
   private static final Pattern idPattern = Pattern.compile("[a-zA-Z0-9_-]+");
   // Allow '.' and '$' for dataset ids since they can be fully qualified class names
   private static final Pattern datasetIdPattern = Pattern.compile("[$\\.a-zA-Z0-9_-]+");
+  // Only allow alphanumeric and _ character for namespace
+  private static final Pattern namespacePattern = Pattern.compile("[a-zA-Z0-9_]+");
+
+  public static void ensureValidId(String propertyName, String name) {
+    if (!isValidId(name)) {
+      throw new IllegalArgumentException(String.format("Invalid %s ID: %s. Should only contain alphanumeric " +
+                                                         "characters and _ or -.", propertyName, name));
+    }
+  }
 
   public static boolean isValidId(String name) {
     return idPattern.matcher(name).matches();
+  }
+
+  public static void ensureValidDatasetId(String propertyName, String datasetId) {
+    if (!isValidDatasetId(datasetId)) {
+      throw new IllegalArgumentException(String.format("Invalid %s ID: %s. Should only contain alphanumeric " +
+                                                         "characters, $, ., _, or -.", propertyName, datasetId));
+    }
   }
 
   public static boolean isValidDatasetId(String datasetId) {
     return datasetIdPattern.matcher(datasetId).matches();
   }
 
+  public static void ensureValidNamespace(String namespace) {
+    if (!isValidNamespace(namespace)) {
+      throw new IllegalArgumentException(String.format("Invalid namespace ID: %s. Should only contain alphanumeric " +
+                                                         "characters or _.", namespace));
+    }
+  }
+
+  public static boolean isValidNamespace(String namespace) {
+    return namespacePattern.matcher(namespace).matches();
+  }
+
   private final EntityType entity;
   private Vector<EntityId> hierarchy;
 
   protected EntityId(EntityType entity) {
+    if (entity == null) {
+      throw new NullPointerException("Entity type cannot be null.");
+    }
     this.entity = entity;
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/FlowletId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/FlowletId.java
@@ -40,6 +40,12 @@ public class FlowletId extends NamespacedEntityId implements ParentedId<ProgramI
 
   public FlowletId(ApplicationId appId, String flow, String flowlet) {
     super(appId.getNamespace(), EntityType.FLOWLET);
+    if (flow == null) {
+      throw new NullPointerException("Flow cannot be null");
+    }
+    if (flowlet == null) {
+      throw new NullPointerException("Flowlet cannot be null");
+    }
     this.application = appId.getApplication();
     this.version = appId.getVersion();
     this.flow = flow;

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/FlowletQueueId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/FlowletQueueId.java
@@ -35,6 +35,18 @@ public class FlowletQueueId extends NamespacedEntityId implements ParentedId<Flo
 
   public FlowletQueueId(String namespace, String application, String flow, String flowlet, String queue) {
     super(namespace, EntityType.FLOWLET_QUEUE);
+    if (application == null) {
+      throw new NullPointerException("Application cannot be null");
+    }
+    if (flow == null) {
+      throw new NullPointerException("Flow cannot be null");
+    }
+    if (flowlet == null) {
+      throw new NullPointerException("Flowlet cannot be null");
+    }
+    if (queue == null) {
+      throw new NullPointerException("Queue cannot be null");
+    }
     this.application = application;
     this.flow = flow;
     this.flowlet = flowlet;

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/InstanceId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/InstanceId.java
@@ -32,6 +32,9 @@ public class InstanceId extends EntityId {
 
   public InstanceId(String instance) {
     super(EntityType.INSTANCE);
+    if (instance == null) {
+      throw new NullPointerException("Instance ID cannot be null");
+    }
     this.instance = instance;
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/NamespacedEntityId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/NamespacedEntityId.java
@@ -26,6 +26,10 @@ public abstract class NamespacedEntityId extends EntityId {
 
   protected NamespacedEntityId(String namespace, EntityType entity) {
     super(entity);
+    if (namespace == null) {
+      throw new NullPointerException("Namespace can not be null.");
+    }
+    ensureValidNamespace(namespace);
     this.namespace = namespace;
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/NotificationFeedId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/NotificationFeedId.java
@@ -34,6 +34,14 @@ public class NotificationFeedId extends NamespacedEntityId implements ParentedId
 
   public NotificationFeedId(String namespace, String category, String feed) {
     super(namespace, EntityType.NOTIFICATION_FEED);
+    if (category == null) {
+      throw new NullPointerException("Category cannot be null.");
+    }
+    if (feed == null) {
+      throw new NullPointerException("Feed ID cannot be null.");
+    }
+    ensureValidId("category", category);
+    ensureValidId("feed", feed);
     this.category = category;
     this.feed = feed;
   }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramId.java
@@ -41,6 +41,12 @@ public class ProgramId extends NamespacedEntityId implements ParentedId<Applicat
 
   ProgramId(ApplicationId appId, ProgramType type, String program) {
     super(appId.getNamespace(), EntityType.PROGRAM);
+    if (type == null) {
+      throw new NullPointerException("Program type cannot be null.");
+    }
+    if (program == null) {
+      throw new NullPointerException("Program ID cannot be null.");
+    }
     this.application = appId.getApplication();
     this.version = appId.getVersion();
     this.type = type;

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramRunId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ProgramRunId.java
@@ -41,6 +41,15 @@ public class ProgramRunId extends NamespacedEntityId implements ParentedId<Progr
 
   public ProgramRunId(ApplicationId appId, ProgramType type, String program, String run) {
     super(appId.getNamespace(), EntityType.PROGRAM_RUN);
+    if (type == null) {
+      throw new NullPointerException("Program type cannot be null.");
+    }
+    if (program == null) {
+      throw new NullPointerException("Program ID cannot be null.");
+    }
+    if (run == null) {
+      throw new NullPointerException("Run cannot be null.");
+    }
     this.application = appId.getApplication();
     this.version = appId.getVersion();
     this.type = type;

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/QueryId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/QueryId.java
@@ -32,6 +32,9 @@ public class QueryId extends EntityId {
 
   public QueryId(String handle) {
     super(EntityType.QUERY);
+    if (handle == null) {
+      throw new NullPointerException("Query Handle cannot be null.");
+    }
     this.handle = handle;
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ScheduleId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ScheduleId.java
@@ -34,6 +34,18 @@ public class ScheduleId extends NamespacedEntityId implements ParentedId<Applica
 
   public ScheduleId(String namespace, String application, String version, String schedule) {
     super(namespace, EntityType.SCHEDULE);
+    if (application == null) {
+      throw new NullPointerException("Application name cannot be null.");
+    }
+    if (application.isEmpty()) {
+      throw new IllegalArgumentException("Application name cannot be empty.");
+    }
+    if (version == null) {
+      throw new NullPointerException("Version cannot be null.");
+    }
+    if (schedule == null) {
+      throw new NullPointerException("Schedule id cannot be null.");
+    }
     this.application = application;
     this.version = version;
     this.schedule = schedule;

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/SecureKeyId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/SecureKeyId.java
@@ -37,6 +37,9 @@ public class SecureKeyId extends NamespacedEntityId implements ParentedId<Namesp
 
   public SecureKeyId(String namespace, String name) {
     super(namespace, EntityType.SECUREKEY);
+    if (name == null) {
+      throw new NullPointerException("Secure key cannot be null.");
+    }
     if (!isValidSecureKey(name)) {
       throw new IllegalArgumentException(String.format("Improperly formatted secure key name '%s'." +
                                                          " The name can contain lower case alphabets," +

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamId.java
@@ -34,6 +34,10 @@ public class StreamId extends NamespacedEntityId implements ParentedId<Namespace
 
   public StreamId(String namespace, String stream) {
     super(namespace, EntityType.STREAM);
+    if (stream == null) {
+      throw new NullPointerException("Stream ID cannot be null.");
+    }
+    ensureValidId("stream", stream);
     this.stream = stream;
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamViewId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/StreamViewId.java
@@ -33,6 +33,14 @@ public class StreamViewId extends NamespacedEntityId implements ParentedId<Strea
 
   public StreamViewId(String namespace, String stream, String view) {
     super(namespace, EntityType.STREAM_VIEW);
+    if (stream == null) {
+      throw new NullPointerException("Stream ID cannot be null.");
+    }
+    if (view == null) {
+      throw new NullPointerException("View ID cannot be null.");
+    }
+    ensureValidId("stream", stream);
+    ensureValidId("view", view);
     this.stream = stream;
     this.view = view;
   }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/SystemServiceId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/SystemServiceId.java
@@ -32,6 +32,9 @@ public class SystemServiceId extends EntityId {
 
   public SystemServiceId(String service) {
     super(EntityType.SYSTEM_SERVICE);
+    if (service == null) {
+      throw new NullPointerException("Service name cannot be null.");
+    }
     this.service = service;
   }
 

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/WorkflowId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/WorkflowId.java
@@ -17,11 +17,8 @@
 
 package co.cask.cdap.proto.id;
 
-import co.cask.cdap.api.workflow.Workflow;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
-
-import java.util.Iterator;
 
 /**
  * Uniquely identifies a workflow.


### PR DESCRIPTION
The new `EntityId` classes do not validate entity names. Without this change, the deprecated `Id` class usages in handlers cannot be replaced with the new classes.
