### PR TITLE
Better error message in explore jdbc driver, when client is unauthenticated

### DIFF
--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/AbstractExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/AbstractExploreClient.java
@@ -19,6 +19,8 @@ package co.cask.cdap.explore.client;
 import co.cask.cdap.api.data.format.FormatSpecification;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.common.ServiceUnavailableException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.explore.service.Explore;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.HandleNotFoundException;
@@ -29,6 +31,7 @@ import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.QueryHandle;
 import co.cask.cdap.proto.QueryResult;
 import co.cask.cdap.proto.QueryStatus;
+import co.cask.common.http.HttpResponse;
 import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -47,6 +50,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -78,8 +82,8 @@ public abstract class AbstractExploreClient extends ExploreHttpClient implements
   }
 
   @Override
-  public boolean isServiceAvailable() {
-    return isAvailable();
+  public void ping() throws UnauthenticatedException, ServiceUnavailableException, ExploreException {
+    super.ping();
   }
 
   @Override

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreClient.java
@@ -19,6 +19,9 @@ package co.cask.cdap.explore.client;
 import co.cask.cdap.api.data.format.FormatSpecification;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.common.ServiceUnavailableException;
+import co.cask.cdap.common.UnauthenticatedException;
+import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.MetaDataInfo;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
@@ -34,9 +37,13 @@ import javax.annotation.Nullable;
 public interface ExploreClient extends Closeable {
 
   /**
-   * Returns true if the explore service is up and running.
+   * Pings the explore service. Returns successfully if explore service is up and running.
+   *
+   * @throws UnauthenticatedException if the client is not authenticated.
+   * @throws ServiceUnavailableException if the explore service is not available.
+   * @throws ExploreException if there is some other error when attempting to ping the explore service.
    */
-  boolean isServiceAvailable();
+  void ping() throws UnauthenticatedException, ServiceUnavailableException, ExploreException;
 
   /**
    * Enables ad-hoc exploration of the given {@link co.cask.cdap.api.data.batch.RecordScannable}.

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/MockExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/MockExploreClient.java
@@ -19,6 +19,7 @@ package co.cask.cdap.explore.client;
 import co.cask.cdap.api.data.format.FormatSpecification;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.explore.service.MetaDataInfo;
 import co.cask.cdap.proto.ColumnDesc;
@@ -58,8 +59,8 @@ public class MockExploreClient extends AbstractIdleService implements ExploreCli
   }
 
   @Override
-  public boolean isServiceAvailable() {
-    return true;
+  public void ping() throws UnauthenticatedException, ExploreException {
+
   }
 
   @Override

--- a/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreDriver.java
+++ b/cdap-explore-jdbc/src/main/java/co/cask/cdap/explore/jdbc/ExploreDriver.java
@@ -16,10 +16,13 @@
 
 package co.cask.cdap.explore.jdbc;
 
+import co.cask.cdap.common.ServiceUnavailableException;
+import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.utils.ProjectInfo;
 import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.explore.client.FixedAddressExploreClient;
+import co.cask.cdap.explore.service.ExploreException;
 import co.cask.cdap.proto.Id;
 import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
@@ -69,8 +72,12 @@ public class ExploreDriver implements Driver {
 
     ExploreClient exploreClient =
       new FixedAddressExploreClient(params.getHost(), params.getPort(), authToken, sslEnabled, verifySSLCert);
-    if (!exploreClient.isServiceAvailable()) {
-      throw new SQLException("Cannot connect to " + url + ", service unavailable");
+    try {
+      exploreClient.ping();
+    } catch (UnauthenticatedException e) {
+      throw new SQLException("Cannot connect to " + url + ", not authenticated.");
+    } catch (ServiceUnavailableException | ExploreException e) {
+      throw new SQLException("Cannot connect to " + url + ", service not available.");
     }
     return new ExploreConnection(exploreClient, namespace, params);
   }

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
@@ -208,7 +208,7 @@ public class BaseHiveExploreServiceTest {
     datasetFramework = injector.getInstance(DatasetFramework.class);
     exploreClient = injector.getInstance(ExploreClient.class);
     exploreService = injector.getInstance(ExploreService.class);
-    Assert.assertTrue(exploreClient.isServiceAvailable());
+    exploreClient.ping();
 
     notificationService = injector.getInstance(NotificationService.class);
     notificationService.startAndWait();

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
@@ -96,7 +96,13 @@ public class ExploreDisabledTest {
     datasetService.startAndWait();
 
     exploreClient = injector.getInstance(DiscoveryExploreClient.class);
-    Assert.assertFalse(exploreClient.isServiceAvailable());
+    try {
+      exploreClient.ping();
+      Assert.fail("Expected not to be able to ping explore client.");
+    } catch (Exception e) {
+      Assert.assertTrue(e.getMessage().contains("Cannot discover service " +
+                                                  Constants.Service.EXPLORE_HTTP_USER_SERVICE));
+    }
 
     datasetFramework = injector.getInstance(DatasetFramework.class);
 


### PR DESCRIPTION
Previously, if the Explore jdbc driver is not given an auth token against an authentication-enabled cluster, the error message would be "Cannot connect to <URL>, service unavailable".
Now it's "Cannot connect to <URL>, not authenticated."

http://builds.cask.co/browse/CDAP-RUT253-1