### PR TITLE
Fix UpgradeTool (DatasetSpecificationUpgrader and StreamStateStoreUpgrader)

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamUtils.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamUtils.java
@@ -432,7 +432,7 @@ public final class StreamUtils {
   /**
    * Gets a TableId for stream consumer state stores within a given namespace.
    * @param namespace the namespace for which the table is for.
-   * @return constructed TableId
+   * @return constructed TableId. Note that the namespace in the returned TableId is the CDAP namespace (CDAP-7344).
    */
   public static TableId getStateStoreTableId(Id.Namespace namespace) {
     String tableName = String.format("%s.%s.state.store",

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/AbstractStreamFileConsumerFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/AbstractStreamFileConsumerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.data2.transaction.stream;
 
 import co.cask.cdap.common.conf.CConfiguration;
@@ -139,6 +140,7 @@ public abstract class AbstractStreamFileConsumerFactory implements StreamConsume
 
   }
 
+  // Usages of this method must perform a mapping of the TableId's namespace. See CDAP-7344.
   private TableId getTableId(Id.Stream streamId, String namespace) {
     return TableId.from(streamId.getNamespace().getId(),
                         String.format("%s.%s.%s", tablePrefix, streamId.getId(), namespace));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
@@ -649,7 +649,7 @@ public abstract class HBaseTableUtil {
    * Lists all tables in the specified namespace
    *
    * @param admin the {@link HBaseAdmin} to use to communicate with HBase
-   * @param namespaceId namespace for which the tables are being requested
+   * @param namespaceId HBase namespace for which the tables are being requested
    */
   public abstract List<TableId> listTablesInNamespace(HBaseAdmin admin, String namespaceId) throws IOException;
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HTableNameConverter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HTableNameConverter.java
@@ -80,9 +80,8 @@ public abstract class HTableNameConverter {
    *
    * @param prefix Prefix string
    * @return System configuration table prefix (full table name minus the table qualifier).
-   * Example input: "cdap_ns.table.name"  -->  output: "cdap_system."   (hbase 94)
-   * Example input: "cdap.table.name"     -->  output: "cdap_system."   (hbase 94. input table is in default namespace)
-   * Example input: "cdap_ns:table.name"  -->  output: "cdap_system:"   (hbase 96, 98)
+   * Example input: "cdap.table.name"     -->  output: "cdap_system."   (input table is in default namespace)
+   * Example input: "cdap_ns:table.name"  -->  output: "cdap_system:"   (input table is in a custom namespace)
    */
   public String getSysConfigTablePrefix(String prefix) {
     return prefix + "_" + NamespaceId.SYSTEM.getNamespace() + ":";

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/increment/hbase/AbstractIncrementHandlerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/increment/hbase/AbstractIncrementHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -259,8 +259,7 @@ public abstract class AbstractIncrementHandlerTest {
       Delete delete = tableUtil.buildDelete(row1)
         .deleteColumns(FAMILY, col)
         .build();
-      // use batch to work around a bug in delete coprocessor hooks on HBase 0.94
-      table.batch(Lists.newArrayList(delete));
+      table.delete(delete);
 
       Get get = tableUtil.buildGet(row1).build();
       Result result = table.get(get);
@@ -295,8 +294,7 @@ public abstract class AbstractIncrementHandlerTest {
 
       // perform a row delete
       delete = tableUtil.buildDelete(row1).build();
-      // use batch to work around a bug in delete coprocessor hooks on HBase 0.94
-      table.batch(Lists.newArrayList(delete));
+      table.delete(delete);
 
       get = tableUtil.buildGet(row1).build();
       result = table.get(get);

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase96/DequeueFilter.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase96/DequeueFilter.java
@@ -136,7 +136,7 @@ public class DequeueFilter extends FilterBase {
     return skipRow;
   }
 
-  /* Writable implementation for HBase 0.94 */
+  /* Writable implementation */
 
   public void write(DataOutput out) throws IOException {
     DequeueScanAttributes.write(out, consumerConfig);

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase98/DequeueFilter.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase98/DequeueFilter.java
@@ -136,7 +136,7 @@ public class DequeueFilter extends FilterBase {
     return skipRow;
   }
 
-  /* Writable implementation for HBase 0.94 */
+  /* Writable implementation */
 
   public void write(DataOutput out) throws IOException {
     DequeueScanAttributes.write(out, consumerConfig);

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10cdh/DequeueFilter.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10cdh/DequeueFilter.java
@@ -141,7 +141,7 @@ public class DequeueFilter extends FilterBase {
     return skipRow;
   }
 
-  /* Writable implementation for HBase 0.94 */
+  /* Writable implementation */
 
   public void write(DataOutput out) throws IOException {
     DequeueScanAttributes.write(out, consumerConfig);

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10cdh550/DequeueFilter.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10cdh550/DequeueFilter.java
@@ -141,7 +141,7 @@ public class DequeueFilter extends FilterBase {
     return skipRow;
   }
 
-  /* Writable implementation for HBase 0.94 */
+  /* Writable implementation */
 
   public void write(DataOutput out) throws IOException {
     DequeueScanAttributes.write(out, consumerConfig);

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10/DequeueFilter.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10/DequeueFilter.java
@@ -141,7 +141,7 @@ public class DequeueFilter extends FilterBase {
     return skipRow;
   }
 
-  /* Writable implementation for HBase 0.94 */
+  /* Writable implementation */
 
   public void write(DataOutput out) throws IOException {
     DequeueScanAttributes.write(out, consumerConfig);

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase11/DequeueFilter.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase11/DequeueFilter.java
@@ -141,7 +141,7 @@ public class DequeueFilter extends FilterBase {
     return skipRow;
   }
 
-  /* Writable implementation for HBase 0.94 */
+  /* Writable implementation */
 
   public void write(DataOutput out) throws IOException {
     DequeueScanAttributes.write(out, consumerConfig);

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase12cdh570/DequeueFilter.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase12cdh570/DequeueFilter.java
@@ -141,7 +141,7 @@ public class DequeueFilter extends FilterBase {
     return skipRow;
   }
 
-  /* Writable implementation for HBase 0.94 */
+  /* Writable implementation */
 
   public void write(DataOutput out) throws IOException {
     DequeueScanAttributes.write(out, consumerConfig);

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetSpecificationUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetSpecificationUpgrader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -24,6 +24,7 @@ import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.ScanBuilder;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
@@ -75,7 +76,7 @@ public class DatasetSpecificationUpgrader {
    * @throws Exception
    */
   public void upgrade() throws Exception {
-    TableId datasetSpecId = TableId.from(Id.Namespace.SYSTEM.getId(), DatasetMetaTableUtil.INSTANCE_TABLE_NAME);
+    TableId datasetSpecId = tableUtil.createHTableId(NamespaceId.SYSTEM, DatasetMetaTableUtil.INSTANCE_TABLE_NAME);
     HBaseAdmin hBaseAdmin = new HBaseAdmin(conf);
     if (!tableUtil.tableExists(hBaseAdmin, datasetSpecId)) {
       LOG.error("Dataset instance table does not exist: {}. Should not happen", datasetSpecId);

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/StreamStateStoreUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/StreamStateStoreUpgrader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -24,7 +24,9 @@ import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
@@ -32,6 +34,7 @@ import org.apache.twill.filesystem.LocationFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import javax.annotation.Nullable;
 
 /**
@@ -54,7 +57,12 @@ public class StreamStateStoreUpgrader extends AbstractQueueUpgrader {
     return Lists.transform(namespaceQueryAdmin.list(), new Function<NamespaceMeta, TableId>() {
       @Override
       public TableId apply(NamespaceMeta input) {
-        return StreamUtils.getStateStoreTableId(Id.Namespace.from(input.getName()));
+        try {
+          TableId tableId = StreamUtils.getStateStoreTableId(input.getNamespaceId().toId());
+          return tableUtil.createHTableId(new NamespaceId(tableId.getNamespace()), tableId.getTableName());
+        } catch (IOException e) {
+          throw Throwables.propagate(e);
+        }
       }
     });
   }


### PR DESCRIPTION
Change how the TableId objects are constructed, so that the dataset instance table and stream state store tables aren't deemed to be nonexistent by HBase.

First commit has the fix; second commit has miscellaneous cleanup.

https://issues.cask.co/browse/CDAP-7321
http://builds.cask.co/browse/CDAP-RUT180-1
