### PR TITLE
CDAP-7314: Fix links so that they go to the correct branch.

### DIFF
--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -220,12 +220,20 @@ if git_build_vars.has_key(GIT_BRANCH_PARENT):
     cdap_java_source_github_pattern = "https://github.com/caskdata/cdap/blob/%s/%%s" % git_build_vars[GIT_BRANCH_PARENT]
 else:
     cdap_java_source_github_pattern = ''
+    
 GIT_BRANCH_CDAP_SECURITY_EXTN = 'GIT_BRANCH_CDAP_SECURITY_EXTN'
 if git_build_vars.has_key(GIT_BRANCH_CDAP_SECURITY_EXTN):
     cdap_security_extn_github_pattern = "https://github.com/caskdata/cdap-security-extn/blob/%s/%%s" % \
         git_build_vars[GIT_BRANCH_CDAP_SECURITY_EXTN]
 else:
     cdap_security_extn_github_pattern = ''
+
+GIT_BRANCH_CDAP_GUIDES = 'GIT_BRANCH_CDAP_GUIDES'
+if git_build_vars.has_key(GIT_BRANCH_CDAP_GUIDES):
+    cdap_guides_github_pattern = "https://github.com/cdap-guides/%%s/tree/%s" % \
+        git_build_vars[GIT_BRANCH_CDAP_GUIDES]
+else:
+    cdap_guides_github_pattern = ''
 
 extlinks = {
     'cdap-ui': ('http://localhost:9999/ns/default/%s', None),
@@ -240,6 +248,7 @@ extlinks = {
     'cdap-java-source-github': (cdap_java_source_github_pattern, None),
     'cdap-security-extn-source-github': (cdap_security_extn_github_pattern, None),
     'cask-issue': ('https://issues.cask.co/browse/%s', ''),
+    'cdap-guides': (cdap_guides_github_pattern, None),
 }
 
 # A string of reStructuredText that will be included at the end of every source file that

--- a/cdap-docs/examples-manual/source/how-to-guides/cdap-bi-guide.rst
+++ b/cdap-docs/examples-manual/source/how-to-guides/cdap-bi-guide.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014-2015 Cask Data, Inc.
+    :copyright: Copyright © 2014-2016 Cask Data, Inc.
 
 .. highlight:: console
 
@@ -12,7 +12,7 @@
 .. pull-quote::
 
   **Source Code Repository:** Source code (and other resources) for this guide are available at the 
-  `CDAP Guides GitHub repository <https://github.com/cdap-guides/cdap-bi-guide>`__.
+  :cdap-guides:`CDAP Guides GitHub repository <cdap-bi-guide>`.
 
 .. include:: ../../target/_includes/cdap-bi-guide/README.rst
    :start-line: 4

--- a/cdap-docs/examples-manual/source/how-to-guides/cdap-cube-guide.rst
+++ b/cdap-docs/examples-manual/source/how-to-guides/cdap-cube-guide.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2015 Cask Data, Inc.
+    :copyright: Copyright © 2015-2016 Cask Data, Inc.
 
 .. highlight:: console
 
@@ -12,7 +12,7 @@
 .. pull-quote::
 
   **Source Code Repository:** Source code (and other resources) for this guide are available at the 
-  `CDAP Guides GitHub repository <https://github.com/cdap-guides/cdap-cube-guide>`__.
+  :cdap-guides:`CDAP Guides GitHub repository <cdap-cube-guide>`.
 
 .. include:: ../../target/_includes/cdap-cube-guide/README.rst
    :start-line: 4

--- a/cdap-docs/examples-manual/source/how-to-guides/cdap-etl-guide.rst
+++ b/cdap-docs/examples-manual/source/how-to-guides/cdap-etl-guide.rst
@@ -14,7 +14,7 @@
 .. pull-quote::
 
   **Source Code Repository:** Source code (and other resources) for this guide are available at the 
-  `CDAP Guides GitHub repository <https://github.com/cdap-guides/cdap-etl-guide>`__.
+  :cdap-guides:`CDAP Guides GitHub repository <cdap-etl-guide>`.
 
 .. include:: ../../target/_includes/cdap-etl-guide/README.rst
    :start-line: 4

--- a/cdap-docs/examples-manual/source/how-to-guides/cdap-flow-guide.rst
+++ b/cdap-docs/examples-manual/source/how-to-guides/cdap-flow-guide.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014-2015 Cask Data, Inc.
+    :copyright: Copyright © 2014-2016 Cask Data, Inc.
 
 .. highlight:: console
 
@@ -12,7 +12,7 @@
 .. pull-quote::
 
   **Source Code Repository:** Source code (and other resources) for this guide are available at the 
-  `CDAP Guides GitHub repository <https://github.com/cdap-guides/cdap-flow-guide>`__.
+  :cdap-guides:`CDAP Guides GitHub repository <cdap-flow-guide>`.
 
 .. include:: ../../target/_includes/cdap-flow-guide/README.rst
    :start-line: 4

--- a/cdap-docs/examples-manual/source/how-to-guides/cdap-flume-guide.rst
+++ b/cdap-docs/examples-manual/source/how-to-guides/cdap-flume-guide.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2016 Cask Data, Inc.
 
 .. highlight:: console
 
@@ -12,7 +12,7 @@
 .. pull-quote::
 
   **Source Code Repository:** Source code (and other resources) for this guide are available at the 
-  `CDAP Guides GitHub repository <https://github.com/cdap-guides/cdap-flume-guide>`__.
+  :cdap-guides:`CDAP Guides GitHub repository <cdap-flume-guide>`.
 
 .. include:: ../../target/_includes/cdap-flume-guide/README.rst
    :start-line: 4

--- a/cdap-docs/examples-manual/source/how-to-guides/cdap-kafka-ingest-guide.rst
+++ b/cdap-docs/examples-manual/source/how-to-guides/cdap-kafka-ingest-guide.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2015 Cask Data, Inc.
+    :copyright: Copyright © 2015-2016 Cask Data, Inc.
 
 .. highlight:: console
 
@@ -12,7 +12,7 @@
 .. pull-quote::
 
   **Source Code Repository:** Source code (and other resources) for this guide are available at the 
-  `CDAP Guides GitHub repository <https://github.com/cdap-guides/cdap-kafka-ingest-guide>`__.
+  :cdap-guides:`CDAP Guides GitHub repository <cdap-kafka-ingest-guide>`.
 
 .. include:: ../../target/_includes/cdap-kafka-ingest-guide/README.rst
    :start-line: 4

--- a/cdap-docs/examples-manual/source/how-to-guides/cdap-mapreduce-guide.rst
+++ b/cdap-docs/examples-manual/source/how-to-guides/cdap-mapreduce-guide.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2016 Cask Data, Inc.
 
 .. highlight:: console
 
@@ -12,7 +12,7 @@
 .. pull-quote::
 
   **Source Code Repository:** Source code (and other resources) for this guide are available at the 
-  `CDAP Guides GitHub repository <https://github.com/cdap-guides/cdap-mapreduce-guide>`__.
+  :cdap-guides:`CDAP Guides GitHub repository <cdap-mapreduce-guide>`.
 
 .. include:: ../../target/_includes/cdap-mapreduce-guide/README.rst
    :start-line: 4

--- a/cdap-docs/examples-manual/source/how-to-guides/cdap-spark-guide.rst
+++ b/cdap-docs/examples-manual/source/how-to-guides/cdap-spark-guide.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2016 Cask Data, Inc.
 
 .. highlight:: console
 
@@ -12,7 +12,7 @@
 .. pull-quote::
 
   **Source Code Repository:** Source code (and other resources) for this guide are available at the 
-  `CDAP Guides GitHub repository <https://github.com/cdap-guides/cdap-spark-guide>`__.
+  :cdap-guides:`CDAP Guides GitHub repository <cdap-spark-guide>`.
 
 .. include:: ../../target/_includes/cdap-spark-guide/README.rst
    :start-line: 4

--- a/cdap-docs/examples-manual/source/how-to-guides/cdap-timeseries-guide.rst
+++ b/cdap-docs/examples-manual/source/how-to-guides/cdap-timeseries-guide.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2016 Cask Data, Inc.
 
 .. highlight:: console
 
@@ -12,7 +12,7 @@
 .. pull-quote::
 
   **Source Code Repository:** Source code (and other resources) for this guide are available at the 
-  `CDAP Guides GitHub repository <https://github.com/cdap-guides/cdap-timeseries-guide>`__.
+  :cdap-guides:`CDAP Guides GitHub repository <cdap-timeseries-guide>`.
 
 .. include:: ../../target/_includes/cdap-timeseries-guide/README.rst
    :start-line: 4

--- a/cdap-docs/examples-manual/source/how-to-guides/cdap-twitter-ingest-guide.rst
+++ b/cdap-docs/examples-manual/source/how-to-guides/cdap-twitter-ingest-guide.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2016 Cask Data, Inc.
 
 .. highlight:: console
 
@@ -12,7 +12,7 @@
 .. pull-quote::
 
   **Source Code Repository:** Source code (and other resources) for this guide are available at the 
-  `CDAP Guides GitHub repository <https://github.com/cdap-guides/cdap-twitter-ingest-guide>`__.
+  :cdap-guides:`CDAP Guides GitHub repository <cdap-twitter-ingest-guide>`.
 
 .. include:: ../../target/_includes/cdap-twitter-ingest-guide/README.rst
    :start-line: 4

--- a/cdap-docs/examples-manual/source/how-to-guides/cdap-workflow-guide.rst
+++ b/cdap-docs/examples-manual/source/how-to-guides/cdap-workflow-guide.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2015 Cask Data, Inc.
+    :copyright: Copyright © 2015-2016 Cask Data, Inc.
 
 .. highlight:: console
 
@@ -12,7 +12,7 @@
 .. pull-quote::
 
   **Source Code Repository:** Source code (and other resources) for this guide are available at the 
-  `CDAP Guides GitHub repository <https://github.com/cdap-guides/cdap-workflow-guide>`__.
+  :cdap-guides:`CDAP Guides GitHub repository <cdap-workflow-guide>`.
 
 .. include:: ../../target/_includes/cdap-workflow-guide/README.rst
    :start-line: 4

--- a/cdap-docs/vars
+++ b/cdap-docs/vars
@@ -49,6 +49,9 @@ GIT_BRANCH_CDAP_INGEST="1.3.0"
 GIT_BRANCH_CDAP_APPS="release/cdap-3.5-compatible"
 GIT_VERSION_CDAP_APPS="0.8.0"
 
+# Used by examples manual
+GIT_BRANCH_CDAP_GUIDES="release/cdap-3.5-compatible"
+
 # Used by integrations-manual
 GIT_BRANCH_CDAP_PACKS="release/cdap-3.5-compatible"
 


### PR DESCRIPTION
Passes a Quick Build: http://builds.cask.co/browse/CDAP-DQB142-1

Corrected page: [Creating ETL Applications](http://builds.cask.co/artifact/CDAP-DQB142/shared/build-1/Docs-HTML/3.5.2-SNAPSHOT/en/examples-manual/how-to-guides/cdap-etl-guide.html): links under "What You Will Create"

Fix for CDAP-7314, though that was also fixed through the repo `cdap-guides/cdap-etl-guide`.

Instead of going to `develop`, they now go to a release-specific branch.
