### PR TITLE
Handle Parcel-based invocation of cdap script

### DIFF
--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -31,14 +31,14 @@ fi
 __target=$(cd $(dirname ${__target}); echo "$(pwd -P)/$(basename ${__target})")
 __app_home=$(cd $(dirname ${__target})/.. >&-; pwd -P)
 
-__comp_home=$(cd ${__target%/*/*} >&- 2>/dev/null; pwd -P)
-# Determine if we're in the SDK or distributed
+__comp_home=${COMPONENT_HOME:-$(cd ${__target%/*/*} >&- 2>/dev/null; pwd -P)}
+# Determine if we're in Distributed from packages or SDK/Parcel
 if [[ ${__comp_home%/*} == /opt/cdap ]] && [[ ${__comp_home} != /opt/cdap/sdk* ]]; then
   __app_home=${__comp_home}
-  __cdap_home=/opt/cdap
+  __cdap_home=${CDAP_HOME:-/opt/cdap}
 else
-  # We're in the SDK, __app_home and __cdap_home are identical
-  __cdap_home=${__app_home}
+  # We're in the SDK, __app_home and __cdap_home are identical, but honor CDAP_HOME if it's set (for Parcel)
+  __cdap_home=${CDAP_HOME:-${__app_home}}
 fi
 
 # Source our functions script, which will be located with us


### PR DESCRIPTION
The CSD for CDAP sets COMPONENT_HOME and CDAP_HOME, so let's simply honor those, if they're set.
