### PR TITLE
(CDAP-7394) Don’t reuse HBaseAdmin across calls

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
@@ -22,7 +22,6 @@ import co.cask.cdap.common.utils.ProjectInfo;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
@@ -70,8 +69,6 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
   protected final CConfiguration cConf;
   protected final HBaseTableUtil tableUtil;
 
-  private HBaseAdmin admin;
-
   protected AbstractHBaseDataSetAdmin(TableId tableId, Configuration hConf, CConfiguration cConf,
                                       HBaseTableUtil tableUtil) {
     this.tableId = tableId;
@@ -87,24 +84,28 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
 
   @Override
   public boolean exists() throws IOException {
-    return tableUtil.tableExists(getAdmin(), tableId);
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      return tableUtil.tableExists(admin, tableId);
+    }
   }
 
   @Override
   public void truncate() throws IOException {
-    tableUtil.truncateTable(getAdmin(), tableId);
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      tableUtil.truncateTable(admin, tableId);
+    }
   }
 
   @Override
   public void drop() throws IOException {
-    tableUtil.dropTable(getAdmin(), tableId);
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      tableUtil.dropTable(admin, tableId);
+    }
   }
 
   @Override
   public void close() throws IOException {
-    if (admin != null) {
-      admin.close();
-    }
+    // no-op
   }
 
   /**
@@ -117,75 +118,77 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
    */
   public void updateTable(boolean force) throws IOException {
 
-    HTableDescriptor tableDescriptor = tableUtil.getHTableDescriptor(getAdmin(), tableId);
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      HTableDescriptor tableDescriptor = tableUtil.getHTableDescriptor(admin, tableId);
 
-    // update any table properties if necessary
-    boolean needUpdate = needsUpdate(tableDescriptor) || force;
+      // update any table properties if necessary
+      boolean needUpdate = needsUpdate(tableDescriptor) || force;
 
-    // Get the cdap version from the table
-    ProjectInfo.Version version = HBaseTableUtil.getVersion(tableDescriptor);
+      // Get the cdap version from the table
+      ProjectInfo.Version version = HBaseTableUtil.getVersion(tableDescriptor);
 
-    if (!needUpdate && version.compareTo(ProjectInfo.getVersion()) >= 0) {
-      // If neither the table spec nor the cdap version have changed, no need to update
-      LOG.info("Table '{}' has not changed and its version '{}' is same or greater " +
-                 "than current CDAP version '{}'", tableId, version, ProjectInfo.getVersion());
-      return;
-    }
+      if (!needUpdate && version.compareTo(ProjectInfo.getVersion()) >= 0) {
+        // If neither the table spec nor the cdap version have changed, no need to update
+        LOG.info("Table '{}' has not changed and its version '{}' is same or greater " +
+                   "than current CDAP version '{}'", tableId, version, ProjectInfo.getVersion());
+        return;
+      }
 
-    // create a new descriptor for the table update
-    HTableDescriptorBuilder newDescriptor = tableUtil.buildHTableDescriptor(tableDescriptor);
+      // create a new descriptor for the table update
+      HTableDescriptorBuilder newDescriptor = tableUtil.buildHTableDescriptor(tableDescriptor);
 
-    // Generate the coprocessor jar
-    CoprocessorJar coprocessorJar = createCoprocessorJar();
-    Location jarLocation = coprocessorJar.getJarLocation();
+      // Generate the coprocessor jar
+      CoprocessorJar coprocessorJar = createCoprocessorJar();
+      Location jarLocation = coprocessorJar.getJarLocation();
 
-    // Check if coprocessor upgrade is needed
-    Map<String, HBaseTableUtil.CoprocessorInfo> coprocessorInfo = HBaseTableUtil.getCoprocessorInfo(tableDescriptor);
-    // For all required coprocessors, check if they've need to be upgraded.
-    for (Class<? extends Coprocessor> coprocessor : coprocessorJar.getCoprocessors()) {
-      HBaseTableUtil.CoprocessorInfo info = coprocessorInfo.get(coprocessor.getName());
-      if (info != null) {
-        // The same coprocessor has been configured, check by the file name hash to see if they are the same.
-        if (!jarLocation.getName().equals(info.getPath().getName())) {
-          // Remove old one and add the new one.
-          newDescriptor.removeCoprocessor(info.getClassName());
+      // Check if coprocessor upgrade is needed
+      Map<String, HBaseTableUtil.CoprocessorInfo> coprocessorInfo = HBaseTableUtil.getCoprocessorInfo(tableDescriptor);
+      // For all required coprocessors, check if they've need to be upgraded.
+      for (Class<? extends Coprocessor> coprocessor : coprocessorJar.getCoprocessors()) {
+        HBaseTableUtil.CoprocessorInfo info = coprocessorInfo.get(coprocessor.getName());
+        if (info != null) {
+          // The same coprocessor has been configured, check by the file name hash to see if they are the same.
+          if (!jarLocation.getName().equals(info.getPath().getName())) {
+            // Remove old one and add the new one.
+            newDescriptor.removeCoprocessor(info.getClassName());
+            addCoprocessor(newDescriptor, coprocessor, jarLocation, coprocessorJar.getPriority(coprocessor));
+          }
+        } else {
+          // The coprocessor is missing from the table, add it.
           addCoprocessor(newDescriptor, coprocessor, jarLocation, coprocessorJar.getPriority(coprocessor));
         }
-      } else {
-        // The coprocessor is missing from the table, add it.
-        addCoprocessor(newDescriptor, coprocessor, jarLocation, coprocessorJar.getPriority(coprocessor));
       }
-    }
 
-    // Removes all old coprocessors
-    Set<String> coprocessorNames = ImmutableSet.copyOf(Iterables.transform(coprocessorJar.coprocessors, CLASS_TO_NAME));
-    for (String remove : Sets.difference(coprocessorInfo.keySet(), coprocessorNames)) {
-      newDescriptor.removeCoprocessor(remove);
-    }
+      // Removes all old coprocessors
+      Set<String> coprocessorNames = ImmutableSet.copyOf(Iterables.transform(coprocessorJar.coprocessors, CLASS_TO_NAME));
+      for (String remove : Sets.difference(coprocessorInfo.keySet(), coprocessorNames)) {
+        newDescriptor.removeCoprocessor(remove);
+      }
 
-    HBaseTableUtil.setVersion(newDescriptor);
-    HBaseTableUtil.setTablePrefix(newDescriptor, cConf);
+      HBaseTableUtil.setVersion(newDescriptor);
+      HBaseTableUtil.setTablePrefix(newDescriptor, cConf);
 
-    LOG.info("Updating table '{}'...", tableId);
-    boolean enableTable = false;
-    try {
-      tableUtil.disableTable(getAdmin(), tableId);
-      enableTable = true;
-    } catch (TableNotEnabledException e) {
-      // TODO (CDAP-7324) This is a workaround and should be removed once we have pure hbase coprocessor upgrade
-      // (CDAP-7095)
-      // If the table is in cdap_system namespace enable it regardless so that they can be used later. See CDAP-7324
-      if (isSystemTable()) {
+      LOG.info("Updating table '{}'...", tableId);
+      boolean enableTable = false;
+      try {
+        tableUtil.disableTable(admin, tableId);
         enableTable = true;
-      } else {
-        LOG.debug("Table '{}' was not enabled before update and will not be enabled after update.", tableId);
+      } catch (TableNotEnabledException e) {
+        // TODO (CDAP-7324) This is a workaround and should be removed once we have pure hbase coprocessor upgrade
+        // (CDAP-7095)
+        // If the table is in cdap_system namespace enable it regardless so that they can be used later. See CDAP-7324
+        if (isSystemTable()) {
+          enableTable = true;
+        } else {
+          LOG.debug("Table '{}' was not enabled before update and will not be enabled after update.", tableId);
+        }
       }
-    }
 
-    tableUtil.modifyTable(getAdmin(), newDescriptor.build());
-    if (enableTable) {
-      LOG.debug("Enabling table '{}'...", tableId);
-      tableUtil.enableTable(getAdmin(), tableId);
+      tableUtil.modifyTable(admin, newDescriptor.build());
+      if (enableTable) {
+        LOG.debug("Enabling table '{}'...", tableId);
+        tableUtil.enableTable(admin, tableId);
+      }
     }
 
     LOG.info("Table '{}' update completed.", tableId);
@@ -259,12 +262,5 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
     public int size() {
       return coprocessors.size();
     }
-  }
-
-  protected HBaseAdmin getAdmin() throws IOException {
-    if (admin == null) {
-      admin = new HBaseAdmin(hConf);
-    }
-    return admin;
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
@@ -160,7 +160,8 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
       }
 
       // Removes all old coprocessors
-      Set<String> coprocessorNames = ImmutableSet.copyOf(Iterables.transform(coprocessorJar.coprocessors, CLASS_TO_NAME));
+      Set<String> coprocessorNames = ImmutableSet.copyOf(Iterables.transform(coprocessorJar.coprocessors,
+                                                                             CLASS_TO_NAME));
       for (String remove : Sets.difference(coprocessorInfo.keySet(), coprocessorNames)) {
         newDescriptor.removeCoprocessor(remove);
       }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Coprocessor;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.tephra.TxConstants;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
@@ -124,7 +125,9 @@ public class HBaseTableAdmin extends AbstractHBaseDataSetAdmin implements Updata
       splits = GSON.fromJson(splitsProperty, byte[][].class);
     }
 
-    tableUtil.createTableIfNotExists(getAdmin(), tableId, tableDescriptor.build(), splits);
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      tableUtil.createTableIfNotExists(admin, tableId, tableDescriptor.build(), splits);
+    }
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data2.transaction.queue.hbase;
 
 import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.table.Row;
@@ -90,8 +91,6 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin implements ProgramContex
   private final TransactionExecutorFactory txExecutorFactory;
   private final DatasetFramework datasetFramework;
 
-  private HBaseAdmin admin;
-
   @Inject
   public HBaseQueueAdmin(Configuration hConf,
                          CConfiguration cConf,
@@ -138,13 +137,6 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin implements ProgramContex
     return QueueConstants.STATE_STORE_NAME + "." + HBaseQueueDatasetModule.STATE_STORE_EMBEDDED_TABLE_NAME;
   }
 
-  protected final synchronized HBaseAdmin getHBaseAdmin() throws IOException {
-    if (admin == null) {
-      admin = new HBaseAdmin(hConf);
-    }
-    return admin;
-  }
-
   /**
    * This determines whether truncating a queue is supported (by truncating the queue's table).
    */
@@ -156,8 +148,10 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin implements ProgramContex
 
   @Override
   public boolean exists(QueueName queueName) throws Exception {
-    return tableUtil.tableExists(getHBaseAdmin(), getDataTableId(queueName)) &&
-      datasetFramework.hasInstance(getStateStoreId(queueName.getFirstComponent()));
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      return tableUtil.tableExists(admin, getDataTableId(queueName)) &&
+        datasetFramework.hasInstance(getStateStoreId(queueName.getFirstComponent()));
+    }
   }
 
   @Override
@@ -174,7 +168,7 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin implements ProgramContex
     createStateStoreDataset(queueName.getFirstComponent());
 
     TableId tableId = getDataTableId(queueName);
-    try (DatasetAdmin dsAdmin = new DatasetAdmin(tableId, hConf, cConf, tableUtil, properties)) {
+    try (QueueDatasetAdmin dsAdmin = new QueueDatasetAdmin(tableId, hConf, cConf, tableUtil, properties)) {
       dsAdmin.create();
     }
   }
@@ -219,40 +213,42 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin implements ProgramContex
   @Override
   public void upgrade() throws Exception {
     // For each table managed by this admin, perform an upgrade
-    List<TableId> tableIds = tableUtil.listTables(getHBaseAdmin());
-    List<TableId> stateStoreTableIds = Lists.newArrayList();
-    Map<String, String> reverseHBaseNamespace = tableUtil.getHBaseToCDAPNamespaceMap();
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      List<TableId> tableIds = tableUtil.listTables(admin);
+      List<TableId> stateStoreTableIds = Lists.newArrayList();
+      Map<String, String> reverseHBaseNamespace = tableUtil.getHBaseToCDAPNamespaceMap();
 
-    for (TableId tableId : tableIds) {
-      // It's important to skip config table enabled.
-      if (isDataTable(tableId)) {
-        LOG.info("Upgrading queue table: {}", tableId);
-        Properties properties = new Properties();
-        HTableDescriptor desc = tableUtil.getHTableDescriptor(getHBaseAdmin(), tableId);
-        if (desc.getValue(HBaseQueueAdmin.PROPERTY_PREFIX_BYTES) == null) {
-          // It's the old queue table. Set the property prefix bytes to SALT_BYTES
-          properties.setProperty(HBaseQueueAdmin.PROPERTY_PREFIX_BYTES,
-                                 Integer.toString(SaltedHBaseQueueStrategy.SALT_BYTES));
+      for (TableId tableId : tableIds) {
+        // It's important to skip config table enabled.
+        if (isDataTable(tableId)) {
+          LOG.info("Upgrading queue table: {}", tableId);
+          Properties properties = new Properties();
+          HTableDescriptor desc = tableUtil.getHTableDescriptor(admin, tableId);
+          if (desc.getValue(HBaseQueueAdmin.PROPERTY_PREFIX_BYTES) == null) {
+            // It's the old queue table. Set the property prefix bytes to SALT_BYTES
+            properties.setProperty(HBaseQueueAdmin.PROPERTY_PREFIX_BYTES,
+                                   Integer.toString(SaltedHBaseQueueStrategy.SALT_BYTES));
+          }
+          upgrade(tableId, properties);
+          LOG.info("Upgraded queue table: {}", tableId);
+        } else if (isStateStoreTable(tableId)) {
+          stateStoreTableIds.add(tableId);
         }
-        upgrade(tableId, properties);
-        LOG.info("Upgraded queue table: {}", tableId);
-      } else if (isStateStoreTable(tableId)) {
-        stateStoreTableIds.add(tableId);
       }
-    }
 
-    // Upgrade of state store table
-    for (TableId tableId : stateStoreTableIds) {
-      LOG.info("Upgrading queue state store: {}", tableId);
-      String cdapNamespace = reverseHBaseNamespace.get(tableId.getNamespace());
-      Id.DatasetInstance stateStoreId = createStateStoreDataset(cdapNamespace);
-      co.cask.cdap.api.dataset.DatasetAdmin admin = datasetFramework.getAdmin(stateStoreId, null);
-      if (admin == null) {
-        LOG.error("No dataset admin available for {}", stateStoreId);
-        continue;
+      // Upgrade of state store table
+      for (TableId tableId : stateStoreTableIds) {
+        LOG.info("Upgrading queue state store: {}", tableId);
+        String cdapNamespace = reverseHBaseNamespace.get(tableId.getNamespace());
+        Id.DatasetInstance stateStoreId = createStateStoreDataset(cdapNamespace);
+        DatasetAdmin datasetAdmin = datasetFramework.getAdmin(stateStoreId, null);
+        if (datasetAdmin == null) {
+          LOG.error("No dataset admin available for {}", stateStoreId);
+          continue;
+        }
+        datasetAdmin.upgrade();
+        LOG.info("Upgraded queue state store: {}", tableId);
       }
-      admin.upgrade();
-      LOG.info("Upgraded queue state store: {}", tableId);
     }
   }
 
@@ -289,14 +285,18 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin implements ProgramContex
   }
 
   private void truncate(TableId tableId) throws IOException {
-    if (tableUtil.tableExists(getHBaseAdmin(), tableId)) {
-      tableUtil.truncateTable(getHBaseAdmin(), tableId);
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      if (tableUtil.tableExists(admin, tableId)) {
+        tableUtil.truncateTable(admin, tableId);
+      }
     }
   }
 
   private void drop(TableId tableId) throws IOException {
-    if (tableUtil.tableExists(getHBaseAdmin(), tableId)) {
-      tableUtil.dropTable(getHBaseAdmin(), tableId);
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      if (tableUtil.tableExists(admin, tableId)) {
+        tableUtil.dropTable(admin, tableId);
+      }
     }
   }
 
@@ -308,7 +308,7 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin implements ProgramContex
     if (!datasetFramework.hasInstance(id)) {
       return;
     }
-    try (final HBaseConsumerStateStore stateStore = getConsumerStateStore(queueName)) {
+    try (HBaseConsumerStateStore stateStore = getConsumerStateStore(queueName)) {
       Transactions.createTransactionExecutor(txExecutorFactory, stateStore)
         .execute(new TransactionExecutor.Subroutine() {
         @Override
@@ -367,19 +367,22 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin implements ProgramContex
   public void dropAllInNamespace(Id.Namespace namespaceId) throws Exception {
     Set<QueueConstants.QueueType> queueTypes = EnumSet.of(QueueConstants.QueueType.QUEUE,
                                                           QueueConstants.QueueType.SHARDED_QUEUE);
-    for (QueueConstants.QueueType queueType : queueTypes) {
-      // Note: The trailing "." is crucial, since otherwise nsId could match nsId1, nsIdx etc
-      // It's important to keep config table enabled while disabling and dropping  queue tables.
-      final String queueTableNamePrefix = String.format("%s.%s.", NamespaceId.SYSTEM.getNamespace(), queueType);
-      final String hbaseNamespace = tableUtil.getHBaseNamespace(namespaceId.toEntityId());
-      final TableId configTableId = TableId.from(hbaseNamespace, getConfigTableName());
-      tableUtil.deleteAllInNamespace(getHBaseAdmin(), hbaseNamespace, new Predicate<TableId>() {
-        @Override
-        public boolean apply(TableId tableId) {
-          // It's a bit hacky here since we know how the Dataset system names table
-          return (tableId.getTableName().startsWith(queueTableNamePrefix)) && !tableId.equals(configTableId);
-        }
-      });
+
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      for (QueueConstants.QueueType queueType : queueTypes) {
+        // Note: The trailing "." is crucial, since otherwise nsId could match nsId1, nsIdx etc
+        // It's important to keep config table enabled while disabling and dropping  queue tables.
+        final String queueTableNamePrefix = String.format("%s.%s.", NamespaceId.SYSTEM.getNamespace(), queueType);
+        final String hbaseNamespace = tableUtil.getHBaseNamespace(namespaceId.toEntityId());
+        final TableId configTableId = TableId.from(hbaseNamespace, getConfigTableName());
+        tableUtil.deleteAllInNamespace(admin, hbaseNamespace, new Predicate<TableId>() {
+          @Override
+          public boolean apply(TableId tableId) {
+            // It's a bit hacky here since we know how the Dataset System names tables
+            return (tableId.getTableName().startsWith(queueTableNamePrefix)) && !tableId.equals(configTableId);
+          }
+        });
+      }
     }
 
     // Delete the state store in the namespace
@@ -414,7 +417,7 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin implements ProgramContex
   }
 
   private void upgrade(TableId tableId, Properties properties) throws Exception {
-    try (AbstractHBaseDataSetAdmin dsAdmin = new DatasetAdmin(tableId, hConf, cConf, tableUtil, properties)) {
+    try (AbstractHBaseDataSetAdmin dsAdmin = new QueueDatasetAdmin(tableId, hConf, cConf, tableUtil, properties)) {
       dsAdmin.upgrade();
     }
   }
@@ -447,11 +450,11 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin implements ProgramContex
   }
 
   // only used for create & upgrade of data table
-  private final class DatasetAdmin extends AbstractHBaseDataSetAdmin {
+  private final class QueueDatasetAdmin extends AbstractHBaseDataSetAdmin {
     private final Properties properties;
 
-    private DatasetAdmin(TableId tableId, Configuration hConf, CConfiguration cConf,
-                         HBaseTableUtil tableUtil, Properties properties) {
+    private QueueDatasetAdmin(TableId tableId, Configuration hConf, CConfiguration cConf,
+                              HBaseTableUtil tableUtil, Properties properties) {
       super(tableId, hConf, cConf, tableUtil);
       this.properties = properties;
     }
@@ -522,7 +525,10 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin implements ProgramContex
                                                                          : SaltedHBaseQueueStrategy.SALT_BYTES;
       htd.setValue(HBaseQueueAdmin.PROPERTY_PREFIX_BYTES, Integer.toString(prefixBytes));
       LOG.info("Create queue table with prefix bytes {}", htd.getValue(HBaseQueueAdmin.PROPERTY_PREFIX_BYTES));
-      tableUtil.createTableIfNotExists(getHBaseAdmin(), tableId, htd.build(), splitKeys);
+
+      try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+        tableUtil.createTableIfNotExists(admin, tableId, htd.build(), splitKeys);
+      }
     }
   }
 }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetSpecificationUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetSpecificationUpgrader.java
@@ -77,10 +77,11 @@ public class DatasetSpecificationUpgrader {
    */
   public void upgrade() throws Exception {
     TableId datasetSpecId = tableUtil.createHTableId(NamespaceId.SYSTEM, DatasetMetaTableUtil.INSTANCE_TABLE_NAME);
-    HBaseAdmin hBaseAdmin = new HBaseAdmin(conf);
-    if (!tableUtil.tableExists(hBaseAdmin, datasetSpecId)) {
-      LOG.error("Dataset instance table does not exist: {}. Should not happen", datasetSpecId);
-      return;
+    try (HBaseAdmin hBaseAdmin = new HBaseAdmin(conf)) {
+      if (!tableUtil.tableExists(hBaseAdmin, datasetSpecId)) {
+        LOG.error("Dataset instance table does not exist: {}. Should not happen", datasetSpecId);
+        return;
+      }
     }
 
     HTable specTable = tableUtil.createHTable(conf, datasetSpecId);

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
@@ -90,12 +90,13 @@ public class DatasetUpgrader extends AbstractUpgrader {
   }
 
   private void upgradeUserTables() throws Exception {
-    HBaseAdmin hAdmin = new HBaseAdmin(hConf);
-    for (HTableDescriptor desc : hAdmin.listTables()) {
-      if (isCDAPUserTable(desc)) {
-        upgradeUserTable(desc);
-      } else if (isStreamOrQueueTable(desc.getNameAsString())) {
-        updateTableDesc(desc, hAdmin);
+    try (HBaseAdmin hAdmin = new HBaseAdmin(hConf)) {
+      for (HTableDescriptor desc : hAdmin.listTables()) {
+        if (isCDAPUserTable(desc)) {
+          upgradeUserTable(desc);
+        } else if (isStreamOrQueueTable(desc.getNameAsString())) {
+          updateTableDesc(desc, hAdmin);
+        }
       }
     }
   }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/upgrade/MetricsDataMigrator.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/store/upgrade/MetricsDataMigrator.java
@@ -179,8 +179,7 @@ public class MetricsDataMigrator {
     String metricsEntityTable27 = defaultDatasetNamespace.namespace(Id.Namespace.SYSTEM, tableName27);
 
     Version version = null;
-    try {
-      HBaseAdmin  hAdmin = new HBaseAdmin(hConf);
+    try (HBaseAdmin  hAdmin = new HBaseAdmin(hConf)) {
       for (HTableDescriptor desc : hAdmin.listTables()) {
         if (desc.getNameAsString().equals(metricsEntityTable27)) {
           System.out.println("Matched HBase Table Name For Migration " + desc.getNameAsString());
@@ -245,9 +244,7 @@ public class MetricsDataMigrator {
   }
 
   private void deleteTables(Configuration hConf, Set<String> tablesToDelete) throws DataMigrationException {
-    HBaseAdmin hAdmin = null;
-    try {
-      hAdmin = new HBaseAdmin(hConf);
+    try (HBaseAdmin hAdmin = new HBaseAdmin(hConf)) {
       for (HTableDescriptor desc : hAdmin.listTables()) {
         if (tablesToDelete.contains(desc.getNameAsString())) {
           // disable the table
@@ -440,8 +437,7 @@ public class MetricsDataMigrator {
                                                Constants.Metrics.DEFAULT_METRIC_TABLE_PREFIX);
     destMetricsTablePrefix = getTableName(rootPrefix, Id.DatasetInstance.from(
       Id.Namespace.SYSTEM, destMetricsTablePrefix));
-    try {
-      HBaseAdmin hAdmin = new HBaseAdmin(hConf);
+    try (HBaseAdmin hAdmin = new HBaseAdmin(hConf)) {
       for (HTableDescriptor desc : hAdmin.listTables()) {
         if (desc.getNameAsString().equals(destEntityTableName) ||
           desc.getNameAsString().startsWith(destMetricsTablePrefix)) {


### PR DESCRIPTION
- The HBaseAdmin has a connection inside that contains the
  current UGI at the creation time.
- Reusing will break impersonation.
