### PR TITLE
Maintain same namespace across all UI webapps

### DIFF
--- a/cdap-ui/app/cdap/components/HeaderSidebar/index.js
+++ b/cdap-ui/app/cdap/components/HeaderSidebar/index.js
@@ -17,17 +17,21 @@
 import React, {PropTypes} from 'react';
 import AbsLinkTo from '../AbsLinkTo';
 import T from 'i18n-react';
+import {default as NamespaceStore} from 'services/store/store';
 
 export default function HeaderSidebar ({onClickHandlerNoOp}) {
   const getContext = (extension) => {
+    let defaultNamespace = NamespaceStore.getState().selectedNamespace;
     switch(extension) {
       case 'hydrator':
         return {
-          uiApp: 'cask-hydrator'
+          uiApp: 'cask-hydrator',
+          namespaceId: defaultNamespace
         };
       case 'tracker':
         return {
-          uiApp: 'cask-tracker'
+          uiApp: 'cask-tracker',
+          namespaceId: defaultNamespace
         };
       default:
         return {};

--- a/cdap-ui/app/directives/my-global-navbar/my-global-navbar.html
+++ b/cdap-ui/app/directives/my-global-navbar/my-global-navbar.html
@@ -198,7 +198,7 @@
 <!-- SIDEBAR MENU -->
 <div class="display-container" ng-if="Navbar.showSidebar" ng-click="Navbar.toggleSidebar()">
   <div class="sidebar" ng-click="$event.stopPropagation()">
-    <a href="/"
+    <a href="{{Navbar.getAbsUIUrl({uiApp: 'cask-cdap', namespaceId: $stateParams.namespace || Navbar.$cookies.get('CDAP_Namespace') || 'default'})}}"
        class="brand sidebar-item top">
       <div class="brand-icon text-center cdap">
         <span class="icon-fist"></span>


### PR DESCRIPTION
While switching from cdap to hydrator or tracker we used to default to 'default' namespace. Now we can navigate to appropriate namespace (the one the user is already in)
