### PR TITLE
Fix MD5 hash and inclusion of Sentry documentation.

### DIFF
--- a/cdap-docs/integrations/build.sh
+++ b/cdap-docs/integrations/build.sh
@@ -26,7 +26,7 @@ function download_includes() {
   
   # Download Apache Sentry File
   local github_source="https://raw.githubusercontent.com/caskdata/cdap-security-extn/${GIT_BRANCH_CDAP_SECURITY_EXTN}/cdap-sentry/cdap-sentry-extension/"
-  download_file ${target_includes_dir} ${github_source} README.rst 26f504896ca0d5a995071be9ee5e5706 cdap-sentry-extension-readme.txt
+  download_file ${target_includes_dir} ${github_source} README.rst 86cb58d0e576e0604a66a94edfa4981a cdap-sentry-extension-readme.txt
 }
 
 run_command ${1}

--- a/cdap-docs/integrations/source/apache-sentry.rst
+++ b/cdap-docs/integrations/source/apache-sentry.rst
@@ -4,14 +4,17 @@
 
 .. _apache-sentry:
 
-=============
+.. NOTE: Because this file includes the cdap-sentry-extension-readme.txt with its headings
+..       a "+" has been used instead of "=" to push all included levels down one level.
+
++++++++++++++
 Apache Sentry
-=============
++++++++++++++
 
 .. _apache-sentry-configuration:
 
 Configuring Apache Sentry for Integration with CDAP
-===================================================
++++++++++++++++++++++++++++++++++++++++++++++++++++
 To use CDAP on a cluster using Apache Sentry for authorization, set this property:
 
 - Add the user ``cdap`` to the Sentry property ``sentry.service.allow.connect``
@@ -31,11 +34,11 @@ We also recommend setting these properties:
 .. _cdap-sentry-authorization-extension:
 
 CDAP Sentry Authorization Extension
-===================================
++++++++++++++++++++++++++++++++++++
 In addition to setting up CDAP to work on a cluster already using Apache Sentry for
 authorization of non-CDAP components, users can also use the CDAP Sentry Authorization
 Extension to enforce authorization on CDAP entities using Apache Sentry.
 
 .. include:: /../target/_includes/cdap-sentry-extension-readme.txt
-    :start-after: ================================================
+    :start-line: 6
     :end-before: Share and Discuss!


### PR DESCRIPTION
- Fixes the inclusion of the Sentry documentation (updates the MD5 hash)
- Changes the inclusion so that the number of levels is adjusted to make it easier to read.
- Removes some duplicated titles.
- Fixes broken build.

Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB144-1

[Current Apache Sentry Page](http://docs.cask.co/cdap/current/en/integrations/apache-sentry.html) (Note the two similar titles "CDAP Sentry Authorization Extension", "CDAP Authorization Extension using Apache Sentry")

Revised Apache Sentry Page (to be completed)
