### PR TITLE
Bump IDEA IntelliJ version to latest

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -91,7 +91,7 @@
         },
         "idea": {
           "setup_dir": "/opt",
-          "version": "2016.2.3"
+          "version": "2016.2.4"
         },
         "hadoop": {
           "distribution": "hdp",


### PR DESCRIPTION
Fixes:

```
07-Oct-2016 14:04:19        cdap-sdk-vm: Recipe: idea::default
07-Oct-2016 14:04:20        cdap-sdk-vm: * remote_file[/var/chef/cache/ideaIC-2016.2.3.tar.gz] action create[2016-10-07T14:04:20+00:00] WARN: remote_file[/var/chef/cache/ideaIC-2016.2.3.tar.gz] cannot be downloaded from https://download-cf.jetbrains.com/idea/ideaIC-2016.2.3.tar.gz: 403 "Forbidden"
07-Oct-2016 14:04:20        cdap-sdk-vm:
07-Oct-2016 14:04:20        cdap-sdk-vm:
07-Oct-2016 14:04:20        cdap-sdk-vm: ================================================================================
07-Oct-2016 14:04:20        cdap-sdk-vm: Error executing action `create` on resource 'remote_file[/var/chef/cache/ideaIC-2016.2.3.tar.gz]'
07-Oct-2016 14:04:20        cdap-sdk-vm: ================================================================================
07-Oct-2016 14:04:20        cdap-sdk-vm:
07-Oct-2016 14:04:20        cdap-sdk-vm: Net::HTTPServerException
07-Oct-2016 14:04:20        cdap-sdk-vm: ------------------------
07-Oct-2016 14:04:20        cdap-sdk-vm: 403 "Forbidden"
```
