### PR TITLE
[CDAP-7391] Fix test framework class loader to allow org.hamcrest classes in unit tests

### DIFF
--- a/cdap-common/src/test/java/co/cask/cdap/common/test/TestRunner.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/test/TestRunner.java
@@ -35,15 +35,20 @@ public class TestRunner extends BlockJUnit4ClassRunner {
   static final ClassLoader TEST_CLASSLOADER;
 
   static {
+    // we will use this classloader only for junit itself. However, since junit uses org.hamcrest classes
+    // in its API, we also have to load those with this class loader. Hence accept resources and packages
+    // from org.junit and org.hamcrest.
     ClassLoader classLoader = MainClassLoader.createFromContext(new FilterClassLoader.Filter() {
       @Override
       public boolean acceptResource(String resource) {
-        return resource.startsWith("org/junit/");
+        return resource.startsWith("org/junit/")
+          || resource.startsWith("org/hamcrest/");
       }
 
       @Override
       public boolean acceptPackage(String packageName) {
-        return packageName.equals("org.junit") || packageName.startsWith("org.junit.");
+        return packageName.equals("org.junit") || packageName.startsWith("org.junit.")
+          || packageName.equals("org.hamcrest") || packageName.startsWith("org.hamcrest.");
       }
     });
     if (classLoader == null) {

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -78,6 +78,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -128,6 +129,12 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
   @Before
   public void setUp() throws Exception {
     getNamespaceAdmin().create(new NamespaceMeta.Builder().setName(testSpace).build());
+  }
+
+  @Test
+  public void testOrgHamcrest() {
+    // this tests that org.hamcrest classes can be used in tests without class loading conflicts (see CDAP-7391)
+    Assert.assertThat("oh hello yeah", CoreMatchers.containsString("hello"));
   }
 
   @Test


### PR DESCRIPTION
Cherrypick of https://github.com/caskdata/cdap/pull/6872

https://issues.cask.co/browse/CDAP-7391
http://builds.cask.co/browse/CDAP-RUT204-1
