### PR TITLE
Revert/6751 Probable cause of https://issues.cask.co/browse/CDAP-7355

### DIFF
--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLITestBase.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLITestBase.java
@@ -41,8 +41,8 @@ public class CLITestBase {
 
   protected static CLIConfig createCLIConfig(URI standaloneUri) throws Exception {
     ConnectionConfig connectionConfig = InstanceURIParser.DEFAULT.parse(standaloneUri.toString());
-    ClientConfig clientConfig =
-      new ClientConfig.Builder().setConnectionConfig(connectionConfig).setAllTimeouts(60000).build();
+    ClientConfig clientConfig = new ClientConfig.Builder().setConnectionConfig(connectionConfig).build();
+    clientConfig.setAllTimeouts(60000);
     return new CLIConfig(clientConfig, System.out, new CsvTableRenderer());
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/CLIConfig.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/CLIConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2016 Cask Data, Inc.
+ * Copyright © 2014-2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -64,10 +64,10 @@ public class CLIConfig implements TableRendererConfig {
   private static final int MIN_LINE_WIDTH = 40;
 
   private static final Gson GSON = new Gson();
+  private final ClientConfig clientConfig;
   private final FilePathResolver resolver;
   private final String version;
   private final PrintStream output;
-  private ClientConfig clientConfig;
   private CLIConnectionConfig connectionConfig;
 
   private TableRenderer tableRenderer;
@@ -141,14 +141,14 @@ public class CLIConfig implements TableRendererConfig {
 
   public void setConnectionConfig(@Nullable CLIConnectionConfig connectionConfig) {
     this.connectionConfig = connectionConfig;
-    this.clientConfig = new ClientConfig.Builder(clientConfig).setConnectionConfig(connectionConfig).build();
+    clientConfig.setConnectionConfig(connectionConfig);
     notifyConnectionChanged();
   }
 
   public void tryConnect(CLIConnectionConfig connectionConfig, boolean verifySSLCert,
                          PrintStream output, boolean debug) throws Exception {
     try {
-      clientConfig = new ClientConfig.Builder(clientConfig).setVerifySSLCert(verifySSLCert).build();
+      clientConfig.setVerifySSLCert(verifySSLCert);
       UserAccessToken userToken = acquireAccessToken(clientConfig, connectionConfig, output, debug);
       AccessToken accessToken = null;
       if (userToken != null) {
@@ -158,7 +158,7 @@ public class CLIConfig implements TableRendererConfig {
       }
       checkConnection(clientConfig, connectionConfig, accessToken);
       setConnectionConfig(connectionConfig);
-      clientConfig = new ClientConfig.Builder(clientConfig).setAccessToken(accessToken).build();
+      clientConfig.setAccessToken(accessToken);
       output.printf("Successfully connected to CDAP instance at %s", connectionConfig.getURI().toString());
       output.println();
     } catch (IOException e) {
@@ -169,11 +169,10 @@ public class CLIConfig implements TableRendererConfig {
 
   public void updateAccessToken(PrintStream output) throws IOException {
     UserAccessToken newAccessToken = getNewAccessToken(clientConfig.getConnectionConfig(), output, false);
-    clientConfig = new ClientConfig.Builder(clientConfig).setAccessToken(newAccessToken.getAccessToken()).build();
+    clientConfig.setAccessToken(newAccessToken.getAccessToken());
   }
 
-  private void checkConnection(ClientConfig baseClientConfig, ConnectionConfig connectionInfo,
-                               @Nullable AccessToken accessToken)
+  private void checkConnection(ClientConfig baseClientConfig, ConnectionConfig connectionInfo, AccessToken accessToken)
     throws IOException, UnauthenticatedException, UnauthorizedException {
     ClientConfig clientConfig = new ClientConfig.Builder(baseClientConfig)
       .setConnectionConfig(connectionInfo)

--- a/cdap-client/src/main/java/co/cask/cdap/client/config/ClientConfig.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/config/ClientConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2015 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -27,12 +27,10 @@ import com.google.common.base.Suppliers;
 import java.net.MalformedURLException;
 import java.net.URL;
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Configuration for the Java client API
  */
-@ThreadSafe
 public class ClientConfig {
 
   private static final boolean DEFAULT_VERIFY_SSL_CERTIFICATE = true;
@@ -47,17 +45,17 @@ public class ClientConfig {
   private static final String DEFAULT_VERSION = Constants.Gateway.API_VERSION_3_TOKEN;
 
   @Nullable
-  private final ConnectionConfig connectionConfig;
-  private final boolean verifySSLCert;
+  private ConnectionConfig connectionConfig;
+  private boolean verifySSLCert;
 
-  private final int defaultReadTimeout;
-  private final int defaultConnectTimeout;
-  private final int uploadReadTimeout;
-  private final int uploadConnectTimeout;
+  private int defaultReadTimeout;
+  private int defaultConnectTimeout;
+  private int uploadReadTimeout;
+  private int uploadConnectTimeout;
 
-  private final int unavailableRetryLimit;
-  private final String apiVersion;
-  private final Supplier<AccessToken> accessToken;
+  private int unavailableRetryLimit;
+  private String apiVersion;
+  private Supplier<AccessToken> accessToken;
 
   private ClientConfig(@Nullable ConnectionConfig connectionConfig,
                        boolean verifySSLCert, int unavailableRetryLimit,
@@ -162,6 +160,10 @@ public class ClientConfig {
     return uploadConnectTimeout;
   }
 
+  public void setConnectionConfig(@Nullable ConnectionConfig connectionConfig) {
+    this.connectionConfig = connectionConfig;
+  }
+
   public ConnectionConfig getConnectionConfig() {
     if (connectionConfig == null) {
       throw new DisconnectedException();
@@ -173,12 +175,47 @@ public class ClientConfig {
     return verifySSLCert;
   }
 
+  public void setVerifySSLCert(boolean verifySSLCert) {
+    this.verifySSLCert = verifySSLCert;
+  }
+
+  public void setDefaultReadTimeout(int defaultReadTimeout) {
+    this.defaultReadTimeout = defaultReadTimeout;
+  }
+
+  public void setDefaultConnectTimeout(int defaultConnectTimeout) {
+    this.defaultConnectTimeout = defaultConnectTimeout;
+  }
+
+  public void setUploadReadTimeout(int uploadReadTimeout) {
+    this.uploadReadTimeout = uploadReadTimeout;
+  }
+
+  public void setUploadConnectTimeout(int uploadConnectTimeout) {
+    this.uploadConnectTimeout = uploadConnectTimeout;
+  }
+
+  public void setUnavailableRetryLimit(int unavailableRetryLimit) {
+    this.unavailableRetryLimit = unavailableRetryLimit;
+  }
+
   public String getApiVersion() {
     return apiVersion;
   }
 
   public int getUnavailableRetryLimit() {
     return unavailableRetryLimit;
+  }
+
+  public void setApiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+  }
+
+  public void setAllTimeouts(int timeout) {
+    this.defaultConnectTimeout = timeout;
+    this.defaultReadTimeout = timeout;
+    this.uploadConnectTimeout = timeout;
+    this.uploadReadTimeout = timeout;
   }
 
   @Nullable
@@ -188,6 +225,14 @@ public class ClientConfig {
 
   public Supplier<AccessToken> getAccessTokenSupplier() {
     return accessToken;
+  }
+
+  public void setAccessToken(Supplier<AccessToken> accessToken) {
+    this.accessToken = accessToken;
+  }
+
+  public void setAccessToken(AccessToken accessToken) {
+    this.accessToken = Suppliers.ofInstance(accessToken);
   }
 
   public static Builder builder() {
@@ -252,14 +297,6 @@ public class ClientConfig {
 
     public Builder setDefaultConnectTimeout(int defaultConnectTimeout) {
       this.defaultConnectTimeout = defaultConnectTimeout;
-      return this;
-    }
-
-    public Builder setAllTimeouts(int defaultTimeout) {
-      this.uploadReadTimeout = defaultTimeout;
-      this.uploadConnectTimeout = defaultTimeout;
-      this.defaultReadTimeout = defaultTimeout;
-      this.defaultConnectTimeout = defaultTimeout;
       return this;
     }
 

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/NettyRouter.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/NettyRouter.java
@@ -247,7 +247,7 @@ public class NettyRouter extends AbstractIdleService {
           ChannelPipeline pipeline = Channels.pipeline();
           if (isSSLEnabled()) {
             // Add SSLHandler is SSL is enabled
-            pipeline.addLast("ssl", sslHandlerFactory.create());
+            pipeline.addLast("ssl", sslHandlerFactory.create(true));
           }
           pipeline.addLast("tracker", connectionTracker);
           pipeline.addLast("http-response-encoder", new HttpResponseEncoder());
@@ -317,6 +317,10 @@ public class NettyRouter extends AbstractIdleService {
       @Override
       public ChannelPipeline getPipeline() throws Exception {
         ChannelPipeline pipeline = Channels.pipeline();
+        if (isSSLEnabled()) {
+          // Add SSLHandler is SSL is enabled
+          pipeline.addLast("ssl", sslHandlerFactory.create(false));
+        }
         pipeline.addLast("tracker", connectionTracker);
         pipeline.addLast("request-encoder", new HttpRequestEncoder());
         // outbound handler gets dynamically added here (after 'request-encoder')

--- a/cdap-security/src/main/java/co/cask/cdap/security/tools/SSLHandlerFactory.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/tools/SSLHandlerFactory.java
@@ -64,9 +64,13 @@ public class SSLHandlerFactory {
     }
   }
 
-  public SslHandler create() {
+  public SslHandler create(boolean isServer) {
     SSLEngine engine = serverContext.createSSLEngine();
-    engine.setUseClientMode(false);
+    if (isServer) {
+      engine.setUseClientMode(false);
+    } else {
+      engine.setUseClientMode(true);
+    }
     SslHandler handler =  new SslHandler(engine);
     handler.setEnableRenegotiation(false);
     return handler;


### PR DESCRIPTION
Revert "Make ClientConfig class ThreadSafe, by making it immutable."

Cause: https://issues.cask.co/browse/CDAP-7355
