### PR TITLE
CDAP-6600 Document how to run CDAP from IDE

### DIFF
--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -344,6 +344,7 @@ if release:
     else:
         source_link = "v%s" % release
     rst_epilog += """
+.. |git-clone-command| replace:: ``$ git clone -b %(source_link)s https://github.com/caskdata/cdap.git``
 .. |source-link| replace:: `GitHub <https://github.com/caskdata/cdap/archive/%(source_link)s.zip>`__
 .. |ui-read-me| replace:: `CDAP UI README <https://github.com/caskdata/cdap/blob/%(source_link)s/cdap-ui/README.rst>`__
 """ % {'source_link': source_link}

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -339,6 +339,15 @@ if release:
 .. |literal-release| replace:: ``%(release)s``
 """ % {'release': release}
 
+    if release.endswith('SNAPSHOT'):
+        source_link = 'develop'
+    else:
+        source_link = "v%s" % release
+    rst_epilog += """
+.. |source-link| replace:: `GitHub <https://github.com/caskdata/cdap/archive/%(source_link)s.zip>`__
+.. |ui-read-me| replace:: `CDAP UI README <https://github.com/caskdata/cdap/blob/%(source_link)s/cdap-ui/README.rst>`__
+""" % {'source_link': source_link}
+
 if current_year:
     rst_epilog += """
 .. |current_year| replace:: %(current_year)s

--- a/cdap-docs/developers-manual/source/getting-started/dev-env.rst
+++ b/cdap-docs/developers-manual/source/getting-started/dev-env.rst
@@ -15,9 +15,9 @@ Development Environment Setup
 Creating an Application
 -----------------------
 
-When writing a CDAP application, it's best to use an integrated development environment that
-understands the application interface to provide code-completion in writing interface
-methods.
+When writing a CDAP application, it's best to use an integrated development environment
+(IDE) that understands the application interface and provides code-completion in writing
+interface methods.
 
 The best way to start developing a CDAP application is by using the Maven archetype:
 
@@ -39,7 +39,6 @@ For an application that contains a MapReduce program, set the ``archetypeArtifac
 
 Using IntelliJ
 --------------
-
 1. Open `IntelliJ <https://www.jetbrains.com/idea/>`__ and import the Maven project.
 #. Go to menu *File -> Import Project*...
 #. Select the ``pom.xml`` in the Maven project's directory.
@@ -49,7 +48,6 @@ Using IntelliJ
 
 Using Eclipse
 -------------
-
 1. In your `Eclipse <https://www.eclipse.org/>`__ installation, make sure you have the
    `m2eclipse <http://m2eclipse.sonatype.org>`__ plugin installed.
 #. Go to menu *File -> Import*
@@ -57,3 +55,34 @@ Using Eclipse
 #. Select *Existing Maven Projects* as the import source.
 #. Browse for the Maven project's directory.
 #. Click *Finish*, and the new CDAP project will be imported, created and opened.
+
+Running CDAP from within an IDE
+-------------------------------
+As CDAP is an open source project, you can download the source, import it into an IDE,
+then modify, build, and run CDAP.
+
+To do so, follow these steps:
+
+1. Install all the :ref:`prerequisite system requirements <system-requirements>` for CDAP development.
+#. Download the source as a ZIP from |source-link|.
+#. Unpack the ZIP in a suitable location.
+#. In your IDE, install the Scala plugin (for 
+   `IntelliJ <https://confluence.jetbrains.com/display/SCA/Scala+Plugin+for+IntelliJ+IDEA>`__
+   or `Eclipse <http://scala-ide.org>`__) as there is Scala code in the project.
+#. Open the CDAP project in the IDE as an existing project by finding and opening the ``cdap/pom.xml``.
+#. Resolve dependencies: this can take quite a while, as there are numerous downloads required.
+#. Before starting CDAP, disable audit logs by changing the ``audit.enabled`` setting in 
+   ``cdap-default.xml`` to ``false``. Otherwise, due to :cask-issue:`CDAP-5864`, Kafka
+   errors will appear in the logs.
+#. In the case of IntelliJ, you can create a run configuration to run CDAP Standalone:
+
+   1. Select ``Run > Edit`` Configurations...
+   #. Add a new "Application" run configuration.
+   #. Set "Main class" to be ``co.cask.cdap.StandaloneMain``.
+   #. Set "VM options" to ``-Xmx1024m`` (for in-memory MapReduce jobs).
+   #. Click "OK".
+   #. You can now use this run configuration to start an instance of CDAP Standalone.
+   
+This will allow you to start CDAP and access it from either the command line (:ref:`CLI <cli>`)
+or through the :ref:`HTTP RESTful API <http-restful-api>`. If you want to run and develop
+the UI, you will need to follow additional instructions in the |ui-read-me|.

--- a/cdap-docs/developers-manual/source/getting-started/dev-env.rst
+++ b/cdap-docs/developers-manual/source/getting-started/dev-env.rst
@@ -64,8 +64,13 @@ then modify, build, and run CDAP.
 To do so, follow these steps:
 
 1. Install all the :ref:`prerequisite system requirements <system-requirements>` for CDAP development.
-#. Download the source as a ZIP from |source-link|.
-#. Unpack the ZIP in a suitable location.
+
+#. Either clone the CDAP repo or download a ZIP of the source:
+
+   - Clone the CDAP repository using |git-clone-command|
+   
+   - Download the source as a ZIP from |source-link| and unpack the ZIP in a suitable location
+
 #. In your IDE, install the Scala plugin (for 
    `IntelliJ <https://confluence.jetbrains.com/display/SCA/Scala+Plugin+for+IntelliJ+IDEA>`__
    or `Eclipse <http://scala-ide.org>`__) as there is Scala code in the project.

--- a/cdap-docs/developers-manual/source/getting-started/dev-env.rst
+++ b/cdap-docs/developers-manual/source/getting-started/dev-env.rst
@@ -79,10 +79,12 @@ To do so, follow these steps:
    1. Select ``Run > Edit`` Configurations...
    #. Add a new "Application" run configuration.
    #. Set "Main class" to be ``co.cask.cdap.StandaloneMain``.
-   #. Set "VM options" to ``-Xmx1024m`` (for in-memory MapReduce jobs).
+   #. Set "VM options" to ``-Xmx1024m -XX:MaxPermSize=128m`` (for in-memory MapReduce jobs).
    #. Click "OK".
    #. You can now use this run configuration to start an instance of CDAP Standalone.
    
 This will allow you to start CDAP and access it from either the command line (:ref:`CLI <cli>`)
-or through the :ref:`HTTP RESTful API <http-restful-api>`. If you want to run and develop
-the UI, you will need to follow additional instructions in the |ui-read-me|.
+or through the :ref:`HTTP RESTful API <http-restful-api>`. To start the CLI, you can either start
+it from a shell using the ``cdap`` script or run the ``CLIMain`` class from the IDE.
+
+If you want to run and develop the UI, you will need to follow additional instructions in the |ui-read-me|.


### PR DESCRIPTION
Add instructions for running CDAP from within an IDE.

Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB161-2

Fails, but unrelated to this PR.

Page of interest (_Development Environment Setup_): http://builds.cask.co/artifact/CDAP-DQB161/shared/build-2/Docs-HTML/4.0.0-SNAPSHOT/en/developers-manual/getting-started/dev-env.html#dev-env
