### PR TITLE
[CDAP-7284] upgrade to tephra 0.10

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -237,6 +237,18 @@ public final class Constants {
     }
 
     public static final String SERVICE_DESCRIPTION = "Service that maintains transaction states.";
+
+    /**
+     * Configuration for the TransactionDataJanitor coprocessor.
+     */
+    public static final class DataJanitor {
+      /**
+       * Whether or not the TransactionDataJanitor coprocessor should be enabled on tables.
+       * Disable for testing.
+       */
+      public static final String CFG_TX_JANITOR_ENABLE = "data.tx.janitor.enable";
+      public static final boolean DEFAULT_TX_JANITOR_ENABLE = true;
+    }
   }
 
   /**

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseFileStreamAdminTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseFileStreamAdminTest.java
@@ -61,6 +61,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionManager;
 import org.apache.tephra.TransactionSystemClient;
 import org.apache.tephra.inmemory.InMemoryTxSystemClient;
+import org.apache.tephra.inmemory.TxInMemory;
 import org.apache.tephra.persist.NoOpTransactionStateStorage;
 import org.apache.tephra.persist.TransactionStateStorage;
 import org.apache.twill.internal.zookeeper.InMemoryZKServer;
@@ -132,7 +133,7 @@ public class HBaseFileStreamAdminTest extends StreamAdminTest {
     zkClientService.startAndWait();
 
     streamAdmin = injector.getInstance(StreamAdmin.class);
-    txManager = injector.getInstance(TransactionManager.class);
+    txManager = TxInMemory.getTransactionManager(injector.getInstance(TransactionSystemClient.class));
     fileWriterFactory = injector.getInstance(StreamFileWriterFactory.class);
     streamCoordinatorClient = injector.getInstance(StreamCoordinatorClient.class);
     inMemoryAuditPublisher = injector.getInstance(InMemoryAuditPublisher.class);

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerTest.java
@@ -59,6 +59,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionManager;
 import org.apache.tephra.TransactionSystemClient;
 import org.apache.tephra.inmemory.InMemoryTxSystemClient;
+import org.apache.tephra.inmemory.TxInMemory;
 import org.apache.tephra.persist.NoOpTransactionStateStorage;
 import org.apache.tephra.persist.TransactionStateStorage;
 import org.apache.twill.internal.zookeeper.InMemoryZKServer;
@@ -136,7 +137,7 @@ public class HBaseStreamConsumerTest extends StreamConsumerTestBase {
     streamAdmin = injector.getInstance(StreamAdmin.class);
     consumerFactory = injector.getInstance(StreamConsumerFactory.class);
     txClient = injector.getInstance(TransactionSystemClient.class);
-    txManager = injector.getInstance(TransactionManager.class);
+    txManager = TxInMemory.getTransactionManager(txClient);
     queueClientFactory = injector.getInstance(QueueClientFactory.class);
     fileWriterFactory = injector.getInstance(StreamFileWriterFactory.class);
 

--- a/cdap-data-fabric-tests/src/test/java/org/apache/tephra/inmemory/TxInMemory.java
+++ b/cdap-data-fabric-tests/src/test/java/org/apache/tephra/inmemory/TxInMemory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.tephra.inmemory;
+
+import org.apache.tephra.TransactionManager;
+import org.apache.tephra.TransactionSystemClient;
+import org.junit.Assert;
+
+/**
+ * Helper class to get the package local txManager from an InMemoryTxSystemClient.
+ * TODO (CDAP-7358): remove this class once TEPHRA-182 is fixed.
+ */
+public class TxInMemory {
+
+  public static TransactionManager getTransactionManager(TransactionSystemClient txClient) {
+    Assert.assertTrue("Unexpected txClient of class " + txClient.getClass().getName(),
+                      txClient instanceof InMemoryTxSystemClient);
+    return ((InMemoryTxSystemClient) txClient).txManager;
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
@@ -206,8 +206,8 @@ public class HBaseTableAdmin extends AbstractHBaseDataSetAdmin implements Updata
     ImmutableList.Builder<Class<? extends Coprocessor>> coprocessors = ImmutableList.builder();
     if (transactional) {
       // tx janitor
-      if (conf.getBoolean(TxConstants.DataJanitor.CFG_TX_JANITOR_ENABLE,
-                          TxConstants.DataJanitor.DEFAULT_TX_JANITOR_ENABLE)) {
+      if (conf.getBoolean(Constants.Transaction.DataJanitor.CFG_TX_JANITOR_ENABLE,
+                          Constants.Transaction.DataJanitor.DEFAULT_TX_JANITOR_ENABLE)) {
         coprocessors.add(dataJanitorClass);
       }
     }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/QueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/QueueTest.java
@@ -83,6 +83,11 @@ public abstract class QueueTest {
   protected static final NamespaceId NAMESPACE_ID = new NamespaceId("namespace");
   protected static final NamespaceId NAMESPACE_ID1 = new NamespaceId("namespace1");
 
+  // TODO (CDAP-7358): remove this method once TEPHRA-182 is fixed.
+  protected TransactionManager getTransactionManager() {
+    return transactionManager;
+  }
+
   @AfterClass
   public static void shutdownTx() {
     if (transactionManager != null) {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueTest.java
@@ -190,12 +190,17 @@ public abstract class HBaseQueueTest extends QueueTest {
 
     // The TransactionManager should be started by the txService.
     // We just want a reference to that so that we can ask for tx snapshot
-    transactionManager = injector.getInstance(TransactionManager.class);
     txSystemClient = injector.getInstance(TransactionSystemClient.class);
     queueClientFactory = injector.getInstance(QueueClientFactory.class);
     queueAdmin = injector.getInstance(QueueAdmin.class);
     executorFactory = injector.getInstance(TransactionExecutorFactory.class);
   }
+
+  // TODO (CDAP-7358): remove this class once TEPHRA-182 is fixed.
+  protected TransactionManager getTransactionManager() {
+    return txService.getTransactionManager();
+  }
+
 
   // TODO: CDAP-1177 Should move to QueueTest after making getApplicationName() etc instance methods in a base class
   @Test
@@ -654,7 +659,7 @@ public abstract class HBaseQueueTest extends QueueTest {
           @Override
           public TransactionVisibilityState get() {
             try {
-              return transactionManager.getSnapshot();
+              return getTransactionManager().getSnapshot();
             } catch (IOException e) {
               throw Throwables.propagate(e);
             }
@@ -672,6 +677,7 @@ public abstract class HBaseQueueTest extends QueueTest {
    * Asks the tx manager to take a snapshot.
    */
   private void takeTxSnapshot() throws Exception {
+    TransactionManager transactionManager = getTransactionManager();
     Method doSnapshot = transactionManager.getClass().getDeclaredMethod("doSnapshot", boolean.class);
     doSnapshot.setAccessible(true);
     doSnapshot.invoke(transactionManager, false);

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <snappy.version>1.1.1.7</snappy.version>
     <shiro.version>1.2.1</shiro.version>
     <slf4j.version>1.7.5</slf4j.version>
-    <tephra.version>0.8.0-incubating</tephra.version>
+    <tephra.version>0.10.0-incubating-SNAPSHOT</tephra.version>
     <thrift.version>0.9.3</thrift.version>
     <twill.version>0.8.0-SNAPSHOT</twill.version>
     <unboundid.version>2.3.6</unboundid.version>


### PR DESCRIPTION
For now, upgrades to the snapshot version. This will be changed after the 0.10 Tephra release.
Fixes failing HBase tests that rely on TransactionManager being a singleton.
