### PR TITLE
use hbase 12 support and IBM version match updated to support IBM

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
@@ -103,7 +103,8 @@ public class HBaseVersion {
             ver.getClassifier().startsWith(CDH58_CLASSIFIER))) {
           currentVersion = Version.HBASE_12_CDH57;
         } else {
-          currentVersion = Version.UNKNOWN;
+          // HBase-11 compat module can be re-used for HBASE-12 as there is no change needed in compat source.
+          currentVersion = Version.HBASE_11;
         }
       } else {
         currentVersion = Version.UNKNOWN;
@@ -152,6 +153,12 @@ public class HBaseVersion {
     private static final Pattern PATTERN =
       Pattern.compile("(\\d+)(\\.(\\d+))?(\\.(\\d+))?(\\.(\\d+))?(\\-(?!SNAPSHOT)([^\\-]+))?(\\-SNAPSHOT)?");
 
+    // IBM has a different format where they add build number at the end,
+    // major[.minor[.patch[.last]][-classifier][-buildNumber],
+    // we ignore build number for now and support only non-snapshot versions.
+    private static final Pattern IBM_PATTERN =
+      Pattern.compile("(\\d+)(\\.(\\d+))?(\\.(\\d+))?(\\.(\\d+))?(\\-(?!SNAPSHOT)([^\\-]+))?(\\-(\\d+))?");
+
     private Integer major;
     private Integer minor;
     private Integer patch;
@@ -195,6 +202,7 @@ public class HBaseVersion {
 
     public static VersionNumber create(String versionString) throws ParseException {
       Matcher matcher = PATTERN.matcher(versionString);
+      Matcher ibmMatcher = IBM_PATTERN.matcher(versionString);
       if (matcher.matches()) {
         String majorString = matcher.group(1);
         String minorString = matcher.group(3);
@@ -208,6 +216,18 @@ public class HBaseVersion {
                                  last != null ? new Integer(last) : null,
                                  classifier,
                                  "-SNAPSHOT".equals(snapshotString));
+      } else if (ibmMatcher.matches()) {
+        String majorString = ibmMatcher.group(1);
+        String minorString = ibmMatcher.group(3);
+        String patchString = ibmMatcher.group(5);
+        String last = ibmMatcher.group(7);
+        String classifier = ibmMatcher.group(9);
+        return new VersionNumber(new Integer(majorString),
+                                 minorString != null ? new Integer(minorString) : null,
+                                 patchString != null ? new Integer(patchString) : null,
+                                 last != null ? new Integer(last) : null,
+                                 classifier,
+                                 false);
       }
       throw new ParseException(
         "Input string did not match expected pattern: major[.minor[.patch]][-classifier][-SNAPSHOT]", 0);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/HBaseVersionTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/HBaseVersionTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.text.ParseException;
+
+/**
+ *
+ */
+public class HBaseVersionTest {
+  @Test
+  public void testHBaseVersions() throws ParseException {
+    // test CDH HBase SNAPSHOT version
+    String version = "1.2.0-cdh5.7.1-SNAPSHOT";
+    HBaseVersion.VersionNumber versionNumber = HBaseVersion.VersionNumber.create(version);
+    Assert.assertEquals(new Integer(1), versionNumber.getMajor());
+    Assert.assertEquals(new Integer(2), versionNumber.getMinor());
+    Assert.assertEquals(new Integer(0), versionNumber.getPatch());
+    Assert.assertNull(versionNumber.getLast());
+    Assert.assertEquals("cdh5.7.1", versionNumber.getClassifier());
+    Assert.assertTrue(versionNumber.isSnapshot());
+
+    // test IBM HBase version
+    version = "1.2.0-IBM-7";
+    versionNumber = HBaseVersion.VersionNumber.create(version);
+    Assert.assertEquals(new Integer(1), versionNumber.getMajor());
+    Assert.assertEquals(new Integer(2), versionNumber.getMinor());
+    Assert.assertEquals(new Integer(0), versionNumber.getPatch());
+    Assert.assertNull(versionNumber.getLast());
+    Assert.assertEquals("IBM", versionNumber.getClassifier());
+    Assert.assertFalse(versionNumber.isSnapshot());
+
+    // test HBase version
+    version = "1.1.1";
+    versionNumber = HBaseVersion.VersionNumber.create(version);
+    Assert.assertEquals(new Integer(1), versionNumber.getMajor());
+    Assert.assertEquals(new Integer(1), versionNumber.getMinor());
+    Assert.assertEquals(new Integer(1), versionNumber.getPatch());
+    Assert.assertNull(versionNumber.getLast());
+    Assert.assertNull(versionNumber.getClassifier());
+    Assert.assertFalse(versionNumber.isSnapshot());
+  }
+}


### PR DESCRIPTION
The HBase-CDAP-1.1 compat module is source compatible with 1.2, so we are using 1.1 compat for non-cdh hbase-1.2 versions. 

This also adds version match for IBM, where the version string is different with existing version match for HDP and CDH Hbase versions. Changes have been tested on IBM cluster successfully.

Also includes HBaseVersion tests.
