### PR TITLE
CDAP-7210 Check for usage of deprecated items; fix documentation build

### DIFF
--- a/cdap-docs/examples-manual/build.sh
+++ b/cdap-docs/examples-manual/build.sh
@@ -99,7 +99,7 @@ function download_includes() {
   local project_img=$project_source/docs/img
 
   # 1:Includes directory  2:GitHub directory 3:Java filename       4:MD5 hash of file
-  download_file $includes $project_main BounceCountsMapReduce.java 0cfc0b3c0e306a4a76483aecc5a46607
+  download_file $includes $project_main BounceCountsMapReduce.java 8e8dd188e7850e75140110243485a51a
   download_file $includes $project_main BounceCountStore.java      d476c15655c6a6c6cd7fe682dea4a8b7
   download_file $includes $project_main PageViewStore.java         7dc8d2fec04ce89fae4f0356db17e19d
   download_file $includes $project_main WiseApp.java               23371436b588c3262fec14ec5d7aa6df

--- a/cdap-docs/examples-manual/source/tutorials/wise.rst
+++ b/cdap-docs/examples-manual/source/tutorials/wise.rst
@@ -418,8 +418,8 @@ The ``configure()`` method is defined as:
 
 .. literalinclude:: /../target/_includes/tutorial-wise/BounceCountsMapReduce.java
    :language: java
-   :lines: 41-48   
-   :append: . . . 
+   :lines: 42-49
+   :append: . . .
 
 It sets the ID (name) of the MapReduce program as *BounceCountsMapReduce*, and specifies any datasets
 that will be used in the program. 
@@ -431,7 +431,7 @@ done in the ``initialize()`` method of the ``BounceCountsMapReduce`` class:
 
 .. literalinclude:: /../target/_includes/tutorial-wise/BounceCountsMapReduce.java
    :language: java
-   :lines: 49-82   
+   :lines: 50-83
    :dedent: 2
 
 As mentioned earlier, the input of the MapReduce is the *logEventStream*. This
@@ -454,12 +454,12 @@ interface:
 .. literalinclude:: /../target/_includes/tutorial-wise/BounceCountStore.java
    :language: java
    :lines: 39-41
-   :append:   . . . 
+   :append:   . . .
 
 .. literalinclude:: /../target/_includes/tutorial-wise/BounceCountStore.java
    :language: java
-   :lines: 96-99   
-   :prepend:   . . . 
+   :lines: 96-99
+   :prepend:   . . .
 
 This ``BatchWritable`` interface, defining a ``write()`` method, is intended to allow datasets to
 be the output of MapReduce programs. The two generic types that it takes as parameters must
@@ -481,16 +481,16 @@ Our Mapper and Reducer are standard Hadoop classes with these signatures:
 
 .. literalinclude:: /../target/_includes/tutorial-wise/BounceCountsMapReduce.java
    :language: java
-   :lines: 87   
-   :prepend: . . . 
-   :append: . . . 
+   :lines: 88
+   :prepend: . . .
+   :append: . . .
    :dedent: 2
 
 .. literalinclude:: /../target/_includes/tutorial-wise/BounceCountsMapReduce.java
    :language: java
-   :lines: 108   
-   :prepend: . . . 
-   :append: . . . 
+   :lines: 109
+   :prepend: . . .
+   :append: . . .
    :dedent: 2
 
 Each generic parameter of the Mapper and the Reducer contains:

--- a/cdap-docs/tools/docs-search-deprecated.py
+++ b/cdap-docs/tools/docs-search-deprecated.py
@@ -33,9 +33,8 @@ try:
     import urllib2
 except Exception, e:
     if sys.version_info < (2, 7):
-        raise Exception("Must use python 2.7 or greater\n" + str(e))
-    else:
-        raise Exception(e)
+        print "\nMust use python 2.7 or greater.\n"
+    raise e
 
 
 def parse_options():

--- a/cdap-docs/tools/docs-search-deprecated.py
+++ b/cdap-docs/tools/docs-search-deprecated.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#  Copyright © 2016 Cask Data, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+# Reads in the Javadocs page 
+# (at http://docs.cask.co/cdap/<release-version>/en/reference-manual/javadocs/deprecated-list.html);
+# extracts all of the listed deprecated items, and then searches in the Java, text, and
+# ReST files of the examples and the documentation for any usage. 
+#
+# It may generate significant false positives as it does not perform a search with any context.
+#
+# Requires Python 2.7 and Beautiful Soup.
+
+try:
+    from bs4 import BeautifulSoup
+    from optparse import OptionParser
+    import os
+    import sys
+    import urllib2
+except Exception, e:
+    print "\nAre you running under Python 2.7? It's required.\n"
+    raise
+
+
+def parse_options():
+    """ Parses args options.
+    """
+
+    parser = OptionParser(
+        usage="%prog [options]",
+        description="Searches for deprecated items in documentation ('cdap-docs') and examples ('cdap-examples')")
+
+    parser.add_option(
+        "-r", "--release",
+        dest="release",
+        help="The release to be checked, such as '3.6.0'; default is 'current'",
+        default='current')
+
+    (options, args) = parser.parse_args()
+
+    return options, args, parser
+
+
+def load_deprecated_items(release):
+    deprecated_url = "http://docs.cask.co/cdap/%s/en/reference-manual/javadocs/deprecated-list.html" % release
+    print "Loading deprecated info from '%s'" % deprecated_url
+    page = urllib2.urlopen(deprecated_url).read()
+    soup = BeautifulSoup(page, 'html.parser')
+    soup.prettify()
+    deprecated_items = dict()
+    longest = 0
+    i = 0
+    for a in soup.select('a[href^="co/cask/cdap"]'):
+        line = None
+        if a.string:
+            line = a.string
+        elif a.contents[0]:
+            line = a.contents[0]
+        else:
+            print "%s: Could not find text in: %s" % (i, a)            
+        if line:
+            line = str(line).strip()
+            paren = line.find('(')
+            if paren != -1:
+                line = line[:paren]
+            period = line.rfind('.')
+            if period == -1:
+                deprecated = line
+            else:
+                deprecated = line[period+1:]
+            if deprecated not in deprecated_items:
+                deprecated_items[deprecated] = line
+                if len(deprecated) > longest:
+                    longest = len(deprecated)
+        i += 1
+    return deprecated_items, longest
+
+
+def search_docs(release):
+    script_dir = os.getcwd()
+    deprecated_items, longest = load_deprecated_items(release)
+    print "Deprecated: %s" % len(deprecated_items)
+    if not deprecated_items:
+        return
+    
+    deprecated_keys = deprecated_items.keys()
+    deprecated_keys.sort()
+    for deprecated in deprecated_keys:
+        deprecated_display = "%s%s" % (deprecated, ' ' * (longest - len(deprecated)))
+        deprecated_display = deprecated_display[0:longest+1]
+        print "  %s: %s" % (deprecated_display, deprecated_items[deprecated])
+    
+    docs = '..'
+    examples = '../../cdap-examples'
+    
+    # Walk directories
+    for dir in (docs, examples):
+        dir_path = os.path.abspath(os.path.join(script_dir, dir))
+        print "Checking %s..." % dir_path
+        file_paths = []
+        for root, dirs, files in os.walk(dir_path):
+            for f in files:
+                if f.endswith('.rst') or f.endswith('.txt') or f.endswith('.java'):
+                    file_path = os.path.join(root, f)
+                    file_paths.append(file_path)
+        print "Files to check: %s" % len(file_paths)
+    
+        for file_path in file_paths:
+            file_object = open(file_path, 'r')
+            file_string = file_object.read()
+            file_object.close()
+        
+            for deprecated in deprecated_items:
+                if file_string.find(deprecated) != -1:
+                    deprecated_display = "%s%s" % (deprecated, ' ' * (longest - len(deprecated)))
+                    deprecated_display = deprecated_display[0:longest+1]
+                    print "Found %s in '%s'" % (deprecated_display, file_path)
+            
+
+def main():
+    """ Main program entry point.
+    """
+    options, args, parser = parse_options()
+    
+    search_docs(options.release)
+        
+if __name__ == '__main__':
+    main()

--- a/cdap-docs/tools/docs-search-deprecated.py
+++ b/cdap-docs/tools/docs-search-deprecated.py
@@ -25,15 +25,17 @@
 #
 # Requires Python 2.7 and Beautiful Soup.
 
+import os
+import sys
 try:
     from bs4 import BeautifulSoup
     from optparse import OptionParser
-    import os
-    import sys
     import urllib2
 except Exception, e:
-    print "\nAre you running under Python 2.7? It's required.\n"
-    raise
+    if sys.version_info < (2, 7):
+        raise Exception("Must use python 2.7 or greater\n" + str(e))
+    else:
+        raise Exception(e)
 
 
 def parse_options():


### PR DESCRIPTION
Adds a Python tool to detect usage of deprecated items in documentation and examples.

Fixes changes introduced by https://github.com/caskdata/cdap-apps/pull/126 into the WISE.
(which breaks the doc build: see https://builds.cask.co/browse/CDAP-DQB-17)

Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB164-1