### PR TITLE
Increase container sizes and twill.reserved memory for HDInsight

### DIFF
--- a/cdap-distributions/src/hdinsight/cdap-conf.json
+++ b/cdap-distributions/src/hdinsight/cdap-conf.json
@@ -2,10 +2,18 @@
   "cdap": {
     "cdap_site": {
       "dashboard.bind.port": "11011",
+      "dataset.executor.container.memory.mb": "1536",
       "explore.enabled": "{{EXPLORE_ENABLED}}",
+      "explore.executor.container.memory.mb": "2304",
       "http.client.read.timeout.ms": "120000",
       "kafka.server.log.dirs": "/var/cdap/kafka-logs",
+      "log.saver.run.memory.megs": "1536",
+      "master.service.memory.mb": "1536",
+      "metrics.memory.mb": "1536",
+      "metrics.processor.memory.mb": "1536",
       "router.bind.port": "11015",
+      "stream.container.memory.mb": "1536",
+      "twill.java.reserved.memory.mb": "350",
       "zookeeper.quorum": "{{ZK_QUORUM}}"
     },
     "cdap_env": {


### PR DESCRIPTION
This increases the default container sizes for CDAP when provisioned via Azure HDInsight.  This will better protect CDAP from OOM when processing real data users may throw at it, at the expense of some Yarn capacity.  Our defaults are simply too low for most real use-cases.

HDInsight clusters use the capacity scheduler with minimum-allocation of **756 mb**, which we shouldn't change.  Currently, CDAP containers are allocated at **756mb** with the exception of explore at **1536mb**.  This PR will increase containers to **1536mb**, explore to **2304mb**.  `twill.java.reserved.memory.mb` is also increased by 100mb to protect against containers getting killed due to non-heap memory.

An HDInsight cluster with the default of 4`D3 v2` worker nodes results in **22 GB** and **32 cores** of usable yarn capacity.  CDAP will use **12 GB** and **8 cores**.  (And this is without tracker enabled).  So it is a little tight on memory, leaving only 10 Gb.  (It's also possible for a user to provision less worker nodes than the default 4.  The default node size is the smallest option.)  Can any of these container settings be reasonably scaled back?

Note, since the current live package is not pinned to a tag, these changes will go live immediately after merge (this was on purpose for launch and can be changed).
