### PR TITLE
update alternatives for new cdap script

### DIFF
--- a/cdap-distributions/src/parcel/meta/alternatives.json
+++ b/cdap-distributions/src/parcel/meta/alternatives.json
@@ -6,8 +6,8 @@
     "isDirectory": true
   },
   "cdap-cli": {
-    "destination": "/usr/bin/cdap-cli.sh",
-    "source": "cli/bin/cdap-cli.sh",
+    "destination": "/usr/bin/cdap",
+    "source": "cli/bin/cdap",
     "priority": 10,
     "isDirectory": false
   }


### PR DESCRIPTION
updates the parcel to set a `cdap` alternative instead of the old `cdap-cli.sh`
