### PR TITLE
remove component env.sh scripts from parcel

### DIFF
--- a/cdap-distributions/src/parcel/meta/cdap_env.sh
+++ b/cdap-distributions/src/parcel/meta/cdap_env.sh
@@ -16,12 +16,7 @@
 
 export CDAP_HOME=${PARCELS_ROOT}/${PARCEL_DIRNAME}
 export CDAP_AUTH_SERVER_HOME=${CDAP_HOME}/security
-export CDAP_AUTH_SERVER_CONF_SCRIPT=${CDAP_AUTH_SERVER_HOME}/conf/auth-server-env.sh
 export CDAP_KAFKA_SERVER_HOME=${CDAP_HOME}/kafka
-export CDAP_KAFKA_SERVER_CONF_SCRIPT=${CDAP_KAFKA_SERVER_HOME}/conf/kafka-server-env.sh
 export CDAP_MASTER_HOME=${CDAP_HOME}/master
-export CDAP_MASTER_CONF_SCRIPT=${CDAP_MASTER_HOME}/conf/master-env.sh
 export CDAP_ROUTER_HOME=${CDAP_HOME}/gateway
-export CDAP_ROUTER_CONF_SCRIPT=${CDAP_ROUTER_HOME}/conf/router-env.sh
 export CDAP_UI_HOME=${CDAP_HOME}/ui
-export CDAP_UI_CONF_SCRIPT=${CDAP_UI_HOME}/conf/ui-env.sh


### PR DESCRIPTION
for 4.0 parcels, we no longer need to define the `[component]-env.sh` scripts as they no longer exists.  The CSD already tolerates this and will not try to source these files.
