### PR TITLE
Run cdap-cli.sh through Maven filtering to replace package.version

### DIFF
--- a/cdap-cli/pom.xml
+++ b/cdap-cli/pom.xml
@@ -172,6 +172,7 @@
                       <targetPath>bin</targetPath>
                       <includes>
                         <include>cdap-cli.bat</include>
+                        <include>cdap-cli.sh</include>
                       </includes>
                       <filtering>true</filtering>
                     </resource>


### PR DESCRIPTION
This filtering happens in the SDK, but was missed in distributed.
