### PR TITLE
Refactor LogHandler to use BodyProducer, instead of ChunkResponder

### DIFF
--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/log/CollectingCallback.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/log/CollectingCallback.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.handlers.log;
+
+import co.cask.cdap.logging.read.Callback;
+import co.cask.cdap.logging.read.LogEvent;
+
+import java.util.ArrayList;
+
+/**
+ * A Callback that simply collects LogEvents into an in-memory array and allows access to them.
+ */
+public class CollectingCallback implements Callback {
+  private ArrayList<LogEvent> logEvents;
+
+  @Override
+  public void init() {
+    logEvents = new ArrayList<>();
+  }
+
+  @Override
+  public void handle(LogEvent event) {
+    logEvents.add(event);
+  }
+
+  @Override
+  public int getCount() {
+    return logEvents.size();
+  }
+
+  @Override
+  public void close() {
+    // no-op
+  }
+
+  public ArrayList<LogEvent> getLogEvents() {
+    return logEvents;
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/AbstractChunkedLogProducer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/AbstractChunkedLogProducer.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.gateway.handlers;
+
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.logging.read.LogEvent;
+import co.cask.http.BodyProducer;
+import com.google.common.collect.Multimap;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBuffers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import javax.annotation.Nullable;
+
+/**
+ * LogReader BodyProducer class that delegates to subclasses for how to encode log events.
+ */
+public abstract class AbstractChunkedLogProducer extends BodyProducer {
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractChunkedLogProducer.class);
+
+  protected static final int BUFFER_BYTES = 8192;
+
+  private final CloseableIterator<LogEvent> logEventIter;
+
+  private boolean hasStarted = false;
+  private boolean hasFinished = false;
+
+  AbstractChunkedLogProducer(CloseableIterator<LogEvent> logEventIter) {
+    this.logEventIter = logEventIter;
+  }
+
+  /**
+   * Return {@link Multimap} of HTTP response headers
+   */
+  protected abstract Multimap<String, String> getResponseHeaders();
+
+  protected abstract ChannelBuffer onWriteStart() throws IOException;
+  protected abstract ChannelBuffer writeLogEvents(CloseableIterator<LogEvent> logEvent) throws IOException;
+  protected abstract ChannelBuffer onWriteFinish() throws IOException;
+
+  public void close() {
+    logEventIter.close();
+  }
+
+  @Override
+  public ChannelBuffer nextChunk() throws Exception {
+    ChannelBuffer startBuffer = ChannelBuffers.EMPTY_BUFFER;
+    if (!hasStarted) {
+      hasStarted = true;
+      startBuffer = ChannelBuffers.copiedBuffer(onWriteStart());
+    }
+
+    if (logEventIter.hasNext()) {
+      ChannelBuffer eventsBuffer = writeLogEvents(logEventIter);
+      return startBuffer.readable() ? ChannelBuffers.wrappedBuffer(startBuffer, eventsBuffer) : eventsBuffer;
+    }
+
+    if (!hasFinished) {
+      hasFinished = true;
+      return onWriteFinish();
+    }
+
+    return ChannelBuffers.EMPTY_BUFFER;
+  }
+
+  @Override
+  public void finished() throws Exception {
+    close();
+  }
+
+  @Override
+  public void handleError(@Nullable Throwable throwable) {
+    // previous behavior was to propagate the exception if its during sendChunk,
+    // but suppress (and simply LOG.debug) if it was during close()
+    // propagate it?
+    LOG.error("Received error while chunking logs.", throwable);
+    close();
+  }
+
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/AbstractJSONLogProducer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/AbstractJSONLogProducer.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.gateway.handlers;
+
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.logging.read.LogEvent;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonWriter;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBufferOutputStream;
+import org.jboss.netty.buffer.ChannelBuffers;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * LogReader BodyProducer that serves log events as JSON objects.
+ */
+public abstract class AbstractJSONLogProducer extends AbstractChunkedLogProducer {
+
+  protected static final Gson GSON = new Gson();
+
+  private final ChannelBuffer channelBuffer;
+  private final JsonWriter jsonWriter;
+
+  private boolean hasStarted = false;
+
+
+  AbstractJSONLogProducer(CloseableIterator<LogEvent> logEventIter) {
+    super(logEventIter);
+    this.channelBuffer = ChannelBuffers.dynamicBuffer(BUFFER_BYTES);
+    this.jsonWriter = new JsonWriter(new OutputStreamWriter(new ChannelBufferOutputStream(channelBuffer),
+                                                            StandardCharsets.UTF_8));
+  }
+
+  @Override
+  protected Multimap<String, String> getResponseHeaders() {
+    return ImmutableMultimap.of(HttpHeaders.Names.CONTENT_TYPE, "application/json");
+  }
+
+  @Override
+  protected ChannelBuffer onWriteStart() throws IOException {
+    channelBuffer.clear();
+    jsonWriter.beginArray();
+    jsonWriter.flush();
+    return channelBuffer;
+  }
+
+  @Override
+  protected ChannelBuffer writeLogEvents(CloseableIterator<LogEvent> logEventIter) throws IOException {
+    channelBuffer.clear();
+
+    while (logEventIter.hasNext() && channelBuffer.readableBytes() < BUFFER_BYTES) {
+      Object encodedObject = encodeSend(logEventIter.next());
+      GSON.toJson(encodedObject, encodedObject.getClass(), jsonWriter);
+      jsonWriter.flush();
+    }
+    return channelBuffer;
+  }
+
+  @Override
+  protected ChannelBuffer onWriteFinish() throws IOException {
+    channelBuffer.clear();
+    jsonWriter.endArray();
+    jsonWriter.flush();
+    return channelBuffer;
+  }
+
+  /**
+   * Return a {@link Object} that will be serialized to a JSON string
+   */
+  protected abstract Object encodeSend(LogEvent logEvent);
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogDataOffsetProducer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogDataOffsetProducer.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.gateway.handlers;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.ThrowableProxyUtil;
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.logging.read.LogEvent;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.List;
+
+/**
+ * LogReader BodyProducer to encode log events, as {@link LogData} objects.
+ */
+public class LogDataOffsetProducer extends AbstractJSONLogProducer {
+  private final List<String> fieldsToSuppress;
+
+  LogDataOffsetProducer(CloseableIterator<LogEvent> logEventIter, List<String> fieldsToSuppress) {
+    super(logEventIter);
+    this.fieldsToSuppress = fieldsToSuppress;
+    validate();
+  }
+
+  @Override
+  public Object encodeSend(LogEvent logEvent) {
+    ILoggingEvent event = logEvent.getLoggingEvent();
+    StackTraceElement[] stackTraceElements = event.getCallerData();
+    String className = "";
+    String simpleClassName = "";
+    int lineNumber = 0;
+    if (stackTraceElements != null && stackTraceElements.length > 0) {
+      StackTraceElement first = stackTraceElements[0];
+      className = first.getClassName();
+      simpleClassName = (className.indexOf('.') >= 0) ? className.substring(className.lastIndexOf('.') + 1) : className;
+      lineNumber = first.getLineNumber();
+    }
+    LogData logData = new LogData(event.getTimeStamp(), event.getLevel().toString(), event.getThreadName(),
+                                  className, simpleClassName, lineNumber, event.getFormattedMessage(),
+                                  ThrowableProxyUtil.asString(event.getThrowableProxy()));
+    return modifyLogJsonElememnt(GSON.toJsonTree(new FormattedLogDataEvent(logData, logEvent.getOffset())));
+  }
+
+  private Object modifyLogJsonElememnt(JsonElement jsonElement) {
+    JsonObject jsonLogData = (JsonObject) jsonElement;
+    JsonObject logData = jsonLogData.getAsJsonObject("log");
+
+    if (!fieldsToSuppress.isEmpty()) {
+      for (String field : fieldsToSuppress) {
+        logData.remove(field);
+      }
+    }
+
+    return jsonLogData;
+  }
+
+  private void validate() {
+    if (fieldsToSuppress.isEmpty()) {
+      return;
+    }
+
+    for (String fieldToSuppress : fieldsToSuppress) {
+      try {
+        LogData.class.getDeclaredField(fieldToSuppress);
+      } catch (NoSuchFieldException e) {
+        throw new IllegalArgumentException(String.format("Field %s is not supported as suppress field",
+                                                         fieldToSuppress));
+      }
+    }
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/DistributedLogReader.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/DistributedLogReader.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.logging.read;
 
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LoggingContext;
@@ -109,9 +110,9 @@ public final class DistributedLogReader implements LogReader {
   }
 
   @Override
-  public void getLog(final LoggingContext loggingContext, final long fromTimeMs, final long toTimeMs,
-                          final Filter filter, final Callback callback) {
-    fileLogReader.getLog(loggingContext, fromTimeMs, toTimeMs, filter, callback);
+  public CloseableIterator<LogEvent> getLog(LoggingContext loggingContext, long fromTimeMs, long toTimeMs,
+                                            Filter filter) {
+    return fileLogReader.getLog(loggingContext, fromTimeMs, toTimeMs, filter);
   }
 
   private long getCheckpointTime(LoggingContext loggingContext) {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/FileLogReader.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/FileLogReader.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.logging.read;
 
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.common.security.Impersonator;
@@ -40,8 +41,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.NavigableMap;
+import java.util.NoSuchElementException;
 
 /**
  * Reads log events from a file.
@@ -157,35 +160,139 @@ public class FileLogReader implements LogReader {
   }
 
   @Override
-  public void getLog(final LoggingContext loggingContext, final long fromTimeMs, final long toTimeMs,
-                     final Filter filter, final Callback callback) {
-    callback.init();
+  public CloseableIterator<LogEvent> getLog(LoggingContext loggingContext, final long fromTimeMs, final long toTimeMs,
+                                            Filter filter) {
     try {
-      Filter logFilter = new AndFilter(ImmutableList.of(LoggingContextHelper.createFilter(loggingContext),
-                                                        filter));
+      final Filter logFilter = new AndFilter(ImmutableList.of(LoggingContextHelper.createFilter(loggingContext),
+                                                              filter));
 
       LOG.trace("Using fromTimeMs={}, toTimeMs={}", fromTimeMs, toTimeMs);
       NavigableMap<Long, Location> sortedFiles = fileMetaDataManager.listFiles(loggingContext);
       if (sortedFiles.isEmpty()) {
-        return;
+        // return empty iterator
+        return null;
       }
 
       List<Location> filesInRange = getFilesInRange(sortedFiles, fromTimeMs, toTimeMs);
-      AvroFileReader avroFileReader = new AvroFileReader(schema);
-      NamespaceId namespaceId = LoggingContextHelper.getNamespaceId(loggingContext);
-      for (Location file : filesInRange) {
-        try {
-          LOG.trace("Reading file {}", file);
-          avroFileReader.readLog(file, logFilter, fromTimeMs, toTimeMs, Integer.MAX_VALUE, callback,
-                                 namespaceId, impersonator);
-        } catch (IOException e) {
-          LOG.warn("Got exception reading log file {}", file, e);
+
+      final AvroFileReader avroFileReader = new AvroFileReader(schema);
+      final Iterator<Location> filesIter = filesInRange.iterator();
+      final NamespaceId namespaceId = LoggingContextHelper.getNamespaceId(loggingContext);
+
+      CloseableIterator closeableIterator = new CloseableIterator() {
+        private CloseableIterator<LogEvent> curr = null;
+
+        @Override
+        public void close() {
+          if (curr != null) {
+            curr.close();
+          }
         }
-      }
+
+        @Override
+        public boolean hasNext() {
+          return filesIter.hasNext();
+        }
+
+        @Override
+        public CloseableIterator<LogEvent> next() {
+          if (curr != null) {
+            curr.close();
+          }
+          Location file = filesIter.next();
+          LOG.trace("Reading file {}", file);
+          curr = avroFileReader.readLog(file, logFilter, fromTimeMs, toTimeMs, Integer.MAX_VALUE,
+                                        namespaceId, impersonator);
+          return curr;
+        }
+
+        @Override
+        public void remove() {
+          throw new UnsupportedOperationException("Remove not supported");
+        }
+      };
+
+      return concat(closeableIterator);
     } catch (Throwable e) {
       LOG.error("Got exception: ", e);
-      throw  Throwables.propagate(e);
+      throw Throwables.propagate(e);
     }
+  }
+
+  /**
+   * See {@link com.google.common.collect.Iterators#concat(Iterator)}. The difference is that the input types and return
+   * type are CloseableIterator, which closes the inputs that it has opened.
+   */
+  public static <T> CloseableIterator<T> concat(
+    final CloseableIterator<? extends CloseableIterator<? extends T>> inputs) {
+    Preconditions.checkNotNull(inputs);
+    return new CloseableIterator<T>() {
+      @Override
+      public void close() {
+        current.close();
+        current = null;
+        while (inputs.hasNext()) {
+          inputs.next().close();
+        }
+        inputs.close();
+        removeFrom = null;
+      }
+
+      CloseableIterator<? extends T> current = new CloseableIterator<T>() {
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public boolean hasNext() {
+          return false;
+        }
+
+        @Override
+        public T next() {
+          throw new NoSuchElementException();
+        }
+
+        @Override
+        public void remove() {
+          throw new IllegalStateException();
+        }
+      };
+
+      CloseableIterator<? extends T> removeFrom;
+
+      @Override
+      public boolean hasNext() {
+        // http://code.google.com/p/google-collections/issues/detail?id=151
+        // current.hasNext() might be relatively expensive, worth minimizing.
+        boolean currentHasNext;
+        // checkNotNull eager for GWT
+        // note: it must be here & not where 'current' is assigned,
+        // because otherwise we'll have called inputs.next() before throwing
+        // the first NPE, and the next time around we'll call inputs.next()
+        // again, incorrectly moving beyond the error.
+        while (!(currentHasNext = Preconditions.checkNotNull(current).hasNext())
+          && inputs.hasNext()) {
+          current = inputs.next();
+        }
+        return currentHasNext;
+      }
+      @Override
+      public T next() {
+        if (!hasNext()) {
+          throw new NoSuchElementException();
+        }
+        removeFrom = current;
+        return current.next();
+      }
+      @Override
+      public void remove() {
+        Preconditions.checkState(removeFrom != null,
+                                 "no calls to next() since last call to remove()");
+        removeFrom.remove();
+        removeFrom = null;
+      }
+    };
   }
 
   @VisibleForTesting

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/KafkaLogReader.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/KafkaLogReader.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.logging.read;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.LoggingContext;
@@ -197,10 +198,11 @@ public class KafkaLogReader implements LogReader {
   }
 
   @Override
-  public void getLog(LoggingContext loggingContext, long fromTimeMs, long toTimeMs,
-                     Filter filter, Callback callback) {
+  public CloseableIterator<LogEvent> getLog(LoggingContext loggingContext, long fromTimeMs, long toTimeMs,
+                                            Filter filter) {
     throw new UnsupportedOperationException("Getting logs by time is not supported by "
                                               + KafkaLogReader.class.getSimpleName());
+
   }
 
   private int fetchLogEvents(KafkaConsumer kafkaConsumer, KafkaCallback kafkaCallback,

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/LogReader.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/LogReader.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.logging.read;
 
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.logging.filter.Filter;
 
@@ -46,13 +47,12 @@ public interface LogReader {
                        Callback callback);
 
   /**
-   * Returns log events of a Flow or Map between given times.
-   * @param loggingContext context to look up log events.
-   * @param fromTimeMs start time.
-   * @param toTimeMs end time.
-   * @param filter filter to select log events
-   * @param callback Callback to handle the log events.
-   */
-  void getLog(LoggingContext loggingContext, long fromTimeMs, long toTimeMs, Filter filter,
-                   Callback callback);
+    * Returns log events for a given LoggingContext between given times.
+    * @param loggingContext context to look up log events.
+    * @param fromTimeMs start time.
+    * @param toTimeMs end time.
+    * @param filter filter to select log events
+    * @return CloseableIterator of log events
+    */
+  CloseableIterator<LogEvent> getLog(LoggingContext loggingContext, long fromTimeMs, long toTimeMs, Filter filter);
 }

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/LoggingTester.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/LoggingTester.java
@@ -18,6 +18,7 @@ package co.cask.cdap.logging.appender;
 
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.core.util.StatusPrinter;
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
 import co.cask.cdap.common.logging.ApplicationLoggingContext;
 import co.cask.cdap.common.logging.LoggingContext;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
@@ -30,6 +31,8 @@ import co.cask.cdap.logging.read.LogOffset;
 import co.cask.cdap.logging.read.LogReader;
 import co.cask.cdap.logging.read.ReadRange;
 import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.junit.Assert;
 import org.slf4j.Logger;

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/file/TestFileLogging.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/appender/file/TestFileLogging.java
@@ -42,6 +42,7 @@ import co.cask.cdap.logging.read.ReadRange;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationTestModule;
+import com.google.common.collect.Lists;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -58,6 +59,7 @@ import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -145,50 +147,47 @@ public class TestFileLogging {
     List<LogEvent> allEvents = logCallback1.getEvents();
     Assert.assertEquals(60, allEvents.size());
 
-    LoggingTester.LogCallback logCallback2 = new LoggingTester.LogCallback();
-    logTail.getLog(loggingContext, allEvents.get(10).getLoggingEvent().getTimeStamp(),
-                   allEvents.get(15).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback2);
-    List<LogEvent> events = logCallback2.getEvents();
+    List<LogEvent> events =
+      Lists.newArrayList(logTail.getLog(loggingContext, allEvents.get(10).getLoggingEvent().getTimeStamp(),
+                                        allEvents.get(15).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER));
+
     Assert.assertEquals(5, events.size());
     Assert.assertEquals(allEvents.get(10).getLoggingEvent().getFormattedMessage(),
                         events.get(0).getLoggingEvent().getFormattedMessage());
     Assert.assertEquals(allEvents.get(14).getLoggingEvent().getFormattedMessage(),
                         events.get(4).getLoggingEvent().getFormattedMessage());
 
-    LoggingTester.LogCallback logCallback3 = new LoggingTester.LogCallback();
-    logTail.getLog(loggingContext, allEvents.get(0).getLoggingEvent().getTimeStamp(),
-                   allEvents.get(59).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback3);
-    events = logCallback3.getEvents();
+
+    events =
+      Lists.newArrayList(logTail.getLog(loggingContext, allEvents.get(0).getLoggingEvent().getTimeStamp(),
+                                        allEvents.get(59).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER));
     Assert.assertEquals(59, events.size());
     Assert.assertEquals(allEvents.get(0).getLoggingEvent().getFormattedMessage(),
                         events.get(0).getLoggingEvent().getFormattedMessage());
     Assert.assertEquals(allEvents.get(58).getLoggingEvent().getFormattedMessage(),
                         events.get(58).getLoggingEvent().getFormattedMessage());
 
-    LoggingTester.LogCallback logCallback4 = new LoggingTester.LogCallback();
-    logTail.getLog(loggingContext, allEvents.get(12).getLoggingEvent().getTimeStamp(),
-                   allEvents.get(41).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback4);
-    events = logCallback4.getEvents();
+    events =
+      Lists.newArrayList(logTail.getLog(loggingContext, allEvents.get(12).getLoggingEvent().getTimeStamp(),
+                                        allEvents.get(41).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER));
     Assert.assertEquals(29, events.size());
     Assert.assertEquals(allEvents.get(12).getLoggingEvent().getFormattedMessage(),
                         events.get(0).getLoggingEvent().getFormattedMessage());
     Assert.assertEquals(allEvents.get(40).getLoggingEvent().getFormattedMessage(),
                         events.get(28).getLoggingEvent().getFormattedMessage());
 
-    LoggingTester.LogCallback logCallback5 = new LoggingTester.LogCallback();
-    logTail.getLog(loggingContext, allEvents.get(22).getLoggingEvent().getTimeStamp(),
-                   allEvents.get(38).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback5);
-    events = logCallback5.getEvents();
+    events =
+      Lists.newArrayList(logTail.getLog(loggingContext, allEvents.get(22).getLoggingEvent().getTimeStamp(),
+                                        allEvents.get(38).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER));
     Assert.assertEquals(16, events.size());
     Assert.assertEquals(allEvents.get(22).getLoggingEvent().getFormattedMessage(),
                         events.get(0).getLoggingEvent().getFormattedMessage());
     Assert.assertEquals(allEvents.get(37).getLoggingEvent().getFormattedMessage(),
                         events.get(15).getLoggingEvent().getFormattedMessage());
 
-    LoggingTester.LogCallback logCallback6 = new LoggingTester.LogCallback();
-    logTail.getLog(loggingContext, allEvents.get(41).getLoggingEvent().getTimeStamp(),
-                   allEvents.get(59).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback6);
-    events = logCallback6.getEvents();
+    events =
+      Lists.newArrayList(logTail.getLog(loggingContext, allEvents.get(41).getLoggingEvent().getTimeStamp(),
+                                        allEvents.get(59).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER));
     Assert.assertEquals(18, events.size());
     Assert.assertEquals(allEvents.get(41).getLoggingEvent().getFormattedMessage(),
                         events.get(0).getLoggingEvent().getFormattedMessage());
@@ -197,9 +196,8 @@ public class TestFileLogging {
 
     // Try with null run id, should get all logs for FLOW_1
     LoggingContext loggingContext1 = new FlowletLoggingContext("TFL_NS_1", "APP_1", "FLOW_1", "", null, "INSTANCE1");
-    LoggingTester.LogCallback logCallback7 = new LoggingTester.LogCallback();
-    logTail.getLog(loggingContext1, 0, Long.MAX_VALUE, Filter.EMPTY_FILTER, logCallback7);
-    events = logCallback7.getEvents();
+    events =
+      Lists.newArrayList(logTail.getLog(loggingContext1, 0, Long.MAX_VALUE, Filter.EMPTY_FILTER));
     Assert.assertEquals(100, events.size());
   }
 }

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/save/LogSaverTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/save/LogSaverTest.java
@@ -20,6 +20,7 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.util.StatusPrinter;
 import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.logging.ApplicationLoggingContext;
@@ -35,6 +36,7 @@ import co.cask.cdap.internal.io.SchemaTypeAdapter;
 import co.cask.cdap.logging.KafkaTestBase;
 import co.cask.cdap.logging.LoggingConfiguration;
 import co.cask.cdap.logging.appender.LogAppenderInitializer;
+import co.cask.cdap.logging.appender.LoggingTester;
 import co.cask.cdap.logging.appender.kafka.KafkaLogAppender;
 import co.cask.cdap.logging.appender.kafka.LoggingEventSerializer;
 import co.cask.cdap.logging.context.FlowletLoggingContext;
@@ -77,6 +79,7 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -219,21 +222,20 @@ public class LogSaverTest extends KafkaTestBase {
   }
 
   private long getCheckpointTime(LoggingContext loggingContext, int numExpectedEvents) throws Exception {
-    LogCallback logCallback = new LogCallback();
     FileLogReader distributedLogReader = injector.getInstance(FileLogReader.class);
-    distributedLogReader.getLog(loggingContext, 0, Long.MAX_VALUE, Filter.EMPTY_FILTER, logCallback);
-    Assert.assertEquals(numExpectedEvents, logCallback.getEvents().size());
+    ArrayList<LogEvent> events =
+      Lists.newArrayList(distributedLogReader.getLog(loggingContext, 0, Long.MAX_VALUE, Filter.EMPTY_FILTER));
+    Assert.assertEquals(numExpectedEvents, events.size());
 
-    return logCallback.getEvents().get(numExpectedEvents - 1).getLoggingEvent().getTimeStamp();
+    return events.get(numExpectedEvents - 1).getLoggingEvent().getTimeStamp();
   }
 
   private void testLogRead(LoggingContext loggingContext) throws Exception {
     LOG.info("Verifying logging context {}", loggingContext.getLogPathFragment(logBaseDir));
     FileLogReader distributedLogReader = injector.getInstance(FileLogReader.class);
 
-    LogCallback logCallback1 = new LogCallback();
-    distributedLogReader.getLog(loggingContext, 0, Long.MAX_VALUE, Filter.EMPTY_FILTER, logCallback1);
-    List<LogEvent> allEvents = logCallback1.getEvents();
+    List<LogEvent> allEvents =
+      Lists.newArrayList(distributedLogReader.getLog(loggingContext, 0, Long.MAX_VALUE, Filter.EMPTY_FILTER));
 
     final Multimap<String, String> contextMessages = getPublishedKafkaMessages();
 
@@ -264,79 +266,69 @@ public class LogSaverTest extends KafkaTestBase {
       }
     }
 
-    LogCallback logCallback2 = new LogCallback();
-    distributedLogReader.getLog(loggingContext, allEvents.get(10).getLoggingEvent().getTimeStamp(),
-                                allEvents.get(20).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback2);
-    List<LogEvent> events = logCallback2.getEvents();
+    List<LogEvent> events = Lists.newArrayList(
+      distributedLogReader.getLog(loggingContext, allEvents.get(10).getLoggingEvent().getTimeStamp(),
+                                  allEvents.get(20).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER));
     Assert.assertEquals(10, events.size());
     Assert.assertEquals("Test log message 10 arg1 arg2", events.get(0).getLoggingEvent().getFormattedMessage());
     Assert.assertEquals("Test log message 19 arg1 arg2", events.get(9).getLoggingEvent().getFormattedMessage());
 
-    LogCallback logCallback3 = new LogCallback();
-    distributedLogReader.getLog(loggingContext, allEvents.get(5).getLoggingEvent().getTimeStamp(),
-                                allEvents.get(55).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback3);
-    events = logCallback3.getEvents();
+    events = Lists.newArrayList(
+      distributedLogReader.getLog(loggingContext, allEvents.get(5).getLoggingEvent().getTimeStamp(),
+                                  allEvents.get(55).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER));
     Assert.assertEquals(50, events.size());
     Assert.assertEquals("Test log message 5 arg1 arg2", events.get(0).getLoggingEvent().getFormattedMessage());
     Assert.assertEquals("Test log message 54 arg1 arg2", events.get(49).getLoggingEvent().getFormattedMessage());
 
-    LogCallback logCallback4 = new LogCallback();
-    distributedLogReader.getLog(loggingContext, allEvents.get(30).getLoggingEvent().getTimeStamp(),
-                                allEvents.get(53).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback4);
-    events = logCallback4.getEvents();
+    events = Lists.newArrayList(
+      distributedLogReader.getLog(loggingContext, allEvents.get(30).getLoggingEvent().getTimeStamp(),
+                                  allEvents.get(53).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER));
     Assert.assertEquals(23, events.size());
     Assert.assertEquals("Test log message 30 arg1 arg2", events.get(0).getLoggingEvent().getFormattedMessage());
     Assert.assertEquals("Test log message 52 arg1 arg2", events.get(22).getLoggingEvent().getFormattedMessage());
 
-    LogCallback logCallback5 = new LogCallback();
-    distributedLogReader.getLog(loggingContext, allEvents.get(35).getLoggingEvent().getTimeStamp(),
-                                allEvents.get(38).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback5);
-    events = logCallback5.getEvents();
+    events = Lists.newArrayList(
+      distributedLogReader.getLog(loggingContext, allEvents.get(35).getLoggingEvent().getTimeStamp(),
+                                  allEvents.get(38).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER));
     Assert.assertEquals(3, events.size());
     Assert.assertEquals("Test log message 35 arg1 arg2", events.get(0).getLoggingEvent().getFormattedMessage());
     Assert.assertEquals("Test log message 37 arg1 arg2", events.get(2).getLoggingEvent().getFormattedMessage());
 
-    LogCallback logCallback6 = new LogCallback();
-    distributedLogReader.getLog(loggingContext, allEvents.get(53).getLoggingEvent().getTimeStamp(),
-                                allEvents.get(59).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback6);
-    events = logCallback6.getEvents();
+    events = Lists.newArrayList(
+      distributedLogReader.getLog(loggingContext, allEvents.get(53).getLoggingEvent().getTimeStamp(),
+                                  allEvents.get(59).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER));
     Assert.assertEquals(6, events.size());
     Assert.assertEquals("Test log message 53 arg1 arg2", events.get(0).getLoggingEvent().getFormattedMessage());
     Assert.assertEquals("Test log message 58 arg1 arg2", events.get(5).getLoggingEvent().getFormattedMessage());
 
-    LogCallback logCallback7 = new LogCallback();
-    distributedLogReader.getLog(loggingContext, allEvents.get(59).getLoggingEvent().getTimeStamp(),
-                                allEvents.get(59).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback7);
-    events = logCallback7.getEvents();
+    events = Lists.newArrayList(
+      distributedLogReader.getLog(loggingContext, allEvents.get(59).getLoggingEvent().getTimeStamp(),
+                                  allEvents.get(59).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER));
     Assert.assertEquals(0, events.size());
 
-    LogCallback logCallback8 = new LogCallback();
-    distributedLogReader.getLog(loggingContext, allEvents.get(0).getLoggingEvent().getTimeStamp(),
-                                allEvents.get(0).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback8);
-    events = logCallback8.getEvents();
+    events = Lists.newArrayList(
+      distributedLogReader.getLog(loggingContext, allEvents.get(0).getLoggingEvent().getTimeStamp(),
+                                  allEvents.get(0).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER));
     Assert.assertEquals(0, events.size());
 
-    LogCallback logCallback9 = new LogCallback();
-    distributedLogReader.getLog(loggingContext, allEvents.get(20).getLoggingEvent().getTimeStamp(),
-                                allEvents.get(20).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback9);
-    events = logCallback9.getEvents();
+    events = Lists.newArrayList(
+      distributedLogReader.getLog(loggingContext, allEvents.get(20).getLoggingEvent().getTimeStamp(),
+                                  allEvents.get(20).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER));
     Assert.assertEquals(0, events.size());
 
-    LogCallback logCallback10 = new LogCallback();
-    distributedLogReader.getLog(loggingContext, allEvents.get(32).getLoggingEvent().getTimeStamp() - 999999,
-                                allEvents.get(45).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER, logCallback10);
-    events = logCallback10.getEvents();
+    events = Lists.newArrayList(
+      distributedLogReader.getLog(loggingContext, allEvents.get(32).getLoggingEvent().getTimeStamp() - 999999,
+                                  allEvents.get(45).getLoggingEvent().getTimeStamp(), Filter.EMPTY_FILTER));
     Assert.assertTrue(events.size() > 13);
     Assert.assertEquals("Test log message 32 arg1 arg2",
                         events.get(events.size() - 13).getLoggingEvent().getFormattedMessage());
     Assert.assertEquals("Test log message 44 arg1 arg2",
                         events.get(events.size() - 1).getLoggingEvent().getFormattedMessage());
 
-    LogCallback logCallback11 = new LogCallback();
-    distributedLogReader.getLog(loggingContext, allEvents.get(18).getLoggingEvent().getTimeStamp(),
-                                allEvents.get(34).getLoggingEvent().getTimeStamp() + 999999,
-                                Filter.EMPTY_FILTER, logCallback11);
-    events = logCallback11.getEvents();
+    events = Lists.newArrayList(
+      distributedLogReader.getLog(loggingContext, allEvents.get(18).getLoggingEvent().getTimeStamp(),
+                                  allEvents.get(34).getLoggingEvent().getTimeStamp() + 999999,
+                                  Filter.EMPTY_FILTER));
     Assert.assertTrue(events.size() > 16);
     Assert.assertEquals("Test log message 18 arg1 arg2", events.get(0).getLoggingEvent().getFormattedMessage());
     Assert.assertEquals("Test log message 33 arg1 arg2",


### PR DESCRIPTION
Refactor LogHandler to use BodyProducer, instead of ChunkResponder

https://issues.cask.co/browse/CDAP-5080
http://builds.cask.co/browse/CDAP-RUT194-5
