### PR TITLE
CDAP-3262 Add test for CDAP_HOME with spaces

### DIFF
--- a/cdap-cli/bin/cdap-cli.bat
+++ b/cdap-cli/bin/cdap-cli.bat
@@ -19,6 +19,13 @@
 @echo OFF
 SET "CDAP_HOME=%~dp0"
 SET "CDAP_HOME=%CDAP_HOME:~0,-5%"
+IF /i NOT "%CDAP_HOME: =%"=="%CDAP_HOME%" (
+  echo CDAP_HOME "%CDAP_HOME%"
+  echo Contains one or more space characters, will not work correctly, and is not supported.
+  echo Exiting. 
+  GOTO :FINALLY
+)
+
 SET "JAVACMD=%JAVA_HOME%\bin\java.exe"
 SET CDAP_VERSION=@@project.version@@
 

--- a/cdap-data-fabric/bin/tx-debugger.bat
+++ b/cdap-data-fabric/bin/tx-debugger.bat
@@ -20,6 +20,13 @@ REM ############################################################################
 
 SET CDAP_HOME=%~dp0
 SET CDAP_HOME=%CDAP_HOME:~0,-5%
+IF /i NOT "%CDAP_HOME: =%"=="%CDAP_HOME%" (
+  echo CDAP_HOME "%CDAP_HOME%"
+  echo Contains one or more space characters, will not work correctly, and is not supported.
+  echo Exiting. 
+  GOTO :FINALLY
+)
+
 SET JAVACMD=%JAVA_HOME%\bin\java.exe
 SET DEFAULT_JVM_OPTS=-Xmx2048m -XX:MaxPermSize=128m
 SET HADOOP_HOME_OPTS=-Dhadoop.home.dir=%CDAP_HOME%\libexec

--- a/cdap-docs/developers-manual/source/_includes/windows-note.txt
+++ b/cdap-docs/developers-manual/source/_includes/windows-note.txt
@@ -1,4 +1,3 @@
 **Note:** There is an issue with running Microsoft Windows and using the CDAP Standalone
-scripts when ``JAVA_HOME`` is defined as a path with spaces in it. A workaround is to use
-a definition of ``JAVA_HOME`` that does not include spaces, such as
-``C:\PROGRA~1\Java\jdk1.7.0_79\bin`` or ``C:\ProgramData\Oracle\Java\javapath``.
+scripts when ``CDAP_HOME`` is defined as a path with spaces in it. Until this is addressed,
+do not use a path with space characters in it for ``CDAP_HOME.``

--- a/cdap-standalone/bin/cdap.bat
+++ b/cdap-standalone/bin/cdap.bat
@@ -22,6 +22,13 @@ REM Double-quotes surround string to include a space character but are not inclu
 REM As CDAP_HOME can include a space, any use of it needs to be surrounded in double-quotes
 SET "CDAP_HOME=%~dp0"
 SET "CDAP_HOME=%CDAP_HOME:~0,-5%"
+IF /i NOT "%CDAP_HOME: =%"=="%CDAP_HOME%" (
+  echo CDAP_HOME "%CDAP_HOME%"
+  echo Contains one or more space characters, will not work correctly, and is not supported.
+  echo Exiting. 
+  GOTO :FINALLY
+)
+
 SET CDAP_VERSION=@@project.version@@
 
 REM Double-quotes surround string to include a space character but are not included in string


### PR DESCRIPTION
Add a test for CDAP_HOME with spaces in it. If so, exit, as we currently don't support that.

Changed the docs (such as the note that appears on the page http://docs.cask.co/cdap/current/en/developers-manual/getting-started/standalone/index.html#standalone-index) from referencing `JAVA_HOME` as an issue to referencing `CDAP_HOME.`

Passes as a Quick Build: http://builds.cask.co/browse/CDAP-DQB160-1

See http://builds.cask.co/artifact/CDAP-DQB160/shared/build-1/Docs-HTML/3.5.2-SNAPSHOT/en/developers-manual/getting-started/standalone/index.html#standalone-index
