### PR TITLE
HYDRATOR-378 add checkpointing to data streams app

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsApp.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsApp.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.datastreams;
 
 import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.dataset.lib.FileSet;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.streaming.StreamingSource;
 import co.cask.cdap.etl.proto.v2.DataStreamsConfig;
@@ -27,6 +28,7 @@ import com.google.common.collect.ImmutableSet;
  * Data Streams Application.
  */
 public class DataStreamsApp extends AbstractApplication<DataStreamsConfig> {
+  public static final String CHECKPOINT_FILESET = "dataStreamsCheckpoints";
 
   @Override
   public void configure() {
@@ -40,6 +42,10 @@ public class DataStreamsApp extends AbstractApplication<DataStreamsConfig> {
         ImmutableSet.of(BatchSink.PLUGIN_TYPE)
       );
     DataStreamsPipelineSpec spec = specGenerator.generateSpec(config);
-    addSpark(new DataStreamsSparkLauncher(spec, config.isUnitTest()));
+    addSpark(new DataStreamsSparkLauncher(spec, config));
+
+    if (!config.checkpointsDisabled()) {
+      createDataset(CHECKPOINT_FILESET, FileSet.class);
+    }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsSparkLauncher.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsSparkLauncher.java
@@ -17,34 +17,47 @@
 package co.cask.cdap.datastreams;
 
 import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.lib.FileSet;
 import co.cask.cdap.api.spark.AbstractSpark;
 import co.cask.cdap.api.spark.SparkClientContext;
 import co.cask.cdap.etl.api.streaming.StreamingSource;
 import co.cask.cdap.etl.common.Constants;
+import co.cask.cdap.etl.proto.v2.DataStreamsConfig;
 import co.cask.cdap.etl.spec.StageSpec;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.apache.spark.SparkConf;
+import org.apache.twill.filesystem.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * CDAP Spark client that configures and launches the actual Spark program.
  */
 public class DataStreamsSparkLauncher extends AbstractSpark {
+  private static final Logger LOG = LoggerFactory.getLogger(DataStreamsSparkLauncher.class);
+  static final String IS_UNIT_TEST = "hydrator.is.unit.test";
+  static final String NUM_SOURCES = "hydrator.num.sources";
+  static final String EXTRA_OPTS = "hydrator.extra.opts";
+  static final String CHECKPOINT_DIR = "hydrator.checkpoint.dir";
+  static final String CHECKPOINTS_DISABLED = "hydrator.checkpoints.disabled";
   public static final String NAME = "DataStreamsSparkStreaming";
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
     .create();
 
   private final DataStreamsPipelineSpec pipelineSpec;
-  private final boolean isUnitTest;
+  private final DataStreamsConfig config;
 
-  public DataStreamsSparkLauncher(DataStreamsPipelineSpec pipelineSpec, boolean isUnitTest) {
+  public DataStreamsSparkLauncher(DataStreamsPipelineSpec pipelineSpec, DataStreamsConfig config) {
     this.pipelineSpec = pipelineSpec;
-    this.isUnitTest = isUnitTest;
+    this.config = config;
   }
 
   @Override
@@ -65,9 +78,12 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
     // add source, sink, transform ids to the properties. These are needed at runtime to instantiate the plugins
     Map<String, String> properties = new HashMap<>();
     properties.put(Constants.PIPELINEID, GSON.toJson(pipelineSpec));
-    properties.put("cask.hydrator.is.unit.test", String.valueOf(isUnitTest));
-    properties.put("cask.hydrator.num.sources", String.valueOf(numSources));
-    properties.put("cask.hydrator.extra.opts", pipelineSpec.getExtraJavaOpts());
+    properties.put(IS_UNIT_TEST, String.valueOf(config.isUnitTest()));
+    properties.put(NUM_SOURCES, String.valueOf(numSources));
+    properties.put(EXTRA_OPTS, pipelineSpec.getExtraJavaOpts());
+    properties.put(CHECKPOINT_DIR,
+                   config.getCheckpointDir() == null ? UUID.randomUUID().toString() : config.getCheckpointDir());
+    properties.put(CHECKPOINTS_DISABLED, String.valueOf(config.checkpointsDisabled()));
     setProperties(properties);
   }
 
@@ -79,19 +95,58 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
     // because it holds one thread per receiver, or one core in distributed mode.
     // so... we have to set this hacky master variable based on the isUnitTest setting in the config
     Map<String, String> programProperties = context.getSpecification().getProperties();
-    String extraOpts = programProperties.get("cask.hydrator.extra.opts");
+    String extraOpts = programProperties.get(EXTRA_OPTS);
     if (extraOpts != null && !extraOpts.isEmpty()) {
       sparkConf.set("spark.driver.extraJavaOptions", extraOpts);
       sparkConf.set("spark.executor.extraJavaOptions", extraOpts);
     }
-    Integer numSources = Integer.valueOf(programProperties.get("cask.hydrator.num.sources"));
+    Integer numSources = Integer.valueOf(programProperties.get(NUM_SOURCES));
     // without this, stopping will hang on machines with few cores.
     sparkConf.set("spark.rpc.netty.dispatcher.numThreads", String.valueOf(numSources + 2));
-    Boolean isUnitTest = Boolean.valueOf(programProperties.get("cask.hydrator.is.unit.test"));
+    Boolean isUnitTest = Boolean.valueOf(programProperties.get(IS_UNIT_TEST));
     if (isUnitTest) {
       sparkConf.setMaster(String.format("local[%d]", numSources + 1));
     }
     context.setSparkConf(sparkConf);
+
+    boolean checkpointsDisabled = Boolean.valueOf(programProperties.get(CHECKPOINTS_DISABLED));
+    if (!checkpointsDisabled) {
+      // Each pipeline has its own checkpoint directory within the checkpoint fileset.
+      // Ideally, when a pipeline is deleted, we would be able to delete that checkpoint directory.
+      // This is because we don't want another pipeline created with the same name to pick up the old checkpoint.
+      // Since CDAP has no way to run application logic on deletion, we instead generate a unique pipeline id
+      // and use that as the checkpoint directory as a subdirectory inside the pipeline name directory.
+      // On start, we check for any other pipeline ids for that pipeline name, and delete them if they exist.
+      FileSet checkpointFileSet = context.getDataset(DataStreamsApp.CHECKPOINT_FILESET);
+      String pipelineName = context.getApplicationSpecification().getName();
+      String checkpointDir = context.getSpecification().getProperty(CHECKPOINT_DIR);
+      Location pipelineCheckpointBase = checkpointFileSet.getBaseLocation().append(pipelineName);
+      Location pipelineCheckpointDir = pipelineCheckpointBase.append(checkpointDir);
+
+      if (!ensureDirExists(pipelineCheckpointBase)) {
+        throw new IOException(
+          String.format("Unable to create checkpoint base directory '%s' for the pipeline.", pipelineCheckpointBase));
+      }
+
+      try {
+        for (Location child : pipelineCheckpointBase.list()) {
+          if (!child.equals(pipelineCheckpointDir) && !child.delete(true)) {
+            LOG.warn("Unable to delete checkpoint directory {} from an old pipeline.", child);
+          }
+        }
+      } catch (Exception e) {
+        LOG.warn("Unable to clean up old checkpoint directories from old pipelines.", e);
+      }
+
+      if (!ensureDirExists(pipelineCheckpointDir)) {
+        throw new IOException(
+          String.format("Unable to create checkpoint directory '%s' for the pipeline.", pipelineCheckpointDir));
+      }
+    }
+  }
+
+  private boolean ensureDirExists(Location location) throws IOException {
+    return location.isDirectory() || location.mkdirs() || location.isDirectory();
   }
 
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/ErrorMacroEvaluator.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/ErrorMacroEvaluator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.datastreams;
+
+import co.cask.cdap.api.macro.InvalidMacroException;
+import co.cask.cdap.api.macro.MacroEvaluator;
+
+/**
+ * Throws an exception if it encounters any macros
+ */
+public class ErrorMacroEvaluator implements MacroEvaluator {
+  private final String message;
+
+  public ErrorMacroEvaluator(String message) {
+    this.message = message;
+  }
+
+  @Override
+  public String lookup(String property) throws InvalidMacroException {
+    throw new IllegalArgumentException(message);
+  }
+
+  @Override
+  public String evaluate(String macroFunction, String... arguments) throws InvalidMacroException {
+    throw new IllegalArgumentException(message);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineDriver.java
@@ -16,8 +16,10 @@
 
 package co.cask.cdap.datastreams;
 
+import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.schema.Schema;
-import co.cask.cdap.api.macro.MacroEvaluator;
+import co.cask.cdap.api.dataset.lib.FileSet;
 import co.cask.cdap.api.spark.JavaSparkExecutionContext;
 import co.cask.cdap.api.spark.JavaSparkMain;
 import co.cask.cdap.etl.api.Transform;
@@ -25,70 +27,42 @@ import co.cask.cdap.etl.api.batch.BatchAggregator;
 import co.cask.cdap.etl.api.batch.BatchJoiner;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.SparkCompute;
-import co.cask.cdap.etl.api.streaming.StreamingContext;
 import co.cask.cdap.etl.api.streaming.StreamingSource;
 import co.cask.cdap.etl.api.streaming.Windower;
 import co.cask.cdap.etl.common.Constants;
-import co.cask.cdap.etl.common.DefaultMacroEvaluator;
 import co.cask.cdap.etl.common.PipelinePhase;
 import co.cask.cdap.etl.planner.StageInfo;
-import co.cask.cdap.etl.spark.SparkCollection;
-import co.cask.cdap.etl.spark.SparkPipelineDriver;
-import co.cask.cdap.etl.spark.function.CountingFunction;
-import co.cask.cdap.etl.spark.function.PluginFunctionContext;
-import co.cask.cdap.etl.spark.streaming.DStreamCollection;
-import co.cask.cdap.etl.spark.streaming.DefaultStreamingContext;
 import co.cask.cdap.etl.spec.StageSpec;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.api.java.function.Function;
 import org.apache.spark.streaming.Durations;
 import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import org.apache.spark.streaming.api.java.JavaStreamingContextFactory;
+import org.apache.twill.filesystem.Location;
 
 import java.util.HashMap;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
 
 /**
  * Driver for running pipelines using Spark Streaming.
  */
-public class SparkStreamingPipelineDriver extends SparkPipelineDriver implements JavaSparkMain {
+public class SparkStreamingPipelineDriver implements JavaSparkMain {
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
     .create();
   private static final Set<String> SUPPORTED_PLUGIN_TYPES = ImmutableSet.of(
     StreamingSource.PLUGIN_TYPE, BatchSink.PLUGIN_TYPE, Transform.PLUGIN_TYPE, BatchAggregator.PLUGIN_TYPE,
     BatchJoiner.PLUGIN_TYPE, SparkCompute.PLUGIN_TYPE, Windower.PLUGIN_TYPE);
-  private JavaSparkExecutionContext sec;
-  private JavaSparkContext sparkContext;
-  private JavaStreamingContext streamingContext;
 
   @Override
-  protected SparkCollection<Object> getSource(final String stageName,
-                                              PluginFunctionContext pluginFunctionContext) throws Exception {
-    MacroEvaluator macroEvaluator = new DefaultMacroEvaluator(sec.getRuntimeArguments(), sec.getLogicalStartTime(),
-                                                              sec.getSecureStore(), stageName);
-    StreamingSource<Object> source = sec.getPluginContext().newPluginInstance(stageName, macroEvaluator);
-    StreamingContext context = new DefaultStreamingContext(stageName, sec, streamingContext);
-    return new DStreamCollection<>(sec, sparkContext, source.getStream(context)
-      .transform(new Function<JavaRDD<Object>, JavaRDD<Object>>() {
-        @Override
-        public JavaRDD<Object> call(JavaRDD<Object> input) throws Exception {
-          return input.map(new CountingFunction<>(stageName, sec.getMetrics(), "records.out"));
-        }
-      }));
-  }
-
-  @Override
-  public void run(JavaSparkExecutionContext sec) throws Exception {
-    this.sec = sec;
-
-    DataStreamsPipelineSpec pipelineSpec = GSON.fromJson(sec.getSpecification().getProperty(Constants.PIPELINEID),
-                                                         DataStreamsPipelineSpec.class);
-
+  public void run(final JavaSparkExecutionContext sec) throws Exception {
+    final DataStreamsPipelineSpec pipelineSpec = GSON.fromJson(sec.getSpecification().getProperty(Constants.PIPELINEID),
+                                                               DataStreamsPipelineSpec.class);
 
     PipelinePhase.Builder phaseBuilder = PipelinePhase.builder(SUPPORTED_PLUGIN_TYPES)
       .addConnections(pipelineSpec.getConnections());
@@ -100,26 +74,72 @@ public class SparkStreamingPipelineDriver extends SparkPipelineDriver implements
                               .setOutputSchema(stageSpec.getOutputSchema())
                               .build());
     }
-    PipelinePhase pipelinePhase = phaseBuilder.build();
+    final PipelinePhase pipelinePhase = phaseBuilder.build();
 
-    sparkContext = new JavaSparkContext();
-    streamingContext = new JavaStreamingContext(sparkContext,
-                                                Durations.milliseconds(pipelineSpec.getBatchIntervalMillis()));
-    // TODO: figure out how to get partitions to use for aggregators and joiners.
-    // Seems like they should be set at configure time instead of runtime? but that requires an API change.
-    runPipeline(pipelinePhase, StreamingSource.PLUGIN_TYPE, sec, new HashMap<String, Integer>());
+    boolean checkpointsDisabled = Boolean.parseBoolean(
+      sec.getSpecification().getProperty(DataStreamsSparkLauncher.CHECKPOINTS_DISABLED));
 
-    streamingContext.start();
+    String checkpointDir = null;
+    if (!checkpointsDisabled) {
+      // Get the location of the checkpoint directory.
+      String pipelineName = sec.getApplicationSpecification().getName();
+      String pipelineId = sec.getSpecification().getProperty(DataStreamsSparkLauncher.CHECKPOINT_DIR);
+
+      // there isn't any way to instantiate the fileset except in a TxRunnable, so need to use a reference.
+      final AtomicReference<Location> checkpointBaseRef = new AtomicReference<>();
+      sec.execute(new TxRunnable() {
+        @Override
+        public void run(DatasetContext context) throws Exception {
+          FileSet checkpointFileSet = context.getDataset(DataStreamsApp.CHECKPOINT_FILESET);
+          checkpointBaseRef.set(checkpointFileSet.getBaseLocation());
+        }
+      });
+      Location pipelineCheckpointDir = checkpointBaseRef.get().append(pipelineName).append(pipelineId);
+      checkpointDir = pipelineCheckpointDir.toURI().toString();
+    }
+
+    JavaStreamingContext jssc = run(pipelineSpec, pipelinePhase, sec, checkpointDir);
+    jssc.start();
     boolean stopped = false;
     try {
       // most programs will just keep running forever.
       // however, when CDAP stops the program, we get an interrupted exception.
       // at that point, we need to call stop on jssc, otherwise the program will hang and never stop.
-      stopped = streamingContext.awaitTerminationOrTimeout(Long.MAX_VALUE);
+      stopped = jssc.awaitTerminationOrTimeout(Long.MAX_VALUE);
     } finally {
       if (!stopped) {
-        streamingContext.stop(true, true);
+        jssc.stop(true, true);
       }
     }
   }
+
+  private JavaStreamingContext run(final DataStreamsPipelineSpec pipelineSpec,
+                                   final PipelinePhase pipelinePhase,
+                                   final JavaSparkExecutionContext sec,
+                                   @Nullable final String checkpointDir) throws Exception {
+
+    JavaStreamingContextFactory contextFactory = new JavaStreamingContextFactory() {
+      @Override
+      public JavaStreamingContext create() {
+        JavaStreamingContext jssc = new JavaStreamingContext(
+          new JavaSparkContext(), Durations.milliseconds(pipelineSpec.getBatchIntervalMillis()));
+        SparkStreamingPipelineRunner runner = new SparkStreamingPipelineRunner(sec, jssc, false);
+        // TODO: figure out how to get partitions to use for aggregators and joiners.
+        // Seems like they should be set at configure time instead of runtime? but that requires an API change.
+        try {
+          runner.runPipeline(pipelinePhase, StreamingSource.PLUGIN_TYPE, sec, new HashMap<String, Integer>());
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+        if (checkpointDir != null) {
+          jssc.checkpoint(checkpointDir);
+        }
+        return jssc;
+      }
+    };
+
+    return JavaStreamingContext.getOrCreate(checkpointDir, contextFactory);
+  }
+
+
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineRunner.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.datastreams;
+
+import co.cask.cdap.api.macro.MacroEvaluator;
+import co.cask.cdap.api.spark.JavaSparkExecutionContext;
+import co.cask.cdap.etl.api.JoinElement;
+import co.cask.cdap.etl.api.streaming.StreamingContext;
+import co.cask.cdap.etl.api.streaming.StreamingSource;
+import co.cask.cdap.etl.planner.StageInfo;
+import co.cask.cdap.etl.spark.SparkCollection;
+import co.cask.cdap.etl.spark.SparkPairCollection;
+import co.cask.cdap.etl.spark.SparkPipelineRunner;
+import co.cask.cdap.etl.spark.function.PluginFunctionContext;
+import co.cask.cdap.etl.spark.streaming.DStreamCollection;
+import co.cask.cdap.etl.spark.streaming.DefaultStreamingContext;
+import co.cask.cdap.etl.spark.streaming.DynamicDriverContext;
+import co.cask.cdap.etl.spark.streaming.PairDStreamCollection;
+import co.cask.cdap.etl.spark.streaming.function.CountingTranformFunction;
+import co.cask.cdap.etl.spark.streaming.function.DynamicJoinMerge;
+import co.cask.cdap.etl.spark.streaming.function.DynamicJoinOn;
+import org.apache.spark.streaming.api.java.JavaDStream;
+import org.apache.spark.streaming.api.java.JavaPairDStream;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+
+import java.util.List;
+
+/**
+ * Driver for running pipelines using Spark Streaming.
+ */
+public class SparkStreamingPipelineRunner extends SparkPipelineRunner {
+
+  private final JavaSparkExecutionContext sec;
+  private final JavaStreamingContext streamingContext;
+  private final boolean checkpointsDisabled;
+
+  public SparkStreamingPipelineRunner(JavaSparkExecutionContext sec, JavaStreamingContext streamingContext,
+                                      boolean checkpointsDisabled) {
+    this.sec = sec;
+    this.streamingContext = streamingContext;
+    this.checkpointsDisabled = checkpointsDisabled;
+  }
+
+  @Override
+  protected SparkCollection<Object> getSource(StageInfo stageInfo) throws Exception {
+    StreamingSource<Object> source;
+    if (checkpointsDisabled) {
+      PluginFunctionContext pluginFunctionContext = new PluginFunctionContext(stageInfo, sec);
+      source = pluginFunctionContext.createPlugin();
+    } else {
+      // check for macros in any StreamingSource. If checkpoints are enabled,
+      // SparkStreaming will serialize all InputDStreams created in the checkpoint, which means
+      // the InputDStream is deserialized directly from the checkpoint instead of instantiated through CDAP.
+      // This means there isn't any way for us to perform macro evaluation on sources when they are loaded from
+      // checkpoints. We can work around this in all other pipeline stages by dynamically instantiating the
+      // plugin in all DStream functions, but can't for InputDStreams because the InputDStream constructor
+      // adds itself to the context dag. Yay for constructors with global side effects.
+      // TODO: (HYDRATOR-1030) figure out how to do this at configure time instead of run time
+      MacroEvaluator macroEvaluator = new ErrorMacroEvaluator(
+        "Due to spark limitations, macro evaluation is not allowed in streaming sources when checkpointing " +
+          "is enabled.");
+      source = sec.getPluginContext().newPluginInstance(stageInfo.getName(), macroEvaluator);
+    }
+
+    StreamingContext sourceContext = new DefaultStreamingContext(stageInfo.getName(), sec, streamingContext);
+    JavaDStream<Object> javaDStream = source.getStream(sourceContext)
+      .transform(new CountingTranformFunction<>(stageInfo.getName(), sec.getMetrics(), "records.out"));
+    return new DStreamCollection<>(sec, javaDStream);
+  }
+
+  @Override
+  protected SparkPairCollection<Object, Object> addJoinKey(StageInfo stageInfo, String inputStageName,
+                                                           SparkCollection<Object> inputCollection) throws Exception {
+    DynamicDriverContext dynamicDriverContext = new DynamicDriverContext(stageInfo, sec);
+    JavaDStream<Object> dStream = inputCollection.getUnderlying();
+    JavaPairDStream<Object, Object> result =
+      dStream.transformToPair(new DynamicJoinOn<>(dynamicDriverContext, inputStageName));
+    return new PairDStreamCollection<>(sec, result);
+  }
+
+  @Override
+  protected SparkCollection<Object> mergeJoinResults(
+    StageInfo stageInfo, SparkPairCollection<Object, List<JoinElement<Object>>> joinedInputs) throws Exception {
+
+    DynamicDriverContext dynamicDriverContext = new DynamicDriverContext(stageInfo, sec);
+    JavaPairDStream<Object, List<JoinElement<Object>>> pairDStream = joinedInputs.getUnderlying();
+    JavaDStream<Object> result = pairDStream.transform(new DynamicJoinMerge<>(dynamicDriverContext));
+    return new DStreamCollection<>(sec, result);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/v2/DataStreamsConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/v2/DataStreamsConfig.java
@@ -21,6 +21,7 @@ import co.cask.cdap.etl.proto.Connection;
 
 import java.util.Objects;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Data Streams Configuration.
@@ -29,6 +30,8 @@ public final class DataStreamsConfig extends ETLConfig {
   private final String batchInterval;
   private final Resources driverResources;
   private final String extraJavaOpts;
+  private final Boolean disableCheckpoints;
+  private final String checkpointDir;
   // See comments in DataStreamsSparkLauncher for explanation on why we need this.
   private final boolean isUnitTest;
 
@@ -38,12 +41,16 @@ public final class DataStreamsConfig extends ETLConfig {
                             Resources driverResources,
                             boolean stageLoggingEnabled,
                             String batchInterval,
-                            boolean isUnitTest) {
+                            boolean isUnitTest,
+                            boolean disableCheckpoints,
+                            @Nullable String checkpointDir) {
     super(stages, connections, resources, stageLoggingEnabled);
     this.batchInterval = batchInterval;
     this.driverResources = driverResources;
     this.isUnitTest = isUnitTest;
     this.extraJavaOpts = "";
+    this.disableCheckpoints = disableCheckpoints;
+    this.checkpointDir = checkpointDir;
   }
 
   public Resources getDriverResources() {
@@ -58,8 +65,29 @@ public final class DataStreamsConfig extends ETLConfig {
     return isUnitTest;
   }
 
+  public boolean checkpointsDisabled() {
+    return disableCheckpoints == null ? false : disableCheckpoints;
+  }
+
   public String getExtraJavaOpts() {
     return extraJavaOpts == null || extraJavaOpts.isEmpty() ? "-XX:MaxPermSize=256m" : extraJavaOpts;
+  }
+
+  @Nullable
+  public String getCheckpointDir() {
+    return checkpointDir;
+  }
+
+  @Override
+  public String toString() {
+    return "DataStreamsConfig{" +
+      "batchInterval='" + batchInterval + '\'' +
+      ", driverResources=" + driverResources +
+      ", extraJavaOpts='" + extraJavaOpts + '\'' +
+      ", disableCheckpoints=" + disableCheckpoints +
+      ", checkpointDir='" + checkpointDir + '\'' +
+      ", isUnitTest=" + isUnitTest +
+      "} " + super.toString();
   }
 
   @Override
@@ -78,22 +106,15 @@ public final class DataStreamsConfig extends ETLConfig {
 
     return Objects.equals(batchInterval, that.batchInterval) &&
       Objects.equals(driverResources, that.driverResources) &&
-      Objects.equals(extraJavaOpts, that.extraJavaOpts);
+      Objects.equals(extraJavaOpts, that.extraJavaOpts) &&
+      Objects.equals(disableCheckpoints, that.disableCheckpoints) &&
+      Objects.equals(checkpointDir, that.checkpointDir);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), batchInterval, driverResources, extraJavaOpts);
-  }
-
-  @Override
-  public String toString() {
-    return "DataStreamsConfig{" +
-      "batchInterval='" + batchInterval + '\'' +
-      ", driverResources=" + driverResources +
-      ", extraJavaOpts='" + extraJavaOpts + '\'' +
-      ", isUnitTest=" + isUnitTest +
-      "} " + super.toString();
+    return Objects.hash(super.hashCode(), batchInterval, driverResources,
+                        extraJavaOpts, disableCheckpoints, checkpointDir);
   }
 
   public static Builder builder() {
@@ -107,6 +128,7 @@ public final class DataStreamsConfig extends ETLConfig {
     private final boolean isUnitTest;
     private String batchInterval;
     private Resources driverResources;
+    private String checkpointDir;
 
     public Builder() {
       this.isUnitTest = true;
@@ -124,9 +146,14 @@ public final class DataStreamsConfig extends ETLConfig {
       return this;
     }
 
+    public Builder setCheckpointDir(String checkpointDir) {
+      this.checkpointDir = checkpointDir;
+      return this;
+    }
+
     public DataStreamsConfig build() {
       return new DataStreamsConfig(stages, connections, resources, driverResources,
-                                   stageLoggingEnabled, batchInterval, isUnitTest);
+                                   stageLoggingEnabled, batchInterval, isUnitTest, false, checkpointDir);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/SparkCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/SparkCollection.java
@@ -19,8 +19,11 @@ package co.cask.cdap.etl.spark;
 import co.cask.cdap.etl.api.batch.SparkCompute;
 import co.cask.cdap.etl.api.batch.SparkSink;
 import co.cask.cdap.etl.api.streaming.Windower;
+import co.cask.cdap.etl.planner.StageInfo;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
+
+import javax.annotation.Nullable;
 
 /**
  * Abstraction over different types of spark collections with common shared operations on those collections.
@@ -40,15 +43,17 @@ public interface SparkCollection<T> {
 
   SparkCollection<T> union(SparkCollection<T> other);
 
-  <U> SparkCollection<U> flatMap(FlatMapFunction<T, U> function);
+  <U> SparkCollection<U> flatMap(StageInfo stageInfo, FlatMapFunction<T, U> function);
+
+  <U> SparkCollection<U> aggregate(StageInfo stageInfo, @Nullable Integer partitions);
 
   <K, V> SparkPairCollection<K, V> flatMapToPair(PairFlatMapFunction<T, K, V> function);
 
-  <U> SparkCollection<U> compute(String stageName, SparkCompute<T, U> compute) throws Exception;
+  <U> SparkCollection<U> compute(StageInfo stageInfo, SparkCompute<T, U> compute) throws Exception;
 
-  void store(String stageName, PairFlatMapFunction<T, Object, Object> sinkFunction);
+  void store(StageInfo stageInfo, PairFlatMapFunction<T, Object, Object> sinkFunction);
 
-  void store(String stageName, SparkSink<T> sink) throws Exception;
+  void store(StageInfo stageInfo, SparkSink<T> sink) throws Exception;
 
-  SparkCollection<T> window(String stageName, Windower windower);
+  SparkCollection<T> window(StageInfo stageInfo, Windower windower);
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/SparkPairCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/SparkPairCollection.java
@@ -38,10 +38,6 @@ public interface SparkPairCollection<K, V> {
 
   <T> SparkPairCollection<K, T> mapValues(Function<V, T> function);
 
-  SparkPairCollection<K, Iterable<V>> groupByKey();
-
-  SparkPairCollection<K, Iterable<V>> groupByKey(int numPartitions);
-
   <T> SparkPairCollection<K, Tuple2<V, T>> join(SparkPairCollection<K, T> other);
 
   <T> SparkPairCollection<K, Tuple2<V, T>> join(SparkPairCollection<K, T> other, int numPartitions);

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/PairRDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/PairRDDCollection.java
@@ -18,8 +18,11 @@ package co.cask.cdap.etl.spark.batch;
 
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.spark.JavaSparkExecutionContext;
+import co.cask.cdap.etl.planner.StageInfo;
 import co.cask.cdap.etl.spark.SparkCollection;
 import co.cask.cdap.etl.spark.SparkPairCollection;
+import co.cask.cdap.etl.spark.function.JoinMergeFunction;
+import co.cask.cdap.etl.spark.function.PluginFunctionContext;
 import com.google.common.base.Optional;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -63,16 +66,6 @@ public class PairRDDCollection<K, V> implements SparkPairCollection<K, V> {
   @Override
   public <T> SparkPairCollection<K, T> mapValues(Function<V, T> function) {
     return wrap(pairRDD.mapValues(function));
-  }
-
-  @Override
-  public SparkPairCollection<K, Iterable<V>> groupByKey() {
-    return wrap(pairRDD.groupByKey());
-  }
-
-  @Override
-  public SparkPairCollection<K, Iterable<V>> groupByKey(int numPartitions) {
-    return wrap(pairRDD.groupByKey(numPartitions));
   }
 
   @SuppressWarnings("unchecked")

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/InitialJoinFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/InitialJoinFunction.java
@@ -25,8 +25,10 @@ import java.util.List;
 /**
  * Transforms an Object into a singleton list containing the JoinElement of that object. Used to map the initial
  * PairRDD of a join into the type expected by other parts of the join.
+ *
+ * @param <T> type of object
  */
-public class InitialJoinFunction implements Function<Object, List<JoinElement<Object>>> {
+public class InitialJoinFunction<T> implements Function<T, List<JoinElement<T>>> {
   private final String inputStageName;
 
   public InitialJoinFunction(String inputStageName) {
@@ -34,8 +36,8 @@ public class InitialJoinFunction implements Function<Object, List<JoinElement<Ob
   }
 
   @Override
-  public List<JoinElement<Object>> call(Object obj) throws Exception {
-    List<JoinElement<Object>> list = new ArrayList<>(1);
+  public List<JoinElement<T>> call(T obj) throws Exception {
+    List<JoinElement<T>> list = new ArrayList<>(1);
     list.add(new JoinElement<>(inputStageName, obj));
     return list;
   }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/JoinFlattenFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/JoinFlattenFunction.java
@@ -24,9 +24,10 @@ import java.util.List;
 
 /**
  * Flattens the Tuple2 of list and object returned by a join into a single list.
+ *
+ * @param <T> type of object to flatten
  */
-public class JoinFlattenFunction implements
-  Function<Tuple2<List<JoinElement<Object>>, Object>, List<JoinElement<Object>>> {
+public class JoinFlattenFunction<T> implements Function<Tuple2<List<JoinElement<T>>, T>, List<JoinElement<T>>> {
   private final String inputStageName;
 
   public JoinFlattenFunction(String inputStageName) {
@@ -34,8 +35,8 @@ public class JoinFlattenFunction implements
   }
 
   @Override
-  public List<JoinElement<Object>> call(Tuple2<List<JoinElement<Object>>, Object> in) throws Exception {
-    List<JoinElement<Object>> output = in._1();
+  public List<JoinElement<T>> call(Tuple2<List<JoinElement<T>>, T> in) throws Exception {
+    List<JoinElement<T>> output = in._1();
     output.add(new JoinElement<>(inputStageName, in._2()));
     return output;
   }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/LeftJoinFlattenFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/LeftJoinFlattenFunction.java
@@ -25,9 +25,11 @@ import java.util.List;
 
 /**
  * Flattens the Tuple2 of list and optional object returned by a left outer join into a single list.
+ *
+ * @param <T> type of object to flatten
  */
-public class LeftJoinFlattenFunction implements
-  Function<Tuple2<List<JoinElement<Object>>, Optional<Object>>, List<JoinElement<Object>>> {
+public class LeftJoinFlattenFunction<T> implements
+  Function<Tuple2<List<JoinElement<T>>, Optional<T>>, List<JoinElement<T>>> {
   private final String inputStageName;
 
   public LeftJoinFlattenFunction(String inputStageName) {
@@ -35,8 +37,8 @@ public class LeftJoinFlattenFunction implements
   }
 
   @Override
-  public List<JoinElement<Object>> call(Tuple2<List<JoinElement<Object>>, Optional<Object>> in) throws Exception {
-    List<JoinElement<Object>> output = in._1();
+  public List<JoinElement<T>> call(Tuple2<List<JoinElement<T>>, Optional<T>> in) throws Exception {
+    List<JoinElement<T>> output = in._1();
     if (in._2().isPresent()) {
       output.add(new JoinElement<>(inputStageName, in._2().get()));
     }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/OuterJoinFlattenFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/OuterJoinFlattenFunction.java
@@ -26,9 +26,11 @@ import java.util.List;
 
 /**
  * Flattens the Tuple2 of optional list and optional object returned by a full outer join into a single list.
+ *
+ * @param <T> type of object to flatten
  */
-public class OuterJoinFlattenFunction implements
-  Function<Tuple2<Optional<List<JoinElement<Object>>>, Optional<Object>>, List<JoinElement<Object>>> {
+public class OuterJoinFlattenFunction<T> implements
+  Function<Tuple2<Optional<List<JoinElement<T>>>, Optional<T>>, List<JoinElement<T>>> {
   private final String inputStageName;
 
   public OuterJoinFlattenFunction(String inputStageName) {
@@ -36,12 +38,11 @@ public class OuterJoinFlattenFunction implements
   }
 
   @Override
-  public List<JoinElement<Object>> call(Tuple2<Optional<List<JoinElement<Object>>>, Optional<Object>> in)
-    throws Exception {
+  public List<JoinElement<T>> call(Tuple2<Optional<List<JoinElement<T>>>, Optional<T>> in) throws Exception {
 
-    List<JoinElement<Object>> output = in._1().isPresent() ? in._1().get() : new ArrayList<JoinElement<Object>>();
+    List<JoinElement<T>> output = in._1().isPresent() ? in._1().get() : new ArrayList<JoinElement<T>>();
     if (in._2().isPresent()) {
-      JoinElement<Object> additionalElement = new JoinElement<>(inputStageName, in._2().get());
+      JoinElement<T> additionalElement = new JoinElement<>(inputStageName, in._2().get());
       output.add(additionalElement);
     }
     return output;

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/DStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/DStreamCollection.java
@@ -18,31 +18,30 @@ package co.cask.cdap.etl.spark.streaming;
 
 import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.data.DatasetContext;
-import co.cask.cdap.api.macro.MacroEvaluator;
 import co.cask.cdap.api.spark.JavaSparkExecutionContext;
-import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.SparkCompute;
 import co.cask.cdap.etl.api.batch.SparkExecutionPluginContext;
 import co.cask.cdap.etl.api.batch.SparkSink;
 import co.cask.cdap.etl.api.streaming.Windower;
-import co.cask.cdap.etl.common.DefaultMacroEvaluator;
+import co.cask.cdap.etl.planner.StageInfo;
 import co.cask.cdap.etl.spark.SparkCollection;
 import co.cask.cdap.etl.spark.SparkPairCollection;
 import co.cask.cdap.etl.spark.batch.BasicSparkExecutionPluginContext;
-import co.cask.cdap.etl.spark.batch.SparkBatchSinkContext;
-import co.cask.cdap.etl.spark.batch.SparkBatchSinkFactory;
-import co.cask.cdap.etl.spark.function.CountingFunction;
-import org.apache.spark.api.java.JavaRDD;
+import co.cask.cdap.etl.spark.streaming.function.ComputeTransformFunction;
+import co.cask.cdap.etl.spark.streaming.function.CountingTranformFunction;
+import co.cask.cdap.etl.spark.streaming.function.DynamicAggregatorAggregate;
+import co.cask.cdap.etl.spark.streaming.function.DynamicAggregatorGroupBy;
+import co.cask.cdap.etl.spark.streaming.function.DynamicSparkCompute;
+import co.cask.cdap.etl.spark.streaming.function.DynamicTransform;
+import co.cask.cdap.etl.spark.streaming.function.StreamingBatchSinkFunction;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
-import org.apache.spark.api.java.function.Function;
-import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
 import org.apache.spark.streaming.Durations;
-import org.apache.spark.streaming.Time;
 import org.apache.spark.streaming.api.java.JavaDStream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.spark.streaming.api.java.JavaPairDStream;
+
+import javax.annotation.Nullable;
 
 /**
  * JavaDStream backed {@link co.cask.cdap.etl.spark.SparkCollection}
@@ -50,14 +49,12 @@ import org.slf4j.LoggerFactory;
  * @param <T> type of objects in the collection
  */
 public class DStreamCollection<T> implements SparkCollection<T> {
-  private static final Logger LOG = LoggerFactory.getLogger(DStreamCollection.class);
+
   private final JavaSparkExecutionContext sec;
-  private final JavaSparkContext sparkContext;
   private final JavaDStream<T> stream;
 
-  public DStreamCollection(JavaSparkExecutionContext sec, JavaSparkContext sparkContext, JavaDStream<T> stream) {
+  public DStreamCollection(JavaSparkExecutionContext sec, JavaDStream<T> stream) {
     this.sec = sec;
-    this.sparkContext = sparkContext;
     this.stream = stream;
   }
 
@@ -79,122 +76,64 @@ public class DStreamCollection<T> implements SparkCollection<T> {
   }
 
   @Override
-  public <U> SparkCollection<U> flatMap(FlatMapFunction<T, U> function) {
-    return wrap(stream.flatMap(function));
+  public <U> SparkCollection<U> flatMap(StageInfo stageInfo, FlatMapFunction<T, U> function) {
+    return wrap(stream.transform(new DynamicTransform<T, U>(new DynamicDriverContext(stageInfo, sec))));
   }
 
   @Override
   public <K, V> SparkPairCollection<K, V> flatMapToPair(PairFlatMapFunction<T, K, V> function) {
-    return new PairDStreamCollection<>(sec, sparkContext, stream.flatMapToPair(function));
+    return new PairDStreamCollection<>(sec, stream.flatMapToPair(function));
   }
 
   @Override
-  public <U> SparkCollection<U> compute(final String stageName, final SparkCompute<T, U> compute) throws Exception {
+  public <U> SparkCollection<U> aggregate(StageInfo stageInfo, @Nullable Integer partitions) {
+    DynamicDriverContext dynamicDriverContext = new DynamicDriverContext(stageInfo, sec);
+    JavaPairDStream<Object, T> keyedCollection =
+      stream.transformToPair(new DynamicAggregatorGroupBy<Object, T>(dynamicDriverContext));
+
+    JavaPairDStream<Object, Iterable<T>> groupedCollection = partitions == null ?
+      keyedCollection.groupByKey() : keyedCollection.groupByKey(partitions);
+
+    return wrap(groupedCollection.transform(new DynamicAggregatorAggregate<Object, T, U>(dynamicDriverContext)));
+  }
+
+  @Override
+  public <U> SparkCollection<U> compute(StageInfo stageInfo, SparkCompute<T, U> compute) throws Exception {
+    final String stageName = stageInfo.getName();
+    final SparkCompute<T, U> wrappedCompute =
+      new DynamicSparkCompute<>(new DynamicDriverContext(stageInfo, sec), compute);
     sec.execute(new TxRunnable() {
       @Override
       public void run(DatasetContext datasetContext) throws Exception {
         SparkExecutionPluginContext sparkPluginContext =
-          new BasicSparkExecutionPluginContext(sec, sparkContext, datasetContext, stageName);
-        compute.initialize(sparkPluginContext);
+          new BasicSparkExecutionPluginContext(sec, JavaSparkContext.fromSparkContext(stream.context().sparkContext()),
+                                               datasetContext, stageName);
+        wrappedCompute.initialize(sparkPluginContext);
       }
     });
-    return wrap(stream.transform(new Function2<JavaRDD<T>, Time, JavaRDD<U>>() {
-                  @Override
-                  public JavaRDD<U> call(JavaRDD<T> data, Time batchTime) throws Exception {
-                    SparkExecutionPluginContext sparkPluginContext =
-                      new SparkStreamingExecutionContext(sec, sparkContext, stageName, batchTime.milliseconds());
-
-                    data = data.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in"));
-                    return compute.transform(sparkPluginContext, data)
-                      .map(new CountingFunction<U>(stageName, sec.getMetrics(), "records.out"));
-                  }
-                }));
+    return wrap(stream.transform(new ComputeTransformFunction<>(sec, stageName, wrappedCompute)));
   }
 
   @Override
-  public void store(final String stageName, final PairFlatMapFunction<T, Object, Object> sinkFunction) {
-    // note: not using foreachRDD(VoidFunction2) method, because spark 1.3 doesn't have VoidFunction2
-    stream.foreachRDD(new Function2<JavaRDD<T>, Time, Void>() {
-      @Override
-      public Void call(JavaRDD<T> data, Time batchTime) throws Exception {
-        final long logicalStartTime = batchTime.milliseconds();
-        MacroEvaluator evaluator = new DefaultMacroEvaluator(sec.getWorkflowToken(),
-                                                             sec.getRuntimeArguments(),
-                                                             logicalStartTime,
-                                                             sec.getSecureStore(),
-                                                             sec.getNamespace());
-        final SparkBatchSinkFactory sinkFactory = new SparkBatchSinkFactory();
-        final BatchSink<Object, Object, Object> batchSink =
-          sec.getPluginContext().newPluginInstance(stageName, evaluator);
-        boolean isPrepared = false;
-        boolean isDone = false;
-
-        try {
-          sec.execute(new TxRunnable() {
-            @Override
-            public void run(DatasetContext datasetContext) throws Exception {
-              SparkBatchSinkContext sinkContext =
-                new SparkBatchSinkContext(sinkFactory, sec, datasetContext, stageName, logicalStartTime);
-              batchSink.prepareRun(sinkContext);
-            }
-          });
-          isPrepared = true;
-
-          data = data.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in"));
-          sinkFactory.writeFromRDD(data.flatMapToPair(sinkFunction), sec, stageName, Object.class, Object.class);
-          isDone = true;
-          sec.execute(new TxRunnable() {
-            @Override
-            public void run(DatasetContext datasetContext) throws Exception {
-              SparkBatchSinkContext sinkContext =
-                new SparkBatchSinkContext(sinkFactory, sec, datasetContext, stageName, logicalStartTime);
-              batchSink.onRunFinish(true, sinkContext);
-            }
-          });
-        } catch (Exception e) {
-          LOG.error("Error writing to sink {} for the batch for time {}.", stageName, logicalStartTime, e);
-        } finally {
-          if (isPrepared && !isDone) {
-            sec.execute(new TxRunnable() {
-              @Override
-              public void run(DatasetContext datasetContext) throws Exception {
-                SparkBatchSinkContext sinkContext =
-                  new SparkBatchSinkContext(sinkFactory, sec, datasetContext, stageName, logicalStartTime);
-                batchSink.onRunFinish(false, sinkContext);
-              }
-            });
-          }
-        }
-        return null;
-      }
-    });
+  public void store(StageInfo stageInfo, PairFlatMapFunction<T, Object, Object> sinkFunction) {
+    stream.foreachRDD(new StreamingBatchSinkFunction<>(sinkFunction, sec, stageInfo.getName()));
   }
 
   @Override
-  public void store(String stageName, SparkSink<T> sink) throws Exception {
+  public void store(StageInfo stageInfo, SparkSink<T> sink) throws Exception {
     // should never be called.
     throw new UnsupportedOperationException("Spark sink not supported in Spark Streaming.");
   }
 
   @Override
-  public SparkCollection<T> window(final String stageName, Windower windower) {
-    return wrap(stream
-                  .transform(new Function<JavaRDD<T>, JavaRDD<T>>() {
-                    @Override
-                    public JavaRDD<T> call(JavaRDD<T> in) throws Exception {
-                      return in.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in"));
-                    }
-                  })
+  public SparkCollection<T> window(StageInfo stageInfo, Windower windower) {
+    String stageName = stageInfo.getName();
+    return wrap(stream.transform(new CountingTranformFunction<T>(stageName, sec.getMetrics(), "records.in"))
                   .window(Durations.seconds(windower.getWidth()), Durations.seconds(windower.getSlideInterval()))
-                  .transform(new Function<JavaRDD<T>, JavaRDD<T>>() {
-                    @Override
-                    public JavaRDD<T> call(JavaRDD<T> in) throws Exception {
-                      return in.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.out"));
-                    }
-                  }));
+                  .transform(new CountingTranformFunction<T>(stageName, sec.getMetrics(), "records.out")));
   }
 
   private <U> SparkCollection<U> wrap(JavaDStream<U> stream) {
-    return new DStreamCollection<>(sec, sparkContext, stream);
+    return new DStreamCollection<>(sec, stream);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/DynamicDriverContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/DynamicDriverContext.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark.streaming;
+
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.spark.JavaSparkExecutionContext;
+import co.cask.cdap.etl.planner.StageInfo;
+import co.cask.cdap.etl.spark.function.PluginFunctionContext;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Map;
+
+/**
+ * Serializable context that can be used to dynamically instantiate plugins from a driver context.
+ * Used for Spark Streaming programs that use checkpoints. Basically just a wrapper around
+ * the {@link PluginFunctionContext}, which is used in Spark executor closures. The reason we need this on top of
+ * the {@link PluginFunctionContext} is because {@link JavaSparkExecutionContext} can only be used in Spark driver
+ * closures and not in spark executor closurers, and we need {@link JavaSparkExecutionContext} to make sure
+ * runtime arguments and logical start time are fetched correctly.
+ */
+public class DynamicDriverContext implements Externalizable {
+  private String serializationVersion;
+  private String stageName;
+  private Map<String, Schema> inputSchemas;
+  private Schema outputSchema;
+  private JavaSparkExecutionContext sec;
+  private PluginFunctionContext pluginFunctionContext;
+
+  public DynamicDriverContext() {
+    // for deserialization
+  }
+
+  public DynamicDriverContext(StageInfo stageInfo, JavaSparkExecutionContext sec) {
+    this(stageInfo.getName(), stageInfo.getInputSchemas(), stageInfo.getOutputSchema(), sec);
+  }
+
+  public DynamicDriverContext(String stageName, Map<String, Schema> inputSchemas,
+                              Schema outputSchema, JavaSparkExecutionContext sec) {
+    this.serializationVersion = "4.0";
+    this.stageName = stageName;
+    this.inputSchemas = inputSchemas;
+    this.outputSchema = outputSchema;
+    this.sec = sec;
+    this.pluginFunctionContext = new PluginFunctionContext(stageName, sec, inputSchemas, outputSchema);
+  }
+
+  @Override
+  public void writeExternal(ObjectOutput out) throws IOException {
+    out.writeUTF(serializationVersion);
+    out.writeUTF(stageName);
+    out.writeObject(inputSchemas);
+    out.writeObject(outputSchema);
+    out.writeObject(sec);
+  }
+
+  @Override
+  public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+    serializationVersion = in.readUTF();
+    stageName = in.readUTF();
+    inputSchemas = (Map<String, Schema>) in.readObject();
+    outputSchema = (Schema) in.readObject();
+    sec = (JavaSparkExecutionContext) in.readObject();
+
+    // we intentionally do not serialize this context in order to ensure that the runtime arguments
+    // and logical start time are picked up from the JavaSparkExecutionContext. If we serialized it,
+    // the arguments and start time of the very first pipeline run would get serialized, then
+    // used for every subsequent run that loads from the checkpoint.
+    pluginFunctionContext = new PluginFunctionContext(stageName, sec, inputSchemas, outputSchema);
+  }
+
+  public JavaSparkExecutionContext getSparkExecutionContext() {
+    return sec;
+  }
+
+  public PluginFunctionContext getPluginFunctionContext() {
+    return pluginFunctionContext;
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/PairDStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/PairDStreamCollection.java
@@ -20,7 +20,6 @@ import co.cask.cdap.api.spark.JavaSparkExecutionContext;
 import co.cask.cdap.etl.spark.SparkCollection;
 import co.cask.cdap.etl.spark.SparkPairCollection;
 import com.google.common.base.Optional;
-import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.streaming.api.java.JavaPairDStream;
@@ -34,13 +33,10 @@ import scala.Tuple2;
  */
 public class PairDStreamCollection<K, V> implements SparkPairCollection<K, V> {
   private final JavaSparkExecutionContext sec;
-  private final JavaSparkContext sparkContext;
   private final JavaPairDStream<K, V> pairStream;
 
-  public PairDStreamCollection(JavaSparkExecutionContext sec, JavaSparkContext sparkContext,
-                               JavaPairDStream<K, V> pairStream) {
+  public PairDStreamCollection(JavaSparkExecutionContext sec, JavaPairDStream<K, V> pairStream) {
     this.sec = sec;
-    this.sparkContext = sparkContext;
     this.pairStream = pairStream;
   }
 
@@ -52,22 +48,12 @@ public class PairDStreamCollection<K, V> implements SparkPairCollection<K, V> {
 
   @Override
   public <T> SparkCollection<T> flatMap(FlatMapFunction<Tuple2<K, V>, T> function) {
-    return new DStreamCollection<>(sec, sparkContext, pairStream.flatMap(function));
+    return new DStreamCollection<>(sec, pairStream.flatMap(function));
   }
 
   @Override
   public <T> SparkPairCollection<K, T> mapValues(Function<V, T> function) {
     return wrap(pairStream.mapValues(function));
-  }
-
-  @Override
-  public SparkPairCollection<K, Iterable<V>> groupByKey() {
-    return wrap(pairStream.groupByKey());
-  }
-
-  @Override
-  public SparkPairCollection<K, Iterable<V>> groupByKey(int numPartitions) {
-    return wrap(pairStream.groupByKey(numPartitions));
   }
 
   @SuppressWarnings("unchecked")
@@ -109,6 +95,6 @@ public class PairDStreamCollection<K, V> implements SparkPairCollection<K, V> {
   }
 
   private <T, U> PairDStreamCollection<T, U> wrap(JavaPairDStream<T, U> pairStream) {
-    return new PairDStreamCollection<>(sec, sparkContext, pairStream);
+    return new PairDStreamCollection<>(sec, pairStream);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/ComputeTransformFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/ComputeTransformFunction.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark.streaming.function;
+
+import co.cask.cdap.api.spark.JavaSparkExecutionContext;
+import co.cask.cdap.etl.api.batch.SparkCompute;
+import co.cask.cdap.etl.api.batch.SparkExecutionPluginContext;
+import co.cask.cdap.etl.spark.function.CountingFunction;
+import co.cask.cdap.etl.spark.streaming.SparkStreamingExecutionContext;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.streaming.Time;
+
+/**
+ * Function used to implement a SparkCompute stage in a DStream.
+ *
+ * @param <T> type of object in the input rdd
+ * @param <U> type of object in the output rdd
+ */
+public class ComputeTransformFunction<T, U> implements Function2<JavaRDD<T>, Time, JavaRDD<U>> {
+  private final JavaSparkExecutionContext sec;
+  private final String stageName;
+  private final SparkCompute<T, U> compute;
+
+  public ComputeTransformFunction(JavaSparkExecutionContext sec, String stageName,
+                                  SparkCompute<T, U> compute) {
+    this.sec = sec;
+    this.stageName = stageName;
+    this.compute = compute;
+  }
+
+  @Override
+  public JavaRDD<U> call(JavaRDD<T> data, Time batchTime) throws Exception {
+    SparkExecutionPluginContext sparkPluginContext =
+      new SparkStreamingExecutionContext(sec, JavaSparkContext.fromSparkContext(data.context()),
+                                         stageName, batchTime.milliseconds());
+
+    data = data.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in"));
+    return compute.transform(sparkPluginContext, data)
+      .map(new CountingFunction<U>(stageName, sec.getMetrics(), "records.out"));
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/CountingTranformFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/CountingTranformFunction.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark.streaming.function;
+
+import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.etl.spark.function.CountingFunction;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.Function;
+
+/**
+ * Function used to emit a metric for every item in an RDD.
+ *
+ * @param <T> type of object in the rdd.
+ */
+public class CountingTranformFunction<T> implements Function<JavaRDD<T>, JavaRDD<T>> {
+  private final Metrics metrics;
+  private final String stageName;
+  private final String metricName;
+
+  public CountingTranformFunction(String stageName, Metrics metrics, String metricName) {
+    this.metrics = metrics;
+    this.stageName = stageName;
+    this.metricName = metricName;
+  }
+
+  @Override
+  public JavaRDD<T> call(JavaRDD<T> in) throws Exception {
+    return in.map(new CountingFunction<T>(stageName, metrics, metricName));
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/DynamicAggregatorAggregate.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/DynamicAggregatorAggregate.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark.streaming.function;
+
+import co.cask.cdap.etl.spark.function.AggregatorAggregateFunction;
+import co.cask.cdap.etl.spark.streaming.DynamicDriverContext;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.streaming.Time;
+
+/**
+ * Serializable function that can be used to perform the aggregate part of an Aggregator. Dynamically instantiates
+ * the Aggregator plugin used to ensure that code changes are picked up and to ensure that macro substitution occurs.
+ *
+ * @param <GROUP_KEY> type of group key
+ * @param <GROUP_VAL> type of group val
+ * @param <OUT> type of output object
+ */
+public class DynamicAggregatorAggregate<GROUP_KEY, GROUP_VAL, OUT>
+  implements Function2<JavaPairRDD<GROUP_KEY, Iterable<GROUP_VAL>>, Time, JavaRDD<OUT>> {
+  private final DynamicDriverContext dynamicDriverContext;
+  private transient AggregatorAggregateFunction<GROUP_KEY, GROUP_VAL, OUT> function;
+
+  public DynamicAggregatorAggregate(DynamicDriverContext dynamicDriverContext) {
+    this.dynamicDriverContext = dynamicDriverContext;
+  }
+
+  @Override
+  public JavaRDD<OUT> call(JavaPairRDD<GROUP_KEY, Iterable<GROUP_VAL>> input, Time batchTime) throws Exception {
+    if (function == null) {
+      function = new AggregatorAggregateFunction<>(dynamicDriverContext.getPluginFunctionContext());
+    }
+    return input.flatMap(function);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/DynamicAggregatorGroupBy.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/DynamicAggregatorGroupBy.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark.streaming.function;
+
+import co.cask.cdap.etl.spark.function.AggregatorGroupByFunction;
+import co.cask.cdap.etl.spark.streaming.DynamicDriverContext;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.streaming.Time;
+
+/**
+ * Serializable function that can be used to perform the group by part of an Aggregator. Dynamically instantiates
+ * the Aggregator plugin used to ensure that code changes are picked up and to ensure that macro substitution occurs.
+ *
+ * @param <GROUP_KEY> type of group key
+ * @param <GROUP_VAL> type of group val
+ */
+public class DynamicAggregatorGroupBy<GROUP_KEY, GROUP_VAL>
+  implements Function2<JavaRDD<GROUP_VAL>, Time, JavaPairRDD<GROUP_KEY, GROUP_VAL>> {
+  private final DynamicDriverContext dynamicDriverContext;
+  private transient AggregatorGroupByFunction<GROUP_KEY, GROUP_VAL> aggregatorGroupByFunction;
+
+  public DynamicAggregatorGroupBy(DynamicDriverContext dynamicDriverContext) {
+    this.dynamicDriverContext = dynamicDriverContext;
+  }
+
+  @Override
+  public JavaPairRDD<GROUP_KEY, GROUP_VAL> call(JavaRDD<GROUP_VAL> input, Time batchTime) throws Exception {
+    if (aggregatorGroupByFunction == null) {
+      aggregatorGroupByFunction = new AggregatorGroupByFunction<>(dynamicDriverContext.getPluginFunctionContext());
+    }
+    return input.flatMapToPair(aggregatorGroupByFunction);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/DynamicJoinMerge.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/DynamicJoinMerge.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark.streaming.function;
+
+import co.cask.cdap.etl.api.JoinElement;
+import co.cask.cdap.etl.spark.function.JoinMergeFunction;
+import co.cask.cdap.etl.spark.streaming.DynamicDriverContext;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.streaming.Time;
+
+import java.util.List;
+
+/**
+ * Serializable function that can be used to perform the merge part of a Joiner. Dynamically instantiates
+ * the relevant Joiner plugin to ensure that code changes are picked up and to ensure
+ * that macro substitution occurs.
+ *
+ * @param <JOIN_KEY> type of join key
+ * @param <INPUT_RECORD> type of input object
+ * @param <OUT> type of output object
+ */
+public class DynamicJoinMerge<JOIN_KEY, INPUT_RECORD, OUT>
+  implements Function2<JavaPairRDD<JOIN_KEY, List<JoinElement<INPUT_RECORD>>>, Time, JavaRDD<OUT>> {
+  private final DynamicDriverContext dynamicDriverContext;
+  private transient JoinMergeFunction<JOIN_KEY, INPUT_RECORD, OUT> function;
+
+  public DynamicJoinMerge(DynamicDriverContext dynamicDriverContext) {
+    this.dynamicDriverContext = dynamicDriverContext;
+  }
+  
+  @Override
+  public JavaRDD<OUT> call(JavaPairRDD<JOIN_KEY, List<JoinElement<INPUT_RECORD>>> input,
+                           Time batchTime) throws Exception {
+    if (function == null) {
+      function = new JoinMergeFunction<>(dynamicDriverContext.getPluginFunctionContext());
+    }
+    return input.flatMap(function);
+  }
+
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/DynamicJoinOn.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/DynamicJoinOn.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark.streaming.function;
+
+import co.cask.cdap.etl.spark.function.JoinOnFunction;
+import co.cask.cdap.etl.spark.streaming.DynamicDriverContext;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.streaming.Time;
+
+/**
+ * Serializable function that can be used to perform the joinOn part of a Joiner. Dynamically instantiates
+ * the relevant Joiner plugin to ensure that code changes are picked up and to ensure
+ * that macro substitution occurs.
+ *
+ * @param <JOIN_KEY> type of join key
+ * @param <T> type of input object
+ */
+public class DynamicJoinOn<JOIN_KEY, T> implements Function2<JavaRDD<T>, Time, JavaPairRDD<JOIN_KEY, T>> {
+  private final DynamicDriverContext dynamicDriverContext;
+  private final String inputStageName;
+  private transient JoinOnFunction<JOIN_KEY, T> function;
+
+  public DynamicJoinOn(DynamicDriverContext dynamicDriverContext, String inputStageName) {
+    this.dynamicDriverContext = dynamicDriverContext;
+    this.inputStageName = inputStageName;
+  }
+
+  @Override
+  public JavaPairRDD<JOIN_KEY, T> call(JavaRDD<T> input, Time batchTime) throws Exception {
+    if (function == null) {
+      function = new JoinOnFunction<>(dynamicDriverContext.getPluginFunctionContext(), inputStageName);
+    }
+    return input.flatMapToPair(function);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/DynamicSparkCompute.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/DynamicSparkCompute.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark.streaming.function;
+
+import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.spark.JavaSparkExecutionContext;
+import co.cask.cdap.etl.api.batch.SparkCompute;
+import co.cask.cdap.etl.api.batch.SparkExecutionPluginContext;
+import co.cask.cdap.etl.spark.batch.BasicSparkExecutionPluginContext;
+import co.cask.cdap.etl.spark.function.PluginFunctionContext;
+import co.cask.cdap.etl.spark.streaming.DynamicDriverContext;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+
+/**
+ * This class is required to make sure that macro substitution occurs each time a pipeline is run instead of just
+ * the first time the pipeline is run. Without this, the SparkCompute plugin gets serialized into the checkpoint and
+ * re-loaded every subsequent time with the properties from the first run.
+ *
+ * @param <T> type of object in the input collection
+ * @param <U> type of object in the output collection
+ */
+public class DynamicSparkCompute<T, U> extends SparkCompute<T, U> {
+  private final DynamicDriverContext dynamicDriverContext;
+  private transient SparkCompute<T, U> delegate;
+
+  public DynamicSparkCompute(DynamicDriverContext dynamicDriverContext, SparkCompute<T, U> compute) {
+    this.dynamicDriverContext = dynamicDriverContext;
+    this.delegate = compute;
+  }
+
+  @Override
+  public void initialize(SparkExecutionPluginContext context) throws Exception {
+    delegate.initialize(context);
+  }
+
+  @Override
+  public JavaRDD<U> transform(SparkExecutionPluginContext context, JavaRDD<T> input) throws Exception {
+    lazyInit(JavaSparkContext.fromSparkContext(input.context()));
+    return delegate.transform(context, input);
+  }
+
+  // when checkpointing is enabled, and Spark is loading DStream operations from an existing checkpoint,
+  // delegate will be null and the initialize() method won't have been called. So we need to instantiate
+  // the delegate and initialize it.
+  private void lazyInit(final JavaSparkContext jsc) throws Exception {
+    if (delegate == null) {
+      PluginFunctionContext pluginFunctionContext = dynamicDriverContext.getPluginFunctionContext();
+      delegate = pluginFunctionContext.createPlugin();
+      final String stageName = pluginFunctionContext.getStageName();
+      final JavaSparkExecutionContext sec = dynamicDriverContext.getSparkExecutionContext();
+      sec.execute(new TxRunnable() {
+        @Override
+        public void run(DatasetContext datasetContext) throws Exception {
+          SparkExecutionPluginContext sparkPluginContext =
+            new BasicSparkExecutionPluginContext(sec, jsc, datasetContext, stageName);
+          delegate.initialize(sparkPluginContext);
+        }
+      });
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/DynamicTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/DynamicTransform.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark.streaming.function;
+
+import co.cask.cdap.etl.spark.function.TransformFunction;
+import co.cask.cdap.etl.spark.streaming.DynamicDriverContext;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.streaming.Time;
+
+/**
+ * Serializable function that can be used to perform a flat map on a DStream. Dynamically instantiates
+ * the Transform plugin used to perform the flat map to ensure that code changes are picked up and to ensure
+ * that macro substitution occurs.
+ *
+ * @param <T> type of input object
+ * @param <U> type of output object
+ */
+public class DynamicTransform<T, U> implements Function2<JavaRDD<T>, Time, JavaRDD<U>> {
+  private final DynamicDriverContext dynamicDriverContext;
+  private transient TransformFunction<T, U> transformFunction;
+
+  public DynamicTransform(DynamicDriverContext dynamicDriverContext) {
+    this.dynamicDriverContext = dynamicDriverContext;
+  }
+
+  @Override
+  public JavaRDD<U> call(JavaRDD<T> input, Time batchTime) throws Exception {
+    if (transformFunction == null) {
+      transformFunction = new TransformFunction<>(dynamicDriverContext.getPluginFunctionContext());
+    }
+    return input.flatMap(transformFunction);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/StreamingBatchSinkFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/StreamingBatchSinkFunction.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark.streaming.function;
+
+import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.macro.MacroEvaluator;
+import co.cask.cdap.api.spark.JavaSparkExecutionContext;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.cdap.etl.common.DefaultMacroEvaluator;
+import co.cask.cdap.etl.spark.batch.SparkBatchSinkContext;
+import co.cask.cdap.etl.spark.batch.SparkBatchSinkFactory;
+import co.cask.cdap.etl.spark.function.CountingFunction;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.api.java.function.PairFlatMapFunction;
+import org.apache.spark.streaming.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Function used to write a batch of data to a batch sink for use with a JavaDStream.
+ * note: not using foreachRDD(VoidFunction2) method, because spark 1.3 doesn't have VoidFunction2.
+ *
+ * @param <T> type of object in the rdd
+ */
+public class StreamingBatchSinkFunction<T> implements Function2<JavaRDD<T>, Time, Void> {
+  private static final Logger LOG = LoggerFactory.getLogger(StreamingBatchSinkFunction.class);
+  private final PairFlatMapFunction<T, Object, Object> sinkFunction;
+  private final JavaSparkExecutionContext sec;
+  private final String stageName;
+
+  public StreamingBatchSinkFunction(PairFlatMapFunction<T, Object, Object> sinkFunction,
+                                    JavaSparkExecutionContext sec, String stageName) {
+    this.sinkFunction = sinkFunction;
+    this.sec = sec;
+    this.stageName = stageName;
+  }
+
+  @Override
+  public Void call(JavaRDD<T> data, Time batchTime) throws Exception {
+    final long logicalStartTime = batchTime.milliseconds();
+    MacroEvaluator evaluator = new DefaultMacroEvaluator(sec.getWorkflowToken(),
+                                                         sec.getRuntimeArguments(),
+                                                         logicalStartTime,
+                                                         sec.getSecureStore(),
+                                                         sec.getNamespace());
+    final SparkBatchSinkFactory sinkFactory = new SparkBatchSinkFactory();
+    final BatchSink<Object, Object, Object> batchSink =
+      sec.getPluginContext().newPluginInstance(stageName, evaluator);
+    boolean isPrepared = false;
+    boolean isDone = false;
+
+    try {
+      sec.execute(new TxRunnable() {
+        @Override
+        public void run(DatasetContext datasetContext) throws Exception {
+          SparkBatchSinkContext sinkContext =
+            new SparkBatchSinkContext(sinkFactory, sec, datasetContext, stageName, logicalStartTime);
+          batchSink.prepareRun(sinkContext);
+        }
+      });
+      isPrepared = true;
+
+      data = data.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in"));
+      sinkFactory.writeFromRDD(data.flatMapToPair(sinkFunction), sec, stageName, Object.class, Object.class);
+      isDone = true;
+      sec.execute(new TxRunnable() {
+        @Override
+        public void run(DatasetContext datasetContext) throws Exception {
+          SparkBatchSinkContext sinkContext =
+            new SparkBatchSinkContext(sinkFactory, sec, datasetContext, stageName, logicalStartTime);
+          batchSink.onRunFinish(true, sinkContext);
+        }
+      });
+    } catch (Exception e) {
+      LOG.error("Error writing to sink {} for the batch for time {}.", stageName, logicalStartTime, e);
+    } finally {
+      if (isPrepared && !isDone) {
+        sec.execute(new TxRunnable() {
+          @Override
+          public void run(DatasetContext datasetContext) throws Exception {
+            SparkBatchSinkContext sinkContext =
+              new SparkBatchSinkContext(sinkFactory, sec, datasetContext, stageName, logicalStartTime);
+            batchSink.onRunFinish(false, sinkContext);
+          }
+        });
+      }
+    }
+    return null;
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/aggregator/FieldCountAggregator.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/aggregator/FieldCountAggregator.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.etl.mock.batch.aggregator;
 
+import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
@@ -54,7 +55,9 @@ public class FieldCountAggregator extends BatchAggregator<Object, StructuredReco
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
     StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
-    stageConfigurer.setOutputSchema(config.getSchema());
+    if (!config.containsMacro("fieldType") && !config.containsMacro("fieldName")) {
+      stageConfigurer.setOutputSchema(config.getSchema());
+    }
   }
 
   @Override
@@ -100,8 +103,10 @@ public class FieldCountAggregator extends BatchAggregator<Object, StructuredReco
    * Conf for the aggregator.
    */
   public static class Config extends PluginConfig {
+    @Macro
     private final String fieldName;
 
+    @Macro
     private final String fieldType;
 
     public Config() {
@@ -135,8 +140,8 @@ public class FieldCountAggregator extends BatchAggregator<Object, StructuredReco
 
   private static PluginClass getPluginClass() {
     Map<String, PluginPropertyField> properties = new HashMap<>();
-    properties.put("fieldName", new PluginPropertyField("fieldName", "", "string", true, false));
-    properties.put("fieldType", new PluginPropertyField("fieldType", "", "string", true, false));
+    properties.put("fieldName", new PluginPropertyField("fieldName", "", "string", true, true));
+    properties.put("fieldType", new PluginPropertyField("fieldType", "", "string", true, true));
     return new PluginClass(BatchAggregator.PLUGIN_TYPE, "FieldCount", "", FieldCountAggregator.class.getName(),
                            "config", properties);
   }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/joiner/DupeFlagger.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/joiner/DupeFlagger.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.batch.joiner;
+
+import co.cask.cdap.api.annotation.Description;
+import co.cask.cdap.api.annotation.Macro;
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginPropertyField;
+import co.cask.cdap.etl.api.JoinConfig;
+import co.cask.cdap.etl.api.JoinElement;
+import co.cask.cdap.etl.api.MultiInputPipelineConfigurer;
+import co.cask.cdap.etl.api.MultiInputStageConfigurer;
+import co.cask.cdap.etl.api.batch.BatchJoiner;
+import co.cask.cdap.etl.proto.v2.ETLPlugin;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Plugin that takes exactly 2 inputs and flags records in one input if they also appear in the other.
+ */
+@Plugin(type = BatchJoiner.PLUGIN_TYPE)
+@Name(DupeFlagger.NAME)
+public class DupeFlagger extends BatchJoiner<StructuredRecord, StructuredRecord, StructuredRecord> {
+  public static final String NAME = "DupeFlagger";
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
+  private final Config config;
+
+  public DupeFlagger(Config config) {
+    this.config = config;
+  }
+
+  @Override
+  public void configurePipeline(MultiInputPipelineConfigurer pipelineConfigurer) {
+    MultiInputStageConfigurer stageConfigurer = pipelineConfigurer.getMultiInputStageConfigurer();
+    Map<String, Schema> inputSchemas = stageConfigurer.getInputSchemas();
+    if (inputSchemas.size() != 2) {
+      throw new IllegalArgumentException(String.format(
+        "The DupeFlagger plugin must have exactly two inputs with the same schema, but found %d inputs.",
+        inputSchemas.size()));
+    }
+    Iterator<Schema> schemaIterator = inputSchemas.values().iterator();
+    Schema schema1 = schemaIterator.next();
+    Schema schema2 = schemaIterator.next();
+    if (!schema1.equals(schema2)) {
+      throw new IllegalArgumentException("The DupeFlagger plugin must have exactly two inputs with the same schema, " +
+                                           "but the schemas are not the same.");
+    }
+    if (!config.containsMacro("keep")) {
+      if (!inputSchemas.keySet().contains(config.keep)) {
+        throw new IllegalArgumentException(config.keep + " is not an input.");
+      }
+    }
+
+    if (!config.containsMacro("flagField")) {
+      stageConfigurer.setOutputSchema(getOutputSchema(schema1));
+    }
+  }
+
+  private Schema getOutputSchema(Schema inputSchema) {
+    List<Schema.Field> fields = new ArrayList<>();
+    fields.addAll(inputSchema.getFields());
+    fields.add(Schema.Field.of(config.flagField, Schema.of(Schema.Type.BOOLEAN)));
+    return Schema.recordOf(inputSchema.getRecordName() + ".flagged", fields);
+  }
+
+  @Override
+  public StructuredRecord joinOn(String stageName, StructuredRecord record) throws Exception {
+    return record;
+  }
+
+  @Override
+  public JoinConfig getJoinConfig() {
+    return new JoinConfig(Collections.singletonList(config.keep));
+  }
+
+  @Override
+  public StructuredRecord merge(StructuredRecord joinKey, Iterable<JoinElement<StructuredRecord>> joinRow) {
+    StructuredRecord record = null;
+    boolean containsDupe = false;
+    for (JoinElement<StructuredRecord> element : joinRow) {
+      if (element.getStageName().equals(config.keep)) {
+        record = element.getInputRecord();
+      } else {
+        containsDupe = true;
+      }
+    }
+    if (record == null) {
+      // can only happen if 'keep' was a macro and did not evaluate to one of the inputs
+      throw new IllegalArgumentException("No record for " + config.keep + " was found.");
+    }
+
+    Schema outputSchema = getOutputSchema(record.getSchema());
+    StructuredRecord.Builder outputBuilder = StructuredRecord.builder(outputSchema)
+      .set(config.flagField, containsDupe);
+    for (Schema.Field field : record.getSchema().getFields()) {
+      outputBuilder.set(field.getName(), record.get(field.getName()));
+    }
+    return outputBuilder.build();
+  }
+
+  /**
+   * Config for except plugin
+   */
+  public static class Config extends PluginConfig {
+    @Macro
+    @Description("input to keep")
+    private final String keep;
+
+    @Macro
+    @Nullable
+    @Description("name of the flag field")
+    private final String flagField;
+
+    public Config() {
+      keep = null;
+      flagField = "isDupe";
+    }
+
+    public Config(String keep, String flagField) {
+      this.keep = keep;
+      this.flagField = flagField;
+    }
+  }
+
+  public static ETLPlugin getPlugin(String keep, String flagField) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("keep", keep);
+    properties.put("flagField", flagField);
+    return new ETLPlugin(DupeFlagger.NAME, BatchJoiner.PLUGIN_TYPE, properties, null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("keep", new PluginPropertyField("keep", "input to keep", "string", true, false));
+    properties.put("flagField", new PluginPropertyField("flagField", "name of the flag field", "string", false, true));
+    return new PluginClass(BatchJoiner.PLUGIN_TYPE, DupeFlagger.NAME, "", DupeFlagger.class.getName(),
+                           "config", properties);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/test/HydratorTestBase.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/test/HydratorTestBase.java
@@ -32,6 +32,7 @@ import co.cask.cdap.etl.mock.batch.MockRuntimeDatasetSource;
 import co.cask.cdap.etl.mock.batch.NodeStatesAction;
 import co.cask.cdap.etl.mock.batch.aggregator.FieldCountAggregator;
 import co.cask.cdap.etl.mock.batch.aggregator.IdentityAggregator;
+import co.cask.cdap.etl.mock.batch.joiner.DupeFlagger;
 import co.cask.cdap.etl.mock.batch.joiner.MockJoiner;
 import co.cask.cdap.etl.mock.realtime.LookupSource;
 import co.cask.cdap.etl.mock.realtime.MockSink;
@@ -66,7 +67,8 @@ public class HydratorTestBase extends TestBase {
     IntValueFilterTransform.PLUGIN_CLASS, StringValueFilterTransform.PLUGIN_CLASS
   );
   private static final Set<PluginClass> BATCH_MOCK_PLUGINS = ImmutableSet.of(
-    FieldCountAggregator.PLUGIN_CLASS, IdentityAggregator.PLUGIN_CLASS, MockJoiner.PLUGIN_CLASS,
+    FieldCountAggregator.PLUGIN_CLASS, IdentityAggregator.PLUGIN_CLASS,
+    MockJoiner.PLUGIN_CLASS, DupeFlagger.PLUGIN_CLASS,
     co.cask.cdap.etl.mock.batch.MockSink.PLUGIN_CLASS, co.cask.cdap.etl.mock.batch.MockSource.PLUGIN_CLASS,
     MockRuntimeDatasetSink.PLUGIN_CLASS, MockRuntimeDatasetSource.PLUGIN_CLASS,
     MockExternalSource.PLUGIN_CLASS, MockExternalSink.PLUGIN_CLASS,
@@ -79,7 +81,8 @@ public class HydratorTestBase extends TestBase {
     co.cask.cdap.etl.mock.batch.MockSink.PLUGIN_CLASS,
     DoubleTransform.PLUGIN_CLASS, ErrorTransform.PLUGIN_CLASS, IdentityTransform.PLUGIN_CLASS,
     IntValueFilterTransform.PLUGIN_CLASS, StringValueFilterTransform.PLUGIN_CLASS,
-    FieldCountAggregator.PLUGIN_CLASS, IdentityAggregator.PLUGIN_CLASS, MockJoiner.PLUGIN_CLASS,
+    FieldCountAggregator.PLUGIN_CLASS, IdentityAggregator.PLUGIN_CLASS,
+    MockJoiner.PLUGIN_CLASS, DupeFlagger.PLUGIN_CLASS,
     StringValueFilterCompute.PLUGIN_CLASS, Window.PLUGIN_CLASS
   );
 

--- a/cdap-test/src/main/java/co/cask/cdap/test/DefaultMapReduceManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/DefaultMapReduceManager.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.test;
 
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramRunStatus;
 
 /**
  * A default implementation of {@link MapReduceManager}.
@@ -25,5 +26,11 @@ public class DefaultMapReduceManager extends AbstractProgramManager<MapReduceMan
 
   public DefaultMapReduceManager(Id.Program programId, ApplicationManager applicationManager) {
     super(programId, applicationManager);
+  }
+
+  @Override
+  public boolean isRunning() {
+    // workaround until CDAP-7479 is fixed
+    return super.isRunning() || !getHistory(ProgramRunStatus.RUNNING).isEmpty();
   }
 }

--- a/cdap-test/src/main/java/co/cask/cdap/test/DefaultSparkManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/DefaultSparkManager.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.test;
 
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramRunStatus;
 
 /**
  * A default implementation of {@link SparkManager}.
@@ -24,5 +25,11 @@ import co.cask.cdap.proto.Id;
 public class DefaultSparkManager extends AbstractProgramManager<SparkManager> implements SparkManager {
   public DefaultSparkManager(Id.Program programId, ApplicationManager applicationManager) {
     super(programId, applicationManager);
+  }
+
+  @Override
+  public boolean isRunning() {
+    // workaround until CDAP-7479 is fixed
+    return super.isRunning() || !getHistory(ProgramRunStatus.RUNNING).isEmpty();
   }
 }


### PR DESCRIPTION
This involves adding a FileSet that will be used to write
checkpoints for all pipelines. The change also requires some
refactoring since all driver functions now need to be
serializable, due to how Spark streaming checkpoints work.
As such, moving all the anonymous classes in the DStreamCollection
class into their own classes. Also had to tweak functions are
serialized/deserialized so that the plugin is instantiated and
initialized every time instead of just once in the driver. This
is so that macro evaluation will be run each time a pipeline is
run, instead of just the very first time the pipeline is run and
then serialized.
