### PR TITLE
CDAP-7361 CDAP-5962 Ignore invalid or missing log files when reading.

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/AvroFileWriter.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/AvroFileWriter.java
@@ -290,6 +290,8 @@ public final class AvroFileWriter implements Closeable, Flushable {
         this.dataFileWriter.create(schema, this.outputStream);
         this.dataFileWriter.setSyncInterval(syncIntervalBytes);
         this.createTime = System.currentTimeMillis();
+        // Sync the file as soon as it is created, otherwise a zero length Avro file can get created on OOM
+        sync();
       } catch (Exception e) {
         close();
         throw new IOException("Exception while creating file " + location, e);


### PR DESCRIPTION
 Also sync soon after creating Avro file to prevent zero length file on OOM.

Note: The only changes in `AvroFileReader` is removing `try-catch` blocks.

JIRAs:
https://issues.cask.co/browse/CDAP-7361
https://issues.cask.co/browse/CDAP-5962

Build:
http://builds.cask.co/browse/CDAP-RUT190-7
