### PR TITLE
CDAP-6587 Impersonation in Explore

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -812,6 +812,7 @@ public final class Constants {
     public static final String EXPLORE_CLASSPATH = "explore.classpath";
     public static final String EXPLORE_CONF_FILES = "explore.conf.files";
     public static final String PREVIEWS_DIR_NAME = "explore.previews.dir";
+    public static final String CREDENTIALS_DIR_NAME = "explore.credentials.dir";
     // a marker so that we know which tables are created by CDAP
     public static final String CDAP_NAME = "cdap.name";
     public static final String CDAP_VERSION = "cdap.version";

--- a/cdap-common/src/main/java/co/cask/cdap/common/security/DefaultUGIProvider.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/security/DefaultUGIProvider.java
@@ -20,6 +20,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.kerberos.SecurityUtil;
 import co.cask.cdap.common.utils.DirUtils;
+import co.cask.cdap.common.utils.FileUtils;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -35,11 +36,6 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
-import java.util.EnumSet;
-import java.util.Set;
 
 /**
  * Provides a UGI by logging in with a keytab file for that user.
@@ -50,8 +46,6 @@ public class DefaultUGIProvider extends AbstractCachedUGIProvider {
 
   private final LocationFactory locationFactory;
   private final File tempDir;
-  private static final FileAttribute<Set<PosixFilePermission>> OWNER_ONLY_ATTRS =
-    PosixFilePermissions.asFileAttribute(EnumSet.of(PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_READ));
 
   @Inject
   DefaultUGIProvider(CConfiguration cConf, LocationFactory locationFactory) {
@@ -106,7 +100,7 @@ public class DefaultUGIProvider extends AbstractCachedUGIProvider {
 
     // create a local file with restricted permissions
     // only allow the owner to read/write, since it contains credentials
-    Path localKeytabFile = Files.createTempFile(tempDir.toPath(), null, "keytab.localized", OWNER_ONLY_ATTRS);
+    Path localKeytabFile = Files.createTempFile(tempDir.toPath(), null, "keytab.localized", FileUtils.OWNER_ONLY_RW);
     // copy to this local file
     LOG.debug("Copying keytab file from {} to {}", keytabLocation, localKeytabFile);
     try (InputStream is = keytabLocation.getInputStream()) {

--- a/cdap-common/src/main/java/co/cask/cdap/common/utils/FileUtils.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/utils/FileUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.utils;
+
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Utility class for File-related operations.
+ */
+public class FileUtils {
+
+  /**
+   * FileAttribute representing owner-only read/write (600). Note that this should not be used to create directories.
+   */
+  public static final FileAttribute<Set<PosixFilePermission>> OWNER_ONLY_RW =
+    PosixFilePermissions.asFileAttribute(EnumSet.of(PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_READ));
+
+  /**
+   * FileAttribute representing owner-only read/write/execute (700).
+   */
+  public static final FileAttribute<Set<PosixFilePermission>> OWNER_ONLY_RWX =
+    PosixFilePermissions.asFileAttribute(EnumSet.of(PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_READ,
+                                                    PosixFilePermission.OWNER_EXECUTE));
+
+  private FileUtils(){ }
+
+}

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreHttpClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreHttpClient.java
@@ -44,6 +44,7 @@ import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.proto.QueryStatus;
 import co.cask.cdap.proto.TableInfo;
 import co.cask.cdap.proto.TableNameInfo;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequestConfig;
@@ -51,6 +52,7 @@ import co.cask.common.http.HttpRequests;
 import co.cask.common.http.HttpResponse;
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
+import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -69,7 +71,6 @@ import java.net.URL;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
@@ -340,7 +341,8 @@ abstract class ExploreHttpClient implements Explore {
   }
 
   @Override
-  public QueryHandle getSchemas(String catalog, String schemaPattern) throws ExploreException, SQLException {
+  public QueryHandle getSchemas(@Nullable String catalog,
+                                @Nullable String schemaPattern) throws ExploreException, SQLException {
     String body = GSON.toJson(new SchemasArgs(catalog, schemaPattern));
     String resource = String.format("namespaces/%s/data/explore/jdbc/schemas", schemaPattern);
     HttpResponse response = doPost(resource, body, null);
@@ -351,7 +353,7 @@ abstract class ExploreHttpClient implements Explore {
   }
 
   @Override
-  public QueryHandle getFunctions(String catalog, String schemaPattern, String functionNamePattern)
+  public QueryHandle getFunctions(@Nullable String catalog, @Nullable String schemaPattern, String functionNamePattern)
     throws ExploreException, SQLException {
     String body = GSON.toJson(new FunctionsArgs(catalog, schemaPattern, functionNamePattern));
     String resource = String.format("namespaces/%s/data/explore/jdbc/functions", schemaPattern);
@@ -372,8 +374,8 @@ abstract class ExploreHttpClient implements Explore {
   }
 
   @Override
-  public QueryHandle getTables(String catalog, String schemaPattern,
-                               String tableNamePattern, List<String> tableTypes) throws ExploreException, SQLException {
+  public QueryHandle getTables(@Nullable String catalog, @Nullable String schemaPattern, String tableNamePattern,
+                               @Nullable List<String> tableTypes) throws ExploreException, SQLException {
     String body = GSON.toJson(new TablesArgs(catalog, schemaPattern, tableNamePattern, tableTypes));
     String resource = String.format("namespaces/%s/data/explore/jdbc/tables", schemaPattern);
     HttpResponse response = doPost(resource, body, null);
@@ -384,8 +386,8 @@ abstract class ExploreHttpClient implements Explore {
   }
 
   @Override
-  public List<TableNameInfo> getTables(@Nullable String database) throws ExploreException {
-    HttpResponse response = doGet(String.format("namespaces/%s/data/explore/tables", database));
+  public List<TableNameInfo> getTables(String namespace) throws ExploreException {
+    HttpResponse response = doGet(String.format("namespaces/%s/data/explore/tables", namespace));
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return parseJson(response, TABLES_TYPE);
     }
@@ -393,15 +395,16 @@ abstract class ExploreHttpClient implements Explore {
   }
 
   @Override
-  public TableInfo getTableInfo(@Nullable String database, String table)
+  public TableInfo getTableInfo(String namespace, String table)
     throws ExploreException, TableNotFoundException {
-    HttpResponse response = doGet(String.format("namespaces/%s/data/explore/tables/%s/info", database, table));
+    HttpResponse response = doGet(String.format("namespaces/%s/data/explore/tables/%s/info", namespace, table));
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return parseJson(response, TableInfo.class);
     } else if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
-      throw new TableNotFoundException("Table " + database + table + " not found.");
+      throw new TableNotFoundException(String.format("Namespace %s, table %s not found.", namespace, table));
     }
-    throw new ExploreException("Cannot get the schema of table " + database + table + ". Reason: " + response);
+    throw new ExploreException(String.format("Cannot get the schema of namespace %s, table %s. Reason: %s",
+                                             namespace, table, response));
   }
 
   @Override

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/service/Explore.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/service/Explore.java
@@ -250,22 +250,22 @@ public interface Explore {
   /**
    * Retrieve a list of all the tables present in Hive Metastore that match the given database name.
    *
-   * @param database database name from which to list the tables. The database has to be accessible by the current
-   *                 user. If it is null, all the databases the user has access to will be inspected.
+   * @param namespace namespace name from which to list the tables. The database has to be accessible by the current
+   *                  user.
    * @return list of table names present in the database.
    * @throws ExploreException on any error getting the tables.
    */
-  List<TableNameInfo> getTables(@Nullable String database) throws ExploreException;
+  List<TableNameInfo> getTables(String namespace) throws ExploreException;
 
   /**
    * Get information about a Hive table.
    *
-   * @param database name of the database the table belongs to.
+   * @param namespace name of the namespace the table belongs to.
    * @param table table name for which to get the schema.
    * @return information about a table.
    * @throws ExploreException on any error getting the tables.
    */
-  TableInfo getTableInfo(@Nullable String database, String table)
+  TableInfo getTableInfo(String namespace, String table)
     throws ExploreException, TableNotFoundException;
 
   /**

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorHttpHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -28,6 +28,7 @@ import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
 import co.cask.cdap.api.dataset.lib.Partitioning;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.security.Impersonator;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
@@ -39,6 +40,7 @@ import co.cask.cdap.explore.service.ExploreTableManager;
 import co.cask.cdap.internal.io.SchemaTypeAdapter;
 import co.cask.cdap.proto.QueryHandle;
 import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import co.cask.http.AbstractHttpHandler;
@@ -61,6 +63,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.sql.SQLException;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import javax.annotation.Nullable;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -80,16 +83,19 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
   private final DatasetFramework datasetFramework;
   private final StreamAdmin streamAdmin;
   private final SystemDatasetInstantiatorFactory datasetInstantiatorFactory;
+  private final Impersonator impersonator;
 
   @Inject
   public ExploreExecutorHttpHandler(ExploreTableManager exploreTableManager,
                                     DatasetFramework datasetFramework,
                                     StreamAdmin streamAdmin,
-                                    SystemDatasetInstantiatorFactory datasetInstantiatorFactory) {
+                                    SystemDatasetInstantiatorFactory datasetInstantiatorFactory,
+                                    Impersonator impersonator) {
     this.exploreTableManager = exploreTableManager;
     this.datasetFramework = datasetFramework;
     this.streamAdmin = streamAdmin;
     this.datasetInstantiatorFactory = datasetInstantiatorFactory;
+    this.impersonator = impersonator;
   }
 
   @POST
@@ -97,14 +103,19 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
   public void enableStream(HttpRequest request, HttpResponder responder,
                            @PathParam("namespace-id") String namespace,
                            @PathParam("stream") String streamName,
-                           @PathParam("table") String tableName) throws Exception {
-    StreamId streamId = new StreamId(namespace, streamName);
+                           @PathParam("table") final String tableName) throws Exception {
+    final StreamId streamId = new StreamId(namespace, streamName);
     try (Reader reader = new InputStreamReader(new ChannelBufferInputStream(request.getContent()))) {
-      FormatSpecification format = GSON.fromJson(reader, FormatSpecification.class);
+      final FormatSpecification format = GSON.fromJson(reader, FormatSpecification.class);
       if (format == null) {
         throw new BadRequestException("Expected format in the body");
       }
-      QueryHandle handle = exploreTableManager.enableStream(tableName, streamId, format);
+      QueryHandle handle = impersonator.doAs(new NamespaceId(namespace), new Callable<QueryHandle>() {
+        @Override
+        public QueryHandle call() throws Exception {
+          return exploreTableManager.enableStream(tableName, streamId, format);
+        }
+      });
       JsonObject json = new JsonObject();
       json.addProperty("handle", handle.getHandle());
       responder.sendJson(HttpResponseStatus.OK, json);
@@ -119,9 +130,9 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
   public void disableStream(HttpRequest request, HttpResponder responder,
                             @PathParam("namespace-id") String namespace,
                             @PathParam("stream") String streamName,
-                            @PathParam("table") String tableName) {
+                            @PathParam("table") final String tableName) {
 
-    StreamId streamId = new StreamId(namespace, streamName);
+    final StreamId streamId = new StreamId(namespace, streamName);
     try {
       // throws io exception if there is no stream
       streamAdmin.getConfig(streamId.toId());
@@ -132,7 +143,12 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
     }
 
     try {
-      QueryHandle handle = exploreTableManager.disableStream(tableName, streamId);
+      QueryHandle handle = impersonator.doAs(new NamespaceId(namespace), new Callable<QueryHandle>() {
+        @Override
+        public QueryHandle call() throws Exception {
+          return exploreTableManager.disableStream(tableName, streamId);
+        }
+      });
       JsonObject json = new JsonObject();
       json.addProperty("handle", handle.getHandle());
       responder.sendJson(HttpResponseStatus.OK, json);
@@ -174,9 +190,15 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
     enableDataset(responder, datasetId, datasetSpec);
   }
 
-  private void enableDataset(HttpResponder responder, DatasetId datasetId, DatasetSpecification datasetSpec) {
+  private void enableDataset(HttpResponder responder, final DatasetId datasetId,
+                             final DatasetSpecification datasetSpec) {
     try {
-      QueryHandle handle = exploreTableManager.enableDataset(datasetId, datasetSpec);
+      QueryHandle handle = impersonator.doAs(datasetId.getParent(), new Callable<QueryHandle>() {
+        @Override
+        public QueryHandle call() throws Exception {
+          return exploreTableManager.enableDataset(datasetId, datasetSpec);
+        }
+      });
       JsonObject json = new JsonObject();
       json.addProperty("handle", handle.getHandle());
       responder.sendJson(HttpResponseStatus.OK, json);
@@ -205,17 +227,22 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
                             @PathParam("namespace-id") String namespace, @PathParam("dataset") String datasetName)
     throws BadRequestException {
 
-    DatasetId datasetId = new DatasetId(namespace, datasetName);
+    final DatasetId datasetId = new DatasetId(namespace, datasetName);
     try {
       UpdateExploreParameters params = readUpdateParameters(request);
-      DatasetSpecification oldSpec = params.getOldSpec();
-      DatasetSpecification datasetSpec = params.getNewSpec();
+      final DatasetSpecification oldSpec = params.getOldSpec();
+      final DatasetSpecification datasetSpec = params.getNewSpec();
 
       QueryHandle handle;
       if (oldSpec.equals(datasetSpec)) {
         handle = QueryHandle.NO_OP;
       } else {
-        handle = exploreTableManager.updateDataset(datasetId, datasetSpec, oldSpec);
+        handle = impersonator.doAs(datasetId.getParent(), new Callable<QueryHandle>() {
+          @Override
+          public QueryHandle call() throws Exception {
+            return exploreTableManager.updateDataset(datasetId, datasetSpec, oldSpec);
+          }
+        });
       }
       JsonObject json = new JsonObject();
       json.addProperty("handle", handle.getHandle());
@@ -263,9 +290,14 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
                              @PathParam("namespace-id") String namespace, @PathParam("dataset") String datasetName) {
 
     LOG.debug("Disabling explore for dataset instance {}", datasetName);
-    DatasetId datasetId = new DatasetId(namespace, datasetName);
+    final DatasetId datasetId = new DatasetId(namespace, datasetName);
     try {
-      QueryHandle handle = exploreTableManager.disableDataset(datasetId);
+      QueryHandle handle = impersonator.doAs(datasetId.getParent(), new Callable<QueryHandle>() {
+        @Override
+        public QueryHandle call() throws Exception {
+          return exploreTableManager.disableDataset(datasetId);
+        }
+      });
       JsonObject json = new JsonObject();
       json.addProperty("handle", handle.getHandle());
       responder.sendJson(HttpResponseStatus.OK, json);
@@ -277,10 +309,22 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
 
   @POST
   @Path("datasets/{dataset}/partitions")
-  public void addPartition(HttpRequest request, HttpResponder responder,
-                           @PathParam("namespace-id") String namespace, @PathParam("dataset") String datasetName) {
-    DatasetId datasetId = new DatasetId(namespace, datasetName);
+  public void addPartition(final HttpRequest request, final HttpResponder responder,
+                           @PathParam("namespace-id") String namespace,
+                           @PathParam("dataset") String datasetName) throws Exception {
+    final DatasetId datasetId = new DatasetId(namespace, datasetName);
     propagateUserId(request);
+    impersonator.doAs(datasetId.getParent(), new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        doAddPartition(request, responder, datasetId);
+        return null;
+      }
+    });
+  }
+
+  private void doAddPartition(HttpRequest request, HttpResponder responder,
+                              DatasetId datasetId) {
     Dataset dataset;
     try (SystemDatasetInstantiator datasetInstantiator = datasetInstantiatorFactory.create()) {
       dataset = datasetInstantiator.getDataset(datasetId.toId());
@@ -298,7 +342,8 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
         return;
       }
       LOG.error("Exception instantiating dataset {}.", datasetId, e);
-      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Exception instantiating dataset " + datasetName);
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                           "Exception instantiating dataset " + datasetId.getDataset());
       return;
     }
 
@@ -339,15 +384,26 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
     }
   }
 
+
   // this should really be a DELETE request. However, the partition key must be passed in the body
   // of the request, and that does not work with many HTTP clients, including Java's URLConnection.
   @POST
   @Path("datasets/{dataset}/deletePartition")
-  public void dropPartition(HttpRequest request, HttpResponder responder,
+  public void dropPartition(final HttpRequest request, final HttpResponder responder,
                             @PathParam("namespace-id") String namespace,
-                            @PathParam("dataset") String datasetName) {
-    DatasetId datasetId = new DatasetId(namespace, datasetName);
+                            @PathParam("dataset") String datasetName) throws Exception {
+    final DatasetId datasetId = new DatasetId(namespace, datasetName);
     propagateUserId(request);
+    impersonator.doAs(datasetId.getParent(), new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        doDropPartition(request, responder, datasetId);
+        return null;
+      }
+    });
+  }
+
+  private void doDropPartition(HttpRequest request, HttpResponder responder, DatasetId datasetId) {
     Dataset dataset;
     try (SystemDatasetInstantiator datasetInstantiator = datasetInstantiatorFactory.create()) {
       dataset = datasetInstantiator.getDataset(datasetId.toId());

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreMetadataHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreMetadataHttpHandler.java
@@ -17,25 +17,27 @@
 package co.cask.cdap.explore.executor;
 
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.security.Impersonator;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.ExploreService;
 import co.cask.cdap.explore.service.MetaDataInfo;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.QueryHandle;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.http.HttpResponder;
 import com.google.common.base.Charsets;
+import com.google.common.base.Throwables;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
-import org.jboss.netty.buffer.ChannelBufferInputStream;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.sql.SQLException;
+import java.util.concurrent.Callable;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -52,10 +54,12 @@ public class ExploreMetadataHttpHandler extends AbstractExploreMetadataHttpHandl
   private static final Gson GSON = new Gson();
 
   private final ExploreService exploreService;
+  private final Impersonator impersonator;
 
   @Inject
-  public ExploreMetadataHttpHandler(ExploreService exploreService) {
+  public ExploreMetadataHttpHandler(ExploreService exploreService, Impersonator impersonator) {
     this.exploreService = exploreService;
+    this.impersonator = impersonator;
   }
 
   @POST
@@ -131,7 +135,20 @@ public class ExploreMetadataHttpHandler extends AbstractExploreMetadataHttpHandl
         // Use the namespace id which was passed as path param. It will be same in the meta but this is for consistency
         // we do the same thing in NamespaceHttpHandler.create
         namespaceMeta = new NamespaceMeta.Builder(namespaceMeta).setName(namespaceId).build();
-        return exploreService.createNamespace(namespaceMeta);
+        final NamespaceMeta finalNamespaceMeta = namespaceMeta;
+        try {
+          return impersonator.doAs(namespaceMeta, new Callable<QueryHandle>() {
+            @Override
+            public QueryHandle call() throws Exception {
+              return exploreService.createNamespace(finalNamespaceMeta);
+            }
+          });
+        } catch (ExploreException | SQLException e) {
+          // we know that the callable only throws the above two declared exceptions:
+          throw e;
+        } catch (Exception e) {
+          throw Throwables.propagate(e);
+        }
       }
     });
   }
@@ -144,7 +161,19 @@ public class ExploreMetadataHttpHandler extends AbstractExploreMetadataHttpHandl
       @Override
       public QueryHandle execute(HttpRequest request, HttpResponder responder)
         throws IllegalArgumentException, SQLException, ExploreException, IOException {
-        return exploreService.deleteNamespace(Id.Namespace.from(namespaceId));
+        try {
+          return impersonator.doAs(new NamespaceId(namespaceId), new Callable<QueryHandle>() {
+            @Override
+            public QueryHandle call() throws Exception {
+              return exploreService.deleteNamespace(Id.Namespace.from(namespaceId));
+            }
+          });
+        } catch (ExploreException | SQLException e) {
+          // we know that the callable only throws the above two declared exceptions:
+          throw e;
+        } catch (Exception e) {
+          throw Throwables.propagate(e);
+        }
       }
     });
   }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/NamespacedQueryExecutorHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/NamespacedQueryExecutorHttpHandler.java
@@ -17,10 +17,13 @@
 package co.cask.cdap.explore.executor;
 
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.security.Impersonator;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.ExploreService;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.QueryHandle;
 import co.cask.cdap.proto.QueryInfo;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.http.HttpResponder;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
@@ -29,11 +32,11 @@ import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -47,25 +50,33 @@ import javax.ws.rs.QueryParam;
 @Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
 public class NamespacedQueryExecutorHttpHandler extends AbstractQueryExecutorHttpHandler {
   private static final Logger LOG = LoggerFactory.getLogger(NamespacedQueryExecutorHttpHandler.class);
+
   private final ExploreService exploreService;
+  private final Impersonator impersonator;
 
   @Inject
-  public NamespacedQueryExecutorHttpHandler(ExploreService exploreService) {
+  public NamespacedQueryExecutorHttpHandler(ExploreService exploreService, Impersonator impersonator) {
     this.exploreService = exploreService;
+    this.impersonator = impersonator;
   }
 
   @POST
   @Path("data/explore/queries")
   public void query(HttpRequest request, HttpResponder responder,
-                    @PathParam("namespace-id") String namespaceId) throws IOException, ExploreException {
+                    @PathParam("namespace-id") final String namespaceId) throws Exception {
     try {
       Map<String, String> args = decodeArguments(request);
-      String query = args.get("query");
-      Map<String, String> additionalSessionConf = new HashMap<>(args);
+      final String query = args.get("query");
+      final Map<String, String> additionalSessionConf = new HashMap<>(args);
       additionalSessionConf.remove("query");
       LOG.trace("Received query: {}", query);
-      responder.sendJson(HttpResponseStatus.OK,
-                         exploreService.execute(Id.Namespace.from(namespaceId), query, additionalSessionConf));
+      QueryHandle queryHandle = impersonator.doAs(new NamespaceId(namespaceId), new Callable<QueryHandle>() {
+        @Override
+        public QueryHandle call() throws Exception {
+          return exploreService.execute(Id.Namespace.from(namespaceId), query, additionalSessionConf);
+        }
+      });
+      responder.sendJson(HttpResponseStatus.OK, queryHandle);
     } catch (IllegalArgumentException e) {
       LOG.debug("Got exception:", e);
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
@@ -86,6 +97,7 @@ public class NamespacedQueryExecutorHttpHandler extends AbstractQueryExecutorHtt
     throws ExploreException, SQLException {
     boolean isForward = "next".equals(cursor);
 
+    // this operation doesn't interact with hive, so doesn't require impersonation
     List<QueryInfo> queries = exploreService.getQueries(Id.Namespace.from(namespaceId));
     // return the queries by after filtering (> offset) and limiting number of queries
     responder.sendJson(HttpResponseStatus.OK, filterQueries(queries, offset, isForward, limit));
@@ -95,6 +107,7 @@ public class NamespacedQueryExecutorHttpHandler extends AbstractQueryExecutorHtt
   @Path("data/explore/queries/count")
   public void getActiveQueryCount(HttpRequest request, HttpResponder responder,
                                   @PathParam("namespace-id") String namespaceId) throws ExploreException {
+    // this operation doesn't interact with hive, so doesn't require impersonation
     int count = exploreService.getActiveQueryCount(Id.Namespace.from(namespaceId));
     responder.sendJson(HttpResponseStatus.OK, ImmutableMap.of("count", count));
   }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreService.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.explore.service;
 
+import co.cask.cdap.explore.service.hive.OperationInfo;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.QueryHandle;
 import com.google.common.util.concurrent.Service;
@@ -39,5 +40,15 @@ public interface ExploreService extends Service, Explore {
    * @throws SQLException if there are errors in the SQL statement.
    */
   QueryHandle execute(Id.Namespace namespace, String[] statements) throws ExploreException, SQLException;
+
+  /**
+   * Returns an {@link OperationInfo} for a specified {@link QueryHandle}, regardless of whether it is an inactive or
+   * active OperationInfo.
+   *
+   * @param queryHandle the requested query handle
+   * @return a {@link OperationInfo} for the given QueryHandle
+   * @throws HandleNotFoundException if the specified query handle is invalid
+   */
+  OperationInfo getOperationInfo(QueryHandle queryHandle) throws HandleNotFoundException;
 
 }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreServiceUtils.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreServiceUtils.java
@@ -600,7 +600,7 @@ public class ExploreServiceUtils {
     return newHiveConfFile;
   }
 
-  public static boolean isSparkAvailable() {
+  private static boolean isSparkAvailable() {
     try {
       // SparkUtils.locateSparkAssemblyJar() throws IllegalStateException if it is not able to locate spark jar
       SparkUtils.locateSparkAssemblyJar();
@@ -614,7 +614,13 @@ public class ExploreServiceUtils {
   public static boolean isSparkEngine(HiveConf hiveConf) {
     // We don't support setting engine through session configuration now
     String engine = hiveConf.get("hive.execution.engine");
-    return "spark".equalsIgnoreCase(engine);
+    return "spark".equals(engine);
+  }
+
+  public static boolean isTezEngine(HiveConf hiveConf) {
+    // We don't support setting engine through session configuration now
+    String engine = hiveConf.get("hive.execution.engine");
+    return "tez".equals(engine);
   }
 
   // This method is used to determine if Tez is enabled based on TEZ_HOME environment variable.

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreTableManager.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreTableManager.java
@@ -78,7 +78,7 @@ import javax.annotation.Nullable;
 public class ExploreTableManager {
   private static final Logger LOG = LoggerFactory.getLogger(ExploreTableManager.class);
 
-  // A GSON object that knowns how to serialize Schema type.
+  // A GSON object that knows how to serialize Schema type.
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
     .create();
@@ -182,9 +182,6 @@ public class ExploreTableManager {
     String createStatement;
     try (SystemDatasetInstantiator datasetInstantiator = datasetInstantiatorFactory.create()) {
       dataset = datasetInstantiator.getDataset(datasetId.toId());
-      if (dataset == null) {
-        throw new DatasetNotFoundException(datasetId.toId());
-      }
       createStatement = generateCreateStatement(dataset, spec, datasetId, tableNaming.getTableName(datasetId));
     } catch (IOException e) {
       LOG.error("Exception instantiating dataset {}.", datasetId, e);
@@ -234,9 +231,6 @@ public class ExploreTableManager {
     List<String> alterStatements;
     try (SystemDatasetInstantiator datasetInstantiator = datasetInstantiatorFactory.create()) {
       dataset = datasetInstantiator.getDataset(datasetId.toId());
-      if (dataset == null) {
-        throw new DatasetNotFoundException(datasetId.toId());
-      }
       alterStatements = generateAlterStatements(datasetId, tableName, dataset, spec, oldSpec);
     } catch (IOException e) {
       LOG.error("Exception instantiating dataset {}.", datasetId, e);
@@ -283,9 +277,6 @@ public class ExploreTableManager {
     String deleteStatement;
     try (SystemDatasetInstantiator datasetInstantiator = datasetInstantiatorFactory.create()) {
       dataset = datasetInstantiator.getDataset(datasetId.toId());
-      if (dataset == null) {
-        throw new DatasetNotFoundException(datasetId.toId());
-      }
       deleteStatement = generateDeleteStatement(dataset, tableName);
     } catch (IOException e) {
       LOG.error("Exception creating dataset classLoaderProvider for dataset {}.", datasetId, e);

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -22,6 +22,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.ConfigurationUtil;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
+import co.cask.cdap.common.utils.FileUtils;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
@@ -29,12 +30,10 @@ import co.cask.cdap.explore.service.Explore;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.ExploreService;
 import co.cask.cdap.explore.service.ExploreServiceUtils;
-import co.cask.cdap.explore.service.ExploreTableManager;
 import co.cask.cdap.explore.service.HandleNotFoundException;
 import co.cask.cdap.explore.service.HiveStreamRedirector;
 import co.cask.cdap.explore.service.MetaDataInfo;
 import co.cask.cdap.explore.service.TableNotFoundException;
-import co.cask.cdap.explore.utils.ExploreTableNaming;
 import co.cask.cdap.hive.context.CConfCodec;
 import co.cask.cdap.hive.context.ContextManager;
 import co.cask.cdap.hive.context.HConfCodec;
@@ -81,6 +80,7 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hive.service.auth.HiveAuthFactory;
@@ -111,12 +111,7 @@ import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -144,7 +139,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
   private static final Gson GSON = new Gson();
   private static final int PREVIEW_COUNT = 5;
   private static final long METASTORE_CLIENT_CLEANUP_PERIOD = 60;
-  public static final String HIVE_METASTORE_TOKEN_KEY = "hive.metastore.token.signature";
+  private static final String HIVE_METASTORE_TOKEN_KEY = "hive.metastore.token.signature";
   public static final String SPARK_YARN_DIST_FILES = "spark.yarn.dist.files";
 
   private final CConfiguration cConf;
@@ -161,12 +156,8 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
   private final ScheduledExecutorService scheduledExecutorService;
   private final long cleanupJobSchedule;
   private final File previewsDir;
+  private final File credentialsDir;
   private final ScheduledExecutorService metastoreClientsExecutorService;
-  private final StreamAdmin streamAdmin;
-  private final DatasetFramework datasetFramework;
-  private final ExploreTableManager exploreTableManager;
-  private final SystemDatasetInstantiatorFactory datasetInstantiatorFactory;
-  private final ExploreTableNaming tableNaming;
   private final NamespaceQueryAdmin namespaceQueryAdmin;
   private final AuthorizationEnforcementService authorizationEnforcementService;
   private final AuthorizationEnforcer authorizationEnforcer;
@@ -198,9 +189,9 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
 
   protected BaseHiveExploreService(TransactionSystemClient txClient, DatasetFramework datasetFramework,
                                    CConfiguration cConf, Configuration hConf,
-                                   File previewsDir, StreamAdmin streamAdmin, NamespaceQueryAdmin namespaceQueryAdmin,
+                                   File previewsDir, File credentialsDir, StreamAdmin streamAdmin,
+                                   NamespaceQueryAdmin namespaceQueryAdmin,
                                    SystemDatasetInstantiatorFactory datasetInstantiatorFactory,
-                                   ExploreTableNaming tableNaming,
                                    AuthorizationEnforcementService authorizationEnforcementService,
                                    AuthorizationEnforcer authorizationEnforcer,
                                    AuthenticationContext authenticationContext) {
@@ -208,15 +199,10 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     this.hConf = hConf;
     this.schedulerQueueResolver = new SchedulerQueueResolver(cConf, namespaceQueryAdmin);
     this.previewsDir = previewsDir;
+    this.credentialsDir = credentialsDir;
     this.metastoreClientLocal = new ThreadLocal<>();
     this.metastoreClientReferences = Maps.newConcurrentMap();
     this.metastoreClientReferenceQueue = new ReferenceQueue<>();
-    this.datasetFramework = datasetFramework;
-    this.streamAdmin = streamAdmin;
-    this.exploreTableManager = new ExploreTableManager(this, datasetInstantiatorFactory,
-                                                       new ExploreTableNaming(), hConf);
-    this.datasetInstantiatorFactory = datasetInstantiatorFactory;
-    this.tableNaming = tableNaming;
     this.namespaceQueryAdmin = namespaceQueryAdmin;
 
     // Create a Timer thread to periodically collect metastore clients that are no longer in used and call close on them
@@ -257,25 +243,11 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     return new CLIService(null);
   }
 
-  protected HiveConf getHiveConf() {
+  private HiveConf getHiveConf() {
     HiveConf conf = new HiveConf();
     // Read delegation token if security is enabled.
     if (UserGroupInformation.isSecurityEnabled()) {
       conf.set(HIVE_METASTORE_TOKEN_KEY, HiveAuthFactory.HS2_CLIENT_TOKEN);
-
-      // mapreduce.job.credentials.binary is added by Hive only if Kerberos credentials are present and impersonation
-      // is enabled. However, in our case we don't have Kerberos credentials for Explore service.
-      // Hence it will not be automatically added by Hive, instead we have to add it ourselves.
-      // TODO: When Explore does secure impersonation this has to be the tokens of the user,
-      // TODO: ... and not the tokens of the service itself.
-      String hadoopAuthToken = System.getenv(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION);
-      if (hadoopAuthToken != null) {
-        conf.set("mapreduce.job.credentials.binary", hadoopAuthToken);
-        if ("tez".equals(conf.get("hive.execution.engine"))) {
-          // Add token file location property for tez if engine is tez
-          conf.set("tez.credentials.path", hadoopAuthToken);
-        }
-      }
     }
 
     // Since we use delegation token in HIVE, unset the SPNEGO authentication if it is
@@ -604,23 +576,16 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
   }
 
   @Override
-  public List<TableNameInfo> getTables(@Nullable final String database) throws ExploreException {
+  public List<TableNameInfo> getTables(final String namespace) throws ExploreException {
     startAndWait();
 
     // TODO check if the database user is allowed to access if security is enabled
     try {
-      List<String> databases;
-      if (database == null) {
-        databases = getMetaStoreClient().getAllDatabases();
-      } else {
-        databases = ImmutableList.of(getHiveDatabase(database));
-      }
+      String database = getHiveDatabase(namespace);
       ImmutableList.Builder<TableNameInfo> builder = ImmutableList.builder();
-      for (String db : databases) {
-        List<String> tables = getMetaStoreClient().getAllTables(db);
-        for (String table : tables) {
-          builder.add(new TableNameInfo(db, table));
-        }
+      List<String> tables = getMetaStoreClient().getAllTables(database);
+      for (String table : tables) {
+        builder.add(new TableNameInfo(database, table));
       }
       return builder.build();
     } catch (TException e) {
@@ -629,13 +594,13 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
   }
 
   @Override
-  public TableInfo getTableInfo(@Nullable String database, String table)
+  public TableInfo getTableInfo(String namespace, String table)
     throws ExploreException, TableNotFoundException {
     startAndWait();
 
     // TODO check if the database user is allowed to access if security is enabled
     try {
-      String db = database == null ? "default" : getHiveDatabase(database);
+      String db = getHiveDatabase(namespace);
 
       Table tableInfo = getMetaStoreClient().getTable(db, table);
       List<FieldSchema> tableFields = tableInfo.getSd().getCols();
@@ -762,7 +727,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
       OperationHandle operationHandle = null;
 
       try {
-        sessionHandle = cliService.openSession("", "", sessionConf);
+        sessionHandle = openHiveSession(sessionConf);
         QueryHandle handle;
         if (Strings.isNullOrEmpty(namespaceMeta.getConfig().getHiveDatabase())) {
           // if no custom hive database was provided get the hive database according to cdap format and create it
@@ -959,7 +924,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
 
     try {
       // Fetch status from Hive
-      QueryStatus status = fetchStatus(getOperationInfo(handle));
+      QueryStatus status = fetchStatus(getActiveOperationInfo(handle));
       LOG.trace("Status of handle {} is {}", handle, status);
 
       // No results or error, so can be timed out aggressively
@@ -1007,11 +972,11 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
                                                           int size) throws Exception;
 
   @SuppressWarnings("unchecked")
-  protected List<QueryResult> fetchNextResults(QueryHandle handle, int size)
+  private List<QueryResult> fetchNextResults(QueryHandle handle, int size)
     throws HiveSQLException, ExploreException, HandleNotFoundException {
     startAndWait();
 
-    Lock nextLock = getOperationInfo(handle).getNextLock();
+    Lock nextLock = getActiveOperationInfo(handle).getNextLock();
     nextLock.lock();
     try {
       // Fetch results from Hive
@@ -1038,7 +1003,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
       throw new HandleNotFoundException("Query is inactive.", true);
     }
 
-    OperationInfo operationInfo = getOperationInfo(handle);
+    OperationInfo operationInfo = getActiveOperationInfo(handle);
     Lock previewLock = operationInfo.getPreviewLock();
     previewLock.lock();
     try {
@@ -1098,7 +1063,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     }
   }
 
-  protected List<ColumnDesc> getResultSchemaInternal(OperationHandle operationHandle) throws SQLException {
+  private List<ColumnDesc> getResultSchemaInternal(OperationHandle operationHandle) throws SQLException {
     ImmutableList.Builder<ColumnDesc> listBuilder = ImmutableList.builder();
     if (operationHandle.hasResultSet()) {
       TableSchema tableSchema = cliService.getResultSetMetadata(operationHandle);
@@ -1110,7 +1075,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     return listBuilder.build();
   }
 
-  private void setCurrentDatabase(String dbName) throws Throwable {
+  private void setCurrentDatabase(String dbName) {
     SessionState.get().setCurrentDatabase(dbName);
   }
 
@@ -1154,7 +1119,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     String namespaceHiveDb = getHiveDatabase(namespace.getId());
     for (Map.Entry<QueryHandle, OperationInfo> entry : activeHandleCache.asMap().entrySet()) {
       try {
-        if (entry.getValue().getHiveDatabase().equals(namespaceHiveDb)) {
+        if (namespaceHiveDb.equals(entry.getValue().getHiveDatabase())) {
           // we use empty query statement for get tables, get schemas, we don't need to return it this method call.
           if (!entry.getValue().getStatement().isEmpty()) {
             QueryStatus status = getStatus(entry.getKey());
@@ -1170,7 +1135,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
 
     for (Map.Entry<QueryHandle, InactiveOperationInfo> entry : inactiveHandleCache.asMap().entrySet()) {
       InactiveOperationInfo inactiveOperationInfo = entry.getValue();
-      if (inactiveOperationInfo.getHiveDatabase().equals(getHiveDatabase(namespace.getId()))) {
+      if (namespaceHiveDb.equals(inactiveOperationInfo.getHiveDatabase())) {
         // we use empty query statement for get tables, get schemas, we don't need to return it this method call.
         if (!inactiveOperationInfo.getStatement().isEmpty()) {
           if (inactiveOperationInfo.getStatus() == null) {
@@ -1193,7 +1158,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     int count = 0;
     String namespaceHiveDb = getHiveDatabase(namespace.getId());
     for (Map.Entry<QueryHandle, OperationInfo> entry : activeHandleCache.asMap().entrySet()) {
-      if (entry.getValue().getHiveDatabase().equals(namespaceHiveDb)) {
+      if (namespaceHiveDb.equals(entry.getValue().getHiveDatabase())) {
         // we use empty query statement for get tables, get schemas, we don't need to return it this method call.
         if (!entry.getValue().getStatement().isEmpty()) {
           count++;
@@ -1234,6 +1199,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     return sessionHandle;
   }
 
+  // no new methods should use this directly. Instead, use openHiveSession
   protected SessionHandle doOpenHiveSession(Map<String, String> sessionConf) throws HiveSQLException {
     return cliService.openSession("", "", sessionConf);
   }
@@ -1246,6 +1212,8 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     }
   }
 
+  @Nullable
+  // returns null iff the input is null
   private String getHiveDatabase(@Nullable String namespace) {
     // null namespace implies that the operation happens across all databases
     if (isNullOrDefault(namespace)) {
@@ -1283,20 +1251,23 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
    * Starts a long running transaction, and also sets up session configuration.
    * @return configuration for a hive session that contains a transaction, and serialized CDAP configuration and
    * HBase configuration. This will be used by the map-reduce tasks started by Hive.
-   * @throws IOException
-   * @throws ExploreException
    */
-  protected Map<String, String> startSession()
-    throws IOException, ExploreException, NamespaceNotFoundException {
+  private Map<String, String> startSession() throws ExploreException, NamespaceNotFoundException, IOException {
     return startSession(null);
   }
 
-  protected Map<String, String> startSession(@Nullable Id.Namespace namespace)
-    throws IOException, ExploreException, NamespaceNotFoundException {
+  private Map<String, String> startSession(@Nullable Id.Namespace namespace)
+    throws ExploreException, IOException, NamespaceNotFoundException {
     return startSession(namespace, null);
   }
 
-  protected Map<String, String> startSession(@Nullable Id.Namespace namespace,
+  private Map<String, String> startSession(@Nullable Id.Namespace namespace,
+                                           @Nullable Map<String, String> additionalSessionConf)
+    throws ExploreException, IOException, NamespaceNotFoundException {
+      return doStartSession(namespace, additionalSessionConf);
+  }
+
+  private Map<String, String> doStartSession(@Nullable Id.Namespace namespace,
                                              @Nullable Map<String, String> additionalSessionConf)
     throws IOException, ExploreException, NamespaceNotFoundException {
 
@@ -1306,7 +1277,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     sessionConf.put(Constants.Explore.QUERY_ID, queryHandle.getHandle());
 
     String schedulerQueue = namespace != null ? schedulerQueueResolver.getQueue(namespace)
-                                              : schedulerQueueResolver.getDefaultQueue();
+      : schedulerQueueResolver.getDefaultQueue();
 
     if (schedulerQueue != null && !schedulerQueue.isEmpty()) {
       sessionConf.put(JobContext.QUEUE_NAME, schedulerQueue);
@@ -1317,7 +1288,9 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     ConfigurationUtil.set(sessionConf, Constants.Explore.CCONF_KEY, CConfCodec.INSTANCE, cConf);
     ConfigurationUtil.set(sessionConf, Constants.Explore.HCONF_KEY, HConfCodec.INSTANCE, hConf);
 
-    if (ExploreServiceUtils.isSparkEngine(getHiveConf())) {
+
+    HiveConf hiveConf = getHiveConf();
+    if (ExploreServiceUtils.isSparkEngine(hiveConf)) {
       sessionConf.putAll(sparkConf);
     }
 
@@ -1325,8 +1298,22 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
       // make sure RM does not cancel delegation tokens after the query is run
       sessionConf.put("mapreduce.job.complete.cancel.delegation.tokens", "false");
       sessionConf.put("spark.hadoop.mapreduce.job.complete.cancel.delegation.tokens", "false");
-      // refresh delegations for the job - TWILL-170
-      updateTokenStore();
+
+      // write the user's credentials to a file, to be used for the query
+      File credentialsFile = writeCredentialsFile(queryHandle);
+      String credentialsFilePath = credentialsFile.getAbsolutePath();
+
+      // mapreduce.job.credentials.binary is added by Hive only if Kerberos credentials are present and impersonation
+      // is enabled. However, in our case we don't have Kerberos credentials for Explore service.
+      // Hence it will not be automatically added by Hive, instead we have to add it ourselves.
+      sessionConf.put(MRJobConfig.MAPREDUCE_JOB_CREDENTIALS_BINARY, credentialsFilePath);
+
+      sessionConf.put(HiveConf.ConfVars.SUBMITLOCALTASKVIACHILD.toString(), Boolean.FALSE.toString());
+      sessionConf.put(HiveConf.ConfVars.SUBMITVIACHILD.toString(), Boolean.FALSE.toString());
+      if (ExploreServiceUtils.isTezEngine(hiveConf)) {
+        // Add token file location property for tez if engine is tez
+        sessionConf.put("tez.credentials.path", credentialsFilePath);
+      }
     }
 
     if (additionalSessionConf != null) {
@@ -1337,37 +1324,27 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
   }
 
   /**
-   * Updates the token store to be used for the hive job, based upon the Explore container's credentials.
-   * This is because twill doesn't update the container_tokens on upon token refresh.
-   * See: https://issues.apache.org/jira/browse/TWILL-170
+   * Writes the {@link Credentials} of the current user to a file in the {@link #credentialsDir}, for a particular query
+   *
+   * @param queryHandle the query handler for the current operation
+   * @return a File where the credentials were written.
    */
-  private void updateTokenStore() throws IOException, ExploreException {
-    String hadoopTokenFileLocation = System.getenv(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION);
-    if (hadoopTokenFileLocation == null) {
-      LOG.warn("Skipping update of token store due to failure to find environment variable '{}'.",
-               UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION);
-      return;
-    }
+  private File writeCredentialsFile(QueryHandle queryHandle) throws IOException, ExploreException {
+    File credentialsFile = new File(credentialsDir, queryHandle.getHandle());
 
-    Path credentialsFile = Paths.get(hadoopTokenFileLocation);
+    // create a local file with restricted permissions
+    // only allow the owner to read/write, since it contains credentials
+    Files.createFile(credentialsFile.toPath(), FileUtils.OWNER_ONLY_RW);
 
-    FileAttribute<Set<PosixFilePermission>> originalPermissionAttributes =
-      PosixFilePermissions.asFileAttribute(Files.getPosixFilePermissions(credentialsFile));
-
-    Path tmpFile = Files.createTempFile(credentialsFile.getParent(), "credentials.store", null,
-                                        originalPermissionAttributes);
-    LOG.debug("Writing to temporary file: {}", tmpFile);
-
-    try (DataOutputStream os = new DataOutputStream(Files.newOutputStream(tmpFile))) {
+    LOG.debug("Writing credentials to file: {}", credentialsFile);
+    try (DataOutputStream os = new DataOutputStream(Files.newOutputStream(credentialsFile.toPath()))) {
       Credentials credentials = UserGroupInformation.getCurrentUser().getCredentials();
       credentials.writeTokenStorageToStream(os);
     }
-
-    Files.move(tmpFile, credentialsFile, StandardCopyOption.ATOMIC_MOVE);
-    LOG.debug("Secure store saved to {}", credentialsFile);
+    return credentialsFile;
   }
 
-  protected QueryHandle getQueryHandle(Map<String, String> sessionConf) throws HandleNotFoundException {
+  private QueryHandle getQueryHandle(Map<String, String> sessionConf) throws HandleNotFoundException {
     return QueryHandle.fromId(sessionConf.get(Constants.Explore.QUERY_ID));
   }
 
@@ -1377,8 +1354,8 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
    * @return OperationHandle.
    * @throws ExploreException
    */
-  protected OperationHandle getOperationHandle(QueryHandle handle) throws ExploreException, HandleNotFoundException {
-    return getOperationInfo(handle).getOperationHandle();
+  private OperationHandle getOperationHandle(QueryHandle handle) throws ExploreException, HandleNotFoundException {
+    return getActiveOperationInfo(handle).getOperationHandle();
   }
 
   protected QueryStatus fetchStatus(OperationInfo operationInfo)
@@ -1459,23 +1436,38 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     activeHandleCache.invalidate(handle);
   }
 
-  private OperationInfo getOperationInfo(QueryHandle handle) throws HandleNotFoundException {
+  @Override
+  public OperationInfo getOperationInfo(QueryHandle queryHandle) throws HandleNotFoundException {
+    InactiveOperationInfo inactiveOperationInfo = inactiveHandleCache.getIfPresent(queryHandle);
+    if (inactiveOperationInfo != null) {
+      return inactiveOperationInfo;
+    }
+    return getActiveOperationInfo(queryHandle);
+  }
+
+  private OperationInfo getActiveOperationInfo(QueryHandle handle) throws HandleNotFoundException {
     // First look in running handles and handles that still can be fetched.
     OperationInfo opInfo = activeHandleCache.getIfPresent(handle);
     if (opInfo != null) {
       return opInfo;
     }
-    throw new HandleNotFoundException("Invalid handle provided");
+    throw new HandleNotFoundException(String.format("Invalid handle provided: %s", handle.getHandle()));
   }
 
   /**
    * Cleans up the metadata associated with active {@link QueryHandle}. It also closes associated transaction.
    * @param handle handle of the running Hive operation.
    */
-  protected void cleanUp(QueryHandle handle, OperationInfo opInfo) {
+  private void cleanUp(QueryHandle handle, OperationInfo opInfo) {
     try {
       if (opInfo.getPreviewFile() != null) {
         opInfo.getPreviewFile().delete();
+      }
+      if (UserGroupInformation.isSecurityEnabled()) {
+        String credentialsFile = opInfo.getSessionConf().get(MRJobConfig.MAPREDUCE_JOB_CREDENTIALS_BINARY);
+        if (!new File(credentialsFile).delete()) {
+          LOG.warn("Failed to delete credentials file: {}", credentialsFile);
+        }
       }
       closeTransaction(handle, opInfo);
     } finally {

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12CDH5ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12CDH5ExploreService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,12 +19,12 @@ package co.cask.cdap.explore.service.hive;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
+import co.cask.cdap.common.security.Impersonator;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.HandleNotFoundException;
-import co.cask.cdap.explore.utils.ExploreTableNaming;
 import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.proto.QueryStatus;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
@@ -65,14 +65,14 @@ public class Hive12CDH5ExploreService extends BaseHiveExploreService {
   protected Hive12CDH5ExploreService(TransactionSystemClient txClient, DatasetFramework datasetFramework,
                                      CConfiguration cConf, Configuration hConf,
                                      @Named(Constants.Explore.PREVIEWS_DIR_NAME) File previewsDir,
+                                     @Named(Constants.Explore.CREDENTIALS_DIR_NAME) File credentialsDir,
                                      StreamAdmin streamAdmin, NamespaceQueryAdmin namespaceQueryAdmin,
                                      SystemDatasetInstantiatorFactory datasetInstantiatorFactory,
-                                     ExploreTableNaming tableNaming,
                                      AuthorizationEnforcementService authorizationEnforcementService,
                                      AuthorizationEnforcer authorizationEnforcer,
                                      AuthenticationContext authenticationContext) {
-    super(txClient, datasetFramework, cConf, hConf, previewsDir, streamAdmin, namespaceQueryAdmin,
-          datasetInstantiatorFactory, tableNaming, authorizationEnforcementService, authorizationEnforcer,
+    super(txClient, datasetFramework, cConf, hConf, previewsDir, credentialsDir, streamAdmin, namespaceQueryAdmin,
+          datasetInstantiatorFactory, authorizationEnforcementService, authorizationEnforcer,
           authenticationContext);
   }
 

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive12ExploreService.java
@@ -19,12 +19,12 @@ package co.cask.cdap.explore.service.hive;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
+import co.cask.cdap.common.security.Impersonator;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.HandleNotFoundException;
-import co.cask.cdap.explore.utils.ExploreTableNaming;
 import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.proto.QueryStatus;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
@@ -74,14 +74,14 @@ public class Hive12ExploreService extends BaseHiveExploreService {
   public Hive12ExploreService(TransactionSystemClient txClient, DatasetFramework datasetFramework,
                               CConfiguration cConf, Configuration hConf,
                               @Named(Constants.Explore.PREVIEWS_DIR_NAME) File previewsDir,
+                              @Named(Constants.Explore.CREDENTIALS_DIR_NAME) File credentialsDir,
                               StreamAdmin streamAdmin, NamespaceQueryAdmin namespaceQueryAdmin,
                               SystemDatasetInstantiatorFactory datasetInstantiatorFactory,
-                              ExploreTableNaming tableNaming,
                               AuthorizationEnforcementService authorizationEnforcementService,
                               AuthorizationEnforcer authorizationEnforcer,
                               AuthenticationContext authenticationContext) {
-    super(txClient, datasetFramework, cConf, hConf, previewsDir, streamAdmin, namespaceQueryAdmin,
-          datasetInstantiatorFactory, tableNaming, authorizationEnforcementService, authorizationEnforcer,
+    super(txClient, datasetFramework, cConf, hConf, previewsDir, credentialsDir, streamAdmin, namespaceQueryAdmin,
+          datasetInstantiatorFactory, authorizationEnforcementService, authorizationEnforcer,
           authenticationContext);
   }
 

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive13ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive13ExploreService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,12 +19,12 @@ package co.cask.cdap.explore.service.hive;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
+import co.cask.cdap.common.security.Impersonator;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.HandleNotFoundException;
-import co.cask.cdap.explore.utils.ExploreTableNaming;
 import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.proto.QueryStatus;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
@@ -59,14 +59,14 @@ public class Hive13ExploreService extends BaseHiveExploreService {
   public Hive13ExploreService(TransactionSystemClient txClient, DatasetFramework datasetFramework,
                               CConfiguration cConf, Configuration hConf,
                               @Named(Constants.Explore.PREVIEWS_DIR_NAME) File previewsDir,
+                              @Named(Constants.Explore.CREDENTIALS_DIR_NAME) File credentialsDir,
                               StreamAdmin streamAdmin, NamespaceQueryAdmin namespaceQueryAdmin,
                               SystemDatasetInstantiatorFactory datasetInstantiatorFactory,
-                              ExploreTableNaming tableNaming,
                               AuthorizationEnforcementService authorizationEnforcementService,
                               AuthorizationEnforcer authorizationEnforcer,
                               AuthenticationContext authenticationContext) {
-    super(txClient, datasetFramework, cConf, hConf, previewsDir, streamAdmin, namespaceQueryAdmin,
-          datasetInstantiatorFactory, tableNaming, authorizationEnforcementService, authorizationEnforcer,
+    super(txClient, datasetFramework, cConf, hConf, previewsDir, credentialsDir, streamAdmin, namespaceQueryAdmin,
+          datasetInstantiatorFactory, authorizationEnforcementService, authorizationEnforcer,
           authenticationContext);
     // This config sets the time Hive CLI getOperationStatus method will wait for the status of
     // a running query.

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive14ExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/Hive14ExploreService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,12 +19,12 @@ package co.cask.cdap.explore.service.hive;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
+import co.cask.cdap.common.security.Impersonator;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.HandleNotFoundException;
-import co.cask.cdap.explore.utils.ExploreTableNaming;
 import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.proto.QueryStatus;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
@@ -58,14 +58,14 @@ public class Hive14ExploreService extends BaseHiveExploreService {
   public Hive14ExploreService(TransactionSystemClient txClient, DatasetFramework datasetFramework,
                               CConfiguration cConf, Configuration hConf,
                               @Named(Constants.Explore.PREVIEWS_DIR_NAME) File previewsDir,
+                              @Named(Constants.Explore.CREDENTIALS_DIR_NAME) File credentialsDir,
                               StreamAdmin streamAdmin, NamespaceQueryAdmin namespaceQueryAdmin,
                               SystemDatasetInstantiatorFactory datasetInstantiatorFactory,
-                              ExploreTableNaming tableNaming,
                               AuthorizationEnforcementService authorizationEnforcementService,
                               AuthorizationEnforcer authorizationEnforcer,
                               AuthenticationContext authenticationContext) {
-    super(txClient, datasetFramework, cConf, hConf, previewsDir, streamAdmin, namespaceQueryAdmin,
-          datasetInstantiatorFactory, tableNaming, authorizationEnforcementService, authorizationEnforcer,
+    super(txClient, datasetFramework, cConf, hConf, previewsDir, credentialsDir, streamAdmin, namespaceQueryAdmin,
+          datasetInstantiatorFactory, authorizationEnforcementService, authorizationEnforcer,
           authenticationContext);
     // This config sets the time Hive CLI getOperationStatus method will wait for the status of
     // a running query.

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/OperationInfo.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/OperationInfo.java
@@ -1,5 +1,3 @@
-package co.cask.cdap.explore.service.hive;
-
 /*
  * Copyright © 2015 Cask Data, Inc.
  *
@@ -16,14 +14,20 @@ package co.cask.cdap.explore.service.hive;
  * the License.
  */
 
+package co.cask.cdap.explore.service.hive;
+
 import co.cask.cdap.proto.QueryStatus;
+import com.google.common.base.Throwables;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hive.service.cli.OperationHandle;
 import org.apache.hive.service.cli.SessionHandle;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import javax.annotation.Nullable;
 
 /**
 * Helper class to store information about a Hive operation in progress.
@@ -41,6 +45,7 @@ public abstract class OperationInfo {
   private final boolean readOnly;
   private final Lock nextLock = new ReentrantLock();
   private final Lock previewLock = new ReentrantLock();
+  private final UserGroupInformation ugi;
 
   private File previewFile;
   private QueryStatus status;
@@ -55,6 +60,12 @@ public abstract class OperationInfo {
     this.timestamp = timestamp;
     this.hiveDatabase = hiveDatabase;
     this.readOnly = readOnly;
+    try {
+      // maintain the UGI who created this operation, to use for future operations
+      this.ugi = UserGroupInformation.getCurrentUser();
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
   }
 
   public SessionHandle getSessionHandle() {
@@ -93,8 +104,13 @@ public abstract class OperationInfo {
     return previewLock;
   }
 
+  @Nullable
   public String getHiveDatabase() {
     return hiveDatabase;
+  }
+
+  public UserGroupInformation getUGI() {
+    return ugi;
   }
 
   public boolean isReadOnly() {

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceTestRun.java
@@ -148,13 +148,7 @@ public class HiveExploreServiceTestRun extends BaseHiveExploreServiceTest {
   public void getUserTables() throws Exception {
     exploreClient.submit(NAMESPACE_ID, "create table test (first INT, second STRING) " +
                            "ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\t'").get();
-    List<TableNameInfo> tables = exploreService.getTables(null);
-    Assert.assertEquals(ImmutableList.of(new TableNameInfo(NAMESPACE_DATABASE, MY_TABLE_NAME),
-                                         new TableNameInfo(NAMESPACE_DATABASE, "test"),
-                                         new TableNameInfo(OTHER_NAMESPACE_DATABASE, OTHER_MY_TABLE_NAME)),
-                        tables);
-
-    tables = exploreService.getTables(NAMESPACE_ID.getId());
+    List<TableNameInfo> tables = exploreService.getTables(NAMESPACE_ID.getId());
     Assert.assertEquals(ImmutableList.of(new TableNameInfo(NAMESPACE_DATABASE, MY_TABLE_NAME),
                                          new TableNameInfo(NAMESPACE_DATABASE, "test")),
                         tables);
@@ -497,7 +491,7 @@ public class HiveExploreServiceTestRun extends BaseHiveExploreServiceTest {
     Assert.assertEquals(DatasetStorageHandler.class.getName(), tableInfo.getParameters().get("storage_handler"));
 
     try {
-      exploreService.getTableInfo(null, "foobar");
+      exploreService.getTableInfo("foo", "foobar");
       Assert.fail("Should throw TableNotFoundException on table foobar");
     } catch (TableNotFoundException e) {
       // Expected


### PR DESCRIPTION
Setting SUBMITLOCALTASKVIACHILD in hiveConf to false, in order to disallow Hive from launching some jobs in child processes. This makes impersonation simpler, at the cost of performance overhead.

This implementation also has the limitation that queries can not live for longer than (approximately) the delegation token expiry time, because we cache the UGI in the OperationInfo object, for future operations on that object.

Various explore queries seem to work in a namespace configured with impersonation, but this still requires more thorough testing.

JDBC is tested to some extent. So far, everything seems to be working.
Some operations are not done while impersonating. See `ExploreMetadataHttpHandler` and `NamespacedExploreMetadataHttpHandler`.
Example operation: Getting JDBCCatalogs, getting JDBCTypes, or JDBCInfo.

https://issues.cask.co/browse/CDAP-6587
http://builds.cask.co/browse/CDAP-RUT249