### PR TITLE
Special case /opt/cdap/sdk when using SDK install from cdap cookbook

### DIFF
--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -31,7 +31,7 @@ __app_home=$(cd $(dirname ${__target})/.. >&-; pwd -P)
 
 __comp_home=$(cd ${__target%/*/*} >&-; pwd -P)
 # Determine if we're in the SDK or distributed
-if [[ ${__comp_home%/*} == /opt/cdap ]]; then
+if [[ ${__comp_home%/*} == /opt/cdap ]] && [[ ${__comp_home} != /opt/cdap/sdk* ]]; then
   __app_home=${__comp_home}
   __cdap_home=/opt/cdap
 else

--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -123,7 +123,7 @@ cdap_home() {
   local readonly __script=${BASH_SOURCE[0]}
   local readonly __script_bin=$(cd $(dirname ${__script}); pwd -P)
   local readonly __comp_home=$(cd ${__script%/*/*} >&-; pwd -P)
-  if [[ ${__comp_home%/*} == /opt/cdap ]]; then
+  if [[ ${__comp_home%/*} == /opt/cdap ]] && [[ ${__comp_home} != /opt/cdap/sdk* ]]; then
     __app_home=${__comp_home}
     __cdap_home=/opt/cdap
   else


### PR DESCRIPTION
Fixes starting the CDAP SDK when installed into `/opt/cdap/sdk` as is the case when using the CDAP cookbook.

Fixes:

```
07-Oct-2016 13:59:00    [2016-10-07T13:59:00+00:00] INFO: Processing service[cdap-sdk] action restart (cdap::sdk line 78)
07-Oct-2016 13:59:03    
07-Oct-2016 13:59:03    ================================================================================
07-Oct-2016 13:59:03    Error executing action `restart` on resource 'service[cdap-sdk]'
07-Oct-2016 13:59:03    ================================================================================
07-Oct-2016 13:59:03    
07-Oct-2016 13:59:03    Mixlib::ShellOut::ShellCommandFailed
07-Oct-2016 13:59:03    ------------------------------------
07-Oct-2016 13:59:03    Expected process to exit with [0], but received '1'
07-Oct-2016 13:59:03    ---- Begin output of /etc/init.d/cdap-sdk start ----
07-Oct-2016 13:59:03    STDOUT: 
07-Oct-2016 13:59:03    STDERR: mkdir: cannot create directory `/opt/cdap/data': Permission denied
07-Oct-2016 13:59:03    [ERROR] Failed to create LOCAL_DIR: /opt/cdap/data
07-Oct-2016 13:59:03    ---- End output of /etc/init.d/cdap-sdk start ----
07-Oct-2016 13:59:03    Ran /etc/init.d/cdap-sdk start returned 1
```
