### PR TITLE
Redirect STDERR to /dev/null

### DIFF
--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -983,8 +983,8 @@ cdap_config_tool() {
   if [[ ${__has_arg} -eq 0 ]] && [[ -f ${__auth_file} ]]; then
     set -- ${@} "--token-file" "${__auth_file}"
   fi
-
-  "${JAVA}" -cp ${CLASSPATH} -Dscript=${__script} ${__class} ${@}
+  # TODO: remove redirect when CDAP-7468 is resolved properly
+  "${JAVA}" -cp ${CLASSPATH} -Dscript=${__script} ${__class} ${@} 2>/dev/null
   __ret=${?}
   return ${__ret}
 }


### PR DESCRIPTION
This is a workaround to prevent the issues described in [CDAP-7468](https://issues.cask.co/browse/CDAP-7468) where output on STDERR causes the UI to fail due to an error parsing the output from the `cdap_config_tool` function.
