### PR TITLE
Docs for Application versioning and RouteConfig

### DIFF
--- a/cdap-docs/developers-manual/source/building-blocks/applications.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/applications.rst
@@ -73,6 +73,19 @@ application could include a stream, a flow, a flowlet, and a dataset. It's possi
 stream is not needed, if other methods of bringing in data are used. In the next pages,
 we'll look at these components, and their interactions.
 
+Application Version
+===================
+
+Applications can be created with a version string. This might be useful when a newer version of the same application
+needs to be created. Programs of a specific version of an Application be started or stopped using the version aware
+program lifecycle HTTP RESTful API. If a version is not provided while creating an application (i.e., applications
+created using the non-version aware API), a default version of "-SNAPSHOT" is used. If an application version that is
+trying to be created already exists,then it will be overriden only if the version string ends with "-SNAPSHOT".
+Otherwise, the versions are immutable.
+
+Information about the version-aware RESTful API to create, list, delete application with versions can be found in
+the Lifecycle HTTP RESTful API documentation.
+
 Application Configuration
 =========================
 Application classes can use a ``Config`` class to receive a configuration when an Application is created.

--- a/cdap-docs/developers-manual/source/building-blocks/applications.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/applications.rst
@@ -75,16 +75,23 @@ we'll look at these components, and their interactions.
 
 Application Version
 ===================
+Applications can be created with a version string. This can be useful when a newer version
+of the same application needs to be created, and you need to distinguish them and run them
+at the same time. Programs of a specific version of an application can be started and
+stopped using the calls of the version-aware :ref:`Lifecycle HTTP RESTful APIs
+<http-restful-api-lifecycle>`. 
 
-Applications can be created with a version string. This might be useful when a newer version of the same application
-needs to be created. Programs of a specific version of an Application be started or stopped using the version aware
-program lifecycle HTTP RESTful API. If a version is not provided while creating an application (i.e., applications
-created using the non-version aware API), a default version of "-SNAPSHOT" is used. If an application version that is
-trying to be created already exists,then it will be overriden only if the version string ends with "-SNAPSHOT".
-Otherwise, the versions are immutable.
+If a version is not provided while creating an application (i.e., the application is
+created using a non-version-aware API), a default version of "-SNAPSHOT" is used.
 
-Information about the version-aware RESTful API to create, list, delete application with versions can be found in
-the Lifecycle HTTP RESTful API documentation.
+If an application version is specified that matches one that already exists, it will be
+overwritten only if the version string ends with "-SNAPSHOT". Otherwise, versions are
+immutable, and the only way to change a version is to delete the application of that
+version and then redeploy it.
+
+Information about the version-aware RESTful APIs to create, list, and delete applications
+using versions can be found in the :ref:`Lifecycle HTTP RESTful API documentation
+<http-restful-api-lifecycle>`.
 
 Application Configuration
 =========================

--- a/cdap-docs/developers-manual/source/building-blocks/services.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/services.rst
@@ -212,6 +212,21 @@ If both the memory and the number of cores needs to be set, this can be done usi
 An example of setting ``Resources`` using runtime arguments is shown in :ref:`Purchase
 <examples-purchase>` example's ``PurchaseHistoryBuilder.java``.
 
+Service Routing
+===============
+
+When multiple versions of the same service is running, the users can control where the service requests are routed to.
+For example, say version 'v1' and version 'v2' of the application is running, user can choose to direct 50% of the requests
+to version 'v1' service and 50% to 'v2'. This is can be achieved by uploading a RouteConfig (which is basically a map of
+version name to the percentage of requests to be routed to that version). For a specific service, if a RouteConfig is
+not present or if it could not be retrieved, the fall back routing strategy is used and it can be configured in cdap-site.xml.
+The possible fallback strategies are - random, smallest, largest, drop. Random is the default fallback strategy. If random
+fallback strategy is chosen, the request can be routed to any version of the service. If smallest is chosen, the request
+is routed to the smallest version (based on string comparison of the version) and similarly for the largest, the request is
+routed to the largest version. If drop is chosen as the fallback strategy, then the request will not be routed to any version.
+The fallback strategy can be configured using the property - 'router.userservice.fallback.strategy' in cdap-site.xml.
+
+Information about how to store, fetch, delete routing configuration, refer to the RouteConfig HTTP RESTful API Documentation
 
 Services Examples
 =================

--- a/cdap-docs/developers-manual/source/building-blocks/services.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/services.rst
@@ -212,21 +212,40 @@ If both the memory and the number of cores needs to be set, this can be done usi
 An example of setting ``Resources`` using runtime arguments is shown in :ref:`Purchase
 <examples-purchase>` example's ``PurchaseHistoryBuilder.java``.
 
+.. _services-routing:
+
 Service Routing
 ===============
+When multiple versions of the same service are running, you can control where service
+requests are routed.
 
-When multiple versions of the same service is running, the users can control where the service requests are routed to.
-For example, say version 'v1' and version 'v2' of the application is running, user can choose to direct 50% of the requests
-to version 'v1' service and 50% to 'v2'. This is can be achieved by uploading a RouteConfig (which is basically a map of
-version name to the percentage of requests to be routed to that version). For a specific service, if a RouteConfig is
-not present or if it could not be retrieved, the fall back routing strategy is used and it can be configured in cdap-site.xml.
-The possible fallback strategies are - random, smallest, largest, drop. Random is the default fallback strategy. If random
-fallback strategy is chosen, the request can be routed to any version of the service. If smallest is chosen, the request
-is routed to the smallest version (based on string comparison of the version) and similarly for the largest, the request is
-routed to the largest version. If drop is chosen as the fallback strategy, then the request will not be routed to any version.
-The fallback strategy can be configured using the property - 'router.userservice.fallback.strategy' in cdap-site.xml.
+For example, if version ``v1`` and version ``v2`` of the same application are running, you
+can choose to direct 50% of the requests to version ``v1`` of the service and 50% to version
+``v2``. This can be achieved by uploading a *route configuration* (also known as a *route
+config*): a map of version names to the percentage of requests to be routed to that
+version.
 
-Information about how to store, fetch, delete routing configuration, refer to the RouteConfig HTTP RESTful API Documentation
+For a specific service, if a route config is not present or if it cannot be retrieved, a
+fallback routing strategy is used. The strategy used can be configured in the
+``cdap-site.xml`` file.
+
+These fallback strategies are available: *random*, *smallest*, *largest*, and *drop*.
+
+**Random** is the default fallback strategy. If the random fallback strategy is chosen,
+the request is routed to any version of the service.
+
+If **smallest** is chosen, the request is routed to the smallest version (based on a
+string comparison of the available versions). Similarly for **largest**: the request
+is routed to the largest version. If **drop** is chosen as the fallback strategy, the
+request is not routed to any version.
+
+The fallback strategy can be configured using the property
+``router.userservice.fallback.strategy`` in the 
+:ref:`cdap-site.xml file <appendix-cdap-site.xml>`.
+
+For information on how to store, fetch, and delete a routing configuration
+(*RouteConfig*), refer to the :ref:`Route Config HTTP RESTful API documentation 
+<http-restful-api-route-config>`.
 
 Services Examples
 =================

--- a/cdap-docs/reference-manual/source/glossary.rst
+++ b/cdap-docs/reference-manual/source/glossary.rst
@@ -221,3 +221,10 @@ Glossary
    Storage Provider
       For :term:`datasets <dataset>` and :term:`streams <stream>`, a storage provider is the underlying
       system that CDAP uses for persistence. Examples include HDFS, HBase, and Hive.
+
+   Route Configuration
+      Also known as a *route config*, a map that allocates requests for a service between
+      different versions of the service.
+
+   Route Config
+      See :term:`route configuration`.

--- a/cdap-docs/reference-manual/source/http-restful-api/index.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/index.rst
@@ -27,7 +27,7 @@ CDAP HTTP RESTful API v3
     Namespace <namespace>
     Preferences <preferences>
     Query <query>
-    RouteConfig <routeconfig>
+    Route Config <routeconfig>
     Security <security>
     Service <service>
     Stream <stream>

--- a/cdap-docs/reference-manual/source/http-restful-api/index.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/index.rst
@@ -27,6 +27,7 @@ CDAP HTTP RESTful API v3
     Namespace <namespace>
     Preferences <preferences>
     Query <query>
+    RouteConfig <routeconfig>
     Security <security>
     Service <service>
     Stream <stream>
@@ -45,7 +46,8 @@ data isolation. This is an inital step towards introducing `multi-tenancy
 
 **Introduction**
 
-- :doc:`Introduction: <introduction>` conventions, converting from HTTP RESTful API v2, naming restrictions, status codes, and working with CDAP security
+- :doc:`Introduction: <introduction>` conventions, converting from HTTP RESTful API v2,
+  naming restrictions, status codes, and working with CDAP security
 
 **General APIs**
 
@@ -53,16 +55,21 @@ data isolation. This is an inital step towards introducing `multi-tenancy
 - :doc:`Metadata: <metadata>` setting, retrieving, and deleting user metadata annotations
 - :doc:`Preferences: <preferences>` setting, retrieving, and deleting preferences
 - :doc:`Configuration: <configuration>` retrieving the CDAP and HBase configurations
-- :doc:`Security: <security>` granting, revoking and listing privileges on CDAP entities, managing secure storage
+- :doc:`Security: <security>` granting, revoking and listing privileges on CDAP entities,
+  managing secure storage
 - :doc:`Transactions: <transactions>` interacting with the transaction service
 
 **Major CDAP Entities APIs**
 
-- :doc:`Artifact: <artifact>` deploying artifacts and retrieving details about plugins available to artifacts and classes contained within artifacts
-- :doc:`Lifecycle: <lifecycle>` deploying and managing applications, and managing the lifecycle of flows, MapReduce programs, Spark programs, workflows, and custom services
+- :doc:`Artifact: <artifact>` deploying artifacts and retrieving details about plugins
+  available to artifacts and classes contained within artifacts
+- :doc:`Lifecycle: <lifecycle>` deploying and managing applications, and managing the
+  lifecycle of flows, MapReduce programs, Spark programs, workflows, and custom services
 - :doc:`Stream: <stream>` sending data events to a stream or to inspect the contents of a stream
 - :doc:`Dataset: <dataset>` interacting with datasets, dataset modules, and dataset types
 - :doc:`Service: <service>` supports making requests to the methods of an application’s services
+- :doc:`Route Config: <query>` create, fetch, and delete route configurations (*route
+  configs*) which allocate requests between different versions of a service
 - :doc:`Workflow: <workflow>` retrieving values from workflow tokens and statistics on workflow runs
 
 **Querying and Viewing APIs**
@@ -79,14 +86,17 @@ data isolation. This is an inital step towards introducing `multi-tenancy
 
 .. rubric:: Alphabetical List of APIs
 
-- :doc:`Introduction: <introduction>` conventions, converting from HTTP RESTful API v2, naming restrictions, status codes, and working with CDAP security
+- :doc:`Introduction: <introduction>` conventions, converting from HTTP RESTful API v2,
+  naming restrictions, status codes, and working with CDAP security
 
 ..
 
-- :doc:`Artifact: <artifact>` deploying artifacts and retrieving details about plugins available to artifacts and classes contained within artifacts
+- :doc:`Artifact: <artifact>` deploying artifacts and retrieving details about plugins
+  available to artifacts and classes contained within artifacts
 - :doc:`Configuration: <configuration>` retrieving the CDAP and HBase configurations
 - :doc:`Dataset: <dataset>` interacting with datasets, dataset modules, and dataset types
-- :doc:`Lifecycle: <lifecycle>` deploying and managing applications, and managing the lifecycle of flows, MapReduce programs, Spark programs, workflows, and custom services
+- :doc:`Lifecycle: <lifecycle>` deploying and managing applications, and managing the
+  lifecycle of flows, MapReduce programs, Spark programs, workflows, and custom services
 - :doc:`Logging: <logging>` retrieving application logs
 - :doc:`Metadata: <metadata>` setting, retrieving, and deleting user metadata annotations
 - :doc:`Metrics: <metrics>` retrieving metrics for system and user applications (user-defined metrics)
@@ -94,6 +104,8 @@ data isolation. This is an inital step towards introducing `multi-tenancy
 - :doc:`Namespace: <namespace>` creating and managing namespaces
 - :doc:`Preferences: <preferences>` setting, retrieving, and deleting preferences
 - :doc:`Query: <query>` sending ad-hoc queries to CDAP datasets
+- :doc:`Route Config: <query>` create, fetch, and delete route configurations (*route
+  configs*) which allocate requests between different versions of a service
 - :doc:`Security: <security>` granting, revoking, and listing privileges, as well as adding, retrieving,
   and managing *Secure Keys*
 - :doc:`Service: <service>` supports making requests to the methods of an application’s services

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -30,11 +30,25 @@ Create an Application
 ---------------------
 To create an application, submit an HTTP PUT request::
 
-  PUT /v3/namespaces/<namespace-id>/apps/<app-name>
+  PUT /v3/namespaces/<namespace-id>/apps/<app-id>
 
-To create an application with a non-default version, submit an HTTP POST request::
+To create an application with a non-default version, submit an HTTP POST request with the version specified::
 
-  POST /v3/namespaces/<namespace-id>/apps/<app-name>/versions/<version-id>/create
+  POST /v3/namespaces/<namespace-id>/apps/<app-id>/versions/<version-id>/create
+  
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``namespace-id``
+     - Namespace ID
+   * - ``app-id``
+     - Name of the application
+   * - ``version-id``
+     - Version of the application, typically following `semantic versioning
+       <http://semver.org>`__; versions ending with ``-SNAPSHOT`` can be overwritten
 
 The request body is a JSON object specifying the artifact to use to create the application,
 and an optional application configuration. For example:
@@ -62,7 +76,7 @@ Update an Application
 ---------------------
 To update an application, submit an HTTP POST request::
 
-  POST /v3/namespaces/<namespace-id>/apps/<app-name>/update
+  POST /v3/namespaces/<namespace-id>/apps/<app-id>/update
 
 The request body is a JSON object specifying the updated artifact version and the updated application
 config. For example, a request body of:
@@ -181,15 +195,15 @@ of the application; the artifact, streams, and datasets that it uses; and all of
      - The event successfully called the method, and the body contains the results
 
 
-Listing all versions of an Application
---------------------------------------
+Listing Versions of an Application
+----------------------------------
 
 To list all the versions of an application, submit an HTTP GET::
 
-  GET /v3/namespaces/<namespace-id>/apps/<application-name>
+  GET /v3/namespaces/<namespace-id>/apps/<app-id>/<program-type>/<program-id>
 
 .. list-table::
-:widths: 20 80
+   :widths: 20 80
    :header-rows: 1
 
    * - Parameter
@@ -198,15 +212,20 @@ To list all the versions of an application, submit an HTTP GET::
      - Namespace ID
    * - ``app-id``
      - Name of the application being called
+   * - ``program-type``
+     - One of ``flows``, ``mapreduce``, ``services``, ``spark``, ``workers``, or ``workflows``
+   * - ``program-id``
+     - Name of the *flow*, *MapReduce*, *custom service*, *Spark*, *worker*, or *workflow*
+       being listed
 
-The response will be a JSON array containing details about the program. The details returned depend on the
-program type.
+The response will be a JSON array containing details about the program. The details
+returned depend on the program type.
 
 For example::
 
   GET /v3/namespaces/default/apps/HelloWorld/flows/WhoFlow
 
-will return in a JSON array information of the versions of the application.
+will return in a JSON array information of the versions of the application::
 
   {
     "1.0.1", "2.0.3"
@@ -220,7 +239,7 @@ programs, schedules, custom services, and workflows |---| submit an HTTP DELETE:
 
   DELETE /v3/namespaces/<namespace-id>/apps/<application-name>
 
-To delete a specific version of an application, submit an HTTP DELETE::
+To delete a specific version of an application, submit an HTTP DELETE that includes the version::
 
   DELETE /v3/namespaces/<namespace-id>/apps/<application-name>/versions/<version-id>
 
@@ -234,6 +253,8 @@ To delete a specific version of an application, submit an HTTP DELETE::
      - Namespace ID
    * - ``application-name``
      - Name of the application to be deleted
+   * - ``version-id``
+     - Version of the application to be deleted
 
 **Note:** The ``application-name`` in this URL is the name of the application
 as configured by the application Specification,
@@ -344,7 +365,8 @@ custom services, workers, and workflows by submitting an HTTP POST request::
 
   POST /v3/namespaces/<namespace-id>/apps/<app-id>/<program-type>/<program-id>/start
 
-You can start a program of a particular version of the application by submitting an HTTP POST request::
+You can start a program of a particular version of the application by submitting an HTTP
+POST request that includes the version::
 
   POST /v3/namespaces/<namespace-id>/apps/<app-id>/versions/<version-id>/<program-type>/<program-id>/start
 
@@ -364,7 +386,7 @@ CDAP will use these these runtime arguments only for this single invocation of t
    * - ``app-id``
      - Name of the application being called
    * - ``version-id``
-     - Name of version of the application being called
+     - Version of the application being called
    * - ``program-type``
      - One of ``flows``, ``mapreduce``, ``services``, ``spark``, ``workers``, or ``workflows``
    * - ``program-id``
@@ -405,7 +427,7 @@ with a JSON array in the request body consisting of multiple JSON objects with t
      - One of ``flow``, ``mapreduce``, ``service``, ``spark``, ``worker``, or ``workflow``
    * - ``"programId"``
      - Name of the *flow*, *MapReduce*, *custom service*, *Spark*, *worker*, or *workflow*
-       being called
+       being started
    * - ``"runtimeargs"``
      - Optional JSON object containing a string to string mapping of runtime arguments to start the program with
 
@@ -424,7 +446,7 @@ Each JSON object will contain these parameters:
      - One of ``flow``, ``mapreduce``, ``service``, ``spark``, ``worker``, or ``workflow``
    * - ``"programId"``
      - Name of the *flow*, *MapReduce*, *custom service*, *Spark*, *worker*, or *workflow*
-       being called
+       being started
    * - ``"statusCode"``
      - The status code from starting an individual JSON object
    * - ``"error"``
@@ -459,7 +481,8 @@ workflows of an application by submitting an HTTP POST request::
 
   POST /v3/namespaces/<namespace-id>/apps/<app-id>/<program-type>/<program-id>/stop
 
-You can stop the programs of a particular application version by submitting an HTTP POST request::
+You can stop the programs of a particular application version by submitting an HTTP POST
+request that includes the version::
 
   POST /v3/namespaces/<namespace-id>/apps/<app-id>/versions/<version-id>/<program-type>/<program-id>/stop
 
@@ -479,7 +502,7 @@ You can stop the programs of a particular application version by submitting an H
      - One of ``flows``, ``mapreduce``, ``services``, ``spark``, ``workers``, or ``workflows``
    * - ``program-id``
      - Name of the *flow*, *MapReduce*, *custom service*, *Spark*, *worker*, or *workflow*
-       being called
+       being stopped
 
 A program that is in the STOPPED state cannot be stopped. If there are multiple runs of the program
 in the RUNNING state, this call will stop one of the runs, but not all of the runs. 
@@ -546,7 +569,7 @@ with a JSON array in the request body consisting of multiple JSON objects with t
      - One of ``flow``, ``mapreduce``, ``service``, ``spark``, ``worker``, or ``workflow``
    * - ``"programId"``
      - Name of the *flow*, *MapReduce*, *custom service*, *Spark*, *worker*, or *workflow*
-       being called
+       being stopped
 
 The response will be a JSON array containing a JSON object corresponding to each object in the input.
 Each JSON object will contain these parameters:
@@ -563,7 +586,7 @@ Each JSON object will contain these parameters:
      - One of ``flow``, ``mapreduce``, ``service``, ``spark``, ``worker``, or ``workflow``
    * - ``"programId"``
      - Name of the *flow*, *MapReduce*, *custom service*, *Spark*, *worker*, or *workflow*
-       being called
+       being stopped
    * - ``"statusCode"``
      - The status code from stopping an individual JSON object
    * - ``"error"``

--- a/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/lifecycle.rst
@@ -32,6 +32,10 @@ To create an application, submit an HTTP PUT request::
 
   PUT /v3/namespaces/<namespace-id>/apps/<app-name>
 
+To create an application with a non-default version, submit an HTTP POST request::
+
+  POST /v3/namespaces/<namespace-id>/apps/<app-name>/versions/<version-id>/create
+
 The request body is a JSON object specifying the artifact to use to create the application,
 and an optional application configuration. For example:
  
@@ -52,7 +56,7 @@ and an optional application configuration. For example:
 
 will create an application named ``purchaseWordCount`` from the example ``WordCount`` artifact. The application
 will receive the specified config, which will configure the application to create a stream named
-``purchaseStream`` instead of using the default stream name. 
+``purchaseStream`` instead of using the default stream name.
 
 Update an Application
 ---------------------
@@ -66,7 +70,7 @@ config. For example, a request body of:
 .. container:: highlight
 
   .. parsed-literal::
-    |$| POST /v3/namespaces/default/apps/purchaseWordCount -d 
+    |$| POST /v3/namespaces/default/apps/purchaseWordCount/update -d
     {
       "artifact": {
         "name": "WordCount",
@@ -177,12 +181,48 @@ of the application; the artifact, streams, and datasets that it uses; and all of
      - The event successfully called the method, and the body contains the results
 
 
+Listing all versions of an Application
+--------------------------------------
+
+To list all the versions of an application, submit an HTTP GET::
+
+  GET /v3/namespaces/<namespace-id>/apps/<application-name>
+
+.. list-table::
+:widths: 20 80
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``namespace-id``
+     - Namespace ID
+   * - ``app-id``
+     - Name of the application being called
+
+The response will be a JSON array containing details about the program. The details returned depend on the
+program type.
+
+For example::
+
+  GET /v3/namespaces/default/apps/HelloWorld/flows/WhoFlow
+
+will return in a JSON array information of the versions of the application.
+
+  {
+    "1.0.1", "2.0.3"
+  }
+
+
 Delete an Application
 ---------------------
 To delete an application |---| together with all of its flows, MapReduce or Spark
 programs, schedules, custom services, and workflows |---| submit an HTTP DELETE::
 
   DELETE /v3/namespaces/<namespace-id>/apps/<application-name>
+
+To delete a specific version of an application, submit an HTTP DELETE::
+
+  DELETE /v3/namespaces/<namespace-id>/apps/<application-name>/versions/<version-id>
 
 .. list-table::
    :widths: 20 80
@@ -304,6 +344,12 @@ custom services, workers, and workflows by submitting an HTTP POST request::
 
   POST /v3/namespaces/<namespace-id>/apps/<app-id>/<program-type>/<program-id>/start
 
+You can start a program of a particular version of the application by submitting an HTTP POST request::
+
+  POST /v3/namespaces/<namespace-id>/apps/<app-id>/versions/<version-id>/<program-type>/<program-id>/start
+
+Note: Concurrent runs of Flows and Workers across multiple versions of the same application is not allowed.
+
 When starting an program, you can optionally specify runtime arguments as a JSON map in the request body.
 CDAP will use these these runtime arguments only for this single invocation of the program.
 
@@ -317,6 +363,8 @@ CDAP will use these these runtime arguments only for this single invocation of t
      - Namespace ID
    * - ``app-id``
      - Name of the application being called
+   * - ``version-id``
+     - Name of version of the application being called
    * - ``program-type``
      - One of ``flows``, ``mapreduce``, ``services``, ``spark``, ``workers``, or ``workflows``
    * - ``program-id``
@@ -411,6 +459,10 @@ workflows of an application by submitting an HTTP POST request::
 
   POST /v3/namespaces/<namespace-id>/apps/<app-id>/<program-type>/<program-id>/stop
 
+You can stop the programs of a particular application version by submitting an HTTP POST request::
+
+  POST /v3/namespaces/<namespace-id>/apps/<app-id>/versions/<version-id>/<program-type>/<program-id>/stop
+
 .. list-table::
    :widths: 20 80
    :header-rows: 1
@@ -421,6 +473,8 @@ workflows of an application by submitting an HTTP POST request::
      - Namespace ID
    * - ``app-id``
      - Name of the application being called
+   * - ``version-id``
+     - Version of the application being called
    * - ``program-type``
      - One of ``flows``, ``mapreduce``, ``services``, ``spark``, ``workers``, or ``workflows``
    * - ``program-id``

--- a/cdap-docs/reference-manual/source/http-restful-api/routeconfig.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/routeconfig.rst
@@ -1,0 +1,158 @@
+.. meta::
+:author: Cask Data, Inc.
+    :description: HTTP RESTful Interface to the Cask Data Application Platform
+      :copyright: Copyright © 2015-2016 Cask Data, Inc.
+
+.. _http-restful-api-routeconfig:
+
+============================
+RouteConfig HTTP RESTful API
+============================
+
+.. highlight:: console
+
+Use the CDAP RouteConfig HTTP RESTful API to create, fetch, and delete route configs.
+
+
+Additional details are found in the :ref:`Developers' Manual: Views <developers:services>`.
+
+
+.. Base URL explanation
+.. --------------------
+.. include:: base-url.txt
+
+
+.. _http-restful-api-routeconfig-uploading-routeconfig:
+
+Uploading a Stream View
+======================
+A routeconfig for a user service can be uploading using an HTTP PUT request to the URL::
+
+  PUT /v3/namespaces/<namespace-id>/apps/<app-id>/services/<service-id>/routeconfig
+
+.. list-table::
+:widths: 20 80
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``namespace-id``
+     - Namespace ID
+   * - ``app-id``
+     - Name of the Application
+   * - ``service-id``
+     - Name of the Service (must be already existing)
+
+The request body is a JSON object which contains a map of version string to an integer specifying the percentage of
+requests that should be routed to that version of the service. Note, that the percentages should add up to 100.
+Also, all the versions specified in the request body should be existing in CDAP already.
+
+.. rubric:: Example
+
+For example, to upload a routeConfig for the service *MyService*:
+
+.. tabbed-parsed-literal::
+
+  $ curl -w"\n" -X PUT "http://example.com:10000/v3/namespaces/default/apps/MyApp/services/MyService/routeconfig" \
+    -H 'Content-Type: application/json' -d \
+    "{
+      "v1" : 50,
+      "v2" : 50
+    }"
+
+.. rubric:: HTTP Responses
+
+.. list-table::
+:widths: 20 80
+   :header-rows: 1
+
+   * - Status Codes
+     - Description
+   * - ``200 OK``
+     - A RouteConfig was successfully uploaded for that service
+   * - ``404 BAD REQUEST``
+     - If service is not present, or if a version of the service is not present or if the percentages don't add upto 100
+
+
+.. _http-restful-api-routeconfig-fetching-routeconfig:
+
+Fetching RouteConfig
+====================
+To fetch the RouteConfig of a service, issue an HTTP GET request to the URL::
+
+  GET /v3/namespaces/<namespace-id>/apps/<app-id>/services/<service-id>/routeconfig
+
+.. list-table::
+:widths: 20 80
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``namespace-id``
+     - Namespace ID
+   * - ``app-id``
+     - Name of the Application
+   * - ``service-id``
+     - Name of the Service
+
+The response body is a JSON object with the map of version to the percentage of requests to be routed to that version.
+If a RouteConfig for that service is not found, an empty map is returned.
+
+.. rubric:: Example
+
+For example, to see to routeConfig of *MyService*, you could use:
+
+.. tabbed-parsed-literal::
+
+  $ curl -w"\n" -X GET "http://example.com:10000/v3/namespaces/default/apps/MyApp/services/MyService/routeconfig"
+
+  { "v1" : 50, "v2" : 50 }
+
+.. rubric:: HTTP Responses
+
+.. list-table::
+:widths: 20 80
+   :header-rows: 1
+
+     * - Status Codes
+       - Description
+     * - ``200 OK``
+       - Map of version to percentage of requests to be routed to that version
+
+Deleting a RouteConfig
+======================
+To delete a RouteConfig for a service, issue an HTTP DELETE request to the URL::
+
+  DELETE /v3/namespaces/<namespace-id>/apps/<app-id>/services/<service-id>/routeconfig
+
+.. list-table::
+:widths: 20 80
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``namespace-id``
+     - Namespace ID
+   * - ``app-id``
+     - Name of the Application
+   * - ``service-id``
+     - Name of the Service
+
+.. rubric:: Example
+
+For example, to delete the RouteConfig of *MyService*, you could use:
+
+.. tabbed-parsed-literal::
+
+  $ curl -w"\n" -X DELETE "http://example.com:10000/v3/namespaces/default/apps/MyApp/services/MyService/routeconfig"
+
+.. rubric:: HTTP Responses
+
+.. list-table::
+:widths: 20 80
+   :header-rows: 1
+
+     * - Status Codes
+       - Description
+     * - ``200 OK``
+       - The route config of the service was successfully deleted

--- a/cdap-docs/reference-manual/source/http-restful-api/routeconfig.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/routeconfig.rst
@@ -57,10 +57,10 @@ For example, to upload a route configuration for the service *MyService*, with d
 
   $ curl -w"\n" -X PUT "http://example.com:10000/v3/namespaces/default/apps/MyApp/services/MyService/routeconfig" \
     -H 'Content-Type: application/json' -d \
-    "{
+    '{
       "v1" : 50,
       "v2" : 50
-    }"
+    }'
 
 .. rubric:: HTTP Responses
 

--- a/cdap-docs/reference-manual/source/http-restful-api/routeconfig.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/routeconfig.rst
@@ -1,20 +1,22 @@
 .. meta::
-:author: Cask Data, Inc.
+    :author: Cask Data, Inc.
     :description: HTTP RESTful Interface to the Cask Data Application Platform
-      :copyright: Copyright © 2015-2016 Cask Data, Inc.
+    :copyright: Copyright © 2016 Cask Data, Inc.
 
-.. _http-restful-api-routeconfig:
+.. _http-restful-api-route-config:
 
-============================
-RouteConfig HTTP RESTful API
-============================
+=============================
+Route Config HTTP RESTful API
+=============================
 
 .. highlight:: console
 
-Use the CDAP RouteConfig HTTP RESTful API to create, fetch, and delete route configs.
+Use the CDAP Route Config HTTP RESTful API to create, fetch, and delete route
+configurations (also known as *route configs*), which allocate requests between different
+versions of a service.
 
-
-Additional details are found in the :ref:`Developers' Manual: Views <developers:services>`.
+Additional details on using route configurations with services are found in the :ref:`Developers'
+Manual: Service Routing <services-routing>`.
 
 
 .. Base URL explanation
@@ -22,16 +24,16 @@ Additional details are found in the :ref:`Developers' Manual: Views <developers:
 .. include:: base-url.txt
 
 
-.. _http-restful-api-routeconfig-uploading-routeconfig:
+.. _http-restful-api-route-config-uploading:
 
-Uploading a Stream View
-======================
-A routeconfig for a user service can be uploading using an HTTP PUT request to the URL::
+Uploading a Route Config
+========================
+A route configuration for a user service can be uploaded using an HTTP PUT request to the URL::
 
   PUT /v3/namespaces/<namespace-id>/apps/<app-id>/services/<service-id>/routeconfig
 
 .. list-table::
-:widths: 20 80
+   :widths: 20 80
    :header-rows: 1
 
    * - Parameter
@@ -43,13 +45,13 @@ A routeconfig for a user service can be uploading using an HTTP PUT request to t
    * - ``service-id``
      - Name of the Service (must be already existing)
 
-The request body is a JSON object which contains a map of version string to an integer specifying the percentage of
-requests that should be routed to that version of the service. Note, that the percentages should add up to 100.
-Also, all the versions specified in the request body should be existing in CDAP already.
+The request body is a JSON object which contains a map of version strings to integers specifying the percentage of
+requests that should be routed to that version of the service. Note that the percentages should total *100*.
+All versions specified in the route configuration should already be deployed in CDAP.
 
 .. rubric:: Example
 
-For example, to upload a routeConfig for the service *MyService*:
+For example, to upload a route configuration for the service *MyService*, with deployed versions *v1* and *v2*:
 
 .. tabbed-parsed-literal::
 
@@ -63,7 +65,7 @@ For example, to upload a routeConfig for the service *MyService*:
 .. rubric:: HTTP Responses
 
 .. list-table::
-:widths: 20 80
+   :widths: 20 80
    :header-rows: 1
 
    * - Status Codes
@@ -71,19 +73,19 @@ For example, to upload a routeConfig for the service *MyService*:
    * - ``200 OK``
      - A RouteConfig was successfully uploaded for that service
    * - ``404 BAD REQUEST``
-     - If service is not present, or if a version of the service is not present or if the percentages don't add upto 100
+     - If service is not present, if a version of the service is not present, or if the percentages don't total 100
 
 
 .. _http-restful-api-routeconfig-fetching-routeconfig:
 
-Fetching RouteConfig
-====================
-To fetch the RouteConfig of a service, issue an HTTP GET request to the URL::
+Fetching a Route Config
+=======================
+To fetch the route configuration of a service, issue an HTTP GET request to the URL::
 
   GET /v3/namespaces/<namespace-id>/apps/<app-id>/services/<service-id>/routeconfig
 
 .. list-table::
-:widths: 20 80
+   :widths: 20 80
    :header-rows: 1
 
    * - Parameter
@@ -95,12 +97,12 @@ To fetch the RouteConfig of a service, issue an HTTP GET request to the URL::
    * - ``service-id``
      - Name of the Service
 
-The response body is a JSON object with the map of version to the percentage of requests to be routed to that version.
-If a RouteConfig for that service is not found, an empty map is returned.
+The response body is a JSON object with the map of versions to percentages of requests to be routed to each version.
+If a route configuration for that service is not found, an empty map is returned.
 
 .. rubric:: Example
 
-For example, to see to routeConfig of *MyService*, you could use:
+For example, to retrieve the route configuration of the service *MyService*, use:
 
 .. tabbed-parsed-literal::
 
@@ -111,22 +113,23 @@ For example, to see to routeConfig of *MyService*, you could use:
 .. rubric:: HTTP Responses
 
 .. list-table::
-:widths: 20 80
+   :widths: 20 80
    :header-rows: 1
 
-     * - Status Codes
-       - Description
-     * - ``200 OK``
-       - Map of version to percentage of requests to be routed to that version
+   * - Status Codes
+     - Description
+   * - ``200 OK``
+     - Map of versions to percentage of requests to be routed to each version
 
-Deleting a RouteConfig
-======================
-To delete a RouteConfig for a service, issue an HTTP DELETE request to the URL::
+
+Deleting a Route Config
+=======================
+To delete a route configuration for a service, issue an HTTP DELETE request to the URL::
 
   DELETE /v3/namespaces/<namespace-id>/apps/<app-id>/services/<service-id>/routeconfig
 
 .. list-table::
-:widths: 20 80
+   :widths: 20 80
    :header-rows: 1
 
    * - Parameter
@@ -140,7 +143,7 @@ To delete a RouteConfig for a service, issue an HTTP DELETE request to the URL::
 
 .. rubric:: Example
 
-For example, to delete the RouteConfig of *MyService*, you could use:
+For example, to delete the route configuration of the service *MyService*, use:
 
 .. tabbed-parsed-literal::
 
@@ -149,10 +152,10 @@ For example, to delete the RouteConfig of *MyService*, you could use:
 .. rubric:: HTTP Responses
 
 .. list-table::
-:widths: 20 80
+   :widths: 20 80
    :header-rows: 1
 
-     * - Status Codes
-       - Description
-     * - ``200 OK``
-       - The route config of the service was successfully deleted
+   * - Status Codes
+     - Description
+   * - ``200 OK``
+     - The route configuration of the service was successfully deleted

--- a/cdap-docs/reference-manual/source/http-restful-api/service.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/service.rst
@@ -17,6 +17,9 @@ control the lifecycle of services.
 
 For system services, see the :ref:`http-restful-api-monitor` and its methods.
 
+See the :ref:`Route Config HTTP RESTful API <http-restful-api-route-config>` for
+allocating requests between different versions of a service.
+
 Additional details and examples are found in the :ref:`Developers' Manual: Services <developers:user-services>`.
 
 .. Base URL explanation


### PR DESCRIPTION
Pages of interest:
- [building-blocks/applications](http://builds.cask.co/artifact/CDAP-DQB147/shared/build-2/Docs-HTML/3.6.0-SNAPSHOT/en/developers-manual/building-blocks/applications.html#application-version)
- [building-blocks/services](http://builds.cask.co/artifact/CDAP-DQB147/shared/build-2/Docs-HTML/3.6.0-SNAPSHOT/en/developers-manual/building-blocks/services.html#service-routing)
- [glossary](http://builds.cask.co/artifact/CDAP-DQB147/shared/build-2/Docs-HTML/3.6.0-SNAPSHOT/en/reference-manual/glossary.html#glossary)
- [http-restful-api/index](http://builds.cask.co/artifact/CDAP-DQB147/shared/build-2/Docs-HTML/3.6.0-SNAPSHOT/en/reference-manual/http-restful-api/index.html#cdap-http-restful-api-v3)
- [http-restful-api/lifecycle](http://builds.cask.co/artifact/CDAP-DQB147/shared/build-2/Docs-HTML/3.6.0-SNAPSHOT/en/reference-manual/http-restful-api/lifecycle.html#listing-versions-of-an-application)
- [http-restful-api/routeconfig](http://builds.cask.co/artifact/CDAP-DQB147/shared/build-2/Docs-HTML/3.6.0-SNAPSHOT/en/reference-manual/http-restful-api/routeconfig.html#route-config-http-restful-api)
