### PR TITLE
Fix for CDAP-7348 and CDAP-7354 to use Hive classpath correctly

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/hive/ExploreUtils.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/hive/ExploreUtils.java
@@ -16,19 +16,26 @@
 
 package co.cask.cdap.hive;
 
-import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.utils.DirUtils;
 import com.google.common.base.Function;
 import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * * Helper class for loading Hive classes.
@@ -36,6 +43,28 @@ import java.net.URLClassLoader;
 public final class ExploreUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(ExploreUtils.class);
+  private static final String EXPLORE_CLASSPATH = "explore.classpath";
+  private static final String EXPLORE_CONF_DIRS = "explore.conf.dirs";
+
+  private static final Function<String, File> STRING_FILE_FUNCTION = new Function<String, File>() {
+    @Override
+    public File apply(String input) {
+      return new File(input).getAbsoluteFile();
+    }
+  };
+
+  private static final Function<File, URL> FILE_TO_URL = new Function<File, URL>() {
+    @Override
+    public URL apply(File file) {
+      try {
+        return file.toURI().toURL();
+      } catch (MalformedURLException e) {
+        // This shouldn't happen
+        throw Throwables.propagate(e);
+      }
+    }
+  };
+
   private static ClassLoader exploreClassLoader = null;
 
   /**
@@ -46,54 +75,93 @@ public final class ExploreUtils {
       return exploreClassLoader;
     }
 
-    // EXPLORE_CLASSPATH and EXPLORE_CONF_FILES will be defined in startup scripts if Hive is installed.
-    String exploreClassPathStr = System.getProperty(Constants.Explore.EXPLORE_CLASSPATH);
-    LOG.debug("Explore classpath = {}", exploreClassPathStr);
-    if (exploreClassPathStr == null) {
-      throw new RuntimeException("System property " + Constants.Explore.EXPLORE_CLASSPATH + " is not set.");
-    }
+    // Use all hive jars and hive conf paths to construct the explore classloader
+    List<URL> urls = new ArrayList<>();
+    Iterables.addAll(urls, Iterables.transform(getExploreClasspathJarFiles(), FILE_TO_URL));
+    Iterables.addAll(urls, Iterables.transform(getExploreConfDirs(), FILE_TO_URL));
 
-    String exploreConfPathStr = System.getProperty(Constants.Explore.EXPLORE_CONF_FILES);
-    LOG.debug("Explore confPath = {}", exploreConfPathStr);
-    if (exploreConfPathStr == null) {
-      throw new RuntimeException("System property " + Constants.Explore.EXPLORE_CONF_FILES + " is not set.");
-    }
+    LOG.debug("Explore ClassLoader urls {}", urls);
 
-    Iterable<File> hiveClassPath = getClassPathJarsFiles(exploreClassPathStr);
-    Iterable<File> hiveConfFiles = getClassPathJarsFiles(exploreConfPathStr);
-    ImmutableList.Builder<URL> builder = ImmutableList.builder();
-    for (File file : Iterables.concat(hiveClassPath, hiveConfFiles)) {
-      try {
-        if (file.getName().matches(".*\\.xml")) {
-          builder.add(file.getParentFile().toURI().toURL());
-        } else {
-          builder.add(file.toURI().toURL());
-        }
-      } catch (MalformedURLException e) {
-        LOG.error("Jar URL is malformed", e);
-        throw Throwables.propagate(e);
-      }
-    }
-    exploreClassLoader = new URLClassLoader(Iterables.toArray(builder.build(), URL.class),
-                                            ClassLoader.getSystemClassLoader());
+    exploreClassLoader = new URLClassLoader(urls.toArray(new URL[urls.size()]), ClassLoader.getSystemClassLoader());
     return exploreClassLoader;
   }
 
   /**
-   * Get all the files contained in a class path.
+   * Returns the set of jar files used by hive. The set is constructed based on the system property
+   * {@link #EXPLORE_CLASSPATH}. The {@link #EXPLORE_CLASSPATH} is expected to contains one or more file paths,
+   * separated by the {@link File#pathSeparatorChar}. Only jar files will be included in the result set and paths
+   * ended with a '*' will be expanded to include all jars under the given path.
+   *
+   * @throws IllegalArgumentException if the system property {@link #EXPLORE_CLASSPATH} is missing.
    */
-  public static Iterable<File> getClassPathJarsFiles(String hiveClassPath) {
-    if (hiveClassPath == null) {
-      return null;
+  public static Iterable<File> getExploreClasspathJarFiles() {
+    String property = System.getProperty(EXPLORE_CLASSPATH);
+    if (property == null) {
+      throw new RuntimeException("System property " + EXPLORE_CLASSPATH + " is not set.");
     }
-    return Iterables.transform(Splitter.on(':').split(hiveClassPath), STRING_FILE_FUNCTION);
+
+    Set<File> result = new LinkedHashSet<>();
+    for (String path : Splitter.on(File.pathSeparator).split(property)) {
+      List<File> jarFiles;
+      // The path has to either ends with "*" or is a jar file. This is because we are only interested in JAR files
+      // in the hive classpath.
+      if (path.endsWith("*")) {
+        jarFiles = DirUtils.listFiles(new File(path.substring(0, path.length() - 1)).getAbsoluteFile(), "jar");
+      } else if (path.endsWith(".jar")) {
+        jarFiles = Collections.singletonList(new File(path));
+      } else {
+        continue;
+      }
+
+      // Resolves all files to the actual file to remove symlinks that point to the same file.
+      // Also, only add files that are readable
+      for (File jarFile : jarFiles) {
+        try {
+          Path jarPath = jarFile.toPath().toRealPath();
+          if (Files.isRegularFile(jarPath) && Files.isReadable(jarPath)) {
+            result.add(jarPath.toFile());
+          }
+        } catch (IOException e) {
+          LOG.debug("Ignore jar file that is not readable {}", jarFile);
+        }
+      }
+    }
+
+    return Collections.unmodifiableSet(result);
   }
 
-  private static final Function<String, File> STRING_FILE_FUNCTION =
-    new Function<String, File>() {
-      @Override
-      public File apply(String input) {
-        return new File(input).getAbsoluteFile();
+  /**
+   * Returns the set of config files used by hive. The set is constructed based on the system property
+   * {@link #EXPLORE_CONF_DIRS}. The {@link #EXPLORE_CONF_DIRS} is expected to contains one or more file paths,
+   * separated by the {@link File#pathSeparatorChar}. If a given path is a directory, the immediate files under that
+   * directory will be included in the result set instead of the directory itself.
+   *
+   * @throws IllegalArgumentException if the system property {@link #EXPLORE_CONF_DIRS} is missing.
+   */
+  public static Iterable<File> getExploreConfFiles() {
+    Set<File> result = new LinkedHashSet<>();
+    for (File confPath : getExploreConfDirs()) {
+      if (confPath.isDirectory()) {
+        result.addAll(DirUtils.listFiles(confPath));
+      } else if (confPath.isFile()) {
+        result.add(confPath);
       }
-    };
+    }
+
+    return Collections.unmodifiableSet(result);
+  }
+
+  /**
+   * Returns the conf file paths based on the {@link #EXPLORE_CONF_DIRS} system property. It simply splits the
+   * property with {@link File#separatorChar} and returns the set of {@link File} representing the paths.
+   *
+   * @throws IllegalArgumentException if the system property {@link #EXPLORE_CONF_DIRS} is missing.
+   */
+  private static Iterable<File> getExploreConfDirs() {
+    String property = System.getProperty(EXPLORE_CONF_DIRS);
+    if (property == null) {
+      throw new IllegalArgumentException("System property " + EXPLORE_CONF_DIRS + " is not set.");
+    }
+    return Iterables.transform(Splitter.on(File.pathSeparator).split(property), STRING_FILE_FUNCTION);
+  }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -824,11 +824,8 @@ public final class Constants {
     public static final String START_ON_DEMAND = "explore.start.on.demand";
     public static final String DATASET_NAME = "explore.dataset.name";
     public static final String DATASET_NAMESPACE = "explore.dataset.namespace";
-    public static final String VIEW_NAME = "explore.view.name";
     public static final String STREAM_NAME = "explore.stream.name";
     public static final String STREAM_NAMESPACE = "explore.stream.namespace";
-    public static final String EXPLORE_CLASSPATH = "explore.classpath";
-    public static final String EXPLORE_CONF_FILES = "explore.conf.files";
     public static final String PREVIEWS_DIR_NAME = "explore.previews.dir";
     // a marker so that we know which tables are created by CDAP
     public static final String CDAP_NAME = "cdap.name";

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/ClassPathResources.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/ClassPathResources.java
@@ -33,6 +33,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -90,6 +92,24 @@ public final class ClassPathResources {
   public static Set<ClassPath.ResourceInfo> getClassPathResources(ClassLoader classLoader,
                                                                   Class<?> cls) throws IOException {
     return getClassPath(classLoader, cls).getResources();
+  }
+
+  /**
+   * Returns a Set containing all bootstrap classpaths as defined in the {@code sun.boot.class.path} property.
+   */
+  public static Set<String> getBootstrapClassPaths() {
+    // Get the bootstrap classpath. This is for exclusion while tracing class dependencies.
+    Set<String> bootstrapPaths = new HashSet<>();
+    for (String classpath : Splitter.on(File.pathSeparatorChar).split(System.getProperty("sun.boot.class.path"))) {
+      File file = new File(classpath);
+      bootstrapPaths.add(file.getAbsolutePath());
+      try {
+        bootstrapPaths.add(file.getCanonicalPath());
+      } catch (IOException e) {
+        // Ignore the exception and proceed.
+      }
+    }
+    return Collections.unmodifiableSet(bootstrapPaths);
   }
 
   /**
@@ -158,24 +178,6 @@ public final class ClassPathResources {
     }, classes);
 
     return result;
-  }
-
-  /**
-   * Returns a Set containing all bootstrap classpaths as defined in the {@code sun.boot.class.path} property.
-   */
-  private static Set<String> getBootstrapClassPaths() {
-    // Get the bootstrap classpath. This is for exclusion while tracing class dependencies.
-    Set<String> bootstrapPaths = Sets.newHashSet();
-    for (String classpath : Splitter.on(File.pathSeparatorChar).split(System.getProperty("sun.boot.class.path"))) {
-      File file = new File(classpath);
-      bootstrapPaths.add(file.getAbsolutePath());
-      try {
-        bootstrapPaths.add(file.getCanonicalPath());
-      } catch (IOException e) {
-        // Ignore the exception and proceed.
-      }
-    }
-    return bootstrapPaths;
   }
 
   /**

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
@@ -19,8 +19,6 @@ package co.cask.cdap.explore.guice;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.runtime.RuntimeModule;
-import co.cask.cdap.data2.datafabric.dataset.RemoteDatasetFramework;
-import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.explore.executor.ExploreExecutorHttpHandler;
 import co.cask.cdap.explore.executor.ExploreExecutorService;
 import co.cask.cdap.explore.executor.ExploreMetadataHttpHandler;
@@ -30,19 +28,10 @@ import co.cask.cdap.explore.executor.NamespacedQueryExecutorHttpHandler;
 import co.cask.cdap.explore.executor.QueryExecutorHttpHandler;
 import co.cask.cdap.explore.service.ExploreService;
 import co.cask.cdap.explore.service.ExploreServiceUtils;
-import co.cask.cdap.explore.service.hive.BaseHiveExploreService;
 import co.cask.cdap.explore.service.hive.Hive14ExploreService;
-import co.cask.cdap.format.RecordFormats;
 import co.cask.cdap.gateway.handlers.CommonHandlers;
-import co.cask.cdap.hive.datasets.DatasetStorageHandler;
 import co.cask.http.HttpHandler;
-import com.google.common.base.Function;
-import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import com.google.inject.Exposed;
 import com.google.inject.Inject;
@@ -59,18 +48,11 @@ import com.google.inject.name.Names;
 import com.google.inject.util.Modules;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.MRConfig;
-import org.apache.twill.api.ClassAcceptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
 
 /**
  * Guice runtime module for the explore functionality.
@@ -156,6 +138,8 @@ public class ExploreRuntimeModule extends RuntimeModule {
 
     @Singleton
     private static final class ExploreServiceProvider implements Provider<ExploreService> {
+      private static final long seed = System.currentTimeMillis();
+
       private final CConfiguration cConf;
       private final Configuration hConf;
       private final ExploreService exploreService;
@@ -171,7 +155,6 @@ public class ExploreRuntimeModule extends RuntimeModule {
         this.isInMemory = isInMemory;
       }
 
-      private static final long seed = System.currentTimeMillis();
       @Override
       public ExploreService get() {
         File hiveDataDir = new File(cConf.get(Constants.Explore.LOCAL_DATA_DIR));
@@ -232,20 +215,7 @@ public class ExploreRuntimeModule extends RuntimeModule {
     @Override
     protected void configure() {
       try {
-        CConfiguration cConf = CConfiguration.create();
-        File tmpDir = new File(new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR)),
-                               cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
-        tmpDir.mkdirs();
-        setupClasspath(tmpDir);
-
-        // Set local tmp dir to an absolute location in the twill runnable otherwise Hive complains
-        String localScratchPath = System.getProperty("java.io.tmpdir") + File.separator +
-          "hive-" + System.getProperty("user.name");
-        System.setProperty(HiveConf.ConfVars.LOCALSCRATCHDIR.toString(),
-                           new File(localScratchPath).getAbsolutePath());
-        LOG.info("Setting {} to {}", HiveConf.ConfVars.LOCALSCRATCHDIR.toString(),
-                 System.getProperty(HiveConf.ConfVars.LOCALSCRATCHDIR.toString()));
-
+        // In distributed mode, the temp directory is always set to the container local directory
         File previewDir = Files.createTempDir();
         LOG.info("Storing preview files in {}", previewDir.getAbsolutePath());
         bind(File.class).annotatedWith(Names.named(Constants.Explore.PREVIEWS_DIR_NAME)).toInstance(previewDir);
@@ -263,87 +233,5 @@ public class ExploreRuntimeModule extends RuntimeModule {
       LOG.info("Using Explore service class {}", hiveExploreServiceCl.getName());
       return injector.getInstance(hiveExploreServiceCl);
     }
-  }
-
-  private static void setupClasspath(File tmpDir) throws IOException {
-    // Here we find the transitive dependencies and remove all paths that come from the boot class path -
-    // those paths are not needed because the new JVM will have them in its boot class path.
-    // It could even be wrong to keep them because in the target container, the boot class path may be different
-    // (for example, if Hadoop uses a different Java version than CDAP).
-
-    final Set<String> bootstrapClassPaths = ExploreServiceUtils.getBoostrapClasses();
-
-    ClassAcceptor classAcceptor = new ClassAcceptor() {
-       /* Excluding any class contained in the bootstrapClassPaths and Kryo classes and hive-exec.jar
-        * We need to remove Kryo dependency in the Explore container. Spark introduced version 2.21 version of Kryo,
-        * which would be normally shipped to the Explore container. Yet, Hive requires Kryo 2.22,
-        * and gets it from the Hive jars - hive-exec.jar to be precise.
-        * we also exclude hive jars as hive dependencies are found in job.jar.
-        * */
-      @Override
-      public boolean accept(String className, URL classUrl, URL classPathUrl) {
-        if (bootstrapClassPaths.contains(classPathUrl.getFile()) ||
-          className.startsWith("com.esotericsoftware.kryo") || classPathUrl.getFile().contains("hive")) {
-          return false;
-        }
-        return true;
-      }
-    };
-
-    Set<File> hBaseTableDeps = ExploreServiceUtils.traceDependencies(
-      null, classAcceptor, tmpDir, HBaseTableUtilFactory.getHBaseTableUtilClass().getName());
-
-    // Note the order of dependency jars is important so that HBase jars come first in the classpath order
-    // LinkedHashSet maintains insertion order while removing duplicate entries.
-    Set<File> orderedDependencies = new LinkedHashSet<>();
-    orderedDependencies.addAll(hBaseTableDeps);
-    orderedDependencies.addAll(ExploreServiceUtils.traceDependencies(null, classAcceptor, tmpDir,
-                                                                     RemoteDatasetFramework.class.getName(),
-                                                                     DatasetStorageHandler.class.getName(),
-                                                                     RecordFormats.class.getName()));
-
-    // Note: the class path entries need to be prefixed with "file://" for the jars to work when
-    // Hive starts local map-reduce job.
-    ImmutableList.Builder<String> builder = ImmutableList.builder();
-    for (File dep : orderedDependencies) {
-      builder.add("file://" + dep.getAbsolutePath());
-    }
-    List<String> orderedDependenciesStr = builder.build();
-
-    // These dependency files need to be copied over to spark container
-    System.setProperty(BaseHiveExploreService.SPARK_YARN_DIST_FILES,
-                       Joiner.on(',').join(Iterables.transform(orderedDependencies, new Function<File, String>() {
-                         @Override
-                         public String apply(File input) {
-                           return input.getAbsolutePath();
-                         }
-                       })));
-    LOG.debug("Setting {} to {}", BaseHiveExploreService.SPARK_YARN_DIST_FILES,
-              System.getProperty(BaseHiveExploreService.SPARK_YARN_DIST_FILES));
-
-    // These dependency files need to be copied over to hive job container
-    System.setProperty(HiveConf.ConfVars.HIVEAUXJARS.toString(), Joiner.on(',').join(orderedDependenciesStr));
-    LOG.debug("Setting {} to {}", HiveConf.ConfVars.HIVEAUXJARS.toString(),
-              System.getProperty(HiveConf.ConfVars.HIVEAUXJARS.toString()));
-
-    // add hive-exec.jar to the HADOOP_CLASSPATH, which is used by the local mapreduce job launched by hive ,
-    // we need to add this, otherwise when hive runs a MapRedLocalTask it cannot find
-    // "org.apache.hadoop.hive.serde2.SerDe" class in its classpath.
-    List<String> orderedDependenciesWithHiveJar = Lists.newArrayList(orderedDependenciesStr);
-    String hiveExecJar = new JobConf(org.apache.hadoop.hive.ql.exec.Task.class).getJar();
-    Preconditions.checkNotNull(hiveExecJar, "Couldn't locate hive-exec.jar to be included in HADOOP_CLASSPATH " +
-      "for MapReduce jobs launched by Hive");
-    orderedDependenciesWithHiveJar.add(hiveExecJar);
-    LOG.debug("Added hive-exec.jar {} to HADOOP_CLASSPATH to be included for MapReduce jobs launched by Hive",
-              hiveExecJar);
-
-    //TODO: Setup HADOOP_CLASSPATH hack, more info on why this is needed, see CDAP-9
-    LocalMapreduceClasspathSetter classpathSetter =
-      new LocalMapreduceClasspathSetter(new HiveConf(), tmpDir.getAbsolutePath(),
-                                        orderedDependenciesWithHiveJar);
-    for (File jar : hBaseTableDeps) {
-      classpathSetter.accept(jar.getAbsolutePath());
-    }
-    classpathSetter.setupClasspathScript();
   }
 }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreServiceUtils.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreServiceUtils.java
@@ -17,31 +17,18 @@
 package co.cask.cdap.explore.service;
 
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
-import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
-import co.cask.cdap.explore.guice.ExploreRuntimeModule;
 import co.cask.cdap.explore.service.hive.Hive12CDH5ExploreService;
 import co.cask.cdap.explore.service.hive.Hive12ExploreService;
 import co.cask.cdap.explore.service.hive.Hive13ExploreService;
 import co.cask.cdap.explore.service.hive.Hive14ExploreService;
 import co.cask.cdap.hive.ExploreUtils;
-import co.cask.cdap.internal.app.runtime.spark.SparkUtils;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Joiner;
-import com.google.common.base.Splitter;
+import com.google.common.base.Objects;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import com.google.common.io.ByteStreams;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.mapreduce.Job;
-import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.util.VersionInfo;
-import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.apache.tez.dag.api.TezConfiguration;
-import org.apache.twill.api.ClassAcceptor;
-import org.apache.twill.internal.utils.Dependencies;
+import org.apache.hive.service.auth.HiveAuthFactory;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
@@ -55,24 +42,12 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.Arrays;
 import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
 import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
 import javax.annotation.Nullable;
 
 /**
@@ -86,7 +61,7 @@ public class ExploreServiceUtils {
   /**
    * Hive support enum.
    */
-  public enum HiveSupport {
+  private enum HiveSupport {
     // The order of the enum values below is very important
     // CDH 5.0 to 5.1 uses Hive 0.12
     HIVE_CDH5_0(Pattern.compile("^.*cdh5.0\\..*$"), Hive12CDH5ExploreService.class),
@@ -121,22 +96,14 @@ public class ExploreServiceUtils {
     }
   }
 
-  // Caching the dependencies so that we don't trace them twice
-  private static Set<File> exploreDependencies = null;
-
-  private static final Pattern HIVE_SITE_FILE_PATTERN = Pattern.compile("^.*/hive-site\\.xml$");
-  private static final Pattern YARN_SITE_FILE_PATTERN = Pattern.compile("^.*/yarn-site\\.xml$");
-  private static final Pattern MAPRED_SITE_FILE_PATTERN = Pattern.compile("^.*/mapred-site\\.xml$");
-  private static final Pattern TEZ_SITE_FILE_PATTERN = Pattern.compile("^.*/tez-site\\.xml$");
-
   public static Class<? extends ExploreService> getHiveService() {
     HiveSupport hiveVersion = checkHiveSupport(null);
     return hiveVersion.getHiveExploreServiceClass();
   }
 
-  public static boolean shouldEscapeColumns(Configuration hConf) {
+  static boolean shouldEscapeColumns(Configuration hConf) {
     // backtick support was added in Hive13.
-    ExploreServiceUtils.HiveSupport hiveSupport = ExploreServiceUtils.checkHiveSupport(hConf.getClassLoader());
+    ExploreServiceUtils.HiveSupport hiveSupport = checkHiveSupport(hConf.getClassLoader());
     if (hiveSupport == HiveSupport.HIVE_12
       || hiveSupport == HiveSupport.HIVE_CDH5_0
       || hiveSupport == HiveSupport.HIVE_CDH5_1) {
@@ -160,12 +127,8 @@ public class ExploreServiceUtils {
     return getHiveVersion(ExploreUtils.getExploreClassloader());
   }
 
-  public static String getHiveVersion(@Nullable ClassLoader hiveClassLoader) {
-    ClassLoader usingCL = hiveClassLoader;
-    if (usingCL == null) {
-      usingCL = ExploreServiceUtils.class.getClassLoader();
-    }
-
+  private static String getHiveVersion(@Nullable ClassLoader hiveClassLoader) {
+    ClassLoader usingCL = Objects.firstNonNull(hiveClassLoader, ExploreServiceUtils.class.getClassLoader());
     try {
       Class<?> hiveVersionInfoClass = usingCL.loadClass("org.apache.hive.common.util.HiveVersionInfo");
       return (String) hiveVersionInfoClass.getDeclaredMethod("getVersion").invoke(null);
@@ -207,407 +170,67 @@ public class ExploreServiceUtils {
   }
 
   /**
-   * Return the list of absolute paths of the bootstrap classes.
-   */
-  public static Set<String> getBoostrapClasses() {
-    ImmutableSet.Builder<String> builder = ImmutableSet.builder();
-    for (String classpath : Splitter.on(File.pathSeparatorChar).split(System.getProperty("sun.boot.class.path"))) {
-      File file = new File(classpath);
-      builder.add(file.getAbsolutePath());
-      try {
-        builder.add(file.getCanonicalPath());
-      } catch (IOException e) {
-        LOG.warn("Could not add canonical path to aux class path for file {}", file.toString(), e);
-      }
-    }
-    return builder.build();
-  }
-
-  /**
-   * Trace the jar dependencies needed by the Explore container. Uses a separate class loader to load Hive classes,
-   * built using the explore classpath passed as a system property to master.
+   * Rewrite the {@link HiveAuthFactory} class in the given source jar. The rewrite is for skipping kerberos
+   * authentication from the explore service container.
    *
-   * @return an ordered set of jar files.
+   * @param sourceJar the source jar to look for the {@link HiveAuthFactory} class.
+   * @param targetJar the target jar to write to if rewrite happened
+   * @return the source jar if there is no rewrite happened; the target jar if rewrite happened.
+   * @throws IOException if failed to read/write to the jar files.
    */
-  public static Set<File> traceExploreDependencies(File tmpDir) throws IOException {
-    if (exploreDependencies != null) {
-      return exploreDependencies;
-    }
-
-    ClassLoader classLoader = ExploreUtils.getExploreClassloader();
-    Set<File> additionalJars = new HashSet<>();
-    if (isSparkAvailable()) {
-      File sparkAssemblyJar = SparkUtils.locateSparkAssemblyJar();
-      LOG.debug("Adding spark jar to explore dependency {}", sparkAssemblyJar);
-      additionalJars.add(sparkAssemblyJar);
-    }
-    if (isTezAvailable()) {
-      additionalJars.addAll(getTezJars());
-    }
-    return traceExploreDependencies(classLoader, tmpDir, additionalJars);
-  }
-
-  /**
-   * Trace the jar dependencies needed by the Explore container.
-   *
-   * @param classLoader class loader to use to trace the dependencies.
-   *                    If it is null, use the class loader of this class.
-   * @param tmpDir temporary directory for storing rewritten jar files.
-   * @param additionalJars additional jars that will be added to the end of the returned set.
-   * @return an ordered set of jar files.
-   */
-  private static Set<File> traceExploreDependencies(ClassLoader classLoader, File tmpDir, Set<File> additionalJars)
-    throws IOException {
-    if (exploreDependencies != null) {
-      return exploreDependencies;
-    }
-
-    ClassLoader usingCL = classLoader;
-    if (classLoader == null) {
-      usingCL = ExploreRuntimeModule.class.getClassLoader();
-    }
-
-    final Set<String> bootstrapClassPaths = getBoostrapClasses();
-
-    ClassAcceptor classAcceptor = new ClassAcceptor() {
-      /* Excluding any class contained in the bootstrapClassPaths and Kryo classes.
-        * We need to remove Kryo dependency in the Explore container. Spark introduced version 2.21 version of Kryo,
-        * which would be normally shipped to the Explore container. Yet, Hive requires Kryo 2.22,
-        * and gets it from the Hive jars - hive-exec.jar to be precise.
-        * */
-      @Override
-      public boolean accept(String className, URL classUrl, URL classPathUrl) {
-        return !(bootstrapClassPaths.contains(classPathUrl.getFile()) ||
-          className.startsWith("com.esotericsoftware.kryo"));
-      }
-    };
-
-    Set<File> hBaseTableDeps = traceDependencies(usingCL, classAcceptor, tmpDir,
-                                                 HBaseTableUtilFactory.getHBaseTableUtilClass().getName());
-
-    // Note the order of dependency jars is important so that HBase jars come first in the classpath order
-    // LinkedHashSet maintains insertion order while removing duplicate entries.
-    Set<File> orderedDependencies = new LinkedHashSet<>();
-    orderedDependencies.addAll(hBaseTableDeps);
-    orderedDependencies.addAll(traceDependencies(usingCL, classAcceptor, tmpDir,
-                                                 DatasetService.class.getName(),
-                                                 // Referred to by string rather than Class.getName()
-                                                 // because DatasetStorageHandler and StreamStorageHandler
-                                                 // extend a Hive class, which isn't present in this class loader
-                                                 "co.cask.cdap.hive.datasets.DatasetStorageHandler",
-                                                 "co.cask.cdap.hive.stream.StreamStorageHandler",
-                                                 "org.apache.hadoop.hive.ql.exec.mr.ExecDriver",
-                                                 "org.apache.hive.service.cli.CLIService",
-                                                 "org.apache.hadoop.mapred.YarnClientProtocolProvider",
-                                                 // Needed for - at least - CDH 4.4 integration
-                                                 "org.apache.hive.builtins.BuiltinUtils",
-                                                 // Needed for - at least - CDH 5 integration
-                                                 "org.apache.hadoop.hive.shims.Hadoop23Shims"));
-    orderedDependencies.addAll(additionalJars);
-
-    exploreDependencies = orderedDependencies;
-    return orderedDependencies;
-  }
-
-  /**
-   * Trace the dependencies files of the given className, using the classLoader,
-   * and including the classes that's accepted by the classAcceptor
-   *
-   * Nothing is returned if the classLoader, or if not provided, the ExploreRuntimeModule class loader,
-   * does not contain the className.
-   */
-  public static Set<File> traceDependencies(@Nullable ClassLoader classLoader, final ClassAcceptor classAcceptor,
-                                            File tmpDir, String... classNames) throws IOException {
-    LOG.debug("Tracing dependencies for classes: {}", Arrays.toString(classNames));
-
-    ClassLoader usingCL = classLoader;
-    if (usingCL == null) {
-      usingCL = ExploreRuntimeModule.class.getClassLoader();
-    }
-
-    final String rewritingClassName = HIVE_AUTHFACTORY_CLASS_NAME;
-    final Set<File> rewritingFiles = Sets.newHashSet();
-
-    final Set<File> jarFiles = Sets.newHashSet();
-    Dependencies.findClassDependencies(
-      usingCL,
-      new ClassAcceptor() {
-        @Override
-        public boolean accept(String className, URL classUrl, URL classPathUrl) {
-          if (!classAcceptor.accept(className, classUrl, classPathUrl)) {
-            return false;
-          }
-
-          if (rewritingClassName.equals(className)) {
-            rewritingFiles.add(new File(classPathUrl.getFile()));
-          }
-
-          jarFiles.add(new File(classPathUrl.getFile()));
-          return true;
-        }
-      },
-      classNames
-    );
-
-    // Rewrite HiveAuthFactory.loginFromKeytab to be a no-op method.
-    // This is needed because we don't want to use Hive's CLIService since
-    // we're already using delegation tokens
-    for (File rewritingFile : rewritingFiles) {
-      // TODO: this may cause lots of rewrites since we may rewrite the same jar multiple times
-      File rewrittenJar = rewriteHiveAuthFactory(
-        rewritingFile, new File(tmpDir, rewritingFile.getName() + "-" + System.currentTimeMillis() + ".jar"));
-      jarFiles.add(rewrittenJar);
-      LOG.debug("Rewrote {} to {}", rewritingFile.getAbsolutePath(), rewrittenJar.getAbsolutePath());
-    }
-    jarFiles.removeAll(rewritingFiles);
-
-    if (LOG.isDebugEnabled()) {
-      for (File jarFile : jarFiles) {
-        LOG.debug("Added jar {}", jarFile.getAbsolutePath());
-      }
-    }
-
-    return jarFiles;
-  }
-
-  @VisibleForTesting
-  static File rewriteHiveAuthFactory(File sourceJar, File targetJar) throws IOException {
-    try (
-      JarFile input = new JarFile(sourceJar);
-      JarOutputStream output = new JarOutputStream(new FileOutputStream(targetJar))
-    ) {
+  public static File rewriteHiveAuthFactory(File sourceJar, File targetJar) throws IOException {
+    try (JarFile input = new JarFile(sourceJar)) {
       String hiveAuthFactoryPath = HIVE_AUTHFACTORY_CLASS_NAME.replace('.', '/') + ".class";
+      ZipEntry hiveAuthFactoryEntry = input.getEntry(hiveAuthFactoryPath);
 
-      Enumeration<JarEntry> sourceEntries = input.entries();
-      while (sourceEntries.hasMoreElements()) {
-        JarEntry entry = sourceEntries.nextElement();
-        output.putNextEntry(new JarEntry(entry.getName()));
+      // If the given jar doesn't contain the hive auth factory class, just return the source jar.
+      if (hiveAuthFactoryEntry == null) {
+        return sourceJar;
+      }
 
-        try (InputStream entryInputStream = input.getInputStream(entry)) {
-          if (!hiveAuthFactoryPath.equals(entry.getName())) {
-            ByteStreams.copy(entryInputStream, output);
-            continue;
-          }
+      // Copy all the entries from the source jar and return the hive auth factory class during the process.
+      try (JarOutputStream output = new JarOutputStream(new FileOutputStream(targetJar))) {
+        Enumeration<JarEntry> sourceEntries = input.entries();
+        while (sourceEntries.hasMoreElements()) {
+          JarEntry entry = sourceEntries.nextElement();
+          output.putNextEntry(new JarEntry(entry.getName()));
 
-          try {
-            // Rewrite the bytecode of HiveAuthFactory.loginFromKeytab method to a no-op method
-            ClassReader cr = new ClassReader(entryInputStream);
-            ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
-            cr.accept(new ClassVisitor(Opcodes.ASM5, cw) {
-              @Override
-              public MethodVisitor visitMethod(final int access, final String name, final String desc,
-                                               String signature, String[] exceptions) {
-                MethodVisitor methodVisitor = super.visitMethod(access, name, desc, signature, exceptions);
-                if (!"loginFromKeytab".equals(name)) {
-                  return methodVisitor;
+          try (InputStream entryInputStream = input.getInputStream(entry)) {
+            if (!hiveAuthFactoryPath.equals(entry.getName())) {
+              ByteStreams.copy(entryInputStream, output);
+              continue;
+            }
+
+            try {
+              // Rewrite the bytecode of HiveAuthFactory.loginFromKeytab method to a no-op method
+              ClassReader cr = new ClassReader(entryInputStream);
+              ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+              cr.accept(new ClassVisitor(Opcodes.ASM5, cw) {
+                @Override
+                public MethodVisitor visitMethod(final int access, final String name, final String desc,
+                                                 String signature, String[] exceptions) {
+                  MethodVisitor methodVisitor = super.visitMethod(access, name, desc, signature, exceptions);
+                  if (!"loginFromKeytab".equals(name)) {
+                    return methodVisitor;
+                  }
+                  GeneratorAdapter adapter = new GeneratorAdapter(methodVisitor, access, name, desc);
+                  adapter.returnValue();
+
+                  // VisitMaxs with 0 so that COMPUTE_MAXS from ClassWriter will compute the right values.
+                  adapter.visitMaxs(0, 0);
+                  return new MethodVisitor(Opcodes.ASM5) {
+                  };
                 }
-                GeneratorAdapter adapter = new GeneratorAdapter(methodVisitor, access, name, desc);
-                adapter.returnValue();
-
-                // VisitMaxs with 0 so that COMPUTE_MAXS from ClassWriter will compute the right values.
-                adapter.visitMaxs(0, 0);
-                return new MethodVisitor(Opcodes.ASM5) { };
-              }
-            }, 0);
-            output.write(cw.toByteArray());
-          } catch (Exception e) {
-            throw new IOException("Unable to generate HiveAuthFactory class", e);
+              }, 0);
+              output.write(cw.toByteArray());
+            } catch (Exception e) {
+              throw new IOException("Unable to generate HiveAuthFactory class", e);
+            }
           }
         }
       }
 
       return targetJar;
-    }
-  }
-
-  /**
-   * Updates environment variables in hive-site.xml, mapred-site.xml and yarn-site.xml for explore.
-   * All other conf files are returned without any update.
-   * @param confFile conf file to update
-   * @param tempDir temp dir to create files if necessary
-   * @param cdapJars set of cdap jar files to be added in the beginning of the classpath
-   * @return the new conf file to use in place of confFile
-   */
-  public static File updateConfFileForExplore(File confFile, File tempDir, Set<File> cdapJars) {
-    if (HIVE_SITE_FILE_PATTERN.matcher(confFile.getAbsolutePath()).matches()) {
-      return updateHiveConfFile(confFile, tempDir);
-    } else if (YARN_SITE_FILE_PATTERN.matcher(confFile.getAbsolutePath()).matches()) {
-      return updateYarnConfFile(confFile, tempDir, cdapJars);
-    } else if (MAPRED_SITE_FILE_PATTERN.matcher(confFile.getAbsolutePath()).matches()) {
-      return updateMapredConfFile(confFile, tempDir, cdapJars);
-    } else if (TEZ_SITE_FILE_PATTERN.matcher(confFile.getAbsolutePath()).matches()) {
-      return updateTezConfFile(confFile, tempDir, cdapJars);
-    } else {
-      return confFile;
-    }
-  }
-
-  /**
-   * Change yarn-site.xml file, and return a temp copy of it to which are added
-   * necessary options.
-   */
-  private static File updateYarnConfFile(File confFile, File tempDir, Set<File> cdapJars) {
-    Configuration conf = new Configuration(false);
-    try {
-      conf.addResource(confFile.toURI().toURL());
-    } catch (MalformedURLException e) {
-      LOG.error("File {} is malformed.", confFile, e);
-      throw Throwables.propagate(e);
-    }
-
-    String yarnAppClassPath = conf.get(YarnConfiguration.YARN_APPLICATION_CLASSPATH,
-                                       Joiner.on(",").join(YarnConfiguration.DEFAULT_YARN_APPLICATION_CLASSPATH));
-
-    // We add cdap jars to the classpath in the beginning. We then add the pwd/* to the classpath.
-    // So user's jar will take precedence. Without pwd/* in the beginning of classpath, job.jar will be at
-    // the beginning of the classpath. Since job.jar has old guava version classes, we want to add pwd/* before.
-    String cdapJarsClassPath = "";
-    for (File cdapJar : cdapJars) {
-      cdapJarsClassPath = cdapJarsClassPath + "$PWD/" + cdapJar.getName() + ",";
-    }
-
-    yarnAppClassPath = cdapJarsClassPath + "$PWD/*," + yarnAppClassPath;
-
-    LOG.debug("Setting yarn.application.classpath to {}", yarnAppClassPath);
-    conf.set(YarnConfiguration.YARN_APPLICATION_CLASSPATH, yarnAppClassPath);
-
-    File newYarnConfFile = new File(tempDir, "yarn-site.xml");
-    try (FileOutputStream os = new FileOutputStream(newYarnConfFile)) {
-      conf.writeXml(os);
-    } catch (IOException e) {
-      LOG.error("Problem creating and writing to temporary yarn-conf.xml conf file at {}", newYarnConfFile, e);
-      throw Throwables.propagate(e);
-    }
-
-    return newYarnConfFile;
-  }
-
-  /**
-   * Change mapred-site.xml file, and return a temp copy of it to which are added
-   * necessary options.
-   */
-  private static File updateMapredConfFile(File confFile, File tempDir, Set<File> cdapJars) {
-    Configuration conf = new Configuration(false);
-    try {
-      conf.addResource(confFile.toURI().toURL());
-    } catch (MalformedURLException e) {
-      LOG.error("File {} is malformed.", confFile, e);
-      throw Throwables.propagate(e);
-    }
-
-    String mrAppClassPath = conf.get(MRJobConfig.MAPREDUCE_APPLICATION_CLASSPATH,
-                                     MRJobConfig.DEFAULT_MAPREDUCE_APPLICATION_CLASSPATH);
-
-    // We add cdap jars to the classpath in the beginning. We then add the pwd/* to the classpath.
-    // so user's jar will take precedence. Without pwd/* in the beginning of classpath, job.jar will be at
-    // the beginning of the classpath. Since job.jar has old guava version classes, we want to add pwd/* before.
-    String cdapJarsClassPath = "";
-    for (File cdapJar : cdapJars) {
-      cdapJarsClassPath = cdapJarsClassPath + "$PWD/" + cdapJar.getName() + ",";
-    }
-    mrAppClassPath = cdapJarsClassPath + "$PWD/*," + mrAppClassPath;
-
-    LOG.debug("Setting mapreduce.application.classpath to {}", mrAppClassPath);
-    conf.set(MRJobConfig.MAPREDUCE_APPLICATION_CLASSPATH, mrAppClassPath);
-
-    File newMapredConfFile = new File(tempDir, "mapred-site.xml");
-    try (FileOutputStream os = new FileOutputStream(newMapredConfFile)) {
-      conf.writeXml(os);
-    } catch (IOException e) {
-      LOG.error("Problem creating and writing to temporary mapred-site.xml conf file at {}", newMapredConfFile, e);
-      throw Throwables.propagate(e);
-    }
-
-    return newMapredConfFile;
-  }
-
-  /**
-   * Change tez-site.xml file, and return a temp copy of it to which are added
-   * necessary options.
-   */
-  private static File updateTezConfFile(File confFile, File tempDir, Set<File> cdapJars) {
-    Configuration conf = new Configuration(false);
-    try {
-      conf.addResource(confFile.toURI().toURL());
-    } catch (MalformedURLException e) {
-      LOG.error("File {} is malformed.", confFile, e);
-      throw Throwables.propagate(e);
-    }
-
-    // We add cdap jars to the classpath in the beginning.
-    String tezClassPath = conf.get(TezConfiguration.TEZ_CLUSTER_ADDITIONAL_CLASSPATH_PREFIX);
-
-    String cdapJarsClassPath = "";
-    for (File cdapJar : cdapJars) {
-      // Note that Tez expects the classpath seperator as ":"
-      cdapJarsClassPath = cdapJarsClassPath + "$PWD/" + cdapJar.getName() + File.pathSeparator;
-    }
-    String additionalClassPath = cdapJarsClassPath;
-    if (tezClassPath != null && !tezClassPath.trim().isEmpty()) {
-      additionalClassPath = cdapJarsClassPath + tezClassPath;
-    }
-
-    LOG.debug(String.format("Setting %s to %s",
-                            TezConfiguration.TEZ_CLUSTER_ADDITIONAL_CLASSPATH_PREFIX, additionalClassPath));
-
-    conf.set(TezConfiguration.TEZ_CLUSTER_ADDITIONAL_CLASSPATH_PREFIX, additionalClassPath);
-    File newTezConfFile = new File(tempDir, "tez-site.xml");
-    try (FileOutputStream os = new FileOutputStream(newTezConfFile)) {
-      conf.writeXml(os);
-    } catch (IOException e) {
-      LOG.error("Problem creating and writing to temporary tez-site.xml conf file at {}", newTezConfFile, e);
-      throw Throwables.propagate(e);
-    }
-
-    return newTezConfFile;
-  }
-
-  /**
-   * Change hive-site.xml file, and return a temp copy of it to which are added
-   * necessary options.
-   */
-  private static File updateHiveConfFile(File confFile, File tempDir) {
-    Configuration conf = new Configuration(false);
-    try {
-      conf.addResource(confFile.toURI().toURL());
-    } catch (MalformedURLException e) {
-      LOG.error("File {} is malformed.", confFile, e);
-      throw Throwables.propagate(e);
-    }
-
-    // we prefer jars at container's root directory before job.jar,
-    // we edit the YARN_APPLICATION_CLASSPATH in yarn-site.xml using
-    // co.cask.cdap.explore.service.ExploreServiceUtils.updateYarnConfFile and
-    // setting the MAPREDUCE_JOB_CLASSLOADER and MAPREDUCE_JOB_USER_CLASSPATH_FIRST to false will put
-    // YARN_APPLICATION_CLASSPATH before job.jar for container's classpath.
-    conf.setBoolean(Job.MAPREDUCE_JOB_USER_CLASSPATH_FIRST, false);
-    conf.setBoolean(MRJobConfig.MAPREDUCE_JOB_CLASSLOADER, false);
-
-    String sparkHome = System.getenv(Constants.SPARK_HOME);
-    if (sparkHome != null) {
-      LOG.debug("Setting spark.home in hive conf to {}", sparkHome);
-      conf.set("spark.home", sparkHome);
-    }
-
-    File newHiveConfFile = new File(tempDir, "hive-site.xml");
-
-    try (FileOutputStream os = new FileOutputStream(newHiveConfFile)) {
-      conf.writeXml(os);
-    } catch (IOException e) {
-      LOG.error("Problem creating temporary hive-site.xml conf file at {}", newHiveConfFile, e);
-      throw Throwables.propagate(e);
-    }
-    return newHiveConfFile;
-  }
-
-  public static boolean isSparkAvailable() {
-    try {
-      // SparkUtils.locateSparkAssemblyJar() throws IllegalStateException if it is not able to locate spark jar
-      SparkUtils.locateSparkAssemblyJar();
-      return true;
-    } catch (IllegalStateException e) {
-      LOG.debug("Got exception while determining spark availability", e);
-      return false;
     }
   }
 
@@ -617,38 +240,4 @@ public class ExploreServiceUtils {
     return "spark".equalsIgnoreCase(engine);
   }
 
-  // This method is used to determine if Tez is enabled based on TEZ_HOME environment variable.
-  // Master prepares the explore container by adding jars available in TEZ_HOME.
-  // However this environment variable is not available to explore container itself(BaseHiveService).
-  // There we check the existence of tez using hive.execution.engine config variable.
-  private static boolean isTezAvailable() {
-    return System.getenv(Constants.TEZ_HOME) != null;
-  }
-
-  private static Set<File> getTezJars() {
-    String tezHome = System.getenv(Constants.TEZ_HOME);
-    Path tezHomeDir = Paths.get(tezHome);
-    final PathMatcher pathMatcher = tezHomeDir.getFileSystem().getPathMatcher("glob:*.jar");
-    final Set<File> tezJars = new HashSet<>();
-    try {
-      Files.walkFileTree(tezHomeDir, new SimpleFileVisitor<Path>() {
-        @Override
-        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-          if (attrs.isRegularFile() && pathMatcher.matches(file.getFileName())) {
-            tezJars.add(file.toFile());
-          }
-          return FileVisitResult.CONTINUE;
-        }
-
-        @Override
-        public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
-          // Ignore error
-          return FileVisitResult.CONTINUE;
-        }
-      });
-    } catch (IOException e) {
-      LOG.warn("Exception raised while inspecting {}", tezHomeDir, e);
-    }
-    return tezJars;
-  }
 }

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -162,6 +162,11 @@
       <artifactId>hbase-protocol</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.tez</groupId>
+      <artifactId>tez-api</artifactId>
+    </dependency>
+
     <!-- for tools -->
     <dependency>
       <groupId>commons-cli</groupId>

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ExploreServiceTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ExploreServiceTwillRunnable.java
@@ -39,6 +39,7 @@ import co.cask.cdap.data2.audit.AuditModule;
 import co.cask.cdap.explore.executor.ExploreExecutorService;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.explore.guice.ExploreRuntimeModule;
+import co.cask.cdap.explore.service.hive.BaseHiveExploreService;
 import co.cask.cdap.internal.app.store.DefaultStore;
 import co.cask.cdap.logging.appender.LogAppenderInitializer;
 import co.cask.cdap.logging.guice.LoggingModules;
@@ -52,20 +53,56 @@ import co.cask.cdap.security.authorization.RemotePrivilegesManager;
 import co.cask.cdap.security.guice.SecureStoreModules;
 import co.cask.cdap.security.spi.authorization.PrivilegesManager;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
+import com.google.common.base.Joiner;
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.Service;
+import com.google.gson.Gson;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.MRJobConfig;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.twill.api.TwillContext;
+import org.apache.twill.api.TwillRunnableSpecification;
 import org.apache.twill.kafka.client.KafkaClientService;
 import org.apache.twill.zookeeper.ZKClientService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
 import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Service for the Explore module that runs user queries in a Twill runnable.
@@ -73,36 +110,60 @@ import java.util.List;
  */
 public class ExploreServiceTwillRunnable extends AbstractMasterTwillRunnable {
   private static final Logger LOG = LoggerFactory.getLogger(ExploreServiceTwillRunnable.class);
+  private static final Function<URL, String> URL_TO_PATH = new Function<URL, String>() {
+    @Override
+    public String apply(URL url) {
+      return url.getPath();
+    }
+  };
 
   private Injector injector;
+  private Set<String> exploreDependencies;
 
-  public ExploreServiceTwillRunnable(String name, String cConfName, String hConfName) {
+  public ExploreServiceTwillRunnable(String name, String cConfName, String hConfName,
+                                     Iterable<String> exploreDependencies) {
     super(name, cConfName, hConfName);
+    this.exploreDependencies = Sets.newHashSet(exploreDependencies);
+  }
+
+  @Override
+  public TwillRunnableSpecification configure() {
+    TwillRunnableSpecification spec = super.configure();
+    return TwillRunnableSpecification.Builder.with()
+      .setName(spec.getName())
+      .withConfigs(ImmutableMap.<String, String>builder()
+                     .putAll(spec.getConfigs())
+                     .put("explore.dependencies", new Gson().toJson(exploreDependencies))
+                     .build()
+      )
+      .build();
   }
 
   @Override
   protected void doInit(TwillContext context) {
+    exploreDependencies = new Gson().fromJson(context.getSpecification().getConfigs().get("explore.dependencies"),
+                                              new TypeToken<Set<String>>() { }.getType());
+    setupHive();
+
     CConfiguration cConf = getCConfiguration();
     Configuration hConf = getConfiguration();
-    URL hiveSiteURL = getClass().getClassLoader().getResource("hive-site.xml");
-    if (hiveSiteURL == null) {
-      // should not happen, as its added as a twill resource in MasterServiceMain
-      LOG.warn("hive-site.xml could not be found as a resource.");
-    } else {
-      hConf.addResource(hiveSiteURL);
-    }
+
+    addResource(hConf, "yarn-site.xml");
+    addResource(hConf, "mapred-site.xml");
+    addResource(hConf, "hive-site.xml");
+    addResource(hConf, "tez-site.xml");
+
+    // Set the host name to the one provided by Twill
+    cConf.set(Constants.Explore.SERVER_ADDRESS, context.getHost().getHostName());
 
     // NOTE: twill client will try to load all the classes present here - including hive classes but it
     // will fail since Hive classes are not in master classpath, and ignore those classes silently
     injector = createInjector(cConf, hConf);
-
     injector.getInstance(LogAppenderInitializer.class).initialize();
 
     LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(NamespaceId.SYSTEM.getNamespace(),
                                                                        Constants.Logging.COMPONENT_NAME,
                                                                        Constants.Service.EXPLORE_HTTP_USER_SERVICE));
-    // Set the host name to the one provided by Twill
-    cConf.set(Constants.Explore.SERVER_ADDRESS, context.getHost().getHostName());
   }
 
   @Override
@@ -111,6 +172,230 @@ public class ExploreServiceTwillRunnable extends AbstractMasterTwillRunnable {
     services.add(injector.getInstance(KafkaClientService.class));
     services.add(injector.getInstance(AuthorizationEnforcementService.class));
     services.add(injector.getInstance(ExploreExecutorService.class));
+  }
+
+  /**
+   * Adds the given resource loaded from the current context classloader to the given {@link Configuration}.
+   */
+  private void addResource(Configuration hConf, String resource) {
+    URL url = Thread.currentThread().getContextClassLoader().getResource(resource);
+    if (url == null) {
+      LOG.warn("{} could not be found as a resource.", resource);
+    } else {
+      LOG.info("Adding {} as configuration resource", url);
+      hConf.addResource(url);
+    }
+  }
+
+  /**
+   * Returns the {@link URL} of the given resource loaded from the current context classloader if it is a local
+   * resource. {@code null} will be returned if either resource is not found or is not a local resource.
+   */
+  @Nullable
+  private URL getLocalResourceURL(String resource) {
+    URL resourceURL = Thread.currentThread().getContextClassLoader().getResource(resource);
+    if (resourceURL == null) {
+      return null;
+    }
+
+    if (!"file".equals(resourceURL.getProtocol())) {
+      return null;
+    }
+    return resourceURL;
+  }
+
+  /**
+   * Returns the file name (the path after the last '/') of the given {@link URL}.
+   */
+  private String getFileName(URL url) {
+    String path = url.getPath();
+    int idx = path.lastIndexOf('/');
+    return idx < 0 ? path : path.substring(idx + 1);
+  }
+
+  /**
+   * Setup the environment needed by the embedded HiveServer2.
+   */
+  private void setupHive() {
+    // Set local tmp dir to an absolute location in the twill runnable otherwise Hive complains
+    File tmpDir = new File(System.getProperty("java.io.tmpdir")).getAbsoluteFile();
+    File localScratchFile = new File(tmpDir, "hive-" + System.getProperty("user.name"));
+    System.setProperty(HiveConf.ConfVars.LOCALSCRATCHDIR.toString(), localScratchFile.getAbsolutePath());
+    LOG.info("Setting {} to {}", HiveConf.ConfVars.LOCALSCRATCHDIR.toString(),
+             System.getProperty(HiveConf.ConfVars.LOCALSCRATCHDIR.toString()));
+
+    ClassLoader classLoader = Objects.firstNonNull(Thread.currentThread().getContextClassLoader(),
+                                                   getClass().getClassLoader());
+
+    // The current classloader should be a URLClassLoader, otherwise, nothing much we can do
+    if (!(classLoader instanceof URLClassLoader)) {
+      LOG.warn("Current ClassLoader is not an URLClassLoader {}." +
+                 " No hive aux jars and *-site.xml classpath manipulation", classLoader);
+      return;
+    }
+
+    // Filter out hive jars, only include non-hive jars (e.g. CDAP jars, hbase jars) from the container directory.
+    // For jars not in container directory, they are from the yarn application classpath (e.g. Hadoop jars), which
+    // we don't need to include as well.
+    List<URL> urls = Arrays.asList(((URLClassLoader) classLoader).getURLs());
+    LOG.debug("Classloader urls: {}", urls);
+
+    Iterable<URL> hiveExtraJars = Iterables.filter(urls, new Predicate<URL>() {
+        private final String userDir = System.getProperty("user.dir");
+
+        @Override
+        public boolean apply(URL url) {
+          String path = url.getPath();
+          return path.endsWith(".jar") && !exploreDependencies.contains(getFileName(url)) && path.startsWith(userDir);
+        }
+      });
+
+    // Set the Hive aux jars property. This is for localizing jars needed for CDAP
+    // These dependency files need to be copied over to hive job container.
+    // The path are prefixed with "file:" in order to work with Hive started MR job.
+    System.setProperty(HiveConf.ConfVars.HIVEAUXJARS.toString(),
+                       Joiner.on(',').join(Iterables.transform(hiveExtraJars, Functions.toStringFunction())));
+    LOG.debug("Setting {} to {}", HiveConf.ConfVars.HIVEAUXJARS.toString(),
+              System.getProperty(HiveConf.ConfVars.HIVEAUXJARS.toString()));
+
+    // These dependency files need to be copied over to spark container
+    System.setProperty(BaseHiveExploreService.SPARK_YARN_DIST_FILES,
+                       Joiner.on(',').join(Iterables.transform(hiveExtraJars, URL_TO_PATH)));
+    LOG.debug("Setting {} to {}", BaseHiveExploreService.SPARK_YARN_DIST_FILES,
+              System.getProperty(BaseHiveExploreService.SPARK_YARN_DIST_FILES));
+
+    // Rewrite the yarn-site.xml, mapred-site.xml, hive-site.xml and tez-site.xml for classpath manipulation
+    String extraClassPath = Joiner.on(',').join(Iterables.transform(hiveExtraJars, new Function<URL, String>() {
+      @Override
+      public String apply(URL url) {
+        return "$PWD/" + getFileName(url);
+      }
+    }));
+    extraClassPath += ",$PWD/*";
+
+    rewriteConfigClasspath("yarn-site.xml", YarnConfiguration.YARN_APPLICATION_CLASSPATH,
+                           Joiner.on(",").join(YarnConfiguration.DEFAULT_YARN_APPLICATION_CLASSPATH), extraClassPath);
+    rewriteConfigClasspath("mapred-site.xml", MRJobConfig.MAPREDUCE_APPLICATION_CLASSPATH,
+                           MRJobConfig.DEFAULT_MAPREDUCE_APPLICATION_CLASSPATH, extraClassPath);
+    rewriteConfigClasspath("tez-site.xml", TezConfiguration.TEZ_CLUSTER_ADDITIONAL_CLASSPATH_PREFIX, null,
+                           extraClassPath);
+    rewriteHiveConfig();
+
+    // add hive-exec.jar to the HADOOP_CLASSPATH, which is used by the local mapreduce job launched by hive ,
+    // we need to add this, otherwise when hive runs a MapRedLocalTask it cannot find
+    // "org.apache.hadoop.hive.serde2.SerDe" class in its classpath.
+
+    String hiveExecJar = new JobConf(org.apache.hadoop.hive.ql.exec.Task.class).getJar();
+    Preconditions.checkNotNull(hiveExecJar, "Couldn't locate hive-exec.jar to be included in HADOOP_CLASSPATH " +
+      "for MapReduce jobs launched by Hive");
+
+    LOG.debug("Added hive-exec.jar {} to HADOOP_CLASSPATH to be included for MapReduce jobs launched by Hive",
+              hiveExecJar);
+    try {
+      setupHadoopBin(Iterables.concat(hiveExtraJars, Collections.singleton(new File(hiveExecJar).toURI().toURL())));
+    } catch (IOException e) {
+      LOG.error("Failed to generate hadoop binary to include hive-exec.jar.", e);
+      throw Throwables.propagate(e);
+    }
+  }
+
+  private void rewriteConfigClasspath(String resource, String key, @Nullable String defaultValue, String valuePrefix) {
+    URL resourceURL = getLocalResourceURL(resource);
+    if (resourceURL == null) {
+      LOG.warn("Cannot find local resource {}. Configuration is not being modified.", resource);
+      return;
+    }
+
+    try (InputStream is = new FileInputStream(new File(resourceURL.toURI()))) {
+      Configuration conf = new Configuration(false);
+      conf.addResource(is);
+      String value = conf.get(key, defaultValue);
+      value = (value == null) ? valuePrefix : valuePrefix + "," + value;
+
+      LOG.debug("Setting {} to {} in {}", key, value, resourceURL);
+      conf.set(key, value);
+
+      File newConfFile = File.createTempFile(resource, ".tmp");
+      try (FileOutputStream os = new FileOutputStream(newConfFile)) {
+        conf.writeXml(os);
+      }
+      Files.move(newConfFile.toPath(), Paths.get(resourceURL.toURI()), StandardCopyOption.REPLACE_EXISTING);
+    } catch (Exception e) {
+      LOG.error("Failed to rewrite config file {}", resourceURL, e);
+      throw Throwables.propagate(e);
+    }
+  }
+
+  private void rewriteHiveConfig() {
+    URL resourceURL = getLocalResourceURL("hive-site.xml");
+    if (resourceURL == null) {
+      LOG.warn("Cannot find local resource hive-site.xml. Configuration is not being modified.");
+      return;
+    }
+
+    try (InputStream is = new FileInputStream(new File(resourceURL.toURI()))) {
+      Configuration conf = new Configuration(false);
+      conf.addResource(is);
+
+      // we prefer jars at container's root directory before job.jar,
+      // we edit the YARN_APPLICATION_CLASSPATH in yarn-site.xml and
+      // setting the MAPREDUCE_JOB_CLASSLOADER and MAPREDUCE_JOB_USER_CLASSPATH_FIRST to false will put
+      // YARN_APPLICATION_CLASSPATH before job.jar for container's classpath.
+      conf.setBoolean(Job.MAPREDUCE_JOB_USER_CLASSPATH_FIRST, false);
+      conf.setBoolean(MRJobConfig.MAPREDUCE_JOB_CLASSLOADER, false);
+
+      String sparkHome = System.getenv(Constants.SPARK_HOME);
+      if (sparkHome != null) {
+        LOG.debug("Setting spark.home in hive conf to {}", sparkHome);
+        conf.set("spark.home", sparkHome);
+      }
+
+      File newConfFile = File.createTempFile("hive-site.xml", ".tmp");
+      try (FileOutputStream os = new FileOutputStream(newConfFile)) {
+        conf.writeXml(os);
+      }
+      Files.move(newConfFile.toPath(), Paths.get(resourceURL.toURI()), StandardCopyOption.REPLACE_EXISTING);
+    } catch (Exception e) {
+      LOG.error("Failed to rewrite config file {}", resourceURL, e);
+      throw Throwables.propagate(e);
+    }
+  }
+
+  private void setupHadoopBin(Iterable<URL> hiveAuxJars) throws IOException {
+    HiveConf hiveConf = new HiveConf();
+    String hadoopBin = hiveConf.get(HiveConf.ConfVars.HADOOPBIN.toString());
+
+    // We over-ride HADOOPBIN setting in HiveConf to the script below, so that Hive uses this script to execute
+    // map reduce jobs.
+    // The below script updates HADOOP_CLASSPATH to contain hbase-protocol jar for RunJar commands,
+    // so that the right version of protocol buffer jar gets loaded for HBase.
+    // It also puts all the user jars, ie hive aux jars, in this classpath and in first position, so that
+    // the right version of ASM jar gets loaded for Twill.
+    // It then calls the real Hadoop bin with the same arguments.
+    Path exploreHadoopBin = Files.createTempFile("explore.hadoop", ".bin",
+                                         PosixFilePermissions.asFileAttribute(
+                                           PosixFilePermissions.fromString("rwx------")));
+    try (PrintWriter writer = new PrintWriter(Files.newBufferedWriter(exploreHadoopBin, StandardCharsets.UTF_8))) {
+      writer.println("#!/usr/bin/env bash");
+      writer.println("# This file is a hack to set HADOOP_CLASSPATH for Hive local mapreduce tasks.");
+      writer.println("# This hack should go away when Twill supports setting of environmental variables for a ");
+      writer.println("# TwillRunnable.");
+      writer.println("if [ $# -ge 1 -a \"$1\" = \"jar\" ]; then");
+      writer.print("  HADOOP_CLASSPATH=\"");
+      Joiner.on(File.pathSeparatorChar).appendTo(writer, hiveAuxJars);
+      writer.append(File.pathSeparatorChar).append("${HADOOP_CLASSPATH}\"").println();
+      writer.println("  # Put user jars first in Hadoop classpath so that the ASM jar needed by Twill has");
+      writer.println("  # the right version, and not the one provided with the Hadoop libs.");
+      writer.println("  export HADOOP_USER_CLASSPATH_FIRST=true");
+      writer.println("  export HADOOP_CLASSPATH");
+      writer.println("  echo \"Explore modified HADOOP_CLASSPATH = $HADOOP_CLASSPATH\" 1>&2");
+      writer.println("fi");
+      writer.println();
+      writer.append("exec ").append(hadoopBin).append(" \"$@\"").println();
+    }
+
+    LOG.info("Setting Hadoop bin to Explore Hadoop bin {}", exploreHadoopBin);
+    System.setProperty(HiveConf.ConfVars.HADOOPBIN.toString(), exploreHadoopBin.toAbsolutePath().toString());
   }
 
   @VisibleForTesting

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterTwillApplication.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterTwillApplication.java
@@ -19,8 +19,7 @@ package co.cask.cdap.data.runtime.main;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.twill.AbortOnTimeoutEventHandler;
-import co.cask.cdap.common.utils.DirUtils;
-import co.cask.cdap.explore.service.ExploreServiceUtils;
+import co.cask.cdap.internal.app.runtime.distributed.LocalizeResource;
 import co.cask.cdap.logging.run.LogSaverTwillRunnable;
 import co.cask.cdap.metrics.runtime.MetricsProcessorTwillRunnable;
 import co.cask.cdap.metrics.runtime.MetricsTwillRunnable;
@@ -33,7 +32,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * TwillApplication wrapper for Master Services running in YARN.
@@ -46,16 +44,17 @@ public class MasterTwillApplication implements TwillApplication {
   private final File cConfFile;
   private final File hConfFile;
 
-  private final boolean runHiveService;
   private final Map<String, Integer> instanceCountMap;
+  private final Map<String, LocalizeResource> exploreDependencies;
 
   public MasterTwillApplication(CConfiguration cConf, File cConfFile, File hConfFile,
-                                Map<String, Integer> instanceCountMap) {
+                                Map<String, Integer> instanceCountMap,
+                                Map<String, LocalizeResource> exploreDependencies) {
     this.cConf = cConf;
     this.cConfFile = cConfFile;
     this.hConfFile = hConfFile;
-    this.runHiveService = cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED);
     this.instanceCountMap = instanceCountMap;
+    this.exploreDependencies = exploreDependencies;
   }
 
   @Override
@@ -72,7 +71,7 @@ public class MasterTwillApplication implements TwillApplication {
                             addMetricsService(
                                 TwillSpecification.Builder.with().setName(NAME).withRunnable()))))));
 
-    if (runHiveService) {
+    if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED)) {
       LOG.info("Adding explore runnable.");
       runnableSetter = addExploreService(runnableSetter);
     } else {
@@ -223,24 +222,18 @@ public class MasterTwillApplication implements TwillApplication {
     TwillSpecification.Builder.MoreFile twillSpecs =
       builder.add(
         new ExploreCustomClassLoaderTwillRunnable(
-          new ExploreServiceTwillRunnable(Constants.Service.EXPLORE_HTTP_USER_SERVICE, "cConf.xml", "hConf.xml")
+          new ExploreServiceTwillRunnable(Constants.Service.EXPLORE_HTTP_USER_SERVICE,
+                                          "cConf.xml", "hConf.xml", exploreDependencies.keySet())
             .configure()),
         resourceSpec)
         .withLocalFiles()
         .add("cConf.xml", cConfFile.toURI())
         .add("hConf.xml", hConfFile.toURI());
 
-    try {
-      // Ship jars needed by Hive to the container
-      File tempDir = DirUtils.createTempDir(new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
-                                                     cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile());
-      Set<File> jars = ExploreServiceUtils.traceExploreDependencies(tempDir);
-      for (File jarFile : jars) {
-        LOG.debug("Adding jar {} for explore.service", jarFile.getAbsolutePath());
-        twillSpecs = twillSpecs.add(jarFile.getName(), jarFile);
-      }
-    } catch (Exception e) {
-      throw new RuntimeException("Unable to trace Explore dependencies", e);
+    for (Map.Entry<String, LocalizeResource> entry : exploreDependencies.entrySet()) {
+      LocalizeResource resource = entry.getValue();
+      LOG.debug("Adding {} for explore.service", resource.getURI());
+      twillSpecs = twillSpecs.add(entry.getKey(), resource.getURI(), resource.isArchive());
     }
 
     return twillSpecs.apply();


### PR DESCRIPTION
- Get rid of the use of trace dependency, which is slow and may miss some jars
- Adjust the launch script to setup the system property based on "hive set" output