### PR TITLE
Fix 3.6 Documentation Build

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -170,8 +170,7 @@
     <name>twill.no.container.timeout</name>
     <value>120000</value>
     <description>
-      Amount of time in milliseconds to wait for at least one container for
-      Apache Twill runnable
+      Duration in milliseconds to wait for at least one container for Apache Twill runnable
     </description>
   </property>
 
@@ -209,7 +208,7 @@
     <description>
       By default, any changes made to existing datasets are not deployed
       when an app is redeployed; setting this value to true allows the
-      dataset changes to be deployed upon app redeployment.
+      dataset changes to be deployed upon app redeployment
     </description>
   </property>
 
@@ -279,8 +278,8 @@
     <name>app.program.runid.corrector.interval</name>
     <value>180</value>
     <description>
-      The interval of how often the run id corrector thread will run in
-      seconds; this value should be greater than 0
+      Interval in seconds of how often the run id corrector thread will run; this value
+      should be greater than 0
     </description>
   </property>
 
@@ -297,8 +296,8 @@
     <name>app.program.spark.yarn.client.rewrite.enabled</name>
     <value>true</value>
     <description>
-      Specify whether to rewrite the yarn.Client class in Spark to work
-      around the issue SPARK-13441 in CDM clusters.
+      Specify whether to rewrite the yarn.client class in Spark to work
+      around the issue SPARK-13441 in CDH clusters
     </description>
   </property>
 
@@ -320,7 +319,7 @@
     <name>app.program.max.start.seconds</name>
     <value>300</value>
     <description>
-      The maximum number of seconds to wait for a program to start before killing it.
+      Maximum number of seconds to wait for a program to start before killing it
     </description>
   </property>
 
@@ -328,7 +327,7 @@
     <name>app.program.max.stop.seconds</name>
     <value>300</value>
     <description>
-      The maximum number of seconds to wait for a program to stop before killing it.
+      Maximum number of seconds to wait for a program to stop before killing it
     </description>
   </property>
 
@@ -344,7 +343,7 @@
     <name>workflow.token.max.size.mb</name>
     <value>30</value>
     <description>
-      Maximum allowed size of a Workflow Token, in megabytes; if the
+      Maximum allowed size in megabytes of a workflow token; if the
       workflow token exceeds this size, no further updates are allowed
     </description>
   </property>
@@ -408,7 +407,7 @@
     <name>data.tx.bind.port</name>
     <value>0</value>
     <description>
-      Transaction service bind port. Binds to random port by default.
+      Transaction service bind port; binds to a random port by default
     </description>
   </property>
 
@@ -467,7 +466,7 @@
     <name>data.tx.memory.mb</name>
     <value>${master.service.memory.mb}</value>
     <description>
-      Memory in megabytes of the transaction service
+      Memory in megabytes for each transaction service instance
     </description>
   </property>
 
@@ -589,7 +588,7 @@
     <name>dataset.executor.container.memory.mb</name>
     <value>512</value>
     <description>
-      Size of Memory in megabytes for each dataset executor instance
+      Memory in megabytes for each dataset executor instance
     </description>
   </property>
 
@@ -665,7 +664,7 @@
     <name>explore.cleanup.job.schedule.secs</name>
     <value>60</value>
     <description>
-      Time in seconds to schedule clean-up job to timeout operations
+      Interval in seconds to schedule the clean-up of timed-out operations
     </description>
   </property>
 
@@ -690,7 +689,7 @@
     <name>explore.executor.container.memory.mb</name>
     <value>1024</value>
     <description>
-      Size of memory in megabytes for each explore executor instance
+      Memory in megabytes for each CDAP Explore executor instance
     </description>
   </property>
 
@@ -869,7 +868,7 @@
     <name>kafka.server.zookeeper.connection.timeout.ms</name>
     <value>1000000</value>
     <description>
-      The maximum time (in milliseconds) that the client will wait to
+      Maximum time in milliseconds that the client will wait to
       establish a connection to Zookeeper
     </description>
   </property>
@@ -929,7 +928,7 @@
     <name>log.retention.duration.days</name>
     <value>7</value>
     <description>
-      Log file HDFS retention duration in days
+      Duration in days of log file HDFS retention
     </description>
   </property>
 
@@ -953,7 +952,7 @@
     <name>log.saver.run.memory.megs</name>
     <value>1024</value>
     <description>
-      Memory in megabytes allocated for log saver instances to run in YARN
+      Memory in megabytes for each log saver instance to run in YARN
     </description>
   </property>
 
@@ -1039,7 +1038,7 @@
     <name>master.service.memory.mb</name>
     <value>512</value>
     <description>
-      Size of memory in megabytes for master service instance
+      Memory in megabytes for each master service instance
     </description>
   </property>
 
@@ -1167,7 +1166,7 @@
     <name>metrics.data.table.retention.resolution.1.seconds</name>
     <value>7200</value>
     <description>
-      Retention resolution of the 1-second resolution table in seconds;
+      Retention resolution in seconds of the 1-second resolution table;
       default retention period is 2 hours
     </description>
   </property>
@@ -1176,7 +1175,7 @@
     <name>metrics.data.table.retention.resolution.3600.seconds</name>
     <value>2592000</value>
     <description>
-      Retention resolution 1-hour resolution table (in seconds); default
+      Retention resolution in seconds of the 1-hour resolution table; default
       retention period is 30 days
     </description>
   </property>
@@ -1185,7 +1184,7 @@
     <name>metrics.data.table.retention.resolution.60.seconds</name>
     <value>2592000</value>
     <description>
-      Retention resolution for 1-minute resolution table (in seconds);
+      Retention resolution in seconds for the 1-minute resolution table;
       default retention period is 30 days
     </description>
   </property>
@@ -1210,7 +1209,7 @@
     <name>metrics.dataset.hbase.stats.report.interval</name>
     <value>60</value>
     <description>
-      Report interval for HBase stats, in seconds
+      Report interval in seconds for HBase stats
     </description>
   </property>
 
@@ -1218,7 +1217,7 @@
     <name>metrics.dataset.leveldb.stats.report.interval</name>
     <value>60</value>
     <description>
-      Report interval for LevelDB stats, in seconds
+      Report interval in seconds for LevelDB stats
     </description>
   </property>
 
@@ -1250,7 +1249,7 @@
     <name>metrics.memory.mb</name>
     <value>${master.service.memory.mb}</value>
     <description>
-      Memory assigned to the metrics service in megabytes
+      Memory in megabytes for each metrics service instance
     </description>
   </property>
 
@@ -1283,8 +1282,8 @@
     <name>metrics.processor.memory.mb</name>
     <value>512</value>
     <description>
-      Size of memory in megabytes for metrics processor service Apache Twill
-      runnable
+      Memory in megabytes for each metrics processor service Apache Twill
+      runnable instance
     </description>
   </property>
 
@@ -1376,7 +1375,7 @@
     <name>data.queue.config.update.interval</name>
     <value>5</value>
     <description>
-      Frequency, in seconds, of updates to the queue consumer configuration
+      Frequency in seconds of updates to the queue consumer configuration
       used in evicting queue entries on flush and compaction
     </description>
   </property>
@@ -1472,7 +1471,7 @@
     <name>router.connection.idle.timeout.secs</name>
     <value>15</value>
     <description>
-      The number of seconds after an HTTP request completes that idle router
+      Time in seconds after an HTTP request completes that idle router
       connections are closed
     </description>
   </property>
@@ -1533,6 +1532,18 @@
   </property>
 
   <property>
+    <name>router.userservice.fallback.strategy</name>
+    <value>random</value>
+    <description>
+      If a RouteConfig is not found for a particular user service, this property is used
+      to set the fallback routing strategy. Allowed options: "random", "smallest",
+      "largest", or "drop". A string comparison of the versions of the user service is
+      used for "smallest" or "largest". The "drop" option will not route the request to
+      any service and will return "service not found".
+    </description>
+  </property>
+
+  <property>
     <name>router.webapp.bind.port</name>
     <value>20000</value>
     <description>
@@ -1546,17 +1557,6 @@
     <description>
       Determines if the webapp listening service should be started
       (deprecated)
-    </description>
-  </property>
-
-  <property>
-    <name>router.userservice.fallback.strategy</name>
-    <value>random</value>
-    <description>
-      If RouteConfig is not found for a particular user service, this property can be used to define the fallback
-      routing strategy. Allowed options are - random, smallest, largest, drop (smallest/largest is based on the string
-      comparison of the version of the user service). Drop option will not route the request to any service and will
-      return service not found.
     </description>
   </property>
 
@@ -1605,7 +1605,7 @@
     <name>kerberos.auth.relogin.interval.seconds</name>
     <value>300</value>
     <description>
-      Relogin interval for Kerberos keytab
+      Re-login interval in seconds for Kerberos keytab
     </description>
   </property>
 
@@ -1689,13 +1689,11 @@
     <name>security.authorization.cache.refresh.interval.secs</name>
     <value>50</value>
     <description>
-      Determines the interval in seconds after which a background thread
-      will refresh cached authorization policies. Defaults to 50 seconds. It
-      is recommended to keep this value slightly lower than
-      ${security.authorization.cache.ttl.secs}, so that the cached
-      authorization policies do not expire unless they have been explicitly
-      revoked. This setting only takes effect if
-      ${security.authorization.cache.enabled} is set to true.
+      The interval in seconds after which a background thread will refresh cached
+      authorization policies. It is recommended to keep this value slightly lower than
+      ${security.authorization.cache.ttl.secs}, so that the cached authorization policies
+      do not expire unless they have been explicitly revoked. This setting only takes
+      effect if ${security.authorization.cache.enabled} is set to true.
     </description>
   </property>
 
@@ -1703,10 +1701,9 @@
     <name>security.authorization.cache.ttl.secs</name>
     <value>60</value>
     <description>
-      Determines the time to live in seconds for entries in the
-      authorization cache used by programs. Defaults to 60 seconds. This
-      setting only takes effect if ${security.authorization.cache.enabled}
-      is set to true.
+      The time-to-live in seconds for entries in the authorization cache used by programs.
+      This setting only takes effect if ${security.authorization.cache.enabled} is set to
+      true.
     </description>
   </property>
 
@@ -1820,8 +1817,8 @@
     <name>security.token.digest.key.expiration.ms</name>
     <value>3600000</value>
     <description>
-      Time duration (in milliseconds) after which an active secret key used
-      for signing tokens should be retired
+      Duration in milliseconds after which an active secret key used for signing tokens should
+      be retired
     </description>
   </property>
 
@@ -1933,7 +1930,7 @@
     <name>stream.container.memory.mb</name>
     <value>512</value>
     <description>
-      Amount of memory in megabytes for the YARN container that runs the
+      Memory in megabytes for each YARN container that runs the
       stream handler
     </description>
   </property>
@@ -1951,7 +1948,7 @@
     <name>stream.event.ttl</name>
     <value>9223372036854775807</value>
     <description>
-      Default time to live in milliseconds (Long.MAX_VALUE) for stream
+      Default time-to-live in milliseconds (Long.MAX_VALUE) for stream
       events
     </description>
   </property>
@@ -1960,8 +1957,7 @@
     <name>stream.file.cleanup.period</name>
     <value>300000</value>
     <description>
-      Default time interval in milliseconds for running the stream file
-      cleanup process
+      Interval in milliseconds for running the stream file cleanup process
     </description>
   </property>
 
@@ -1977,7 +1973,7 @@
     <name>stream.index.interval</name>
     <value>10000</value>
     <description>
-      Default time interval in milliseconds for emitting new index entry in
+      Interval in milliseconds for emitting new index entry in
       stream file
     </description>
   </property>
@@ -1995,7 +1991,7 @@
     <name>stream.notification.threshold</name>
     <value>1024</value>
     <description>
-      Size of data, in megabytes, to be ingested by a stream before a
+      Size of data in megabytes to be ingested by a stream before a
       notification is published
     </description>
   </property>
@@ -2004,7 +2000,7 @@
     <name>stream.partition.duration</name>
     <value>3600000</value>
     <description>
-      The default duration of a stream partition in milliseconds
+      Duration in milliseconds of a stream partition
     </description>
   </property>
 
@@ -2012,7 +2008,7 @@
     <name>stream.size.schedule.polling.delay</name>
     <value>600</value>
     <description>
-      Delay, in seconds, to poll a stream in a StreamSizeSchedule if no
+      Delay in seconds to poll a stream in a StreamSizeSchedule if no
       notification is received
     </description>
   </property>
@@ -2048,9 +2044,8 @@
     <name>dashboard.router.check.timeout.secs</name>
     <value>0</value>
     <description>
-      Amount of time, in seconds, CDAP UI waits before exiting when unable
-      to connect to CDAP Router service on startup; use a timeout of 0 to
-      wait indefinitely
+      Interval in seconds that the CDAP UI waits before exiting when unable to connect to
+      the CDAP Router service on startup; use a timeout of 0 to wait indefinitely
     </description>
   </property>
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="7c881d800066b81f6be0975bfef04253"
+DEFAULT_XML_MD5_HASH="b41515eddb6ef9555e23619f10f9d92b"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
Fix MD5 hash; back port changes in 4.0.0's cdap-default.xml to 3.6.

Passed as a Quick Build: http://builds.cask.co/browse/CDAP-DQB162-1