### PR TITLE
Update to release/cdap-3.6-compatible.

### DIFF
--- a/cdap-docs/vars
+++ b/cdap-docs/vars
@@ -46,14 +46,14 @@ GIT_BRANCH_CDAP_SECURITY_EXTN="release/0.2"
 GIT_BRANCH_CDAP_CLIENTS="1.2.0"
 GIT_BRANCH_CDAP_INGEST="1.3.0"
 
-GIT_BRANCH_CDAP_APPS="release/cdap-3.5-compatible" # Using until 3.6 versions available
+GIT_BRANCH_CDAP_APPS="release/cdap-3.6-compatible"
 GIT_VERSION_CDAP_APPS="0.8.0"
 
 # Used by examples manual
-GIT_BRANCH_CDAP_GUIDES="release/cdap-3.5-compatible" # Using until 3.6 versions available
+GIT_BRANCH_CDAP_GUIDES="release/cdap-3.6-compatible"
 
 # Used by integrations-manual
-GIT_BRANCH_CDAP_PACKS="release/cdap-3.5-compatible" # Using until 3.6 versions available
+GIT_BRANCH_CDAP_PACKS="release/cdap-3.6-compatible"
 
 # Used for building Hydrator documentation
 GIT_BRANCH_CASK_HYDRATOR="release/1.4"


### PR DESCRIPTION
This update the docs to build with `release/cdap-3.6-compatible` branches. The docs will not build with this change currently, as the branches have not been created yet.
