### PR TITLE
CDAP-6938 Update EMR installer to use CDAP 4.0

### DIFF
--- a/cdap-distributions/src/emr/install.sh
+++ b/cdap-distributions/src/emr/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -15,33 +15,90 @@
 # the License.
 
 #
-# Install CDAP under hadoop user for EMR
+# Install CDAP for EMR
 #
 
 die() { echo "ERROR: ${*}"; exit 1; };
 
-# Fetch repo file for YUM
-# HBase 0.94 was supported till 3.0 so the below version is 3.0, which is the last supported on EMR
-# Note: Do not update the version below
-curl http://repository.cask.co/centos/6/x86_64/cdap/3.0/cask.repo > /etc/yum.repos.d/cdap-3.0.repo || die "Cannot
-fetch repo"
-rpm --import http://repository.cask.co/centos/6/x86_64/cdap/3.0/pubkey.gpg || die "Cannot import GPG key from repo"
-# Enable EPEL packages (req'd for nodejs)
-sed -i -e '0,/enabled=0/s//enabled=1/' /etc/yum.repos.d/epel.repo || die "Unable to enable EPEL"
+# This should return the latest released CDAP version... do not put -SNAPSHOT here
+export CDAP_VERSION=${CDAP_VERSION:-4.0.0-1}
+
+__repo_url=${CDAP_REPO_URL:-http://repository.cask.co/centos/6/x86_64/cdap/MAJ_MIN}
+
+while [[ ${#} -gt 0 ]]; do
+  case ${1} in
+    --cdap-version*)
+      __tmp=${1#*=} # only keep after = if given
+      shift
+      if [[ ${__tmp} =~ ^- ]]; then # maybe version is next argument?
+        __arg=${1}
+        if [[ ${__arg} =~ ^- ]]; then
+          echo "WARNING: --cdap-version should specify a version afterwards, using default ${CDAP_VERSION}"
+          continue
+        else
+          CDAP_VERSION=${__arg}
+          echo "INFO: Setting CDAP version to ${CDAP_VERSION}"
+          shift
+        fi
+      else
+        CDAP_VERSION=${__tmp}
+        echo "INFO: Setting CDAP version to ${CDAP_VERSION}"
+      fi
+      ;;
+    --cdap-repo-url*)
+      __tmp=${1#*=}
+      shift
+      if [[ ${__tmp} =~ ^- ]]; then # maybe url is next argument?
+        __arg=${1}
+        if [[ ${__arg} =~ ^- ]]; then
+          __maj_min=$(echo ${CDAP_VERSION} | cut -d. -f1,2)
+          echo "WARNING: --cdap-repo-url should specify a URL afterwards, using default ${__repo_url/MAJ_MIN/${__maj_min}}"
+          continue
+        else
+          CDAP_REPO_URL=${__arg}
+          echo "INFO: Setting CDAP repository URL to ${CDAP_REPO_URL}"
+          shift
+        fi
+      else
+        CDAP_REPO_URL=${__tmp}
+        echo "INFO: Setting CDAP repository URL to ${CDAP_REPO_URL}"
+      fi
+      ;;
+    *) break ;;
+  esac
+done
+
+# Get major/minor from CDAP version
+__maj_min=$(echo ${CDAP_VERSION} | cut -d. -f1,2)
+
+# One last sed-fu, if we're using the default CDAP_REPO_URL, in case version's been updated
+CDAP_REPO_URL=${CDAP_REPO_URL:-${__repo_url/MAJ_MIN/${__maj_min}}}
+
+# echo "CDAP_VERSION:  $CDAP_VERSION"
+# echo "CDAP_REPO_URL: $CDAP_REPO_URL"
+
+# Create YUM repo file
+__repo_file=/etc/yum.repos.d/cdap-${__maj_min}.repo
+echo "[CDAP-${__maj_min}]" > ${__repo_file}
+echo "name=CDAP ${__maj_min}" >> ${__repo_file}
+echo "baseurl=${CDAP_REPO_URL}" >> ${__repo_file}
+echo "enabled=1" >> ${__repo_file}
+
+# Do GPG check on official repos
+if [[ ${CDAP_REPO_URL} == ${__repo_url/MAJ_MIN/${__maj_min}} ]]; then
+  echo "gpgcheck=1" >> ${__repo_file}
+  rpm --import ${CDAP_REPO_URL}/pubkey.gpg || die "Cannot import GPG key from repo"
+fi
+
 yum makecache
-# Install dependencies
-yum install --downloadonly chkconfig -y || die "Cannot download chkconfig package"
-rpm --install --force /var/cache/yum/x86_64/latest/amzn-main/packages/chkconfig-* || die "Unable to install chkconfig"
-yum install gyp http-parser-devel redhat-rpm-config icu nodejs nodejs-devel npm cdap-{gateway,kafka,master,ui} -y || die "Failed installing packages"
-# Update permissions and symlink logs
-mkdir -p /mnt/var/log/cdap /mnt/cdap/kafka-logs
-chown -R hadoop:hadoop /var/cdap/run /var/run/cdap /var/tmp/cdap /mnt/var/log/cdap /mnt/cdap/kafka-logs
-rm -rf /var/log/cdap
-ln -sf /mnt/var/log/cdap /var/log/cdap
+yum install cdap-{cli,gateway,kafka,master,security,ui} -y || die "Failed installing packages"
+
+mkdir -p /mnt/cdap/kafka-logs
+chown -R cdap:cdap /mnt/cdap/kafka-logs
+
 # Configure CDAP
 __ipaddr=`ifconfig eth0 | grep addr: | cut -d: -f2 | head -n 1 | awk '{print $1}'`
 sed \
-  -e 's/yarn/hadoop/' \
   -e "s/FQDN1:2181,FQDN2/${__ipaddr}/" \
   -e 's:/data/cdap/kafka-logs:/mnt/cdap/kafka-logs:' \
   -e "s/FQDN1:9092,FQDN2:9092/${__ipaddr}:9092/" \
@@ -51,13 +108,17 @@ sed \
   -e 's/LOCAL-WATCHDOG-IP//' \
   -e "s/ROUTER-HOST-IP/${__ipaddr}/" \
   /etc/cdap/conf/cdap-site.xml.example > /etc/cdap/conf/cdap-site.xml
-# Start services
-for i in \
-  /opt/cdap/gateway/bin/svc-router \
-  /opt/cdap/kafka/bin/svc-kafka-server \
-  /opt/cdap/master/bin/svc-master \
-  /opt/cdap/ui/bin/svc-ui
+
+# Temporary Hack to workaround CDAP-4089
+rm -f /opt/cdap/kafka/lib/log4j.log4j-1.2.14.jar
+
+# Setup HDFS directories
+su - hdfs -c 'for d in /cdap /user/cdap; do hdfs dfs -mkdir -p ${d} ; hdfs dfs -chown cdap ${d}; done'
+
+# Start CDAP Services
+for i in /etc/init.d/cdap-*
 do
-  su - hadoop -c "$i start" || die "Failed to start $i"
+  ${i} start || die "Failed to start ${i}"
 done
+
 exit 0


### PR DESCRIPTION
This is a major update to the EMR installer for CDAP 4.0+ on EMR 4.6.0+ AMIs.
- [x] Allow user-configured version
  - [x] Default to CDAP 4.0
  - [x] Support both `--cdap-version=4.0.0-1` and `--cdap-version 4.0.0-1`
  - [x] Support CDAP_VERSION environment variable
- [x] Allow user-configured URL
  - [x] Default to Cask's official repository
  - [x] Default updated with version changes
  - [x] Support both `--cdap-repo-url=URI` and `--cdap-repo-url URI`
  - [x] Support CDAP_REPO_URL environment variable
- [x] Manage YUM repository file
  - [x] generate file, versus download it (for custom repos)
  - [x] GPG checking updates
    - [x] Official repository
      - [x] Import GPG key
      - [x] Enable GPG checking
    - [x] Custom repository
      - [x] Disable GPG checking
- [x] Installation updates
  - [x] Run as "cdap" user
  - [x] Install CLI and Auth Server
  - [x] Create CDAP HDFS directories

 This requires the user to install HBase on the cluster when provisioning it. 

Fixes CDAP-6938