### PR TITLE
CDAP-7473 Be able to write program.log file, even if 'yarn.nodemanage…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.twill.api.EventHandler;
 import org.apache.twill.api.TwillApplication;
@@ -233,7 +234,9 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner 
                 twillPreparer.setSchedulerQueue(schedulerQueueName);
               }
               if (logbackURI != null) {
-                twillPreparer.withResources(logbackURI);
+                twillPreparer
+                  .withResources(logbackURI)
+                  .withEnv(Collections.singletonMap("CDAP_LOG_DIR", ApplicationConstants.LOG_DIR_EXPANSION_VAR));
               }
 
               String logLevelConf = cConf.get(Constants.COLLECT_APP_CONTAINER_LOG_LEVEL).toUpperCase();

--- a/cdap-distributions/src/etc/cdap/conf.dist/logback-container.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/logback-container.xml
@@ -44,14 +44,14 @@
   <logger name="Explore.stderr" level="INFO"/>
 
     <appender name="Rolling" class="ch.qos.logback.core.rolling.RollingFileAppender">
-      <!-- LOG_DIRS is the environment variable set by YARN for container logs -->
-      <file>${LOG_DIRS}/program.log</file>
+      <!-- CDAP_LOG_DIR is the environment variable set by CDAP for logs -->
+      <file>${CDAP_LOG_DIR}/program.log</file>
       <encoder>
         <pattern>%d{ISO8601} - %-5p [%t:%logger{1}@%L] - %m%n</pattern>
       </encoder>
       <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
         <!-- Daily rollover at midnight-->
-        <fileNamePattern>${LOG_DIRS}/program.%d.log</fileNamePattern>
+        <fileNamePattern>${CDAP_LOG_DIR}/program.%d.log</fileNamePattern>
 
         <!-- Keep 2 weeks of history -->
         <maxHistory>14</maxHistory>

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -97,6 +97,7 @@ import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.twill.api.ElectionHandler;
 import org.apache.twill.api.TwillApplication;
@@ -131,6 +132,7 @@ import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -785,7 +787,9 @@ public class MasterServiceMain extends DaemonMain {
 
           // Add logback xml
           if (Files.exists(logbackFile)) {
-            preparer.withResources().withResources(logbackFile.toUri());
+            preparer
+              .withResources(logbackFile.toUri())
+              .withEnv(Collections.singletonMap("CDAP_LOG_DIR", ApplicationConstants.LOG_DIR_EXPANSION_VAR));
           }
 
           // Add yarn queue name if defined


### PR DESCRIPTION
Be able to write program.log file, even if 'yarn.nodemanager.log-dirs' is not configured as a single directory.
JIRA has detailed explanation of the issue.

https://issues.cask.co/browse/CDAP-7473
http://builds.cask.co/browse/CDAP-RUT236-1
