### PR TITLE
CDAP-7474 Fix NPE by making FileLogReader#getLog never return null.

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/DistributedLogReader.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/DistributedLogReader.java
@@ -45,8 +45,8 @@ public final class DistributedLogReader implements LogReader {
    */
   @Inject
   DistributedLogReader(CConfiguration cConf,
-                              KafkaLogReader kafkaLogReader, FileLogReader fileLogReader,
-                              CheckpointManagerFactory checkpointManagerFactory, StringPartitioner partitioner) {
+                       KafkaLogReader kafkaLogReader, FileLogReader fileLogReader,
+                       CheckpointManagerFactory checkpointManagerFactory, StringPartitioner partitioner) {
     this.kafkaLogReader = kafkaLogReader;
     this.fileLogReader = fileLogReader;
     this.checkpointManager = checkpointManagerFactory.create(cConf.get(Constants.Logging.KAFKA_TOPIC),

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/FileLogReader.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/FileLogReader.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.logging.read;
 
+import co.cask.cdap.api.dataset.lib.AbstractCloseableIterator;
 import co.cask.cdap.api.dataset.lib.CloseableIterator;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.logging.LoggingContext;
@@ -170,7 +171,18 @@ public class FileLogReader implements LogReader {
       NavigableMap<Long, Location> sortedFiles = fileMetaDataManager.listFiles(loggingContext);
       if (sortedFiles.isEmpty()) {
         // return empty iterator
-        return null;
+        return new AbstractCloseableIterator<LogEvent>() {
+          @Override
+          protected LogEvent computeNext() {
+            endOfData();
+            return null;
+          }
+
+          @Override
+          public void close() {
+            // no-op
+          }
+        };
       }
 
       List<Location> filesInRange = getFilesInRange(sortedFiles, fromTimeMs, toTimeMs);


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-7474
http://builds.cask.co/browse/CDAP-RUT241-1
