### PR TITLE
Two minor doc fixes.

### DIFF
--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -240,6 +240,7 @@ extlinks = {
     'cdap-java-source-github': (cdap_java_source_github_pattern, None),
     'cdap-security-extn-source-github': (cdap_security_extn_github_pattern, None),
     'cask-issue': ('https://issues.cask.co/browse/%s', ''),
+    'cask-repository-parcels-cdap': ("http://repository.cask.co/parcels/cdap/%s/%%s" % short_version, None),
 }
 
 # A string of reStructuredText that will be included at the end of every source file that

--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -225,7 +225,8 @@ cm_ig_parcels.html>`__, but in summary these are the steps:
 - If the Cask parcel repository is inaccessible to your cluster, please see :ref:`these
   suggestions <faqs-cloudera-direct-parcel-access>`.
 - The CDAP parcels are hosted at a repository determined by the CDAP version.
-  For instance, the CDAP |short-version| parcel metadata is accessed by Cloudera Manager at this URL:
+  For instance, the CDAP |short-version| parcel metadata is accessed by Cloudera Manager at 
+  :cask-repository-parcels-cdap:`this URL: <manifest.json>`
   
   .. parsed-literal::
   

--- a/cdap-docs/introduction/source/index.rst
+++ b/cdap-docs/introduction/source/index.rst
@@ -120,7 +120,7 @@ Installation
 
             $ ./bin/cdap-cli.sh
             
-            Successfully connected to CDAP instance at \http://localhost:10000/default
+            Successfully connected to CDAP instance at http://localhost:10000/default
             |cdap >| 
 
 


### PR DESCRIPTION
Correct a formatting error in the Introduction page, and adds a dynamically-created URL link for the Cloudera parcels manifest file.

Passes a Quick Build: http://builds.cask.co/browse/CDAP-DQB139-2
