### PR TITLE
CDAP-7401 add start of docs for Cask Market

### DIFF
--- a/cdap-docs/_common/_source/index.rst
+++ b/cdap-docs/_common/_source/index.rst
@@ -125,29 +125,41 @@ CDAP extensions provide additional capabilities, such as *Cask Hydrator* and *Ca
 .. |integrations| replace:: **Integrations:**
 .. _integrations: integrations/index.html
 
-.. |integ-man-c-black| replace:: `Cloudera:`
-.. _integ-man-c-black: integrations/partners/cloudera/index.html
+.. |integ-man-cm-black| replace:: `Cask Market:`
+.. _integ-man-cm-black: integrations/cask-market/index.html
 
-.. |integ-man-j-black| replace:: `JDBC:`
-.. _integ-man-j-black: integrations/jdbc.html
+.. |integ-man-cl-black| replace:: `Cloudera:`
+.. _integ-man-cl-black: integrations/partners/cloudera/index.html
 
-.. |integ-man-o-black| replace:: `ODBC:`
-.. _integ-man-o-black: integrations/odbc.html
+.. |integ-man-as-black| replace:: `Apache Sentry:`
+.. _integ-man-as-black: integrations/apache-sentry.html
 
-.. |integ-man-p-black| replace:: `Pentaho:`
-.. _integ-man-p-black: integrations/pentaho.html
+.. |integ-man-ah-black| replace:: `Apache Hadoop KMS:`
+.. _integ-man-ah-black: integrations/hadoop-kms.html
 
-.. |integ-man-s-black| replace:: `Squirrel:`
-.. _integ-man-s-black: integrations/squirrel.html
+.. |integ-man-jd-black| replace:: `JDBC:`
+.. _integ-man-jd-black: integrations/jdbc.html
+
+.. |integ-man-od-black| replace:: `ODBC:`
+.. _integ-man-od-black: integrations/odbc.html
+
+.. |integ-man-pe-black| replace:: `Pentaho:`
+.. _integ-man-pe-black: integrations/pentaho.html
+
+.. |integ-man-sq-black| replace:: `Squirrel:`
+.. _integ-man-sq-black: integrations/squirrel.html
 
 - |integrations|_ 
 
-  - |integ-man-c-black|_ Integrating CDAP into Cloudera, using Cloudera Manager, running interactive queries with Impala, and
+  - |integ-man-cm-black|_ A source for re-usable applications, data, and code for all CDAP users
+  - |integ-man-cl-black|_ Integrating CDAP into Cloudera, using Cloudera Manager, running interactive queries with Impala, and
     bridging CDAP Metadata with Cloudera's data management tool, Navigator
-  - |integ-man-j-black|_ The CDAP JDBC driver, included with CDAP
-  - |integ-man-o-black|_ The CDAP ODBC driver available for CDAP
-  - |integ-man-p-black|_ *Pentaho Data Integration*, a business intelligence tool that can be used with CDAP
-  - |integ-man-s-black|_ *SquirrelSQL*, a simple JDBC client that can be integrated with CDAP
+  - |integ-man-as-black|_ Configuring and integrating CDAP with *Apache Sentry*
+  - |integ-man-ah-black|_ Configuring and integrating CDAP with *Apache Hadoop Key Management Service (KMS)*
+  - |integ-man-jd-black|_ The CDAP JDBC driver, included with CDAP
+  - |integ-man-od-black|_ The CDAP ODBC driver available for CDAP
+  - |integ-man-pe-black|_ *Pentaho Data Integration*, a business intelligence tool that can be used with CDAP
+  - |integ-man-sq-black|_ *SquirrelSQL*, a simple JDBC client that can be integrated with CDAP
 
 
 .. |examples-manual| replace:: **Examples, Guides, and Tutorials:**

--- a/cdap-docs/integrations/source/cask-market/api.rst
+++ b/cdap-docs/integrations/source/cask-market/api.rst
@@ -3,13 +3,20 @@
     :copyright: Copyright © 2016 Cask Data, Inc.
 
 .. _cask-market-api:
-================
-Cask Market APIs
-================
 
-The Cask Market APIs are simply a contract about the directory structure of the marketplace.
-All APIs are relative to a base path. For example, the base path for the public Cask hosted market
-is 'market.cask.co'. The directory structure must be::
+============================
+Cask Market HTTP RESTful API
+============================
+
+.. highlight:: console
+
+The Cask Market HTTP RESTful APIs are simply a contract about the directory structure of the marketplace.
+All APIs are relative to a base path. For example, the base path for the public Cask-hosted market
+is ``'market.cask.co'``. 
+
+.. directory-structure-start
+
+The directory structure must be::
 
   <base>/v1/packages.json
   <base>/v1/packages/<package-name>/<version>/icon.png
@@ -21,56 +28,72 @@ is 'market.cask.co'. The directory structure must be::
   <base>/v1/packages/<package-name>/<version>/<resource2>.asc
   ...
 
+.. directory-structure-end
+
+.. Base URL explanation
+.. --------------------
+.. include:: ../../../reference-manual/source/http-restful-api/base-url.txt
+
 .. _cask-market-get-catalog:
 
 Get Market Catalog
 ==================
+
+.. highlight:: console
+
 To retrieve a list of available packages, submit an HTTP GET request::
 
   GET /v1/packages.json
+
+.. highlight:: json-ellipsis
 
 This will return a JSON array that lists each package and its metadata::
 
   [
     {
-      name: "access-log",
-      version: "1.0.0",
-      description: "Sample access logs in Combined Log Format (CLF)",
-      label: "Access Log Sample",
-      author: "Cask",
-      org: "Cask Data, Inc.",
-      cdapVersion: "[4.0.0-SNAPSHOT,4.1.0)",
-      created: 1473901763,
-      categories: [ "datapack" ]
+      "name": "access-log",
+      "version": "1.0.0",
+      "description": "Sample access logs in Combined Log Format (CLF)",
+      "label": "Access Log Sample",
+      "author": "Cask",
+      "org": "Cask Data, Inc.",
+      "cdapVersion": "[4.0.0-SNAPSHOT,4.1.0)",
+      "created": 1473901763,
+      "categories": [ "datapack" ]
     },
     {
-      name: "bulk-data-transfer",
-      version: "1.0.0",
-      description: "Moving data from structured data source likes traditional relational database into Hadoop is very common in building Data Lakes.
+      "name": "bulk-data-transfer",
+      "version": "1.0.0",
+      "description": "Moving data from structured data source such as a traditional relational database into Hadoop is very common in building Data Lakes.
                     This data application allows you to set-up periodic full data dumps from RDBMS into Hadoop cluster.
                     Data on Hadoop is stored as DB table snapshot. Supports other relational databases.",
-      label: "Bulk Data Transfer",
-      author: "Cask",
-      org: "Cask Data, Inc.",
-      cdapVersion: "[4.0.0-SNAPSHOT,4.1.0)",
-      created: 1473901763,
-      categories: [ "usecase" ]
+      "label": "Bulk Data Transfer",
+      "author": "Cask",
+      "org": "Cask Data, Inc.",
+      "cdapVersion": "[4.0.0-SNAPSHOT,4.1.0)",
+      "created": 1473901763,
+      "categories": [ "usecase" ]
     },
     ...
   ]
 
 Get Package Specification
 =========================
+
+.. highlight:: console
+
 To retrieve a package specification, submit an HTTP GET request::
 
   GET /v1/packages/<package-name>/<version>/spec.json
+
+.. highlight:: json-ellipsis
 
 This will return a JSON object that contains metadata about the package,
 and a list of actions required to install the package::
 
   {
     "label": "Bulk Data Transfer",
-    "description": "Moving data from structured data source likes traditional relational database into Hadoop is very common in building Data Lakes.
+    "description": "Moving data from structured data source such as a traditional relational database into Hadoop is very common in building Data Lakes.
                     This data application allows you to set-up periodic full data dumps from RDBMS into Hadoop cluster.
                     Data on Hadoop is stored as DB table snapshot. Supports other relational databases.",
     "author": "Cask",
@@ -86,9 +109,9 @@ and a list of actions required to install the package::
           {
             "name": "steps",
             "value": [
-              "Download the zip file from Mysql at https://dev.mysql.com/downloads/file/?id=462850",
+              "Download the ZIP file from MySQL at https://dev.mysql.com/downloads/file/?id=462850",
               "Unzip the file",
-              "In the next step, upload the 'mysql-connector-java-5.1.39-bin.jar' file from the zip"
+              "In the next step, upload the 'mysql-connector-java-5.1.39-bin.jar' file from the ZIP"
             ]
           }
         ]
@@ -141,34 +164,47 @@ and a list of actions required to install the package::
     ]
   }
 
+Action Specification
+--------------------
+
 There are several supported actions, each with its own specification.
 If an action fails for any reason, actions completed before it are
 not rolled back. However, each action is idempotent, which means the
-installation can simply be retried once the underylying failure cause has
+installation can simply be retried once the underlying cause of the failure has
 been fixed.
 
-Action Specification
---------------------
 Each action contains a label, type, and arguments::
 
   {
-    "label": [display label],
-    "type": [action type],
+    "label": "<display-label>",
+    "type": "<action-type>",
     "arguments": [
-      "name": [argument name],
-      "value": [argument value],
-      "canModify": true | false (defaults to false)
+      {
+        "name": "<argument-name>",
+        "value": "<argument-value>",
+        "canModify": "true | false (defaults to false)"
+      },
+      ...
     ]
   }
 
-The label is short description that will be displayed to users during the install process.
+The label is a short description that will be displayed to users during the install process.
 Some arguments will reference package resources.
-Descriptions of each action type and their supported arguments are listed below.
+
+Descriptions of each action type and their supported arguments are listed below:
+
+- `informational`_
+- `create_artifact`_
+- `create_stream`_
+- `load_datapack`_
+- `create_app`_
+- `create_pipeline`_
+- `create_pipeline_draft`_
 
 informational
-^^^^^^^^^^^^^
+.............
 Displays information for the user. Does not perform any actions against the CDAP RESTful APIs.
-This can be used, for example, to tell the user to download a jar from a 3rd party website.
+This can be used, for example, to tell the user to download a JAR from a 3rd-party website.
 
 .. list-table::
    :widths: 20 50 10 20
@@ -178,10 +214,12 @@ This can be used, for example, to tell the user to download a jar from a 3rd par
      - Description
      - Required?
      - Default
-   * - steps
+   * - ``steps``
      - JSON array of strings listing steps the user should take
-     - yes
+     - Yes
      -
+
+.. highlight:: json-ellipsis
 
 Example action::
 
@@ -192,16 +230,16 @@ Example action::
       {
         "name": "steps",
         "value": [
-          "Download the zip file from Oracle at https://dev.mysql.com/downloads/file/?id=462850",
+          "Download the ZIP file from Oracle at https://dev.mysql.com/downloads/file/?id=462850",
           "Unzip the file",
-          "In the next step, upload the 'mysql-connector-java-5.1.39-bin.jar' file from the zip"
+          "In the next step, upload the 'mysql-connector-java-5.1.39-bin.jar' file from the ZIP"
         ]
       }
     ]
   }
 
 create_artifact
-^^^^^^^^^^^^^^^
+...............
 Creates a CDAP artifact.
 
 .. list-table::
@@ -212,30 +250,32 @@ Creates a CDAP artifact.
      - Description
      - Required?
      - Default
-   * - name
-     - artifact name
-     - yes
+   * - ``name``
+     - Artifact name
+     - Yes
      -
-   * - jar
-     - package resource containing the artifact jar contents
-     - yes
+   * - ``jar``
+     - Package resource containing the artifact JAR contents
+     - Yes
      -
-   * - scope
-     - artifact scope
-     - no
-     - user
-   * - version
-     - artifact version
-     - no
-     - version contained in the jar manifest
-   * - config
-     - package resource containing artifact parents, plugins, and properties
-     - no
+   * - ``scope``
+     - Artifact scope
+     - No
+     - ``user``
+   * - ``version``
+     - Artifact version
+     - No
+     - Version contained in the JAR manifest
+   * - ``config``
+     - Package resource containing artifact parents, plugins, and properties
+     - No
      -
 
 If the artifact is a plugin artifact, the config argument is used to specify its
-parent artifacts, any 3rd party plugins contained in the artifact, and any properties
+parent artifacts, any 3rd-party plugins contained in the artifact, and any properties
 of the artifact.
+
+.. highlight:: json-ellipsis
 
 Example action::
 
@@ -281,7 +321,7 @@ where mysql-connector-java.json is a package resource with content::
   }
 
 create_stream
-^^^^^^^^^^^^^
+.............
 Creates a CDAP stream.
 
 .. list-table::
@@ -292,18 +332,20 @@ Creates a CDAP stream.
      - Description
      - Required?
      - Default
-   * - name
-     - stream name
-     - yes
+   * - ``name``
+     - Stream name
+     - Yes
      -
-   * - description
-     - stream description
-     - no
+   * - ``description``
+     - Stream description
+     - No
      -
-   * - properties
-     - package resource containing stream properties like the format, ttl, and notification threshold
-     - no
+   * - ``properties``
+     - Package resource containing stream properties such as format, TTL, and notification threshold
+     - No
      -
+
+.. highlight:: json-ellipsis
 
 Example action::
 
@@ -326,7 +368,7 @@ Example action::
     ]
   }
 
-where properties.json is a package resource with content::
+where ``properties.json`` is a package resource with content such as::
 
   {
     "ttl": 9223372036854775,
@@ -345,8 +387,8 @@ where properties.json is a package resource with content::
   }
 
 load_datapack
-^^^^^^^^^^^^^
-Loads a datapack into a CDAP entity, like a stream or dataset.
+.............
+Loads a datapack into a CDAP entity, such as a stream or dataset.
 
 .. list-table::
    :widths: 20 50 10 20
@@ -356,14 +398,16 @@ Loads a datapack into a CDAP entity, like a stream or dataset.
      - Description
      - Required?
      - Default
-   * - name
-     - the name of the CDAP entity to load the data into
-     - yes
+   * - ``name``
+     - The name of the CDAP entity to load the data into
+     - Yes
      -
-   * - files
-     - a JSON array of package resources to load into the CDAP entity
-     - yes
+   * - ``files``
+     - A JSON array of package resources to load into the CDAP entity
+     - Yes
      -
+
+.. highlight:: json-ellipsis
 
 Example action::
 
@@ -382,10 +426,10 @@ Example action::
     ]
   }
 
-where texts1.tsv and texts2.tsv are package resources containing the data to load into the stream.
+where ``texts1.tsv`` and ``texts2.tsv`` are package resources containing the data to load into the stream.
 
 create_app
-^^^^^^^^^^
+..........
 Creates a CDAP application from an existing CDAP artifact.
 
 .. list-table::
@@ -396,18 +440,20 @@ Creates a CDAP application from an existing CDAP artifact.
      - Description
      - Required?
      - Default
-   * - artifact
+   * - ``artifact``
      - JSON Object containing the application's artifact scope, name, and version
-     - yes
+     - Yes
      -
-   * - name
-     - application name
-     - yes
+   * - ``name``
+     - Application name
+     - Yes
      -
-   * - config
-     - package resource containing the application config
-     - no
+   * - ``config``
+     - Package resource containing the application config
+     - No
      -
+
+.. highlight:: json-ellipsis
 
 Example action::
 
@@ -435,7 +481,7 @@ Example action::
     ]
   }
 
-where config.json is a package resource that contains the application configuration::
+where ``config.json`` is a package resource that contains the application configuration::
 
   {
     "stream": "wordStream",
@@ -446,9 +492,9 @@ where config.json is a package resource that contains the application configurat
   }
 
 create_pipeline
-^^^^^^^^^^^^^^^
-Creates a Hydrator pipeline. Very similar to the create_app pipeline,
-except the config is required and the UI will take the user to the Hydrator UI
+...............
+Creates a Hydrator pipeline. Very similar to the ``create_app`` pipeline,
+except that the config is required and the UI will take the user to the Hydrator UI
 instead of the CDAP UI after installation is complete.
 
 .. list-table::
@@ -459,18 +505,20 @@ instead of the CDAP UI after installation is complete.
      - Description
      - Required?
      - Default
-   * - artifact
+   * - ``artifact``
      - JSON Object containing the pipeline's artifact scope, name, and version
-     - yes
+     - Yes
      -
-   * - name
-     - pipeline name
-     - yes
+   * - ``name``
+     - Pipeline name
+     - Yes
      -
-   * - config
-     - package resource containing the pipeline config
-     - yes
+   * - ``config``
+     - Package resource containing the pipeline config
+     - Yes
      -
+
+.. highlight:: json-ellipsis
 
 Example action::
 
@@ -498,13 +546,12 @@ Example action::
     ]
   }
 
-where pipeline.json is a package resource containing the pipeline config.
+where ``pipeline.json`` is a package resource containing the pipeline config.
 
 create_pipeline_draft
-^^^^^^^^^^^^^^^^^^^^^
-Creates a Hydrator pipeline draft. Similar to create_pipeline, except the pipeline
-will not be published. Instead, a draft will be created that the user can then
-go and modify.
+.....................
+Creates a Hydrator pipeline draft. Similar to ``create_pipeline``, except that the pipeline
+will not be published. Instead, a draft will be created that the user can then modify.
 
 .. list-table::
    :widths: 20 50 10 20
@@ -514,18 +561,20 @@ go and modify.
      - Description
      - Required?
      - Default
-   * - artifact
+   * - ``artifact``
      - JSON Object containing the pipeline's artifact scope, name, and version
-     - yes
+     - Yes
      -
-   * - name
-     - pipeline name
-     - yes
+   * - ``name``
+     - Pipeline name
+     - Yes
      -
-   * - config
-     - package resource containing the pipeline config
-     - yes
+   * - ``config``
+     - Package resource containing the pipeline config
+     - Yes
      -
+
+.. highlight:: json-ellipsis
 
 Example action::
 
@@ -555,6 +604,9 @@ Example action::
 
 Get Package Specification Signature
 ===================================
+
+.. highlight:: console
+
 To retrieve the signature for a package specification, submit an HTTP GET request::
 
   GET /v1/packages/<package-name>/<version>/spec.json.asc
@@ -566,15 +618,21 @@ was signed by the publisher.
 
 Get Package Resource
 ====================
+
+.. highlight:: console
+
 To retrieve a package resource, submit an HTTP GET request::
 
   GET /v1/packages/<package-name>/<version>/<resource-name>
 
-The resource can contain arbitrary data. They can be artifact jars, configuration files,
-sample data, or anything else a package action may require.
+The resource can contain arbitrary data. They can be artifact JARs, configuration files,
+sample data, or anything else that a package action may require.
 
 Get Package Resource Signature
 ==============================
+
+.. highlight:: console
+
 To retrieve the signature for a package resource, submit an HTTP GET request::
 
   GET /v1/packages/<package-name>/<version>/<resource-name>.asc
@@ -586,6 +644,9 @@ resource was signed by the publisher.
 
 Get Package Icon
 ================
+
+.. highlight:: console
+
 To retrieve the icon for a package, submit an HTTP GET request::
 
   GET /v1/packages/<package-name>/<version>/icon.png

--- a/cdap-docs/integrations/source/cask-market/api.rst
+++ b/cdap-docs/integrations/source/cask-market/api.rst
@@ -1,0 +1,592 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2016 Cask Data, Inc.
+
+.. _cask-market-api:
+================
+Cask Market APIs
+================
+
+The Cask Market APIs are simply a contract about the directory structure of the marketplace.
+All APIs are relative to a base path. For example, the base path for the public Cask hosted market
+is 'market.cask.co'. The directory structure must be::
+
+  <base>/v1/packages.json
+  <base>/v1/packages/<package-name>/<version>/icon.png
+  <base>/v1/packages/<package-name>/<version>/spec.json
+  <base>/v1/packages/<package-name>/<version>/spec.json.asc
+  <base>/v1/packages/<package-name>/<version>/<resource1>
+  <base>/v1/packages/<package-name>/<version>/<resource1>.asc
+  <base>/v1/packages/<package-name>/<version>/<resource2>
+  <base>/v1/packages/<package-name>/<version>/<resource2>.asc
+  ...
+
+.. _cask-market-get-catalog:
+
+Get Market Catalog
+==================
+To retrieve a list of available packages, submit an HTTP GET request::
+
+  GET /v1/packages.json
+
+This will return a JSON array that lists each package and its metadata::
+
+  [
+    {
+      name: "access-log",
+      version: "1.0.0",
+      description: "Sample access logs in Combined Log Format (CLF)",
+      label: "Access Log Sample",
+      author: "Cask",
+      org: "Cask Data, Inc.",
+      cdapVersion: "[4.0.0-SNAPSHOT,4.1.0)",
+      created: 1473901763,
+      categories: [ "datapack" ]
+    },
+    {
+      name: "bulk-data-transfer",
+      version: "1.0.0",
+      description: "Moving data from structured data source likes traditional relational database into Hadoop is very common in building Data Lakes.
+                    This data application allows you to set-up periodic full data dumps from RDBMS into Hadoop cluster.
+                    Data on Hadoop is stored as DB table snapshot. Supports other relational databases.",
+      label: "Bulk Data Transfer",
+      author: "Cask",
+      org: "Cask Data, Inc.",
+      cdapVersion: "[4.0.0-SNAPSHOT,4.1.0)",
+      created: 1473901763,
+      categories: [ "usecase" ]
+    },
+    ...
+  ]
+
+Get Package Specification
+=========================
+To retrieve a package specification, submit an HTTP GET request::
+
+  GET /v1/packages/<package-name>/<version>/spec.json
+
+This will return a JSON object that contains metadata about the package,
+and a list of actions required to install the package::
+
+  {
+    "label": "Bulk Data Transfer",
+    "description": "Moving data from structured data source likes traditional relational database into Hadoop is very common in building Data Lakes.
+                    This data application allows you to set-up periodic full data dumps from RDBMS into Hadoop cluster.
+                    Data on Hadoop is stored as DB table snapshot. Supports other relational databases.",
+    "author": "Cask",
+    "org": "Cask Data, Inc.",
+    "created": 1473901763,
+    "categories": [ "usecase" ],
+    "cdapVersion": "[4.0.0-SNAPSHOT,4.1.0)",
+    "actions": [
+      {
+        "type": "informational",
+        "label": "Download MySQL JDBC Driver",
+        "arguments": [
+          {
+            "name": "steps",
+            "value": [
+              "Download the zip file from Mysql at https://dev.mysql.com/downloads/file/?id=462850",
+              "Unzip the file",
+              "In the next step, upload the 'mysql-connector-java-5.1.39-bin.jar' file from the zip"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "create_artifact",
+        "label": "MySQL Driver Plugin",
+        "arguments": [
+          {
+            "name": "name",
+            "value": "mysql-connector-java"
+          },
+          {
+            "name": "version",
+            "value": "5.1.39"
+          },
+          {
+            "name": "scope",
+            "value": "user"
+          },
+          {
+            "name": "config",
+            "value": "mysql-connector-java.json"
+          }
+        ]
+      },
+      {
+        "type": "create_pipeline",
+        "label": "Bulk Data Transfer Pipeline",
+        "arguments": [
+          {
+            "name": "artifact",
+            "value": {
+              "scope": "system",
+              "name": "cdap-data-pipeline",
+              "version": "4.0.0-SNAPSHOT"
+            }
+          },
+          {
+            "name": "name",
+            "value": "bulkDataTransfer",
+            "canModify": true
+          },
+          {
+            "name": "config",
+            "value": "pipeline.json"
+          }
+        ]
+      }
+    ]
+  }
+
+There are several supported actions, each with its own specification.
+If an action fails for any reason, actions completed before it are
+not rolled back. However, each action is idempotent, which means the
+installation can simply be retried once the underylying failure cause has
+been fixed.
+
+Action Specification
+--------------------
+Each action contains a label, type, and arguments::
+
+  {
+    "label": [display label],
+    "type": [action type],
+    "arguments": [
+      "name": [argument name],
+      "value": [argument value],
+      "canModify": true | false (defaults to false)
+    ]
+  }
+
+The label is short description that will be displayed to users during the install process.
+Some arguments will reference package resources.
+Descriptions of each action type and their supported arguments are listed below.
+
+informational
+^^^^^^^^^^^^^
+Displays information for the user. Does not perform any actions against the CDAP RESTful APIs.
+This can be used, for example, to tell the user to download a jar from a 3rd party website.
+
+.. list-table::
+   :widths: 20 50 10 20
+   :header-rows: 1
+
+   * - Argument
+     - Description
+     - Required?
+     - Default
+   * - steps
+     - JSON array of strings listing steps the user should take
+     - yes
+     -
+
+Example action::
+
+  {
+    "type": "informational",
+    "label": "Download MySQL JDBC Driver",
+    "arguments": [
+      {
+        "name": "steps",
+        "value": [
+          "Download the zip file from Oracle at https://dev.mysql.com/downloads/file/?id=462850",
+          "Unzip the file",
+          "In the next step, upload the 'mysql-connector-java-5.1.39-bin.jar' file from the zip"
+        ]
+      }
+    ]
+  }
+
+create_artifact
+^^^^^^^^^^^^^^^
+Creates a CDAP artifact.
+
+.. list-table::
+   :widths: 20 50 10 20
+   :header-rows: 1
+
+   * - Argument
+     - Description
+     - Required?
+     - Default
+   * - name
+     - artifact name
+     - yes
+     -
+   * - jar
+     - package resource containing the artifact jar contents
+     - yes
+     -
+   * - scope
+     - artifact scope
+     - no
+     - user
+   * - version
+     - artifact version
+     - no
+     - version contained in the jar manifest
+   * - config
+     - package resource containing artifact parents, plugins, and properties
+     - no
+     -
+
+If the artifact is a plugin artifact, the config argument is used to specify its
+parent artifacts, any 3rd party plugins contained in the artifact, and any properties
+of the artifact.
+
+Example action::
+
+  {
+    "type": "create_artifact",
+    "label": "MySQL Driver Plugin",
+    "arguments": [
+      {
+        "name": "name",
+        "value": "mysql-connector-java"
+      },
+      {
+        "name": "version",
+        "value": "5.1.39"
+      },
+      {
+        "name": "scope",
+        "value": "user"
+      },
+      {
+        "name": "config",
+        "value": "mysql-connector-java.json"
+      }
+    ]
+  }
+
+where mysql-connector-java.json is a package resource with content::
+
+  {
+    "parents": [
+      "system:cdap-data-pipeline[3.0.0,10.0.0]",
+      "system:cdap-data-streams[3.0.0,10.0.0]"
+    ],
+    "plugins": [
+      {
+        "name" : "mysql",
+        "type" : "jdbc",
+        "className" : "com.mysql.jdbc.Driver",
+        "description" : "Plugin for MySQL JDBC driver"
+      }
+    ],
+    "properties": { }
+  }
+
+create_stream
+^^^^^^^^^^^^^
+Creates a CDAP stream.
+
+.. list-table::
+   :widths: 20 50 10 20
+   :header-rows: 1
+
+   * - Argument
+     - Description
+     - Required?
+     - Default
+   * - name
+     - stream name
+     - yes
+     -
+   * - description
+     - stream description
+     - no
+     -
+   * - properties
+     - package resource containing stream properties like the format, ttl, and notification threshold
+     - no
+     -
+
+Example action::
+
+  {
+    "type": "create_stream",
+    "label": "Labeled SMS Texts",
+    "arguments": [
+      {
+        "name": "name",
+        "value": "labeledSMS"
+      },
+      {
+        "name": "description",
+        "value": "SMS texts that have been labeled as spam or not"
+      },
+      {
+        "name": "properties",
+        "value": "properties.json"
+      }
+    ]
+  }
+
+where properties.json is a package resource with content::
+
+  {
+    "ttl": 9223372036854775,
+    "format": {
+      "name": "tsv",
+      "schema": {
+        "type": "record",
+        "name": "labeledSMS",
+        "fields": [
+          { "name": "label", "type": "string" },
+          { "name": "message", "type": "string" }
+        ]
+      }
+    },
+    "notification.threshold.mb": 1024
+  }
+
+load_datapack
+^^^^^^^^^^^^^
+Loads a datapack into a CDAP entity, like a stream or dataset.
+
+.. list-table::
+   :widths: 20 50 10 20
+   :header-rows: 1
+
+   * - Argument
+     - Description
+     - Required?
+     - Default
+   * - name
+     - the name of the CDAP entity to load the data into
+     - yes
+     -
+   * - files
+     - a JSON array of package resources to load into the CDAP entity
+     - yes
+     -
+
+Example action::
+
+  {
+    "type": "load_datapack",
+    "label": "Labeled SMS Text Data",
+    "arguments": [
+      {
+        "name": "name",
+        "value": "labeledSMS"
+      },
+      {
+        "name": "files",
+        "value": [ "texts1.tsv", "texts2.tsv" ]
+      }
+    ]
+  }
+
+where texts1.tsv and texts2.tsv are package resources containing the data to load into the stream.
+
+create_app
+^^^^^^^^^^
+Creates a CDAP application from an existing CDAP artifact.
+
+.. list-table::
+   :widths: 20 50 10 20
+   :header-rows: 1
+
+   * - Argument
+     - Description
+     - Required?
+     - Default
+   * - artifact
+     - JSON Object containing the application's artifact scope, name, and version
+     - yes
+     -
+   * - name
+     - application name
+     - yes
+     -
+   * - config
+     - package resource containing the application config
+     - no
+     -
+
+Example action::
+
+  {
+    "type": "create_app",
+    "label": "Word Count Example App",
+    "arguments": [
+      {
+        "name": "artifact",
+        "value": {
+          "scope": "user",
+          "name": "WordCount",
+          "version": "4.0.0"
+        }
+      },
+      {
+        "name": "name",
+        "value": "WordCount",
+        "canModify": true
+      },
+      {
+        "name": "config",
+        "value": "config.json"
+      }
+    ]
+  }
+
+where config.json is a package resource that contains the application configuration::
+
+  {
+    "stream": "wordStream",
+    "wordStatsTable": "wordStats",
+    "wordCountTable": "wordCounts",
+    "uniqueCountTable": "uniqueCount",
+    "wordAssocTable": "wordAssocs"
+  }
+
+create_pipeline
+^^^^^^^^^^^^^^^
+Creates a Hydrator pipeline. Very similar to the create_app pipeline,
+except the config is required and the UI will take the user to the Hydrator UI
+instead of the CDAP UI after installation is complete.
+
+.. list-table::
+   :widths: 20 50 10 20
+   :header-rows: 1
+
+   * - Argument
+     - Description
+     - Required?
+     - Default
+   * - artifact
+     - JSON Object containing the pipeline's artifact scope, name, and version
+     - yes
+     -
+   * - name
+     - pipeline name
+     - yes
+     -
+   * - config
+     - package resource containing the pipeline config
+     - yes
+     -
+
+Example action::
+
+  {
+    "type": "create_pipeline",
+    "label": "Omniture Hits Pipeline",
+    "arguments": [
+      {
+        "name": "artifact",
+        "value": {
+          "scope": "system",
+          "name": "cdap-data-pipeline",
+          "version": "4.0.0"
+        }
+      },
+      {
+        "name": "name",
+        "value": "omnitureHitsPipeline",
+        "canModify": true
+      },
+      {
+        "name": "config",
+        "value": "pipeline.json"
+      }
+    ]
+  }
+
+where pipeline.json is a package resource containing the pipeline config.
+
+create_pipeline_draft
+^^^^^^^^^^^^^^^^^^^^^
+Creates a Hydrator pipeline draft. Similar to create_pipeline, except the pipeline
+will not be published. Instead, a draft will be created that the user can then
+go and modify.
+
+.. list-table::
+   :widths: 20 50 10 20
+   :header-rows: 1
+
+   * - Argument
+     - Description
+     - Required?
+     - Default
+   * - artifact
+     - JSON Object containing the pipeline's artifact scope, name, and version
+     - yes
+     -
+   * - name
+     - pipeline name
+     - yes
+     -
+   * - config
+     - package resource containing the pipeline config
+     - yes
+     -
+
+Example action::
+
+  {
+    "type": "create_pipeline",
+    "label": "Omniture Hits Pipeline",
+    "arguments": [
+      {
+        "name": "artifact",
+        "value": {
+          "scope": "system",
+          "name": "cdap-data-pipeline",
+          "version": "4.0.0-SNAPSHOT"
+        }
+      },
+      {
+        "name": "name",
+        "value": "omnitureHitsPipeline",
+        "canModify": true
+      },
+      {
+        "name": "config",
+        "value": "pipeline.json"
+      }
+    ]
+  }
+
+Get Package Specification Signature
+===================================
+To retrieve the signature for a package specification, submit an HTTP GET request::
+
+  GET /v1/packages/<package-name>/<version>/spec.json.asc
+
+The signature is a PGP signature that can be used to validate a package resource. The
+package publisher signs the package specification with their private key. The signature can
+then be used in conjunction with the publisher's public key to validate that the specification
+was signed by the publisher.
+
+Get Package Resource
+====================
+To retrieve a package resource, submit an HTTP GET request::
+
+  GET /v1/packages/<package-name>/<version>/<resource-name>
+
+The resource can contain arbitrary data. They can be artifact jars, configuration files,
+sample data, or anything else a package action may require.
+
+Get Package Resource Signature
+==============================
+To retrieve the signature for a package resource, submit an HTTP GET request::
+
+  GET /v1/packages/<package-name>/<version>/<resource-name>.asc
+
+The signature is a PGP signature that can be used to validate a package resource. The
+package publisher signs the package resource with their private key. The signature can
+then be used in conjunction with the publisher's public key to validate that a package
+resource was signed by the publisher.
+
+Get Package Icon
+================
+To retrieve the icon for a package, submit an HTTP GET request::
+
+  GET /v1/packages/<package-name>/<version>/icon.png
+

--- a/cdap-docs/integrations/source/cask-market/custom.rst
+++ b/cdap-docs/integrations/source/cask-market/custom.rst
@@ -1,0 +1,33 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2016 Cask Data, Inc.
+
+.. _cask-market-custom:
+============================
+Hosting a Custom Cask Market
+============================
+
+The Cask Market APIs are simply a contract about the directory structure of the marketplace.
+The directory structure must be::
+
+  <base>/v1/packages.json
+  <base>/v1/packages/<package-name>/<version>/icon.png
+  <base>/v1/packages/<package-name>/<version>/spec.json
+  <base>/v1/packages/<package-name>/<version>/spec.json.asc
+  <base>/v1/packages/<package-name>/<version>/<resource1>
+  <base>/v1/packages/<package-name>/<version>/<resource1>.asc
+  <base>/v1/packages/<package-name>/<version>/<resource2>
+  <base>/v1/packages/<package-name>/<version>/<resource2>.asc
+  ...
+
+As such, hosting a custom market can be done by setting up a server that follows the same
+path structure.
+
+One possible setup is to keep your packages in a source control repository whose directory
+structure matches the one required by the Market. The repository can be checked out onto one or
+more machines, with an Apache server configured to serve content from that directory. A tool
+can be run to create the catalog file from all the package specifications, and to create all
+the signature files.
+
+Another possible setup is to serve the market catalog and packages from S3.
+

--- a/cdap-docs/integrations/source/cask-market/custom.rst
+++ b/cdap-docs/integrations/source/cask-market/custom.rst
@@ -7,6 +7,8 @@
 Hosting a Custom Cask Market
 ============================
 
+.. highlight:: console
+
 The Cask Market APIs are simply a contract about the directory structure of the marketplace.
 The directory structure must be::
 
@@ -24,10 +26,9 @@ As such, hosting a custom market can be done by setting up a server that follows
 path structure.
 
 One possible setup is to keep your packages in a source control repository whose directory
-structure matches the one required by the Market. The repository can be checked out onto one or
+structure matches the one required by the market. The repository can be checked out onto one or
 more machines, with an Apache server configured to serve content from that directory. A tool
 can be run to create the catalog file from all the package specifications, and to create all
 the signature files.
 
-Another possible setup is to serve the market catalog and packages from S3.
-
+Another possible setup is to serve the market catalog and packages from Amazon S3.

--- a/cdap-docs/integrations/source/cask-market/custom.rst
+++ b/cdap-docs/integrations/source/cask-market/custom.rst
@@ -3,6 +3,7 @@
     :copyright: Copyright © 2016 Cask Data, Inc.
 
 .. _cask-market-custom:
+
 ============================
 Hosting a Custom Cask Market
 ============================
@@ -10,17 +11,12 @@ Hosting a Custom Cask Market
 .. highlight:: console
 
 The Cask Market APIs are simply a contract about the directory structure of the marketplace.
-The directory structure must be::
 
-  <base>/v1/packages.json
-  <base>/v1/packages/<package-name>/<version>/icon.png
-  <base>/v1/packages/<package-name>/<version>/spec.json
-  <base>/v1/packages/<package-name>/<version>/spec.json.asc
-  <base>/v1/packages/<package-name>/<version>/<resource1>
-  <base>/v1/packages/<package-name>/<version>/<resource1>.asc
-  <base>/v1/packages/<package-name>/<version>/<resource2>
-  <base>/v1/packages/<package-name>/<version>/<resource2>.asc
-  ...
+.. Directory structure
+.. --------------------
+.. include:: api.rst
+    :start-after: .. directory-structure-start
+    :end-before: .. directory-structure-end
 
 As such, hosting a custom market can be done by setting up a server that follows the same
 path structure.

--- a/cdap-docs/integrations/source/cask-market/index.rst
+++ b/cdap-docs/integrations/source/cask-market/index.rst
@@ -1,0 +1,52 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2016 Cask Data, Inc.
+
+===========
+Cask Market
+===========
+
+.. rubric:: Overview
+
+The Cask Market allows CDAP users to create and update CDAP artifacts, applications,
+and datasets using simple wizards. Instead of building code, deploying artifacts,
+and configuring applications, users can simply point and click.
+This allows users of varying technical skills to deploy and run common use
+cases in a self-service manner.
+
+The Cask Market allows system administrators to distribute re-usable applications, data, and code
+to all CDAP users in their organization. Though there is currently no way to publish packages to the public
+Cask hosted market, administrators can host their own market, then configure their CDAP
+instances to use their own market instead of the public Cask Market.
+
+.. rubric:: Terminology
+
+package - A collection of entities (artifacts, applications, datasets, streams, configuration) to add to CDAP.
+A package is identified by a name and version, and can be tagged with one or more categories. Each package
+must contain a specification, and may contain resources.
+
+package specification - A package specification define metadata about the package, such as a display label,
+description, creation time, and CDAP compatibilities. It also contains a list of actions that must be
+performed to install the package. Each action corresponds to a wizard in the installation process.
+
+package resources - A package resource is a file that can be used during the installation process. It can
+be a configuration file, a jar, or data that should be loaded into a dataset. Resources are referenced
+by name in the actions defined in the package specification.
+
+catalog - The catalog is a list of all packages in the CDAP market. The catalog contains metadata
+about each package.
+
+.. rubric:: Architecture
+
+The Cask market is a service that is separate from a CDAP instance. Each CDAP UI instance can be configured
+to read from a separate Cask market instance. By default, the UI points to the public Cask hosted market.
+During package installation, the UI will make calls to the CDAP Market and to a CDAP Router instance to
+create or update various CDAP entities. For example, a package may contain an action to create a stream,
+then load data to a stream. The market UI will interact with the CDAP RESTful APIs to first create a stream,
+then fetch the data from the CDAP market and add it to the CDAP stream through the CDAP RESTful APIs.
+
+The market is essentially just a server that serves static package specifications and resources.
+As such, administrators can easily set up their own markets in the same way they would serve any
+static content. For example, an Apache web server can be placed on top of a local directory structure
+that matches the expected market directory structure.
+

--- a/cdap-docs/integrations/source/cask-market/index.rst
+++ b/cdap-docs/integrations/source/cask-market/index.rst
@@ -2,51 +2,64 @@
     :author: Cask Data, Inc.
     :copyright: Copyright © 2016 Cask Data, Inc.
 
+:hide-toc: true
+
+.. _cask-market:
+
 ===========
 Cask Market
 ===========
 
+.. toctree::
+   :maxdepth: 6
+   
+    Cask Market HTTP RESTful API <api>
+    Hosting a Custom Cask Market <custom>
+
 .. rubric:: Overview
 
-The Cask Market allows CDAP users to create and update CDAP artifacts, applications,
-and datasets using simple wizards. Instead of building code, deploying artifacts,
-and configuring applications, users can simply point and click.
-This allows users of varying technical skills to deploy and run common use
-cases in a self-service manner.
+The Cask Market allows CDAP users to create and update CDAP artifacts, applications, and
+datasets using simple wizards. Instead of building code, deploying artifacts, and
+configuring applications, users can simply point and click. This allows users of varying
+technical skill the ability to deploy and run common use-cases in a self-service manner.
 
-The Cask Market allows system administrators to distribute re-usable applications, data, and code
-to all CDAP users in their organization. Though there is currently no way to publish packages to the public
-Cask hosted market, administrators can host their own market, then configure their CDAP
-instances to use their own market instead of the public Cask Market.
+The Cask Market allows system administrators to distribute re-usable applications, data,
+and code to all CDAP users in their organization. Though there is currently no method for
+publishing packages to the public Cask-hosted market, administrators can host their own
+market and then configure their CDAP instances to use their own market instead of the
+public Cask Market.
 
 .. rubric:: Terminology
 
-package - A collection of entities (artifacts, applications, datasets, streams, configuration) to add to CDAP.
-A package is identified by a name and version, and can be tagged with one or more categories. Each package
-must contain a specification, and may contain resources.
+**Package:** A collection of entities (artifacts, applications, datasets, streams,
+configuration) to add to CDAP. A package is identified by a name and version, and can be
+tagged with one or more categories. Each package must contain a specification, and may
+contain resources.
 
-package specification - A package specification define metadata about the package, such as a display label,
-description, creation time, and CDAP compatibilities. It also contains a list of actions that must be
-performed to install the package. Each action corresponds to a wizard in the installation process.
+**Package Specification:** Defines metadata about the package, such as display label,
+description, creation time, and CDAP compatibilities. It contains a list of actions that
+must be performed to install the package. Each action corresponds to a wizard in the
+installation process.
 
-package resources - A package resource is a file that can be used during the installation process. It can
-be a configuration file, a jar, or data that should be loaded into a dataset. Resources are referenced
-by name in the actions defined in the package specification.
+**Package Resource:** A file that can be used during the installation process. It can be a
+configuration file, a JAR, or data that should be loaded into a dataset. Resources are
+referenced by name in the actions defined in the package specification.
 
-catalog - The catalog is a list of all packages in the CDAP market. The catalog contains metadata
-about each package.
+**Catalog:** The catalog is a list of all the packages in the Cask Market. The catalog
+contains metadata about each package.
 
 .. rubric:: Architecture
 
-The Cask market is a service that is separate from a CDAP instance. Each CDAP UI instance can be configured
-to read from a separate Cask market instance. By default, the UI points to the public Cask hosted market.
-During package installation, the UI will make calls to the CDAP Market and to a CDAP Router instance to
-create or update various CDAP entities. For example, a package may contain an action to create a stream,
-then load data to a stream. The market UI will interact with the CDAP RESTful APIs to first create a stream,
-then fetch the data from the CDAP market and add it to the CDAP stream through the CDAP RESTful APIs.
+The Cask Market is a service that is separate from a CDAP instance. Each CDAP UI instance
+can be configured to read from a separate Cask Market instance. By default, the UI points
+to the public Cask-hosted market. During package installation, the UI will make calls to
+the Cask Market and to a CDAP Router instance to create or update various CDAP entities.
+For example, a package may contain an action to create a stream, and then load data to a
+stream. The Cask Market UI will interact with the CDAP RESTful APIs to create the stream,
+then fetch the data from the Cask Market and add it to the CDAP stream through the CDAP
+RESTful APIs.
 
-The market is essentially just a server that serves static package specifications and resources.
-As such, administrators can easily set up their own markets in the same way they would serve any
-static content. For example, an Apache web server can be placed on top of a local directory structure
-that matches the expected market directory structure.
-
+A market is essentially just a server that serves static package specifications and
+resources. As such, administrators can easily set up their own markets in the same way
+they would serve any static content. For example, an Apache web server can be placed on
+top of a local directory structure that matches the expected market directory structure.

--- a/cdap-docs/integrations/source/index.rst
+++ b/cdap-docs/integrations/source/index.rst
@@ -14,7 +14,8 @@ Integrations
 .. |cask-market-overview| replace:: **Overview:**
 .. _cask-market-overview: cask-market/index.html
 
-- |cask-market-overview|_ Overview of the **Cask Market**
+- |cask-market-overview|_ Summary of the **Cask Market,** a source for re-usable
+  applications, data, and code for CDAP users
 
 .. |cask-market-api| replace:: **API:**
 .. _cask-market-api: cask-market/api.html

--- a/cdap-docs/integrations/source/index.rst
+++ b/cdap-docs/integrations/source/index.rst
@@ -9,6 +9,24 @@ Integrations
 ============
 
 
+.. rubric:: Cask Market
+
+.. |cask-market-overview| replace:: **Overview:**
+.. _cask-market-overview: cask-market/index.html
+
+- |cask-market-overview|_ Overview of the **Cask Market**
+
+.. |cask-market-api| replace:: **API:**
+.. _cask-market-api: cask-market/api.html
+
+- |cask-market-api|_ Cask Market APIs
+
+.. |cask-market-custom| replace:: **Custom Hosting:**
+.. _cask-market-custom: cask-market/custom.html
+
+- |cask-market-custom|_ Hosting your own custom Cask Market
+
+
 .. rubric:: Cloudera
 
 .. |cloudera-introduction| replace:: **Overview:**
@@ -56,22 +74,6 @@ Integrations
 
 - |mapr|_ Configuring and installing CDAP on **MapR** *(Administration Manual)*
 
-.. rubric:: Cask Market
-
-.. |cask-market-overview| replace:: **Overview:**
-.. _cask-market-overview: cask-market/index.html
-
-- |cask-market-overview|_ Overview of the **Cask Market**
-
-.. |cask-market-api| replace:: **API:**
-.. _cask-market-api: cask-market/api.html
-
-- |cask-market-api|_ Cask Market APIs
-
-.. |cask-market-custom| replace:: **Custom Hosting:**
-.. _cask-market-custom: cask-market/custom.html
-
-- |cask-market-custom|_ Hosting your own custom Cask Market
 
 .. rubric:: Apache Sentry
 

--- a/cdap-docs/integrations/source/index.rst
+++ b/cdap-docs/integrations/source/index.rst
@@ -56,6 +56,22 @@ Integrations
 
 - |mapr|_ Configuring and installing CDAP on **MapR** *(Administration Manual)*
 
+.. rubric:: Cask Market
+
+.. |cask-market-overview| replace:: **Overview:**
+.. _cask-market-overview: cask-market/index.html
+
+- |cask-market-overview|_ Overview of the **Cask Market**
+
+.. |cask-market-api| replace:: **API:**
+.. _cask-market-api: cask-market/api.html
+
+- |cask-market-api|_ Cask Market APIs
+
+.. |cask-market-custom| replace:: **Custom Hosting:**
+.. _cask-market-custom: cask-market/custom.html
+
+- |cask-market-custom|_ Hosting your own custom Cask Market
 
 .. rubric:: Apache Sentry
 

--- a/cdap-docs/integrations/source/table-of-contents.rst
+++ b/cdap-docs/integrations/source/table-of-contents.rst
@@ -7,9 +7,10 @@ CDAP Integrations Table of Contents
 ===================================
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 4
 
     Introduction <index>
+    Cask Market <cask-market/index>
     Cloudera <partners/cloudera/index>
     Apache Sentry <apache-sentry>
     Apache Hadoop KMS <hadoop-kms>


### PR DESCRIPTION
Mostly trying to get the api documented early. The final location
and structure of these docs may (and probably should) change.
More information about hosting a custom market should also be
provided later.

Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB156-2

Pages of interest:
- Integrations: http://builds.cask.co/artifact/CDAP-DQB156/shared/build-2/Docs-HTML/4.0.0-SNAPSHOT/en/integrations/index.html
- Cask Market: http://builds.cask.co/artifact/CDAP-DQB156/shared/build-2/Docs-HTML/4.0.0-SNAPSHOT/en/integrations/cask-market/index.html

Fixes two missing links from the Integration section of the main index page.
