### PR TITLE
CDAP-7399 Update Descriptions from cdap-default.xml

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -305,7 +305,7 @@
     <value>true</value>
     <description>
       Specify whether to rewrite the yarn.client class in Spark to work
-      around the issue SPARK-13441 in CDM clusters
+      around the issue SPARK-13441 in CDH clusters
     </description>
   </property>
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="788b8faed1ed42f8d0a4e5768c806864"
+DEFAULT_XML_MD5_HASH="b38a2ab7f345e193599a6689bbd943e5"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-docs/tools/cdap-default/cdap-xml-files.txt
+++ b/cdap-docs/tools/cdap-default/cdap-xml-files.txt
@@ -1,3 +1,4 @@
+# Paths are relative to this file or HTTP URLs
 # Line starting with a # or space are ignored
 
 cdap-distributions/src/etc/cdap/conf.dist/cdap-site.xml.example
@@ -5,9 +6,9 @@ cdap-examples/Purchase/src/test/resources/cdap-site.xml
 cdap-standalone/src/main/resources/cdap-site.xml
 
 ../cdap-ambari-service/configuration/cdap-site.xml
-https://raw.githubusercontent.com/caskdata/cdap-ambari-service/develop/configuration/cdap-site.xml
-https://raw.githubusercontent.com/caskdata/cdap-ambari-service/release/3.3/configuration/cdap-site.xml
+  https://raw.githubusercontent.com/caskdata/cdap-ambari-service/develop/configuration/cdap-site.xml
+  https://raw.githubusercontent.com/caskdata/cdap-ambari-service/release/3.3/configuration/cdap-site.xml
 
 ../cm_csd/src/descriptor/service.sdl
-https://raw.githubusercontent.com/caskdata/cm_csd/develop/src/descriptor/service.sdl
-https://raw.githubusercontent.com/caskdata/cm_csd/release/3.3/src/descriptor/service.sdl
+  https://raw.githubusercontent.com/caskdata/cm_csd/develop/src/descriptor/service.sdl
+  https://raw.githubusercontent.com/caskdata/cm_csd/release/3.3/src/descriptor/service.sdl

--- a/cdap-docs/tools/cdap-default/cdap-xml-sdl-files.txt
+++ b/cdap-docs/tools/cdap-default/cdap-xml-sdl-files.txt
@@ -1,11 +1,14 @@
 # Paths are relative to this file or HTTP URLs
 # Line starting with a # or space are ignored
+# Properties preceded with "-" are ignored for the previous file or source
 
 cdap-distributions/src/etc/cdap/conf.dist/cdap-site.xml.example
 cdap-examples/Purchase/src/test/resources/cdap-site.xml
 cdap-standalone/src/main/resources/cdap-site.xml
 
 ../cdap-ambari-service/configuration/cdap-site.xml
+- app.program.spark.yarn.client.rewrite.enabled
+- stream.container.instances
   https://raw.githubusercontent.com/caskdata/cdap-ambari-service/develop/configuration/cdap-site.xml
   https://raw.githubusercontent.com/caskdata/cdap-ambari-service/release/3.3/configuration/cdap-site.xml
 

--- a/cdap-docs/tools/cdap-default/doc-cdap-default.py
+++ b/cdap-docs/tools/cdap-default/doc-cdap-default.py
@@ -783,17 +783,18 @@ def compare_xml_sdl(source, other_source, target=None, update=False, compare_val
     # "roles": a list; each element has a "parameters"
     # some parameters have a configName and description
     other_items = []
-    for p in sdl["parameters"]:
-        if "configName" in p:
-            value = p["default"] if "default" in p else None
-            other_items.append(Item(name=p["configName"], value=value, description=p["description"]))
-#             print "configName: %s\n value: %s" % (p["configName"], value)
+    params_list = []
+    if "parameters" in sdl:
+        params_list.append(sdl["parameters"])
     for r in sdl["roles"]:
         if "parameters" in r:
-            for p in r["parameters"]:
-                if "configName" in p:
-                    value = p["default"] if "default" in p else None
-                    other_items.append(Item(name=p["configName"], value=value, description=p["description"]))
+            params_list.append(r["parameters"])
+    for params in params_list:
+        for p in params:
+            if "configName" in p:
+                value = str(p["default"]) if "default" in p else ""
+                value = value.lower() if value in ("True", "False") else value
+                other_items.append(Item(name=p["configName"], value=value, description=p["description"]))
     print "  Items: %s" % len(other_items)
     other_items.sort(key = lambda p: p.name)
     other_items_keys = []
@@ -824,7 +825,6 @@ def compare_xml_sdl(source, other_source, target=None, update=False, compare_val
             print SDL_CONFIG_NAME % config_name
             if compare_values and item_display:
                 print SDL_DEFAULT % item_display
-            print
             if not compare_values and item_display:
                 print SDL_OTHER
                 print SDL_DESCRIPTION % other_items_dict[config_name].description

--- a/cdap-examples/Purchase/src/test/resources/cdap-site.xml
+++ b/cdap-examples/Purchase/src/test/resources/cdap-site.xml
@@ -21,7 +21,7 @@
     <name>stream.notification.threshold</name>
     <value>1</value>
     <description>
-      Size of data, in megabytes, to be ingested by a stream before a
+      Size of data in megabytes to be ingested by a stream before a
       notification is published
     </description>
   </property>

--- a/cdap-standalone/src/main/resources/cdap-site.xml
+++ b/cdap-standalone/src/main/resources/cdap-site.xml
@@ -43,7 +43,8 @@
     <name>app.program.runtime.extensions.dir</name>
     <value>ext/runtimes</value>
     <description>
-      Semicolon-separated list of local directories scanned for program runtime extension.
+      Semicolon-separated list of local directories that are scanned for
+      program runtime extensions
     </description>
   </property>
 
@@ -54,7 +55,7 @@
     <name>data.local.storage.blocksize</name>
     <value>1024</value>
     <description>
-      Block size in bytes for data fabric when in standalone mode
+      Block size in bytes for data fabric when in Standalone CDAP
     </description>
   </property>
 
@@ -62,7 +63,7 @@
     <name>data.local.storage.cachesize</name>
     <value>104857600</value>
     <description>
-      Cache size in bytes for data fabric when in standalone mode
+      Cache size in bytes for data fabric when in Standalone CDAP
     </description>
   </property>
 
@@ -89,7 +90,7 @@
     <name>log.retention.duration.days</name>
     <value>7</value>
     <description>
-      Log file HDFS retention duration in days
+      Duration in days of log file HDFS retention
     </description>
   </property>
 
@@ -100,7 +101,7 @@
     <name>metrics.data.table.retention.resolution.1.seconds</name>
     <value>7200</value>
     <description>
-      Retention resolution of the 1-second resolution table in seconds;
+      Retention resolution in seconds of the 1-second resolution table;
       default retention period is 2 hours
     </description>
   </property>
@@ -139,8 +140,8 @@
     <name>stream.container.instances</name>
     <value>1</value>
     <description>
-      Number of YARN container instances for the stream handler; 
-      in standalone mode, it's always one
+      Number of YARN container instances for the stream handler; in
+      Standalone CDAP, it is always one
     </description>
   </property>
 
@@ -178,7 +179,7 @@
     <name>kafka.server.log.dirs</name>
     <value>${local.data.dir}/kafka-logs</value>
     <description>
-      Log directory for Kafka server
+      Comma-separated list of CDAP Kafka service log storage directories
     </description>
   </property>
 


### PR DESCRIPTION
Update tool used to compare descriptions in other files to `cdap-common/src/main/resources/cdap-default.xml`.

Added ability to compare by value instead of just by description.
Fixed a bug comparing XML and SDL files.

Update the `cdap-examples` and `cdap-standalone` descriptions.

Fix for https://issues.cask.co/browse/CDAP-7399
