### PR TITLE
(CDAP-7355) Since ClientConfig is now immutable, bind it as well as a…

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/AbstractGetPreferencesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/AbstractGetPreferencesCommand.java
@@ -25,6 +25,7 @@ import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.common.cli.Arguments;
 import com.google.common.base.Joiner;
+import com.google.inject.Provider;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -34,11 +35,11 @@ import java.util.Map;
  * Abstract Class for getting preferences for instance, namespace, application, program.
  */
 public abstract class AbstractGetPreferencesCommand extends AbstractCommand {
-  private final PreferencesClient client;
+  private final Provider<PreferencesClient> client;
   private final ElementType type;
   private final boolean resolved;
 
-  protected AbstractGetPreferencesCommand(ElementType type, PreferencesClient client, CLIConfig cliConfig,
+  protected AbstractGetPreferencesCommand(ElementType type, Provider<PreferencesClient> client, CLIConfig cliConfig,
                                           boolean resolved) {
     super(cliConfig);
     this.type = type;
@@ -66,18 +67,19 @@ public abstract class AbstractGetPreferencesCommand extends AbstractCommand {
     switch(type) {
       case INSTANCE:
         checkInputLength(programIdParts, 0);
-        return client.getInstancePreferences();
+        return client.get().getInstancePreferences();
       case NAMESPACE:
         checkInputLength(programIdParts, 0);
-        return client.getNamespacePreferences(cliConfig.getCurrentNamespace().toId(), resolved);
+        return client.get().getNamespacePreferences(cliConfig.getCurrentNamespace().toId(), resolved);
       case APP:
-        return client.getApplicationPreferences(parseAppId(programIdParts).toId(), resolved);
+        return client.get().getApplicationPreferences(parseAppId(programIdParts).toId(), resolved);
       case FLOW:
       case MAPREDUCE:
       case WORKFLOW:
       case SERVICE:
       case SPARK:
-        return client.getProgramPreferences(parseProgramId(programIdParts, type.getProgramType()).toId(), resolved);
+        return client.get().getProgramPreferences(parseProgramId(programIdParts, type.getProgramType()).toId(),
+                                                  resolved);
       default:
         throw new IllegalArgumentException("Unrecognized element type for preferences: "  + type.getShortName());
     }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/AbstractSetPreferencesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/AbstractSetPreferencesCommand.java
@@ -21,6 +21,7 @@ import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.ElementType;
 import co.cask.cdap.cli.util.AbstractCommand;
 import co.cask.cdap.client.PreferencesClient;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.Map;
@@ -30,10 +31,10 @@ import java.util.Map;
  */
 public abstract class AbstractSetPreferencesCommand extends AbstractCommand {
 
-  private final PreferencesClient client;
+  private final Provider<PreferencesClient> client;
   private final ElementType type;
 
-  protected AbstractSetPreferencesCommand(ElementType type, PreferencesClient client, CLIConfig cliConfig) {
+  protected AbstractSetPreferencesCommand(ElementType type, Provider<PreferencesClient> client, CLIConfig cliConfig) {
     super(cliConfig);
     this.type = type;
     this.client = client;
@@ -46,18 +47,18 @@ public abstract class AbstractSetPreferencesCommand extends AbstractCommand {
     switch (type) {
       case INSTANCE:
         checkInputLength(programIdParts, 0);
-        client.setInstancePreferences(args);
+        client.get().setInstancePreferences(args);
         printSuccessMessage(printStream, type);
         break;
 
       case NAMESPACE:
         checkInputLength(programIdParts, 0);
-        client.setNamespacePreferences(cliConfig.getCurrentNamespace().toId(), args);
+        client.get().setNamespacePreferences(cliConfig.getCurrentNamespace().toId(), args);
         printSuccessMessage(printStream, type);
         break;
 
       case APP:
-        client.setApplicationPreferences(parseAppId(programIdParts).toId(), args);
+        client.get().setApplicationPreferences(parseAppId(programIdParts).toId(), args);
         printSuccessMessage(printStream, type);
         break;
 
@@ -66,7 +67,7 @@ public abstract class AbstractSetPreferencesCommand extends AbstractCommand {
       case WORKFLOW:
       case SERVICE:
       case SPARK:
-        client.setProgramPreferences(parseProgramId(programIdParts, type.getProgramType()).toId(), args);
+        client.get().setProgramPreferences(parseProgramId(programIdParts, type.getProgramType()).toId(), args);
         printSuccessMessage(printStream, type);
         break;
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CallServiceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CallServiceCommand.java
@@ -39,6 +39,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.net.URL;
@@ -50,16 +51,15 @@ import java.util.Map;
 public class CallServiceCommand extends AbstractCommand implements Categorized {
   private static final Gson GSON = new Gson();
 
-
   private final ClientConfig clientConfig;
   private final RESTClient restClient;
-  private final ServiceClient serviceClient;
+  private final Provider<ServiceClient> serviceClient;
   private final FilePathResolver filePathResolver;
 
   @Inject
-  public CallServiceCommand(ClientConfig clientConfig, RESTClient restClient,
-                            ServiceClient serviceClient, CLIConfig cliConfig,
-                            FilePathResolver filePathResolver) {
+  CallServiceCommand(ClientConfig clientConfig, RESTClient restClient,
+                     Provider<ServiceClient> serviceClient, CLIConfig cliConfig,
+                     FilePathResolver filePathResolver) {
     super(cliConfig);
     this.clientConfig = clientConfig;
     this.restClient = restClient;
@@ -94,7 +94,7 @@ public class CallServiceCommand extends AbstractCommand implements Categorized {
     }
 
     Map<String, String> headerMap = GSON.fromJson(headers, new TypeToken<Map<String, String>>() { }.getType());
-    URL url = new URL(serviceClient.getServiceURL(service.toId()), path);
+    URL url = new URL(serviceClient.get().getServiceURL(service.toId()), path);
 
     HttpMethod httpMethod = HttpMethod.valueOf(method);
     HttpRequest.Builder builder = HttpRequest.builder(httpMethod, url).addHeaders(headerMap);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CheckServiceAvailabilityCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CheckServiceAvailabilityCommand.java
@@ -30,6 +30,7 @@ import co.cask.cdap.client.ServiceClient;
 import co.cask.cdap.proto.id.ServiceId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -37,10 +38,10 @@ import java.io.PrintStream;
  * Check whether a {@link Service} has reached active status.
  */
 public class CheckServiceAvailabilityCommand extends AbstractAuthCommand implements Categorized {
-  private final ServiceClient serviceClient;
+  private final Provider<ServiceClient> serviceClient;
 
   @Inject
-  public CheckServiceAvailabilityCommand(ServiceClient serviceClient, CLIConfig cliConfig) {
+  CheckServiceAvailabilityCommand(Provider<ServiceClient> serviceClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.serviceClient = serviceClient;
   }
@@ -55,7 +56,7 @@ public class CheckServiceAvailabilityCommand extends AbstractAuthCommand impleme
     String appId = appAndServiceId[0];
     String serviceName = appAndServiceId[1];
     ServiceId serviceId = cliConfig.getCurrentNamespace().app(appId).service(serviceName);
-    output.println(serviceClient.getAvailability(serviceId.toId()));
+    output.println(serviceClient.get().getAvailability(serviceId.toId()));
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ConnectCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ConnectCommand.java
@@ -37,8 +37,7 @@ public class ConnectCommand implements Command {
   private final boolean debug;
 
   @Inject
-  public ConnectCommand(CLIConfig cliConfig, InstanceURIParser instanceURIParser,
-                        LaunchOptions launchOptions) {
+  ConnectCommand(CLIConfig cliConfig, InstanceURIParser instanceURIParser, LaunchOptions launchOptions) {
     this.cliConfig = cliConfig;
     this.instanceURIParser = instanceURIParser;
     this.debug = launchOptions.isDebug();

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateDatasetInstanceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateDatasetInstanceCommand.java
@@ -28,6 +28,7 @@ import co.cask.cdap.proto.DatasetInstanceConfiguration;
 import co.cask.common.cli.Arguments;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.Map;
@@ -38,10 +39,10 @@ import java.util.Map;
 public class CreateDatasetInstanceCommand extends AbstractAuthCommand {
 
   private static final Gson GSON = new Gson();
-  private final DatasetClient datasetClient;
+  private final Provider<DatasetClient> datasetClient;
 
   @Inject
-  public CreateDatasetInstanceCommand(DatasetClient datasetClient, CLIConfig cliConfig) {
+  CreateDatasetInstanceCommand(Provider<DatasetClient> datasetClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.datasetClient = datasetClient;
   }
@@ -50,13 +51,13 @@ public class CreateDatasetInstanceCommand extends AbstractAuthCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     String datasetType = arguments.get(ArgumentName.DATASET_TYPE.toString());
     String datasetName = arguments.get(ArgumentName.NEW_DATASET.toString());
-    String datasetPropertiesString = arguments.get(ArgumentName.DATASET_PROPERTIES.toString(), "");
-    String datasetDescription = arguments.get(ArgumentName.DATASET_DESCRIPTON.toString(), null);
+    String datasetPropertiesString = arguments.getOptional(ArgumentName.DATASET_PROPERTIES.toString(), "");
+    String datasetDescription = arguments.getOptional(ArgumentName.DATASET_DESCRIPTON.toString(), null);
     Map<String, String> datasetProperties = ArgumentParser.parseMap(datasetPropertiesString);
     DatasetInstanceConfiguration datasetConfig =
       new DatasetInstanceConfiguration(datasetType, datasetProperties, datasetDescription);
 
-    datasetClient.create(cliConfig.getCurrentNamespace().dataset(datasetName).toId(), datasetConfig);
+    datasetClient.get().create(cliConfig.getCurrentNamespace().dataset(datasetName).toId(), datasetConfig);
     output.printf("Successfully created dataset named '%s' with type '%s' and properties '%s'",
                   datasetName, datasetType, GSON.toJson(datasetProperties));
     output.println();

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateNamespaceCommand.java
@@ -25,6 +25,7 @@ import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.common.cli.Arguments;
 import co.cask.common.cli.Command;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -34,10 +35,10 @@ import java.io.PrintStream;
 public class CreateNamespaceCommand extends AbstractCommand {
   private static final String SUCCESS_MSG = "Namespace '%s' created successfully.";
 
-  private final NamespaceClient namespaceClient;
+  private final Provider<NamespaceClient> namespaceClient;
 
   @Inject
-  public CreateNamespaceCommand(CLIConfig cliConfig, NamespaceClient namespaceClient) {
+  CreateNamespaceCommand(CLIConfig cliConfig, Provider<NamespaceClient> namespaceClient) {
     super(cliConfig);
     this.namespaceClient = namespaceClient;
   }
@@ -58,7 +59,7 @@ public class CreateNamespaceCommand extends AbstractCommand {
     builder.setName(name).setDescription(description).setPrincipal(principal).setKeytabURI(keytabPath)
       .setRootDirectory(rootDir).setHBaseNamespace(hbaseNamespace).setHiveDatabase(hiveDatabase)
       .setSchedulerQueueName(schedulerQueueName);
-    namespaceClient.create(builder.build());
+    namespaceClient.get().create(builder.build());
     output.println(String.format(SUCCESS_MSG, name));
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateStreamCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateStreamCommand.java
@@ -32,6 +32,7 @@ import com.google.common.io.Files;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -46,10 +47,10 @@ public class CreateStreamCommand extends AbstractAuthCommand {
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
     .create();
-  private final StreamClient streamClient;
+  private final Provider<StreamClient> streamClient;
 
   @Inject
-  public CreateStreamCommand(StreamClient streamClient, CLIConfig cliConfig) {
+  CreateStreamCommand(Provider<StreamClient> streamClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.streamClient = streamClient;
   }
@@ -70,7 +71,7 @@ public class CreateStreamCommand extends AbstractAuthCommand {
       }
     }
 
-    streamClient.create(cliConfig.getCurrentNamespace().stream(streamId).toId(), streamProperties);
+    streamClient.get().create(cliConfig.getCurrentNamespace().stream(streamId).toId(), streamProperties);
     output.printf("Successfully created stream with ID '%s'\n", streamId);
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteDatasetInstanceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteDatasetInstanceCommand.java
@@ -26,6 +26,7 @@ import co.cask.cdap.client.DatasetClient;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -34,10 +35,10 @@ import java.io.PrintStream;
  */
 public class DeleteDatasetInstanceCommand extends AbstractAuthCommand {
 
-  private final DatasetClient datasetClient;
+  private final Provider<DatasetClient> datasetClient;
 
   @Inject
-  public DeleteDatasetInstanceCommand(DatasetClient datasetClient, CLIConfig cliConfig) {
+  DeleteDatasetInstanceCommand(Provider<DatasetClient> datasetClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.datasetClient = datasetClient;
   }
@@ -46,7 +47,7 @@ public class DeleteDatasetInstanceCommand extends AbstractAuthCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     DatasetId dataset = cliConfig.getCurrentNamespace().dataset(arguments.get(ArgumentName.DATASET.toString()));
 
-    datasetClient.delete(dataset.toId());
+    datasetClient.get().delete(dataset.toId());
     output.printf("Successfully deleted dataset instance '%s'\n", dataset.getEntityName());
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteDatasetModuleCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteDatasetModuleCommand.java
@@ -26,6 +26,7 @@ import co.cask.cdap.client.DatasetModuleClient;
 import co.cask.cdap.proto.id.DatasetModuleId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -34,10 +35,10 @@ import java.io.PrintStream;
  */
 public class DeleteDatasetModuleCommand extends AbstractAuthCommand {
 
-  private final DatasetModuleClient datasetClient;
+  private final Provider<DatasetModuleClient> datasetClient;
 
   @Inject
-  public DeleteDatasetModuleCommand(DatasetModuleClient datasetClient, CLIConfig cliConfig) {
+  DeleteDatasetModuleCommand(Provider<DatasetModuleClient> datasetClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.datasetClient = datasetClient;
   }
@@ -47,7 +48,7 @@ public class DeleteDatasetModuleCommand extends AbstractAuthCommand {
     DatasetModuleId module = cliConfig.getCurrentNamespace().datasetModule(
       arguments.get(ArgumentName.DATASET_MODULE.toString()));
 
-    datasetClient.delete(module.toId());
+    datasetClient.get().delete(module.toId());
     output.printf("Successfully deleted dataset module '%s'\n", module.getEntityName());
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteNamespaceCommand.java
@@ -27,6 +27,7 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.common.cli.Arguments;
 import co.cask.common.cli.Command;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 import jline.console.ConsoleReader;
 
 import java.io.PrintStream;
@@ -36,11 +37,11 @@ import java.io.PrintStream;
  */
 public class DeleteNamespaceCommand extends AbstractCommand {
   private static final String SUCCESS_MSG = "Namespace '%s' deleted successfully.";
-  private final NamespaceClient namespaceClient;
+  private final Provider<NamespaceClient> namespaceClient;
   private final CLIConfig cliConfig;
 
   @Inject
-  public DeleteNamespaceCommand(CLIConfig cliConfig, NamespaceClient namespaceClient) {
+  public DeleteNamespaceCommand(CLIConfig cliConfig, Provider<NamespaceClient> namespaceClient) {
     super(cliConfig);
     this.cliConfig = cliConfig;
     this.namespaceClient = namespaceClient;
@@ -57,7 +58,7 @@ public class DeleteNamespaceCommand extends AbstractCommand {
                                     namespaceId.getNamespace());
       String userConfirm = consoleReader.readLine(prompt);
       if ("y".equalsIgnoreCase(userConfirm)) {
-        namespaceClient.delete(namespaceId.toId());
+        namespaceClient.get().delete(namespaceId.toId());
         out.printf("Contents of namespace '%s' were deleted successfully", namespaceId.getNamespace());
         out.println();
       }
@@ -67,7 +68,7 @@ public class DeleteNamespaceCommand extends AbstractCommand {
                                     namespaceId.getNamespace());
       String userConfirm = consoleReader.readLine(prompt);
       if ("y".equalsIgnoreCase(userConfirm)) {
-        namespaceClient.delete(namespaceId.toId());
+        namespaceClient.get().delete(namespaceId.toId());
         out.println(String.format(SUCCESS_MSG, namespaceId));
         if (cliConfig.getCurrentNamespace().equals(namespaceId)) {
           cliConfig.setNamespace(NamespaceId.DEFAULT);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeletePreferencesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeletePreferencesCommand.java
@@ -23,6 +23,7 @@ import co.cask.cdap.cli.english.Fragment;
 import co.cask.cdap.cli.util.AbstractCommand;
 import co.cask.cdap.client.PreferencesClient;
 import co.cask.common.cli.Arguments;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -32,11 +33,11 @@ import java.io.PrintStream;
 public class DeletePreferencesCommand extends AbstractCommand {
   private static final String SUCCESS = "Deleted preferences successfully for the '%s'";
 
-  private final PreferencesClient client;
+  private final Provider<PreferencesClient> client;
   private final ElementType type;
   private final CLIConfig cliConfig;
 
-  protected DeletePreferencesCommand(ElementType type, PreferencesClient client, CLIConfig cliConfig) {
+  DeletePreferencesCommand(ElementType type, Provider<PreferencesClient> client, CLIConfig cliConfig) {
     super(cliConfig);
     this.type = type;
     this.client = client;
@@ -54,18 +55,18 @@ public class DeletePreferencesCommand extends AbstractCommand {
     switch (type) {
       case INSTANCE:
         checkInputLength(programIdParts, 0);
-        client.deleteInstancePreferences();
+        client.get().deleteInstancePreferences();
         printStream.printf(SUCCESS + "\n", type.getName());
         break;
 
       case NAMESPACE:
         checkInputLength(programIdParts, 0);
-        client.deleteNamespacePreferences(cliConfig.getCurrentNamespace().toId());
+        client.get().deleteNamespacePreferences(cliConfig.getCurrentNamespace().toId());
         printStream.printf(SUCCESS + "\n", type.getName());
         break;
 
       case APP:
-        client.deleteApplicationPreferences(parseAppId(programIdParts).toId());
+        client.get().deleteApplicationPreferences(parseAppId(programIdParts).toId());
         printStream.printf(SUCCESS + "\n", type.getName());
         break;
 
@@ -75,7 +76,7 @@ public class DeletePreferencesCommand extends AbstractCommand {
       case SERVICE:
       case SPARK:
         checkInputLength(programIdParts, 2);
-        client.deleteProgramPreferences(parseProgramId(programIdParts, type.getProgramType()).toId());
+        client.get().deleteProgramPreferences(parseProgramId(programIdParts, type.getProgramType()).toId());
         printStream.printf(SUCCESS + "\n", type.getName());
         break;
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteStreamCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteStreamCommand.java
@@ -26,6 +26,7 @@ import co.cask.cdap.client.StreamClient;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -34,10 +35,10 @@ import java.io.PrintStream;
  */
 public class DeleteStreamCommand extends AbstractAuthCommand {
 
-  private final StreamClient streamClient;
+  private final Provider<StreamClient> streamClient;
 
   @Inject
-  public DeleteStreamCommand(StreamClient streamClient, CLIConfig cliConfig) {
+  DeleteStreamCommand(Provider<StreamClient> streamClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.streamClient = streamClient;
   }
@@ -45,7 +46,7 @@ public class DeleteStreamCommand extends AbstractAuthCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     StreamId streamId = cliConfig.getCurrentNamespace().stream(arguments.get(ArgumentName.STREAM.toString()));
-    streamClient.delete(streamId.toId());
+    streamClient.get().delete(streamId.toId());
     output.printf("Successfully deleted stream '%s'\n", streamId.getEntityName());
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteWorkflowLocalDatasetsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteWorkflowLocalDatasetsCommand.java
@@ -25,6 +25,7 @@ import co.cask.cdap.client.WorkflowClient;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.common.cli.Arguments;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -33,9 +34,9 @@ import java.io.PrintStream;
  */
 public class DeleteWorkflowLocalDatasetsCommand extends AbstractCommand {
   private final ElementType elementType;
-  private final WorkflowClient workflowClient;
+  private final Provider<WorkflowClient> workflowClient;
 
-  public DeleteWorkflowLocalDatasetsCommand(WorkflowClient workflowClient, CLIConfig cliConfig) {
+  DeleteWorkflowLocalDatasetsCommand(Provider<WorkflowClient> workflowClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.elementType = ElementType.WORKFLOW;
     this.workflowClient = workflowClient;
@@ -53,7 +54,7 @@ public class DeleteWorkflowLocalDatasetsCommand extends AbstractCommand {
                                                  ProgramType.WORKFLOW, programIdParts[1],
                                                  arguments.get(ArgumentName.RUN_ID.toString()));
 
-    workflowClient.deleteWorkflowLocalDatasets(programRunId);
+    workflowClient.get().deleteWorkflowLocalDatasets(programRunId);
     printStream.printf("Successfully deleted local datasets associated with the workflow run.");
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeployDatasetModuleCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeployDatasetModuleCommand.java
@@ -27,6 +27,7 @@ import co.cask.cdap.client.DatasetModuleClient;
 import co.cask.common.cli.Arguments;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.File;
 import java.io.PrintStream;
@@ -36,11 +37,11 @@ import java.io.PrintStream;
  */
 public class DeployDatasetModuleCommand extends AbstractAuthCommand {
 
-  private final DatasetModuleClient datasetModuleClient;
+  private final Provider<DatasetModuleClient> datasetModuleClient;
   private final FilePathResolver resolver;
 
   @Inject
-  public DeployDatasetModuleCommand(DatasetModuleClient datasetModuleClient, FilePathResolver resolver,
+  DeployDatasetModuleCommand(Provider<DatasetModuleClient> datasetModuleClient, FilePathResolver resolver,
                                     CLIConfig cliConfig) {
     super(cliConfig);
     this.datasetModuleClient = datasetModuleClient;
@@ -56,8 +57,8 @@ public class DeployDatasetModuleCommand extends AbstractAuthCommand {
     String moduleName = arguments.get(ArgumentName.NEW_DATASET_MODULE.toString());
     String moduleJarClassname = arguments.get(ArgumentName.DATASET_MODULE_JAR_CLASSNAME.toString());
 
-    datasetModuleClient.add(cliConfig.getCurrentNamespace().datasetModule(moduleName).toId(),
-                            moduleJarClassname, moduleJarFile);
+    datasetModuleClient.get().add(cliConfig.getCurrentNamespace().datasetModule(moduleName).toId(),
+                                  moduleJarClassname, moduleJarFile);
     output.printf("Successfully deployed dataset module '%s'\n", moduleName);
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeDatasetInstanceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeDatasetInstanceCommand.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -42,10 +43,10 @@ import java.util.List;
 public class DescribeDatasetInstanceCommand extends AbstractAuthCommand {
 
   private static final Gson GSON = new Gson();
-  private final DatasetClient datasetClient;
+  private final Provider<DatasetClient> datasetClient;
 
   @Inject
-  public DescribeDatasetInstanceCommand(DatasetClient datasetClient, CLIConfig cliConfig) {
+  DescribeDatasetInstanceCommand(Provider<DatasetClient> datasetClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.datasetClient = datasetClient;
   }
@@ -53,7 +54,7 @@ public class DescribeDatasetInstanceCommand extends AbstractAuthCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     DatasetId instance = cliConfig.getCurrentNamespace().dataset(arguments.get(ArgumentName.DATASET.toString()));
-    DatasetMeta meta = datasetClient.get(instance.toId());
+    DatasetMeta meta = datasetClient.get().get(instance.toId());
 
     Table table = Table.builder()
       .setHeader("hive table", "spec", "type")

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeDatasetModuleCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeDatasetModuleCommand.java
@@ -32,6 +32,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -41,10 +42,10 @@ import java.util.List;
  */
 public class DescribeDatasetModuleCommand extends AbstractAuthCommand {
 
-  private final DatasetModuleClient datasetModuleClient;
+  private final Provider<DatasetModuleClient> datasetModuleClient;
 
   @Inject
-  public DescribeDatasetModuleCommand(DatasetModuleClient datasetModuleClient, CLIConfig cliConfig) {
+  DescribeDatasetModuleCommand(Provider<DatasetModuleClient> datasetModuleClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.datasetModuleClient = datasetModuleClient;
   }
@@ -53,7 +54,7 @@ public class DescribeDatasetModuleCommand extends AbstractAuthCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     DatasetModuleId moduleId = cliConfig.getCurrentNamespace().datasetModule(
       arguments.get(ArgumentName.DATASET_MODULE.toString()));
-    DatasetModuleMeta datasetModuleMeta = datasetModuleClient.get(moduleId.toId());
+    DatasetModuleMeta datasetModuleMeta = datasetModuleClient.get().get(moduleId.toId());
 
     Table table = Table.builder()
       .setHeader("name", "className", "jarLocation", "types", "usesModules", "usedByModules")

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeDatasetTypeCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeDatasetTypeCommand.java
@@ -32,6 +32,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -41,10 +42,10 @@ import java.util.List;
  */
 public class DescribeDatasetTypeCommand extends AbstractAuthCommand {
 
-  private final DatasetTypeClient datasetTypeClient;
+  private final Provider<DatasetTypeClient> datasetTypeClient;
 
   @Inject
-  public DescribeDatasetTypeCommand(DatasetTypeClient datasetTypeClient, CLIConfig cliConfig) {
+  DescribeDatasetTypeCommand(Provider<DatasetTypeClient> datasetTypeClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.datasetTypeClient = datasetTypeClient;
   }
@@ -53,7 +54,7 @@ public class DescribeDatasetTypeCommand extends AbstractAuthCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     DatasetTypeId type = cliConfig.getCurrentNamespace().datasetType(
       arguments.get(ArgumentName.DATASET_TYPE.toString()));
-    DatasetTypeMeta datasetTypeMeta = datasetTypeClient.get(type.toId());
+    DatasetTypeMeta datasetTypeMeta = datasetTypeClient.get().get(type.toId());
 
     Table table = Table.builder()
       .setHeader("name", "modules")

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeNamespaceCommand.java
@@ -31,6 +31,7 @@ import co.cask.common.cli.Arguments;
 import co.cask.common.cli.Command;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -40,10 +41,10 @@ import java.util.List;
  */
 public class DescribeNamespaceCommand extends AbstractCommand {
 
-  private final NamespaceClient namespaceClient;
+  private final Provider<NamespaceClient> namespaceClient;
 
   @Inject
-  public DescribeNamespaceCommand(CLIConfig cliConfig, NamespaceClient namespaceClient) {
+  DescribeNamespaceCommand(CLIConfig cliConfig, Provider<NamespaceClient> namespaceClient) {
     super(cliConfig);
     this.namespaceClient = namespaceClient;
   }
@@ -51,7 +52,7 @@ public class DescribeNamespaceCommand extends AbstractCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     NamespaceId namespace = new NamespaceId(arguments.get(ArgumentName.NAMESPACE_NAME.getName()));
-    NamespaceMeta namespaceMeta = namespaceClient.get(namespace.toId());
+    NamespaceMeta namespaceMeta = namespaceClient.get().get(namespace.toId());
     Table table = Table.builder()
       .setHeader("name", "description", "config")
       .setRows(Lists.newArrayList(namespaceMeta), new RowMaker<NamespaceMeta>() {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeStreamCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeStreamCommand.java
@@ -32,6 +32,7 @@ import co.cask.common.cli.Arguments;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -41,10 +42,10 @@ import java.util.List;
  */
 public class DescribeStreamCommand extends AbstractAuthCommand {
 
-  private final StreamClient streamClient;
+  private final Provider<StreamClient> streamClient;
 
   @Inject
-  public DescribeStreamCommand(StreamClient streamClient, CLIConfig cliConfig) {
+  DescribeStreamCommand(Provider<StreamClient> streamClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.streamClient = streamClient;
   }
@@ -52,7 +53,7 @@ public class DescribeStreamCommand extends AbstractAuthCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     StreamId streamId = cliConfig.getCurrentNamespace().stream(arguments.get(ArgumentName.STREAM.toString()));
-    StreamProperties config = streamClient.getConfig(streamId.toId());
+    StreamProperties config = streamClient.get().getConfig(streamId.toId());
 
     Table table = Table.builder()
       .setHeader("ttl", "format", "schema", "notification.threshold.mb", "description")

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ExecuteQueryCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ExecuteQueryCommand.java
@@ -37,6 +37,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.sql.SQLException;
@@ -52,10 +53,10 @@ import java.util.concurrent.TimeoutException;
 public class ExecuteQueryCommand extends AbstractAuthCommand implements Categorized {
 
   private static final long DEFAULT_TIMEOUT_MIN = Long.MAX_VALUE;
-  private final QueryClient queryClient;
+  private final Provider<QueryClient> queryClient;
 
   @Inject
-  public ExecuteQueryCommand(QueryClient queryClient, CLIConfig cliConfig) {
+  ExecuteQueryCommand(Provider<QueryClient> queryClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.queryClient = queryClient;
   }
@@ -65,8 +66,8 @@ public class ExecuteQueryCommand extends AbstractAuthCommand implements Categori
     String query = arguments.get(ArgumentName.QUERY.toString());
     long timeOutMins = arguments.getLong(ArgumentName.TIMEOUT.toString(), DEFAULT_TIMEOUT_MIN);
 
-    ListenableFuture<ExploreExecutionResult> future = queryClient.execute(cliConfig.getCurrentNamespace().toId(),
-                                                                          query);
+    ListenableFuture<ExploreExecutionResult> future = queryClient.get().execute(cliConfig.getCurrentNamespace().toId(),
+                                                                                query);
     try {
       ExploreExecutionResult executionResult = future.get(timeOutMins, TimeUnit.MINUTES);
       if (!executionResult.canContainResults()) {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetDatasetInstancePropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetDatasetInstancePropertiesCommand.java
@@ -27,6 +27,7 @@ import co.cask.cdap.proto.id.DatasetId;
 import co.cask.common.cli.Arguments;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.Map;
@@ -37,10 +38,10 @@ import java.util.Map;
 public class GetDatasetInstancePropertiesCommand extends AbstractCommand {
 
   private static final Gson GSON = new Gson();
-  private final DatasetClient datasetClient;
+  private final Provider<DatasetClient> datasetClient;
 
   @Inject
-  public GetDatasetInstancePropertiesCommand(DatasetClient datasetClient, CLIConfig cliConfig) {
+  GetDatasetInstancePropertiesCommand(Provider<DatasetClient> datasetClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.datasetClient = datasetClient;
   }
@@ -50,7 +51,7 @@ public class GetDatasetInstancePropertiesCommand extends AbstractCommand {
     DatasetId instance = cliConfig.getCurrentNamespace().dataset(
       arguments.get(ArgumentName.DATASET.toString()));
 
-    Map<String, String> properties = datasetClient.getProperties(instance.toId());
+    Map<String, String> properties = datasetClient.get().getProperties(instance.toId());
     output.printf(GSON.toJson(properties));
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetPreferencesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetPreferencesCommand.java
@@ -21,6 +21,7 @@ import co.cask.cdap.cli.ElementType;
 import co.cask.cdap.cli.english.Article;
 import co.cask.cdap.cli.english.Fragment;
 import co.cask.cdap.client.PreferencesClient;
+import com.google.inject.Provider;
 
 /**
  * Gets preferences for instance, namespace, application, program.
@@ -28,7 +29,7 @@ import co.cask.cdap.client.PreferencesClient;
 public class GetPreferencesCommand extends AbstractGetPreferencesCommand {
   private final ElementType type;
 
-  protected GetPreferencesCommand(ElementType type, PreferencesClient client, CLIConfig cliConfig) {
+  GetPreferencesCommand(ElementType type, Provider<PreferencesClient> client, CLIConfig cliConfig) {
     super(type, client, cliConfig, false);
     this.type = type;
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramInstancesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramInstancesCommand.java
@@ -28,6 +28,7 @@ import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.FlowletId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.common.cli.Arguments;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -36,10 +37,10 @@ import java.io.PrintStream;
  */
 public class GetProgramInstancesCommand extends AbstractAuthCommand {
 
-  private final ProgramClient programClient;
+  private final Provider<ProgramClient> programClient;
   private final ElementType elementType;
 
-  protected GetProgramInstancesCommand(ElementType elementType, ProgramClient programClient, CLIConfig cliConfig) {
+  GetProgramInstancesCommand(ElementType elementType, Provider<ProgramClient> programClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.elementType = elementType;
     this.programClient = programClient;
@@ -60,7 +61,7 @@ public class GetProgramInstancesCommand extends AbstractAuthCommand {
         String flowId = programIdParts[1];
         String flowletName = programIdParts[2];
         FlowletId flowlet = appId.flow(flowId).flowlet(flowletName);
-        instances = programClient.getFlowletInstances(flowlet.toId());
+        instances = programClient.get().getFlowletInstances(flowlet.toId());
         break;
       case WORKER:
         if (programIdParts.length < 2)  {
@@ -68,14 +69,14 @@ public class GetProgramInstancesCommand extends AbstractAuthCommand {
         }
         String workerId = programIdParts[1];
         ProgramId worker = appId.worker(workerId);
-        instances = programClient.getWorkerInstances(Id.Worker.from(worker.getParent().toId(), workerId));
+        instances = programClient.get().getWorkerInstances(Id.Worker.from(worker.getParent().toId(), workerId));
         break;
       case SERVICE:
         if (programIdParts.length < 2) {
           throw new CommandInputError(this);
         }
         String serviceName = programIdParts[1];
-        instances = programClient.getServiceInstances(appId.service(serviceName).toId());
+        instances = programClient.get().getServiceInstances(appId.service(serviceName).toId());
         break;
       default:
         // TODO: remove this

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramInstancesCommandSet.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramInstancesCommandSet.java
@@ -23,7 +23,9 @@ import co.cask.common.cli.Command;
 import co.cask.common.cli.CommandSet;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -32,12 +34,12 @@ import java.util.List;
 public class GetProgramInstancesCommandSet extends CommandSet<Command> {
 
   @Inject
-  public GetProgramInstancesCommandSet(ProgramClient programClient, CLIConfig cliConfig) {
+  GetProgramInstancesCommandSet(Provider<ProgramClient> programClient, CLIConfig cliConfig) {
     super(generateCommands(programClient, cliConfig));
   }
 
-  private static List<Command> generateCommands(ProgramClient programClient, CLIConfig cliConfig) {
-    List<Command> commands = Lists.newArrayList();
+  private static List<Command> generateCommands(Provider<ProgramClient> programClient, CLIConfig cliConfig) {
+    List<Command> commands = new ArrayList<>();
     for (ElementType elementType : ElementType.values()) {
       if (elementType.canScale()) {
         commands.add(new GetProgramInstancesCommand(elementType, programClient, cliConfig));

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLiveInfoCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLiveInfoCommand.java
@@ -31,6 +31,7 @@ import co.cask.cdap.proto.id.ProgramId;
 import co.cask.common.cli.Arguments;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -40,10 +41,10 @@ import java.util.List;
  */
 public class GetProgramLiveInfoCommand extends AbstractAuthCommand {
 
-  private final ProgramClient programClient;
+  private final Provider<ProgramClient> programClient;
   private final ElementType elementType;
 
-  protected GetProgramLiveInfoCommand(ElementType elementType, ProgramClient programClient, CLIConfig cliConfig) {
+  GetProgramLiveInfoCommand(ElementType elementType, Provider<ProgramClient> programClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.elementType = elementType;
     this.programClient = programClient;
@@ -58,7 +59,7 @@ public class GetProgramLiveInfoCommand extends AbstractAuthCommand {
     String appId = programIdParts[0];
     String programName = programIdParts[1];
     ProgramId program = cliConfig.getCurrentNamespace().app(appId).program(elementType.getProgramType(), programName);
-    DistributedProgramLiveInfo liveInfo = programClient.getLiveInfo(program.toId());
+    DistributedProgramLiveInfo liveInfo = programClient.get().getLiveInfo(program.toId());
 
     if (liveInfo == null) {
       output.println("No live info found");

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLiveInfoCommandSet.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLiveInfoCommandSet.java
@@ -21,9 +21,10 @@ import co.cask.cdap.cli.ElementType;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.common.cli.Command;
 import co.cask.common.cli.CommandSet;
-import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -32,12 +33,12 @@ import java.util.List;
 public class GetProgramLiveInfoCommandSet extends CommandSet<Command> {
 
   @Inject
-  public GetProgramLiveInfoCommandSet(ProgramClient programClient, CLIConfig cliConfig) {
+  GetProgramLiveInfoCommandSet(Provider<ProgramClient> programClient, CLIConfig cliConfig) {
     super(generateCommands(programClient, cliConfig));
   }
 
-  private static List<Command> generateCommands(ProgramClient programClient, CLIConfig cliConfig) {
-    List<Command> commands = Lists.newArrayList();
+  private static List<Command> generateCommands(Provider<ProgramClient> programClient, CLIConfig cliConfig) {
+    List<Command> commands = new ArrayList<>();
     for (ElementType elementType : ElementType.values()) {
       if (elementType.hasLiveInfo()) {
         commands.add(new GetProgramLiveInfoCommand(elementType, programClient, cliConfig));

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLogsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLogsCommand.java
@@ -27,6 +27,7 @@ import co.cask.cdap.client.ProgramClient;
 import co.cask.cdap.common.utils.TimeMathParser;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.common.cli.Arguments;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -35,10 +36,10 @@ import java.io.PrintStream;
  */
 public class GetProgramLogsCommand extends AbstractAuthCommand {
 
-  private final ProgramClient programClient;
+  private final Provider<ProgramClient> programClient;
   private final ElementType elementType;
 
-  protected GetProgramLogsCommand(ElementType elementType, ProgramClient programClient, CLIConfig cliConfig) {
+  GetProgramLogsCommand(ElementType elementType, Provider<ProgramClient> programClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.elementType = elementType;
     this.programClient = programClient;
@@ -48,9 +49,9 @@ public class GetProgramLogsCommand extends AbstractAuthCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     String[] programIdParts = arguments.get(elementType.getArgumentName().toString()).split("\\.");
     String appId = programIdParts[0];
-    String startString = arguments.get(ArgumentName.START_TIME.toString(), "0");
+    String startString = arguments.getOptional(ArgumentName.START_TIME.toString(), "0");
     long start = TimeMathParser.parseTimeInSeconds(startString);
-    String stopString = arguments.get(ArgumentName.END_TIME.toString(), Long.toString(Integer.MAX_VALUE));
+    String stopString = arguments.getOptional(ArgumentName.END_TIME.toString(), Long.toString(Integer.MAX_VALUE));
     long stop = TimeMathParser.parseTimeInSeconds(stopString);
 
     String logs;
@@ -61,7 +62,7 @@ public class GetProgramLogsCommand extends AbstractAuthCommand {
       String programName = programIdParts[1];
       ProgramId programId = cliConfig.getCurrentNamespace().app(appId).program(elementType.getProgramType(),
                                                                                programName);
-      logs = programClient.getProgramLogs(programId.toId(), start, stop);
+      logs = programClient.get().getProgramLogs(programId.toId(), start, stop);
     } else {
       throw new IllegalArgumentException("Cannot get logs for " + elementType.getNamePlural());
     }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLogsCommandSet.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramLogsCommandSet.java
@@ -21,9 +21,10 @@ import co.cask.cdap.cli.ElementType;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.common.cli.Command;
 import co.cask.common.cli.CommandSet;
-import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -32,12 +33,12 @@ import java.util.List;
 public class GetProgramLogsCommandSet extends CommandSet<Command> {
 
   @Inject
-  public GetProgramLogsCommandSet(ProgramClient programClient, CLIConfig cliConfig) {
+  GetProgramLogsCommandSet(Provider<ProgramClient> programClient, CLIConfig cliConfig) {
     super(generateCommands(programClient, cliConfig));
   }
 
-  private static List<Command> generateCommands(ProgramClient programClient, CLIConfig cliConfig) {
-    List<Command> commands = Lists.newArrayList();
+  private static List<Command> generateCommands(Provider<ProgramClient> programClient, CLIConfig cliConfig) {
+    List<Command> commands = new ArrayList<>();
     for (ElementType elementType : ElementType.values()) {
       if (elementType.hasLogs()) {
         commands.add(new GetProgramLogsCommand(elementType, programClient, cliConfig));

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRunsCommandSet.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRunsCommandSet.java
@@ -21,9 +21,10 @@ import co.cask.cdap.cli.ElementType;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.common.cli.Command;
 import co.cask.common.cli.CommandSet;
-import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -32,12 +33,12 @@ import java.util.List;
 public class GetProgramRunsCommandSet extends CommandSet<Command> {
 
   @Inject
-  public GetProgramRunsCommandSet(ProgramClient programClient, CLIConfig cliConfig) {
+  GetProgramRunsCommandSet(Provider<ProgramClient> programClient, CLIConfig cliConfig) {
     super(generateCommands(programClient, cliConfig));
   }
 
-  private static Iterable<Command> generateCommands(ProgramClient programClient, CLIConfig cliConfig) {
-    List<Command> commands = Lists.newArrayList();
+  private static Iterable<Command> generateCommands(Provider<ProgramClient> programClient, CLIConfig cliConfig) {
+    List<Command> commands = new ArrayList<>();
     for (ElementType elementType : ElementType.values()) {
       if (elementType.hasRuns()) {
         commands.add(new GetProgramRunsCommand(elementType, programClient, cliConfig));

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRuntimeArgsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRuntimeArgsCommand.java
@@ -25,6 +25,7 @@ import co.cask.cdap.client.ProgramClient;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.common.cli.Arguments;
 import com.google.gson.Gson;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.Map;
@@ -36,10 +37,10 @@ public class GetProgramRuntimeArgsCommand extends AbstractAuthCommand {
 
   private static final Gson GSON = new Gson();
 
-  private final ProgramClient programClient;
+  private final Provider<ProgramClient> programClient;
   private final ElementType elementType;
 
-  public GetProgramRuntimeArgsCommand(ElementType elementType, ProgramClient programClient, CLIConfig cliConfig) {
+  GetProgramRuntimeArgsCommand(ElementType elementType, Provider<ProgramClient> programClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.elementType = elementType;
     this.programClient = programClient;
@@ -51,7 +52,7 @@ public class GetProgramRuntimeArgsCommand extends AbstractAuthCommand {
     String appId = programIdParts[0];
     String programName = programIdParts[1];
     ProgramId programId = cliConfig.getCurrentNamespace().app(appId).program(elementType.getProgramType(), programName);
-    Map<String, String> runtimeArgs = programClient.getRuntimeArgs(programId.toId());
+    Map<String, String> runtimeArgs = programClient.get().getRuntimeArgs(programId.toId());
     output.printf(GSON.toJson(runtimeArgs));
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRuntimeArgsCommandSet.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRuntimeArgsCommandSet.java
@@ -23,7 +23,9 @@ import co.cask.common.cli.Command;
 import co.cask.common.cli.CommandSet;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -32,12 +34,12 @@ import java.util.List;
 public class GetProgramRuntimeArgsCommandSet extends CommandSet<Command> {
 
   @Inject
-  public GetProgramRuntimeArgsCommandSet(ProgramClient programClient, CLIConfig cliConfig) {
+  GetProgramRuntimeArgsCommandSet(Provider<ProgramClient> programClient, CLIConfig cliConfig) {
     super(generateCommands(programClient, cliConfig));
   }
 
-  public static List<Command> generateCommands(ProgramClient programClient, CLIConfig cliConfig) {
-    List<Command> commands = Lists.newArrayList();
+  public static List<Command> generateCommands(Provider<ProgramClient> programClient, CLIConfig cliConfig) {
+    List<Command> commands = new ArrayList<>();
     for (ElementType elementType : ElementType.values()) {
       if (elementType.hasRuntimeArgs()) {
         commands.add(new GetProgramRuntimeArgsCommand(elementType, programClient, cliConfig));

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramStatusCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramStatusCommand.java
@@ -25,6 +25,7 @@ import co.cask.cdap.cli.util.AbstractAuthCommand;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.common.cli.Arguments;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -33,10 +34,10 @@ import java.io.PrintStream;
  */
 public class GetProgramStatusCommand extends AbstractAuthCommand {
 
-  private final ProgramClient programClient;
+  private final Provider<ProgramClient> programClient;
   private final ElementType elementType;
 
-  protected GetProgramStatusCommand(ElementType elementType, ProgramClient programClient, CLIConfig cliConfig) {
+  GetProgramStatusCommand(ElementType elementType, Provider<ProgramClient> programClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.elementType = elementType;
     this.programClient = programClient;
@@ -52,7 +53,7 @@ public class GetProgramStatusCommand extends AbstractAuthCommand {
     String appId = programIdParts[0];
     String programName = programIdParts[1];
     ProgramId programId = cliConfig.getCurrentNamespace().app(appId).program(elementType.getProgramType(), programName);
-    String status = programClient.getStatus(programId.toId());
+    String status = programClient.get().getStatus(programId.toId());
     output.println(status);
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramStatusCommandSet.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramStatusCommandSet.java
@@ -21,9 +21,10 @@ import co.cask.cdap.cli.ElementType;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.common.cli.Command;
 import co.cask.common.cli.CommandSet;
-import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -32,12 +33,12 @@ import java.util.List;
 public class GetProgramStatusCommandSet extends CommandSet<Command> {
 
   @Inject
-  public GetProgramStatusCommandSet(ProgramClient programClient, CLIConfig cliConfig) {
+  GetProgramStatusCommandSet(Provider<ProgramClient> programClient, CLIConfig cliConfig) {
     super(generateCommands(programClient, cliConfig));
   }
 
-  private static List<Command> generateCommands(ProgramClient programClient, CLIConfig cliConfig) {
-    List<Command> commands = Lists.newArrayList();
+  private static List<Command> generateCommands(Provider<ProgramClient> programClient, CLIConfig cliConfig) {
+    List<Command> commands = new ArrayList<>();
     for (ElementType elementType : ElementType.values()) {
       if (elementType.hasStatus()) {
         commands.add(new GetProgramStatusCommand(elementType, programClient, cliConfig));

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetResolvedPreferencesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetResolvedPreferencesCommand.java
@@ -21,6 +21,7 @@ import co.cask.cdap.cli.ElementType;
 import co.cask.cdap.cli.english.Article;
 import co.cask.cdap.cli.english.Fragment;
 import co.cask.cdap.client.PreferencesClient;
+import com.google.inject.Provider;
 
 /**
  * Get Resolved Preferences for instance, namespace, application, program
@@ -28,7 +29,7 @@ import co.cask.cdap.client.PreferencesClient;
 public class GetResolvedPreferencesCommand extends AbstractGetPreferencesCommand {
   private final ElementType type;
 
-  protected GetResolvedPreferencesCommand(ElementType type, PreferencesClient client, CLIConfig cliConfig) {
+  GetResolvedPreferencesCommand(ElementType type, Provider<PreferencesClient> client, CLIConfig cliConfig) {
     super(type, client, cliConfig, true);
     this.type = type;
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetServiceEndpointsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetServiceEndpointsCommand.java
@@ -34,6 +34,7 @@ import co.cask.cdap.proto.id.ServiceId;
 import co.cask.common.cli.Arguments;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -43,10 +44,10 @@ import java.util.List;
  */
 public class GetServiceEndpointsCommand extends AbstractAuthCommand implements Categorized {
 
-  private final ServiceClient serviceClient;
+  private final Provider<ServiceClient> serviceClient;
 
   @Inject
-  public GetServiceEndpointsCommand(ServiceClient serviceClient, CLIConfig cliConfig) {
+  GetServiceEndpointsCommand(Provider<ServiceClient> serviceClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.serviceClient = serviceClient;
   }
@@ -61,7 +62,7 @@ public class GetServiceEndpointsCommand extends AbstractAuthCommand implements C
     String appId = appAndServiceId[0];
     String serviceName = appAndServiceId[1];
     ServiceId serviceId = cliConfig.getCurrentNamespace().app(appId).service(serviceName);
-    List<ServiceHttpEndpoint> endpoints = serviceClient.getEndpoints(serviceId.toId());
+    List<ServiceHttpEndpoint> endpoints = serviceClient.get().getEndpoints(serviceId.toId());
 
     Table table = Table.builder()
       .setHeader("method", "path")

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetStreamEventsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetStreamEventsCommand.java
@@ -30,8 +30,10 @@ import co.cask.cdap.proto.id.StreamId;
 import co.cask.common.cli.Arguments;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -39,10 +41,10 @@ import java.util.List;
  */
 public class GetStreamEventsCommand extends AbstractCommand {
 
-  private final StreamClient streamClient;
+  private final Provider<StreamClient> streamClient;
 
   @Inject
-  public GetStreamEventsCommand(StreamClient streamClient, CLIConfig cliConfig) {
+  GetStreamEventsCommand(Provider<StreamClient> streamClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.streamClient = streamClient;
   }
@@ -52,13 +54,13 @@ public class GetStreamEventsCommand extends AbstractCommand {
     long currentTime = System.currentTimeMillis();
 
     StreamId streamId = cliConfig.getCurrentNamespace().stream(arguments.get(ArgumentName.STREAM.toString()));
-    long startTime = getTimestamp(arguments.get(ArgumentName.START_TIME.toString(), "min"), currentTime);
-    long endTime = getTimestamp(arguments.get(ArgumentName.END_TIME.toString(), "max"), currentTime);
+    long startTime = getTimestamp(arguments.getOptional(ArgumentName.START_TIME.toString(), "min"), currentTime);
+    long endTime = getTimestamp(arguments.getOptional(ArgumentName.END_TIME.toString(), "max"), currentTime);
     int limit = arguments.getInt(ArgumentName.LIMIT.toString(), Integer.MAX_VALUE);
 
     // Get a list of stream events and prints it.
-    List<StreamEvent> events = streamClient.getEvents(streamId.toId(), startTime, endTime,
-                                                      limit, Lists.<StreamEvent>newArrayList());
+    List<StreamEvent> events = streamClient.get().getEvents(streamId.toId(), startTime, endTime,
+                                                            limit, new ArrayList<StreamEvent>());
     Table table = Table.builder()
       .setHeader("timestamp", "headers", "body size", "body")
       .setRows(events, new RowMaker<StreamEvent>() {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowCurrentRunCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowCurrentRunCommand.java
@@ -28,6 +28,7 @@ import co.cask.cdap.client.ProgramClient;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.common.cli.Arguments;
 import com.google.common.collect.Lists;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -37,10 +38,10 @@ import java.util.List;
  */
 public class GetWorkflowCurrentRunCommand extends AbstractCommand {
 
-  private final ProgramClient programClient;
+  private final Provider<ProgramClient> programClient;
   private final ElementType elementType;
 
-  protected GetWorkflowCurrentRunCommand(ElementType elementType, ProgramClient programClient, CLIConfig cliConfig) {
+  GetWorkflowCurrentRunCommand(ElementType elementType, Provider<ProgramClient> programClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.elementType = elementType;
     this.programClient = programClient;
@@ -59,7 +60,7 @@ public class GetWorkflowCurrentRunCommand extends AbstractCommand {
       String workflowId = programIdParts[1];
       String runId = arguments.get(ArgumentName.RUN_ID.toString());
 
-      nodes = programClient.getWorkflowCurrent(appId.toId(), workflowId, runId);
+      nodes = programClient.get().getWorkflowCurrent(appId.toId(), workflowId, runId);
     } else {
       throw new IllegalArgumentException("Unrecognized program element type for current runs: " + elementType);
     }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowLocalDatasetsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowLocalDatasetsCommand.java
@@ -30,6 +30,7 @@ import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.common.cli.Arguments;
 import com.google.common.collect.Lists;
+import com.google.inject.Provider;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -42,9 +43,9 @@ import java.util.Map;
  */
 public class GetWorkflowLocalDatasetsCommand extends AbstractCommand {
   private final ElementType elementType;
-  private final WorkflowClient workflowClient;
+  private final Provider<WorkflowClient> workflowClient;
 
-  public GetWorkflowLocalDatasetsCommand(WorkflowClient workflowClient, CLIConfig cliConfig) {
+  GetWorkflowLocalDatasetsCommand(Provider<WorkflowClient> workflowClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.elementType = ElementType.WORKFLOW;
     this.workflowClient = workflowClient;
@@ -78,7 +79,7 @@ public class GetWorkflowLocalDatasetsCommand extends AbstractCommand {
   private Table getWorkflowLocalDatasets(ProgramRunId programRunId)
     throws UnauthenticatedException, IOException, NotFoundException, UnauthorizedException {
     Map<String, DatasetSpecificationSummary> workflowLocalDatasets
-      = workflowClient.getWorkflowLocalDatasets(programRunId);
+      = workflowClient.get().getWorkflowLocalDatasets(programRunId);
     List<Map.Entry<String, DatasetSpecificationSummary>> localDatasetSummaries = new ArrayList<>();
     localDatasetSummaries.addAll(workflowLocalDatasets.entrySet());
     return Table.builder()

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowStateCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowStateCommand.java
@@ -31,6 +31,7 @@ import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.common.cli.Arguments;
 import com.google.common.collect.Lists;
+import com.google.inject.Provider;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -43,14 +44,13 @@ import java.util.Map;
  */
 public class GetWorkflowStateCommand extends AbstractCommand {
   private final ElementType elementType;
-  private final WorkflowClient workflowClient;
+  private final Provider<WorkflowClient> workflowClient;
 
-  public GetWorkflowStateCommand(WorkflowClient workflowClient, CLIConfig cliConfig) {
+  GetWorkflowStateCommand(Provider<WorkflowClient> workflowClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.elementType = ElementType.WORKFLOW;
     this.workflowClient = workflowClient;
   }
-
 
   @Override
   public void perform(Arguments arguments, PrintStream printStream) throws Exception {
@@ -79,7 +79,7 @@ public class GetWorkflowStateCommand extends AbstractCommand {
 
   private Table getWorkflowNodeStates(ProgramRunId programRunId)
     throws UnauthenticatedException, IOException, NotFoundException, UnauthorizedException {
-    Map<String, WorkflowNodeStateDetail> workflowNodeStates = workflowClient.getWorkflowNodeStates(programRunId);
+    Map<String, WorkflowNodeStateDetail> workflowNodeStates = workflowClient.get().getWorkflowNodeStates(programRunId);
     List<Map.Entry<String, WorkflowNodeStateDetail>> nodeStates = new ArrayList<>();
     nodeStates.addAll(workflowNodeStates.entrySet());
     return Table.builder()

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowTokenCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowTokenCommand.java
@@ -36,6 +36,7 @@ import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.common.cli.Arguments;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
+import com.google.inject.Provider;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -50,9 +51,9 @@ public class GetWorkflowTokenCommand extends AbstractCommand {
   private static final Gson GSON = new Gson();
 
   private final ElementType elementType;
-  private final WorkflowClient workflowClient;
+  private final Provider<WorkflowClient> workflowClient;
 
-  public GetWorkflowTokenCommand(WorkflowClient workflowClient, CLIConfig cliConfig) {
+  GetWorkflowTokenCommand(Provider<WorkflowClient> workflowClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.elementType = ElementType.WORKFLOW;
     this.workflowClient = workflowClient;
@@ -102,7 +103,7 @@ public class GetWorkflowTokenCommand extends AbstractCommand {
 
   private Table getWorkflowToken(ProgramRunId runId, WorkflowToken.Scope workflowTokenScope, String key)
     throws UnauthenticatedException, IOException, NotFoundException, UnauthorizedException {
-    WorkflowTokenDetail workflowToken = workflowClient.getWorkflowToken(runId.toId(), workflowTokenScope, key);
+    WorkflowTokenDetail workflowToken = workflowClient.get().getWorkflowToken(runId.toId(), workflowTokenScope, key);
     List<Map.Entry<String, List<WorkflowTokenDetail.NodeValueDetail>>> tokenKeys = new ArrayList<>();
     tokenKeys.addAll(workflowToken.getTokenData().entrySet());
     return Table.builder()
@@ -120,8 +121,8 @@ public class GetWorkflowTokenCommand extends AbstractCommand {
   private Table getWorkflowToken(ProgramRunId runId, WorkflowToken.Scope workflowTokenScope,
                                  String key, String nodeName)
     throws UnauthenticatedException, IOException, NotFoundException, UnauthorizedException {
-    WorkflowTokenNodeDetail workflowToken = workflowClient.getWorkflowTokenAtNode(runId.toId(), nodeName,
-                                                                                  workflowTokenScope, key);
+    WorkflowTokenNodeDetail workflowToken = workflowClient.get().getWorkflowTokenAtNode(runId.toId(), nodeName,
+                                                                                        workflowTokenScope, key);
     List<Map.Entry<String, String>> tokenKeys = new ArrayList<>();
     tokenKeys.addAll(workflowToken.getTokenDataAtNode().entrySet());
     return Table.builder()

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListAllProgramsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListAllProgramsCommand.java
@@ -28,6 +28,7 @@ import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.common.cli.Arguments;
 import com.google.common.collect.Lists;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -39,10 +40,10 @@ import javax.inject.Inject;
  */
 public class ListAllProgramsCommand extends AbstractAuthCommand implements Categorized {
 
-  private final ApplicationClient appClient;
+  private final Provider<ApplicationClient> appClient;
 
   @Inject
-  public ListAllProgramsCommand(ApplicationClient appClient, CLIConfig cliConfig) {
+  ListAllProgramsCommand(Provider<ApplicationClient> appClient,  CLIConfig cliConfig) {
     super(cliConfig);
     this.appClient = appClient;
   }
@@ -50,7 +51,7 @@ public class ListAllProgramsCommand extends AbstractAuthCommand implements Categ
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     Map<ProgramType, List<ProgramRecord>> allPrograms =
-      appClient.listAllPrograms(cliConfig.getCurrentNamespace().toId());
+      appClient.get().listAllPrograms(cliConfig.getCurrentNamespace().toId());
     List<ProgramRecord> allProgramsList = Lists.newArrayList();
     for (List<ProgramRecord> subList : allPrograms.values()) {
       allProgramsList.addAll(subList);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetInstancesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetInstancesCommand.java
@@ -26,6 +26,7 @@ import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.common.cli.Arguments;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -35,17 +36,17 @@ import java.util.List;
  */
 public class ListDatasetInstancesCommand extends AbstractAuthCommand {
 
-  private final DatasetClient datasetClient;
+  private final Provider<DatasetClient> datasetClient;
 
   @Inject
-  public ListDatasetInstancesCommand(DatasetClient datasetClient, CLIConfig cliConfig) {
+  ListDatasetInstancesCommand(Provider<DatasetClient> datasetClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.datasetClient = datasetClient;
   }
 
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
-    List<DatasetSpecificationSummary> datasetMetas = datasetClient.list(cliConfig.getCurrentNamespace().toId());
+    List<DatasetSpecificationSummary> datasetMetas = datasetClient.get().list(cliConfig.getCurrentNamespace().toId());
 
     Table table = Table.builder()
       .setHeader("name", "type", "description")

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetModulesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetModulesCommand.java
@@ -26,6 +26,7 @@ import co.cask.cdap.proto.DatasetModuleMeta;
 import co.cask.common.cli.Arguments;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -35,17 +36,17 @@ import java.util.List;
  */
 public class ListDatasetModulesCommand extends AbstractAuthCommand {
 
-  private final DatasetModuleClient client;
+  private final Provider<DatasetModuleClient> client;
 
   @Inject
-  public ListDatasetModulesCommand(DatasetModuleClient client, CLIConfig cliConfig) {
+  ListDatasetModulesCommand(Provider<DatasetModuleClient> client, CLIConfig cliConfig) {
     super(cliConfig);
     this.client = client;
   }
 
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
-    List<DatasetModuleMeta> modules = client.list(cliConfig.getCurrentNamespace().toId());
+    List<DatasetModuleMeta> modules = client.get().list(cliConfig.getCurrentNamespace().toId());
     Table table = Table.builder()
       .setHeader("name", "className")
       .setRows(modules, new RowMaker<DatasetModuleMeta>() {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetTypesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListDatasetTypesCommand.java
@@ -28,6 +28,7 @@ import co.cask.common.cli.Arguments;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -37,17 +38,17 @@ import java.util.List;
  */
 public class ListDatasetTypesCommand extends AbstractAuthCommand {
 
-  private final DatasetTypeClient datasetTypeClient;
+  private final Provider<DatasetTypeClient> datasetTypeClient;
 
   @Inject
-  public ListDatasetTypesCommand(DatasetTypeClient datasetTypeClient, CLIConfig cliConfig) {
+  ListDatasetTypesCommand(Provider<DatasetTypeClient> datasetTypeClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.datasetTypeClient = datasetTypeClient;
   }
 
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
-    List<DatasetTypeMeta> datasetTypeMetas = datasetTypeClient.list(cliConfig.getCurrentNamespace().toId());
+    List<DatasetTypeMeta> datasetTypeMetas = datasetTypeClient.get().list(cliConfig.getCurrentNamespace().toId());
 
     Table table = Table.builder()
       .setHeader("name", "modules")

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListNamespacesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListNamespacesCommand.java
@@ -27,6 +27,7 @@ import co.cask.common.cli.Arguments;
 import co.cask.common.cli.Command;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -36,10 +37,10 @@ import java.util.List;
  */
 public class ListNamespacesCommand extends AbstractCommand {
 
-  private final NamespaceClient namespaceClient;
+  private final Provider<NamespaceClient> namespaceClient;
 
   @Inject
-  public ListNamespacesCommand(CLIConfig cliConfig, NamespaceClient namespaceClient) {
+  ListNamespacesCommand(CLIConfig cliConfig, Provider<NamespaceClient> namespaceClient) {
     super(cliConfig);
     this.namespaceClient = namespaceClient;
   }
@@ -48,7 +49,7 @@ public class ListNamespacesCommand extends AbstractCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     Table table = Table.builder()
       .setHeader("name", "description", "config")
-      .setRows(namespaceClient.list(), new RowMaker<NamespaceMeta>() {
+      .setRows(namespaceClient.get().list(), new RowMaker<NamespaceMeta>() {
         @Override
         public List<?> makeRow(NamespaceMeta object) {
           return Lists.newArrayList(object.getName(), object.getDescription(),

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListProgramsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListProgramsCommand.java
@@ -26,6 +26,7 @@ import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.common.cli.Arguments;
 import com.google.common.collect.Lists;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -35,10 +36,10 @@ import java.util.List;
  */
 public class ListProgramsCommand extends AbstractAuthCommand {
 
-  private final ApplicationClient appClient;
+  private final Provider<ApplicationClient> appClient;
   private final ProgramType programType;
 
-  public ListProgramsCommand(ProgramType programType, ApplicationClient appClient, CLIConfig cliConfig) {
+  ListProgramsCommand(ProgramType programType, Provider<ApplicationClient> appClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.programType = programType;
     this.appClient = appClient;
@@ -46,7 +47,7 @@ public class ListProgramsCommand extends AbstractAuthCommand {
 
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
-    List<ProgramRecord> programs = appClient.listAllPrograms(cliConfig.getCurrentNamespace().toId(), programType);
+    List<ProgramRecord> programs = appClient.get().listAllPrograms(cliConfig.getCurrentNamespace().toId(), programType);
 
     Table table = Table.builder()
       .setHeader("app", "id", "description")

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListProgramsCommandSet.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListProgramsCommandSet.java
@@ -21,9 +21,10 @@ import co.cask.cdap.cli.ElementType;
 import co.cask.cdap.client.ApplicationClient;
 import co.cask.common.cli.Command;
 import co.cask.common.cli.CommandSet;
-import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -32,12 +33,12 @@ import java.util.List;
 public class ListProgramsCommandSet extends CommandSet<Command> {
 
   @Inject
-  public ListProgramsCommandSet(ApplicationClient applicationClient, CLIConfig cliConfig) {
+  ListProgramsCommandSet(Provider<ApplicationClient> applicationClient, CLIConfig cliConfig) {
     super(generateCommands(applicationClient, cliConfig));
   }
 
-  private static List<Command> generateCommands(ApplicationClient applicationClient, CLIConfig cliConfig) {
-    List<Command> commands = Lists.newArrayList();
+  private static List<Command> generateCommands(Provider<ApplicationClient> applicationClient, CLIConfig cliConfig) {
+    List<Command> commands = new ArrayList<>();
     for (ElementType elementType : ElementType.values()) {
       if (elementType.getProgramType() != null && elementType.getProgramType().isListable()) {
         commands.add(new ListProgramsCommand(elementType.getProgramType(), applicationClient, cliConfig));

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListStreamsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListStreamsCommand.java
@@ -26,6 +26,7 @@ import co.cask.cdap.proto.StreamDetail;
 import co.cask.common.cli.Arguments;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -35,10 +36,10 @@ import java.util.List;
  */
 public class ListStreamsCommand extends AbstractAuthCommand {
 
-  private final StreamClient streamClient;
+  private final Provider<StreamClient> streamClient;
 
   @Inject
-  public ListStreamsCommand(StreamClient streamClient, CLIConfig cliConfig) {
+  ListStreamsCommand(Provider<StreamClient> streamClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.streamClient = streamClient;
   }
@@ -47,7 +48,7 @@ public class ListStreamsCommand extends AbstractAuthCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     Table table = Table.builder()
       .setHeader("name")
-      .setRows(streamClient.list(cliConfig.getCurrentNamespace().toId()), new RowMaker<StreamDetail>() {
+      .setRows(streamClient.get().list(cliConfig.getCurrentNamespace().toId()), new RowMaker<StreamDetail>() {
         @Override
         public List<?> makeRow(StreamDetail object) {
           return Lists.newArrayList(object.getName());

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/LoadPreferencesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/LoadPreferencesCommand.java
@@ -24,10 +24,10 @@ import co.cask.cdap.cli.english.Fragment;
 import co.cask.cdap.client.PreferencesClient;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.common.cli.Arguments;
-import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
+import com.google.inject.Provider;
 
 import java.io.File;
 import java.io.FileReader;
@@ -45,7 +45,7 @@ public class LoadPreferencesCommand extends AbstractSetPreferencesCommand {
 
   private final ElementType type;
 
-  protected LoadPreferencesCommand(ElementType type, PreferencesClient client, CLIConfig cliConfig) {
+  LoadPreferencesCommand(ElementType type, Provider<PreferencesClient> client, CLIConfig cliConfig) {
     super(type, client, cliConfig);
     this.type = type;
   }
@@ -59,14 +59,14 @@ public class LoadPreferencesCommand extends AbstractSetPreferencesCommand {
   @Override
   public void perform(Arguments arguments, PrintStream printStream) throws Exception {
     String[] programIdParts = new String[0];
-    String contentType = arguments.get(ArgumentName.CONTENT_TYPE.toString(), "");
+    String contentType = arguments.getOptional(ArgumentName.CONTENT_TYPE.toString(), "");
     File file = new File(arguments.get(ArgumentName.LOCAL_FILE_PATH.toString()));
 
     if (!file.isFile()) {
       throw new IllegalArgumentException("Not a file: " + file);
     }
 
-    Map<String, String> args = Maps.newHashMap();
+    Map<String, String> args;
     try (FileReader reader = new FileReader(file)) {
       if (contentType.equals("json")) {
         args = GSON.fromJson(reader, MAP_STRING_STRING_TYPE);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/LoadStreamCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/LoadStreamCommand.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.File;
 import java.io.PrintStream;
@@ -56,11 +57,11 @@ public class LoadStreamCommand extends AbstractAuthCommand implements Categorize
     CONTENT_TYPE_MAP = contentTypes;
   }
 
-  private final StreamClient streamClient;
+  private final Provider<StreamClient> streamClient;
   private final FilePathResolver resolver;
 
   @Inject
-  public LoadStreamCommand(StreamClient streamClient, CLIConfig cliConfig, FilePathResolver resolver) {
+  LoadStreamCommand(Provider<StreamClient> streamClient, CLIConfig cliConfig, FilePathResolver resolver) {
     super(cliConfig);
     this.streamClient = streamClient;
     this.resolver = resolver;
@@ -70,7 +71,7 @@ public class LoadStreamCommand extends AbstractAuthCommand implements Categorize
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     StreamId streamId = cliConfig.getCurrentNamespace().stream(arguments.get(ArgumentName.STREAM.toString()));
     File file = resolver.resolvePathToFile(arguments.get(ArgumentName.LOCAL_FILE_PATH.toString()));
-    String contentType = arguments.get(ArgumentName.CONTENT_TYPE.toString(), "");
+    String contentType = arguments.getOptional(ArgumentName.CONTENT_TYPE.toString(), "");
 
     if (!file.isFile()) {
       throw new IllegalArgumentException("Not a file: " + file);
@@ -82,7 +83,7 @@ public class LoadStreamCommand extends AbstractAuthCommand implements Categorize
       throw new IllegalArgumentException("Unsupported file format.");
     }
 
-    streamClient.sendFile(streamId.toId(), contentType, file);
+    streamClient.get().sendFile(streamId.toId(), contentType, file);
     output.printf("Successfully loaded file to stream '%s'\n", streamId.getEntityName());
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/PreferencesCommandSet.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/PreferencesCommandSet.java
@@ -23,9 +23,10 @@ import co.cask.cdap.cli.ElementType;
 import co.cask.cdap.client.PreferencesClient;
 import co.cask.common.cli.Command;
 import co.cask.common.cli.CommandSet;
-import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -34,12 +35,12 @@ import java.util.List;
 public class PreferencesCommandSet extends CommandSet<Command> implements Categorized {
 
   @Inject
-  public PreferencesCommandSet(PreferencesClient client, CLIConfig cliConfig) {
+  PreferencesCommandSet(Provider<PreferencesClient> client, CLIConfig cliConfig) {
     super(generateCommands(client, cliConfig));
   }
 
-  private static List<Command> generateCommands(PreferencesClient client, CLIConfig cliConfig) {
-    List<Command> commands = Lists.newArrayList();
+  private static List<Command> generateCommands(Provider<PreferencesClient> client, CLIConfig cliConfig) {
+    List<Command> commands = new ArrayList<>();
     for (ElementType elementType : ElementType.values()) {
       if (elementType.hasPreferences()) {
         commands.add(new GetPreferencesCommand(elementType, client, cliConfig));

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SendStreamEventCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SendStreamEventCommand.java
@@ -30,16 +30,17 @@ import co.cask.common.cli.Arguments;
 
 import java.io.PrintStream;
 import javax.inject.Inject;
+import javax.inject.Provider;
 
 /**
  * Sends an event to a stream.
  */
 public class SendStreamEventCommand extends AbstractAuthCommand implements Categorized {
 
-  private final StreamClient streamClient;
+  private final Provider<StreamClient> streamClient;
 
   @Inject
-  public SendStreamEventCommand(StreamClient streamClient, CLIConfig cliConfig) {
+  SendStreamEventCommand(Provider<StreamClient> streamClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.streamClient = streamClient;
   }
@@ -48,7 +49,7 @@ public class SendStreamEventCommand extends AbstractAuthCommand implements Categ
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     StreamId streamId = cliConfig.getCurrentNamespace().stream(arguments.get(ArgumentName.STREAM.toString()));
     String streamEvent = arguments.get(ArgumentName.STREAM_EVENT.toString());
-    streamClient.sendEvent(streamId.toId(), streamEvent);
+    streamClient.get().sendEvent(streamId.toId(), streamEvent);
     output.printf("Successfully sent stream event to stream '%s'\n", streamId.getEntityName());
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetDatasetInstancePropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetDatasetInstancePropertiesCommand.java
@@ -28,6 +28,7 @@ import co.cask.cdap.proto.id.DatasetId;
 import co.cask.common.cli.Arguments;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.Map;
@@ -38,10 +39,10 @@ import java.util.Map;
 public class SetDatasetInstancePropertiesCommand extends AbstractCommand {
 
   private static final Gson GSON = new Gson();
-  private final DatasetClient datasetClient;
+  private final Provider<DatasetClient> datasetClient;
 
   @Inject
-  public SetDatasetInstancePropertiesCommand(DatasetClient datasetClient, CLIConfig cliConfig) {
+  SetDatasetInstancePropertiesCommand(Provider<DatasetClient> datasetClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.datasetClient = datasetClient;
   }
@@ -52,7 +53,7 @@ public class SetDatasetInstancePropertiesCommand extends AbstractCommand {
     Map<String, String> properties = ArgumentParser.parseMap(
       arguments.get(ArgumentName.DATASET_PROPERTIES.toString()));
 
-    datasetClient.updateExisting(instance.toId(), properties);
+    datasetClient.get().updateExisting(instance.toId(), properties);
     output.printf("Successfully updated properties for dataset instance '%s' to %s",
                   instance.getEntityName(), GSON.toJson(properties));
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetPreferencesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetPreferencesCommand.java
@@ -24,6 +24,7 @@ import co.cask.cdap.cli.english.Fragment;
 import co.cask.cdap.cli.util.ArgumentParser;
 import co.cask.cdap.client.PreferencesClient;
 import co.cask.common.cli.Arguments;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.Map;
@@ -35,7 +36,7 @@ public class SetPreferencesCommand extends AbstractSetPreferencesCommand {
   protected static final String SUCCESS = "Set preferences successfully for the '%s'";
   private final ElementType type;
 
-  protected SetPreferencesCommand(ElementType type, PreferencesClient client, CLIConfig cliConfig) {
+  SetPreferencesCommand(ElementType type, Provider<PreferencesClient> client, CLIConfig cliConfig) {
     super(type, client, cliConfig);
     this.type = type;
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetProgramInstancesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetProgramInstancesCommand.java
@@ -30,6 +30,7 @@ import co.cask.cdap.proto.id.FlowletId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.ServiceId;
 import co.cask.common.cli.Arguments;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -38,10 +39,10 @@ import java.io.PrintStream;
  */
 public class SetProgramInstancesCommand extends AbstractAuthCommand {
 
-  private final ProgramClient programClient;
+  private final Provider<ProgramClient> programClient;
   private final ElementType elementType;
 
-  public SetProgramInstancesCommand(ElementType elementType, ProgramClient programClient, CLIConfig cliConfig) {
+  SetProgramInstancesCommand(ElementType elementType, Provider<ProgramClient> programClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.elementType = elementType;
     this.programClient = programClient;
@@ -61,7 +62,7 @@ public class SetProgramInstancesCommand extends AbstractAuthCommand {
         String flowId = programIdParts[1];
         String flowletName = programIdParts[2];
         FlowletId flowletId = appId.flow(flowId).flowlet(flowletName);
-        programClient.setFlowletInstances(flowletId.toId(), numInstances);
+        programClient.get().setFlowletInstances(flowletId.toId(), numInstances);
         output.printf("Successfully set flowlet '%s' of flow '%s' of app '%s' to %d instances\n",
                       flowId, flowletId, appId.getEntityName(), numInstances);
         break;
@@ -71,7 +72,7 @@ public class SetProgramInstancesCommand extends AbstractAuthCommand {
         }
         String workerName = programIdParts[1];
         ProgramId workerId = appId.worker(workerName);
-        programClient.setWorkerInstances(Id.Worker.from(workerId.getParent().toId(), workerName), numInstances);
+        programClient.get().setWorkerInstances(Id.Worker.from(workerId.getParent().toId(), workerName), numInstances);
         output.printf("Successfully set worker '%s' of app '%s' to %d instances\n",
                       workerName, appId.getEntityName(), numInstances);
         break;
@@ -81,7 +82,7 @@ public class SetProgramInstancesCommand extends AbstractAuthCommand {
         }
         String serviceName = programIdParts[1];
         ServiceId service = appId.service(serviceName);
-        programClient.setServiceInstances(service.toId(), numInstances);
+        programClient.get().setServiceInstances(service.toId(), numInstances);
         output.printf("Successfully set service '%s' of app '%s' to %d instances\n",
                       serviceName, appId.getEntityName(), numInstances);
         break;

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetProgramInstancesCommandSet.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetProgramInstancesCommandSet.java
@@ -23,7 +23,9 @@ import co.cask.common.cli.Command;
 import co.cask.common.cli.CommandSet;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -32,12 +34,12 @@ import java.util.List;
 public class SetProgramInstancesCommandSet extends CommandSet<Command> {
 
   @Inject
-  public SetProgramInstancesCommandSet(ProgramClient programClient, CLIConfig cliConfig) {
+  SetProgramInstancesCommandSet(Provider<ProgramClient> programClient, CLIConfig cliConfig) {
     super(generateCommands(programClient, cliConfig));
   }
 
-  public static List<Command> generateCommands(ProgramClient programClient, CLIConfig cliConfig) {
-    List<Command> commands = Lists.newArrayList();
+  public static List<Command> generateCommands(Provider<ProgramClient> programClient, CLIConfig cliConfig) {
+    List<Command> commands = new ArrayList<>();
     for (ElementType elementType : ElementType.values()) {
       if (elementType.canScale()) {
         commands.add(new SetProgramInstancesCommand(elementType, programClient, cliConfig));

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetProgramRuntimeArgsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetProgramRuntimeArgsCommand.java
@@ -26,7 +26,7 @@ import co.cask.cdap.cli.util.ArgumentParser;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.common.cli.Arguments;
-import com.google.gson.Gson;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.Map;
@@ -36,12 +36,10 @@ import java.util.Map;
  */
 public class SetProgramRuntimeArgsCommand extends AbstractAuthCommand {
 
-  private static final Gson GSON = new Gson();
-
-  private final ProgramClient programClient;
+  private final Provider<ProgramClient> programClient;
   private final ElementType elementType;
 
-  public SetProgramRuntimeArgsCommand(ElementType elementType, ProgramClient programClient, CLIConfig cliConfig) {
+  SetProgramRuntimeArgsCommand(ElementType elementType, Provider<ProgramClient> programClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.elementType = elementType;
     this.programClient = programClient;
@@ -55,7 +53,7 @@ public class SetProgramRuntimeArgsCommand extends AbstractAuthCommand {
     ProgramId programId = cliConfig.getCurrentNamespace().app(appId).program(elementType.getProgramType(), programName);
     String runtimeArgsString = arguments.get(ArgumentName.RUNTIME_ARGS.toString());
     Map<String, String> runtimeArgs = ArgumentParser.parseMap(runtimeArgsString);
-    programClient.setRuntimeArgs(programId.toId(), runtimeArgs);
+    programClient.get().setRuntimeArgs(programId.toId(), runtimeArgs);
     output.printf("Successfully set runtime args of %s '%s' of application '%s' to '%s'\n",
                   elementType.getName(), programName, appId, runtimeArgsString);
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetProgramRuntimeArgsCommandSet.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetProgramRuntimeArgsCommandSet.java
@@ -23,7 +23,9 @@ import co.cask.common.cli.Command;
 import co.cask.common.cli.CommandSet;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -32,12 +34,12 @@ import java.util.List;
 public class SetProgramRuntimeArgsCommandSet extends CommandSet<Command> {
 
   @Inject
-  public SetProgramRuntimeArgsCommandSet(ProgramClient programClient, CLIConfig cliConfig) {
+  SetProgramRuntimeArgsCommandSet(Provider<ProgramClient> programClient, CLIConfig cliConfig) {
     super(generateCommands(programClient, cliConfig));
   }
 
-  public static List<Command> generateCommands(ProgramClient programClient, CLIConfig cliConfig) {
-    List<Command> commands = Lists.newArrayList();
+  public static List<Command> generateCommands(Provider<ProgramClient> programClient, CLIConfig cliConfig) {
+    List<Command> commands = new ArrayList<>();
     for (ElementType elementType : ElementType.values()) {
       if (elementType.hasRuntimeArgs()) {
         commands.add(new SetProgramRuntimeArgsCommand(elementType, programClient, cliConfig));

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamDescriptionCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamDescriptionCommand.java
@@ -26,6 +26,7 @@ import co.cask.cdap.client.StreamClient;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -34,10 +35,10 @@ import java.io.PrintStream;
  */
 public class SetStreamDescriptionCommand extends AbstractAuthCommand {
 
-  private final StreamClient streamClient;
+  private final Provider<StreamClient> streamClient;
 
   @Inject
-  public SetStreamDescriptionCommand(StreamClient streamClient, CLIConfig cliConfig) {
+  SetStreamDescriptionCommand(Provider<StreamClient> streamClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.streamClient = streamClient;
   }
@@ -46,7 +47,7 @@ public class SetStreamDescriptionCommand extends AbstractAuthCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     StreamId streamId = cliConfig.getCurrentNamespace().stream(arguments.get(ArgumentName.STREAM.toString()));
     String description = arguments.get(ArgumentName.STREAM_DESCRIPTION.toString());
-    streamClient.setDescription(streamId.toId(), description);
+    streamClient.get().setDescription(streamId.toId(), description);
     output.printf("Successfully set stream description of stream '%s' to '%s'\n", streamId.getEntityName(),
                   description);
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamFormatCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamFormatCommand.java
@@ -34,6 +34,7 @@ import com.google.common.base.Joiner;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -46,10 +47,10 @@ import java.util.Map;
 public class SetStreamFormatCommand extends AbstractAuthCommand {
 
   private static final Gson GSON = new Gson();
-  private final StreamClient streamClient;
+  private final Provider<StreamClient> streamClient;
 
   @Inject
-  public SetStreamFormatCommand(StreamClient streamClient, CLIConfig cliConfig) {
+  SetStreamFormatCommand(Provider<StreamClient> streamClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.streamClient = streamClient;
   }
@@ -57,7 +58,7 @@ public class SetStreamFormatCommand extends AbstractAuthCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     StreamId streamId = cliConfig.getCurrentNamespace().stream(arguments.get(ArgumentName.STREAM.toString()));
-    StreamProperties currentProperties = streamClient.getConfig(streamId.toId());
+    StreamProperties currentProperties = streamClient.get().getConfig(streamId.toId());
 
     String formatName = arguments.get(ArgumentName.FORMAT.toString());
     Schema schema = getSchema(arguments);
@@ -70,7 +71,7 @@ public class SetStreamFormatCommand extends AbstractAuthCommand {
                                                              formatSpecification,
                                                              currentProperties.getNotificationThresholdMB(),
                                                              currentProperties.getDescription());
-    streamClient.setStreamProperties(streamId.toId(), streamProperties);
+    streamClient.get().setStreamProperties(streamId.toId(), streamProperties);
     output.printf("Successfully set format of stream '%s'\n", streamId.getEntityName());
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamNotificationThresholdCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamNotificationThresholdCommand.java
@@ -27,6 +27,7 @@ import co.cask.cdap.proto.StreamProperties;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -35,10 +36,10 @@ import java.io.PrintStream;
  */
 public class SetStreamNotificationThresholdCommand extends AbstractAuthCommand {
 
-  private final StreamClient streamClient;
+  private final Provider<StreamClient> streamClient;
 
   @Inject
-  public SetStreamNotificationThresholdCommand(StreamClient streamClient, CLIConfig cliConfig) {
+  SetStreamNotificationThresholdCommand(Provider<StreamClient> streamClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.streamClient = streamClient;
   }
@@ -47,7 +48,7 @@ public class SetStreamNotificationThresholdCommand extends AbstractAuthCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     StreamId streamId = cliConfig.getCurrentNamespace().stream(arguments.get(ArgumentName.STREAM.toString()));
     int notificationThresholdMB = arguments.getInt(ArgumentName.NOTIFICATION_THRESHOLD_MB.toString());
-    streamClient.setStreamProperties(streamId.toId(), new StreamProperties(null, null, notificationThresholdMB));
+    streamClient.get().setStreamProperties(streamId.toId(), new StreamProperties(null, null, notificationThresholdMB));
     output.printf("Successfully set notification threshold of stream '%s' to %dMB\n",
                   streamId.getEntityName(), notificationThresholdMB);
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamPropertiesCommand.java
@@ -30,6 +30,7 @@ import com.google.common.io.Files;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.File;
 import java.io.PrintStream;
@@ -43,10 +44,10 @@ public class SetStreamPropertiesCommand extends AbstractAuthCommand {
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
     .create();
-  private final StreamClient streamClient;
+  private final Provider<StreamClient> streamClient;
 
   @Inject
-  public SetStreamPropertiesCommand(StreamClient streamClient, CLIConfig cliConfig) {
+  SetStreamPropertiesCommand(Provider<StreamClient> streamClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.streamClient = streamClient;
   }
@@ -67,7 +68,7 @@ public class SetStreamPropertiesCommand extends AbstractAuthCommand {
       throw new IllegalArgumentException("Stream properties are malformed.", e);
     }
 
-    streamClient.setStreamProperties(streamId.toId(), streamProperties);
+    streamClient.get().setStreamProperties(streamId.toId(), streamProperties);
     output.printf("Successfully set properties of stream '%s'\n", streamId.getEntityName());
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamTTLCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamTTLCommand.java
@@ -26,6 +26,7 @@ import co.cask.cdap.client.StreamClient;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -34,10 +35,10 @@ import java.io.PrintStream;
  */
 public class SetStreamTTLCommand extends AbstractAuthCommand {
 
-  private final StreamClient streamClient;
+  private final Provider<StreamClient> streamClient;
 
   @Inject
-  public SetStreamTTLCommand(StreamClient streamClient, CLIConfig cliConfig) {
+  SetStreamTTLCommand(Provider<StreamClient> streamClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.streamClient = streamClient;
   }
@@ -46,7 +47,7 @@ public class SetStreamTTLCommand extends AbstractAuthCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     StreamId streamId = cliConfig.getCurrentNamespace().stream(arguments.get(ArgumentName.STREAM.toString()));
     long ttlInSeconds = arguments.getLong(ArgumentName.TTL_IN_SECONDS.toString());
-    streamClient.setTTL(streamId.toId(), ttlInSeconds);
+    streamClient.get().setTTL(streamId.toId(), ttlInSeconds);
     output.printf("Successfully set TTL of stream '%s' to %d\n", streamId.getEntityName(), ttlInSeconds);
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/StartDebugProgramCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/StartDebugProgramCommand.java
@@ -22,13 +22,14 @@ import co.cask.cdap.cli.ElementType;
 import co.cask.cdap.cli.english.Article;
 import co.cask.cdap.cli.english.Fragment;
 import co.cask.cdap.client.ProgramClient;
+import com.google.inject.Provider;
 
 /**
  * Starts a program in debug mode.
  */
 public class StartDebugProgramCommand extends StartProgramCommand {
 
-  public StartDebugProgramCommand(ElementType elementType, ProgramClient programClient, CLIConfig cliConfig) {
+  StartDebugProgramCommand(ElementType elementType, Provider<ProgramClient> programClient, CLIConfig cliConfig) {
     super(elementType, programClient, cliConfig);
     this.isDebug = true;
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/StartProgramCommandSet.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/StartProgramCommandSet.java
@@ -21,9 +21,10 @@ import co.cask.cdap.cli.ElementType;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.common.cli.Command;
 import co.cask.common.cli.CommandSet;
-import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -32,12 +33,12 @@ import java.util.List;
 public class StartProgramCommandSet extends CommandSet<Command> {
 
   @Inject
-  public StartProgramCommandSet(ProgramClient programClient, CLIConfig cliConfig) {
+  StartProgramCommandSet(Provider<ProgramClient> programClient, CLIConfig cliConfig) {
     super(generateCommands(programClient, cliConfig));
   }
 
-  private static List<Command> generateCommands(ProgramClient programClient, CLIConfig cliConfig) {
-    List<Command> commands = Lists.newArrayList();
+  private static List<Command> generateCommands(Provider<ProgramClient> programClient, CLIConfig cliConfig) {
+    List<Command> commands = new ArrayList<>();
     for (ElementType elementType : ElementType.values()) {
       if (elementType.canStart()) {
         commands.add(new StartProgramCommand(elementType, programClient, cliConfig));

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/StopProgramCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/StopProgramCommand.java
@@ -25,6 +25,7 @@ import co.cask.cdap.cli.util.AbstractAuthCommand;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.common.cli.Arguments;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -33,10 +34,10 @@ import java.io.PrintStream;
  */
 public class StopProgramCommand extends AbstractAuthCommand {
 
-  private final ProgramClient programClient;
+  private final Provider<ProgramClient> programClient;
   private final ElementType elementType;
 
-  public StopProgramCommand(ElementType elementType, ProgramClient programClient, CLIConfig cliConfig) {
+  StopProgramCommand(ElementType elementType, Provider<ProgramClient> programClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.elementType = elementType;
     this.programClient = programClient;
@@ -53,7 +54,7 @@ public class StopProgramCommand extends AbstractAuthCommand {
     String programName = programIdParts[1];
     ProgramId programId = cliConfig.getCurrentNamespace().app(appId).program(elementType.getProgramType(), programName);
 
-    programClient.stop(programId.toId());
+    programClient.get().stop(programId.toId());
     output.printf("Successfully stopped %s '%s' of application '%s'\n", elementType.getName(), programName, appId);
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/StopProgramCommandSet.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/StopProgramCommandSet.java
@@ -21,9 +21,10 @@ import co.cask.cdap.cli.ElementType;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.common.cli.Command;
 import co.cask.common.cli.CommandSet;
-import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -32,12 +33,12 @@ import java.util.List;
 public class StopProgramCommandSet extends CommandSet<Command> {
 
   @Inject
-  public StopProgramCommandSet(ProgramClient programClient, CLIConfig cliConfig) {
+  StopProgramCommandSet(Provider<ProgramClient> programClient, CLIConfig cliConfig) {
     super(generateCommands(programClient, cliConfig));
   }
 
-  private static List<Command> generateCommands(ProgramClient programClient, CLIConfig cliConfig) {
-    List<Command> commands = Lists.newArrayList();
+  private static List<Command> generateCommands(Provider<ProgramClient> programClient, CLIConfig cliConfig) {
+    List<Command> commands = new ArrayList<>();
     for (ElementType elementType : ElementType.values()) {
       if (elementType.canStop()) {
         commands.add(new StopProgramCommand(elementType, programClient, cliConfig));

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/TruncateDatasetInstanceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/TruncateDatasetInstanceCommand.java
@@ -26,6 +26,7 @@ import co.cask.cdap.client.DatasetClient;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -34,10 +35,10 @@ import java.io.PrintStream;
  */
 public class TruncateDatasetInstanceCommand extends AbstractAuthCommand {
 
-  private final DatasetClient datasetClient;
+  private final Provider<DatasetClient> datasetClient;
 
   @Inject
-  public TruncateDatasetInstanceCommand(DatasetClient datasetClient, CLIConfig cliConfig) {
+  TruncateDatasetInstanceCommand(Provider<DatasetClient> datasetClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.datasetClient = datasetClient;
   }
@@ -45,7 +46,7 @@ public class TruncateDatasetInstanceCommand extends AbstractAuthCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     DatasetId instance = cliConfig.getCurrentNamespace().dataset(arguments.get(ArgumentName.DATASET.toString()));
-    datasetClient.truncate(instance.toId());
+    datasetClient.get().truncate(instance.toId());
     output.printf("Successfully truncated dataset '%s'\n", instance.getEntityName());
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/TruncateStreamCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/TruncateStreamCommand.java
@@ -26,6 +26,7 @@ import co.cask.cdap.client.StreamClient;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -34,10 +35,10 @@ import java.io.PrintStream;
  */
 public class TruncateStreamCommand extends AbstractAuthCommand {
 
-  private final StreamClient streamClient;
+  private final Provider<StreamClient> streamClient;
 
   @Inject
-  public TruncateStreamCommand(StreamClient streamClient, CLIConfig cliConfig) {
+  public TruncateStreamCommand(Provider<StreamClient> streamClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.streamClient = streamClient;
   }
@@ -45,7 +46,7 @@ public class TruncateStreamCommand extends AbstractAuthCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     StreamId streamId = cliConfig.getCurrentNamespace().stream(arguments.get(ArgumentName.STREAM.toString()));
-    streamClient.truncate(streamId.toId());
+    streamClient.get().truncate(streamId.toId());
     output.printf("Successfully truncated stream '%s'\n", streamId.getEntityName());
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/UseNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/UseNamespaceCommand.java
@@ -24,6 +24,7 @@ import co.cask.cdap.client.NamespaceClient;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -33,11 +34,10 @@ import java.io.PrintStream;
 public class UseNamespaceCommand extends AbstractAuthCommand {
 
   private final CLIConfig cliConfig;
-  private final NamespaceClient namespaceClient;
-
+  private final Provider<NamespaceClient> namespaceClient;
 
   @Inject
-  public UseNamespaceCommand(CLIConfig cliConfig, NamespaceClient namespaceClient) {
+  UseNamespaceCommand(CLIConfig cliConfig, Provider<NamespaceClient> namespaceClient) {
     super(cliConfig);
     this.cliConfig = cliConfig;
     this.namespaceClient = namespaceClient;
@@ -47,7 +47,7 @@ public class UseNamespaceCommand extends AbstractAuthCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     NamespaceId namespace = new NamespaceId(arguments.get(ArgumentName.NAMESPACE_NAME.toString()));
     // Check if namespace exists; throws exception if namespace doesn't exist.
-    namespaceClient.get(namespace.toId());
+    namespaceClient.get().get(namespace.toId());
     cliConfig.setNamespace(namespace);
     output.printf("Now using namespace '%s'\n", namespace.getNamespace());
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/WorkflowCommandSet.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/WorkflowCommandSet.java
@@ -23,6 +23,7 @@ import co.cask.cdap.client.WorkflowClient;
 import co.cask.common.cli.Command;
 import co.cask.common.cli.CommandSet;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,11 +34,13 @@ import java.util.List;
 public class WorkflowCommandSet extends CommandSet<Command> {
 
   @Inject
-  public WorkflowCommandSet(ProgramClient programClient, WorkflowClient workflowClient, CLIConfig cliConfig) {
+  WorkflowCommandSet(Provider<ProgramClient> programClient, Provider<WorkflowClient> workflowClient,
+                     CLIConfig cliConfig) {
     super(generateCommands(programClient, workflowClient, cliConfig));
   }
 
-  private static Iterable<Command> generateCommands(ProgramClient programClient, WorkflowClient workflowClient,
+  private static Iterable<Command> generateCommands(Provider<ProgramClient> programClient,
+                                                    Provider<WorkflowClient> workflowClient,
                                                     CLIConfig cliConfig) {
     List<Command> commands = new ArrayList<>();
     commands.add(new GetWorkflowCurrentRunCommand(ElementType.WORKFLOW, programClient, cliConfig));

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/BaseBatchCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/BaseBatchCommand.java
@@ -33,6 +33,7 @@ import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.common.cli.Arguments;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
+import com.google.inject.Provider;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -48,9 +49,9 @@ import java.util.Set;
  * @param <T> the type of input object for the batch request
  */
 public abstract class BaseBatchCommand<T extends BatchProgram> extends AbstractAuthCommand {
-  private final ApplicationClient appClient;
+  private final Provider<ApplicationClient> appClient;
 
-  protected BaseBatchCommand(ApplicationClient appClient, CLIConfig cliConfig) {
+  protected BaseBatchCommand(Provider<ApplicationClient> appClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.appClient = appClient;
   }
@@ -87,7 +88,7 @@ public abstract class BaseBatchCommand<T extends BatchProgram> extends AbstractA
     }
 
     List<T> programs = new ArrayList<>();
-    Map<ProgramType, List<ProgramRecord>> appPrograms = appClient.listProgramsByType(appId.toId());
+    Map<ProgramType, List<ProgramRecord>> appPrograms = appClient.get().listProgramsByType(appId.toId());
     for (ProgramType programType : programTypes) {
       List<ProgramRecord> programRecords = appPrograms.get(programType);
       if (programRecords != null) {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/CreateAppCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/CreateAppCommand.java
@@ -33,6 +33,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.File;
 import java.io.FileReader;
@@ -45,11 +46,11 @@ import java.lang.reflect.Type;
 public class CreateAppCommand extends AbstractAuthCommand {
   private static final Type configType = new TypeToken<AppRequest<JsonObject>>() { }.getType();
   private static final Gson GSON = new Gson();
-  private final ApplicationClient applicationClient;
+  private final Provider<ApplicationClient> applicationClient;
   private final FilePathResolver resolver;
 
   @Inject
-  public CreateAppCommand(ApplicationClient applicationClient, FilePathResolver resolver, CLIConfig cliConfig) {
+  CreateAppCommand(Provider<ApplicationClient> applicationClient, FilePathResolver resolver, CLIConfig cliConfig) {
     super(cliConfig);
     this.applicationClient = applicationClient;
     this.resolver = resolver;
@@ -76,7 +77,7 @@ public class CreateAppCommand extends AbstractAuthCommand {
     }
 
     AppRequest<JsonObject> appRequest = new AppRequest<>(artifact, config);
-    applicationClient.deploy(appId.toId(), appRequest);
+    applicationClient.get().deploy(appId.toId(), appRequest);
     output.println("Successfully created application");
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/DeleteAppCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/DeleteAppCommand.java
@@ -26,6 +26,7 @@ import co.cask.cdap.client.ApplicationClient;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -34,10 +35,10 @@ import java.io.PrintStream;
  */
 public class DeleteAppCommand extends AbstractAuthCommand {
 
-  private final ApplicationClient appClient;
+  private final Provider<ApplicationClient> appClient;
 
   @Inject
-  public DeleteAppCommand(ApplicationClient appClient, CLIConfig cliConfig) {
+  DeleteAppCommand(Provider<ApplicationClient> appClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.appClient = appClient;
   }
@@ -46,7 +47,7 @@ public class DeleteAppCommand extends AbstractAuthCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     ApplicationId appId = cliConfig.getCurrentNamespace().app(arguments.get(ArgumentName.APP.toString()));
 
-    appClient.delete(appId.toId());
+    appClient.get().delete(appId.toId());
     output.printf("Successfully deleted application '%s'\n", appId.getEntityName());
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/DeployAppCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/DeployAppCommand.java
@@ -27,6 +27,7 @@ import co.cask.cdap.client.ApplicationClient;
 import co.cask.common.cli.Arguments;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.File;
 import java.io.PrintStream;
@@ -36,11 +37,11 @@ import java.io.PrintStream;
  */
 public class DeployAppCommand extends AbstractAuthCommand {
 
-  private final ApplicationClient applicationClient;
+  private final Provider<ApplicationClient> applicationClient;
   private final FilePathResolver resolver;
 
   @Inject
-  public DeployAppCommand(ApplicationClient applicationClient, FilePathResolver resolver, CLIConfig cliConfig) {
+  DeployAppCommand(Provider<ApplicationClient> applicationClient, FilePathResolver resolver, CLIConfig cliConfig) {
     super(cliConfig);
     this.applicationClient = applicationClient;
     this.resolver = resolver;
@@ -51,8 +52,8 @@ public class DeployAppCommand extends AbstractAuthCommand {
     File file = resolver.resolvePathToFile(arguments.get(ArgumentName.APP_JAR_FILE.toString()));
     Preconditions.checkArgument(file.exists(), "File " + file.getAbsolutePath() + " does not exist");
     Preconditions.checkArgument(file.canRead(), "File " + file.getAbsolutePath() + " is not readable");
-    String appConfig = arguments.get(ArgumentName.APP_CONFIG.toString(), "");
-    applicationClient.deploy(cliConfig.getCurrentNamespace().toId(), file, appConfig);
+    String appConfig = arguments.getOptional(ArgumentName.APP_CONFIG.toString(), "");
+    applicationClient.get().deploy(cliConfig.getCurrentNamespace().toId(), file, appConfig);
     output.println("Successfully deployed application");
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/DescribeAppCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/DescribeAppCommand.java
@@ -30,6 +30,7 @@ import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.common.cli.Arguments;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -39,10 +40,10 @@ import java.util.List;
  */
 public class DescribeAppCommand extends AbstractAuthCommand {
 
-  private final ApplicationClient applicationClient;
+  private final Provider<ApplicationClient> applicationClient;
 
   @Inject
-  public DescribeAppCommand(ApplicationClient applicationClient, CLIConfig cliConfig) {
+  DescribeAppCommand(Provider<ApplicationClient> applicationClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.applicationClient = applicationClient;
   }
@@ -50,7 +51,7 @@ public class DescribeAppCommand extends AbstractAuthCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     ApplicationId appId = cliConfig.getCurrentNamespace().app(arguments.get(ArgumentName.APP.toString()));
-    List<ProgramRecord> programsList = applicationClient.listPrograms(appId.toId());
+    List<ProgramRecord> programsList = applicationClient.get().listPrograms(appId.toId());
 
     Table table = Table.builder()
       .setHeader("type", "id", "description")

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/ListAppsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/ListAppsCommand.java
@@ -28,6 +28,7 @@ import co.cask.common.cli.Arguments;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.HashSet;
@@ -39,10 +40,10 @@ import java.util.Set;
  */
 public class ListAppsCommand extends AbstractAuthCommand {
 
-  private final ApplicationClient appClient;
+  private final Provider<ApplicationClient> appClient;
 
   @Inject
-  public ListAppsCommand(ApplicationClient appClient, CLIConfig cliConfig) {
+  public ListAppsCommand(Provider<ApplicationClient> appClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.appClient = appClient;
   }
@@ -59,7 +60,7 @@ public class ListAppsCommand extends AbstractAuthCommand {
     }
     Table table = Table.builder()
       .setHeader("id", "description", "artifactName", "artifactVersion", "artifactScope")
-      .setRows(appClient.list(cliConfig.getCurrentNamespace().toId(), artifactNames, artifactVersion),
+      .setRows(appClient.get().list(cliConfig.getCurrentNamespace().toId(), artifactNames, artifactVersion),
         new RowMaker<ApplicationRecord>() {
           @Override
           public List<?> makeRow(ApplicationRecord object) {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/RestartProgramsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/RestartProgramsCommand.java
@@ -25,6 +25,7 @@ import co.cask.cdap.proto.BatchProgramStart;
 import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.id.NamespaceId;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -34,10 +35,11 @@ import java.util.List;
  * Restarts one or more programs in an application.
  */
 public class RestartProgramsCommand extends BaseBatchCommand<BatchProgram> {
-  private final ProgramClient programClient;
+  private final Provider<ProgramClient> programClient;
 
   @Inject
-  public RestartProgramsCommand(ApplicationClient appClient, ProgramClient programClient, CLIConfig cliConfig) {
+  RestartProgramsCommand(Provider<ApplicationClient> appClient,  Provider<ProgramClient> programClient,
+                         CLIConfig cliConfig) {
     super(appClient, cliConfig);
     this.programClient = programClient;
   }
@@ -52,14 +54,14 @@ public class RestartProgramsCommand extends BaseBatchCommand<BatchProgram> {
     NamespaceId namespace = args.appId.getParent();
 
     printStream.print("Stopping programs...\n");
-    programClient.stop(namespace.toId(), args.programs);
+    programClient.get().stop(namespace.toId(), args.programs);
 
     printStream.print("Starting programs...\n");
     List<BatchProgramStart> startList = new ArrayList<>(args.programs.size());
     for (BatchProgram program : args.programs) {
       startList.add(new BatchProgramStart(program));
     }
-    programClient.start(namespace.toId(), startList);
+    programClient.get().start(namespace.toId(), startList);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/StartProgramsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/StartProgramsCommand.java
@@ -27,6 +27,7 @@ import co.cask.cdap.proto.BatchProgramStart;
 import co.cask.cdap.proto.ProgramRecord;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -35,10 +36,11 @@ import java.util.List;
  * Starts one or more programs in an application.
  */
 public class StartProgramsCommand extends BaseBatchCommand<BatchProgramStart> {
-  private final ProgramClient programClient;
+  private final Provider<ProgramClient> programClient;
 
   @Inject
-  public StartProgramsCommand(ApplicationClient appClient, ProgramClient programClient, CLIConfig cliConfig) {
+  StartProgramsCommand(Provider<ApplicationClient> appClient,  Provider<ProgramClient> programClient,
+                       CLIConfig cliConfig) {
     super(appClient, cliConfig);
     this.programClient = programClient;
   }
@@ -50,7 +52,7 @@ public class StartProgramsCommand extends BaseBatchCommand<BatchProgramStart> {
 
   @Override
   protected void runBatchCommand(PrintStream printStream, Args<BatchProgramStart> args) throws Exception {
-    List<BatchProgramResult> results = programClient.start(args.appId.getParent().toId(), args.programs);
+    List<BatchProgramResult> results = programClient.get().start(args.appId.getParent().toId(), args.programs);
 
     Table table = Table.builder()
       .setHeader("name", "type", "error")

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/StatusProgramsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/StatusProgramsCommand.java
@@ -29,6 +29,7 @@ import co.cask.cdap.proto.ProgramRecord;
 import co.cask.cdap.proto.ProgramType;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.HashSet;
@@ -39,10 +40,11 @@ import java.util.Set;
  * Gets status of one or more programs in an application.
  */
 public class StatusProgramsCommand extends BaseBatchCommand<BatchProgram> {
-  private final ProgramClient programClient;
+  private final Provider<ProgramClient> programClient;
 
   @Inject
-  public StatusProgramsCommand(ApplicationClient appClient, ProgramClient programClient, CLIConfig cliConfig) {
+  StatusProgramsCommand(Provider<ApplicationClient> appClient, Provider<ProgramClient> programClient,
+                        CLIConfig cliConfig) {
     super(appClient, cliConfig);
     this.programClient = programClient;
   }
@@ -54,7 +56,7 @@ public class StatusProgramsCommand extends BaseBatchCommand<BatchProgram> {
 
   @Override
   protected void runBatchCommand(PrintStream printStream, Args<BatchProgram> args) throws Exception {
-    List<BatchProgramStatus> results = programClient.getStatus(args.appId.getParent().toId(), args.programs);
+    List<BatchProgramStatus> results = programClient.get().getStatus(args.appId.getParent().toId(), args.programs);
 
     Table table = Table.builder()
       .setHeader("name", "type", "status", "error")

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/StopProgramsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/StopProgramsCommand.java
@@ -27,6 +27,7 @@ import co.cask.cdap.proto.BatchProgramResult;
 import co.cask.cdap.proto.ProgramRecord;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -35,10 +36,11 @@ import java.util.List;
  * Stops one or more programs in an application.
  */
 public class StopProgramsCommand extends BaseBatchCommand<BatchProgram> {
-  private final ProgramClient programClient;
+  private final Provider<ProgramClient> programClient;
 
   @Inject
-  public StopProgramsCommand(ApplicationClient appClient, ProgramClient programClient, CLIConfig cliConfig) {
+  StopProgramsCommand(Provider<ApplicationClient> appClient, Provider<ProgramClient> programClient,
+                      CLIConfig cliConfig) {
     super(appClient, cliConfig);
     this.programClient = programClient;
   }
@@ -50,7 +52,7 @@ public class StopProgramsCommand extends BaseBatchCommand<BatchProgram> {
 
   @Override
   protected void runBatchCommand(PrintStream printStream, Args<BatchProgram> args) throws Exception {
-    List<BatchProgramResult> results = programClient.stop(args.appId.getParent().toId(), args.programs);
+    List<BatchProgramResult> results = programClient.get().stop(args.appId.getParent().toId(), args.programs);
 
     Table table = Table.builder()
       .setHeader("name", "type", "error")

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/UpdateAppCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/UpdateAppCommand.java
@@ -33,6 +33,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.File;
 import java.io.FileReader;
@@ -45,11 +46,11 @@ import java.lang.reflect.Type;
 public class UpdateAppCommand extends AbstractAuthCommand {
   private static final Type CONFIG_TYPE = new TypeToken<AppRequest<JsonObject>>() { }.getType();
   private static final Gson GSON = new Gson();
-  private final ApplicationClient applicationClient;
+  private final Provider<ApplicationClient> applicationClient;
   private final FilePathResolver resolver;
 
   @Inject
-  public UpdateAppCommand(ApplicationClient applicationClient, FilePathResolver resolver, CLIConfig cliConfig) {
+  UpdateAppCommand(Provider<ApplicationClient> applicationClient, FilePathResolver resolver, CLIConfig cliConfig) {
     super(cliConfig);
     this.applicationClient = applicationClient;
     this.resolver = resolver;
@@ -76,7 +77,7 @@ public class UpdateAppCommand extends AbstractAuthCommand {
     }
 
     AppRequest<JsonObject> appRequest = new AppRequest<>(artifact, config);
-    applicationClient.update(appId.toId(), appRequest);
+    applicationClient.get().update(appId.toId(), appRequest);
     output.println("Successfully updated application");
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DeleteArtifactCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DeleteArtifactCommand.java
@@ -25,8 +25,8 @@ import co.cask.cdap.cli.util.AbstractAuthCommand;
 import co.cask.cdap.client.ArtifactClient;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.common.cli.Arguments;
-import com.google.gson.Gson;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -35,11 +35,10 @@ import java.io.PrintStream;
  */
 public class DeleteArtifactCommand extends AbstractAuthCommand {
 
-  private static final Gson GSON = new Gson();
-  private final ArtifactClient artifactClient;
+  private final Provider<ArtifactClient> artifactClient;
 
   @Inject
-  public DeleteArtifactCommand(ArtifactClient artifactClient, CLIConfig cliConfig) {
+  DeleteArtifactCommand(Provider<ArtifactClient> artifactClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.artifactClient = artifactClient;
   }
@@ -51,7 +50,7 @@ public class DeleteArtifactCommand extends AbstractAuthCommand {
     String artifactVersion = arguments.get(ArgumentName.ARTIFACT_VERSION.toString());
     ArtifactId artifactId = cliConfig.getCurrentNamespace().artifact(artifactName, artifactVersion);
 
-    artifactClient.delete(artifactId.toId());
+    artifactClient.get().delete(artifactId.toId());
 
     output.printf("Successfully deleted artifact\n");
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DescribeArtifactCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DescribeArtifactCommand.java
@@ -31,6 +31,7 @@ import co.cask.common.cli.Arguments;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -41,10 +42,10 @@ import java.util.List;
 public class DescribeArtifactCommand extends AbstractAuthCommand {
 
   private static final Gson GSON = new Gson();
-  private final ArtifactClient artifactClient;
+  private final Provider<ArtifactClient> artifactClient;
 
   @Inject
-  public DescribeArtifactCommand(ArtifactClient artifactClient, CLIConfig cliConfig) {
+  DescribeArtifactCommand(Provider<ArtifactClient> artifactClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.artifactClient = artifactClient;
   }
@@ -59,10 +60,10 @@ public class DescribeArtifactCommand extends AbstractAuthCommand {
 
     ArtifactInfo info;
     if (scopeStr == null) {
-      info = artifactClient.getArtifactInfo(artifactId.toId());
+      info = artifactClient.get().getArtifactInfo(artifactId.toId());
     } else {
       ArtifactScope scope = ArtifactScope.valueOf(scopeStr.toUpperCase());
-      info = artifactClient.getArtifactInfo(artifactId.toId(), scope);
+      info = artifactClient.get().getArtifactInfo(artifactId.toId(), scope);
     }
 
     Table table = Table.builder()

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DescribeArtifactPluginCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DescribeArtifactPluginCommand.java
@@ -30,6 +30,7 @@ import co.cask.common.cli.Arguments;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -40,10 +41,10 @@ import java.util.List;
 public class DescribeArtifactPluginCommand extends AbstractAuthCommand {
   private static final Gson GSON = new Gson();
 
-  private final ArtifactClient artifactClient;
+  private final Provider<ArtifactClient> artifactClient;
 
   @Inject
-  public DescribeArtifactPluginCommand(ArtifactClient artifactClient, CLIConfig cliConfig) {
+  DescribeArtifactPluginCommand(Provider<ArtifactClient> artifactClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.artifactClient = artifactClient;
   }
@@ -60,9 +61,9 @@ public class DescribeArtifactPluginCommand extends AbstractAuthCommand {
     List<PluginInfo> pluginInfos;
     String scopeStr = arguments.getOptional(ArgumentName.SCOPE.toString());
     if (scopeStr == null) {
-      pluginInfos = artifactClient.getPluginInfo(artifactId.toId(), pluginType, pluginName);
+      pluginInfos = artifactClient.get().getPluginInfo(artifactId.toId(), pluginType, pluginName);
     } else {
-      pluginInfos = artifactClient.getPluginInfo(artifactId.toId(), pluginType, pluginName,
+      pluginInfos = artifactClient.get().getPluginInfo(artifactId.toId(), pluginType, pluginName,
         ArtifactScope.valueOf(scopeStr.toUpperCase()));
     }
     Table table = Table.builder()

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/GetArtifactPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/GetArtifactPropertiesCommand.java
@@ -30,6 +30,7 @@ import co.cask.cdap.proto.artifact.ArtifactInfo;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -40,10 +41,10 @@ import java.util.Map;
  * Gets properties for an artifact.
  */
 public class GetArtifactPropertiesCommand extends AbstractAuthCommand {
-  private final ArtifactClient artifactClient;
+  private final Provider<ArtifactClient> artifactClient;
 
   @Inject
-  public GetArtifactPropertiesCommand(ArtifactClient artifactClient, CLIConfig cliConfig) {
+  GetArtifactPropertiesCommand(Provider<ArtifactClient> artifactClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.artifactClient = artifactClient;
   }
@@ -58,10 +59,10 @@ public class GetArtifactPropertiesCommand extends AbstractAuthCommand {
 
     ArtifactInfo info;
     if (scopeStr == null) {
-      info = artifactClient.getArtifactInfo(artifactId.toId());
+      info = artifactClient.get().getArtifactInfo(artifactId.toId());
     } else {
       ArtifactScope scope = ArtifactScope.valueOf(scopeStr.toUpperCase());
-      info = artifactClient.getArtifactInfo(artifactId.toId(), scope);
+      info = artifactClient.get().getArtifactInfo(artifactId.toId(), scope);
     }
 
     List<Map.Entry<String, String>> rows = new ArrayList<>(info.getProperties().size());

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactPluginTypesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactPluginTypesCommand.java
@@ -28,6 +28,7 @@ import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.common.cli.Arguments;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -37,10 +38,10 @@ import java.util.List;
  */
 public class ListArtifactPluginTypesCommand extends AbstractAuthCommand {
 
-  private final ArtifactClient artifactClient;
+  private final Provider<ArtifactClient> artifactClient;
 
   @Inject
-  public ListArtifactPluginTypesCommand(ArtifactClient artifactClient, CLIConfig cliConfig) {
+  ListArtifactPluginTypesCommand(Provider<ArtifactClient> artifactClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.artifactClient = artifactClient;
   }
@@ -55,9 +56,9 @@ public class ListArtifactPluginTypesCommand extends AbstractAuthCommand {
     List<String> types;
     String scopeStr = arguments.getOptional(ArgumentName.SCOPE.toString());
     if (scopeStr == null) {
-      types = artifactClient.getPluginTypes(artifactId.toId());
+      types = artifactClient.get().getPluginTypes(artifactId.toId());
     } else {
-      types = artifactClient.getPluginTypes(artifactId.toId(), ArtifactScope.valueOf(scopeStr.toUpperCase()));
+      types = artifactClient.get().getPluginTypes(artifactId.toId(), ArtifactScope.valueOf(scopeStr.toUpperCase()));
     }
 
     Table table = Table.builder()

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactPluginsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactPluginsCommand.java
@@ -29,6 +29,7 @@ import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.common.cli.Arguments;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -38,10 +39,10 @@ import java.util.List;
  */
 public class ListArtifactPluginsCommand extends AbstractAuthCommand {
 
-  private final ArtifactClient artifactClient;
+  private final Provider<ArtifactClient> artifactClient;
 
   @Inject
-  public ListArtifactPluginsCommand(ArtifactClient artifactClient, CLIConfig cliConfig) {
+  ListArtifactPluginsCommand(Provider<ArtifactClient> artifactClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.artifactClient = artifactClient;
   }
@@ -57,10 +58,10 @@ public class ListArtifactPluginsCommand extends AbstractAuthCommand {
     final List<PluginSummary> pluginSummaries;
     String scopeStr = arguments.getOptional(ArgumentName.SCOPE.toString());
     if (scopeStr == null) {
-      pluginSummaries = artifactClient.getPluginSummaries(artifactId.toId(), pluginType);
+      pluginSummaries = artifactClient.get().getPluginSummaries(artifactId.toId(), pluginType);
     } else {
-      pluginSummaries = artifactClient.getPluginSummaries(artifactId.toId(), pluginType,
-        ArtifactScope.valueOf(scopeStr.toUpperCase()));
+      pluginSummaries = artifactClient.get().getPluginSummaries(artifactId.toId(), pluginType,
+                                                                ArtifactScope.valueOf(scopeStr.toUpperCase()));
     }
     Table table = Table.builder()
       .setHeader("type", "name", "classname", "description", "artifact")

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactVersionsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactVersionsCommand.java
@@ -28,6 +28,7 @@ import co.cask.cdap.proto.artifact.ArtifactSummary;
 import co.cask.common.cli.Arguments;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -37,10 +38,10 @@ import java.util.List;
  */
 public class ListArtifactVersionsCommand extends AbstractAuthCommand {
 
-  private final ArtifactClient artifactClient;
+  private final Provider<ArtifactClient> artifactClient;
 
   @Inject
-  public ListArtifactVersionsCommand(ArtifactClient artifactClient, CLIConfig cliConfig) {
+  ListArtifactVersionsCommand(Provider<ArtifactClient> artifactClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.artifactClient = artifactClient;
   }
@@ -51,10 +52,11 @@ public class ListArtifactVersionsCommand extends AbstractAuthCommand {
     String artifactName = arguments.get(ArgumentName.ARTIFACT_NAME.toString());
     List<ArtifactSummary> artifactSummaries;
     if (scopeStr == null) {
-      artifactSummaries = artifactClient.listVersions(cliConfig.getCurrentNamespace().toId(), artifactName);
+      artifactSummaries = artifactClient.get().listVersions(cliConfig.getCurrentNamespace().toId(), artifactName);
     } else {
       ArtifactScope scope = ArtifactScope.valueOf(scopeStr.toUpperCase());
-      artifactSummaries = artifactClient.listVersions(cliConfig.getCurrentNamespace().toId(), artifactName, scope);
+      artifactSummaries = artifactClient.get().listVersions(cliConfig.getCurrentNamespace().toId(), artifactName,
+                                                            scope);
     }
 
     Table table = Table.builder()

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactsCommand.java
@@ -28,6 +28,7 @@ import co.cask.cdap.proto.artifact.ArtifactSummary;
 import co.cask.common.cli.Arguments;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -37,10 +38,10 @@ import java.util.List;
  */
 public class ListArtifactsCommand extends AbstractAuthCommand {
 
-  private final ArtifactClient artifactClient;
+  private final Provider<ArtifactClient> artifactClient;
 
   @Inject
-  public ListArtifactsCommand(ArtifactClient artifactClient, CLIConfig cliConfig) {
+  ListArtifactsCommand(Provider<ArtifactClient> artifactClient, CLIConfig cliConfig) {
     super(cliConfig);
     this.artifactClient = artifactClient;
   }
@@ -51,10 +52,10 @@ public class ListArtifactsCommand extends AbstractAuthCommand {
     List<ArtifactSummary> artifactSummaries;
     String artifactScope = arguments.getOptional(ArgumentName.SCOPE.toString());
     if (artifactScope == null) {
-      artifactSummaries = artifactClient.list(cliConfig.getCurrentNamespace().toId());
+      artifactSummaries = artifactClient.get().list(cliConfig.getCurrentNamespace().toId());
     } else {
-      artifactSummaries = artifactClient.list(cliConfig.getCurrentNamespace().toId(),
-                                              ArtifactScope.valueOf(artifactScope.toUpperCase()));
+      artifactSummaries = artifactClient.get().list(cliConfig.getCurrentNamespace().toId(),
+                                                    ArtifactScope.valueOf(artifactScope.toUpperCase()));
     }
     Table table = Table.builder()
       .setHeader("name", "version", "scope")

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/SetArtifactPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/SetArtifactPropertiesCommand.java
@@ -30,6 +30,7 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.common.cli.Arguments;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.File;
 import java.io.FileReader;
@@ -42,11 +43,12 @@ import java.util.Map;
  */
 public class SetArtifactPropertiesCommand extends AbstractAuthCommand {
   private static final Gson GSON = new Gson();
-  private final ArtifactClient artifactClient;
+  private final Provider<ArtifactClient> artifactClient;
   private final FilePathResolver resolver;
 
   @Inject
-  public SetArtifactPropertiesCommand(ArtifactClient artifactClient, CLIConfig cliConfig, FilePathResolver resolver) {
+  SetArtifactPropertiesCommand(Provider<ArtifactClient> artifactClient, CLIConfig cliConfig,
+                               FilePathResolver resolver) {
     super(cliConfig);
     this.artifactClient = artifactClient;
     this.resolver = resolver;
@@ -74,7 +76,7 @@ public class SetArtifactPropertiesCommand extends AbstractAuthCommand {
                                      "and that it contains a 'properties' key whose value is a JSON object of the " +
                                      "artifact properties.", e);
       }
-      artifactClient.writeProperties(artifactId.toId(), properties.properties);
+      artifactClient.get().writeProperties(artifactId.toId(), properties.properties);
     }
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/lineage/GetDatasetLineageCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/lineage/GetDatasetLineageCommand.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.Collections;
@@ -39,10 +40,10 @@ import java.util.List;
 public class GetDatasetLineageCommand extends AbstractCommand {
 
   private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
-  private final LineageClient client;
+  private final Provider<LineageClient> client;
 
   @Inject
-  public GetDatasetLineageCommand(CLIConfig cliConfig, LineageClient client) {
+  GetDatasetLineageCommand(CLIConfig cliConfig, Provider<LineageClient> client) {
     super(cliConfig);
     this.client = client;
   }
@@ -55,7 +56,7 @@ public class GetDatasetLineageCommand extends AbstractCommand {
     long end = getTimestamp(arguments.getOptional("end", "max"), currentTime);
     Integer levels = arguments.getIntOptional("levels", null);
 
-    LineageRecord lineage = client.getLineage(dataset.toId(), start, end, levels);
+    LineageRecord lineage = client.get().getLineage(dataset.toId(), start, end, levels);
     Table table = Table.builder()
       .setHeader("start", "end", "relations", "programs", "data")
       .setRows(

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/lineage/GetStreamLineageCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/lineage/GetStreamLineageCommand.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.Collections;
@@ -39,10 +40,10 @@ import java.util.List;
 public class GetStreamLineageCommand extends AbstractCommand {
 
   private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
-  private final LineageClient client;
+  private final Provider<LineageClient> client;
 
   @Inject
-  public GetStreamLineageCommand(CLIConfig cliConfig, LineageClient client) {
+  GetStreamLineageCommand(CLIConfig cliConfig, Provider<LineageClient> client) {
     super(cliConfig);
     this.client = client;
   }
@@ -55,7 +56,7 @@ public class GetStreamLineageCommand extends AbstractCommand {
     long end = getTimestamp(arguments.getOptional("end", "max"), currentTime);
     Integer levels = arguments.getIntOptional("levels", null);
 
-    LineageRecord lineage = client.getLineage(stream.toId(), start, end, levels);
+    LineageRecord lineage = client.get().getLineage(stream.toId(), start, end, levels);
     Table table = Table.builder()
       .setHeader("start", "end", "relations", "programs", "data")
       .setRows(

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/AddMetadataPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/AddMetadataPropertiesCommand.java
@@ -23,6 +23,7 @@ import co.cask.cdap.client.MetadataClient;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.Map;
@@ -32,10 +33,10 @@ import java.util.Map;
  */
 public class AddMetadataPropertiesCommand extends AbstractCommand {
 
-  private final MetadataClient client;
+  private final Provider<MetadataClient> client;
 
   @Inject
-  public AddMetadataPropertiesCommand(CLIConfig cliConfig, MetadataClient client) {
+  AddMetadataPropertiesCommand(CLIConfig cliConfig, Provider<MetadataClient> client) {
     super(cliConfig);
     this.client = client;
   }
@@ -44,7 +45,7 @@ public class AddMetadataPropertiesCommand extends AbstractCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
     Map<String, String> properties = parseMap(arguments.get("properties"));
-    client.addProperties(entity.toId(), properties);
+    client.get().addProperties(entity.toId(), properties);
     output.println("Successfully added metadata properties");
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/AddMetadataTagsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/AddMetadataTagsCommand.java
@@ -24,6 +24,7 @@ import co.cask.cdap.proto.id.EntityId;
 import co.cask.common.cli.Arguments;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.Set;
@@ -33,10 +34,10 @@ import java.util.Set;
  */
 public class AddMetadataTagsCommand extends AbstractCommand {
 
-  private final MetadataClient client;
+  private final Provider<MetadataClient> client;
 
   @Inject
-  public AddMetadataTagsCommand(CLIConfig cliConfig, MetadataClient client) {
+  AddMetadataTagsCommand(CLIConfig cliConfig, Provider<MetadataClient> client) {
     super(cliConfig);
     this.client = client;
   }
@@ -45,7 +46,7 @@ public class AddMetadataTagsCommand extends AbstractCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
     Set<String> tags = ImmutableSet.copyOf(parseList(arguments.get("tags")));
-    client.addTags(entity.toId(), tags);
+    client.get().addTags(entity.toId(), tags);
     output.println("Successfully added metadata tags");
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataCommand.java
@@ -30,6 +30,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -41,10 +42,10 @@ import javax.annotation.Nullable;
  */
 public class GetMetadataCommand extends AbstractCommand {
 
-  private final MetadataClient client;
+  private final Provider<MetadataClient> client;
 
   @Inject
-  public GetMetadataCommand(CLIConfig cliConfig, MetadataClient client) {
+  GetMetadataCommand(CLIConfig cliConfig, Provider<MetadataClient> client) {
     super(cliConfig);
     this.client = client;
   }
@@ -53,14 +54,13 @@ public class GetMetadataCommand extends AbstractCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
     String scope = arguments.getOptional(ArgumentName.METADATA_SCOPE.toString());
-    Set<MetadataRecord> metadata = scope == null ? client.getMetadata(entity.toId()) :
-      client.getMetadata(entity.toId(), MetadataScope.valueOf(scope.toUpperCase()));
+    Set<MetadataRecord> metadata = scope == null ? client.get().getMetadata(entity.toId()) :
+      client.get().getMetadata(entity.toId(), MetadataScope.valueOf(scope.toUpperCase()));
 
     Table table = Table.builder()
       .setHeader("entity", "tags", "properties", "scope")
       .setRows(
         Iterables.transform(metadata, new Function<MetadataRecord, List<String>>() {
-          @Nullable
           @Override
           public List<String> apply(MetadataRecord record) {
             return Lists.newArrayList(

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataPropertiesCommand.java
@@ -28,6 +28,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -39,10 +40,10 @@ import javax.annotation.Nullable;
  */
 public class GetMetadataPropertiesCommand extends AbstractCommand {
 
-  private final MetadataClient client;
+  private final Provider<MetadataClient> client;
 
   @Inject
-  public GetMetadataPropertiesCommand(CLIConfig cliConfig, MetadataClient client) {
+  GetMetadataPropertiesCommand(CLIConfig cliConfig, Provider<MetadataClient> client) {
     super(cliConfig);
     this.client = client;
   }
@@ -51,16 +52,15 @@ public class GetMetadataPropertiesCommand extends AbstractCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
     String scope = arguments.getOptional(ArgumentName.METADATA_SCOPE.toString());
-    Map<String, String> properties = scope == null ? client.getProperties(entity.toId()) :
-      client.getProperties(entity.toId(), MetadataScope.valueOf(scope.toUpperCase()));
+    Map<String, String> properties = scope == null ? client.get().getProperties(entity.toId()) :
+      client.get().getProperties(entity.toId(), MetadataScope.valueOf(scope.toUpperCase()));
 
     Table table = Table.builder()
       .setHeader("key", "value")
       .setRows(
         Iterables.transform(properties.entrySet(), new Function<Map.Entry<String, String>, List<String>>() {
-          @Nullable
           @Override
-          public List<String> apply(@Nullable Map.Entry<String, String> entry) {
+          public List<String> apply(Map.Entry<String, String> entry) {
             return Lists.newArrayList(entry.getKey(), entry.getValue());
           }
         })

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataTagsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataTagsCommand.java
@@ -28,6 +28,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -39,10 +40,10 @@ import javax.annotation.Nullable;
  */
 public class GetMetadataTagsCommand extends AbstractCommand {
 
-  private final MetadataClient client;
+  private final Provider<MetadataClient> client;
 
   @Inject
-  public GetMetadataTagsCommand(CLIConfig cliConfig, MetadataClient client) {
+  GetMetadataTagsCommand(CLIConfig cliConfig, Provider<MetadataClient> client) {
     super(cliConfig);
     this.client = client;
   }
@@ -51,8 +52,8 @@ public class GetMetadataTagsCommand extends AbstractCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
     String scope = arguments.getOptional(ArgumentName.METADATA_SCOPE.toString());
-    Set<String> tags = scope == null ? client.getTags(entity.toId()) :
-      client.getTags(entity.toId(), MetadataScope.valueOf(scope.toUpperCase()));
+    Set<String> tags = scope == null ? client.get().getTags(entity.toId()) :
+      client.get().getTags(entity.toId(), MetadataScope.valueOf(scope.toUpperCase()));
 
     Table table = Table.builder()
       .setHeader("tags")

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataCommand.java
@@ -23,6 +23,7 @@ import co.cask.cdap.client.MetadataClient;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -31,10 +32,10 @@ import java.io.PrintStream;
  */
 public class RemoveMetadataCommand extends AbstractCommand {
 
-  private final MetadataClient client;
+  private final Provider<MetadataClient> client;
 
   @Inject
-  public RemoveMetadataCommand(CLIConfig cliConfig, MetadataClient client) {
+  RemoveMetadataCommand(CLIConfig cliConfig, Provider<MetadataClient> client) {
     super(cliConfig);
     this.client = client;
   }
@@ -42,7 +43,7 @@ public class RemoveMetadataCommand extends AbstractCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
-    client.removeMetadata(entity.toId());
+    client.get().removeMetadata(entity.toId());
     output.println("Successfully removed metadata");
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataPropertiesCommand.java
@@ -23,6 +23,7 @@ import co.cask.cdap.client.MetadataClient;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -31,10 +32,10 @@ import java.io.PrintStream;
  */
 public class RemoveMetadataPropertiesCommand extends AbstractCommand {
 
-  private final MetadataClient client;
+  private final Provider<MetadataClient> client;
 
   @Inject
-  public RemoveMetadataPropertiesCommand(CLIConfig cliConfig, MetadataClient client) {
+  RemoveMetadataPropertiesCommand(CLIConfig cliConfig, Provider<MetadataClient> client) {
     super(cliConfig);
     this.client = client;
   }
@@ -42,7 +43,7 @@ public class RemoveMetadataPropertiesCommand extends AbstractCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
-    client.removeProperties(entity.toId());
+    client.get().removeProperties(entity.toId());
     output.println("Successfully removed metadata properties");
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataPropertyCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataPropertyCommand.java
@@ -23,6 +23,7 @@ import co.cask.cdap.client.MetadataClient;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -31,10 +32,10 @@ import java.io.PrintStream;
  */
 public class RemoveMetadataPropertyCommand extends AbstractCommand {
 
-  private final MetadataClient client;
+  private final Provider<MetadataClient> client;
 
   @Inject
-  public RemoveMetadataPropertyCommand(CLIConfig cliConfig, MetadataClient client) {
+  RemoveMetadataPropertyCommand(CLIConfig cliConfig, Provider<MetadataClient> client) {
     super(cliConfig);
     this.client = client;
   }
@@ -43,7 +44,7 @@ public class RemoveMetadataPropertyCommand extends AbstractCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
     String property = arguments.get("property");
-    client.removeProperty(entity.toId(), property);
+    client.get().removeProperty(entity.toId(), property);
     output.println("Successfully removed metadata property");
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataTagCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataTagCommand.java
@@ -23,6 +23,7 @@ import co.cask.cdap.client.MetadataClient;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -31,10 +32,10 @@ import java.io.PrintStream;
  */
 public class RemoveMetadataTagCommand extends AbstractCommand {
 
-  private final MetadataClient client;
+  private final Provider<MetadataClient> client;
 
   @Inject
-  public RemoveMetadataTagCommand(CLIConfig cliConfig, MetadataClient client) {
+  RemoveMetadataTagCommand(CLIConfig cliConfig, Provider<MetadataClient> client) {
     super(cliConfig);
     this.client = client;
   }
@@ -43,7 +44,7 @@ public class RemoveMetadataTagCommand extends AbstractCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
     String tag = arguments.get("tag");
-    client.removeTag(entity.toId(), tag);
+    client.get().removeTag(entity.toId(), tag);
     output.println("Successfully removed metadata tag");
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataTagsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataTagsCommand.java
@@ -23,6 +23,7 @@ import co.cask.cdap.client.MetadataClient;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -31,10 +32,10 @@ import java.io.PrintStream;
  */
 public class RemoveMetadataTagsCommand extends AbstractCommand {
 
-  private final MetadataClient client;
+  private final Provider<MetadataClient> client;
 
   @Inject
-  public RemoveMetadataTagsCommand(CLIConfig cliConfig, MetadataClient client) {
+  RemoveMetadataTagsCommand(CLIConfig cliConfig, Provider<MetadataClient> client) {
     super(cliConfig);
     this.client = client;
   }
@@ -42,7 +43,7 @@ public class RemoveMetadataTagsCommand extends AbstractCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
-    client.removeTags(entity.toId());
+    client.get().removeTags(entity.toId());
     output.println("Successfully removed metadata tags");
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/SearchMetadataCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/SearchMetadataCommand.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -49,10 +50,10 @@ public class SearchMetadataCommand extends AbstractCommand {
       }
     };
 
-  private final MetadataClient metadataClient;
+  private final Provider<MetadataClient> metadataClient;
 
   @Inject
-  public SearchMetadataCommand(CLIConfig cliConfig, MetadataClient metadataClient) {
+  SearchMetadataCommand(CLIConfig cliConfig, Provider<MetadataClient> metadataClient) {
     super(cliConfig);
     this.metadataClient = metadataClient;
   }
@@ -62,7 +63,7 @@ public class SearchMetadataCommand extends AbstractCommand {
     String searchQuery = arguments.get(ArgumentName.SEARCH_QUERY.toString());
     String type = arguments.getOptional(ArgumentName.TARGET_TYPE.toString());
     Set<MetadataSearchResultRecord> searchResults =
-      metadataClient.searchMetadata(cliConfig.getCurrentNamespace().toId(), searchQuery, parseTargetType(type));
+      metadataClient.get().searchMetadata(cliConfig.getCurrentNamespace().toId(), searchQuery, parseTargetType(type));
     Table table = Table.builder()
       .setHeader("Entity")
       .setRows(Lists.newArrayList(searchResults), new RowMaker<MetadataSearchResultRecord>() {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metrics/GetMetricCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metrics/GetMetricCommand.java
@@ -28,6 +28,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -38,10 +39,10 @@ import java.util.Map;
  */
 public class GetMetricCommand extends AbstractAuthCommand {
 
-  private final MetricsClient client;
+  private final Provider<MetricsClient> client;
 
   @Inject
-  public GetMetricCommand(MetricsClient client, CLIConfig cliConfig) {
+  GetMetricCommand(Provider<MetricsClient> client, CLIConfig cliConfig) {
     super(cliConfig);
     this.client = client;
   }
@@ -49,11 +50,11 @@ public class GetMetricCommand extends AbstractAuthCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     String metric = arguments.get("metric-name");
-    Map<String, String> tags = ArgumentParser.parseMap(arguments.get("tags", ""));
-    String start = arguments.get("start", "");
-    String end = arguments.get("end", "");
+    Map<String, String> tags = ArgumentParser.parseMap(arguments.getOptional("tags", ""));
+    String start = arguments.getOptional("start", "");
+    String end = arguments.getOptional("end", "");
 
-    MetricQueryResult result = client.query(
+    MetricQueryResult result = client.get().query(
       tags, ImmutableList.of(metric), ImmutableList.<String>of(),
       start.isEmpty() ? null : start,
       end.isEmpty() ? null : end);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metrics/SearchMetricNamesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metrics/SearchMetricNamesCommand.java
@@ -22,6 +22,7 @@ import co.cask.cdap.cli.util.ArgumentParser;
 import co.cask.cdap.client.MetricsClient;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -32,18 +33,18 @@ import java.util.Map;
  */
 public class SearchMetricNamesCommand extends AbstractAuthCommand {
 
-  private final MetricsClient client;
+  private final Provider<MetricsClient> client;
 
   @Inject
-  public SearchMetricNamesCommand(MetricsClient client, CLIConfig cliConfig) {
+  SearchMetricNamesCommand(Provider<MetricsClient> client, CLIConfig cliConfig) {
     super(cliConfig);
     this.client = client;
   }
 
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
-    Map<String, String> tags = ArgumentParser.parseMap(arguments.get("tags", ""));
-    List<String> results = client.searchMetrics(tags);
+    Map<String, String> tags = ArgumentParser.parseMap(arguments.getOptional("tags", ""));
+    List<String> results = client.get().searchMetrics(tags);
     for (String result : results) {
       output.println(result);
     }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metrics/SearchMetricTagsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metrics/SearchMetricTagsCommand.java
@@ -23,6 +23,7 @@ import co.cask.cdap.client.MetricsClient;
 import co.cask.cdap.proto.MetricTagValue;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -33,18 +34,18 @@ import java.util.Map;
  */
 public class SearchMetricTagsCommand extends AbstractAuthCommand {
 
-  private final MetricsClient client;
+  private final Provider<MetricsClient> client;
 
   @Inject
-  public SearchMetricTagsCommand(MetricsClient client, CLIConfig cliConfig) {
+  SearchMetricTagsCommand(Provider<MetricsClient> client, CLIConfig cliConfig) {
     super(cliConfig);
     this.client = client;
   }
 
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
-    Map<String, String> tags = ArgumentParser.parseMap(arguments.get("tags", ""));
-    List<MetricTagValue> results = client.searchTags(tags);
+    Map<String, String> tags = ArgumentParser.parseMap(arguments.getOptional("tags", ""));
+    List<MetricTagValue> results = client.get().searchTags(tags);
     for (MetricTagValue result : results) {
       output.printf("%s=%s\n", result.getName(), result.getValue());
     }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/AddRoleToPrincipalCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/AddRoleToPrincipalCommand.java
@@ -24,6 +24,7 @@ import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Role;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -32,10 +33,10 @@ import java.io.PrintStream;
  */
 public class AddRoleToPrincipalCommand extends AbstractAuthCommand {
 
-  private final AuthorizationClient client;
+  private final Provider<AuthorizationClient> client;
 
   @Inject
-  AddRoleToPrincipalCommand(AuthorizationClient client, CLIConfig cliConfig) {
+  AddRoleToPrincipalCommand(Provider<AuthorizationClient> client, CLIConfig cliConfig) {
     super(cliConfig);
     this.client = client;
   }
@@ -45,8 +46,8 @@ public class AddRoleToPrincipalCommand extends AbstractAuthCommand {
     String roleName = arguments.get("role-name");
     String principalType = arguments.get("principal-type");
     String principalName = arguments.get("principal-name");
-    client.addRoleToPrincipal(new Role(roleName), new Principal(principalName, Principal.PrincipalType.valueOf
-      (principalType.toUpperCase())));
+    Principal principal = new Principal(principalName, Principal.PrincipalType.valueOf(principalType.toUpperCase()));
+    client.get().addRoleToPrincipal(new Role(roleName), principal);
     output.printf("Successfully added role '%s' to '%s' '%s'\n", roleName, principalType, principalName);
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/CreateRoleCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/CreateRoleCommand.java
@@ -23,6 +23,7 @@ import co.cask.cdap.client.AuthorizationClient;
 import co.cask.cdap.proto.security.Role;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -31,10 +32,10 @@ import java.io.PrintStream;
  */
 public class CreateRoleCommand extends AbstractAuthCommand {
 
-  private final AuthorizationClient client;
+  private final Provider<AuthorizationClient> client;
 
   @Inject
-  CreateRoleCommand(AuthorizationClient client, CLIConfig cliConfig) {
+  CreateRoleCommand(Provider<AuthorizationClient> client, CLIConfig cliConfig) {
     super(cliConfig);
     this.client = client;
   }
@@ -42,7 +43,7 @@ public class CreateRoleCommand extends AbstractAuthCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     String roleName = arguments.get("role-name");
-    client.createRole(new Role(roleName));
+    client.get().createRole(new Role(roleName));
     output.printf("Successfully created role '%s'\n", roleName);
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/DropRoleCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/DropRoleCommand.java
@@ -23,6 +23,7 @@ import co.cask.cdap.client.AuthorizationClient;
 import co.cask.cdap.proto.security.Role;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -31,10 +32,10 @@ import java.io.PrintStream;
  */
 public class DropRoleCommand extends AbstractAuthCommand {
 
-  private final AuthorizationClient client;
+  private final Provider<AuthorizationClient> client;
 
   @Inject
-  DropRoleCommand(AuthorizationClient client, CLIConfig cliConfig) {
+  DropRoleCommand(Provider<AuthorizationClient> client, CLIConfig cliConfig) {
     super(cliConfig);
     this.client = client;
   }
@@ -42,7 +43,7 @@ public class DropRoleCommand extends AbstractAuthCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     String roleName = arguments.get("role-name");
-    client.dropRole(new Role(roleName));
+    client.get().dropRole(new Role(roleName));
     output.printf("Successfully dropped role '%s'\n", roleName);
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/GrantActionCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/GrantActionCommand.java
@@ -27,6 +27,7 @@ import co.cask.common.cli.Arguments;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.Set;
@@ -36,10 +37,10 @@ import java.util.Set;
  */
 public class GrantActionCommand extends AbstractAuthCommand {
 
-  private final AuthorizationClient client;
+  private final Provider<AuthorizationClient> client;
 
   @Inject
-  GrantActionCommand(AuthorizationClient client, CLIConfig cliConfig) {
+  GrantActionCommand(Provider<AuthorizationClient> client, CLIConfig cliConfig) {
     super(cliConfig);
     this.client = client;
   }
@@ -55,7 +56,7 @@ public class GrantActionCommand extends AbstractAuthCommand {
     // actions is not an optional argument so should never be null
     Preconditions.checkNotNull(actions, "Actions can never be null in the grant command.");
 
-    client.grant(entity, principal, actions);
+    client.get().grant(entity, principal, actions);
     output.printf("Successfully granted action(s) '%s' on entity '%s' to %s '%s'\n",
                   Joiner.on(",").join(actions), entity.toString(), principal.getType(), principal.getName());
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/ListPrivilegesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/ListPrivilegesCommand.java
@@ -27,6 +27,7 @@ import co.cask.cdap.proto.security.Privilege;
 import co.cask.common.cli.Arguments;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -36,10 +37,10 @@ import java.util.List;
  */
 public class ListPrivilegesCommand extends AbstractAuthCommand {
 
-  private final AuthorizationClient client;
+  private final Provider<AuthorizationClient> client;
 
   @Inject
-  ListPrivilegesCommand(AuthorizationClient client, CLIConfig cliConfig) {
+  ListPrivilegesCommand(Provider<AuthorizationClient> client, CLIConfig cliConfig) {
     super(cliConfig);
     this.client = client;
   }
@@ -48,10 +49,11 @@ public class ListPrivilegesCommand extends AbstractAuthCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     String principalType = arguments.get(ArgumentName.PRINCIPAL_TYPE.toString());
     String principalName = arguments.get(ArgumentName.PRINCIPAL_NAME.toString());
+    Principal.PrincipalType type = Principal.PrincipalType.valueOf(principalType.toUpperCase());
     Table table = Table.builder()
       .setHeader("Entity", "Action")
-      .setRows(Lists.newArrayList(client.listPrivileges(new Principal(principalName, Principal.PrincipalType.valueOf
-        (principalType.toUpperCase())))), new RowMaker<Privilege>() {
+      .setRows(Lists.newArrayList(client.get().listPrivileges(new Principal(principalName, type))
+      ), new RowMaker<Privilege>() {
         @Override
         public List<?> makeRow(Privilege privilege) {
           return Lists.newArrayList(privilege.getEntity().toString(), privilege.getAction().name());

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/ListRolesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/ListRolesCommand.java
@@ -28,6 +28,7 @@ import co.cask.common.cli.Arguments;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -38,10 +39,10 @@ import java.util.Set;
  */
 public class ListRolesCommand extends AbstractAuthCommand {
 
-  private final AuthorizationClient client;
+  private final Provider<AuthorizationClient> client;
 
   @Inject
-  ListRolesCommand(AuthorizationClient client, CLIConfig cliConfig) {
+  ListRolesCommand(Provider<AuthorizationClient> client, CLIConfig cliConfig) {
     super(cliConfig);
     this.client = client;
   }
@@ -53,10 +54,10 @@ public class ListRolesCommand extends AbstractAuthCommand {
 
     Set<Role> roles;
     if (!(Strings.isNullOrEmpty(principalType) && Strings.isNullOrEmpty(principalName))) {
-      roles = client.listRoles(new Principal(principalName,
-                                             Principal.PrincipalType.valueOf(principalType.toUpperCase())));
+      roles = client.get().listRoles(
+        new Principal(principalName, Principal.PrincipalType.valueOf(principalType.toUpperCase())));
     } else {
-      roles = client.listAllRoles();
+      roles = client.get().listAllRoles();
     }
 
     Table table = Table.builder()

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/RemoveRoleFromPrincipalCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/RemoveRoleFromPrincipalCommand.java
@@ -24,6 +24,7 @@ import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Role;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -32,10 +33,10 @@ import java.io.PrintStream;
  */
 public class RemoveRoleFromPrincipalCommand extends AbstractAuthCommand {
 
-  private final AuthorizationClient client;
+  private final Provider<AuthorizationClient> client;
 
   @Inject
-  RemoveRoleFromPrincipalCommand(AuthorizationClient client, CLIConfig cliConfig) {
+  RemoveRoleFromPrincipalCommand(Provider<AuthorizationClient> client, CLIConfig cliConfig) {
     super(cliConfig);
     this.client = client;
   }
@@ -45,8 +46,8 @@ public class RemoveRoleFromPrincipalCommand extends AbstractAuthCommand {
     String roleName = arguments.get("role-name");
     String principalType = arguments.get("principal-type");
     String principalName = arguments.get("principal-name");
-    client.removeRoleFromPrincipal(new Role(roleName), new Principal(principalName, Principal.PrincipalType.valueOf
-      (principalType.toUpperCase())));
+    client.get().removeRoleFromPrincipal(
+      new Role(roleName), new Principal(principalName, Principal.PrincipalType.valueOf(principalType.toUpperCase())));
     output.printf("Successfully removed role '%s' from %s '%s'\n", roleName, principalType, principalName);
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/RevokeActionCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/RevokeActionCommand.java
@@ -27,6 +27,7 @@ import co.cask.common.cli.Arguments;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.Set;
@@ -36,10 +37,10 @@ import java.util.Set;
  */
 public abstract class RevokeActionCommand extends AbstractAuthCommand {
 
-  private final AuthorizationClient client;
+  private final Provider<AuthorizationClient> client;
 
   @Inject
-  RevokeActionCommand(AuthorizationClient client, CLIConfig cliConfig) {
+  RevokeActionCommand(Provider<AuthorizationClient> client, CLIConfig cliConfig) {
     super(cliConfig);
     this.client = client;
   }
@@ -55,7 +56,7 @@ public abstract class RevokeActionCommand extends AbstractAuthCommand {
     String actionsString = arguments.getOptional("actions", null);
     Set<Action> actions = actionsString == null ? null : ACTIONS_STRING_TO_SET.apply(actionsString);
 
-    client.revoke(entity, principal, actions);
+    client.get().revoke(entity, principal, actions);
     if (principal == null && actions == null) {
       // Revoked all actions for all principals on the entity
       output.printf("Successfully revoked all actions on entity '%s' for all principals", entity.toString());

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/RevokeActionForPrincipalCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/RevokeActionForPrincipalCommand.java
@@ -20,6 +20,7 @@ import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.client.AuthorizationClient;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 /**
  * Revokes a principal's permission to perform certain actions on an entity.
@@ -27,7 +28,7 @@ import com.google.inject.Inject;
 public class RevokeActionForPrincipalCommand extends RevokeActionCommand {
 
   @Inject
-  RevokeActionForPrincipalCommand(AuthorizationClient client, CLIConfig cliConfig) {
+  RevokeActionForPrincipalCommand(Provider<AuthorizationClient> client, CLIConfig cliConfig) {
     super(client, cliConfig);
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/RevokeEntityCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/RevokeEntityCommand.java
@@ -20,6 +20,7 @@ import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.client.AuthorizationClient;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 /**
  * Revokes all permissions for all principal on an entity
@@ -27,7 +28,7 @@ import com.google.inject.Inject;
 public class RevokeEntityCommand extends RevokeActionCommand {
 
   @Inject
-  RevokeEntityCommand(AuthorizationClient client, CLIConfig cliConfig) {
+  RevokeEntityCommand(Provider<AuthorizationClient> client, CLIConfig cliConfig) {
     super(client, cliConfig);
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/stream/view/CreateOrUpdateStreamViewCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/stream/view/CreateOrUpdateStreamViewCommand.java
@@ -30,6 +30,7 @@ import co.cask.cdap.proto.id.StreamViewId;
 import co.cask.common.cli.Arguments;
 import com.google.common.base.Joiner;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -42,10 +43,10 @@ import javax.annotation.Nullable;
  */
 public class CreateOrUpdateStreamViewCommand extends AbstractAuthCommand {
 
-  private final StreamViewClient client;
+  private final Provider<StreamViewClient> client;
 
   @Inject
-  public CreateOrUpdateStreamViewCommand(StreamViewClient client, CLIConfig cliConfig) {
+  CreateOrUpdateStreamViewCommand(Provider<StreamViewClient> client, CLIConfig cliConfig) {
     super(cliConfig);
     this.client = client;
   }
@@ -64,7 +65,7 @@ public class CreateOrUpdateStreamViewCommand extends AbstractAuthCommand {
     FormatSpecification formatSpecification = new FormatSpecification(formatName, schema, settings);
     ViewSpecification viewSpecification = new ViewSpecification(formatSpecification);
 
-    boolean created = client.createOrUpdate(viewId.toId(), viewSpecification);
+    boolean created = client.get().createOrUpdate(viewId.toId(), viewSpecification);
     if (created) {
       output.printf("Successfully created stream-view '%s'\n", viewId.getEntityName());
     } else {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/stream/view/DeleteStreamViewCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/stream/view/DeleteStreamViewCommand.java
@@ -25,6 +25,7 @@ import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.id.StreamViewId;
 import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 
@@ -33,10 +34,10 @@ import java.io.PrintStream;
  */
 public class DeleteStreamViewCommand extends AbstractAuthCommand {
 
-  private final StreamViewClient client;
+  private final Provider<StreamViewClient> client;
 
   @Inject
-  public DeleteStreamViewCommand(StreamViewClient client, CLIConfig cliConfig) {
+  DeleteStreamViewCommand(Provider<StreamViewClient> client, CLIConfig cliConfig) {
     super(cliConfig);
     this.client = client;
   }
@@ -45,7 +46,7 @@ public class DeleteStreamViewCommand extends AbstractAuthCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     StreamId streamId = cliConfig.getCurrentNamespace().stream(arguments.get(ArgumentName.STREAM.toString()));
     StreamViewId view = streamId.view(arguments.get(ArgumentName.VIEW.toString()));
-    client.delete(view.toId());
+    client.get().delete(view.toId());
     output.printf("Successfully deleted stream-view '%s'\n", view.getEntityName());
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/stream/view/DescribeStreamViewCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/stream/view/DescribeStreamViewCommand.java
@@ -32,6 +32,7 @@ import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.Collections;
@@ -45,10 +46,10 @@ public class DescribeStreamViewCommand extends AbstractAuthCommand {
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
     .create();
-  private final StreamViewClient client;
+  private final Provider<StreamViewClient> client;
 
   @Inject
-  public DescribeStreamViewCommand(StreamViewClient client, CLIConfig cliConfig) {
+  DescribeStreamViewCommand(Provider<StreamViewClient> client, CLIConfig cliConfig) {
     super(cliConfig);
     this.client = client;
   }
@@ -56,7 +57,7 @@ public class DescribeStreamViewCommand extends AbstractAuthCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     StreamId streamId = cliConfig.getCurrentNamespace().stream(arguments.get(ArgumentName.STREAM.toString()));
-    ViewDetail detail = client.get(streamId.view(arguments.get(ArgumentName.VIEW.toString())).toId());
+    ViewDetail detail = client.get().get(streamId.view(arguments.get(ArgumentName.VIEW.toString())).toId());
 
     Table table = Table.builder()
       .setHeader("id", "format", "table", "schema", "settings")

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/stream/view/ListStreamViewsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/stream/view/ListStreamViewsCommand.java
@@ -27,6 +27,7 @@ import co.cask.cdap.proto.id.StreamId;
 import co.cask.common.cli.Arguments;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -36,10 +37,10 @@ import java.util.List;
  */
 public class ListStreamViewsCommand extends AbstractAuthCommand {
 
-  private final StreamViewClient client;
+  private final Provider<StreamViewClient> client;
 
   @Inject
-  public ListStreamViewsCommand(StreamViewClient client, CLIConfig cliConfig) {
+  ListStreamViewsCommand(Provider<StreamViewClient> client, CLIConfig cliConfig) {
     super(cliConfig);
     this.client = client;
   }
@@ -47,7 +48,7 @@ public class ListStreamViewsCommand extends AbstractAuthCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     StreamId streamId = cliConfig.getCurrentNamespace().stream(arguments.get(ArgumentName.STREAM.toString()));
-    List<String> views = client.list(streamId.toId());
+    List<String> views = client.get().list(streamId.toId());
 
     Table table = Table.builder()
       .setHeader("id")

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/system/RenderAsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/system/RenderAsCommand.java
@@ -52,7 +52,7 @@ public class RenderAsCommand implements Command {
   private final CLIConfig cliConfig;
 
   @Inject
-  public RenderAsCommand(CLIConfig cliConfig) {
+  RenderAsCommand(CLIConfig cliConfig) {
     this.cliConfig = cliConfig;
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/system/VersionCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/system/VersionCommand.java
@@ -31,7 +31,7 @@ public class VersionCommand implements Command {
   private final CLIConfig cliConfig;
 
   @Inject
-  public VersionCommand(CLIConfig cliConfig) {
+  VersionCommand(CLIConfig cliConfig) {
     this.cliConfig = cliConfig;
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/ArtifactNameCompleter.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/ArtifactNameCompleter.java
@@ -22,6 +22,7 @@ import co.cask.cdap.client.ArtifactClient;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;
+import com.google.inject.Provider;
 
 import java.util.Collection;
 import java.util.List;
@@ -33,12 +34,12 @@ import javax.inject.Inject;
 public class ArtifactNameCompleter extends StringsCompleter {
 
   @Inject
-  public ArtifactNameCompleter(final ArtifactClient artifactClient, final CLIConfig cliConfig) {
+  ArtifactNameCompleter(final Provider<ArtifactClient> artifactClient, final CLIConfig cliConfig) {
     super(new Supplier<Collection<String>>() {
       @Override
       public Collection<String> get() {
         try {
-          List<ArtifactSummary> artifactSummaries = artifactClient.list(cliConfig.getCurrentNamespace().toId());
+          List<ArtifactSummary> artifactSummaries = artifactClient.get().list(cliConfig.getCurrentNamespace().toId());
           List<String> names = Lists.newArrayList();
           for (ArtifactSummary summary : artifactSummaries) {
             names.add(summary.getName());

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/DatasetNameCompleter.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/DatasetNameCompleter.java
@@ -26,6 +26,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.inject.Provider;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,13 +40,12 @@ import javax.inject.Inject;
 public class DatasetNameCompleter extends StringsCompleter {
 
   @Inject
-  public DatasetNameCompleter(final DatasetClient datasetClient,
-                              final CLIConfig cliConfig) {
+  DatasetNameCompleter(final Provider<DatasetClient> datasetClient, final CLIConfig cliConfig) {
     super(new Supplier<Collection<String>>() {
       @Override
       public Collection<String> get() {
         try {
-          List<DatasetSpecificationSummary> list = datasetClient.list(cliConfig.getCurrentNamespace().toId());
+          List<DatasetSpecificationSummary> list = datasetClient.get().list(cliConfig.getCurrentNamespace().toId());
           return Lists.newArrayList(
             Iterables.transform(list, new Function<DatasetSpecificationSummary, String>() {
               @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/HttpEndpointPrefixCompleter.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/HttpEndpointPrefixCompleter.java
@@ -23,10 +23,10 @@ import co.cask.cdap.cli.util.ArgumentParser;
 import co.cask.cdap.client.ServiceClient;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.UnauthenticatedException;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.ServiceId;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.common.cli.completers.PrefixCompleter;
+import com.google.inject.Provider;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -44,11 +44,11 @@ public class HttpEndpointPrefixCompleter extends PrefixCompleter {
   private static final String METHOD = "method";
   private static final String PATTERN = String.format("call service <%s> <%s>", PROGRAM_ID, METHOD);
 
-  private final ServiceClient serviceClient;
+  private final Provider<ServiceClient> serviceClient;
   private final EndpointCompleter completer;
   private final CLIConfig cliConfig;
 
-  public HttpEndpointPrefixCompleter(final ServiceClient serviceClient, CLIConfig cliConfig,
+  public HttpEndpointPrefixCompleter(Provider<ServiceClient> serviceClient, CLIConfig cliConfig,
                                      String prefix, EndpointCompleter completer) {
     super(prefix, completer);
     this.cliConfig = cliConfig;
@@ -73,7 +73,7 @@ public class HttpEndpointPrefixCompleter extends PrefixCompleter {
   public Collection<String> getEndpoints(ServiceId serviceId, String method) {
     Collection<String> httpEndpoints = new ArrayList<>();
     try {
-      for (ServiceHttpEndpoint endpoint : serviceClient.getEndpoints(serviceId.toId())) {
+      for (ServiceHttpEndpoint endpoint : serviceClient.get().getEndpoints(serviceId.toId())) {
         if (endpoint.getMethod().equals(method)) {
           httpEndpoints.add(endpoint.getPath());
         }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/HttpMethodPrefixCompleter.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/HttpMethodPrefixCompleter.java
@@ -27,6 +27,7 @@ import co.cask.cdap.proto.id.ServiceId;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.common.cli.completers.PrefixCompleter;
 import com.google.common.collect.Lists;
+import com.google.inject.Provider;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -42,11 +43,11 @@ public class HttpMethodPrefixCompleter extends PrefixCompleter {
   private static final String PROGRAM_ID = "programId";
   private static final String PATTERN = String.format("call service <%s>", PROGRAM_ID);
 
-  private final ServiceClient serviceClient;
+  private final Provider<ServiceClient> serviceClient;
   private final EndpointCompleter completer;
   private final CLIConfig cliConfig;
 
-  public HttpMethodPrefixCompleter(final ServiceClient serviceClient, final CLIConfig cliConfig,
+  public HttpMethodPrefixCompleter(Provider<ServiceClient> serviceClient, CLIConfig cliConfig,
                                    String prefix, EndpointCompleter completer) {
     super(prefix, completer);
     this.cliConfig = cliConfig;
@@ -71,7 +72,7 @@ public class HttpMethodPrefixCompleter extends PrefixCompleter {
   public Collection<String> getMethods(ServiceId serviceId) {
     Collection<String> httpMethods = Lists.newArrayList();
     try {
-      for (ServiceHttpEndpoint endpoint : serviceClient.getEndpoints(serviceId.toId())) {
+      for (ServiceHttpEndpoint endpoint : serviceClient.get().getEndpoints(serviceId.toId())) {
         String method = endpoint.getMethod();
         if (!httpMethods.contains(method)) {
           httpMethods.add(method);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/NamespaceNameCompleter.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/NamespaceNameCompleter.java
@@ -22,6 +22,7 @@ import co.cask.cdap.proto.NamespaceMeta;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,13 +34,13 @@ import java.util.List;
 public class NamespaceNameCompleter extends StringsCompleter {
 
   @Inject
-  public NamespaceNameCompleter(final NamespaceClient namespaceClient) {
+  NamespaceNameCompleter(final Provider<NamespaceClient> namespaceClient) {
     super(new Supplier<Collection<String>>() {
       @Override
       public Collection<String> get() {
         List<String> namespaceIds = new ArrayList<>();
         try {
-          for (NamespaceMeta namespaceMeta : namespaceClient.list()) {
+          for (NamespaceMeta namespaceMeta : namespaceClient.get().list()) {
             namespaceIds.add(namespaceMeta.getName());
           }
         } catch (Exception e) {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/StreamIdCompleter.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/element/StreamIdCompleter.java
@@ -26,6 +26,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.inject.Provider;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,12 +40,12 @@ import javax.inject.Inject;
 public class StreamIdCompleter extends StringsCompleter {
 
   @Inject
-  public StreamIdCompleter(final StreamClient streamClient, final CLIConfig cliConfig) {
+  public StreamIdCompleter(final Provider<StreamClient> streamClient, final CLIConfig cliConfig) {
     super(new Supplier<Collection<String>>() {
       @Override
       public Collection<String> get() {
         try {
-          List<StreamDetail> list = streamClient.list(cliConfig.getCurrentNamespace().toId());
+          List<StreamDetail> list = streamClient.get().list(cliConfig.getCurrentNamespace().toId());
           return Lists.newArrayList(
             Iterables.transform(list, new Function<StreamDetail, String>() {
               @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/completer/supplier/EndpointSupplier.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/completer/supplier/EndpointSupplier.java
@@ -23,6 +23,7 @@ import co.cask.cdap.cli.completer.element.HttpMethodPrefixCompleter;
 import co.cask.cdap.client.ServiceClient;
 import co.cask.common.cli.supplier.CompleterSupplier;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 import jline.console.completer.Completer;
 
 /**
@@ -33,11 +34,11 @@ public class EndpointSupplier implements CompleterSupplier {
   private static final String METHOD_PREFIX = "call service <>";
   private static final String ENDPOINT_PREFIX = "call service <> <>";
 
-  private final ServiceClient serviceClient;
+  private final Provider<ServiceClient> serviceClient;
   private final CLIConfig cliConfig;
 
   @Inject
-  private EndpointSupplier(final ServiceClient serviceClient, CLIConfig cliConfig) {
+  private EndpointSupplier(final Provider<ServiceClient> serviceClient, CLIConfig cliConfig) {
     this.serviceClient = serviceClient;
     this.cliConfig = cliConfig;
   }

--- a/cdap-client/src/main/java/co/cask/cdap/client/config/ClientConfig.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/config/ClientConfig.java
@@ -36,25 +36,20 @@ import javax.annotation.concurrent.ThreadSafe;
 public class ClientConfig {
 
   private static final boolean DEFAULT_VERIFY_SSL_CERTIFICATE = true;
-
   private static final int DEFAULT_UPLOAD_READ_TIMEOUT = 0;
   private static final int DEFAULT_UPLOAD_CONNECT_TIMEOUT = 0;
   private static final int DEFAULT_SERVICE_UNAVAILABLE_RETRY_LIMIT = 50;
-
   private static final int DEFAULT_READ_TIMEOUT = 15000;
   private static final int DEFAULT_CONNECT_TIMEOUT = 15000;
-
   private static final String DEFAULT_VERSION = Constants.Gateway.API_VERSION_3_TOKEN;
 
   @Nullable
   private final ConnectionConfig connectionConfig;
   private final boolean verifySSLCert;
-
   private final int defaultReadTimeout;
   private final int defaultConnectTimeout;
   private final int uploadReadTimeout;
   private final int uploadConnectTimeout;
-
   private final int unavailableRetryLimit;
   private final String apiVersion;
   private final Supplier<AccessToken> accessToken;


### PR DESCRIPTION
…ll Client classes lazily using Providers so updated connection config is available whenever it is changed.

Most logic change is in `CLIMain.java`. The other files just replace the injection of all cdap-clients in CLI command classes with a Provider.

Summary of the problem:
- The CLI process is built to share a single `CLIConfig` and its contained `ClientConfig` object.
- This helps because whenever any connection parameters change, they are changed in the same `ClientConfig` object that is shared across the process.
- When the CLI starts off, the `ConnectionConfig` inside the shared `ClientConfig` is `null`.
- As the CLI connects to CDAP (or changes its connection), this `ConnectionConfig` object is updated. Since the `ClientConfig` object is the same throughout, everyone sees this change.
- However, #6751 made `ClientConfig` immutable. Thereby, every change to `ClientConfig` happens in a new object, and the object that the CLI started with never gets the updated `ConnectionConfig`.
- This PR fixes it by not injecting the `ClientConfig` in the CLI or in the cdap-client classes directly, but does it lazily using a `Provider`.

Jira: [CDAP-7355](https://issues.cask.co/browse/CDAP-7355)
Build: http://builds.cask.co/browse/CDAP-DUT4856
