### PR TITLE
Impersonation during UpgradeTool

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/twill/AbstractMasterTwillRunnable.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/twill/AbstractMasterTwillRunnable.java
@@ -70,10 +70,10 @@ public abstract class AbstractMasterTwillRunnable extends AbstractTwillRunnable 
 
   @Override
   public final void initialize(TwillContext context) {
-    LOG.info("Initializing runnable {}", name);
     super.initialize(context);
 
     name = context.getSpecification().getName();
+    LOG.info("Initializing runnable {}", name);
     Map<String, String> configs = context.getSpecification().getConfigs();
 
     try {

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseMetricsTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -26,6 +26,8 @@ import co.cask.cdap.common.guice.DiscoveryRuntimeModule;
 import co.cask.cdap.common.guice.LocationRuntimeModule;
 import co.cask.cdap.common.guice.NamespaceClientUnitTestModule;
 import co.cask.cdap.common.guice.ZKClientModule;
+import co.cask.cdap.common.security.UGIProvider;
+import co.cask.cdap.common.security.UnsupportedUGIProvider;
 import co.cask.cdap.data.hbase.HBaseTestBase;
 import co.cask.cdap.data.hbase.HBaseTestFactory;
 import co.cask.cdap.data.runtime.DataFabricDistributedModule;
@@ -45,6 +47,7 @@ import co.cask.cdap.security.authorization.AuthorizationTestModule;
 import co.cask.cdap.test.SlowTests;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.junit.AfterClass;
@@ -60,7 +63,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 
 /**
- * metrics table test for levelDB.
+ * metrics table test for HBase.
  */
 @Category(SlowTests.class)
 public class HBaseMetricsTableTest extends MetricsTableTest {
@@ -86,7 +89,13 @@ public class HBaseMetricsTableTest extends MetricsTableTest {
                                              new DataSetsModules().getInMemoryModules(),
                                              new AuthorizationTestModule(),
                                              new AuthorizationEnforcementModule().getInMemoryModules(),
-                                             new AuthenticationContextModules().getNoOpModule());
+                                             new AuthenticationContextModules().getNoOpModule(),
+                                             new AbstractModule() {
+                                               @Override
+                                               protected void configure() {
+                                                 bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
+                                               }
+                                             });
 
     dsFramework = injector.getInstance(DatasetFramework.class);
     tableUtil = injector.getInstance(HBaseTableUtil.class);

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.data2.transaction.distributed;
 
 import co.cask.cdap.common.conf.CConfiguration;
@@ -23,6 +24,8 @@ import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.namespace.SimpleNamespaceQueryAdmin;
+import co.cask.cdap.common.security.UGIProvider;
+import co.cask.cdap.common.security.UnsupportedUGIProvider;
 import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -114,6 +117,7 @@ public class TransactionServiceClientTest extends TransactionSystemTest {
         @Override
         protected void configure() {
           bind(NamespaceQueryAdmin.class).to(SimpleNamespaceQueryAdmin.class);
+          bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
         }
       },
       Modules.override(new DataSetsModules().getDistributedModules()).with(new AbstractModule() {

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceTest.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.data2.transaction.distributed;
 
 import co.cask.cdap.api.common.Bytes;
@@ -25,6 +26,8 @@ import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
 import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.namespace.SimpleNamespaceQueryAdmin;
+import co.cask.cdap.common.security.UGIProvider;
+import co.cask.cdap.common.security.UnsupportedUGIProvider;
 import co.cask.cdap.common.utils.Networks;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -100,6 +103,7 @@ public class TransactionServiceTest {
           @Override
           protected void configure() {
             bind(NamespaceQueryAdmin.class).to(SimpleNamespaceQueryAdmin.class);
+            bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
           }
         },
         new DataFabricModules().getDistributedModules(),
@@ -220,6 +224,7 @@ public class TransactionServiceTest {
                              @Override
                              protected void configure() {
                                bind(NamespaceQueryAdmin.class).to(SimpleNamespaceQueryAdmin.class);
+                               bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
                              }
                            },
                            new DataFabricModules().getDistributedModules(),

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/AbstractQueueUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/AbstractQueueUpgrader.java
@@ -19,13 +19,16 @@ package co.cask.cdap.data.tools;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.namespace.NamespacedLocationFactory;
+import co.cask.cdap.common.security.Impersonator;
 import co.cask.cdap.common.utils.ProjectInfo;
 import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.ScanBuilder;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
@@ -38,8 +41,12 @@ import org.apache.twill.filesystem.LocationFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.NavigableMap;
+import java.util.concurrent.Callable;
 import javax.annotation.Nullable;
 
 /**
@@ -50,21 +57,24 @@ public abstract class AbstractQueueUpgrader extends AbstractUpgrader {
   protected final HBaseTableUtil tableUtil;
   protected final Configuration conf;
   protected final NamespaceQueryAdmin namespaceQueryAdmin;
+  private final Impersonator impersonator;
 
   protected AbstractQueueUpgrader(LocationFactory locationFactory,
                                   NamespacedLocationFactory namespacedLocationFactory,
                                   HBaseTableUtil tableUtil, Configuration conf,
-                                  NamespaceQueryAdmin namespaceQueryAdmin) {
+                                  NamespaceQueryAdmin namespaceQueryAdmin,
+                                  Impersonator impersonator) {
     super(locationFactory, namespacedLocationFactory);
     this.tableUtil = tableUtil;
     this.conf = conf;
     this.namespaceQueryAdmin = namespaceQueryAdmin;
+    this.impersonator = impersonator;
   }
 
   /**
-   * @return Iterable of TableId of the tables to upgrade
+   * @return Multimap from the NamespaceId to the TableIds of the tables within that namespace to upgrade
    */
-  protected abstract Iterable<TableId> getTableIds() throws Exception;
+  protected abstract Multimap<NamespaceId, TableId> getTableIds() throws Exception;
 
   /**
    * @param oldRowKey the old row key of the row to migrate
@@ -75,21 +85,35 @@ public abstract class AbstractQueueUpgrader extends AbstractUpgrader {
 
   @Override
   void upgrade() throws Exception {
-    Iterable<TableId> tableIds = getTableIds();
+    Multimap<NamespaceId, TableId> tableIdsMap = getTableIds();
+    for (Map.Entry<NamespaceId, Collection<TableId>> namespaceIdTableIds : tableIdsMap.asMap().entrySet()) {
+      NamespaceId namespaceId = namespaceIdTableIds.getKey();
+      final Collection<TableId> tableIds = namespaceIdTableIds.getValue();
+      impersonator.doAs(namespaceId, new Callable<Void>() {
+        @Override
+        public Void call() throws Exception {
+          upgradeQueueTables(tableIds);
+          return null;
+        }
+      });
+    }
+  }
+
+  private void upgradeQueueTables(Collection<TableId> tableIds) throws IOException {
     try (HBaseAdmin admin = new HBaseAdmin(conf)) {
       for (TableId tableId : tableIds) {
         LOG.info("Upgrading table {}", tableId);
 
         if (!tableUtil.tableExists(admin, tableId)) {
           LOG.info("Table does not exist: {}. No upgrade necessary.", tableId);
-          continue;
+          return;
         }
         HTable hTable = tableUtil.createHTable(conf, tableId);
         ProjectInfo.Version tableVersion = HBaseTableUtil.getVersion(hTable.getTableDescriptor());
         // Only upgrade if Upgrader's version is greater than table's version.
         if (ProjectInfo.getVersion().compareTo(tableVersion) <= 0) {
           LOG.info("Table {} has already been upgraded. Its version is: {}", tableId, tableVersion);
-          continue;
+          return;
         }
 
         LOG.info("Starting upgrade for table {}", Bytes.toString(hTable.getTableName()));

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -413,7 +413,6 @@ public class UpgradeTool {
   }
 
   private void performCoprocessorUpgrade() throws Exception {
-
     LOG.info("Upgrading User and System HBase Tables ...");
     dsUpgrade.upgrade();
 
@@ -425,7 +424,6 @@ public class UpgradeTool {
     try {
       UpgradeTool upgradeTool = new UpgradeTool();
       upgradeTool.doMain(args);
-      LOG.info("Upgrade completed successfully");
     } catch (Throwable t) {
       LOG.error("Failed to upgrade ...", t);
       System.exit(1);

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsProcessorTwillRunnable.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/runtime/MetricsProcessorTwillRunnable.java
@@ -29,6 +29,9 @@ import co.cask.cdap.common.guice.ZKClientModule;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.common.logging.ServiceLoggingContext;
 import co.cask.cdap.common.namespace.guice.NamespaceClientRuntimeModule;
+import co.cask.cdap.common.security.RemoteUGIProvider;
+import co.cask.cdap.common.security.UGIProvider;
+import co.cask.cdap.common.security.UnsupportedUGIProvider;
 import co.cask.cdap.common.twill.AbstractMasterTwillRunnable;
 import co.cask.cdap.data.runtime.DataFabricModules;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -48,10 +51,13 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
+import co.cask.cdap.security.authorization.RemotePrivilegesManager;
+import co.cask.cdap.security.spi.authorization.PrivilegesManager;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Service;
+import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.PrivateModule;
@@ -139,8 +145,15 @@ public final class MetricsProcessorTwillRunnable extends AbstractMasterTwillRunn
       new MetricsProcessorStatusServiceModule(),
       new AuditModule().getDistributedModules(),
       new AuthorizationEnforcementModule().getDistributedModules(),
-      new AuthenticationContextModules().getMasterModule()
-     );
+      new AuthenticationContextModules().getMasterModule(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          // MetricsProcessor should never need to use UGIProvider. It is simply bound in HBaseQueueAdmin
+          bind(UGIProvider.class).to(UnsupportedUGIProvider.class).in(Scopes.SINGLETON);
+        }
+      }
+    );
   }
 
   static final class KafkaMetricsProcessorModule extends PrivateModule {


### PR DESCRIPTION
Perform impersonation during execution of UpgradeTool.

Core changes (Impersonation):
- HBaseQueueAdmin#upgrade
- AbstractQueueUpgrader#upgrade
- DatasetUpgrader#upgradeUserTables
- ExistingEntitySystemMetadataWriter#writeSystemMetadataForDatasets

Other change:
- Removed a log statement in UpgradeTool#main, which is redundant and potentially misleading (in the case that user gives 'help' as the action, for instance).

https://issues.cask.co/browse/CDAP-6577
http://builds.cask.co/browse/CDAP-RUT230-4
