### PR TITLE
[CDAP-7476] move input/output format configuration into the same transaction as initialize()

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DatasetInputFormatProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/DatasetInputFormatProvider.java
@@ -58,13 +58,6 @@ public class DatasetInputFormatProvider implements InputFormatProvider {
     this.batchReadableInputFormat = batchReadableInputFormat;
   }
 
-  public DatasetInputFormatProvider(String datasetName, Map<String, String> datasetArgs,
-                                    Dataset dataset, @Nullable List<Split> splits,
-                                    Class<? extends AbstractBatchReadableInputFormat> batchReadableInputFormat) {
-
-    this(null, datasetName, datasetArgs, dataset, splits, batchReadableInputFormat);
-  }
-
   @Override
   public String getInputFormatClassName() {
     return dataset instanceof InputFormatProvider

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/MapperInput.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/MapperInput.java
@@ -19,32 +19,52 @@ package co.cask.cdap.internal.app.runtime.batch.dataset.input;
 import co.cask.cdap.api.data.batch.InputFormatProvider;
 import org.apache.hadoop.mapreduce.Mapper;
 
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
  * Encapsulates {@link InputFormatProvider} and a {@link Mapper} to use for that input.
  */
 public class MapperInput {
+  private final String alias;
   private final InputFormatProvider inputFormatProvider;
+  private final String inputFormatClassName;
+  private final Map<String, String> inputFormatConfiguration;
   private final Class<? extends Mapper> mapper;
-
-  /**
-   * Creates an instance of MapperInput with the given InputFormatProvider.
-   */
-  public MapperInput(InputFormatProvider inputFormatProvider) {
-    this(inputFormatProvider, null);
-  }
 
   /**
    * Creates an instance of MapperInput with the given InputFormatProvider and specified Mapper class.
    */
-  public MapperInput(InputFormatProvider inputFormatProvider, @Nullable Class<? extends Mapper> mapper) {
+  public MapperInput(String alias, InputFormatProvider inputFormatProvider, @Nullable Class<? extends Mapper> mapper) {
+    this.alias = alias;
     this.inputFormatProvider = inputFormatProvider;
+    this.inputFormatClassName = inputFormatProvider.getInputFormatClassName();
+    this.inputFormatConfiguration = inputFormatProvider.getInputFormatConfiguration();
     this.mapper = mapper;
+    if (inputFormatClassName == null) {
+      throw new IllegalArgumentException(
+        "Input '" + alias + "' provided null as the input format");
+    }
+    if (inputFormatConfiguration == null) {
+      throw new IllegalArgumentException(
+        "Input '" + alias + "' provided null as the input format configuration");
+    }
+  }
+
+  public String getAlias() {
+    return alias;
   }
 
   public InputFormatProvider getInputFormatProvider() {
     return inputFormatProvider;
+  }
+
+  public String getInputFormatClassName() {
+    return inputFormatClassName;
+  }
+
+  public Map<String, String> getInputFormatConfiguration() {
+    return inputFormatConfiguration;
   }
 
   @Nullable

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/ProvidedOutput.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/ProvidedOutput.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.output;
+
+import co.cask.cdap.api.data.batch.OutputFormatProvider;
+
+import java.util.Map;
+
+/**
+ * Internal helper class to represent an output format provider and its configuration.
+ */
+public class ProvidedOutput {
+  private final String alias;
+  private final OutputFormatProvider outputFormatProvider;
+  private final String outputFormatClassName;
+  private final Map<String, String> outputFormatConfiguration;
+
+  public ProvidedOutput(String alias, OutputFormatProvider outputFormatProvider) {
+    this.alias = alias;
+    this.outputFormatProvider = outputFormatProvider;
+    this.outputFormatClassName = outputFormatProvider.getOutputFormatClassName();
+    this.outputFormatConfiguration = outputFormatProvider.getOutputFormatConfiguration();
+    if (outputFormatClassName == null) {
+      throw new IllegalArgumentException("Output '" + alias + "' provided null as the output format");
+    }
+    if (outputFormatConfiguration == null) {
+      throw new IllegalArgumentException("Output '" + alias + "' provided null as the output format configuration");
+    }
+  }
+
+  public String getAlias() {
+    return alias;
+  }
+
+  public OutputFormatProvider getOutputFormatProvider() {
+    return outputFormatProvider;
+  }
+
+  public String getOutputFormatClassName() {
+    return outputFormatClassName;
+  }
+
+  public Map<String, String> getOutputFormatConfiguration() {
+    return outputFormatConfiguration;
+  }
+}


### PR DESCRIPTION
This means: when you addInput() or addOutput() of an Input/OutputFormatProvider, then that is called immediately to create its configuration. Previously, we only remembered the provider and call the getConfig() later, after initialize() finished. But we want a failure in this (it may involve reading data, etc.) to fail the initialize() transaction. 

Adds a test case with a MapReduce that fails in the input or output format provider, depending on runtime arguments. Two variants of this MapReduceL one with explicit, one with implicit transaction control. 

Build is here: http://builds.cask.co/browse/CDAP-DUT5021