### PR TITLE
CDAP-7439 Remove "kinit" instruction

### DIFF
--- a/cdap-docs/admin-manual/source/upgrading/packages.rst
+++ b/cdap-docs/admin-manual/source/upgrading/packages.rst
@@ -77,12 +77,6 @@ and then restart CDAP:
 
        $ sudo apt-get install --only-upgrade '^cdap.*'
 
-#. If you are upgrading a secure Hadoop cluster, you should authenticate with ``kinit``
-   as the user that runs CDAP Master (the CDAP user)
-   before the next step (the running of the upgrade tool)::
-
-     $ kinit -kt <keytab> <principal>
-
 #. Run the upgrade tool, as the user that runs CDAP Master (the CDAP user, indicated by ``<cdap-user>``)::
 
      $ sudo -u <cdap-user> /opt/cdap/master/bin/svc-master run co.cask.cdap.data.tools.UpgradeTool upgrade


### PR DESCRIPTION
Passes a Quick Build: http://builds.cask.co/browse/CDAP-DQB155-1

Page of interest: Packages Upgrade page

Removing current `Step #6`.

Current 3.5.1 page: http://docs.cask.co/cdap/3.5.1/en/admin-manual/upgrading/packages.html#upgrade-steps

Revised 3.5.2 page: http://builds.cask.co/artifact/CDAP-DQB155/shared/build-1/Docs-HTML/3.5.2-SNAPSHOT/en/admin-manual/upgrading/packages.html#upgrade-steps
