### PR TITLE
CDAP-7557 Allow users to disable concurrent writers from DynamicPartitioner.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/DynamicPartitionerWriterWrapper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/DynamicPartitionerWriterWrapper.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.partitioned;
+
+import co.cask.cdap.api.dataset.lib.DynamicPartitioner;
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
+import co.cask.cdap.api.dataset.lib.Partitioning;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.lang.InstantiatorFactory;
+import co.cask.cdap.data2.dataset2.lib.partitioned.PartitionedFileSetDataset;
+import co.cask.cdap.internal.app.runtime.batch.BasicMapReduceTaskContext;
+import co.cask.cdap.internal.app.runtime.batch.MapReduceClassLoader;
+import com.google.common.reflect.TypeToken;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
+
+import java.io.IOException;
+
+/**
+ * A RecordWriter that allows writing dynamically to multiple partitions of a PartitionedFileSet.
+ */
+abstract class DynamicPartitionerWriterWrapper<K, V> extends RecordWriter<K, V> {
+
+  private TaskAttemptContext job;
+  private String outputName;
+  private Partitioning partitioning;
+  private FileOutputFormat<K, V> fileOutputFormat;
+
+  @SuppressWarnings("unchecked")
+  DynamicPartitioner<K, V> dynamicPartitioner;
+  BasicMapReduceTaskContext<K, V> taskContext;
+
+  DynamicPartitionerWriterWrapper(TaskAttemptContext job) {
+    this.job = job;
+    this.outputName = DynamicPartitioningOutputFormat.getOutputName(job);
+
+    Configuration configuration = job.getConfiguration();
+    Class<? extends DynamicPartitioner> partitionerClass = configuration
+      .getClass(PartitionedFileSetArguments.DYNAMIC_PARTITIONER_CLASS_NAME, null, DynamicPartitioner.class);
+    this.dynamicPartitioner = new InstantiatorFactory(false).get(TypeToken.of(partitionerClass)).create();
+
+    MapReduceClassLoader classLoader = MapReduceClassLoader.getFromConfiguration(configuration);
+    this.taskContext = classLoader.getTaskContextProvider().get(job);
+
+    String outputDatasetName = configuration.get(Constants.Dataset.Partitioned.HCONF_ATTR_OUTPUT_DATASET);
+    PartitionedFileSet outputDataset = taskContext.getDataset(outputDatasetName);
+    this.partitioning = outputDataset.getPartitioning();
+
+    this.dynamicPartitioner.initialize(taskContext);
+  }
+
+  // returns a TaskAttemptContext whose configuration will reflect the specified partitionKey's path as the output path
+  TaskAttemptContext getKeySpecificContext(PartitionKey partitionKey) throws IOException {
+    String relativePath = PartitionedFileSetDataset.getOutputPath(partitionKey, partitioning);
+    String finalPath = relativePath + "/" + outputName;
+    return getTaskAttemptContext(job, finalPath);
+  }
+
+  /**
+   * @return A RecordWriter object for the given TaskAttemptContext (configured for a particular file name).
+   * @throws IOException
+   */
+  RecordWriter<K, V> getBaseRecordWriter(TaskAttemptContext job) throws IOException, InterruptedException {
+    return getFileOutputFormat(job).getRecordWriter(job);
+  }
+
+  // returns a TaskAttemptContext whose configuration will reflect the specified newOutputName as the output path
+  private TaskAttemptContext getTaskAttemptContext(TaskAttemptContext context,
+                                                   String newOutputName) throws IOException {
+    Job job = new Job(context.getConfiguration());
+    DynamicPartitioningOutputFormat.setOutputName(job, newOutputName);
+    // CDAP-4806 We must set this parameter in addition to calling FileOutputFormat#setOutputName, because
+    // AvroKeyOutputFormat/AvroKeyValueOutputFormat use a different parameter for the output name than FileOutputFormat.
+    if (isAvroOutputFormat(getFileOutputFormat(context))) {
+      job.getConfiguration().set("avro.mo.config.namedOutput", newOutputName);
+    }
+
+    Path jobOutputPath = DynamicPartitioningOutputFormat.createJobSpecificPath(FileOutputFormat.getOutputPath(job),
+                                                                               context);
+    DynamicPartitioningOutputFormat.setOutputPath(job, jobOutputPath);
+
+    return new TaskAttemptContextImpl(job.getConfiguration(), context.getTaskAttemptID());
+  }
+
+  private FileOutputFormat<K, V> getFileOutputFormat(TaskAttemptContext job) {
+    if (fileOutputFormat == null) {
+      Class<? extends FileOutputFormat> delegateOutputFormat = job.getConfiguration()
+        .getClass(Constants.Dataset.Partitioned.HCONF_ATTR_OUTPUT_FORMAT_CLASS_NAME, null, FileOutputFormat.class);
+
+      @SuppressWarnings("unchecked")
+      FileOutputFormat<K, V> fileOutputFormat =
+        new InstantiatorFactory(false).get(TypeToken.of(delegateOutputFormat)).create();
+      this.fileOutputFormat = fileOutputFormat;
+    }
+    return fileOutputFormat;
+  }
+
+  private static boolean isAvroOutputFormat(FileOutputFormat fileOutputFormat) {
+    String className = fileOutputFormat.getClass().getName();
+    // use class name String in order avoid having a dependency on the Avro libraries here
+    return "org.apache.avro.mapreduce.AvroKeyOutputFormat".equals(className)
+      || "org.apache.avro.mapreduce.AvroKeyValueOutputFormat".equals(className);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/MultiWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/MultiWriter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.partitioned;
+
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.internal.app.runtime.batch.dataset.output.MultipleOutputs;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A RecordWriter that can concurrently to multiple partitions of a PartitionedFileSet.
+ */
+final class MultiWriter<K, V> extends DynamicPartitionerWriterWrapper<K, V> {
+
+  // a cache storing the record writers for different output files.
+  private Map<PartitionKey, RecordWriter<K, V>> recordWriters = new HashMap<>();
+  private Map<PartitionKey, TaskAttemptContext> contexts = new HashMap<>();
+
+  MultiWriter(TaskAttemptContext job) {
+    super(job);
+  }
+
+  public void write(K key, V value) throws IOException, InterruptedException {
+    PartitionKey partitionKey = dynamicPartitioner.getPartitionKey(key, value);
+    RecordWriter<K, V> rw = this.recordWriters.get(partitionKey);
+    if (rw == null) {
+      // if we don't have the record writer yet for the final path, create one and add it to the cache
+      TaskAttemptContext taskAttemptContext = getKeySpecificContext(partitionKey);
+      rw = getBaseRecordWriter(taskAttemptContext);
+      this.recordWriters.put(partitionKey, rw);
+      this.contexts.put(partitionKey, taskAttemptContext);
+    }
+    rw.write(key, value);
+  }
+
+  @Override
+  public void close(TaskAttemptContext context) throws IOException, InterruptedException {
+    try {
+      Map<PartitionKey, RecordWriter<?, ?>> recordWriters = new HashMap<>();
+      recordWriters.putAll(this.recordWriters);
+      MultipleOutputs.closeRecordWriters(recordWriters, contexts);
+      taskContext.flushOperations();
+    } catch (Exception e) {
+      throw new IOException(e);
+    } finally {
+      dynamicPartitioner.destroy();
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/SingleWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/SingleWriter.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.partitioned;
+
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A RecordWriter that can only write to a single partition of a PartitionedFileSet at any given time, but over time
+ * can write to multiple partitions. Once it starts writing to a new partition, the previous partition is closed and
+ * the previous partition can not be written to after that point.
+ *
+ * See {@link PartitionedFileSetArguments#setDynamicPartitionerConcurrency(Map, boolean)}.
+ */
+final class SingleWriter<K, V> extends DynamicPartitionerWriterWrapper<K, V> {
+
+  // partition keys for which we have already written to and closed the corresponding RecordWriter
+  private final Set<PartitionKey> closedKeys = new HashSet<>();
+
+  private PartitionKey currPartitionKey;
+  private RecordWriter<K, V> currRecordWriter;
+  private TaskAttemptContext currContext;
+
+  SingleWriter(TaskAttemptContext job) {
+    super(job);
+  }
+
+  public void write(K key, V value) throws IOException, InterruptedException {
+    PartitionKey partitionKey = dynamicPartitioner.getPartitionKey(key, value);
+    if (!partitionKey.equals(currPartitionKey)) {
+      // make sure we haven't written to this partition previously
+      if (closedKeys.contains(partitionKey)) {
+        throw new IllegalStateException(
+          String.format("Encountered a partition key for which the writer has already been closed: '%s'.",
+                        partitionKey));
+      }
+
+      // currPartitionKey can be null for the first key value pair, in which case there's no writer to close
+      if (currPartitionKey != null) {
+        // close the existing RecordWriter and create a new one for the new PartitionKEy
+        currRecordWriter.close(currContext);
+        closedKeys.add(currPartitionKey);
+      }
+
+      currPartitionKey = partitionKey;
+      currContext = getKeySpecificContext(currPartitionKey);
+      currRecordWriter = getBaseRecordWriter(currContext);
+    }
+    currRecordWriter.write(key, value);
+  }
+
+  @Override
+  public void close(TaskAttemptContext context) throws IOException, InterruptedException {
+    try {
+      // the writer can be null if this writer didn't get any records (split with no data, for instance)
+      if (currRecordWriter != null) {
+        currRecordWriter.close(currContext);
+      }
+      taskContext.flushOperations();
+    } catch (Exception e) {
+      throw new IOException(e);
+    } finally {
+      dynamicPartitioner.destroy();
+    }
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
@@ -765,6 +765,8 @@ public class PartitionedFileSetDataset extends AbstractDataset implements Partit
       PartitionedFileSetArguments.setOutputPartitionMetadata(outputArgs, outputMetadata);
 
       PartitionedFileSetArguments.setDynamicPartitioner(outputArgs, dynamicPartitionerClassName);
+      PartitionedFileSetArguments.setDynamicPartitionerConcurrency(
+        outputArgs, PartitionedFileSetArguments.isDynamicPartitionerConcurrencyAllowed(runtimeArguments));
       outputArgs.put(Constants.Dataset.Partitioned.HCONF_ATTR_OUTPUT_FORMAT_CLASS_NAME,
                      files.getOutputFormatClassName());
       outputArgs.put(Constants.Dataset.Partitioned.HCONF_ATTR_OUTPUT_DATASET, getName());

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetArgumentsTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetArgumentsTest.java
@@ -145,6 +145,35 @@ public class PartitionedFileSetArgumentsTest {
 
   }
 
+  @Test
+  public void testDynamicPartitionerWriterConcurrency() {
+    Map<String, String> arguments = new HashMap<>();
+
+    // should not be able to get or set the concurrency setting, without a dynamic partitioner set on the arguments
+    try {
+      PartitionedFileSetArguments.isDynamicPartitionerConcurrencyAllowed(arguments);
+      Assert.fail();
+    } catch (IllegalArgumentException expected) {
+    }
+    try {
+      PartitionedFileSetArguments.setDynamicPartitionerConcurrency(arguments, false);
+      Assert.fail();
+    } catch (IllegalArgumentException expected) {
+    }
+
+    // set a DynamicPartitioner
+    PartitionedFileSetArguments.setDynamicPartitioner(arguments, TestDynamicPartitioner.class.getName());
+    // default value should be true
+    Assert.assertTrue(PartitionedFileSetArguments.isDynamicPartitionerConcurrencyAllowed(arguments));
+
+    // try set+get
+    PartitionedFileSetArguments.setDynamicPartitionerConcurrency(arguments, false);
+    Assert.assertFalse(PartitionedFileSetArguments.isDynamicPartitionerConcurrencyAllowed(arguments));
+
+    PartitionedFileSetArguments.setDynamicPartitionerConcurrency(arguments, true);
+    Assert.assertTrue(PartitionedFileSetArguments.isDynamicPartitionerConcurrencyAllowed(arguments));
+  }
+
   private static final class TestDynamicPartitioner extends DynamicPartitioner<Integer, Integer> {
     @Override
     public PartitionKey getPartitionKey(Integer key, Integer value) {


### PR DESCRIPTION
Allow users to disable concurrent writers from DynamicPartitioner.
Refactored the existing RecordWriter in DynamicPartitioningOutputFormat into a DynamicPartitionerWriterWrapper/MultiWriter.
Introduced a SingleWriter that only allows a single writer open at any given time.
See JIRA for more details.

https://issues.cask.co/browse/CDAP-7557
http://builds.cask.co/browse/CDAP-RUT257-2