### PR TITLE
Fix ScheduleClient

### DIFF
--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/ScheduleClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/ScheduleClientTestRun.java
@@ -25,6 +25,7 @@ import co.cask.cdap.internal.schedule.StreamSizeSchedule;
 import co.cask.cdap.internal.schedule.TimeSchedule;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ScheduledRuntime;
+import co.cask.cdap.proto.id.ScheduleId;
 import co.cask.cdap.test.XSlowTests;
 import org.junit.After;
 import org.junit.Assert;
@@ -48,6 +49,8 @@ public class ScheduleClientTestRun extends ClientTestBase {
   private final Id.Application app = Id.Application.from(namespace, FakeApp.NAME);
   private final Id.Workflow workflow = Id.Workflow.from(app, FakeWorkflow.NAME);
   private final Id.Schedule schedule = Id.Schedule.from(app, FakeApp.SCHEDULE_NAME);
+
+  private final ScheduleId scheduleId = schedule.toEntityId();
 
   private ScheduleClient scheduleClient;
   private ApplicationClient appClient;
@@ -93,9 +96,19 @@ public class ScheduleClientTestRun extends ClientTestBase {
 
     String status = scheduleClient.getStatus(schedule);
     Assert.assertEquals("SUSPENDED", status);
+    status = scheduleClient.getStatus(scheduleId);
+    Assert.assertEquals("SUSPENDED", status);
 
     scheduleClient.resume(schedule);
     status = scheduleClient.getStatus(schedule);
+    Assert.assertEquals("SCHEDULED", status);
+
+    scheduleClient.suspend(scheduleId);
+    status = scheduleClient.getStatus(scheduleId);
+    Assert.assertEquals("SUSPENDED", status);
+
+    scheduleClient.resume(scheduleId);
+    status = scheduleClient.getStatus(scheduleId);
     Assert.assertEquals("SCHEDULED", status);
 
     scheduleClient.suspend(schedule);

--- a/cdap-client/src/main/java/co/cask/cdap/client/ScheduleClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ScheduleClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -26,7 +26,6 @@ import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ScheduledRuntime;
 import co.cask.cdap.proto.codec.ScheduleSpecificationCodec;
-import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ScheduleId;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.common.http.HttpMethod;
@@ -125,7 +124,7 @@ public class ScheduleClient {
     UnauthorizedException {
     String path = String.format("apps/%s/versions/%s/schedules/%s/suspend", scheduleId.getApplication(),
                                 scheduleId.getVersion(), scheduleId.getSchedule());
-    URL url = config.resolveNamespacedURLV3(NamespaceId.fromString(scheduleId.getNamespace()).toId(), path);
+    URL url = config.resolveNamespacedURLV3(scheduleId.toId().getNamespace(), path);
     HttpResponse response = restClient.execute(HttpMethod.POST, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
     if (HttpURLConnection.HTTP_NOT_FOUND == response.getResponseCode()) {
@@ -148,7 +147,7 @@ public class ScheduleClient {
     UnauthorizedException {
     String path = String.format("apps/%s/versions/%s/schedules/%s/resume", scheduleId.getApplication(),
                                 scheduleId.getVersion(), scheduleId.getSchedule());
-    URL url = config.resolveNamespacedURLV3(NamespaceId.fromString(scheduleId.getNamespace()).toId(), path);
+    URL url = config.resolveNamespacedURLV3(scheduleId.toId().getNamespace(), path);
     HttpResponse response = restClient.execute(HttpMethod.POST, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
     if (HttpURLConnection.HTTP_NOT_FOUND == response.getResponseCode()) {
@@ -175,7 +174,7 @@ public class ScheduleClient {
     UnauthorizedException {
     String path = String.format("apps/%s/versions/%s/schedules/%s/status", scheduleId.getApplication(),
                                 scheduleId.getVersion(), scheduleId.getSchedule());
-    URL url = config.resolveNamespacedURLV3(NamespaceId.fromString(scheduleId.getNamespace()).toId(), path);
+    URL url = config.resolveNamespacedURLV3(scheduleId.toId().getNamespace(), path);
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
     if (HttpURLConnection.HTTP_NOT_FOUND == response.getResponseCode()) {


### PR DESCRIPTION
NamespaceId#fromString() expects a string in the format as outputted by NamespaceId#toString.
Simply `NamespaceId.fromString("default")` would not work.

Example failure stack trace:

```
java.lang.IllegalArgumentException: Expected type separator ':' to be in the ID string: default
    at co.cask.cdap.proto.id.EntityId.fromString(EntityId.java:111)
    at co.cask.cdap.proto.id.NamespaceId.fromString(NamespaceId.java:114)
    at co.cask.cdap.client.ScheduleClient.resume(ScheduleClient.java:151)
    at co.cask.cdap.test.remote.RemoteWorkflowManager$1.resume(RemoteWorkflowManager.java:119)
    at co.cask.cdap.apps.purchase.PurchaseAudiTest.test(PurchaseAudiTest.java:168)
```

http://builds.cask.co/browse/CDAP-RUT208-1
