### PR TITLE
Resolve __target to canonical PATH

### DIFF
--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -27,9 +27,11 @@ __target=$(readlink ${__script}) # TODO: readlink isn't portable, if we support 
 if [[ $? -ne 0 ]]; then
   __target=${__script} # no symlink
 fi
+# Resolve __target
+__target=$(cd $(dirname ${__target}); echo "$(pwd -P)/$(basename ${__target})")
 __app_home=$(cd $(dirname ${__target})/.. >&-; pwd -P)
 
-__comp_home=$(cd ${__target%/*/*} >&-; pwd -P)
+__comp_home=$(cd ${__target%/*/*} >&- 2>/dev/null; pwd -P)
 # Determine if we're in the SDK or distributed
 if [[ ${__comp_home%/*} == /opt/cdap ]] && [[ ${__comp_home} != /opt/cdap/sdk* ]]; then
   __app_home=${__comp_home}

--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -704,10 +704,13 @@ cdap_version() {
 # returns: true
 #
 cdap_sdk_usage() {
+  echo
   echo "Usage: ${0} sdk {start|stop|restart|status|usage}"
+  echo
   echo "Additional options with start, restart:"
   echo "--enable-debug [ <port> ] to connect to a debug port for Standalone CDAP (default port is 5005)"
   echo "--foreground to run the SDK in the foreground, showing logs on STDOUT"
+  echo
   return 0
 }
 


### PR DESCRIPTION
This cleans up the following error, which was introduced in #6855 and completes the resolution for CDAP-7384

```
$ bin/cdap sdk
bin/cdap: line 32: cd: bin/cdap: Not a directory
Usage: bin/cdap sdk {start|stop|restart|status|usage}
Additional options with start, restart:
--enable-debug [ <port> ] to connect to a debug port for Standalone CDAP (default port is 5005)
--foreground to run the SDK in the foreground, showing logs on STDOUT
```

Rather than use `__target` as input by the user, resolve it to a canonical PATH on the file-system.

Example, as given:

```
$ bin/cdap sdk

Usage: bin/cdap sdk {start|stop|restart|status|usage}

Additional options with start, restart:
--enable-debug [ <port> ] to connect to a debug port for Standalone CDAP (default port is 5005)
--foreground to run the SDK in the foreground, showing logs on STDOUT
```

From `bin`:

```
$ cd bin && ./cdap sdk

Usage: ./cdap sdk {start|stop|restart|status|usage}

Additional options with start, restart:
--enable-debug [ <port> ] to connect to a debug port for Standalone CDAP (default port is 5005)
--foreground to run the SDK in the foreground, showing logs on STDOUT
```

Using full PATH, from `CDAP_HOME` with `../` included, like UI uses:

```
$ $(pwd -P)/ui/server/config/../../../bin/cdap config-tool --cdap | python -mjson.tool >/dev/null ; ret=$? ; if [[ $ret == 0 ]]; then echo "JSON passed" ; else echo "JSON failed" ; fi
JSON passed
```

Using symlink:

```
$ ln -sf bin/cdap symlink && ./symlink sdk

Usage: ./symlink sdk {start|stop|restart|status|usage}

Additional options with start, restart:
--enable-debug [ <port> ] to connect to a debug port for Standalone CDAP (default port is 5005)
--foreground to run the SDK in the foreground, showing logs on STDOUT
```

From system PATH:

```
$ PATH=$PATH:$(pwd -P)/bin cdap sdk

Usage: /Users/chris/tmp/cdap-sdk-4.0.0-SNAPSHOT/bin/cdap sdk {start|stop|restart|status|usage}

Additional options with start, restart:
--enable-debug [ <port> ] to connect to a debug port for Standalone CDAP (default port is 5005)
--foreground to run the SDK in the foreground, showing logs on STDOUT
```
