### PR TITLE
CDAP-5224 Remove stream batch readable

### DIFF
--- a/cdap-app-templates/cdap-data-quality/src/test/java/co/cask/cdap/dq/testclasses/StreamBatchSource.java
+++ b/cdap-app-templates/cdap-data-quality/src/test/java/co/cask/cdap/dq/testclasses/StreamBatchSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016016 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -159,7 +159,7 @@ public class StreamBatchSource extends BatchSource<LongWritable, Object, Structu
   }
 
   /**
-   * {@link PluginConfig} class for {@link co.cask.cdap.etl.batch.source.StreamBatchSource}
+   * {@link PluginConfig} class for {@link StreamBatchSource}
    */
   public static class StreamBatchConfig extends PluginConfig {
 

--- a/cdap-docs/developers-manual/source/building-blocks/streams.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/streams.rst
@@ -110,5 +110,5 @@ Streams are included in just about every CDAP :ref:`application <apps-and-packs>
   reads events from a stream. 
 
 - For an example of **reading from a stream with a MapReduce program,** see the 
-  :ref:`cdap-mapreduce-guide`, where the class ``TopClientsMapReduce`` uses the method
-  ``StreamBatchReadable`` to read events from a stream.
+  :ref:`cdap-mapreduce-guide`, where the class ``TopClientsMapReduce``
+  reads events from a stream using the method ``Input.ofStream()``. 

--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -99,7 +99,7 @@ function download_includes() {
   local project_img=$project_source/docs/img
 
   # 1:Includes directory  2:GitHub directory 3:Java filename       4:MD5 hash of file
-  download_file $includes $project_main BounceCountsMapReduce.java 4474e5437a15d341572842613ba712bd
+  download_file $includes $project_main BounceCountsMapReduce.java 0cfc0b3c0e306a4a76483aecc5a46607
   download_file $includes $project_main BounceCountStore.java      d476c15655c6a6c6cd7fe682dea4a8b7
   download_file $includes $project_main PageViewStore.java         7dc8d2fec04ce89fae4f0356db17e19d
   download_file $includes $project_main WiseApp.java               23371436b588c3262fec14ec5d7aa6df

--- a/cdap-docs/examples-manual/source/tutorials/wise.rst
+++ b/cdap-docs/examples-manual/source/tutorials/wise.rst
@@ -94,7 +94,7 @@ WISE source code:
   $ curl -w"\n" -X GET "https://codeload.github.com/caskdata/cdap-apps/zip/release/cdap-|short-version|-compatible" \
   --output examples/cdap-apps-release-cdap-|short-version|-compatible.zip  
 
-Unzip the directory and build the application (without running the self-test) by executing:
+Unzip the directory and change to the source directory:
 
 .. tabbed-parsed-literal::
 
@@ -116,7 +116,7 @@ To build WISE (skipping the tests), you use:
 
   $ mvn clean package -DskipTests
     
-(To build WISE and run the WISE Example Tests, you would use:)
+(To build WISE and run the WISE example tests, you would instead use:)
 
 .. tabbed-parsed-literal::
 

--- a/cdap-docs/examples-manual/source/tutorials/wise.rst
+++ b/cdap-docs/examples-manual/source/tutorials/wise.rst
@@ -1,7 +1,7 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: Advanced Tutorial, Web Analytics Application
-    :copyright: Copyright © 2014-2015 Cask Data, Inc.
+    :copyright: Copyright © 2014-2016 Cask Data, Inc.
 
 .. cdap-apps-version is set in _common/common_conf.py
 
@@ -435,7 +435,7 @@ done in the ``initialize()`` method of the ``BounceCountsMapReduce`` class:
    :dedent: 2
 
 As mentioned earlier, the input of the MapReduce is the *logEventStream*. This
-connection is made above using the ``StreamBatchReadable.useStreamInput()`` method.
+connection is made above using the ``context.addInput(Input.ofStream())`` methods.
 
 This MapReduce program runs as part of a workflow that is scheduled every ten minutes.
 Every time it runs, it reads ten minutes' worth of events from the stream, ending at the

--- a/cdap-examples/README.rst
+++ b/cdap-examples/README.rst
@@ -18,11 +18,19 @@ Building
 Each example comes with a Maven pom.xml file. To build, install Maven, and from the
 /examples directory prompt, enter::
 
-  mvn clean package
+  $ mvn clean package
+  
+To build while skipping tests, use::
+
+  $ mvn clean package -DskipTests
 
 
 List of Example Apps
 ====================
+
+ClicksAndViews
+--------------
+- Demonstrates a reduce-side join across two streams using a MapReduce program.
 
 CountRandom
 -----------
@@ -30,9 +38,6 @@ CountRandom
 - For each number *i*, generates i%10000, i%1000, i%100, i%10.
 - Increments the counter for each number.
 - Demonstrates the ``@Tick`` feature of flows.
-
-.. CubeService
-.. -----------
 
 DataCleansing
 -------------
@@ -84,6 +89,12 @@ Purchase
     *PurcaseHistoryBuilder*) after entering the first customers' purchases or the *PurchaseQuery*
     will return a "not found" error.
 
+SpamClassifier
+--------------
+- Demonstrates a Spark Streaming application.
+- Classifies Kafka messages as either "spam" or "ham" (not "spam")
+- Based on a trained Spark MLlib NaiveBayes model.
+
 SparkKMeans
 -----------
 - An application that demonstrates streaming text analysis using a Spark program.
@@ -130,12 +141,13 @@ WordCount
   complex data.
 - It uses a configuration class to configure the application at deployment time.
 
+
 License and Trademarks
 ======================
 
 Cask is a trademark of Cask Data, Inc. All rights reserved.
 
-Copyright © 2014-2015 Cask Data, Inc.
+Copyright © 2014-2016 Cask Data, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 except in compliance with the License. You may obtain a copy of the License at

--- a/cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/StreamToDataset.java
+++ b/cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/StreamToDataset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,7 +19,7 @@ package co.cask.cdap.examples.wikipedia;
 import co.cask.cdap.api.ProgramStatus;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.common.Bytes;
-import co.cask.cdap.api.data.stream.StreamBatchReadable;
+import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.mapreduce.AbstractMapReduce;
@@ -78,7 +78,7 @@ public class StreamToDataset extends AbstractMapReduce {
     }
     LOG.info("Using '{}' as the input stream and '{}' as the output dataset.", inputStream, outputDataset);
     job.setMapperClass(mapper);
-    StreamBatchReadable.useStreamInput(context, inputStream);
+    context.addInput(Input.ofStream(inputStream));
     context.addOutput(outputDataset);
   }
 


### PR DESCRIPTION
Removes usage of the deprecated StreamBatchReadable in documentation and examples.

Fixes some minor documentation nits found along the way.

Fix for https://issues.cask.co/browse/CDAP-5224.

Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB152-1

Fails, but that's because:
`WARNING: cdap-default.xml has changed! Compare files and update hash!`
which will be addressed in a separate PR (https://github.com/caskdata/cdap/pull/6907)
