### PR TITLE
Honor the CDAP_USER environment

### DIFF
--- a/cdap-distributions/src/debian/init.d/cdap-service
+++ b/cdap-distributions/src/debian/init.d/cdap-service
@@ -48,10 +48,13 @@ CDAP_USER=${CDAP_USER:-cdap}
 # drop permissions to cdap user and run service script
 
 if [[ ${UID} -eq 0 ]]; then
-  su ${CDAP_USER} -c "${SVC_COMMAND}"
+  su - ${CDAP_USER} -c "${SVC_COMMAND}"
+  ret=$?
 elif [[ ${USER} == ${CDAP_USER} ]]; then
   ${SVC_COMMAND}
+  ret=$?
 else
   echo "ERROR: Must run this script as root or ${CDAP_USER}!"
   exit 1
 fi
+exit $ret

--- a/cdap-distributions/src/rpm/init.d/cdap-service
+++ b/cdap-distributions/src/rpm/init.d/cdap-service
@@ -48,10 +48,13 @@ CDAP_USER=${CDAP_USER:-cdap}
 # drop permissions to cdap user and run service script
 
 if [[ ${UID} -eq 0 ]]; then
-  su ${CDAP_USER} -c "${SVC_COMMAND}"
+  su - ${CDAP_USER} -c "${SVC_COMMAND}"
+  ret=$?
 elif [[ ${USER} == ${CDAP_USER} ]]; then
   ${SVC_COMMAND}
+  ret=$?
 else
   echo "ERROR: Must run this script as root or ${CDAP_USER}!"
   exit 1
 fi
+exit $ret


### PR DESCRIPTION
This causes CDAP to run under a login shell as `CDAP_USER` and allows for customizing the environment under which CDAP runs. This would most commonly be used to set `CDAP_HOME` to an alternate location.
