### PR TITLE
[CDAP-7462] - Build HeaderActions & HeaderBrand as library

### DIFF
--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -370,33 +370,12 @@
                     </resource>
                     <!-- Copy cdap-ui -->
                     <resource>
-                      <directory>${project.parent.basedir}/cdap-ui/server</directory>
-                      <targetPath>ui/server</targetPath>
-                    </resource>
-                    <resource>
-                      <directory>${project.parent.basedir}/cdap-ui/dist</directory>
-                      <targetPath>ui/dist</targetPath>
-                    </resource>
-		    <resource>
-		      <directory>${project.parent.basedir}/cdap-ui/cdap_dist</directory>
-                      <targetPath>ui/cdap_dist</targetPath>
-		    </resource>
-                    <resource>
-                      <directory>${project.parent.basedir}/cdap-ui/node_modules</directory>
-                      <targetPath>ui/node_modules</targetPath>
-                    </resource>
-                    <resource>
-                      <directory>${project.parent.basedir}/cdap-ui/templates</directory>
-                      <targetPath>ui/templates</targetPath>
-                    </resource>
-                    <resource>
-                      <directory>${project.parent.basedir}/cdap-ui/</directory>
-                      <targetPath>ui/</targetPath>
-                      <includes>
-                        <include>server.js</include>
-                        <include>package.json</include>
-                      </includes>
-                    </resource>
+                     <directory>${project.parent.basedir}/cdap-ui/target/stage-packaging/opt/cdap/ui</directory>
+                     <targetPath>ui</targetPath>
+                     <excludes>
+                      <exclude>**LICENSE**</exclude>
+                     </excludes>
+                   </resource>
                     <!-- Copy examples. This assumes the examples are already built -->
                     <resource>
                       <directory>${project.parent.basedir}/cdap-examples</directory>

--- a/cdap-ui/.eslintignore
+++ b/cdap-ui/.eslintignore
@@ -1,4 +1,5 @@
 dist/
 cdap_dist/
+common_dist/
 node_modules/
 bower_components/

--- a/cdap-ui/.gitignore
+++ b/cdap-ui/.gitignore
@@ -8,7 +8,7 @@ dist/
 cdap_dist/
 login_dist/
 plusbutton_dist
-market_dist/
+common_dist/
 target/
 cdap-config.json
 cdap-security-config.json

--- a/cdap-ui/Gulpfile.js
+++ b/cdap-ui/Gulpfile.js
@@ -21,10 +21,7 @@ var gulp = require('gulp'),
     del = require('del'),
     mainBowerFiles = require('main-bower-files'),
     merge = require('merge-stream'),
-    autoprefixer = require('autoprefixer'),
-    plusbuttonwebpack = require('./webpack.config.plusbutton'),
-    gutil = require("gulp-util"),
-    webpack = require('webpack');
+    autoprefixer = require('autoprefixer');
 
 function getEs6Directives(isNegate) {
   var es6directives = [
@@ -342,8 +339,8 @@ gulp.task('tpl', function() {
     .pipe(plug.livereload());
 });
 
-gulp.task('js', ['js:lib', 'js:aceworkers', 'js:app', 'polyfill', 'webpack:plusbutton:build-dev']);
-gulp.task('watch:js', ['watch:js:app', 'watch:js:app:babel', 'polyfill', 'watch:webpack:plusbutton:build-dev']);
+gulp.task('js', ['js:lib', 'js:aceworkers', 'js:app', 'polyfill']);
+gulp.task('watch:js', ['watch:js:app', 'watch:js:app:babel', 'polyfill']);
 
 gulp.task('css', ['css:lib', 'css:app']);
 gulp.task('style', ['css']);
@@ -355,7 +352,7 @@ gulp.task('lint', function() {
     '!./app/cdap/**/*.js',
     '!./app/login/**/*.js',
     '!./app/lib/**/*.js',
-    '!./app/plusbutton/**/*.js',
+    '!./app/common/**/*.js',
     './server/*.js'
   ])
     .pipe(plug.plumber())
@@ -409,33 +406,6 @@ gulp.task('rev:replace', ['html:main', 'rev:manifest'], function() {
 gulp.task('watch:build', ['watch:js', 'css', 'img', 'tpl', 'html']);
 gulp.task('distribute', ['clean', 'build', 'rev:replace']);
 gulp.task('default', ['lint', 'build']);
-
-gulp.task('watch:webpack:plusbutton:build-dev', function(callback) {
-  // run webpack
-  var firstTime = false;
-  webpack(plusbuttonwebpack, function(err, stats) {
-    if(err) throw new gutil.PluginError("webpack:build-dev", err);
-    gutil.log("[webpack:build-dev]", stats.toString({
-      chunks: false,
-      colors: true
-    }));
-    if (!firstTime) {
-      firstTime = true;
-      callback();
-    }
-  });
-});
-
-gulp.task('webpack:plusbutton:build-dev', function(callback) {
-  webpack(plusbuttonwebpack, function(err, stats) {
-    if(err) throw new gutil.PluginError("webpack:build-dev", err);
-    gutil.log("[webpack:build-dev]", stats.toString({
-      chunks: false,
-      colors: true
-    }));
-    callback();
-  });
-});
 /*
   watch
  */
@@ -450,7 +420,7 @@ gulp.task('watch', ['jshint', 'build'], function() {
   ];
   jsAppSource = jsAppSource.concat(getEs6Directives(true));
 
-  gulp.watch(jsAppSource, ['jshint', 'watch:js:app', 'watch:webpack:plusbutton:build-dev']);
+  gulp.watch(jsAppSource, ['jshint', 'watch:js:app']);
 
   var jsAppBabelSource = [];
   jsAppBabelSource = jsAppBabelSource.concat(getEs6Directives(false));

--- a/cdap-ui/app/cdap/components/CdapHeader/index.js
+++ b/cdap-ui/app/cdap/components/CdapHeader/index.js
@@ -27,11 +27,13 @@ export default function CdapHeader() {
       title: T.translate('features.Navbar.CDAP.home')
     },
     {
-      linkTo: 'dashboard',
+      linkTo: '/dashboard',
+      disabled: true,
+      className: 'disabled',
       title: T.translate('features.Navbar.CDAP.dashboard')
     },
     {
-      linkTo: 'management',
+      linkTo: '/management',
       title: T.translate('features.Navbar.CDAP.management')
     }
   ];

--- a/cdap-ui/app/cdap/components/Header/index.js
+++ b/cdap-ui/app/cdap/components/Header/index.js
@@ -44,9 +44,13 @@ export default class Header extends Component {
             <HeaderBrand/>
             <HeaderNavbarList
               list={this.state.navbarItemList}
+              tag={this.props.tag}
               store={Store}
             />
-            <HeaderActions />
+          <HeaderActions
+            tag={this.props.tag}
+            product="cdap"
+          />
           </nav>
         </div>
       </div>
@@ -58,5 +62,6 @@ Header.propTypes = {
   navbarItemList: PropTypes.arrayOf(PropTypes.shape({
     linkTo: PropTypes.string,
     title: PropTypes.string
-  }))
+  })),
+  tag: PropTypes.string
 };

--- a/cdap-ui/app/cdap/components/HeaderActions/index.js
+++ b/cdap-ui/app/cdap/components/HeaderActions/index.js
@@ -14,7 +14,7 @@
  * the License.
  */
 
-import React, {Component} from 'react';
+import React, {Component, PropTypes} from 'react';
 import { Dropdown, DropdownMenu, DropdownItem } from 'reactstrap';
 import cookie from 'react-cookie';
 import PlusButton from '../PlusButton';
@@ -134,13 +134,18 @@ export default class HeaderActions extends Component {
             </Dropdown>
           </div>
           <div className="namespace-dropdown">
-            <NamespaceDropdown />
+            <NamespaceDropdown tag={this.props.tag}/>
           </div>
           <div className="products-dropdown">
-            <ProductsDrawer currentChoice="cdap"/>
+            <ProductsDrawer currentChoice={this.props.product}/>
           </div>
         </ul>
       </div>
     );
   }
 }
+
+HeaderActions.propTypes = {
+  tag: PropTypes.string,
+  product: PropTypes.string
+};

--- a/cdap-ui/app/cdap/components/HeaderNavbarList/index.js
+++ b/cdap-ui/app/cdap/components/HeaderNavbarList/index.js
@@ -16,6 +16,7 @@
 import React, {PropTypes} from 'react';
 import { connect } from 'react-redux';
 import {Link} from 'react-router';
+import shortid from 'shortid';
 
 const mapStateToProps = (state) => {
   return {
@@ -23,32 +24,34 @@ const mapStateToProps = (state) => {
   };
 };
 
-function HeaderNavbarList({namespace}){
+function HeaderNavbarList({list}){
   return (
     <ul className="navbar-list">
-      <li>
-        <Link
-          to={`/ns/${namespace}`}
-          activeClassName="active"
-          activeOnlyWhenExact
-        >
-          Home
-        </Link>
-      </li>
-
-      <li className="disabled">
-        Dashboard
-      </li>
-
-      <li>
-        <Link
-          to="/management"
-          activeClassName="active"
-          activeOnlyWhenExact
-        >
-          Management
-        </Link>
-      </li>
+        {
+          Array.isArray(list) ?
+            list.map(item => {
+              return (
+                <li
+                  key={shortid.generate()}
+                  className={item.className}
+                >
+                  {
+                    item.disabled ?
+                      item.title
+                    :
+                      <Link
+                        to={item.linkTo}
+                        activeClassName="active"
+                      >
+                        {item.title}
+                      </Link>
+                    }
+                </li>
+              );
+            })
+          :
+            null
+        }
     </ul>
   );
 }
@@ -58,7 +61,6 @@ HeaderNavbarList.propTypes = {
     title: PropTypes.string,
     linkTo: PropTypes.string
   })),
-  namespace: PropTypes.string,
   store: PropTypes.object
 };
 

--- a/cdap-ui/app/cdap/components/NamespaceDropdown/NamespaceDropdown.less
+++ b/cdap-ui/app/cdap/components/NamespaceDropdown/NamespaceDropdown.less
@@ -51,7 +51,7 @@
   .no-namespace {
     .dropdown-menu {
       width: 160px;
-      left: -1px;
+      left: 0;
     }
   }
   .current-namespace {
@@ -74,7 +74,7 @@
     }
   }
   .dropdown-menu {
-    position: relative;
+    position: absolute;
     width: 220px;
     left: -61px;
     border-bottom-left-radius: 3px;

--- a/cdap-ui/app/cdap/components/NamespaceDropdown/index.js
+++ b/cdap-ui/app/cdap/components/NamespaceDropdown/index.js
@@ -14,7 +14,7 @@
  * the License.
  */
 
-import React, {Component} from 'react';
+import React, {Component, PropTypes} from 'react';
 import {Dropdown, DropdownMenu} from 'reactstrap';
 import classnames from 'classnames';
 import AbstractWizard from 'components/AbstractWizard';
@@ -70,6 +70,14 @@ export default class NamespaceDropdown extends Component {
     });
   }
   render() {
+    let LinkEl = Link;
+    let baseurl = '';
+    if (this.props.tag) {
+      let basename = document.querySelector('base');
+      basename = basename.getAttribute('href') ? basename.getAttribute('href') : null;
+      LinkEl = this.props.tag;
+      baseurl = `${basename}`;
+    }
     return (
       <div>
         <Dropdown
@@ -97,8 +105,9 @@ export default class NamespaceDropdown extends Component {
                     let checkClass = classnames({ "fa fa-star":  defaultNamespace === item.name });
                     let check = <span className={checkClass}></span>;
                     return (
-                      <Link
-                        to={`/ns/${item.name}`}
+                      <LinkEl
+                        href={baseurl + `/ns/${item.name}`}
+                        to={baseurl + `/ns/${item.name}`}
                         className="namespace-link"
                         key={shortid.generate()}
                       >
@@ -126,7 +135,7 @@ export default class NamespaceDropdown extends Component {
                             }
                           </span>
                         </div>
-                      </Link>
+                      </LinkEl>
                     );
                   })
               }
@@ -164,3 +173,7 @@ export default class NamespaceDropdown extends Component {
     );
   }
 }
+
+NamespaceDropdown.propTypes = {
+  tag: PropTypes.node
+};

--- a/cdap-ui/app/cdap/main.js
+++ b/cdap-ui/app/cdap/main.js
@@ -37,7 +37,7 @@ import Router from 'react-router/BrowserRouter';
 import T from 'i18n-react';
 import Match from 'react-router/Match';
 import Miss from 'react-router/Miss';
-import Store from 'services/store/store';
+import {default as NamespaceStore} from 'services/store/store';
 import CaskVideoModal from 'components/CaskVideoModal';
 import RouteToNamespace from 'components/RouteToNamespace';
 import Helmet from 'react-helmet';
@@ -49,7 +49,7 @@ class CDAP extends Component {
     this.closeCaskVideo = this.closeCaskVideo.bind(this);
     this.openCaskVideo = this.openCaskVideo.bind(this);
     this.state = {
-      selectedNamespace : Store.getState().selectedNamespace,
+      selectedNamespace : NamespaceStore.getState().selectedNamespace,
       videoOpen : false
     };
   }
@@ -71,7 +71,7 @@ class CDAP extends Component {
     MyNamespaceApi.pollList()
       .subscribe((res) => {
         if (res.length > 0){
-          Store.dispatch({
+          NamespaceStore.dispatch({
             type: 'UPDATE_NAMESPACES',
             payload: {
               namespaces : res
@@ -92,6 +92,14 @@ class CDAP extends Component {
         clientId: 'cdap'
       });
       return null;
+    }
+    if (window.CDAP_CONFIG.securityEnabled) {
+      NamespaceStore.dispatch({
+        type: 'UPDATE_USERNAME',
+        payload: {
+          username: cookie.load('CDAP_Auth_User')
+        }
+      });
     }
 
     return (

--- a/cdap-ui/app/common/cask-header.js
+++ b/cdap-ui/app/common/cask-header.js
@@ -13,9 +13,10 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import T from 'i18n-react';
-T.setTexts(require('../cdap/text/text-en.yaml'));
-var PlusButton = require('../cdap/components/PlusButton').default;
-var Store = require('../cdap/services/store/store').default;
-export default PlusButton;
-export {Store};
+
+ import T from 'i18n-react';
+ T.setTexts(require('../cdap/text/text-en.yaml'));
+ var HeaderActions = require('../cdap/components/HeaderActions').default;
+ var HeaderBrand = require('../cdap/components/HeaderBrand').default;
+ var Store = require('../cdap/services/store/store').default;
+ export {Store, HeaderBrand, HeaderActions};

--- a/cdap-ui/app/directives/my-global-navbar/my-global-navbar.html
+++ b/cdap-ui/app/directives/my-global-navbar/my-global-navbar.html
@@ -13,226 +13,62 @@
   License for the specific language governing permissions and limitations under
   the License.
 -->
-
-<header class="navbar navbar-fixed-top">
-  <nav class="navbar {{ Navbar.activeProduct }}">
-    <div class="brand-header">
-      <a href="" class="navbar-brand" ng-click="Navbar.toggleSidebar()"
-         ng-mouseenter="Navbar.mouseHoverBrand = true"
-         ng-mouseleave="Navbar.mouseHoverBrand = false">
-        <span class="icon-fist"
-              ng-if="Navbar.activeProduct === 'cdap' || Navbar.mouseHoverBrand"></span>
-        <span class="icon-hydrator"
-              ng-if="Navbar.activeProduct === 'hydrator' && !Navbar.mouseHoverBrand"></span>
-        <span class="icon-tracker"
-              ng-if="Navbar.activeProduct === 'tracker' && !Navbar.mouseHoverBrand"></span>
-      </a>
-
-      <a href="/"
-         class="menu-item product-title"
-         ng-if="Navbar.activeProduct === 'cdap'">
-        CDAP
-      </a>
-
-      <a href=""
-         ng-click="Navbar.getAbsUIUrl({uiApp: 'cask-hydrator', namespaceId: $stateParams.namespace})"
-         class="menu-item product-title"
-         ng-if="Navbar.activeProduct === 'hydrator'">
-        Cask Hydrator
-      </a>
-
-      <a href=""
-         ng-click="Navbar.getAbsUIUrl({uiApp: 'cask-tracker', namespaceId: $stateParams.namespace})"
-         class="menu-item product-title"
-         ng-if="Navbar.activeProduct === 'tracker'">
-        Cask Tracker
-      </a>
-
-    </div>
-
-    <!-- CDAP -->
-    <ul class="navbar-list" ng-if="Navbar.activeProduct === 'cdap'">
-      <li>
-        <a ui-sref="overview({namespace: $stateParams.namespace})"
-           ng-class="{ 'active': Navbar.highlightTab === 'development' }">
-          Home
-        </a>
-      </li>
-      <li>
-        <a ui-sref="dashboard.standard.cdap({namespace: $stateParams.namespace})"
-           ng-class="{ 'active': Navbar.highlightTab === 'dashboard' }">
-          Dashboard
-        </a>
-      </li>
-      <li>
-        <a ui-sref="admin.overview"
-           ng-class="{ 'active': Navbar.highlightTab === 'management' }">
-          Management
-        </a>
-      </li>
-    </ul>
-
-    <!-- HYDRATOR -->
-    <ul class="navbar-list" ng-if="Navbar.activeProduct === 'hydrator'">
-      <li>
-        <a ui-sref="hydrator.create({ namespace: $stateParams.namespace })"
-           ui-sref-opts="{ inherit: false }"
-           ng-class="{ 'active': Navbar.highlightTab === 'hydratorStudioPlusPlus'}">
-          Studio
-        </a>
-      </li>
-      <li>
-        <a ui-sref="hydrator.list({ namespace: $stateParams.namespace })"
-           ng-class="{ 'active': Navbar.highlightTab === 'hydratorList'}">
-          Pipelines
-        </a>
-      </li>
-    </ul>
-
-    <!-- TRACKER -->
-    <ul class="navbar-list" ng-if="Navbar.activeProduct === 'tracker'">
-      <li>
-        <a ui-sref="tracker.home({ namespace: $stateParams.namespace })"
-           ng-class="{ 'active': Navbar.highlightTab === 'search'}">
-          Search
-        </a>
-      </li>
-      <li>
-        <a ui-sref="tracker.integrations({ namespace: $stateParams.namespace })"
-           ng-class="{ 'active': Navbar.highlightTab === 'integrations'}">
-          Integrations
-        </a>
-      </li>
-      <li>
-        <a ui-sref="tracker.tags({ namespace: $stateParams.namespace })"
-           ng-class="{ 'active': Navbar.highlightTab === 'tags'}">
-          Tags
-        </a>
-      </li>
-    </ul>
-
-
-    <!-- RIGHT MENUS -->
-    <div class="pull-right right-menu">
-      <div class="environment">
-        <span>{{ ::Navbar.environment }}</span>
-        <span class="icon-lock_close" ng-if="Navbar.securityEnabled"></span>
-        <span class="icon-lock_open" ng-if="!Navbar.securityEnabled"></span>
-      </div>
-      <my-search></my-search>
-
-      <div class="navbar-item">
-        <my-error></my-error>
-      </div>
-
-      <div class="navbar-item text-success">
-        <plus-button></plus-button>
-      </div>
-      <div class="navbar-item" uib-dropdown>
-        <div uib-dropdown-toggle>
-          <span class="fa fa-cog"></span>
-        </div>
-
-        <ul uib-dropdown-menu>
-          <li ng-if="Navbar.securityEnabled && Navbar.currentUser">
-            <a>
-              <span> Signed in as </span>
-              <span class="username" ng-bind="Navbar.currentUser"></span>
-            </a>
-          </li>
-          <li class="divider" ng-if="Navbar.securityEnabled && Navbar.currentUser"></li>
+<div class="cask-header">
+  <div class="navbar navbar-fixed-top">
+    <nav class="navbar {{Navbar.activeProduct}}">
+      <cask-header-brand></cask-header-brand>
+      <!-- HYDRATOR -->
+      <div ng-if="Navbar.activeProduct === 'hydrator'">
+        <ul class="navbar-list {{Navbar.activeProduct}}">
           <li>
-            <a href="http://cask.co" target="_blank">
-              <span class="fa fa-fw fa-book"></span>
-              <span>Cask Home</span>
+            <a ui-sref="hydrator.create({ namespace: $stateParams.namespace })"
+               ui-sref-opts="{ inherit: false }"
+               ng-class="{ 'active': Navbar.highlightTab === 'hydratorStudioPlusPlus'}">
+              Studio
             </a>
           </li>
           <li>
-            <a href="http://cask.co/community">
-              <span class="fa fa-fw fa-support"></span>
-              <span>Support</span>
-            </a>
-          </li>
-
-          <li ng-show="Navbar.securityEnabled && Navbar.currentUser" ur-sref-active="disabled">
-            <a ui-sref="userprofile">
-              <span class="fa fa-fw fa-user"></span>
-              <span>Profile</span>
-            </a>
-          </li>
-
-          <li role="presentation" ng-show="Navbar.securityEnabled && Navbar.currentUser">
-            <a href="" ng-click="Navbar.securityEnabled && Navbar.logout()">
-              <span class="fa fa-fw fa-sign-out"></span>
-              <span>Log Out</span>
+            <a ui-sref="hydrator.list({ namespace: $stateParams.namespace })"
+               ng-class="{ 'active': Navbar.highlightTab === 'hydratorList'}">
+              Pipelines
             </a>
           </li>
         </ul>
+        <cask-header-actions
+          tag="'a'"
+          product="'hydrator'"
+        >
+        </cask-header-actions>
       </div>
-      <div class="navbar-item namespace-dropdown" uib-dropdown>
-        <div uib-dropdown-toggle ng-disabled="$state.includes('admin.**') || Navbar.namespaces.length === 0">
-          <div ng-if="Navbar.namespaces.length > 0" class="namespace-holder">
-            <div class="namespace-display">
-              <span>{{ $state.params.namespace || 'Management' }}</span>
-            </div>
-            <div class="namespace-caret pull-right">
-              <span class="fa fa-angle-down"></span>
-            </div>
-          </div>
-        </div>
 
-        <ul uib-dropdown-menu>
-          <li ng-repeat="ns in Navbar.namespaces | orderBy: 'name'">
-            <a href="" ng-click="Navbar.changeNamespace(ns)">
-              <span ng-class="{'fa fa-check': ns.name === $state.params.namespace}"></span>
-              {{ ns.name | myEllipsis: 15 }}
+      <!-- TRACKER -->
+      <div ng-if="Navbar.activeProduct === 'tracker'">
+        <ul class="navbar-list" >
+          <li>
+            <a ui-sref="tracker.home({ namespace: $stateParams.namespace })"
+               ng-class="{ 'active': Navbar.highlightTab === 'search'}">
+              Search
+            </a>
+          </li>
+          <li>
+            <a ui-sref="tracker.integrations({ namespace: $stateParams.namespace })"
+               ng-class="{ 'active': Navbar.highlightTab === 'integrations'}">
+              Integrations
+            </a>
+          </li>
+          <li>
+            <a ui-sref="tracker.tags({ namespace: $stateParams.namespace })"
+               ng-class="{ 'active': Navbar.highlightTab === 'tags'}">
+              Tags
             </a>
           </li>
         </ul>
+        <cask-header-actions
+          tag="'a'"
+          product="'tracker'"
+        >
+        </cask-header-actions>
       </div>
-    </div>
-
-  </nav>
-</header>
-
-<!-- SIDEBAR MENU -->
-<div class="display-container" ng-if="Navbar.showSidebar" ng-click="Navbar.toggleSidebar()">
-  <div class="sidebar" ng-click="$event.stopPropagation()">
-    <a href="{{Navbar.getAbsUIUrl({uiApp: 'cask-cdap', namespaceId: $stateParams.namespace || Navbar.$cookies.get('CDAP_Namespace') || 'default'})}}"
-       class="brand sidebar-item top">
-      <div class="brand-icon text-center cdap">
-        <span class="icon-fist"></span>
-      </div>
-
-      <div class="product-name">
-        <span>CDAP</span>
-      </div>
-    </a>
-
-    <h5>Extensions:</h5>
-
-    <!-- HYDRATOR -->
-    <a href="{{Navbar.getAbsUIUrl({uiApp: 'cask-hydrator', namespaceId: $stateParams.namespace || Navbar.$cookies.get('CDAP_Namespace') || 'default'})}}"
-       class="brand sidebar-item">
-      <div class="brand-icon text-center hydrator">
-        <span class="icon-hydrator"></span>
-      </div>
-
-      <div class="product-name">
-        <span>Cask Hydrator</span>
-      </div>
-    </a>
-
-    <!-- TRACKER -->
-    <a href="{{Navbar.getAbsUIUrl({uiApp: 'cask-tracker', namespaceId: $stateParams.namespace || Navbar.$cookies.get('CDAP_Namespace') || 'default'})}}"
-       class="brand sidebar-item">
-      <div class="brand-icon text-center tracker">
-        <span class="icon-tracker"></span>
-      </div>
-
-      <div class="product-name">
-        <span>Cask Tracker</span>
-      </div>
-    </a>
+    </nav>
   </div>
 </div>

--- a/cdap-ui/app/directives/my-global-navbar/my-global-navbar.js
+++ b/cdap-ui/app/directives/my-global-navbar/my-global-navbar.js
@@ -14,117 +14,85 @@
  * the License.
  */
 
-function NavbarController ($scope, $state, myNamespace, EventPipe, MYAUTH_EVENT, myAuth, MY_CONFIG, $cookies, myHelpers) {
-  'ngInject';
-
-  let vm = this;
-
-  vm.$cookies = $cookies;
-
-  function findActiveProduct() {
-    var baseTag, baseUrl;
-    if ($state.is('userprofile')) {
-      baseTag = document.getElementsByTagName('base');
-      baseUrl = baseTag[0].getAttribute('href');
-      if (baseUrl.indexOf('hydrator') !== -1) {
-        return 'hydrator';
-      } else if (baseUrl.indexOf('tracker') !== -1) {
-        return 'tracker';
-      } else {
-        return 'cdap';
-      }
-    }
-    if ($state.includes('hydrator.**')) {
-      return 'hydrator';
-    } else if ($state.includes('tracker.**') || $state.is('tracker-enable')) {
-      return 'tracker';
-    } else {
-      return 'cdap';
-    }
-  }
-  vm.showSidebar = false;
-  vm.toggleSidebar = () => {
-    vm.showSidebar = !vm.showSidebar;
-  };
-  vm.securityEnabled = MY_CONFIG.securityEnabled;
-  vm.environment = MY_CONFIG.isEnterprise ? 'Distributed' : 'Standalone';
-
-  $scope.$on('$stateChangeSuccess', function(event, toState) {
-    vm.highlightTab = toState.data && toState.data.highlightTab;
-    vm.activeProduct = findActiveProduct();
-    vm.showSidebar = false;
-    if (window.PlusButton && window.PlusButton.Store) {
-      window.PlusButton.Store.dispatch({
-        type: 'SELECT_NAMESPACE',
-        payload: {
-          selectedNamespace : $state.params.namespace
-        }
-      });
-      window.PlusButton.Store.dispatch({
-        type: 'UPDATE_NAMESPACES',
-        payload: {
-          namespaces: vm.namespaces
-        }
-      });
-    }
-  });
-
-  // NAMESPACE
-  vm.namespaces = [];
-  function updateNamespaceList() {
-    myNamespace.getList(true)
-      .then(function(list) {
-        vm.namespaces = list;
-      });
-  }
-  // Listening for event from namespace create or namespace delete
-  EventPipe.on('namespace.update', updateNamespaceList);
-
-  vm.currentUser = myAuth.getUsername();
-  $scope.$on (MYAUTH_EVENT.loginSuccess, () => {
-    vm.currentUser = myAuth.getUsername();
-    updateNamespaceList();
-  });
-  $scope.$on (MYAUTH_EVENT.logoutSuccess, () => {
-    vm.currentUser = myAuth.getUsername();
-    vm.namespaces = [];
-  });
-
-  vm.logout = myAuth.logout.bind(myAuth);
-  vm.changeNamespace = (ns) => {
-    if ($state.params.namespace === ns.name) { return; }
-
-    $cookies.put('CDAP_Namespace', ns.name);
-
-    if ($state.includes('hydrator.**')) {
-      $state.go('hydrator.list', { namespace: ns.name });
-    } else if ($state.includes('tracker.**') || $state.is('tracker-enable')) {
-      $state.go('tracker.home', { namespace: ns.name });
-    } else if ($state.includes('dashboard.**')){
-      $state.go('dashboard.standard.cdap', { namespace: ns.name });
-    } else {
-      $state.go('overview', { namespace: ns.name });
-    }
-  };
-
-  vm.getAbsUIUrl = myHelpers.getAbsUIUrl;
-  $scope.$on('$destroy', () => {
-    $cookies.remove('CDAP_Namespace');
-  });
-
-}
-
-
 angular.module(PKG.name+'.commons')
-  .directive('plusButton', function(reactDirective) {
-    return reactDirective(window.PlusButton.default);
-
+  .directive('caskHeaderActions', function(reactDirective) {
+    return reactDirective(window.CaskCommon.HeaderActions);
+  })
+  .directive('caskHeaderBrand', function(reactDirective) {
+    return reactDirective(window.CaskCommon.HeaderBrand);
   })
   .directive('myGlobalNavbar', () => {
     return {
       restrict: 'E',
       templateUrl: 'my-global-navbar/my-global-navbar.html',
-      controller: NavbarController,
+      controller: function($scope, $state, myNamespace, EventPipe, myAuth) {
+        var vm = this;
+        function findActiveProduct() {
+          var baseTag, baseUrl;
+          if ($state.is('userprofile')) {
+            baseTag = document.getElementsByTagName('base');
+            baseUrl = baseTag[0].getAttribute('href');
+            if (baseUrl.indexOf('hydrator') !== -1) {
+              return 'hydrator';
+            } else if (baseUrl.indexOf('tracker') !== -1) {
+              return 'tracker';
+            } else {
+              return 'cdap';
+            }
+          }
+          if ($state.includes('hydrator.**')) {
+            return 'hydrator';
+          } else if ($state.includes('tracker.**') || $state.is('tracker-enable')) {
+            return 'tracker';
+          } else {
+            return 'cdap';
+          }
+        }
+        if (window.CDAP_CONFIG.securityEnabled && myAuth.isAuthenticated()) {
+          window.CaskCommon.Store.dispatch({
+            type: 'UPDATE_USERNAME',
+            payload: {
+              username: myAuth.getUsername()
+            }
+          });
+          vm.currentUser = myAuth.getUsername();
+        }
+        $scope.$on('$stateChangeSuccess', function(event, toState) {
+          vm.highlightTab = toState.data && toState.data.highlightTab;
+          if (!$state.params.namespace) {
+            return;
+          }
+          if (window.CaskCommon && window.CaskCommon.Store) {
+            window.CaskCommon.Store.dispatch({
+              type: 'SELECT_NAMESPACE',
+              payload: {
+                selectedNamespace : $state.params.namespace
+              }
+            });
+            window.CaskCommon.Store.dispatch({
+              type: 'UPDATE_NAMESPACES',
+              payload: {
+                namespaces: vm.namespaces
+              }
+            });
+          }
+          vm.activeProduct = findActiveProduct();
+        });
+        vm.namespaces = [];
+        function updateNamespaceList() {
+          myNamespace.getList(true)
+            .then(function(list) {
+              vm.namespaces = list;
+              window.CaskCommon.Store.dispatch({
+                type: 'UPDATE_NAMESPACES',
+                payload: {
+                  namespaces: vm.namespaces
+                }
+              });
+            });
+        }
+        EventPipe.on('namespace.update', updateNamespaceList);
+      },
       controllerAs: 'Navbar'
     };
   });

--- a/cdap-ui/app/directives/my-global-navbar/my-global-navbar.less
+++ b/cdap-ui/app/directives/my-global-navbar/my-global-navbar.less
@@ -29,17 +29,16 @@ my-global-navbar {
     font-weight: 500;
 
     &.cdap { .product-navbar-mixins(@cdap-orange, @cdap-orange); }
-    &.hydrator { .product-navbar-mixins(@hydrator-blue, #43AAFF); }
+    &.hydrator { .product-navbar-mixins(@hydrator-blue, @hydrator-blue); }
     &.tracker { .product-navbar-mixins(@tracker-green, @tracker-green); }
 
     .brand-header {
-      width: 200px;
-      float: left;
       a { color: white; }
 
       .navbar-brand {
-        border-right: 4px solid;
-        background-color: @navbar-brand-bg;
+        border: 0;
+        background: transparent;
+        padding: 10px;
       }
     }
 
@@ -67,10 +66,6 @@ my-global-navbar {
         color: #cccccc;
         text-decoration: none;
         font-size: 14px;
-        &:hover,
-        &:focus {
-          background-color: inherit;
-        }
       }
     }
 
@@ -98,7 +93,7 @@ my-global-navbar {
       font-size: 17px;
       cursor: pointer;
       float: left;
-      padding: 0 20px;
+      padding: 0 12px;
 
       .namespace-holder {
         height: inherit;
@@ -126,7 +121,7 @@ my-global-navbar {
     .namespace-dropdown {
       width: 160px;
       border-left: 1px solid #666666;
-      padding: 0 10px;
+      padding: 0;
       font-size: 14px;
       user-select: none;
 
@@ -227,5 +222,6 @@ my-global-navbar {
         color: @active-link-color;
       }
     }
+
   }
 }

--- a/cdap-ui/app/hydrator/hydrator.html
+++ b/cdap-ui/app/hydrator/hydrator.html
@@ -69,8 +69,8 @@
   <script type="text/javascript" src="/ui-config.js"></script>
   <script type="text/javascript" src="/assets/bundle/polyfill.js"></script>
   <script type="text/javascript" src="/assets/bundle/lib.js"></script>
-  <script type="text/javascript" src="/plusbutton_assets/plusbutton-lib.js"></script>
-  <script type="text/javascript" src="/plusbutton_assets/plusbutton.js"></script>
+  <script type="text/javascript" src="/common_assets/common-lib.js"></script>
+  <script type="text/javascript" src="/common_assets/common.js"></script>
   <script type="text/javascript" src="/assets/bundle/hydrator.js"></script>
   <script type="text/javascript" src="/assets/bundle/common.es6.js"></script>
   <script type="text/javascript" src="/assets/bundle/tpl.js"></script>

--- a/cdap-ui/app/styles/css/fonts.less
+++ b/cdap-ui/app/styles/css/fonts.less
@@ -1,0 +1,525 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+@font-face {
+	font-family: 'icomoon';
+	src:url('../fonts/icomoon.eot');
+	src:url('../fonts/icomoon.eot') format('embedded-opentype'),
+  		url('../fonts/icomoon.woff') format('woff'),
+  		url('../fonts/icomoon.ttf') format('truetype'),
+  		url('../fonts/icomoon.svg') format('svg');
+	font-weight: normal;
+	font-style: normal;
+}
+
+.icon-tagmanagement:before {
+  content: "\e99b";
+}
+.icon-viewinvalidtransactions:before {
+  content: "\e99c";
+}
+.icon-deletealldatasets:before {
+  content: "\e99d";
+}
+.icon-resetinstance:before {
+  content: "\e99e";
+}
+.icon-manageroles:before {
+  content: "\e99f";
+}
+.icon-addroles:before {
+  content: "\e9a0";
+}
+.icon-instancepreference:before {
+  content: "\e9a1";
+}
+.icon-managenamespaces:before {
+  content: "\e9a2";
+}
+.icon-deletenamespaces:before {
+  content: "\e9a3";
+}
+.icon-addnamespaces:before {
+  content: "\e9a4";
+}
+.icon-viewconfiguration:before {
+  content: "\e9a5";
+}
+.icon-CaskMarket:before {
+  content: "\e998";
+}
+.icon-CDAPExtensions:before {
+  content: "\e999";
+}
+.icon-resourcecenter:before {
+  content: "\e99a";
+}
+.icon-datapacks:before {
+  content: "\e993";
+}
+.icon-usecases:before {
+  content: "\e994";
+}
+.icon-pipelines:before {
+  content: "\e995";
+}
+.icon-artifacts:before {
+  content: "\e996";
+}
+.icon-all:before {
+  content: "\e997";
+}
+.icon-support:before {
+  content: "\e98f";
+}
+.icon-logout:before {
+  content: "\e990";
+}
+.icon-caskhome:before {
+  content: "\e991";
+}
+.icon-documentation:before {
+  content: "\e992";
+}
+.icon-Encryptor:before {
+  content: "\e98e";
+}
+.icon-Decryptor:before {
+  content: "\e97c";
+}
+.icon-Amazon-Kinesis:before {
+  content: "\e97d";
+}
+.icon-Big-Query:before {
+  content: "\e97e";
+}
+.icon-ORC:before {
+  content: "\e97f";
+}
+.icon-rowdenormalizer:before {
+  content: "\e980";
+}
+.icon-joiner:before {
+  content: "\e981";
+}
+.icon-COBOLcopybookreader:before {
+  content: "\e982";
+}
+.icon-deduplicator:before {
+  content: "\e983";
+}
+.icon-azureblobstore:before {
+  content: "\e984";
+}
+.icon-FTP:before {
+  content: "\e985";
+}
+.icon-groupby:before {
+  content: "\e986";
+}
+.icon-sparkmachinelearning:before {
+  content: "\e987";
+}
+.icon-excelinputsource:before {
+  content: "\e988";
+}
+.icon-solr:before {
+  content: "\e989";
+}
+.icon-XMLparser:before {
+  content: "\e98a";
+}
+.icon-XMLreader:before {
+  content: "\e98b";
+}
+.icon-valuemapper:before {
+  content: "\e98c";
+}
+.icon-sparkstreaming:before {
+  content: "\e98d";
+}
+.icon-rename:before {
+  content: "\e979";
+}
+.icon-archive:before {
+  content: "\e97a";
+}
+.icon-ssh:before {
+  content: "\e97b";
+}
+.icon-runtimestart:before {
+  content: "\e975";
+}
+.icon-runtimestarttime:before {
+  content: "\e976";
+}
+.icon-runtimestop:before {
+  content: "\e977";
+}
+.icon-runtimestoptime:before {
+  content: "\e978";
+}
+.icon-emailaction:before {
+  content: "\e96f";
+}
+.icon-filecopyaction:before {
+  content: "\e970";
+}
+.icon-filemoveaction:before {
+  content: "\e971";
+}
+.icon-impalahiveaction:before {
+  content: "\e972";
+}
+.icon-SQLaction:before {
+  content: "\e973";
+}
+.icon-sshaction:before {
+  content: "\e974";
+}
+.icon-lock_close:before {
+    content: "\e96d";
+}
+.icon-lock_open:before {
+    content: "\e96e";
+}
+.icon-disable:before {
+    content: "\e969";
+}
+.icon-enable:before {
+    content: "\e96a";
+}
+.icon-needle_sl:before {
+    content: "\e96b";
+}
+.icon-needle_lg:before {
+    content: "\e96c";
+}
+.icon-collapse:before {
+    content: "\e964";
+}
+.icon-config:before {
+    content: "\e965";
+}
+.icon-expend:before {
+    content: "\e966";
+}
+.icon-eye:before {
+    content: "\e967";
+}
+.icon-logview:before {
+    content: "\e968";
+}
+.icon-deduper:before {
+    content: "\e95e";
+}
+.icon-distinct:before {
+    content: "\e95f";
+}
+.icon-naivebayestrainer:before {
+    content: "\e960";
+}
+.icon-groupbyaggregate:before {
+    content: "\e961";
+}
+.icon-naivebayesclassifier:before {
+    content: "\e962";
+}
+.icon-upload:before {
+    content: "\e963";
+}
+.icon-streamview:before {
+    content: "\e95d";
+}
+.icon-tracker:before {
+    content: "\e95c";
+}
+.icon-javascript:before {
+    content: "\e95b";
+}
+.icon-jsonformatter:before {
+    content: "\e95a";
+}
+.icon-structuredrecord:before {
+    content: "\e93f";
+}
+.icon-csvformatter:before {
+    content: "\e940";
+}
+.icon-csvparser:before {
+    content: "\e949";
+}
+.icon-jsonparser:before {
+    content: "\e94a";
+}
+.icon-clonerecord:before {
+    content: "\e94b";
+}
+.icon-streamformatter:before {
+    content: "\e94c";
+}
+.icon-compressor:before {
+    content: "\e94d";
+}
+.icon-decompressor:before {
+    content: "\e94e";
+}
+.icon-hasher:before {
+    content: "\e94f";
+}
+.icon-decoder:before {
+    content: "\e950";
+}
+.icon-encoder:before {
+    content: "\e951";
+}
+.icon-pythonevaluator:before {
+    content: "\e952";
+}
+.icon-mongodb:before {
+    content: "\e953";
+}
+.icon-teradata:before {
+    content: "\e954";
+}
+.icon-cassandra:before {
+    content: "\e955";
+}
+.icon-elasticsearch:before {
+    content: "\e956";
+}
+.icon-hive:before {
+    content: "\e957";
+}
+.icon-hdfs:before {
+    content: "\e958";
+}
+.icon-hbase:before {
+    content: "\e959";
+}
+.icon-jms:before {
+    content: "\e93e";
+}
+.icon-amazonsqs:before {
+    content: "\e900";
+}
+.icon-corevalidator:before {
+    content: "\e901";
+}
+.icon-cube:before {
+    content: "\e902";
+}
+.icon-database:before {
+    content: "\e903";
+}
+.icon-datagenerator:before {
+    content: "\e904";
+}
+.icon-file:before {
+    content: "\e905";
+}
+.icon-kafka:before {
+    content: "\e906";
+}
+.icon-kvtable:before {
+    content: "\e907";
+}
+.icon-logparser:before {
+    content: "\e908";
+}
+.icon-s3:before {
+    content: "\e909";
+}
+.icon-s3avro:before {
+    content: "\e90a";
+}
+.icon-s3parquet:before {
+    content: "\e90b";
+}
+.icon-script:before {
+    content: "\e90c";
+}
+.icon-scriptfilter:before {
+    content: "\e90d";
+}
+.icon-sink:before {
+    content: "\e90e";
+}
+.icon-snapshotavro:before {
+    content: "\e90f";
+}
+.icon-snapshotparquet:before {
+    content: "\e910";
+}
+.icon-streams:before {
+    content: "\e911";
+}
+.icon-table:before {
+    content: "\e912";
+}
+.icon-tpfsavro:before {
+    content: "\e913";
+}
+.icon-tpfsparquet:before {
+    content: "\e914";
+}
+.icon-twitter:before {
+    content: "\e915";
+}
+.icon-validator:before {
+    content: "\e916";
+}
+.icon-adapter:before {
+    content: "\e917";
+}
+.icon-app:before {
+    content: "\e918";
+}
+.icon-applicationtemplates:before {
+    content: "\e919";
+}
+.icon-avro:before {
+    content: "\e91a";
+}
+.icon-calendar:before {
+    content: "\e91b";
+}
+.icon-clean:before {
+    content: "\e91c";
+}
+.icon-clone:before {
+    content: "\e91d";
+}
+.icon-configuration:before {
+    content: "\e91e";
+}
+.icon-datasets:before {
+    content: "\e91f";
+}
+.icon-datatypes:before {
+    content: "\e920";
+}
+.icon-delete:before {
+    content: "\e921";
+}
+.icon-draft:before {
+    content: "\e922";
+}
+.icon-ETLBatch:before, .icon-cdap-etl-batch:before {
+    content: "\e923";
+}
+.icon-ETLRealtime:before, .icon-cdap-etl-realtime:before {
+    content: "\e924";
+}
+.icon-ETLsinks:before {
+    content: "\e925";
+}
+.icon-ETLsources:before {
+    content: "\e926";
+}
+.icon-ETLtemplates:before {
+    content: "\e927";
+}
+.icon-ETLtransforms:before {
+    content: "\e928";
+}
+.icon-export:before {
+    content: "\e929";
+}
+.icon-failed:before {
+    content: "\e92a";
+}
+.icon-fist:before {
+    content: "\e92b";
+}
+.icon-fit:before {
+    content: "\e92c";
+}
+.icon-hydrator:before {
+    content: "\e92d";
+}
+.icon-import:before {
+    content: "\e92e";
+}
+.icon-mapreduce:before {
+    content: "\e92f";
+}
+.icon-paused:before {
+    content: "\e930";
+}
+.icon-plugin-stream:before {
+    content: "\e931";
+}
+.icon-programtypes:before {
+    content: "\e932";
+}
+.icon-projection:before {
+    content: "\e933";
+}
+.icon-publish:before {
+    content: "\e934";
+}
+.icon-reset:before {
+    content: "\e935";
+}
+.icon-running:before {
+    content: "\e936";
+}
+.icon-savedraft:before {
+    content: "\e937";
+}
+.icon-schemaedge:before {
+    content: "\e938";
+}
+.icon-service:before {
+    content: "\e939";
+}
+.icon-spark:before {
+    content: "\e93a";
+}
+.icon-start:before {
+    content: "\e93b";
+}
+.icon-stopped:before {
+    content: "\e93c";
+}
+.icon-suspend:before {
+    content: "\e93d";
+}
+.icon-systempreferences:before {
+    content: "\e941";
+}
+.icon-systemsecurity:before {
+    content: "\e942";
+}
+.icon-tigon:before {
+    content: "\e943";
+}
+.icon-validate:before {
+    content: "\e944";
+}
+.icon-worker:before {
+    content: "\e945";
+}
+.icon-workflow:before {
+    content: "\e946";
+}
+.icon-zoomIn:before {
+    content: "\e947";
+}
+.icon-zoomout:before {
+    content: "\e948";
+}

--- a/cdap-ui/app/tracker/tracker.html
+++ b/cdap-ui/app/tracker/tracker.html
@@ -68,8 +68,8 @@
   <script type="text/javascript" src="/ui-config.js"></script>
   <script type="text/javascript" src="/assets/bundle/polyfill.js"></script>
   <script type="text/javascript" src="/assets/bundle/lib.js"></script>
-  <script type="text/javascript" src="/plusbutton_assets/plusbutton-lib.js"></script>
-  <script type="text/javascript" src="/plusbutton_assets/plusbutton.js"></script>
+  <script type="text/javascript" src="/common_assets/common-lib.js"></script>
+  <script type="text/javascript" src="/common_assets/common.js"></script>
   <script type="text/javascript" src="/assets/bundle/tracker.js"></script>
   <script type="text/javascript" src="/assets/bundle/common.es6.js"></script>
   <script type="text/javascript" src="/assets/bundle/tpl.js"></script>

--- a/cdap-ui/pom.xml
+++ b/cdap-ui/pom.xml
@@ -71,6 +71,18 @@
               <followSymlinks>false</followSymlinks>
             </fileset>
             <fileset>
+              <directory>cdap_dist</directory>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+            <fileset>
+              <directory>login_dist</directory>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+            <fileset>
+              <directory>common_dist</directory>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+            <fileset>
               <directory>node</directory>
               <followSymlinks>false</followSymlinks>
             </fileset>
@@ -133,7 +145,7 @@
                   <exclude>**/bower_components/**</exclude>
                   <exclude>**/node_modules/**</exclude>
                   <exclude>**/dist/**</exclude>
-                  <exclude>**/plusbutton_dist/**</exclude>
+                  <exclude>**/common_dist/**</exclude>
                   <exclude>**/cdap_dist/**</exclude>
                   <exclude>**/login_dist/**</exclude>
                   <exclude>**/logs/**</exclude>
@@ -293,8 +305,8 @@
                     <copy todir = "${stage.opt.dir}/dist">
                       <fileset dir = "dist" />
                     </copy>
-                    <copy todir = "${stage.opt.dir}/plusbutton_dist">
-                      <fileset dir = "plusbutton_dist" />
+                    <copy todir = "${stage.opt.dir}/common_dist">
+                      <fileset dir = "common_dist" />
                     </copy>
                     <copy todir = "${stage.opt.dir}/cdap_dist">
                       <fileset dir = "cdap_dist" />

--- a/cdap-ui/server/express.js
+++ b/cdap-ui/server/express.js
@@ -47,7 +47,7 @@ var express = require('express'),
       __dirname + '/../cdap_dist'
     ),
     MARKET_DIST_PATH=require('path').normalize(
-      __dirname + '/../plusbutton_dist'
+      __dirname + '/../common_dist'
     ),
     fs = require('fs');
 
@@ -288,7 +288,7 @@ function makeApp (authAddress, cdapConfig, uiSettings) {
       finalhandler(req, res)(false); // 404
     }
   ]);
-  app.use('/plusbutton_assets', [
+  app.use('/common_assets', [
     express.static(MARKET_DIST_PATH, {
       index: false
     }),

--- a/cdap-ui/webpack.config.cdap.js
+++ b/cdap-ui/webpack.config.cdap.js
@@ -115,7 +115,8 @@ module.exports = {
           /node_modules/,
           /bower_components/,
           /dist/,
-          /cdap_dist/
+          /cdap_dist/,
+          /common_dist/
         ]
       }
     ],

--- a/cdap-ui/webpack.config.common.js
+++ b/cdap-ui/webpack.config.common.js
@@ -16,7 +16,7 @@
 var webpack = require('webpack');
 var plugins = [
   new webpack.optimize.DedupePlugin(),
-  new webpack.optimize.CommonsChunkPlugin("plusbutton-lib", "plusbutton-lib.js", Infinity),
+  new webpack.optimize.CommonsChunkPlugin("common-lib", "common-lib.js", Infinity),
   // by default minify it.
   new webpack.DefinePlugin({
     'process.env':{
@@ -58,10 +58,10 @@ var loaders = [
 ];
 
 module.exports = {
-  context: __dirname + '/app/plusbutton',
+  context: __dirname + '/app/common',
   entry: {
-    'plusbutton': ['./plusbutton.js'],
-    'plusbutton-lib': [
+    'common': ['./cask-header.js'],
+    'common-lib': [
       'classnames',
       'reactstrap',
       'i18n-react',
@@ -80,7 +80,8 @@ module.exports = {
           /node_modules/,
           /bower_components/,
           /dist/,
-          /cdap_dist/
+          /cdap_dist/,
+          /login_dist/
         ]
       }
     ],
@@ -88,8 +89,8 @@ module.exports = {
   },
   output: {
     filename: './[name].js',
-    path: __dirname + '/plusbutton_dist',
-    library: 'PlusButton',
+    path: __dirname + '/common_dist',
+    library: 'CaskCommon',
     libraryTarget: 'umd'
   },
   externals: {

--- a/cdap-ui/webpack.config.js
+++ b/cdap-ui/webpack.config.js
@@ -16,7 +16,9 @@
 
 var cdapWebpackConfig = require('./webpack.config.cdap.js');
 var loginWebpackConfig = require('./webpack.config.login.js');
+var commonWebpackConfig = require('./webpack.config.common.js');
 module.exports = [
   cdapWebpackConfig,
-  loginWebpackConfig
+  loginWebpackConfig,
+  commonWebpackConfig
 ];

--- a/cdap-ui/webpack.config.login.js
+++ b/cdap-ui/webpack.config.login.js
@@ -87,7 +87,8 @@ module.exports = {
           /node_modules/,
           /bower_components/,
           /dist/,
-          /cdap_dist/
+          /cdap_dist/,
+          /common_dist/
         ]
       }
     ],


### PR DESCRIPTION
- Builds a common library to be shared between the webapps
- Exports `HeaderActions` and `HeaderBrand` as of now to be shared between the webapps
- Separates out webpack build process from Gulp.
- Adds option to `NamespaceDropdown` to accept a tag to use for link. This is to use `<a/>` tag in angular apps and `<Link />` in react app.( `react-router` will refresh the entire page if `<Link />` is not used)
### Note:
- Need to figure out a build process with less `npm-scripts`. Right now this is a little confusing. We need to have a clean separation between `dev-build` and `prod-build`
