### PR TITLE
[CDAP-7475] Remove Deprecated setInput/setOutput methods

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/AbstractMapReduce.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/AbstractMapReduce.java
@@ -21,8 +21,6 @@ import co.cask.cdap.api.ProgramStatus;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.annotation.TransactionControl;
 import co.cask.cdap.api.annotation.TransactionPolicy;
-import co.cask.cdap.api.data.batch.Input;
-import co.cask.cdap.api.data.stream.StreamBatchReadable;
 import co.cask.cdap.internal.api.AbstractPluginConfigurable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,56 +101,6 @@ public abstract class AbstractMapReduce extends AbstractPluginConfigurable<MapRe
    */
   protected final void setReducerResources(Resources resources) {
     configurer.setReducerResources(resources);
-  }
-
-  /**
-   * Sets the name of the Dataset used as input for the {@link MapReduce}.
-   *
-   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)}
-   * in {@link #initialize()}, instead.
-   */
-  @Deprecated
-  protected final void setInputDataset(String dataset) {
-    configurer.setInputDataset(dataset);
-  }
-
-  /**
-   * Uses Stream as input for the {@link MapReduce}.
-   *
-   * @param stream Name of the stream
-   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)}
-   *             in {@link #initialize()}, instead.
-   */
-  @Deprecated
-  protected final void useStreamInput(String stream) {
-    useStreamInput(new StreamBatchReadable(stream));
-  }
-
-  /**
-   * Uses Stream as input for the {@link MapReduce} with specific time range. Same as calling
-   * {@link #useStreamInput(StreamBatchReadable) setInputStream(new StreamBatchReadable(stream, startTime, endTime))}.
-   *
-   * @see StreamBatchReadable
-   *
-   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)}
-   *             in {@link #initialize()}, instead.
-   */
-  @Deprecated
-  protected final void useStreamInput(String stream, long startTime, long endTime) {
-    useStreamInput(new StreamBatchReadable(stream, startTime, endTime));
-  }
-
-  /**
-   * Uses Stream as input for the {@link MapReduce}.
-   *
-   * @see StreamBatchReadable
-   *
-   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)}
-   *             in {@link #initialize()}, instead.
-   */
-  @Deprecated
-  protected final void useStreamInput(StreamBatchReadable streamBatchReadable) {
-    configurer.setInputDataset(streamBatchReadable.toURI().toString());
   }
 
   @Override

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceConfigurer.java
@@ -19,32 +19,12 @@ package co.cask.cdap.api.mapreduce;
 import co.cask.cdap.api.DatasetConfigurer;
 import co.cask.cdap.api.ProgramConfigurer;
 import co.cask.cdap.api.Resources;
-import co.cask.cdap.api.data.batch.Input;
-import co.cask.cdap.api.data.batch.Output;
 import co.cask.cdap.api.plugin.PluginConfigurer;
 
 /**
  * Configurer for configuring {@link MapReduce}.
  */
 public interface MapReduceConfigurer extends DatasetConfigurer, ProgramConfigurer, PluginConfigurer {
-
-  /**
-   * Sets the name of the dataset used as input for the {@link MapReduce}.
-   *
-   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)}
-   *             in beforeSubmit, instead.
-   */
-  @Deprecated
-  void setInputDataset(String dataset);
-
-  /**
-   * Sets the name of the dataset used as output for the {@link MapReduce}.
-   *
-   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addOutput(Output)}
-   *             in beforeSubmit, instead.
-   */
-  @Deprecated
-  void setOutputDataset(String dataset);
 
   /**
    * Sets the resources requirement for the driver of the MapReduce.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/mapreduce/DefaultMapReduceConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/mapreduce/DefaultMapReduceConfigurer.java
@@ -74,16 +74,6 @@ public final class DefaultMapReduceConfigurer extends DefaultPluginConfigurer im
   }
 
   @Override
-  public void setInputDataset(String dataset) {
-    this.inputDataset = dataset;
-  }
-
-  @Override
-  public void setOutputDataset(String dataset) {
-    this.outputDataset = dataset;
-  }
-
-  @Override
   public void setDriverResources(Resources resources) {
     this.driverResources = resources;
   }

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/fileset.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/fileset.rst
@@ -96,11 +96,12 @@ Using a FileSet as input or output of a MapReduce program is the same as for any
   public class WordCount extends AbstractMapReduce {
 
     @Override
-    public void configure() {
-      setInputDataset("lines");
-      setOutputDataset("counts");
+    public void initialize() {
+      MapReduceContext context = getContext();
+      context.addInput(Input.ofDataset("lines"));
+      context.addOutput(Output.ofDataset("counts"));
+      ...
     }
-    ...
 
 The MapReduce program only needs to specify the names of the input and output datasets.
 Whether they are FileSets or another type of dataset is handled by the CDAP runtime system.

--- a/cdap-docs/developers-manual/source/building-blocks/mapreduce-programs.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/mapreduce-programs.rst
@@ -43,25 +43,26 @@ implementation of three methods:
       setName("Purchase History Builder MapReduce");
       setDescription("Builds a purchase history for each customer");
       useDatasets("frequentCustomers");
-      setInputDataset("purchases");
-      setOutputDataset("history");
     }
 
 The configure method is similar to the one found in flows and
 applications. It defines the name and description of the MapReduce.
-You can also :ref:`specify datasets <mapreduce-datasets>` to be used as input or output
-and :ref:`specify resources <mapreduce-resources>` (memory and virtual cores) used by the
+You can also :ref:`specify resources <mapreduce-resources>` (memory and virtual cores) used by the
 mappers and reducers.
 
 The ``initialize()`` method is invoked at runtime, before the MapReduce is executed.
-Through the ``getContext()`` method, an instance of the ``MapReduceContext`` provides you
-with access to the actual Hadoop job configuration, as though you were running the
-MapReduce directly on Hadoop. For example, you can specify the mapper and reducer classes
-as well as the intermediate data format::
+Through the ``getContext()`` method you can obtain an instance of the ``MapReduceContext``.
+It allows you to :ref:`specify datasets <mapreduce-datasets>` to be used as input or output;
+it also provides you access to the actual Hadoop job configuration, as though you were running the
+MapReduce directly on Hadoop. For example, you can specify the input and output datasets,
+the mapper and reducer classes as well as the intermediate data format::
 
   @Override
   public void initialize() throws Exception {
     MapReduceContext context = getContext();
+    context.addInput(Input.ofDataset("purchases"));
+    context.addOutput(Output.ofDataset("history"));
+
     Job job = context.getHadoopJob();
     job.setMapperClass(PurchaseMapper.class);
     job.setMapOutputKeyClass(Text.class);

--- a/cdap-docs/examples-manual/source/tutorials/wise.rst
+++ b/cdap-docs/examples-manual/source/tutorials/wise.rst
@@ -443,7 +443,7 @@ logical start time of the job (the same as the scheduled time of the containing 
 
 Writing to the *bounceCountStore* dataset from the MapReduce 
 ------------------------------------------------------------
-In the ``BounceCountsMapReduce.configure()`` method seen earlier, the ``setOutputDataset``
+In the ``BounceCountsMapReduce.initialize()`` method seen earlier, the ``context.addOutput()``
 method sets the ``bounceCountsStore`` dataset as the output of the job.
 It means that the key/value pairs output by the reducer of the MapReduce will be directly
 written to that dataset.


### PR DESCRIPTION
Built this locally and hydrator against it. all passed.

Fix for: https://issues.cask.co/browse/CDAP-7475