### PR TITLE
[CDAP-7475] Remove deprecated setInput/addOutput methods from MapReduceContext

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/data/stream/StreamBatchReadable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/stream/StreamBatchReadable.java
@@ -100,7 +100,7 @@ public class StreamBatchReadable implements BatchReadable<Long, String> {
    * @param endTime End timestamp in milliseconds (exclusive) of stream events provided to the job
    */
   public static void useStreamInput(MapReduceContext context, String streamName, long startTime, long endTime) {
-    context.setInput(new StreamBatchReadable(streamName, startTime, endTime));
+    context.addInput(Input.ofStream(streamName, startTime, endTime));
   }
 
   /**
@@ -115,7 +115,7 @@ public class StreamBatchReadable implements BatchReadable<Long, String> {
    */
   public static void useStreamInput(MapReduceContext context, String streamName,
                                     long startTime, long endTime, Class<? extends StreamEventDecoder> decoderType) {
-    context.setInput(new StreamBatchReadable(streamName, startTime, endTime, decoderType));
+    context.addInput(Input.ofStream(streamName, startTime, endTime, decoderType));
   }
 
   /**
@@ -131,7 +131,7 @@ public class StreamBatchReadable implements BatchReadable<Long, String> {
    */
   public static void useStreamInput(MapReduceContext context, String streamName,
                                     long startTime, long endTime, FormatSpecification bodyFormatSpec) {
-    context.setInput(new StreamBatchReadable(streamName, startTime, endTime, bodyFormatSpec));
+    context.addInput(Input.ofStream(streamName, startTime, endTime, bodyFormatSpec));
   }
 
   /**

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
@@ -24,17 +24,10 @@ import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.batch.Input;
-import co.cask.cdap.api.data.batch.InputFormatProvider;
 import co.cask.cdap.api.data.batch.Output;
-import co.cask.cdap.api.data.batch.OutputFormatProvider;
-import co.cask.cdap.api.data.batch.Split;
-import co.cask.cdap.api.data.stream.StreamBatchReadable;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.workflow.WorkflowInfoProvider;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * MapReduce job execution context.
@@ -57,73 +50,9 @@ public interface MapReduceContext extends RuntimeContext, DatasetContext, Servic
   long getLogicalStartTime();
 
   /**
+   * Returns the actual Hadoop job.
    */
   <T> T getHadoopJob();
-
-  /**
-   * Overrides the input configuration of this MapReduce job to use the specific stream as the single input.
-   *
-   * @param stream the input stream.
-   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)} instead.
-   */
-  @Deprecated
-  void setInput(StreamBatchReadable stream);
-
-  /**
-   * Overrides the input configuration of this MapReduce job to use the specified dataset by its name,
-   * as the single input.
-   *
-   * @param datasetName the name of the input dataset.
-   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)} instead.
-   */
-  @Deprecated
-  void setInput(String datasetName);
-
-  /**
-   * Overrides the input configuration of this MapReduce job to use he specified dataset by its name and arguments,
-   * as the single input.
-   *
-   * @param datasetName the the name of the input dataset
-   * @param arguments the arguments to use when instantiating the dataset
-   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)} instead.
-   */
-  @Deprecated
-  void setInput(String datasetName, Map<String, String> arguments);
-
-  /**
-   * Overrides the input configuration of this MapReduce job to use the specified dataset by its name and data
-   * selection splits, as teh single input
-   *
-   * @param datasetName the name of the input dataset
-   * @param splits the data selection splits. If the dataset type is
-   *               not {@link co.cask.cdap.api.data.batch.BatchReadable}, splits will be ignored.
-   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)} instead.
-   */
-  @Deprecated
-  void setInput(String datasetName, List<Split> splits);
-
-  /**
-   * Overrides the input configuration of this MapReduce job to use the specified dataset by its name and arguments
-   * with the given data selection splits, as the single input.
-   *
-   * @param datasetName the name of the input dataset
-   * @param arguments the arguments to use when instantiating the dataset
-   * @param splits the data selection splits. If dataset type is
-   *               not {@link co.cask.cdap.api.data.batch.BatchReadable}, splits will be ignored.
-   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)} instead.
-   */
-  @Deprecated
-  void setInput(String datasetName, Map<String, String> arguments, List<Split> splits);
-
-  /**
-   * Overrides the input configuration of this MapReduce job to the one provided by the given
-   * {@link InputFormatProvider}, as the single input.
-   *
-   * @param inputFormatProvider provider for InputFormat and configurations to be used
-   * @deprecated as of 3.4.0. Use {@link MapReduceContext#addInput(Input)} instead.
-   */
-  @Deprecated
-  void setInput(InputFormatProvider inputFormatProvider);
 
   /**
    * Updates the input configuration of this MapReduce job to use the specified {@link Input}.
@@ -140,43 +69,6 @@ public interface MapReduceContext extends RuntimeContext, DatasetContext, Servic
    */
   void addInput(Input input, Class<?> mapperCls);
 
-  /**
-   * Overrides the output configuration of this MapReduce job to also allow writing to the specified dataset by
-   * its name.
-   *
-   * @param datasetName the name of the output dataset
-   * Deprecated as of version 3.4.0. Use {@link #addOutput(Output)}, instead.
-   */
-  @Deprecated
-  void addOutput(String datasetName);
-
-  /**
-   * Updates the output configuration of this MapReduce job to also allow writing to the specified dataset.
-   * Currently, the dataset specified in must be an {@link OutputFormatProvider}.
-   * You may want to use this method instead of {@link #addOutput(String)} if your output dataset uses runtime
-   * arguments set in your own program logic.
-   *
-   * @param datasetName the name of the output dataset
-   * @param arguments the arguments to use when instantiating the dataset
-   * @throws IllegalArgumentException if the specified dataset is not an OutputFormatProvider.
-   * Deprecated as of version 3.4.0. Use {@link #addOutput(Output)}, instead.
-   */
-  @Deprecated
-  void addOutput(String datasetName, Map<String, String> arguments);
-
-  /**
-   * Updates the output configuration of this MapReduce job to also allow writing using the given
-   * {@link OutputFormatProvider}.
-   *
-   * @param alias the alias of the output
-   * @param outputFormatProvider the outputFormatProvider which specifies an OutputFormat and configuration to be used
-   *                             when writing to this output
-   * Deprecated as of version 3.4.0. Use {@link #addOutput(Output)}, instead.
-   */
-  @Deprecated
-  void addOutput(String alias, OutputFormatProvider outputFormatProvider);
-
-  // TODO: (CDAP-5651) change usages of above three deprecated methods to use this
   /**
    * Updates the output configuration of this MapReduce job to use the specified {@link Output}.
    * @param output the output to be used

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -178,38 +178,6 @@ final class BasicMapReduceContext extends AbstractContext implements MapReduceCo
   }
 
   @Override
-  public void setInput(StreamBatchReadable stream) {
-    setInput(new StreamInputFormatProvider(Id.Namespace.from(getProgram().getNamespaceId()), stream, streamAdmin));
-  }
-
-  @Override
-  public void setInput(String datasetName) {
-    setInput(datasetName, ImmutableMap.<String, String>of());
-  }
-
-  @Override
-  public void setInput(String datasetName, Map<String, String> arguments) {
-    setInput(createInputFormatProvider(datasetName, arguments, null));
-  }
-
-  @Override
-  public void setInput(String datasetName, List<Split> splits) {
-    setInput(datasetName, ImmutableMap.<String, String>of(), splits);
-  }
-
-  @Override
-  public void setInput(String datasetName, Map<String, String> arguments, List<Split> splits) {
-    setInput(createInputFormatProvider(datasetName, arguments, splits));
-  }
-
-  @Override
-  public void setInput(InputFormatProvider inputFormatProvider) {
-    // with the setInput method, only 1 input will be set, and so the name does not matter much.
-    // make it immutable to prevent calls to addInput after setting a single input.
-    inputs = ImmutableMap.of(inputFormatProvider.getInputFormatClassName(), new MapperInput(inputFormatProvider));
-  }
-
-  @Override
   public void addInput(Input input) {
     addInput(input, null);
   }
@@ -257,18 +225,7 @@ final class BasicMapReduceContext extends AbstractContext implements MapReduceCo
     }
   }
 
-  @Override
-  public void addOutput(String datasetName) {
-    addOutput(datasetName, Collections.<String, String>emptyMap());
-  }
-
-  @Override
-  public void addOutput(String datasetName, Map<String, String> arguments) {
-    addOutput(Output.ofDataset(datasetName, arguments));
-  }
-
-  @Override
-  public void addOutput(String alias, OutputFormatProvider outputFormatProvider) {
+  private void addOutput(String alias, OutputFormatProvider outputFormatProvider) {
     if (this.outputFormatProviders.containsKey(alias)) {
       throw new IllegalArgumentException("Output already configured: " + alias);
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
@@ -24,11 +24,8 @@ import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.data.DatasetInstantiationException;
 import co.cask.cdap.api.data.batch.Input;
-import co.cask.cdap.api.data.batch.InputFormatProvider;
 import co.cask.cdap.api.data.batch.Output;
 import co.cask.cdap.api.data.batch.OutputFormatProvider;
-import co.cask.cdap.api.data.batch.Split;
-import co.cask.cdap.api.data.stream.StreamBatchReadable;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.macro.MacroEvaluator;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
@@ -48,7 +45,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
-import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -205,57 +201,12 @@ public class MapReduceLifecycleContext<KEY, VALUE> implements MapReduceTaskConte
   }
 
   @Override
-  public void setInput(StreamBatchReadable stream) {
-    LOG.warn(UNSUPPORTED_OPERATION_MESSAGE);
-  }
-
-  @Override
-  public void setInput(String datasetName) {
-    LOG.warn(UNSUPPORTED_OPERATION_MESSAGE);
-  }
-
-  @Override
-  public void setInput(String datasetName, Map<String, String> arguments) {
-    LOG.warn(UNSUPPORTED_OPERATION_MESSAGE);
-  }
-
-  @Override
-  public void setInput(String datasetName, List<Split> splits) {
-    LOG.warn(UNSUPPORTED_OPERATION_MESSAGE);
-  }
-
-  @Override
-  public void setInput(String datasetName, Map<String, String> arguments, List<Split> splits) {
-    LOG.warn(UNSUPPORTED_OPERATION_MESSAGE);
-  }
-
-  @Override
-  public void setInput(InputFormatProvider inputFormatProvider) {
-    LOG.warn(UNSUPPORTED_OPERATION_MESSAGE);
-  }
-
-  @Override
   public void addInput(Input input) {
     LOG.warn(UNSUPPORTED_OPERATION_MESSAGE);
   }
 
   @Override
   public void addInput(Input input, Class<?> mapperCls) {
-    LOG.warn(UNSUPPORTED_OPERATION_MESSAGE);
-  }
-
-  @Override
-  public void addOutput(String datasetName) {
-    LOG.warn(UNSUPPORTED_OPERATION_MESSAGE);
-  }
-
-  @Override
-  public void addOutput(String datasetName, Map<String, String> arguments) {
-    LOG.warn(UNSUPPORTED_OPERATION_MESSAGE);
-  }
-
-  @Override
-  public void addOutput(String alias, OutputFormatProvider outputFormatProvider) {
     LOG.warn(UNSUPPORTED_OPERATION_MESSAGE);
   }
 

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/partitioned-fileset.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/partitioned-fileset.rst
@@ -149,8 +149,7 @@ a partition with that league as the only key::
     Map<String, String> inputArgs = Maps.newHashMap();
     PartitionedFileSetArguments.setInputPartitionFilter(
       inputArgs, PartitionFilter.builder().addValueCondition("league", league).build());
-    PartitionedFileSet input = context.getDataset("results", inputArgs);
-    context.setInput("results", input);
+    context.addInput(Input.ofDataset("results", inputArgs));
 
     // Each run writes its output to a partition for the league
     Map<String, String> outputArgs = Maps.newHashMap();
@@ -205,7 +204,7 @@ Then set the class of the custom partitioner as runtime arguments of the output 
 
   Map<String, String> cleanRecordsArgs = new HashMap<>();
   PartitionedFileSetArguments.setDynamicPartitioner(cleanRecordsArgs, TimeAndZipPartitioner.class);
-  context.addOutput(DataCleansing.CLEAN_RECORDS, cleanRecordsArgs);
+  context.addOutput(Output.ofDataset(DataCleansing.CLEAN_RECORDS, cleanRecordsArgs));
 
 With this, each record processed by the MapReduce job will be written to a path corresponding
 to the ``Partition`` that it was mapped to by the ``DynamicPartitioner``, and the set of new ``Partition``\ s

--- a/cdap-docs/developers-manual/source/building-blocks/mapreduce-programs.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/mapreduce-programs.rst
@@ -268,7 +268,7 @@ To read a range of keys and give a hint that you want 16 splits, write::
   public void initialize() throws Exception {
     MapReduceContext context = getContext();
     ...
-    context.setInput("myTable", kvTable.getSplits(16, startKey, stopKey));
+    context.addInput(Input.ofDataset("myTable", kvTable.getSplits(16, startKey, stopKey)));
   }
 
 .. _mapreduce-datasets-output:
@@ -294,8 +294,8 @@ To write to multiple output datasets from a MapReduce program, begin by adding t
 
   public void beforeSubmit(MapReduceContext context) throws Exception {
     ...
-    context.addOutput("productCounts");
-    context.addOutput("catalog");
+    context.addOutput(Input.ofDataset("productCounts"));
+    context.addOutput(Input.ofDataset("catalog"));
   }
 
 Then, have the ``Mapper`` and/or ``Reducer`` implement ``ProgramLifeCycle<MapReduceTaskContext>``.

--- a/cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/StreamToDataset.java
+++ b/cdap-examples/WikipediaPipeline/src/main/java/co/cask/cdap/examples/wikipedia/StreamToDataset.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.ProgramStatus;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.data.batch.Input;
+import co.cask.cdap.api.data.batch.Output;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
 import co.cask.cdap.api.mapreduce.AbstractMapReduce;
@@ -79,7 +80,7 @@ public class StreamToDataset extends AbstractMapReduce {
     LOG.info("Using '{}' as the input stream and '{}' as the output dataset.", inputStream, outputDataset);
     job.setMapperClass(mapper);
     context.addInput(Input.ofStream(inputStream));
-    context.addOutput(outputDataset);
+    context.addOutput(Output.ofDataset(outputDataset));
   }
 
   @Override


### PR DESCRIPTION
Continuation of previous PR, forgot some methods. 

This builds and does not break the hydrator build 