### PR TITLE
Fix deployment of docs.

### DIFF
--- a/cdap-docs/deploy.sh
+++ b/cdap-docs/deploy.sh
@@ -114,7 +114,7 @@ set_remote_dir
 #
 USER=bamboo
 PROJECT_DOCS=${PROJECT}-docs
-ZIP_FILE=${PROJECT}-docs-${VERSION}.zip
+ZIP_FILE=${PROJECT}-docs-${VERSION}-web.zip
 FILE_PATH=${BUILD_WORKING_DIR}/${PROJECT}/${PROJECT_DOCS}/target
 DOCS_SERVERS="${DOCS_SERVER1} ${DOCS_SERVER2}"
 REMOTE_STG_DIR="${REMOTE_STG_BASE}/${PROJECT}"		# e.g. /var/www/html/staging/cdap


### PR DESCRIPTION
Fixes an error in deployment introduced with the new changes to the documentation build and deployment. This reverts the pattern of the ZIP file naming back to the previous.