### PR TITLE
CDAP-7318 fix an error getting app spec when there are many macros

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
@@ -26,6 +26,7 @@ import co.cask.cdap.internal.app.runtime.codec.ArgumentsCodec;
 import co.cask.cdap.internal.app.runtime.codec.ProgramOptionsCodec;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
 import co.cask.cdap.proto.id.ProgramId;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -110,7 +111,8 @@ public final class MapReduceContextConfig {
   /**
    * Serialize the {@link ApplicationSpecification} to the configuration.
    */
-  private void setApplicationSpecification(ApplicationSpecification spec) {
+  @VisibleForTesting
+  void setApplicationSpecification(ApplicationSpecification spec) {
     hConf.set(HCONF_ATTR_APP_SPEC, GSON.toJson(spec, ApplicationSpecification.class));
   }
 
@@ -125,7 +127,7 @@ public final class MapReduceContextConfig {
    * @return the {@link ApplicationSpecification} stored in the configuration.
    */
   public ApplicationSpecification getApplicationSpecification() {
-    return GSON.fromJson(hConf.get(HCONF_ATTR_APP_SPEC), ApplicationSpecification.class);
+    return GSON.fromJson(hConf.getRaw(HCONF_ATTR_APP_SPEC), ApplicationSpecification.class);
   }
 
   private void setWorkflowProgramInfo(@Nullable WorkflowProgramInfo info) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfigTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfigTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch;
+
+import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.api.artifact.ArtifactId;
+import co.cask.cdap.api.artifact.ArtifactScope;
+import co.cask.cdap.api.artifact.ArtifactVersion;
+import co.cask.cdap.api.data.stream.StreamSpecification;
+import co.cask.cdap.api.flow.FlowSpecification;
+import co.cask.cdap.api.mapreduce.MapReduceSpecification;
+import co.cask.cdap.api.plugin.Plugin;
+import co.cask.cdap.api.schedule.ScheduleSpecification;
+import co.cask.cdap.api.service.ServiceSpecification;
+import co.cask.cdap.api.spark.SparkSpecification;
+import co.cask.cdap.api.worker.WorkerSpecification;
+import co.cask.cdap.api.workflow.WorkflowSpecification;
+import co.cask.cdap.internal.app.DefaultApplicationSpecification;
+import co.cask.cdap.internal.dataset.DatasetCreationSpec;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+
+/**
+ */
+public class MapReduceContextConfigTest {
+
+  @Test
+  public void testManyMacrosInAppSpec() {
+    Configuration hConf = new Configuration();
+    MapReduceContextConfig cfg = new MapReduceContextConfig(hConf);
+    StringBuilder appCfg = new StringBuilder();
+    for (int i = 0; i < 100; i++) {
+      appCfg.append("${").append(i).append("}");
+      hConf.setInt(String.valueOf(i), i);
+    }
+    ApplicationSpecification appSpec = new DefaultApplicationSpecification(
+      "name", "desc", appCfg.toString(),
+      new ArtifactId("artifact", new ArtifactVersion("1.0.0"), ArtifactScope.USER),
+      Collections.<String, StreamSpecification>emptyMap(),
+      Collections.<String, String>emptyMap(),
+      Collections.<String, DatasetCreationSpec>emptyMap(),
+      Collections.<String, FlowSpecification>emptyMap(),
+      Collections.<String, MapReduceSpecification>emptyMap(),
+      Collections.<String, SparkSpecification>emptyMap(),
+      Collections.<String, WorkflowSpecification>emptyMap(),
+      Collections.<String, ServiceSpecification>emptyMap(),
+      Collections.<String, ScheduleSpecification>emptyMap(),
+      Collections.<String, WorkerSpecification>emptyMap(),
+      Collections.<String, Plugin>emptyMap()
+    );
+    cfg.setApplicationSpecification(appSpec);
+    Assert.assertEquals(appSpec.getConfiguration(), cfg.getApplicationSpecification().getConfiguration());
+  }
+}

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextConfig.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextConfig.java
@@ -101,7 +101,7 @@ public class SparkRuntimeContextConfig {
    * @return the {@link ApplicationSpecification} stored in the configuration.
    */
   public ApplicationSpecification getApplicationSpecification() {
-    return GSON.fromJson(hConf.get(HCONF_ATTR_APP_SPEC), ApplicationSpecification.class);
+    return GSON.fromJson(hConf.getRaw(HCONF_ATTR_APP_SPEC), ApplicationSpecification.class);
   }
 
   /**


### PR DESCRIPTION
If there are more than 20 macros in the app spec, Hadoop's
Configuration will throw an error. Switching to getRaw() instead of
just get() so that no substitution will be attempted on the app spec.
