### PR TITLE
Update shell scripts

### DIFF
--- a/cdap-cli/bin/cdap-cli.sh
+++ b/cdap-cli/bin/cdap-cli.sh
@@ -16,9 +16,9 @@
 # the License.
 #
 
-# This script is a wrapper for "cdap cli" and will be removed in 4.1
+# This script is a wrapper for "cdap cli" and will be removed in 5.0
 echo
-echo "[WARN] ${0} is deprecated and will be removed in CDAP 4.1. Please use 'cdap cli' for CDAP command line."
+echo "[WARN] ${0} is deprecated and will be removed in CDAP 5.0. Please use 'cdap cli' for CDAP command line."
 echo
 echo "  cdap cli ${@}"
 echo

--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -63,7 +63,7 @@ case ${1} in
   run) shift; cdap_run_class ${@}; __ret=${?} ;;
   sdk) shift; cdap_sdk ${@}; __ret=${?} ;;
   tx-debugger) shift; cdap_tx_debugger ${@}; __ret=${?} ;;
-  -h|--help|usage|'')
+  *)
     echo
     echo "Usage: ${0} <command> [arguments]"
     echo
@@ -93,7 +93,6 @@ case ${1} in
     echo " ${0} <command> --help"
     echo
     ;;
-  *) cdap_cli ${@}; __ret=${?} ;;
 esac
 
 exit ${__ret}

--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -62,7 +62,7 @@ case ${1} in
   upgrade) shift; cdap_upgrade_tool ${@}; __ret=${?} ;;
   run) shift; cdap_run_class ${@}; __ret=${?} ;;
   sdk) shift; cdap_sdk ${@}; __ret=${?} ;;
-  tx-debugger) shift; cdap_tx_debugger ${@}; __ret=${?} ;;
+  debug) shift; cdap_debug ${@}; __ret=${?} ;;
   *)
     echo
     echo "Usage: ${0} <command> [arguments]"
@@ -86,7 +86,7 @@ case ${1} in
     echo
     fi
     echo "    cli          - Starts an interactive CDAP CLI session"
-    echo "    tx-debugger  - Runs CDAP transaction debugger"
+    echo "    debug        - Runs CDAP debug functions"
     echo "    upgrade      - Runs the CDAP Upgrade Tool with arguments"
     echo
     echo " Get more help for each command by executing:"

--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -59,7 +59,7 @@ case ${1} in
   classpath) cdap_service master classpath; __ret=${?} ;;
   cli) shift; cdap_cli ${@}; __ret=${?} ;;
   config-tool) shift; cdap_config_tool ${@}; __ret=${?} ;;
-  upgrade-tool) shift; cdap_run_class co.cask.cdap.data.tools.UpgradeTool ${@}; __ret=${?} ;;
+  upgrade) shift; cdap_upgrade_tool ${@}; __ret=${?} ;;
   run) shift; cdap_run_class ${@}; __ret=${?} ;;
   sdk) shift; cdap_sdk ${@}; __ret=${?} ;;
   tx-debugger) shift; cdap_tx_debugger ${@}; __ret=${?} ;;
@@ -87,7 +87,7 @@ case ${1} in
     fi
     echo "    cli          - Starts an interactive CDAP CLI session"
     echo "    tx-debugger  - Runs CDAP transaction debugger"
-    echo "    upgrade-tool - Runs the CDAP Upgrade Tool with arguments"
+    echo "    upgrade      - Runs the CDAP Upgrade Tool with arguments"
     echo
     echo " Get more help for each command by executing:"
     echo " ${0} <command> --help"

--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -79,6 +79,7 @@ case ${1} in
     echo
     echo "    classpath    - Returns the Java CLASSPATH of the CDAP Master service"
     echo "    run          - Runs a given class with arguments using the CDAP Master CLASSPATH and environment"
+    echo "    upgrade      - Runs the CDAP Upgrade with optional arguments"
     echo
     else
     echo "    sdk          - Sends the arguments (start/stop/etc.) to the Standalone CDAP service on this host"
@@ -86,7 +87,6 @@ case ${1} in
     fi
     echo "    cli          - Starts an interactive CDAP CLI session"
     echo "    debug        - Runs CDAP debug functions"
-    echo "    upgrade      - Runs the CDAP Upgrade with optional arguments"
     echo
     echo " Get more help for each command by executing:"
     echo " ${0} <command> --help"

--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -78,7 +78,6 @@ case ${1} in
     echo "    ui"
     echo
     echo "    classpath    - Returns the Java CLASSPATH of the CDAP Master service"
-    echo "    config-tool  - Returns JSON-encoded CDAP configuration key/value pairs"
     echo "    run          - Runs a given class with arguments using the CDAP Master CLASSPATH and environment"
     echo
     else

--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -86,7 +86,7 @@ case ${1} in
     fi
     echo "    cli          - Starts an interactive CDAP CLI session"
     echo "    debug        - Runs CDAP debug functions"
-    echo "    upgrade      - Runs the CDAP Upgrade Tool with arguments"
+    echo "    upgrade      - Runs the CDAP Upgrade with optional arguments"
     echo
     echo " Get more help for each command by executing:"
     echo " ${0} <command> --help"

--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -18,7 +18,7 @@
 # This script is the main script for performing all CDAP functions. With it,
 # you can start, stop, or get status on CDAP and its services, run queries,
 # execute CLI commands, and more. Anything not handled by this script is passed
-# to the CDAP CLI to be interpreted. 
+# to the CDAP CLI to be interpreted.
 #
 
 __script=${BASH_SOURCE[0]}

--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -261,7 +261,7 @@ cdap_get_conf() {
 #
 # cdap_kinit
 # Initializes Kerberos ticket using principal/keytab
-# 
+#
 cdap_kinit() {
   local readonly __principal=${CDAP_PRINCIPAL:-$(cdap_get_conf "cdap.master.kerberos.principal" "${CDAP_CONF}"/cdap-site.xml)}
   local readonly __keytab=${CDAP_KEYTAB:-$(cdap_get_conf "cdap.master.kerberos.keytab" "${CDAP_CONF}"/cdap-site.xml)}
@@ -555,7 +555,7 @@ cdap_start_java() {
   local readonly __name=$(echo ${CDAP_SERVICE/-/ } | awk '{for(i=1;i<=NF;i++){ $i=toupper(substr($i,1,1)) substr($i,2) }}1')
   cdap_check_pidfile ${__pidfile} || exit 0 # Error output is done in function
   cdap_create_pid_dir || die "Could not create PID dir: ${PID_DIR}"
-  # Check and set classpath if in development environment. 
+  # Check and set classpath if in development environment.
   cdap_check_and_set_classpath_for_dev_environment "${CDAP_HOME}"
   # Setup classpaths.
   cdap_set_classpath "${CDAP_HOME}"/${__comp_home} "${CDAP_CONF}"
@@ -610,7 +610,7 @@ cdap_run_class() {
   local readonly __ret
   local JAVA_HEAPMAX=${JAVA_HEAPMAX:--Xmx1024m}
   [[ -z ${__class} ]] && echo "[ERROR] No class name given!" && die "Usage: ${0} run <fully-qualified-class> [arguments]"
-  # Check and set classpath if in development environment. 
+  # Check and set classpath if in development environment.
   cdap_check_and_set_classpath_for_dev_environment "${CDAP_HOME}"
   # Setup classpaths.
   cdap_set_classpath "${CDAP_HOME}"/master "${CDAP_CONF}"
@@ -675,7 +675,7 @@ cdap_context() {
 cdap_version() {
   local readonly __component=${1}
   local readonly __cdap_major __cdap_minor __cdap_patch __cdap_snapshot
-  local __version 
+  local __version
   if [[ -z ${__component} ]]; then
     __version=$(<${CDAP_HOME}/VERSION)
   else

--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -1014,12 +1014,11 @@ cdap_upgrade_tool() {
   fi
 
   # check arguments
-  if [[ ${#__args} -eq 0 ]]; then
-    set -- "upgrade" ${@}
-  fi
   if [[ ${1} == 'hbase' ]]; then
     shift
     set -- "upgrade_hbase" ${@}
+  else
+    set -- "upgrade" ${@}
   fi
 
   "${JAVA}" -cp ${CLASSPATH} -Dscript=${__script} ${__class} ${@}

--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -986,6 +986,46 @@ cdap_config_tool() {
   return ${__ret}
 }
 
+#
+# cdap_upgrade_tool [arguments]
+#
+cdap_upgrade_tool() {
+  local readonly __args=${@}
+  local readonly __path __libexec __lib __script="$(basename ${0}):cdap_upgrade_tool"
+  local readonly __ret __class=co.cask.cdap.data.tools.UpgradeTool
+  cdap_set_java || die "Unable to locate JAVA or JAVA_HOME"
+  __path=${CDAP_HOME}
+  if [[ -d ${__path}/master/lib ]]; then
+    __libexec=${__path}/master/libexec
+    __lib=${__path}/master/lib
+  else
+    __libexec=${__path}/libexec
+    __lib=${__path}/lib
+  fi
+  if [[ ${CLASSPATH} == "" ]]; then
+    CLASSPATH=${__lib}/*
+  else
+    CLASSPATH=${CLASSPATH}:${__lib}/*
+  fi
+  if [[ -d ${CDAP_CONF} ]]; then
+    CLASSPATH=${CLASSPATH}:"${CDAP_CONF}"
+  elif [[ -d ${__path}/conf ]]; then
+    CLASSPATH=${CLASSPATH}:"${__path}"/conf/
+  fi
+
+  # check arguments
+  if [[ ${#__args} -eq 0 ]]; then
+    set -- "upgrade" ${@}
+  fi
+  if [[ ${1} == 'hbase' ]]; then
+    shift
+    set -- "upgrade_hbase" ${@}
+  fi
+
+  "${JAVA}" -cp ${CLASSPATH} -Dscript=${__script} ${__class} ${@}
+  __ret=${?}
+  return ${__ret}
+}
 # Runs CDAP SDK with the given options
 cdap_sdk() {
   local readonly __action=${1}

--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -1075,7 +1075,7 @@ cdap_debug() {
   shift
   local readonly __ret __args=${@}
   case ${__entity} in
-    transactions) cdap_tx_debugger ${__args}; __ret=$? ;;
+    transactions) cdap_tx_debugger ${__args}; __ret=${?} ;;
     *) echo "Usage: ${0} debug transactions [arguments]"; __ret=1
   esac
   return ${__ret}

--- a/cdap-gateway/bin/svc-router
+++ b/cdap-gateway/bin/svc-router
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+#
+# Copyright © 2014-2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# This script is a wrapper for "cdap router" and will be removed in 5.0
+echo
+echo "[WARN] ${0} is deprecated and will be removed in CDAP 5.0. Please use 'cdap router' to manage Distributed CDAP."
+echo
+echo "  cdap router ${@}"
+echo
+echo
+
+__script=${BASH_SOURCE[0]}
+
+__target=$(readlink ${__script}) # TODO: readlink isn't portable, if we support more than Linux/macOS
+if [[ $? -ne 0 ]]; then
+  __target=${__script} # no symlink
+fi
+__app_home=$(cd $(dirname ${__target})/.. >&-; pwd -P)
+${__app_home}/bin/cdap router ${@}

--- a/cdap-kafka/bin/svc-kafka-server
+++ b/cdap-kafka/bin/svc-kafka-server
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+#
+# Copyright © 2014-2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# This script is a wrapper for "cdap kafka-server" and will be removed in 5.0
+echo
+echo "[WARN] ${0} is deprecated and will be removed in CDAP 5.0. Please use 'cdap kafka-server' to manage Distributed CDAP."
+echo
+echo "  cdap kafka-server ${@}"
+echo
+echo
+
+__script=${BASH_SOURCE[0]}
+
+__target=$(readlink ${__script}) # TODO: readlink isn't portable, if we support more than Linux/macOS
+if [[ $? -ne 0 ]]; then
+  __target=${__script} # no symlink
+fi
+__app_home=$(cd $(dirname ${__target})/.. >&-; pwd -P)
+${__app_home}/bin/cdap kafka-server ${@}

--- a/cdap-master/bin/svc-master
+++ b/cdap-master/bin/svc-master
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+#
+# Copyright © 2014-2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# This script is a wrapper for "cdap master" and will be removed in 5.0
+echo
+echo "[WARN] ${0} is deprecated and will be removed in CDAP 5.0. Please use 'cdap master' to manage Distributed CDAP."
+echo
+echo "  cdap master ${@}"
+echo
+echo
+
+__script=${BASH_SOURCE[0]}
+
+__target=$(readlink ${__script}) # TODO: readlink isn't portable, if we support more than Linux/macOS
+if [[ $? -ne 0 ]]; then
+  __target=${__script} # no symlink
+fi
+__app_home=$(cd $(dirname ${__target})/.. >&-; pwd -P)
+${__app_home}/bin/cdap master ${@}

--- a/cdap-security/bin/svc-auth-server
+++ b/cdap-security/bin/svc-auth-server
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+#
+# Copyright © 2014-2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# This script is a wrapper for "cdap auth-server" and will be removed in 5.0
+echo
+echo "[WARN] ${0} is deprecated and will be removed in CDAP 5.0. Please use 'cdap auth-server' to manage Distributed CDAP."
+echo
+echo "  cdap auth-server ${@}"
+echo
+echo
+
+__script=${BASH_SOURCE[0]}
+
+__target=$(readlink ${__script}) # TODO: readlink isn't portable, if we support more than Linux/macOS
+if [[ $? -ne 0 ]]; then
+  __target=${__script} # no symlink
+fi
+__app_home=$(cd $(dirname ${__target})/.. >&-; pwd -P)
+${__app_home}/bin/cdap auth-server ${@}

--- a/cdap-standalone/bin/cdap.sh
+++ b/cdap-standalone/bin/cdap.sh
@@ -16,9 +16,9 @@
 # the License.
 #
 
-# This script is a wrapper for "cdap sdk" and will be removed in 4.1
+# This script is a wrapper for "cdap sdk" and will be removed in 5.0
 echo
-echo "[WARN] ${0} is deprecated and will be removed in CDAP 4.1. Please use 'cdap sdk' to manage Standalone CDAP."
+echo "[WARN] ${0} is deprecated and will be removed in CDAP 5.0. Please use 'cdap sdk' to manage Standalone CDAP."
 echo
 echo "  cdap sdk ${@}"
 echo

--- a/cdap-ui/bin/svc-ui
+++ b/cdap-ui/bin/svc-ui
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+#
+# Copyright © 2014-2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# This script is a wrapper for "cdap ui" and will be removed in 5.0
+echo
+echo "[WARN] ${0} is deprecated and will be removed in CDAP 5.0. Please use 'cdap ui' to manage Distributed CDAP."
+echo
+echo "  cdap ui ${@}"
+echo
+echo
+
+__script=${BASH_SOURCE[0]}
+
+__target=$(readlink ${__script}) # TODO: readlink isn't portable, if we support more than Linux/macOS
+if [[ $? -ne 0 ]]; then
+  __target=${__script} # no symlink
+fi
+__app_home=$(cd $(dirname ${__target})/.. >&-; pwd -P)
+${__app_home}/bin/cdap ui ${@}


### PR DESCRIPTION
Multiple updates to the shell scripts to move towards the approved [design](https://wiki.cask.co/display/CE/CDAP+Scripts) for CDAP 4.0:
- [x] Deprecation until CDAP 5.0
- [x] Restore `svc-*` scripts as wrappers for backwards compatibility
- [x] Remove CLI fallback capabilities
- [x] Change `cdap upgrade-tool` to `cdap upgrade`
- [x] Change `cdap tx-debugger` to `cdap debug transactions`
