### PR TITLE
CDAP-7384 Fully resolve directories in cdap script

### DIFF
--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -29,7 +29,7 @@ if [[ $? -ne 0 ]]; then
 fi
 __app_home=$(cd $(dirname ${__target})/.. >&-; pwd -P)
 
-__comp_home=${__target%/*/*}
+__comp_home=$(cd ${__target%/*/*} >&-; pwd -P)
 # Determine if we're in the SDK or distributed
 if [[ ${__comp_home%/*} == /opt/cdap ]]; then
   __app_home=${__comp_home}

--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -122,7 +122,7 @@ cdap_home() {
   fi
   local readonly __script=${BASH_SOURCE[0]}
   local readonly __script_bin=$(cd $(dirname ${__script}); pwd -P)
-  local readonly __comp_home=${__script%/*/*}
+  local readonly __comp_home=$(cd ${__script%/*/*} >&-; pwd -P)
   if [[ ${__comp_home%/*} == /opt/cdap ]]; then
     __app_home=${__comp_home}
     __cdap_home=/opt/cdap


### PR DESCRIPTION
This resolves the directory from a user-supplied PATH to a fully resolved canonical PATH on disk.

This would present itself when running `cdap config-tool --cdap` in a way the CDAP UI would do so:

``` bash
/opt/cdap/ui/server/config/../../bin/cdap config-tool --cdap
```

Without this, `__comp_home` retains the `..` directories and doesn't point to the canonical location for comparison.
