### PR TITLE
Support HBase 1.2 in functions.sh

### DIFF
--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -367,6 +367,7 @@ cdap_set_hbase() {
     1.0*) __compat="${CDAP_HOME}"/hbase-compat-1.0/lib/* ;;
     1.1*) __compat="${CDAP_HOME}"/hbase-compat-1.1/lib/* ;;
     1.2-cdh*) __compat="${CDAP_HOME}"/hbase-compat-1.2-cdh5.7.0/lib/* ;; # 5.7 and 5.8 are compatible
+    1.2*) __compat="${CDAP_HOME}"/hbase-compat-1.1/lib/* ;; # 1.1 and 1.2 are compatible
     "") die "Unable to determine HBase version! Aborting." ;;
     *) die "Unknown/Unsupported HBase version found: ${HBASE_VERSION}" ;;
   esac


### PR DESCRIPTION
This instructs the script to load the HBase 1.1 compatibility module on HBase 1.2 (non-CDH).

https://github.com/caskdata/cdap/pull/6881 is platform-side support.
