### PR TITLE
Fix DefaultUGIProvider.

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/security/DefaultUGIProvider.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/security/DefaultUGIProvider.java
@@ -74,7 +74,8 @@ public class DefaultUGIProvider extends AbstractCachedUGIProvider {
     URI keytabURI = URI.create(impersonationInfo.getKeytabURI());
     boolean isKeytabLocal = keytabURI.getScheme() == null || "file".equals(keytabURI.getScheme());
 
-    File localKeytabFile = isKeytabLocal ? new File(keytabURI) : localizeKeytab(locationFactory.create(keytabURI));
+    File localKeytabFile = isKeytabLocal ?
+      new File(keytabURI.getPath()) : localizeKeytab(locationFactory.create(keytabURI));
     try {
       String expandedPrincipal = SecurityUtil.expandPrincipal(impersonationInfo.getPrincipal());
       LOG.debug("Logging in as: principal={}, keytab={}", expandedPrincipal, localKeytabFile);

--- a/cdap-common/src/test/java/co/cask/cdap/common/security/UGIProviderTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/security/UGIProviderTest.java
@@ -116,7 +116,7 @@ public class UGIProviderTest {
     DefaultUGIProvider provider = new DefaultUGIProvider(cConf, locationFactory);
 
     // Try with local keytab file
-    ImpersonationInfo aliceInfo = new ImpersonationInfo(getPrincipal("alice"), keytabFile.toURI().toString());
+    ImpersonationInfo aliceInfo = new ImpersonationInfo(getPrincipal("alice"), keytabFile.getAbsolutePath());
     UserGroupInformation aliceUGI = provider.getConfiguredUGI(aliceInfo);
     Assert.assertEquals(UserGroupInformation.AuthenticationMethod.KERBEROS, aliceUGI.getAuthenticationMethod());
     Assert.assertTrue(aliceUGI.hasKerberosCredentials());


### PR DESCRIPTION
If a URI is passed to the `new File(URI)` constructor, it must have a scheme. So, instead, just pass the path String.

This does not affect any released version, and only was an issue due to a recently merged PR (https://github.com/caskdata/cdap/pull/6954), and hence I didn't file a JIRA for it.

http://builds.cask.co/browse/CDAP-RUT237-1
