### PR TITLE
quote curl credentials for hdinsight to protect against $ in the pass…

### DIFF
--- a/cdap-distributions/src/hdinsight/pageblob-configure.sh
+++ b/cdap-distributions/src/hdinsight/pageblob-configure.sh
@@ -30,7 +30,7 @@ PASSWD=$(python -c 'import hdinsight_common.ClusterManifestParser as ClusterMani
                     print base64.b64decode(base64pwd)')
 
 AMBARICREDS="-u ${USERID} -p ${PASSWD}"
-AMBARICURLCREDS="-u \"${USERID}\":\"${PASSWD}\""
+AMBARICURLCREDS="-u '${USERID}':'${PASSWD}'"
 
 
 # Function definitions


### PR DESCRIPTION
…word

fixes the following:

```
curl -s -u "username":"VEqhL:5|7-1$O+" -H 'X-Requested-By: ambari' -X GET http://headnodehost:8080/api/v1/clusters
{
  "status": 403,
  "message": "Bad credentials"
}
```

with single quotes:

```
curl -v -s -u "username":'VEqhL:5|7-1$O+' -H 'X-Requested-By: ambari' -X GET http://headnodehost:8080/api/v1/clusters
{
  "href" : "http://headnodehost:8080/api/v1/clusters",
  "items" : [
    {
      "href" : "http://headnodehost:8080/api/v1/clusters/v2base18",
      "Clusters" : {
        "cluster_name" : "v2base18",
        "version" : "HDP-2.4"
      }
    }
  ]
* Connection #0 to host headnodehost left intact
}
```
