### PR TITLE
Perform cleanup before running integration test cases.

### DIFF
--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
@@ -96,6 +96,7 @@ public abstract class IntegrationTestBase {
 
   @Before
   public void setUp() throws Exception {
+    LOG.info("Beginning setUp.");
     checkSystemServices();
     assertUnrecoverableResetEnabled();
 
@@ -104,13 +105,17 @@ public abstract class IntegrationTestBase {
       getNamespaceClient().create(new NamespaceMeta.Builder().setName(configuredNamespace.toId()).build());
       // if we created the configured namespace, delete it upon teardown
       deleteUponTeardown = true;
+    } else {
+      // only need to clear the namespace if it already existed
+      doClear(configuredNamespace, false);
     }
     registeredNamespaces.put(configuredNamespace, deleteUponTeardown);
-    assertIsClear(configuredNamespace);
+    LOG.info("Completed setUp.");
   }
 
   @After
   public void tearDown() throws Exception {
+    LOG.info("Beginning tearDown.");
     for (Map.Entry<NamespaceId, Boolean> namespaceEntry : registeredNamespaces.entrySet()) {
       // there could be a race condition that test case registers the namespace, but fails before
       // creating the actual namespace, so check existence before clearing/deleting the namespace
@@ -121,6 +126,7 @@ public abstract class IntegrationTestBase {
       // if we didn't create the namespace, don't delete it; only clear the data/programs within it
       doClear(namespaceEntry.getKey(), deleteUponTeardown);
     }
+    LOG.info("Completed tearDown.");
   }
 
   /**


### PR DESCRIPTION
Perform cleanup before running integration test cases.
Use cases:
- User has some app running on a namespace that was left behind by a previously-failing test case. Cleanup in its `@After` may have failed for some transient reason.
- CDAP SDK starts Tracker app automatically, so the first test case run against it would fail otherwise.

Also added some log statements for debuggability.

http://builds.cask.co/browse/CDAP-RUT258-1