### PR TITLE
Support CDH 5.9, by reusing the HBASE_12_CDH57 compat module.

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
@@ -39,6 +39,7 @@ public class HBaseVersion {
   private static final String CDH56_CLASSIFIER = "cdh5.6";
   private static final String CDH57_CLASSIFIER = "cdh5.7";
   private static final String CDH58_CLASSIFIER = "cdh5.8";
+  private static final String CDH59_CLASSIFIER = "cdh5.9";
   private static final String CDH_CLASSIFIER = "cdh";
 
   private static final Logger LOG = LoggerFactory.getLogger(HBaseVersion.class);
@@ -99,8 +100,9 @@ public class HBaseVersion {
         VersionNumber ver = VersionNumber.create(versionString);
         if (ver.getClassifier() != null &&
           (ver.getClassifier().startsWith(CDH57_CLASSIFIER) ||
-            // CDH 5.7 compat module can be re-used with CDH 5.8
-            ver.getClassifier().startsWith(CDH58_CLASSIFIER))) {
+            // CDH 5.7 compat module can be re-used with CDH 5.8 and CDH 5.9
+            ver.getClassifier().startsWith(CDH58_CLASSIFIER) ||
+            ver.getClassifier().startsWith(CDH59_CLASSIFIER))) {
           currentVersion = Version.HBASE_12_CDH57;
         } else {
           // HBase-11 compat module can be re-used for HBASE-12 as there is no change needed in compat source.


### PR DESCRIPTION
This has been tested once on a CDH 5.9 (enables master to start up, whereas it wouldn't even start w/o this fix).
Pending further testing.

https://issues.cask.co/browse/CDAP-7291
