### PR TITLE
Adding SSL to app-fabric-server using a generated and self signed cer…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/StandaloneAppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/StandaloneAppFabricServer.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.app.runtime.ProgramRuntimeService;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.conf.SConfiguration;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.data.stream.StreamCoordinatorClient;
 import co.cask.cdap.internal.app.runtime.artifact.SystemArtifactLoader;
@@ -50,7 +51,8 @@ public class StandaloneAppFabricServer extends AppFabricServer {
    * Construct the Standalone AppFabricServer with service factory and configuration coming from guice injection.
    */
   @Inject
-  public StandaloneAppFabricServer(CConfiguration configuration,
+  public StandaloneAppFabricServer(CConfiguration cConf,
+                                   SConfiguration sConf,
                                    DiscoveryService discoveryService,
                                    SchedulerService schedulerService,
                                    NotificationService notificationService,
@@ -69,7 +71,7 @@ public class StandaloneAppFabricServer extends AppFabricServer {
                                    PluginService pluginService,
                                    PrivilegesFetcherProxyService privilegesFetcherProxyService,
                                    RouteStore routeStore) {
-    super(configuration, discoveryService, schedulerService, notificationService, hostname, handlers,
+    super(cConf, sConf, discoveryService, schedulerService, notificationService, hostname, handlers,
           metricsCollectionService, programRuntimeService, applicationLifecycleService,
           programLifecycleService, streamCoordinatorClient, servicesNames, handlerHookNames, namespaceAdmin,
           systemArtifactLoader, pluginService, privilegesFetcherProxyService, routeStore);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/AppFabricServerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/AppFabricServerTest.java
@@ -16,35 +16,40 @@
 
 package co.cask.cdap.internal.app.services;
 
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.conf.SConfiguration;
+import co.cask.cdap.common.discovery.EndpointStrategy;
+import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.internal.AppFabricTestHelper;
+import co.cask.cdap.security.server.LDAPLoginModule;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.Service;
+import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
+import org.apache.twill.discovery.Discoverable;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.discovery.ServiceDiscovered;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLSocket;
 
 /**
  *
  */
 public class AppFabricServerTest {
-  private static AppFabricServer server;
-  private static DiscoveryServiceClient discoveryServiceClient;
-
-  @BeforeClass
-  public static void before() throws Exception {
-    Injector injector = AppFabricTestHelper.getInjector();
-    server = injector.getInstance(AppFabricServer.class);
-    discoveryServiceClient = injector.getInstance(DiscoveryServiceClient.class);
-  }
 
   @Test
   public void startStopServer() throws Exception {
+    Injector injector = AppFabricTestHelper.getInjector();
+    AppFabricServer server = injector.getInstance(AppFabricServer.class);
+    DiscoveryServiceClient discoveryServiceClient = injector.getInstance(DiscoveryServiceClient.class);
     Service.State state = server.startAndWait();
     Assert.assertTrue(state == Service.State.RUNNING);
     // Sleep shortly for the discovery
@@ -57,5 +62,43 @@ public class AppFabricServerTest {
 
     TimeUnit.SECONDS.sleep(1);
     Assert.assertTrue(Iterables.isEmpty(discovered));
+  }
+
+  @Test
+  public void testSSL() throws IOException {
+    CConfiguration cConf = CConfiguration.create();
+    cConf.setBoolean(Constants.Security.SSL.INTERNAL_ENABLED, true);
+    cConf.setInt(Constants.AppFabric.SERVER_SSL_PORT, 20443);
+    SConfiguration sConf = SConfiguration.create();
+    final Injector injector = AppFabricTestHelper.getInjector(cConf, sConf, new AbstractModule() {
+      @Override
+      protected void configure() {
+        // no overrides
+      }
+    });
+
+    final DiscoveryServiceClient discoveryServiceClient = injector.getInstance(DiscoveryServiceClient.class);
+    AppFabricServer appFabricServer = injector.getInstance(AppFabricServer.class);
+    appFabricServer.startAndWait();
+    Assert.assertTrue(appFabricServer.isRunning());
+
+    Supplier<EndpointStrategy> endpointStrategySupplier = Suppliers.memoize(new Supplier<EndpointStrategy>() {
+      @Override
+      public EndpointStrategy get() {
+        return new RandomEndpointStrategy(discoveryServiceClient.discover(Constants.Service.APP_FABRIC_HTTP));
+      }
+    });
+    Discoverable discoverable = endpointStrategySupplier.get().pick(3, TimeUnit.SECONDS);
+    Assert.assertNotNull(discoverable);
+    Assert.assertArrayEquals(Constants.Security.SSL_DISCOVERABLE_KEY.getBytes(), discoverable.getPayload());
+    InetSocketAddress addr = discoverable.getSocketAddress();
+    // Since the server uses a self signed certificate we need a client that trusts all certificates
+    SSLSocket socket = (SSLSocket) LDAPLoginModule.TrustAllSSLSocketFactory.getDefault()
+      .createSocket(addr.getHostName(), addr.getPort());
+    socket.setSoTimeout(5000); // in millis
+    // Would throw exception if the server does not support ssl.
+    // "javax.net.ssl.SSLException: Unrecognized SSL message, plaintext connection?"
+    socket.startHandshake();
+    appFabricServer.stopAndWait();
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -25,6 +25,7 @@ public final class Constants {
 
   public static final String[] FEATURE_TOGGLE_PROPS = {
     Security.SSL_ENABLED,
+    Security.SSL.INTERNAL_ENABLED,
     Security.ENABLED,
     Explore.EXPLORE_ENABLED,
   };
@@ -32,6 +33,7 @@ public final class Constants {
   public static final String[] PORT_PROPS = {
     Router.ROUTER_PORT,
     Router.ROUTER_SSL_PORT,
+    AppFabric.SERVER_SSL_PORT,
     Dashboard.BIND_PORT,
     Dashboard.SSL_BIND_PORT,
     Security.AUTH_SERVER_BIND_PORT,
@@ -128,6 +130,7 @@ public final class Constants {
     public static final String SERVER_ADDRESS_DEPRECATED = "app.bind.address";
     public static final String SERVER_PORT = "app.bind.port";
     public static final String SERVER_ANNOUNCE_PORT = "app.announce.port";
+    public static final String SERVER_SSL_PORT = "app.ssl.bind.port";
     public static final String OUTPUT_DIR = "app.output.dir";
     public static final String TEMP_DIR = "app.temp.dir";
     public static final String REST_PORT = "app.rest.port";
@@ -743,8 +746,28 @@ public final class Constants {
     public static final String LOGIN_MODULE_CLASS_NAME = "security.authentication.loginmodule.className";
     /** Realm file for Basic Authentication */
     public static final String BASIC_REALM_FILE = "security.authentication.basic.realmfile";
-    /** Enables SSL */
+    /** Enables external SSL */
+    @Deprecated
     public static final String SSL_ENABLED = "ssl.enabled";
+    /** Key to mark a discoverable which supports ssl */
+    public static final String SSL_DISCOVERABLE_KEY = "ssl";
+
+    /**
+     * App Fabric
+     */
+    public static final class SSL {
+      /** Enables SSL for external services. */
+      @SuppressWarnings("unused")
+      public static final String EXTERNAL_ENABLED = "ssl.external.enabled";
+      /** Enables SSL for internal services. */
+      public static final String INTERNAL_ENABLED = "ssl.internal.enabled";
+      /** Password for the java keystore. */
+      public static final String KEYSTORE_PASSWORD = "ssl.internal.keystore.password";
+      /** Type for the java keystore. e.g. JCEKS. */
+      public static final String KEYSTORE_TYPE = "ssl.internal.keystore.type";
+      /** Validity of the self generated certificate in days */
+      public static final String CERT_VALIDITY = "ssl.internal.cert.validity";
+    }
 
     /**
      * Authorization.

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -260,6 +260,22 @@
   </property>
 
   <property>
+    <name>ssl.internal.enabled</name>
+    <value>false</value>
+    <description>
+      Enable SSL between Router and App Fabric
+    </description>
+  </property>
+
+  <property>
+    <name>app.ssl.bind.port</name>
+    <value>30443</value>
+    <description>
+      App Fabric service bind port
+    </description>
+  </property>
+
+  <property>
     <name>app.output.dir</name>
     <value>/programs</value>
     <description>
@@ -1886,8 +1902,16 @@
   </property>
 
   <property>
-    <name>ssl.enabled</name>
+    <name>ssl.external.enabled</name>
     <value>false</value>
+    <description>
+      Determines if SSL for external services is enabled
+    </description>
+  </property>
+
+  <property>
+    <name>ssl.enabled</name>
+    <value>${ssl.external.enabled}</value>
     <description>
       Determines if SSL is enabled
     </description>

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="98acec132154e462f335761c059b6443"
+DEFAULT_XML_MD5_HASH="9e190beadf969e7edd870d339f129c06"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/WrappedDiscoverable.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/handlers/WrappedDiscoverable.java
@@ -40,11 +40,16 @@ public class WrappedDiscoverable {
     return discoverable.getSocketAddress();
   }
 
+  public byte[] getPayload() {
+    return discoverable.getPayload();
+  }
+
   @Override
   public int hashCode() {
     return Objects.hashCode(discoverable.getName(),
                             discoverable.getSocketAddress().getHostName(),
-                            discoverable.getSocketAddress().getPort());
+                            discoverable.getSocketAddress().getPort(),
+                            discoverable.getPayload());
   }
 
   @Override
@@ -58,6 +63,7 @@ public class WrappedDiscoverable {
     WrappedDiscoverable that = (WrappedDiscoverable) object;
     return Objects.equal(discoverable.getName(), that.getName()) &&
            Objects.equal(discoverable.getSocketAddress().getHostName(), that.getSocketAddress().getHostName()) &&
-           Objects.equal(discoverable.getSocketAddress().getPort(), that.getSocketAddress().getPort());
+           Objects.equal(discoverable.getSocketAddress().getPort(), that.getSocketAddress().getPort()) &&
+           Objects.equal(discoverable.getPayload(), that.getPayload());
   }
 }

--- a/cdap-gateway/src/test/resources/cdap-security.xml
+++ b/cdap-gateway/src/test/resources/cdap-security.xml
@@ -31,4 +31,9 @@
       <value>JKS</value>
       <description>Specifies the ssl keystore type</description>
     </property>
+    <property>
+      <name>app.ssl.keystore.password</name>
+      <value>secret</value>
+      <description>Specifies the ssl keystore password for app fabric</description>
+    </property>
 </configuration>

--- a/cdap-security/src/main/java/co/cask/cdap/security/tools/KeyStores.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/tools/KeyStores.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.tools;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.conf.SConfiguration;
+import org.apache.commons.lang.time.DateUtils;
+import sun.security.x509.AlgorithmId;
+import sun.security.x509.CertificateAlgorithmId;
+import sun.security.x509.CertificateIssuerName;
+import sun.security.x509.CertificateSerialNumber;
+import sun.security.x509.CertificateSubjectName;
+import sun.security.x509.CertificateValidity;
+import sun.security.x509.CertificateVersion;
+import sun.security.x509.CertificateX509Key;
+import sun.security.x509.X500Name;
+import sun.security.x509.X509CertImpl;
+import sun.security.x509.X509CertInfo;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.SignatureException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+
+/**
+ * Utility class with methods for generating a X.509 self signed certificate
+ * and creating a Java key store with a self signed certificate.
+ */
+public final class KeyStores {
+  private static final String KEY_PAIR_ALGORITHM = "RSA";
+  private static final String SECURE_RANDOM_ALGORITHM = "SHA1PRNG";
+  private static final String SECURE_RANDOM_PROVIDER = "SUN";
+
+  /* This is based on https://www.ietf.org/rfc/rfc1779.txt
+     CN      CommonName
+     L       LocalityName
+     ST      StateOrProvinceName
+     O       OrganizationName
+     OU      OrganizationalUnitName
+     C       CountryName
+     STREET  StreetAddress
+
+     All fields are not required.
+    */
+  private static final String DISTINGUISHED_NAME = "CN=CDAP, L=Palo Alto, C=US";
+  private static final String SIGNATURE_ALGORITHM = "MD5withRSA";
+  private static final String SSL_KEYSTORE_TYPE = "JKS";
+  private static final String CERT_ALIAS = "cert";
+  private static final int KEY_SIZE = 2048;
+  private static final int VALIDITY = 999;
+
+  /* private constructor */
+  private KeyStores() {}
+
+  /**
+   * Create a Java key store with a stored self-signed certificate.
+   * @return Java keystore which has a self signed X.509 certificate
+   */
+  public static KeyStore generatedCertKeyStore(SConfiguration sConf, String password) {
+    try {
+      KeyPairGenerator keyGen = KeyPairGenerator.getInstance(KEY_PAIR_ALGORITHM);
+      SecureRandom random = SecureRandom.getInstance(SECURE_RANDOM_ALGORITHM, SECURE_RANDOM_PROVIDER);
+      keyGen.initialize(KEY_SIZE, random);
+      // generate a key pair
+      KeyPair pair = keyGen.generateKeyPair();
+      int validity = sConf.getInt(Constants.Security.SSL.CERT_VALIDITY, VALIDITY);
+
+      X509Certificate cert = getCertificate(DISTINGUISHED_NAME, pair, validity, SIGNATURE_ALGORITHM);
+
+      KeyStore keyStore = KeyStore.getInstance(SSL_KEYSTORE_TYPE);
+      keyStore.load(null, password.toCharArray());
+      keyStore.setKeyEntry(CERT_ALIAS, pair.getPrivate(), password.toCharArray(),
+                           new java.security.cert.Certificate[]{cert});
+      return keyStore;
+    } catch (Exception e) {
+      throw new RuntimeException("SSL is enabled but a key store file could not be created. A keystore is required " +
+                                   "for SSL to be used.", e);
+    }
+  }
+
+  /**
+   * Generate an X.509 certificate
+   *
+   * @param dn Distinguished name for the owner of the certificate, it will also be the signer of the certificate.
+   * @param pair Key pair used for signing the certificate.
+   * @param days Validity of the certificate.
+   * @param algorithm Name of the signature algorithm used.
+   * @return A X.509 certificate
+   */
+  private static X509Certificate getCertificate(String dn, KeyPair pair, int days, String algorithm) throws IOException,
+    CertificateException, NoSuchProviderException, NoSuchAlgorithmException, InvalidKeyException, SignatureException {
+    // Calculate the validity interval of the certificate
+    Date from = new Date();
+    Date to = DateUtils.addDays(from, days);
+    CertificateValidity interval = new CertificateValidity(from, to);
+    // Generate a random number to use as the serial number for the certificate
+    BigInteger sn = new BigInteger(64, new SecureRandom());
+    // Create the name of the owner based on the provided distinguished name
+    X500Name owner = new X500Name(dn);
+    // Create an info objects with the provided information, which will be used to create the certificate
+    X509CertInfo info = new X509CertInfo();
+    info.set(X509CertInfo.VALIDITY, interval);
+    info.set(X509CertInfo.SERIAL_NUMBER, new CertificateSerialNumber(sn));
+    // This certificate will be self signed, hence the subject and the issuer are same.
+    info.set(X509CertInfo.SUBJECT, new CertificateSubjectName(owner));
+    info.set(X509CertInfo.ISSUER, new CertificateIssuerName(owner));
+    info.set(X509CertInfo.KEY, new CertificateX509Key(pair.getPublic()));
+    info.set(X509CertInfo.VERSION, new CertificateVersion(CertificateVersion.V3));
+    AlgorithmId algo = new AlgorithmId(AlgorithmId.md5WithRSAEncryption_oid);
+    info.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(algo));
+    // Create the certificate and sign it with the private key
+    X509CertImpl cert = new X509CertImpl(info);
+    PrivateKey privateKey = pair.getPrivate();
+    cert.sign(privateKey, algorithm);
+    return cert;
+  }
+}

--- a/cdap-security/src/test/java/co/cask/cdap/security/tools/KeyStoresTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/tools/KeyStoresTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.tools;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.conf.SConfiguration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+
+public class KeyStoresTest {
+  private static final String CERT_ALIAS = "cert";
+  private static final String DISTINGUISHED_NAME = "CN=CDAP, L=Palo Alto, C=US";
+  private static final String SIGNATURE_ALGORITHM = "MD5withRSA";
+  private static final String SSL_KEYSTORE_TYPE = "JKS";
+  private static final String CERTIFICATE_TYPE = "X.509";
+  private static final String SSL_PASSWORD = "pass";
+
+  @Test
+  public void testGetSSLKeyStore() throws Exception {
+    SConfiguration sConf = SConfiguration.create();
+    sConf.set(Constants.Security.SSL.KEYSTORE_PASSWORD, SSL_PASSWORD);
+    KeyStore ks = KeyStores.generatedCertKeyStore(sConf, SSL_PASSWORD);
+    Assert.assertEquals(SSL_KEYSTORE_TYPE, ks.getType());
+    Assert.assertEquals(CERT_ALIAS, ks.aliases().nextElement());
+    Assert.assertEquals(1, ks.size());
+    Assert.assertTrue(ks.getCertificate(CERT_ALIAS) instanceof X509Certificate);
+
+    X509Certificate cert = (X509Certificate) ks.getCertificate(CERT_ALIAS);
+    cert.checkValidity(); // throws an exception on failure
+    Assert.assertEquals(CERTIFICATE_TYPE, cert.getType());
+    Assert.assertEquals(SIGNATURE_ALGORITHM, cert.getSigAlgName());
+    Assert.assertEquals(DISTINGUISHED_NAME, cert.getIssuerDN().getName());
+    Assert.assertEquals(3, cert.getVersion());
+  }
+}


### PR DESCRIPTION
…tificate. The certificate is signed using a generated key-pair and is not supposed to be validated by the client. The primary purpose of adding this is to enable encryption between router and app-fabric.

The clients will be changed to use SSL, if it is enabled, in a followup change.

Associated JIRA https://issues.cask.co/browse/CDAP-6984

As a followup to this, we will add authentication to prevent MIM attacks. https://issues.cask.co/browse/CDAP-7605