### PR TITLE
CDAP-7566 IntegrationTest's ServiceManager#getServiceURL should block on service availability

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CheckServiceAvailabilityCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CheckServiceAvailabilityCommand.java
@@ -55,7 +55,8 @@ public class CheckServiceAvailabilityCommand extends AbstractAuthCommand impleme
     String appId = appAndServiceId[0];
     String serviceName = appAndServiceId[1];
     Id.Service serviceId = Id.Service.from(cliConfig.getCurrentNamespace(), appId, serviceName);
-    output.println(serviceClient.getAvailability(serviceId));
+    serviceClient.checkAvailability(serviceId);
+    output.println("Service is available to accept requests.");
   }
 
   @Override

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/ServiceClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/ServiceClientTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -66,7 +66,7 @@ public class ServiceClientTestRun extends ClientTestBase {
     serviceClient = new ServiceClient(clientConfig);
     programClient = new ProgramClient(clientConfig);
     try {
-      serviceClient.getAvailability(service);
+      serviceClient.checkAvailability(service);
       Assert.fail();
     } catch (NotFoundException ex) {
       // Expected since the app has not been deployed yet
@@ -74,7 +74,7 @@ public class ServiceClientTestRun extends ClientTestBase {
 
     appClient.deploy(namespace, createAppJarFile(FakeApp.class));
     try {
-      serviceClient.getAvailability(service);
+      serviceClient.checkAvailability(service);
       Assert.fail();
     } catch (ServiceUnavailableException ex) {
       // Expected since the service has not been started
@@ -112,8 +112,7 @@ public class ServiceClientTestRun extends ClientTestBase {
 
   @Test
   public void testActiveStatus() throws Exception {
-    String responseBody = serviceClient.getAvailability(service);
-    Assert.assertTrue(responseBody.contains("Service is available"));
+    serviceClient.checkAvailability(service);
   }
 
   @Test

--- a/cdap-client/src/main/java/co/cask/cdap/client/ServiceClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ServiceClient.java
@@ -103,16 +103,15 @@ public class ServiceClient {
   }
 
   /**
-   * Checks whether the {@link Service} is active.
+   * Checks whether the {@link Service} is active. Returns without throwing any exception if it is active.
    *
    * @param service ID of the service
-   * @return 'Active' message when service is active
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
    * @throws NotFoundException if the app or service could not be found
-   * @throws ServiceUnavailableException if the service has started but is not available right now
+   * @throws ServiceUnavailableException if the service is not available
    */
-  public String getAvailability(Id.Service service) throws IOException, UnauthenticatedException, NotFoundException,
+  public void checkAvailability(Id.Service service) throws IOException, UnauthenticatedException, NotFoundException,
     ServiceUnavailableException, UnauthorizedException {
     URL url = config.resolveNamespacedURLV3(service.getNamespace(),
                                             String.format("apps/%s/services/%s/available",
@@ -127,7 +126,6 @@ public class ServiceClient {
     if (response.getResponseCode() == HttpURLConnection.HTTP_UNAVAILABLE) {
       throw new ServiceUnavailableException(service.getId());
     }
-    return response.getResponseBodyAsString();
   }
 
   public URL getServiceURL(Id.Service service)


### PR DESCRIPTION
IntegrationTest's ServiceManager#getServiceURL should block on service availability before returning the service's URL.
Also fixed ServiceClient's javadoc and modified its return type to be cleaner.

https://issues.cask.co/browse/CDAP-7566
http://builds.cask.co/browse/CDAP-RUT255-2