### PR TITLE
HYDRATOR-978 macro substitute streaming sources

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineDriver.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.datastreams;
 
 import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.macro.MacroEvaluator;
 import co.cask.cdap.api.spark.JavaSparkExecutionContext;
 import co.cask.cdap.api.spark.JavaSparkMain;
 import co.cask.cdap.etl.api.Transform;
@@ -28,6 +29,7 @@ import co.cask.cdap.etl.api.streaming.StreamingContext;
 import co.cask.cdap.etl.api.streaming.StreamingSource;
 import co.cask.cdap.etl.api.streaming.Windower;
 import co.cask.cdap.etl.common.Constants;
+import co.cask.cdap.etl.common.DefaultMacroEvaluator;
 import co.cask.cdap.etl.common.PipelinePhase;
 import co.cask.cdap.etl.planner.StageInfo;
 import co.cask.cdap.etl.spark.SparkCollection;
@@ -67,7 +69,9 @@ public class SparkStreamingPipelineDriver extends SparkPipelineDriver implements
   @Override
   protected SparkCollection<Object> getSource(final String stageName,
                                               PluginFunctionContext pluginFunctionContext) throws Exception {
-    StreamingSource<Object> source = sec.getPluginContext().newPluginInstance(stageName);
+    MacroEvaluator macroEvaluator = new DefaultMacroEvaluator(sec.getRuntimeArguments(), sec.getLogicalStartTime(),
+                                                              sec.getSecureStore(), stageName);
+    StreamingSource<Object> source = sec.getPluginContext().newPluginInstance(stageName, macroEvaluator);
     StreamingContext context = new DefaultStreamingContext(stageName, sec, streamingContext);
     return new DStreamCollection<>(sec, sparkContext, source.getStream(context)
       .transform(new Function<JavaRDD<Object>, JavaRDD<Object>>() {

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/DataStreamsTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/DataStreamsTest.java
@@ -99,8 +99,8 @@ public class DataStreamsTest extends HydratorTestBase {
     DataStreamsConfig etlConfig = DataStreamsConfig.builder()
       .addStage(new ETLStage("source", MockSource.getPlugin(schema, input)))
       .addStage(new ETLStage("sink", MockSink.getPlugin("output")))
-      .addStage(new ETLStage("jacksonFilter", StringValueFilterTransform.getPlugin("name", "jackson")))
-      .addStage(new ETLStage("dwayneFilter", StringValueFilterCompute.getPlugin("name", "dwayne")))
+      .addStage(new ETLStage("jacksonFilter", StringValueFilterTransform.getPlugin("${field}", "jackson")))
+      .addStage(new ETLStage("dwayneFilter", StringValueFilterCompute.getPlugin("${field}", "dwayne")))
       .addConnection("source", "jacksonFilter")
       .addConnection("jacksonFilter", "dwayneFilter")
       .addConnection("dwayneFilter", "sink")
@@ -112,7 +112,7 @@ public class DataStreamsTest extends HydratorTestBase {
     ApplicationManager appManager = deployApplication(appId.toId(), appRequest);
 
     SparkManager sparkManager = appManager.getSparkManager(DataStreamsSparkLauncher.NAME);
-    sparkManager.start();
+    sparkManager.start(ImmutableMap.of("field", "name"));
     sparkManager.waitForStatus(true, 10, 1);
 
     final DataSetManager<Table> outputManager = getDataset("output");

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/spark/compute/StringValueFilterCompute.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/spark/compute/StringValueFilterCompute.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.etl.mock.spark.compute;
 
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
@@ -60,7 +61,10 @@ public class StringValueFilterCompute extends SparkCompute<StructuredRecord, Str
    * Config for the plugin.
    */
   public static class Conf extends PluginConfig {
+    @Macro
     private String field;
+
+    @Macro
     private String value;
   }
 
@@ -73,8 +77,8 @@ public class StringValueFilterCompute extends SparkCompute<StructuredRecord, Str
 
   private static PluginClass getPluginClass() {
     Map<String, PluginPropertyField> properties = new HashMap<>();
-    properties.put("field", new PluginPropertyField("field", "", "string", true, false));
-    properties.put("value", new PluginPropertyField("value", "", "string", true, false));
+    properties.put("field", new PluginPropertyField("field", "", "string", true, true));
+    properties.put("value", new PluginPropertyField("value", "", "string", true, true));
     return new PluginClass(SparkCompute.PLUGIN_TYPE, "StringValueFilterCompute", "",
                            StringValueFilterCompute.class.getName(),
                            "conf", properties);

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/StringValueFilterTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/StringValueFilterTransform.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.etl.mock.transform;
 
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
@@ -55,7 +56,10 @@ public class StringValueFilterTransform extends Transform<StructuredRecord, Stru
    * Config for the transform.
    */
   public static class Config extends PluginConfig {
+    @Macro
     private String field;
+
+    @Macro
     private String value;
   }
 
@@ -68,8 +72,8 @@ public class StringValueFilterTransform extends Transform<StructuredRecord, Stru
 
   private static PluginClass getPluginClass() {
     Map<String, PluginPropertyField> properties = new HashMap<>();
-    properties.put("field", new PluginPropertyField("field", "", "string", true, false));
-    properties.put("value", new PluginPropertyField("value", "", "string", true, false));
+    properties.put("field", new PluginPropertyField("field", "", "string", true, true));
+    properties.put("value", new PluginPropertyField("value", "", "string", true, true));
     return new PluginClass(Transform.PLUGIN_TYPE, "StringValueFilter", "", StringValueFilterTransform.class.getName(),
                            "config", properties);
   }


### PR DESCRIPTION
Fix a bug where macros are not getting substituted in any
streaming source plugins.
