### PR TITLE
Use file:// URL to point to locally-downloaded files

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -74,6 +74,18 @@
       "only": ["cdap-sdk-vm"]
     },
     {
+      "type": "file",
+      "source": "files/eclipse.tar.gz",
+      "destination": "/tmp/eclipse.tar.gz",
+      "only": ["cdap-sdk-vm"]
+    },
+    {
+      "type": "file",
+      "source": "files/idea.tar.gz",
+      "destination": "/tmp/idea.tar.gz",
+      "only": ["cdap-sdk-vm"]
+    },
+    {
       "type": "chef-solo",
       "remote_cookbook_paths": "/var/chef/cookbooks",
       "run_list": "recipe[maven],recipe[hadoop::flume_agent],recipe[idea],recipe[eclipse]",
@@ -87,11 +99,12 @@
             { "http://download.eclipse.org/releases/luna": "org.eclipse.egit.feature.group" },
             { "http://download.eclipse.org/technology/m2e/releases": "org.eclipse.m2e.feature.feature.group" }
           ],
-          "url": "http://ftp.osuosl.org/pub/eclipse/technology/epp/downloads/release/luna/SR2/eclipse-jee-luna-SR2-linux-gtk-x86_64.tar.gz"
+          "url": "file:///tmp/eclipse.tar.gz"
         },
         "idea": {
           "setup_dir": "/opt",
-          "version": "2016.2.5"
+          "version": "2016.2.5",
+          "url": "file:///tmp/idea.tar.gz"
         },
         "hadoop": {
           "distribution": "hdp",

--- a/cdap-distributions/src/packer/scripts/lxde.sh
+++ b/cdap-distributions/src/packer/scripts/lxde.sh
@@ -42,19 +42,6 @@ Icon=eclipse
 Categories=GNOME;GTK;Development;
 EOF
 
-# IntelliJ Menu entry
-cat > /usr/share/applications/idea.desktop << EOF
-[Desktop Entry]
-Encoding=UTF-8
-Name=IntelliJ IDEA
-Comment=Start IntelliJ
-Exec=/opt/idea/bin/idea.sh
-TryExec=/opt/idea/bin/idea.sh
-Type=Application
-Icon=idea
-Categories=GNOME;GTK;Development;
-EOF
-
 # CDAP Docs Menu Entry
 cat > /usr/share/applications/cdap-docs.desktop << EOF
 [Desktop Entry]


### PR DESCRIPTION
This changes the build for the VM to use locally-downloaded files for the large tarballs for Eclipse/Idea IntelliJ. This leaves it up to the builder to put these files in place under `cdap-distributions/src/packer/files` prior to running the build. Also, removing the desktop entry because the cookbook does it.