### PR TITLE
Service Version Routing

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceHttpServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ServiceHttpServer.java
@@ -105,6 +105,7 @@ public class ServiceHttpServer extends AbstractIdleService {
   private final NettyHttpService service;
 
   private Cancellable cancelDiscovery;
+  private Cancellable cancelVersionDiscovery;
   private Timer timer;
 
   public ServiceHttpServer(String host, Program program, ProgramOptions programOptions, ServiceSpecification spec,
@@ -239,6 +240,7 @@ public class ServiceHttpServer extends AbstractIdleService {
     // Announce the service with its version as the payload
     cancelDiscovery = serviceAnnouncer.announce(ServiceDiscoverable.getName(programId), port,
                                                 Bytes.toBytes(programId.getVersion()));
+    cancelVersionDiscovery = serviceAnnouncer.announce(ServiceDiscoverable.getVersionedName(programId), port);
     LOG.info("Announced HTTP Service for Service {} at {}", programId, bindAddress);
 
     // Create a Timer thread to periodically collect handler that are no longer in used and call destroy on it
@@ -255,6 +257,7 @@ public class ServiceHttpServer extends AbstractIdleService {
   @Override
   protected void shutDown() throws Exception {
     cancelDiscovery.cancel();
+    cancelVersionDiscovery.cancel();
     try {
       service.stopAndWait();
     } finally {

--- a/cdap-common/src/main/java/co/cask/cdap/common/service/ServiceDiscoverable.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/service/ServiceDiscoverable.java
@@ -30,9 +30,17 @@ public final class ServiceDiscoverable {
     return getName(programId.getNamespace(), programId.getApplication(), programId.getProgram());
   }
 
-  public static String getName(String namespaceId, String applicationId, String serviceId) {
-    return String.format("%s.%s.%s.%s", ProgramType.SERVICE.name().toLowerCase(), namespaceId,
-                         applicationId, serviceId);
+  public static String getName(String namespaceId, String appId, String serviceId) {
+    return String.format("%s.%s.%s.%s", ProgramType.SERVICE.name().toLowerCase(), namespaceId, appId, serviceId);
+  }
+
+  public static String getVersionedName(ProgramId programId) {
+    return getVersionedName(programId.getNamespace(), programId.getApplication(), programId.getVersion(),
+                            programId.getProgram());
+  }
+
+  public static String getVersionedName(String namespaceId, String appId, String versionId, String serviceId) {
+    return String.format("serviceversion.%s.%s.%s.%s", namespaceId, appId, versionId, serviceId);
   }
 
   public static ProgramId getId(String name) {

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
@@ -67,6 +67,12 @@ public final class RouterPathLookup extends AbstractHttpHandler {
     if ((uriParts.length >= 2) && uriParts[1].equals("feeds")) {
       // TODO find a better way to handle that - this looks hackish
       return null;
+    } else if ((uriParts.length >= 9) && "versions".equals(uriParts[5]) && "services".equals(uriParts[7])
+      && "methods".equals(uriParts[9])) {
+      // User defined services (version specific) handle methods on them:
+      //Path: "/v3/namespaces/{namespace-id}/apps/{app-id}/versions/{version-id}/services/{service-id}/methods/
+      //       <user-defined-method-path>"
+      return ServiceDiscoverable.getVersionedName(uriParts[2], uriParts[4], uriParts[6], uriParts[8]);
     } else if ((uriParts.length >= 9) && "services".equals(uriParts[5]) && "methods".equals(uriParts[7])) {
       //User defined services handle methods on them:
       //Path: "/v3/namespaces/{namespace-id}/apps/{app-id}/services/{service-id}/methods/<user-defined-method-path>"

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathTest.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.gateway.router;
 
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.service.ServiceDiscoverable;
 import com.google.common.collect.ImmutableList;
 import org.jboss.netty.handler.codec.http.DefaultHttpRequest;
 import org.jboss.netty.handler.codec.http.HttpMethod;
@@ -39,6 +40,21 @@ public class RouterPathTest {
   @BeforeClass
   public static void init() throws Exception {
     pathLookup = new RouterPathLookup();
+  }
+
+  @Test
+  public void testUserServicePath() {
+    String path = "/v3/namespaces/n1/apps/a1/services/s1/methods/m1";
+    HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), path);
+    String result = pathLookup.getRoutingService(FALLBACKSERVICE, path, httpRequest);
+    Assert.assertEquals(ServiceDiscoverable.getName("n1", "a1", "s1"), result);
+    Assert.assertTrue(ServiceDiscoverable.isServiceDiscoverable(result));
+
+    path = "/v3/namespaces/n1/apps/a1/versions/v1/services/s1/methods/m1";
+    httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), path);
+    result = pathLookup.getRoutingService(FALLBACKSERVICE, path, httpRequest);
+    Assert.assertEquals(ServiceDiscoverable.getVersionedName("n1", "a1", "v1", "s1"), result);
+    Assert.assertFalse(ServiceDiscoverable.isServiceDiscoverable(result));
   }
 
   @Test


### PR DESCRIPTION
- We want to route to specific versions of services in addition to doing configuration based routing to multiple versions
- Announce two discoverables - we will be refactoring RoutePathLookup to avoid this in a later PR. JIRA for that : https://issues.cask.co/browse/CDAP-7305

Build : http://builds.cask.co/browse/CDAP-RUT175
