### PR TITLE
Remove code that's no longer necessary since CDAP-1280

### DIFF
--- a/cdap-distributions/src/debian/scripts/postinst
+++ b/cdap-distributions/src/debian/scripts/postinst
@@ -30,20 +30,6 @@ case "$1" in
     chown -R cdap.cdap /var/log/cdap
     chown -R cdap.cdap /var/run/cdap
     chown -R cdap.cdap /var/cdap/run
-    chmod +x /opt/cdap/$package_name/bin/service
-
-    if stat -t /opt/cdap/$package_name/conf/*-env.sh >/dev/null 2>&1 ; then
-      find -L /opt/cdap/$package_name/conf -name '*-env.sh' | xargs -n1 basename | sed 's/-env.sh//' | while read svcname; do
-        # refresh internal symlinks
-        if [ -h "/opt/cdap/$package_name/bin/svc-$svcname" ]; then
-          unlink /opt/cdap/$package_name/bin/svc-$svcname
-        fi
-        ln -s /opt/cdap/$package_name/bin/service /opt/cdap/$package_name/bin/svc-$svcname
-        if [ -x "/etc/init.d/cdap-$svcname" ]; then
-          update-rc.d cdap-$svcname defaults >/dev/null
-        fi
-      done
-    fi
   ;;
 
   abort-upgrade|abort-remove|abort-deconfigure)

--- a/cdap-distributions/src/debian/scripts/prerm
+++ b/cdap-distributions/src/debian/scripts/prerm
@@ -24,29 +24,9 @@ version="<%= @version %>"
 
 case "$1" in
     remove)
-      if stat -t /opt/cdap/$package_name/conf/*-env.sh >/dev/null 2>&1 ; then
-        find -L /opt/cdap/$package_name/conf -name '*-env.sh' | xargs -n1 basename | sed 's/-env.sh//' | while read svcname; do
-          # stop each service
-          if [ -x "/etc/init.d/cdap-$svcname" ]; then
-            invoke-rc.d cdap-$svcname stop || :
-          fi
-          if [ -h "/opt/cdap/$package_name/bin/svc-$svcname" ]; then
-            unlink /opt/cdap/$package_name/bin/svc-$svcname > /dev/null 2>&1 ||:
-          fi
-          rm -f /opt/cdap/$package_name/version ||:
-        done
-      fi
     ;;
 
     upgrade|deconfigure)
-      if stat -t /opt/cdap/$package_name/conf/*-env.sh >/dev/null 2>&1 ; then
-        find -L /opt/cdap/$package_name/conf -name '*-env.sh' | xargs -n1 basename | sed 's/-env.sh//' | while read svcname; do
-          if [ -h "/opt/cdap/$package_name/bin/svc-$svcname" ]; then
-            unlink /opt/cdap/$package_name/bin/svc-$svcname > /dev/null 2>&1 ||:
-          fi
-          rm -f /opt/cdap/$package_name/version ||:
-        done
-      fi
     ;;
 
     failed-upgrade)

--- a/cdap-distributions/src/rpm/scripts/postinst
+++ b/cdap-distributions/src/rpm/scripts/postinst
@@ -1,5 +1,5 @@
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -25,13 +25,3 @@ chown -R cdap.cdap /opt/cdap/$package_name
 chown -R cdap.cdap /var/log/cdap
 chown -R cdap.cdap /var/run/cdap
 chown -R cdap.cdap /var/cdap/run
-chmod +x /opt/cdap/$package_name/bin/service
-if stat -t /opt/cdap/$package_name/conf/*-env.sh >/dev/null 2>&1 ; then
-  find -L /opt/cdap/$package_name/conf -name '*-env.sh' | xargs -n1 basename | sed 's/-env.sh//' | while read svcname; do
-    if [[ -h /opt/cdap/$package_name/bin/svc-$svcname ]]; then
-      unlink /opt/cdap/$package_name/bin/svc-$svcname
-    fi
-    ln -s /opt/cdap/$package_name/bin/service /opt/cdap/$package_name/bin/svc-$svcname
-  done
-fi
-

--- a/cdap-distributions/src/rpm/scripts/prerm
+++ b/cdap-distributions/src/rpm/scripts/prerm
@@ -1,5 +1,5 @@
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -18,17 +18,3 @@
 
 package_name="<%= project %>"
 version="<%= @version %>"
-
-# if no remaining packages installed, stop and remove the service link
-if [ $1 = 0 ]; then 
-  if stat -t /opt/cdap/$package_name/conf/*-env.sh >/dev/null 2>&1 ; then
-    find -L /opt/cdap/$package_name/conf -name '*-env.sh' | xargs -n1 basename | sed 's/-env.sh//' | while read svcname; do
-      service cdap-$svcname stop > /dev/null 2>&1
-      if [[ -h /opt/cdap/$package_name/bin/svc-$svcname ]]; then
-        unlink /opt/cdap/$package_name/bin/svc-$svcname > /dev/null 2>&1
-      fi
-      rm -f /opt/cdap/$package_name/version
-    done
-  fi
-fi
-


### PR DESCRIPTION
These files are no longer present in the installed packages, so remove reference to them.