### PR TITLE
Implement recursive readlink shell function

### DIFF
--- a/cdap-cli/bin/cdap-cli.sh
+++ b/cdap-cli/bin/cdap-cli.sh
@@ -25,10 +25,17 @@ echo
 echo
 
 __script=${BASH_SOURCE[0]}
-
-__target=$(readlink ${__script}) # TODO: readlink isn't portable, if we support more than Linux/macOS
-if [[ $? -ne 0 ]]; then
-  __target=${__script} # no symlink
-fi
+__readlink() {
+  local __target_file=${1}
+  cd $(dirname ${__target_file})
+  __target_file=$(basename ${__target_file})
+  while test -L ${__target_file}; do
+    __target_file=$(readlink ${__target_file})
+    cd $(dirname ${__target_file})
+    __target_file=$(basename ${__target_file})
+  done
+  echo "$(pwd -P)/${__target_file}"
+}
+__target=$(__readlink ${__script})
 __app_home=$(cd $(dirname ${__target})/.. >&-; pwd -P)
 ${__app_home}/bin/cdap cli ${@}

--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -23,15 +23,25 @@
 
 __script=${BASH_SOURCE[0]}
 
-__target=$(readlink ${__script}) # TODO: readlink isn't portable, if we support more than Linux/macOS
-if [[ $? -ne 0 ]]; then
-  __target=${__script} # no symlink
-fi
-# Resolve __target
-__target=$(cd $(dirname ${__target}); echo "$(pwd -P)/$(basename ${__target})")
-__app_home=$(cd $(dirname ${__target})/.. >&-; pwd -P)
+# Resolve symlinks
+__readlink() {
+  local __target_file=${1}
+  cd $(dirname ${__target_file})
+  __target_file=$(basename ${__target_file})
+  while test -L ${__target_file}; do
+    __target_file=$(readlink ${__target_file})
+    cd $(dirname ${__target_file})
+    __target_file=$(basename ${__target_file})
+  done
+  echo "$(pwd -P)/${__target_file}"
+}
 
+__target=$(__readlink ${__script})
+__target=$(cd $(dirname ${__target}); echo "$(pwd -P)/$(basename ${__target})")
+
+__app_home=$(cd $(dirname ${__target})/.. >&-; pwd -P)
 __comp_home=${COMPONENT_HOME:-$(cd ${__target%/*/*} >&- 2>/dev/null; pwd -P)}
+
 # Determine if we're in Distributed from packages or SDK/Parcel
 if [[ ${__comp_home%/*} == /opt/cdap ]] && [[ ${__comp_home} != /opt/cdap/sdk* ]]; then
   __app_home=${__comp_home}

--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -96,6 +96,21 @@ logecho() {
   echo ${@} | tee -a ${__logfile}
 }
 
+#
+# __readlink <file|directory>
+#
+__readlink() {
+  local __target_file=${1}
+  cd $(dirname ${__target_file})
+  __target_file=$(basename ${__target_file})
+  while test -L ${__target_file}; do
+    __target_file=$(readlink ${__target_file})
+    cd $(dirname ${__target_file})
+    __target_file=$(basename ${__target_file})
+  done
+  echo "$(pwd -P)/${__target_file}"
+}
+
 ###
 #
 # Directory functions

--- a/cdap-standalone/bin/cdap.sh
+++ b/cdap-standalone/bin/cdap.sh
@@ -25,10 +25,17 @@ echo
 echo
 
 __script=${BASH_SOURCE[0]}
-
-__target=$(readlink ${__script}) # TODO: readlink isn't portable, if we support more than Linux/macOS
-if [[ $? -ne 0 ]]; then
-  __target=${__script} # no symlink
-fi
+__readlink() {
+  local __target_file=${1}
+  cd $(dirname ${__target_file})
+  __target_file=$(basename ${__target_file})
+  while test -L ${__target_file}; do
+    __target_file=$(readlink ${__target_file})
+    cd $(dirname ${__target_file})
+    __target_file=$(basename ${__target_file})
+  done
+  echo "$(pwd -P)/${__target_file}"
+}
+__target=$(__readlink ${__script})
 __app_home=$(cd $(dirname ${__target})/.. >&-; pwd -P)
 ${__app_home}/bin/cdap sdk ${@}


### PR DESCRIPTION
Since different `readlink` usages weren't portable, implement `__readlink` shell function to provide recursive readlink, using standard readlink.
