### PR TITLE
CDAP-5734 Fix flaky test case 'MapReduceProgramRunnerTest#testJobSuccess

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AggregateMetricsByTag.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/AggregateMetricsByTag.java
@@ -75,8 +75,6 @@ public class AggregateMetricsByTag {
       metrics.gauge("in.map.setup", 1);
       LOG.info("in mapper: setup()");
       long mappersCount = counters.incrementAndGet(new Increment("mapper", "count", 1L)).getLong("count", 0);
-      Assert.assertEquals(mappersCount, countersFromContext.incrementAndGet(new Increment("mapper", "count", 1L))
-                                                                                                  .getLong("count", 0));
       LOG.info("mappers started so far: " + mappersCount);
       metrics.gauge("in.map.setup", 1);
     }
@@ -126,8 +124,6 @@ public class AggregateMetricsByTag {
       metrics.gauge("in.reduce.setup", 1);
       LOG.info("in reducer: setup()");
       long reducersCount = counters.incrementAndGet(new Increment("reducer", "count", 1L)).getLong("count", 0);
-      Assert.assertEquals(reducersCount, countersFromContext.incrementAndGet(new Increment("reducer", "count", 1L))
-                                                                                                  .getLong("count", 0));
       LOG.info("reducers started so far: " + reducersCount);
       metrics.gauge("in.reduce.setup", 1);
     }


### PR DESCRIPTION
Fix flaky test case 'MapReduceProgramRunnerTest#testJobSuccess' by removing an assertion which doesn't seem necessary and has a race condition.

If there are two mappers, then the assertion can fail in the following scenario:
The first mapper increments the `counters` table. The second mapper then increments the `counters` table and the `countersFromContext` table, before the first mapper gets to increment the `counters` table.
I also don't see the value of the assertion, and the test case is not utilizing these incremented values.

https://issues.cask.co/browse/CDAP-5734
http://builds.cask.co/browse/CDAP-RUT259-1