### PR TITLE
(CDAP-7527) Not to add logback.xml as container resources

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -43,6 +43,7 @@ import co.cask.cdap.data2.transaction.Transactions;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.internal.app.runtime.LocalizationUtils;
+import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.batch.dataset.UnsupportedOutputFormat;
 import co.cask.cdap.internal.app.runtime.batch.dataset.input.MapperInput;
 import co.cask.cdap.internal.app.runtime.batch.dataset.input.MultipleInputs;
@@ -98,7 +99,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -267,7 +267,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
         List<String> classpath = new ArrayList<>();
 
         // Localize logback.xml
-        Location logbackLocation = createLogbackJar(tempLocation);
+        Location logbackLocation = ProgramRunners.createLogbackJar(tempLocation);
         if (logbackLocation != null) {
           job.addCacheFile(logbackLocation.toURI());
           classpath.add(logbackLocation.getName());
@@ -1031,30 +1031,6 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
     Location pluginLocation = targetDir.append(pluginArchive.getName()).getTempFile(".jar");
     Files.copy(pluginArchive, Locations.newOutputSupplier(pluginLocation));
     return pluginLocation;
-  }
-
-  /**
-   * Creates a jar in the given directory that contains a logback.xml loaded from the current ClassLoader.
-   *
-   * @param targetDir directory where the logback.xml should be copied to
-   * @return the {@link Location} where the logback.xml jar copied to or {@code null} if "logback.xml" is not found
-   *         in the current ClassLoader.
-   */
-  @Nullable
-  private Location createLogbackJar(Location targetDir) throws IOException {
-    try (InputStream input = Thread.currentThread().getContextClassLoader().getResourceAsStream("logback.xml")) {
-      if (input != null) {
-        Location logbackJar = targetDir.append("logback").getTempFile(".jar");
-        try (JarOutputStream output = new JarOutputStream(logbackJar.getOutputStream())) {
-          output.putNextEntry(new JarEntry("logback.xml"));
-          ByteStreams.copy(input, output);
-        }
-        return logbackJar;
-      } else {
-        LOG.warn("Could not find logback.xml for MapReduce!");
-      }
-    }
-    return null;
   }
 
   /**

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeService.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeService.java
@@ -37,6 +37,7 @@ import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.internal.app.runtime.DataSetFieldSetter;
 import co.cask.cdap.internal.app.runtime.LocalizationUtils;
 import co.cask.cdap.internal.app.runtime.MetricsFieldSetter;
+import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.batch.distributed.ContainerLauncherGenerator;
 import co.cask.cdap.internal.app.runtime.distributed.LocalizeResource;
 import co.cask.cdap.internal.lang.Fields;
@@ -44,13 +45,11 @@ import co.cask.cdap.internal.lang.Reflections;
 import co.cask.cdap.security.store.SecureStoreUtils;
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
 import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -74,7 +73,6 @@ import scala.Tuple2;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.Writer;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -94,7 +92,6 @@ import java.util.Properties;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import javax.annotation.Nullable;
 
@@ -208,7 +205,7 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
           localizeResources.add(new LocalizeResource(pluginArchive, true));
         }
 
-        File logbackJar = createLogbackJar(tempDir);
+        File logbackJar = ProgramRunners.createLogbackJar(tempDir);
         if (logbackJar != null) {
           localizeResources.add(new LocalizeResource(logbackJar));
           logbackJarName = logbackJar.getName();
@@ -565,32 +562,6 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
       cConf.writeXml(writer);
     }
     return file;
-  }
-
-  /**
-   * Creates a jar in the given directory that contains a logback.xml loaded from the current ClassLoader.
-   *
-   * @param targetDir directory where the logback.xml should be copied to
-   * @return the {@link File} where the logback.xml jar copied to or {@code null} if "logback.xml" is not found
-   *         in the current ClassLoader.
-   */
-  @Nullable
-  private File createLogbackJar(File targetDir) throws IOException {
-    // Localize logback.xml
-    ClassLoader cl = Objects.firstNonNull(Thread.currentThread().getContextClassLoader(), getClass().getClassLoader());
-    try (InputStream input = cl.getResourceAsStream("logback.xml")) {
-      if (input != null) {
-        File logbackJar = File.createTempFile("logback.xml", ".jar", targetDir);
-        try (JarOutputStream output = new JarOutputStream(new FileOutputStream(logbackJar))) {
-          output.putNextEntry(new JarEntry("logback.xml"));
-          ByteStreams.copy(input, output);
-        }
-        return logbackJar;
-      } else {
-        LOG.warn("Could not find logback.xml for Spark!");
-      }
-    }
-    return null;
   }
 
   /**


### PR DESCRIPTION
- Due to jar caching introduced in CDAP-7021, the container jar 
  won’t get regenerated across different runs. Having logback.xml
  as container resources means means different program cannot define
  their own logback.xml in the app jar.
- Instead of using container resources, localize the logback.xml file
  to the container directly and use the Java system property
  “logback.configurationFile” to configure logbook to use that
  localized logback.xml file
