### PR TITLE
[CDAP-7281] Validate partition keys in the builder and also in the PFS dataset

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionOutput.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionOutput.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.api.dataset.lib;
 
+import co.cask.cdap.api.dataset.DataSetException;
+
 import java.util.Map;
 
 /**
@@ -25,6 +27,8 @@ public interface PartitionOutput extends Partition {
 
   /**
    * Add the partition to the partitioned file set.
+   *
+   * @throws DataSetException if a partition for the same key already exists
    */
   void addPartition();
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/PartitionedFileSet.java
@@ -30,8 +30,10 @@ import javax.annotation.Nullable;
 
 /**
  * Represents a dataset that is split into partitions that can be uniquely addressed
- * by partitioning keys along multiple dimensions. Each partition is a path in a file set,
- * the partitioning keys attached as meta data.
+ * by partition keys along multiple dimensions. Each partition is a path in a file set,
+ * the partition key attached as meta data. Note that the partitioning of the dataset
+ * is fixed, that is, all operations that accept a partition key as a parameter require
+ * that that key has exactly the same schema as the partitioning.
  *
  * This dataset can be made available for querying with SQL (explore). This is enabled through dataset
  * properties when the dataset is created. See {@link FileSetProperties}
@@ -48,12 +50,18 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
 
   /**
    * Add a partition for a given partition key, stored at a given path (relative to the file set's base path).
+   *
+   * @throws DataSetException if a partition for the same key already exists
+   * @throws IllegalArgumentException if the partition key does not match the partitioning of the dataset
    */
   void addPartition(PartitionKey key, String path);
 
   /**
    * Add a partition for a given partition key, stored at a given path (relative to the file set's base path),
    * with the given metadata.
+   *
+   * @throws DataSetException if a partition for the same key already exists
+   * @throws IllegalArgumentException if the partition key does not match the partitioning of the dataset
    */
   void addPartition(PartitionKey key, String path, Map<String, String> metadata);
 
@@ -61,8 +69,9 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
    * Adds a new metadata entry for a particular partition.
    * Note that existing entries cannot be updated.
    * 
-   * @throws DataSetException when an attempt is made to either update an existing entry
+   * @throws DataSetException when an attempt is made to update an existing entry
    * @throws PartitionNotFoundException when a partition for the given key is not found
+   * @throws IllegalArgumentException if the partition key does not match the partitioning of the dataset
    */
   void addMetadata(PartitionKey key, String metadataKey, String metadataValue);
 
@@ -70,18 +79,23 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
    * Adds a set of new metadata entries for a particular partition.
    * Note that existing entries cannot be updated.
    *
-   * @throws DataSetException when an attempt is made to either update existing entries
+   * @throws DataSetException when an attempt is made to update existing entries
    * @throws PartitionNotFoundException when a partition for the given key is not found
+   * @throws IllegalArgumentException if the partition key does not match the partitioning of the dataset
    */
   void addMetadata(PartitionKey key, Map<String, String> metadata);
 
   /**
    * Remove a partition for a given partition key, silently ignoring if the key is not found.
+   *
+   * @throws IllegalArgumentException if the partition key does not match the partitioning of the dataset
    */
   void dropPartition(PartitionKey key);
 
   /**
    * Return the partition for a specific partition key, or null if key is not found.
+   *
+   * @throws IllegalArgumentException if the partition key does not match the partitioning of the dataset
    */
   @Nullable
   PartitionDetail getPartition(PartitionKey key);
@@ -124,6 +138,8 @@ public interface PartitionedFileSet extends Dataset, InputFormatProvider, Output
    * Return a partition output for a specific partition key, in preparation for creating a new partition.
    * Obtain the location to write from the PartitionOutput, then call the {@link PartitionOutput#addPartition}
    * to add the partition to this dataset.
+   *
+   * @throws IllegalArgumentException if the partition key does not match the partitioning of the dataset
    */
   PartitionOutput getPartitionOutput(PartitionKey key);
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/Partitioning.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/Partitioning.java
@@ -39,17 +39,32 @@ public class Partitioning {
       public String parse(String value) {
         return value;
       }
+
+      @Override
+      public void validate(Comparable value) {
+        validate(value, String.class);
+      }
     },
     LONG {
       @Override
       public Long parse(String value) {
         return Long.parseLong(value);
       }
+
+      @Override
+      public void validate(Comparable value) {
+        validate(value, Long.class);
+      }
     },
     INT {
       @Override
       public Integer parse(String value) {
         return Integer.parseInt(value);
+      }
+
+      @Override
+      public void validate(Comparable value) {
+        validate(value, Integer.class);
       }
     };
 
@@ -59,6 +74,20 @@ public class Partitioning {
      * @param value the string to parse
      */
     public abstract Comparable parse(String value);
+
+    /**
+     * Validate that a value has the correct type for this field type.
+     * @param value the value to validate
+     * @throws IllegalArgumentException if the value is of wrong type.
+     */
+    public abstract void validate(Comparable value);
+
+    protected void validate(Comparable value, Class<? extends Comparable> expectedClass) {
+      if (!expectedClass.equals(value.getClass())) {
+        throw new IllegalArgumentException(String.format("Value %s of type %s cannot be assigned to a %s field",
+                                                         value, value.getClass().getSimpleName(), this));
+      }
+    }
   }
 
   private final Map<String, FieldType> fields;
@@ -118,6 +147,7 @@ public class Partitioning {
      * @throws java.lang.IllegalArgumentException if the field name is null, empty, or already exists,
      *         or if the type is null.
      */
+    @SuppressWarnings("ConstantConditions")
     public Builder addField(@Nonnull String name, @Nonnull FieldType type) {
       if (name == null || name.isEmpty()) {
         throw new IllegalArgumentException("Field name cannot be null or empty.");

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/FieldTypes.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/FieldTypes.java
@@ -128,22 +128,6 @@ public class FieldTypes {
   }
 
   /**
-   * Validate that a given value has the type that is required by this field type.
-   */
-  public static boolean validateType(Comparable value, FieldType type) {
-    switch(type) {
-      case STRING:
-        return value instanceof String;
-      case LONG:
-        return value instanceof Long;
-      case INT:
-        return value instanceof Integer;
-      default:
-        throw new IllegalArgumentException("Unhandled field type: " + type.name());
-    }
-  }
-
-  /**
    * @return the type name used by the Hive DDL to represent this field type
    */
   public static String toHiveType(FieldType type) {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionFilterTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionFilterTest.java
@@ -157,7 +157,7 @@ public class PartitionFilterTest {
     PartitionFilter.Condition<? extends Comparable> condition = filter.getCondition(field);
     Assert.assertNotNull(condition);
     Assert.assertEquals(single, condition.isSingleValue());
-    Assert.assertTrue(FieldTypes.validateType(condition.getValue(), type));
+    type.validate(condition.getValue());
     boolean expectMatch = true;
     for (T value : values) {
       if (value == null) {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionKeyTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionKeyTest.java
@@ -17,8 +17,12 @@
 package co.cask.cdap.data2.dataset2.lib.partitioned;
 
 import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.api.dataset.lib.Partitioning;
+import com.google.common.base.Function;
 import org.junit.Assert;
 import org.junit.Test;
+
+import javax.annotation.Nullable;
 
 /**
  * Tests for partition keys.
@@ -48,6 +52,120 @@ public class PartitionKeyTest {
   @Test(expected = IllegalArgumentException.class)
   public void testBuilderDuplicateField() {
     PartitionKey.builder().addField("x", 10).addField("y", 10L).addField("x", 14).build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBuilderUnknownField() {
+    PartitionKey.builder(
+      Partitioning.builder().addIntField("x").addLongField("y").build())
+      .addField("x", 10).addField("y", 10L).addField("z", 15).build();
+  }
+
+  @Test()
+  @SuppressWarnings("ConstantConditions")
+  public void testBuilderIllegalFieldValue() {
+    testIllegalFieldValue(new Function<PartitionKey.Builder, PartitionKey.Builder>() {
+      @Nullable
+      @Override
+      public PartitionKey.Builder apply(@Nullable PartitionKey.Builder builder) {
+        return builder.addLongField("x", 1L);
+      }
+    });
+    testIllegalFieldValue(new Function<PartitionKey.Builder, PartitionKey.Builder>() {
+      @Nullable
+      @Override
+      public PartitionKey.Builder apply(@Nullable PartitionKey.Builder builder) {
+        return builder.addField("x", 1L);
+      }
+    });
+    testIllegalFieldValue(new Function<PartitionKey.Builder, PartitionKey.Builder>() {
+      @Nullable
+      @Override
+      public PartitionKey.Builder apply(@Nullable PartitionKey.Builder builder) {
+        return builder.addStringField("x", "a");
+      }
+    });
+    testIllegalFieldValue(new Function<PartitionKey.Builder, PartitionKey.Builder>() {
+      @Nullable
+      @Override
+      public PartitionKey.Builder apply(@Nullable PartitionKey.Builder builder) {
+        return builder.addField("x", "a");
+      }
+    });
+    testIllegalFieldValue(new Function<PartitionKey.Builder, PartitionKey.Builder>() {
+      @Nullable
+      @Override
+      public PartitionKey.Builder apply(@Nullable PartitionKey.Builder builder) {
+        return builder.addIntField("y", 1);
+      }
+    });
+    testIllegalFieldValue(new Function<PartitionKey.Builder, PartitionKey.Builder>() {
+      @Nullable
+      @Override
+      public PartitionKey.Builder apply(@Nullable PartitionKey.Builder builder) {
+        return builder.addField("y", 1);
+      }
+    });
+    testIllegalFieldValue(new Function<PartitionKey.Builder, PartitionKey.Builder>() {
+      @Nullable
+      @Override
+      public PartitionKey.Builder apply(@Nullable PartitionKey.Builder builder) {
+        return builder.addStringField("y", "a");
+      }
+    });
+    testIllegalFieldValue(new Function<PartitionKey.Builder, PartitionKey.Builder>() {
+      @Nullable
+      @Override
+      public PartitionKey.Builder apply(@Nullable PartitionKey.Builder builder) {
+        return builder.addField("y", "a");
+      }
+    });
+    testIllegalFieldValue(new Function<PartitionKey.Builder, PartitionKey.Builder>() {
+      @Nullable
+      @Override
+      public PartitionKey.Builder apply(@Nullable PartitionKey.Builder builder) {
+        return builder.addIntField("z", 1);
+      }
+    });
+    testIllegalFieldValue(new Function<PartitionKey.Builder, PartitionKey.Builder>() {
+      @Nullable
+      @Override
+      public PartitionKey.Builder apply(@Nullable PartitionKey.Builder builder) {
+        return builder.addField("z", 1);
+      }
+    });
+    testIllegalFieldValue(new Function<PartitionKey.Builder, PartitionKey.Builder>() {
+      @Nullable
+      @Override
+      public PartitionKey.Builder apply(@Nullable PartitionKey.Builder builder) {
+        return builder.addLongField("z", 1L);
+      }
+    });
+    testIllegalFieldValue(new Function<PartitionKey.Builder, PartitionKey.Builder>() {
+      @Nullable
+      @Override
+      public PartitionKey.Builder apply(@Nullable PartitionKey.Builder builder) {
+        return builder.addField("z", 1L);
+      }
+    });
+  }
+
+  private void testIllegalFieldValue(Function<PartitionKey.Builder, PartitionKey.Builder> function) {
+    PartitionKey.Builder builder = PartitionKey.builder(
+      Partitioning.builder().addIntField("x").addLongField("y").addStringField("z").build());
+    try {
+      function.apply(builder);
+      Assert.fail("builder should have thrown exception for invalid field type");
+    } catch (IllegalArgumentException e) {
+      //expected
+    }
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testBuilderMissingField() {
+    PartitionKey.builder(
+      Partitioning.builder().addIntField("x").addLongField("y").addStringField("z").build())
+      .addField("x", 10).addField("y", 10L).build();
   }
 
   @Test

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitioningTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitioningTest.java
@@ -122,7 +122,7 @@ public class PartitioningTest {
     byte[][] byteValues = new byte[values.length][];
     int index = 0;
     for (Comparable value : values) {
-      Assert.assertTrue(FieldTypes.validateType(value, type));
+      type.validate(value);
       byte[] byteValue = FieldTypes.toBytes(value, type);
       int determined = FieldTypes.determineLengthInBytes(byteValue, 0, type);
       Assert.assertEquals(byteValue.length, determined);


### PR DESCRIPTION
This is to give developers a way to make sure a partition key matches the partitioning of the PFS. Also fixes some bugs in PFS dataset when a partition key does not actually match.
