### PR TITLE
[CDAP-7319] add an execute() with timeout to Transactional

### DIFF
--- a/cdap-api-spark/src/main/java/co/cask/cdap/api/spark/JavaSparkExecutionContext.java
+++ b/cdap-api-spark/src/main/java/co/cask/cdap/api/spark/JavaSparkExecutionContext.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.RuntimeContext;
 import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.TaskLocalizationContext;
 import co.cask.cdap.api.Transactional;
+import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.DatasetInstantiationException;
 import co.cask.cdap.api.data.batch.Split;
@@ -37,6 +38,7 @@ import org.apache.hadoop.io.Text;
 import org.apache.spark.Partition;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
+import org.apache.tephra.TransactionFailureException;
 
 import java.io.Serializable;
 import java.util.Collections;
@@ -477,4 +479,12 @@ public abstract class JavaSparkExecutionContext implements RuntimeContext, Trans
    */
   public abstract <K, V> void saveAsDataset(JavaPairRDD<K, V> rdd, String namespace, String datasetName,
                                             Map<String, String> arguments);
+
+  /**
+   * Transactions with a custom timeout are not supported in Spark.
+   *
+   * @throws TransactionFailureException always
+   */
+  public abstract void execute(int timeoutInSeconds, TxRunnable runnable) throws TransactionFailureException;
+
 }

--- a/cdap-api-spark/src/main/scala/co/cask/cdap/api/spark/SparkExecutionContext.scala
+++ b/cdap-api-spark/src/main/scala/co/cask/cdap/api/spark/SparkExecutionContext.scala
@@ -25,9 +25,10 @@ import co.cask.cdap.api.plugin.PluginContext
 import co.cask.cdap.api.security.store.SecureStore
 import co.cask.cdap.api.stream.GenericStreamEventData
 import co.cask.cdap.api.workflow.{WorkflowInfo, WorkflowToken}
-import co.cask.cdap.api.{RuntimeContext, ServiceDiscoverer, TaskLocalizationContext, Transactional}
+import co.cask.cdap.api._
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
+import org.apache.tephra.TransactionFailureException
 
 import scala.reflect.ClassTag
 
@@ -257,4 +258,11 @@ trait SparkExecutionContext extends RuntimeContext with Transactional {
     */
   def saveAsDataset[K: ClassTag, V: ClassTag](rdd: RDD[(K, V)], namespace: String, datasetName: String,
                                               arguments: Map[String, String]): Unit
+
+  /**
+    * Transactions with a custom timeout are not supported in Spark.
+    *
+    * @throws TransactionFailureException always
+    */
+  def execute(timeoutInSeconds: Int, runnable: TxRunnable): Unit
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/Transactional.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/Transactional.java
@@ -20,6 +20,11 @@ import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.dataset.Dataset;
 import org.apache.tephra.TransactionFailureException;
 
+// TODO: add an annotation that indicates: this is a system interface, do not implement it yourself as it may evolve
+//       Perhaps this annotation can be called @Evolving. For such an interface we would provide a corresponding
+//       abstract class that developers can extend, instead of implementing the interface. That will help us
+//       evolve the interface without breaking compatibility.
+
 /**
  * An object that executes submitted {@link TxRunnable} tasks. Each task submitted will be executed inside
  * a transaction.
@@ -28,10 +33,21 @@ public interface Transactional {
 
   /**
    * Executes a set of operations via a {@link TxRunnable} that are committed as a single transaction.
-   * The {@link TxRunnable} can gain access to {@link Dataset} through the provided {@link DatasetContext}.
+   * The {@link TxRunnable} can gain access to a {@link Dataset} through the provided {@link DatasetContext}.
    *
    * @param runnable the runnable to be executed in the transaction
    * @throws TransactionFailureException if failed to execute the given {@link TxRunnable} in a transaction
    */
   void execute(TxRunnable runnable) throws TransactionFailureException;
+
+  /**
+   * Executes a set of operations via a {@link TxRunnable} that are committed as a single transaction with a given
+   * timeout. The {@link TxRunnable} can gain access to a {@link Dataset} through the provided {@link DatasetContext}.
+   *
+   * @param timeoutInSeconds the transaction timeout for the transaction, in seconds
+   * @param runnable the runnable to be executed in the transaction
+   *
+   * @throws TransactionFailureException if failed to execute the given {@link TxRunnable} in a transaction
+   */
+  void execute(int timeoutInSeconds, TxRunnable runnable) throws TransactionFailureException;
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/customaction/BasicCustomActionContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/customaction/BasicCustomActionContext.java
@@ -90,6 +90,11 @@ public class BasicCustomActionContext extends AbstractContext implements CustomA
   }
 
   @Override
+  public void execute(int timeout, TxRunnable runnable) throws TransactionFailureException {
+    transactional.execute(timeout, runnable);
+  }
+
+  @Override
   public WorkflowToken getWorkflowToken() {
     return workflowProgramInfo.getWorkflowToken();
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/AbstractHttpHandlerDelegator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/AbstractHttpHandlerDelegator.java
@@ -41,6 +41,7 @@ import org.apache.twill.common.Cancellable;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 
 import java.util.Arrays;
+import javax.annotation.Nullable;
 
 /**
  * An abstract base class for all {@link HttpHandler} generated through the {@link HttpHandlerGenerator}.
@@ -183,15 +184,30 @@ public abstract class AbstractHttpHandlerDelegator<T extends HttpServiceHandler>
                                             final ClassLoader programContextClassLoader,
                                             final HttpServiceContext serviceContext) {
     return new Transactional() {
+
       @Override
       public void execute(final TxRunnable runnable) throws TransactionFailureException {
+        executeInternal(null, runnable);
+      }
+
+      @Override
+      public void execute(int timeoutInSeconds, TxRunnable runnable) throws TransactionFailureException {
+        executeInternal(timeoutInSeconds, runnable);
+      }
+
+      private void executeInternal(@Nullable Integer timeout, final TxRunnable runnable)
+        throws TransactionFailureException {
         // This method maybe called from user code, hence the context classloader maybe the
         // program context classloader (or whatever the user set to).
         // We need to switch the classloader back to CDAP system classloader before calling txExecute
         // since it starting of transaction should happens in CDAP system context, not program context
         ClassLoader callerClassLoader = ClassLoaders.setContextClassLoader(getClass().getClassLoader());
         try {
-          txContext.start();
+          if (null == timeout) {
+            txContext.start();
+          } else {
+            txContext.start(timeout);
+          }
           try {
             ClassLoader oldClassLoader = ClassLoaders.setContextClassLoader(programContextClassLoader);
             try {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
@@ -108,6 +108,13 @@ final class BasicWorkerContext extends AbstractContext implements WorkerContext 
     }
   }
 
+  // TODO (CDAP-6837): this is not consistent with execute(runnable). Streamline this in the course of CDAP-6837
+
+  @Override
+  public void execute(int timeout, TxRunnable runnable) throws TransactionFailureException {
+    transactional.execute(timeout, runnable);
+  }
+
   @Override
   public int getInstanceCount() {
     return instanceCount;

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/customaction/BasicActionContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/customaction/BasicActionContext.java
@@ -56,6 +56,11 @@ public class BasicActionContext extends AbstractStageContext implements ActionCo
   }
 
   @Override
+  public void execute(int timeout, TxRunnable runnable) throws TransactionFailureException {
+    context.execute(timeout, runnable);
+  }
+
+  @Override
   public Map<String, String> listSecureData(String namespace) throws Exception {
     return context.listSecureData(namespace);
   }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/DefaultStreamingContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/DefaultStreamingContext.java
@@ -45,4 +45,9 @@ public class DefaultStreamingContext extends AbstractStageContext implements Str
   public void execute(TxRunnable runnable) throws TransactionFailureException {
     sec.execute(runnable);
   }
+
+  @Override
+  public void execute(int timeout, TxRunnable runnable) throws TransactionFailureException {
+    sec.execute(timeout, runnable);
+  }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/action/MockActionContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/action/MockActionContext.java
@@ -110,6 +110,11 @@ public class MockActionContext implements ActionContext {
     // no-op; unused
   }
 
+  @Override
+  public void execute(int timeoutInSeconds, TxRunnable runnable) {
+    // no-op; unused
+  }
+
   /**
    * SettableArguments class for MockActionContext.
    */

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationContext.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationContext.java
@@ -136,6 +136,11 @@ public class DefaultAuthorizationContext implements AuthorizationContext {
   }
 
   @Override
+  public void execute(int timeout, TxRunnable runnable) throws TransactionFailureException {
+    delegateTxnl.execute(timeout, runnable);
+  }
+
+  @Override
   public Properties getExtensionProperties() {
     return extensionProperties;
   }

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/NoOpAuthorizationContextFactory.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/NoOpAuthorizationContextFactory.java
@@ -49,6 +49,11 @@ public class NoOpAuthorizationContextFactory implements AuthorizationContextFact
     public void execute(TxRunnable runnable) throws TransactionFailureException {
       // no-op
     }
+
+    @Override
+    public void execute(int timeoutInSeconds, TxRunnable runnable) throws TransactionFailureException {
+      // no-op
+    }
   }
 
   private static class NoOpDatasetContext implements DatasetContext {

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactional.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactional.java
@@ -133,6 +133,11 @@ final class SparkTransactional implements Transactional {
     execute(wrap(runnable), TransactionType.EXPLICIT);
   }
 
+  @Override
+  public void execute(int timeout, TxRunnable runnable) throws TransactionFailureException {
+    throw new TransactionFailureException("Transaction with explicit timeout is not supported in Spark");
+  }
+
   @Nullable
   TransactionInfo getTransactionInfo(String key) {
     return transactionInfos.get(key);

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
@@ -79,6 +79,8 @@ class DefaultJavaSparkExecutionContext(sec: SparkExecutionContext) extends JavaS
 
   override def execute(runnable: TxRunnable): Unit = sec.execute(runnable)
 
+  override def execute(timeout: Int, runnable: TxRunnable): Unit = sec.execute(timeout, runnable)
+
   override def fromDataset[K, V](datasetName: String, arguments: util.Map[String, String],
                                  splits: java.lang.Iterable[_ <: Split]): JavaPairRDD[K, V] = {
     // Create the implicit fake ClassTags to satisfy scala type system at compilation time.

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultSparkExecutionContext.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultSparkExecutionContext.scala
@@ -155,6 +155,10 @@ class DefaultSparkExecutionContext(runtimeContext: SparkRuntimeContext,
     transactional.execute(runnable)
   }
 
+  override def execute(timeout: Int, runnable: TxRunnable): Unit = {
+    transactional.execute(timeout, runnable)
+  }
+
   override def fromDataset[K: ClassTag, V: ClassTag](sc: SparkContext,
                                                      datasetName: String,
                                                      arguments: Map[String, String],

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/SerializableSparkExecutionContext.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/SerializableSparkExecutionContext.scala
@@ -54,6 +54,8 @@ class SerializableSparkExecutionContext(val delegate: SparkExecutionContext) ext
 
   override def execute(runnable: TxRunnable) = delegate.execute(runnable)
 
+  override def execute(timeout: Int, runnable: TxRunnable) = delegate.execute(timeout, runnable)
+
   override def saveAsDataset[K: ClassTag, V: ClassTag](rdd: RDD[(K, V)], namespace: String,
                                                        datasetName: String, arguments: Map[String, String]) =
     delegate.saveAsDataset(rdd, namespace, datasetName, arguments)

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/RevealingTxSystemClient.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/RevealingTxSystemClient.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test;
+
+import com.google.inject.Inject;
+import org.apache.tephra.InvalidTruncateTimeException;
+import org.apache.tephra.Transaction;
+import org.apache.tephra.TransactionCouldNotTakeSnapshotException;
+import org.apache.tephra.TransactionNotInProgressException;
+import org.apache.tephra.TransactionSystemClient;
+import org.apache.tephra.inmemory.InMemoryTxSystemClient;
+
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * A TransactionSystemClient that creates transaction objects with additional fields for validation.
+ */
+public class RevealingTxSystemClient implements TransactionSystemClient {
+
+  private final InMemoryTxSystemClient txClient;
+
+  @Inject
+  RevealingTxSystemClient(InMemoryTxSystemClient txClient) {
+    this.txClient = txClient;
+  }
+
+  @Override
+  public Transaction startLong() {
+    return txClient.startLong();
+  }
+
+  @Override
+  public Transaction startShort() {
+    return txClient.startShort();
+  }
+
+  @Override
+  public Transaction startShort(int timeout) {
+    return new RevealingTransaction(txClient.startShort(timeout), timeout);
+  }
+
+  @Override
+  public boolean canCommit(Transaction tx, Collection<byte[]> changeIds) throws TransactionNotInProgressException {
+    return txClient.canCommit(tx, changeIds);
+  }
+
+  @Override
+  public boolean commit(Transaction tx) throws TransactionNotInProgressException {
+    return txClient.commit(tx);
+  }
+
+  @Override
+  public void abort(Transaction tx) {
+    txClient.abort(tx);
+  }
+
+  @Override
+  public boolean invalidate(long tx) {
+    return txClient.invalidate(tx);
+  }
+
+  @Override
+  public Transaction checkpoint(Transaction tx) throws TransactionNotInProgressException {
+    return txClient.checkpoint(tx);
+  }
+
+  @Override
+  public InputStream getSnapshotInputStream() throws TransactionCouldNotTakeSnapshotException {
+    return txClient.getSnapshotInputStream();
+  }
+
+  @Override
+  public String status() {
+    return txClient.status();
+  }
+
+  @Override
+  public void resetState() {
+    txClient.resetState();
+  }
+
+  @Override
+  public boolean truncateInvalidTx(Set<Long> invalidTxIds) {
+    return txClient.truncateInvalidTx(invalidTxIds);
+  }
+
+  @Override
+  public boolean truncateInvalidTxBefore(long time) throws InvalidTruncateTimeException {
+    return txClient.truncateInvalidTxBefore(time);
+  }
+
+  @Override
+  public int getInvalidSize() {
+    return txClient.getInvalidSize();
+  }
+
+  /**
+   * This transaction class allows us to return additional details about the transaction to the client.
+   * For now, it is only the transaction timeout, but we can add more information later.
+   * This can then be used by test cases to validate that the transaction was started with the right properties.
+   */
+  public static class RevealingTransaction extends Transaction {
+
+    // making this field public: Because this will be loaded in a different classloader than the test app,
+    // the app cannot cast to this class and call a getter. Since it will have to use reflection anyway, it may
+    // as well access the field directly.
+    public final int timeout;
+
+    RevealingTransaction(Transaction tx, int timeout) {
+      super(tx, tx.getWritePointer(), tx.getCheckpointWritePointers());
+      this.timeout = timeout;
+    }
+
+    @Override
+    public String toString() {
+      return super.toString() + ",timeout=" + timeout;
+    }
+  }
+}

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -125,6 +125,8 @@ import com.google.inject.Singleton;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.util.Modules;
 import org.apache.tephra.TransactionManager;
+import org.apache.tephra.TransactionSystemClient;
+import org.apache.tephra.inmemory.InMemoryTxSystemClient;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -417,6 +419,9 @@ public class TestBase {
           bind(StreamAdmin.class).to(FileStreamAdmin.class).in(Singleton.class);
           bind(StreamConsumerFactory.class).to(LevelDBStreamFileConsumerFactory.class).in(Singleton.class);
           bind(StreamFileWriterFactory.class).to(LocationStreamFileWriterFactory.class).in(Singleton.class);
+          // we inject a TxSystemClient that creates transaction objects with additional fields for validation
+          bind(InMemoryTxSystemClient.class).in(Scopes.SINGLETON);
+          bind(TransactionSystemClient.class).to(RevealingTxSystemClient.class).in(Scopes.SINGLETON);
         }
       });
   }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithTimedTransactions.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithTimedTransactions.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.app;
+
+import co.cask.cdap.api.Transactional;
+import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.customaction.AbstractCustomAction;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.dataset.table.Put;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.api.service.AbstractService;
+import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
+import co.cask.cdap.api.service.http.HttpContentConsumer;
+import co.cask.cdap.api.service.http.HttpContentProducer;
+import co.cask.cdap.api.service.http.HttpServiceRequest;
+import co.cask.cdap.api.service.http.HttpServiceResponder;
+import co.cask.cdap.api.worker.AbstractWorker;
+import co.cask.cdap.api.worker.WorkerContext;
+import co.cask.cdap.api.workflow.AbstractWorkflow;
+import co.cask.cdap.test.RevealingTxSystemClient;
+import com.google.common.base.Throwables;
+import org.apache.http.entity.ContentType;
+import org.apache.tephra.Transaction;
+import org.apache.tephra.TransactionFailureException;
+import org.junit.Assert;
+
+import java.nio.ByteBuffer;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+
+/**
+ * An app that starts transactions with custom timeout and validates the timeout using a custom dataset.
+ * This relies on TestBase to inject {@link RevealingTxSystemClient} for this test.
+ */
+public class AppWithTimedTransactions extends AbstractApplication {
+
+  public static final String NAME = "AppWithTimedTransactions";
+  public static final String SERVICE = "TimeoutService";
+  public static final String WORKER = "TimeoutWorker";
+  public static final String WORKFLOW = "TimeoutWorkflow";
+  public static final String ACTION = "TimeoutAction";
+  public static final String CONSUMER = "HttpContentConsumer";
+  public static final String PRODUCER = "HttpContentProducer";
+  public static final String CAPTURE = "capture";
+  public static final String INITIALIZE = "initialize";
+  public static final String DESTROY = "destroy";
+  public static final String RUNTIME = "runtime";
+
+  public static final int TIMEOUT_WORKER_INITIALIZE = 20;
+  public static final int TIMEOUT_WORKER_DESTROY = 21;
+  public static final int TIMEOUT_WORKER_RUNTIME = 22;
+  public static final int TIMEOUT_CONSUMER_RUNTIME = 23;
+  public static final int TIMEOUT_PRODUCER_RUNTIME = 24;
+  public static final int TIMEOUT_ACTION_RUNTIME = 25;
+
+  @Override
+  public void configure() {
+    setName(NAME);
+    createDataset(CAPTURE, CapturingDataset.class);
+    addWorker(new TimeoutWorker());
+    addService(new AbstractService() {
+      @Override
+      protected void configure() {
+        setName(SERVICE);
+        addHandler(new TimeoutHandler());
+      }
+    });
+    addWorkflow(new AbstractWorkflow() {
+      @Override
+      protected void configure() {
+        setName(WORKFLOW);
+        addAction(new TimeoutAction());
+      }
+    });
+  }
+
+  /**
+   * Uses the provided Transactional with the given timeout, and validates that the transaction that is started
+   * was actually given that timeout.
+   */
+  static void recordTimedTransaction(Transactional transactional, final String where, final String key, int timeout) {
+    try {
+      transactional.execute(timeout, new TxRunnable() {
+        @Override
+        public void run(DatasetContext context) throws Exception {
+          CapturingDataset capture = context.getDataset(CAPTURE);
+          Transaction tx = capture.getTx();
+          // we cannot cast because the RevealingTransaction is not visible in the program class loader
+          Assert.assertEquals("RevealingTransaction", tx.getClass().getSimpleName());
+          int txTimeout = (int) tx.getClass().getField("timeout").get(tx);
+          Table t = capture.getTable();
+          t.put(new Put(where, key, String.valueOf(txTimeout)));
+        }
+      });
+    } catch (TransactionFailureException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  private static class TimeoutWorker extends AbstractWorker {
+
+    @Override
+    protected void configure() {
+      setName(WORKER);
+    }
+
+    @Override
+    public void initialize(WorkerContext context) throws Exception {
+      super.initialize(context);
+      recordTimedTransaction(context, WORKER, INITIALIZE, TIMEOUT_WORKER_INITIALIZE);
+    }
+
+    @Override
+    public void run() {
+      recordTimedTransaction(getContext(), WORKER, RUNTIME, TIMEOUT_WORKER_RUNTIME);
+    }
+
+    @Override
+    public void destroy() {
+      recordTimedTransaction(getContext(), WORKER, DESTROY, TIMEOUT_WORKER_DESTROY);
+      super.destroy();
+    }
+  }
+
+  public static class TimeoutHandler extends AbstractHttpServiceHandler {
+
+    // service context does not have Transactional, no need to test lifecycle methods
+
+    @PUT
+    @Path("test")
+    public HttpContentConsumer handle(HttpServiceRequest request, HttpServiceResponder responder) {
+      return new HttpContentConsumer() {
+
+        @Override
+        public void onReceived(ByteBuffer chunk, Transactional transactional) throws Exception {
+          recordTimedTransaction(transactional, CONSUMER, RUNTIME, TIMEOUT_CONSUMER_RUNTIME);
+        }
+
+        @Override
+        public void onFinish(HttpServiceResponder responder) throws Exception {
+          responder.send(200, new HttpContentProducer() {
+
+            @Override
+            public ByteBuffer nextChunk(Transactional transactional) throws Exception {
+              recordTimedTransaction(transactional, PRODUCER, RUNTIME, TIMEOUT_PRODUCER_RUNTIME);
+              return ByteBuffer.allocate(0);
+            }
+
+            @Override
+            public void onFinish() throws Exception {
+            }
+
+            @Override
+            public void onError(Throwable failureCause) {
+            }
+          }, ContentType.TEXT_PLAIN.getMimeType());
+        }
+
+        @Override
+        public void onError(HttpServiceResponder responder, Throwable failureCause) {
+        }
+      };
+    }
+  }
+
+  public static class TimeoutAction extends AbstractCustomAction {
+
+    @Override
+    protected void configure() {
+      setName(ACTION);
+    }
+
+    @Override
+    public void run() throws Exception {
+      recordTimedTransaction(getContext(), ACTION, RUNTIME,  TIMEOUT_ACTION_RUNTIME);
+    }
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/CapturingDataset.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/CapturingDataset.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.app;
+
+import co.cask.cdap.api.dataset.DatasetSpecification;
+import co.cask.cdap.api.dataset.lib.AbstractDataset;
+import co.cask.cdap.api.dataset.module.EmbeddedDataset;
+import co.cask.cdap.api.dataset.table.Table;
+import org.apache.tephra.Transaction;
+
+/**
+ * A dataset whose only purpose is to remember the transaction when it is started.
+ */
+public class CapturingDataset extends AbstractDataset {
+
+  private Transaction tx;
+  private final Table table;
+
+  public CapturingDataset(DatasetSpecification spec, @EmbeddedDataset("t") Table embedded) {
+    super(spec.getName(), embedded);
+    table = embedded;
+  }
+
+  @Override
+  public void startTx(Transaction tx) {
+    super.startTx(tx);
+    this.tx = tx;
+  }
+
+  public Transaction getTx() {
+    return tx;
+  }
+
+  public Table getTable() {
+    return table;
+  }
+}


### PR DESCRIPTION
- adds execute(int timeout, TxRunnable) to Transactional interface and implements it in all places. 
