### PR TITLE
[CDAP-7578] Application overview in homepage

### DIFF
--- a/cdap-ui/app/cdap/components/AppOverview/AppOverview.less
+++ b/cdap-ui/app/cdap/components/AppOverview/AppOverview.less
@@ -18,12 +18,58 @@
 .entity-overview {
   position: absolute;
   z-index: 1;
-  border: 1px solid #ccc;
   background: white;
 
   &.right,
   &.left {
     top: 0;
+    .overview-header {
+      &:before {
+        width: 0;
+        height: 0;
+        border: 12px solid #464a56;
+        position: absolute;
+        content: ' ';
+        border-top-color: transparent;
+        border-bottom-color: transparent;
+      }
+    }
+  }
+  &.bottom {
+    margin-top: 12px;
+    .overview-header {
+      &:before {
+        width: 0;
+        height: 0;
+        border: 12px solid #464a56;
+        position: absolute;
+        content: ' ';
+        top: -24px;
+        right: 8px;
+        border-left-color: transparent;
+        border-top-color: transparent;
+        border-right-color: transparent;
+      }
+    }
+  }
+
+  &.right {
+    .overview-header {
+      &:before {
+        left: -12px;
+        top: 8px;
+        border-left: 0;
+      }
+    }
+  }
+  &.left {
+    .overview-header {
+      &:before {
+        right: -12px;
+        top: 8px;
+        border-right: 0;
+      }
+    }
   }
 
   .overview-header {
@@ -62,6 +108,8 @@
   }
   .overview-content {
     position: relative;
+    border: 1px solid #ccc;
+    border-top: 0;
     .cask-tabs {
       &.horizontal {
         > div:first-child {

--- a/cdap-ui/app/cdap/components/AppOverview/AppOverview.less
+++ b/cdap-ui/app/cdap/components/AppOverview/AppOverview.less
@@ -86,20 +86,20 @@
       border: 0;
       border-right: 1px solid;
       padding: 5px 10px;
-      &:nth-child(2) {
-        flex-direction: column;
-        small {
-          font-size: 70%;
-        }
+      flex-direction: column;
+      small {
+        font-size: 70%;
       }
       &:last-child {
         border-right: 0;
         width: 20%;
         justify-content: flex-end;
+        flex-direction: row;
       }
     }
     i {
       line-height: inherit;
+      cursor: pointer;
       &:nth-child(2) {
         margin: 0 20px;
         line-height: 2;

--- a/cdap-ui/app/cdap/components/AppOverview/AppOverview.less
+++ b/cdap-ui/app/cdap/components/AppOverview/AppOverview.less
@@ -73,15 +73,26 @@
             }
           }
         }
+        .tab-content {
+          .tab-pane {
+            .metrics-container {
+              position: static;
+            }
+          }
+        }
+      }
+    }
+    > .metrics-container {
+      position: absolute;
+      right: 0;
+      border-bottom: 0;
+      .metric-item {
+        padding: 5px 20px;
       }
     }
     .metrics-container {
-      position: absolute;
-      border-bottom: 0;
-      right: 0;
       .metric-item {
         border: 0;
-        padding: 5px 20px;
       }
     }
   }

--- a/cdap-ui/app/cdap/components/AppOverview/AppOverview.less
+++ b/cdap-ui/app/cdap/components/AppOverview/AppOverview.less
@@ -13,19 +13,76 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+@import '../../styles/variables.less';
 
 .entity-overview {
   position: absolute;
   z-index: 1;
+  border: 1px solid #ccc;
+  background: white;
 
   &.right,
   &.left {
     top: 0;
   }
-  &.right {
-    left: 310px;
+
+  .overview-header {
+    border-bottom: 1px solid #ccc;
+    background: @navbar-bg;
+    color: white;
+    font-size: 15px;
+    display: flex;
+
+    span {
+      display: flex;
+      width: 40%;
+      padding: 10px;
+      border: 0;
+      border-right: 1px solid;
+      padding: 5px 10px;
+      &:nth-child(2) {
+        flex-direction: column;
+        small {
+          font-size: 70%;
+        }
+      }
+      &:last-child {
+        border-right: 0;
+        width: 20%;
+        justify-content: flex-end;
+      }
+    }
+    i {
+      line-height: inherit;
+      &:nth-child(2) {
+        margin: 0 20px;
+        line-height: 2;
+      }
+    }
   }
-  &.left {
-    right: 310px;
+  .overview-content {
+    position: relative;
+    .cask-tabs {
+      &.horizontal {
+        > div:first-child {
+          &.cask-tab-headers {
+            height: 50px;
+            line-height: 50px;
+            .cask-tab-head {
+              padding: 0 10px;
+            }
+          }
+        }
+      }
+    }
+    .metrics-container {
+      position: absolute;
+      border-bottom: 0;
+      right: 0;
+      .metric-item {
+        border: 0;
+        padding: 5px 20px;
+      }
+    }
   }
 }

--- a/cdap-ui/app/cdap/components/AppOverview/AppOverview.less
+++ b/cdap-ui/app/cdap/components/AppOverview/AppOverview.less
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+.entity-overview {
+  position: absolute;
+  z-index: 1;
+
+  &.right,
+  &.left {
+    top: 0;
+  }
+  &.right {
+    left: 310px;
+  }
+  &.left {
+    right: 310px;
+  }
+}

--- a/cdap-ui/app/cdap/components/AppOverview/OverviewTabConfig.js
+++ b/cdap-ui/app/cdap/components/AppOverview/OverviewTabConfig.js
@@ -1,0 +1,20 @@
+import React from 'react';
+const OverviewTabConfig = {
+  defaultTab: 1,
+  layout: 'horizontal',
+  tabs: [
+    {
+      id: 1,
+      icon: '',
+      name: 'Main',
+      content: <div> Main Tab Content</div>
+    },
+    {
+      id: 3,
+      icon: '',
+      name: 'Dataset',
+      content: <div> Dataset Tab Content </div>
+    }
+  ]
+};
+export default OverviewTabConfig;

--- a/cdap-ui/app/cdap/components/AppOverview/Tabs/DatasetsTab.js
+++ b/cdap-ui/app/cdap/components/AppOverview/Tabs/DatasetsTab.js
@@ -68,6 +68,12 @@ export default class DatasetsTab extends Component {
                 );
               })
         }
+        {
+          !this.context.entity.datasets.length && !this.context.entity.streams.length ?
+            <i className="fa fa-spin fa-spinner"></i>
+          :
+            null
+        }
       </div>
     );
   }

--- a/cdap-ui/app/cdap/components/AppOverview/Tabs/DatasetsTab.js
+++ b/cdap-ui/app/cdap/components/AppOverview/Tabs/DatasetsTab.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, {Component, PropTypes} from 'react';
+import EntityCard from 'components/EntityCard';
+import {parseMetadata} from 'services/metadata-parser';
+require('./DatasetsTab.less');
+
+export default class DatasetsTab extends Component {
+  constructor(props) {
+    super(props);
+  }
+  render() {
+    return (
+      <div className="app-datasets-tab">
+        {
+          this.context
+              .entity
+              .datasets
+              .map( dataset => {
+                let entity = {
+                  entityId: dataset.entityId,
+                  metadata: {
+                    SYSTEM: {}
+                  }
+                };
+                entity = parseMetadata(entity);
+                return (
+                  <EntityCard
+                    className="entity-card-container"
+                    entity={entity}
+                    key={dataset.uniqueId}
+                  />
+                );
+              })
+        }
+        {
+          this.context
+              .entity
+              .streams
+              .map( stream => {
+                let entity = {
+                  entityId: stream.entityId,
+                  metadata: {
+                    SYSTEM: {}
+                  }
+                };
+                entity = parseMetadata(entity);
+                return (
+                  <EntityCard
+                    className="entity-card-container"
+                    entity={entity}
+                    key={stream.uniqueId}
+                  />
+                );
+              })
+        }
+      </div>
+    );
+  }
+}
+
+
+DatasetsTab.contextTypes = {
+  entity: PropTypes.object
+};

--- a/cdap-ui/app/cdap/components/AppOverview/Tabs/DatasetsTab.less
+++ b/cdap-ui/app/cdap/components/AppOverview/Tabs/DatasetsTab.less
@@ -14,26 +14,11 @@
  * the License.
  */
 
-import React from 'react';
-import MainTab from 'components/AppOverview/Tabs/MainTab';
-import DatasetsTab from 'components/AppOverview/Tabs/DatasetsTab';
-
-const OverviewTabConfig = {
-  defaultTab: 1,
-  layout: 'horizontal',
-  tabs: [
-    {
-      id: 1,
-      icon: '',
-      name: 'Main',
-      content: <MainTab />
-    },
-    {
-      id: 3,
-      icon: '',
-      name: 'Dataset',
-      content: <DatasetsTab />
-    }
-  ]
-};
-export default OverviewTabConfig;
+.app-datasets-tab {
+  padding: 10px;
+  .home-cards {
+    display: inline-block;
+    margin: 10px 10px 10px 0;
+    width: 300px;
+  }
+}

--- a/cdap-ui/app/cdap/components/AppOverview/Tabs/MainTab.js
+++ b/cdap-ui/app/cdap/components/AppOverview/Tabs/MainTab.js
@@ -24,38 +24,40 @@ export default class MainTab extends Component {
     super(props);
   }
   render() {
-    console.log('context: ', this.context);
     return (
       <div className="app-overview-main-tab">
         {
-          this.context
-              .entity
-              .programs
-              .map( program => {
-                let entity = {
-                  entityId: {
-                    id: {
-                      id: program.id,
-                      application: {
-                        applicationId: program.app
+          this.context.entity.programs.length ?
+            this.context
+                .entity
+                .programs
+                .map( program => {
+                  let entity = {
+                    entityId: {
+                      id: {
+                        id: program.id,
+                        application: {
+                          applicationId: program.app
+                        },
+                        type: program.type
                       },
-                      type: program.type
+                      type: 'program',
                     },
-                    type: 'program',
-                  },
-                  metadata: {
-                    SYSTEM: {}
-                  }
-                };
-                entity = parseMetadata(entity);
-                return (
-                  <EntityCard
-                    className="entity-card-container"
-                    entity={entity}
-                    key={program.uniqueId}
-                  />
-                );
-              })
+                    metadata: {
+                      SYSTEM: {}
+                    }
+                  };
+                  entity = parseMetadata(entity);
+                  return (
+                    <EntityCard
+                      className="entity-card-container"
+                      entity={entity}
+                      key={program.uniqueId}
+                    />
+                  );
+                })
+          :
+            <i className="fa fa-spin fa-spinner"></i>
         }
       </div>
     );

--- a/cdap-ui/app/cdap/components/AppOverview/Tabs/MainTab.js
+++ b/cdap-ui/app/cdap/components/AppOverview/Tabs/MainTab.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, {Component, PropTypes} from 'react';
+import EntityCard from 'components/EntityCard';
+import {parseMetadata} from 'services/metadata-parser';
+require('./MainTab.less');
+
+export default class MainTab extends Component {
+  constructor(props) {
+    super(props);
+  }
+  render() {
+    console.log('context: ', this.context);
+    return (
+      <div className="app-overview-main-tab">
+        {
+          this.context
+              .entity
+              .programs
+              .map( program => {
+                let entity = {
+                  entityId: {
+                    id: {
+                      id: program.id,
+                      application: {
+                        applicationId: program.app
+                      },
+                      type: program.type
+                    },
+                    type: 'program',
+                  },
+                  metadata: {
+                    SYSTEM: {}
+                  }
+                };
+                entity = parseMetadata(entity);
+                return (
+                  <EntityCard
+                    className="entity-card-container"
+                    entity={entity}
+                    key={program.uniqueId}
+                  />
+                );
+              })
+        }
+      </div>
+    );
+  }
+}
+
+MainTab.contextTypes = {
+  entity: PropTypes.object
+};

--- a/cdap-ui/app/cdap/components/AppOverview/Tabs/MainTab.less
+++ b/cdap-ui/app/cdap/components/AppOverview/Tabs/MainTab.less
@@ -14,26 +14,11 @@
  * the License.
  */
 
-import React from 'react';
-import MainTab from 'components/AppOverview/Tabs/MainTab';
-import DatasetsTab from 'components/AppOverview/Tabs/DatasetsTab';
-
-const OverviewTabConfig = {
-  defaultTab: 1,
-  layout: 'horizontal',
-  tabs: [
-    {
-      id: 1,
-      icon: '',
-      name: 'Main',
-      content: <MainTab />
-    },
-    {
-      id: 3,
-      icon: '',
-      name: 'Dataset',
-      content: <DatasetsTab />
-    }
-  ]
-};
-export default OverviewTabConfig;
+.app-overview-main-tab {
+  padding: 10px;
+  .home-cards {
+    display: inline-block;
+    margin: 10px 10px 10px 0;
+    width: 300px;
+  }
+}

--- a/cdap-ui/app/cdap/components/AppOverview/index.js
+++ b/cdap-ui/app/cdap/components/AppOverview/index.js
@@ -29,7 +29,16 @@ export default class AppOverview extends Component {
     super(props);
     this.state = {
       entity: this.props.entity,
-      entityDetail: {},
+      entityDetail: {
+        name: '',
+        artifact: {
+          version: '--',
+          name: '--'
+        },
+        programs: [],
+        datasets: [],
+        streams: []
+      },
       dimension: {}
     };
   }
@@ -38,20 +47,13 @@ export default class AppOverview extends Component {
       entity: this.state.entityDetail
     };
   }
-  componentWillReceiveProps(newProps) {
-    if (newProps.isOpen !== this.state.isOpen) {
-      this.setState({
-        isOpen: newProps.isOpen
-      });
-    }
-  }
   componentDidMount() {
     let {right, left, width} = this.overviewRef.parentElement.getBoundingClientRect();
     if (right && left) {
       this.setState({
         dimension: {
           right,
-          left: ( left < width ? width: left)
+          left: ( left < width ? width : left)
         }
       });
     }
@@ -102,6 +104,8 @@ export default class AppOverview extends Component {
     let {left, right} = this.state.dimension;
     let {right: parentRight} = this.props.parentdimension;
     if (this.overviewRef) {
+      // FIXME: This is a hack. We need to make this as an elegant component that will intelligently
+      // figure out the position based on the intent and containing component.
       if (this.props.position === 'right') {
         style.left = 310;
         style.width = `calc(100vw - ${right + 30}px)`; // factoring the container-fluid on body
@@ -122,35 +126,36 @@ export default class AppOverview extends Component {
         style={style}
         onClick={(e) => e.stopPropagation()}
       >
-        {
-          Object.keys(this.state.entityDetail).length ?
-            <div>
-              <div className="overview-header clearfix">
-                <span>
-                  {this.state.entityDetail.name}
-                </span>
-                <span>
-                  {this.state.entityDetail.artifact.name}
-                  <small>
-                    Version: {this.state.entityDetail.artifact.version}
-                  </small>
-                </span>
-                <span className="text-right">
-                  <i className="fa fa-info fa-lg"></i>
-                  <i className="fa fa-arrows-alt"></i>
-                  <i className="fa fa-times fa-lg"></i>
-                </span>
-              </div>
-              <div className="overview-content">
-                <ApplicationMetrics entity={this.props.entity}/>
-                <ConfigurableTab
-                  tabConfig={OverviewTabConfig}
-                />
-              </div>
-            </div>
-          :
-            null
-        }
+        <div>
+          <div className="overview-header clearfix">
+            <span>
+              {this.state.entityDetail.name}
+              <small>
+                {this.state.entityDetail.description}
+              </small>
+            </span>
+            <span>
+              {this.state.entityDetail.artifact.name}
+              <small>
+                Version: {this.state.entityDetail.artifact.version}
+              </small>
+            </span>
+            <span className="text-right">
+              <i className="fa fa-info fa-lg"></i>
+              <i className="fa fa-arrows-alt"></i>
+              <i
+                className="fa fa-times fa-lg"
+                onClick={this.props.onClose}
+              ></i>
+            </span>
+          </div>
+          <div className="overview-content">
+            <ApplicationMetrics entity={this.props.entity}/>
+            <ConfigurableTab
+              tabConfig={OverviewTabConfig}
+            />
+          </div>
+        </div>
       </div>
     );
   }
@@ -183,5 +188,6 @@ AppOverview.propTypes = {
     'right',
     'top',
     'bottom'
-  ])
+  ]),
+  onClose: PropTypes.func
 };

--- a/cdap-ui/app/cdap/components/AppOverview/index.js
+++ b/cdap-ui/app/cdap/components/AppOverview/index.js
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, {Component, PropTypes} from 'react';
+import classnames from 'classnames';
+require('./AppOverview.less');
+
+export default class AppOverview extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      entity: {},
+      dimension: null
+    };
+  }
+  componentWillReceiveProps(newProps) {
+    if (newProps.isOpen !== this.state.isOpen) {
+      this.setState({
+        isOpen: newProps.isOpen
+      });
+    }
+  }
+  componentDidMount() {
+    let width = this.overviewRef.getBoundingClientRect();
+    if (width) {
+      this.setState({
+        dimension: {
+          width
+        }
+      });
+    }
+  }
+  render() {
+    let style={};
+
+    if (this.overviewRef) {
+      if (this.props.position === 'right') {
+        style.left = this.state.dimension.width;
+      }
+      if (this.props.position === 'left') {
+        style.right = this.state.dimension.width;
+      }
+    }
+    return (
+      <div
+        className={classnames("entity-overview", this.props.position)}
+        ref={ref=> this.overviewRef = ref}
+      >
+        {
+          this.state.dimension ?
+            <div className="panel panel-default">
+              <div className="panel-heading">Panel heading without title</div>
+              <div className="panel-body">
+                Position: {this.props.position}
+                {JSON.stringify(this.props.entity, null, 4)}
+              </div>
+            </div>
+          :
+            null
+        }
+      </div>
+    );
+  }
+}
+AppOverview.defaultPropTypes = {
+  position: 'left'
+};
+
+AppOverview.propTypes = {
+  entity: PropTypes.shape({
+    id: PropTypes.string,
+    type: PropTypes.string,
+    version: PropTypes.string,
+    metadata: PropTypes.object, // FIXME: Shouldn't be an object
+    icon: PropTypes.string,
+    isHydrator: PropTypes.bool
+  }),
+  position: PropTypes.oneOf([
+    'left',
+    'right',
+    'top',
+    'bottom'
+  ])
+};

--- a/cdap-ui/app/cdap/components/Card/index.js
+++ b/cdap-ui/app/cdap/components/Card/index.js
@@ -103,6 +103,7 @@ export default class Card extends Component {
 
     return (
       <div
+        id={this.props.id}
         className={cardClass}
         onClick={this.onClickHandler.bind(this)}
         style={this.props.cardStyle}
@@ -129,5 +130,6 @@ Card.propTypes = {
   cardClass: PropTypes.string,
   size: PropTypes.oneOf(['SM', 'MD', 'LG']),
   cardStyle: PropTypes.object,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  id: PropTypes.string
 };

--- a/cdap-ui/app/cdap/components/EntityCard/EntityCard.less
+++ b/cdap-ui/app/cdap/components/EntityCard/EntityCard.less
@@ -23,15 +23,7 @@
   text-align: left;
   border-radius: 0;
 
-  &.artifact .card-header { background-color: #bdc3c7; }
-  &.application .card-header { background-color: #ff6600; }
-  &.datasetinstance .card-header { background-color: #27ae60; }
-  &.stream .card-header { background-color: #3498db; }
-  &.view .card-header { background-color: #1abc9c; }
-  &.program .card-header { background-color: #2c3e50; }
-
   .card-header {
-    justify-content: flex-start;
     border-bottom: @entity-card-border;
     color: white;
   }
@@ -93,7 +85,6 @@
         margin-bottom: 5px;
         font-size: 15px;
         color: #333333;
-        font-weight: 500;
       }
       .metric-header {
         font-weight: 500;

--- a/cdap-ui/app/cdap/components/EntityCard/EntityCard.less
+++ b/cdap-ui/app/cdap/components/EntityCard/EntityCard.less
@@ -17,18 +17,21 @@
 @entity-card-border: 1px solid #cccccc;
 @jump-button-container-size: 80px;
 
-.home-cards.cask-card {
+.home-cards {
   padding: 0;
   border: @entity-card-border;
   text-align: left;
   border-radius: 0;
+  position: relative;
 
-  .card-header {
-    border-bottom: @entity-card-border;
-    color: white;
+  .cask-card {
+    padding: 0;
+    .card-header {
+      border-bottom: @entity-card-border;
+      color: white;
+    }
+    .card-body { padding: 0; }
   }
-  .card-body { padding: 0; }
-
   .entity-information {
     height: 35px;
     border-bottom: @entity-card-border;

--- a/cdap-ui/app/cdap/components/EntityCard/EntityCardHeader/EntityCardHeader.less
+++ b/cdap-ui/app/cdap/components/EntityCard/EntityCardHeader/EntityCardHeader.less
@@ -15,8 +15,8 @@
  */
 
 .entity-card-header {
-  margin-left: 10px;
-
+  padding-left: 10px;
+  width: 100%;
   h4 {
     line-height: 15px;
     margin-top: 5px;
@@ -27,4 +27,10 @@
   }
 
   .entity-type { margin-left: 5px; }
+  &.artifact { background-color: #bdc3c7; }
+  &.application { background-color: #ff6600; }
+  &.datasetinstance { background-color: #27ae60; }
+  &.stream { background-color: #3498db; }
+  &.view { background-color: #1abc9c; }
+  &.program { background-color: #2c3e50; }
 }

--- a/cdap-ui/app/cdap/components/EntityCard/EntityCardHeader/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/EntityCardHeader/index.js
@@ -56,6 +56,10 @@ export default class EntityCardHeader extends Component {
   }
 }
 
+EntityCardHeader.defaultProps = {
+  systemTags: []
+};
+
 EntityCardHeader.propTypes = {
   entity: PropTypes.object,
   systemTags: PropTypes.array,

--- a/cdap-ui/app/cdap/components/EntityCard/EntityCardHeader/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/EntityCardHeader/index.js
@@ -17,6 +17,7 @@
 import React, {Component, PropTypes} from 'react';
 import T from 'i18n-react';
 require('./EntityCardHeader.less');
+import classnames from 'classnames';
 
 const classNames = require('classnames');
 
@@ -43,7 +44,7 @@ export default class EntityCardHeader extends Component {
 
   render() {
     return (
-      <div className="entity-card-header">
+      <div className={classnames("entity-card-header", this.props.className)}>
         <h4>
           <span className={classNames('entity-icon', this.props.entity.icon)}></span>
           <span className="entity-type">
@@ -57,6 +58,6 @@ export default class EntityCardHeader extends Component {
 
 EntityCardHeader.propTypes = {
   entity: PropTypes.object,
-  systemTags: PropTypes.array
+  systemTags: PropTypes.array,
+  className: PropTypes.string
 };
-

--- a/cdap-ui/app/cdap/components/EntityCard/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/index.js
@@ -68,6 +68,7 @@ export default class EntityCard extends Component {
   render() {
     const header = (
       <EntityCardHeader
+        className={this.props.entity.type}
         entity={this.props.entity}
         systemTags={this.props.entity.metadata.metadata.SYSTEM.tags}
       />

--- a/cdap-ui/app/cdap/components/EntityCard/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/index.js
@@ -80,6 +80,9 @@ export default class EntityCard extends Component {
   }
 
   render() {
+    if (!this.props.entity) {
+      return null;
+    }
     const header = (
       <EntityCardHeader
         className={this.props.entity.type}
@@ -88,26 +91,31 @@ export default class EntityCard extends Component {
       />
     );
     let position = 'left';
-    console.log('Overview mode', this.state.overviewMode, this.props.entity.id);
+    let parentdimension = {};
     if (this.cardRef && this.state.overviewMode) {
       let cardDimension = this.cardRef.getBoundingClientRect();
       let parentDimension = this.cardRef.parentElement.getBoundingClientRect();
-      let spaceOnLeft = parentDimension.left - cardDimension.left;
+      let spaceOnLeft = cardDimension.left - parentDimension.left;
       let spaceOnRight = parentDimension.right - cardDimension.right;
-      let spaceOnTop = parentDimension.top - cardDimension.top;
+      let spaceOnTop = cardDimension.top - parentDimension.top;
       let spaceOnBottom = parentDimension.bottom - cardDimension.bottom;
       let maxSpace = Math.max(spaceOnLeft, spaceOnRight, spaceOnBottom, spaceOnTop);
-      if (spaceOnLeft === maxSpace) {
-        position = 'left';
-      }
-      if (spaceOnRight === maxSpace) {
-        position = 'right';
-      }
-      if (spaceOnBottom === maxSpace) {
+      parentdimension = parentDimension;
+      if (maxSpace < 330) {
         position = 'bottom';
-      }
-      if (spaceOnTop === maxSpace) {
-        position = 'top';
+      } else {
+        if (spaceOnLeft === maxSpace) {
+          position = 'left';
+        }
+        if (spaceOnRight === maxSpace) {
+          position = 'right';
+        }
+        if (spaceOnBottom === maxSpace) {
+          position = 'bottom';
+        }
+        if (spaceOnTop === maxSpace) {
+          position = 'top';
+        }
       }
     }
     return (
@@ -143,6 +151,7 @@ export default class EntityCard extends Component {
             <AppOverview
               isOpen={this.state.overviewMode}
               position={position}
+              parentdimension={parentdimension}
               entity={this.props.entity}
             />
           :
@@ -152,6 +161,10 @@ export default class EntityCard extends Component {
     );
   }
 }
+
+EntityCard.defaultProps = {
+  onClick: () => {}
+};
 
 EntityCard.propTypes = {
   entity: PropTypes.object,

--- a/cdap-ui/app/cdap/components/EntityCard/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/index.js
@@ -38,6 +38,14 @@ export default class EntityCard extends Component {
     this.cardRef = null;
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.activeEntity !== this.props.entity.uniqueId) {
+      this.setState({
+        overviewMode: false
+      });
+    }
+  }
+
   renderEntityStatus() {
     switch (this.props.entity.type) {
       case 'application':
@@ -77,6 +85,9 @@ export default class EntityCard extends Component {
     this.setState({
       overviewMode: !this.state.overviewMode
     });
+    if (this.props.onClick) {
+      this.props.onClick();
+    }
   }
 
   render() {
@@ -172,5 +183,6 @@ EntityCard.propTypes = {
   entity: PropTypes.object,
   onUpdate: PropTypes.func,
   className: PropTypes.string,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  activeEntity: PropTypes.string
 };

--- a/cdap-ui/app/cdap/components/EntityCard/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/index.js
@@ -101,6 +101,8 @@ export default class EntityCard extends Component {
       let spaceOnBottom = parentDimension.bottom - cardDimension.bottom;
       let maxSpace = Math.max(spaceOnLeft, spaceOnRight, spaceOnBottom, spaceOnTop);
       parentdimension = parentDimension;
+      // FIXME: ALERT! Magic number. This is the minimum width needed for the overview popover to look nice.
+      // Definitely needs to be more adaptive & come from css.
       if (maxSpace < 400) {
         position = 'bottom';
       } else {
@@ -149,7 +151,7 @@ export default class EntityCard extends Component {
         {
           this.state.overviewMode ?
             <AppOverview
-              isOpen={this.state.overviewMode}
+              onClose={this.toggleOverviewMode.bind(this)}
               position={position}
               parentdimension={parentdimension}
               entity={this.props.entity}

--- a/cdap-ui/app/cdap/components/EntityCard/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/index.js
@@ -88,6 +88,7 @@ export default class EntityCard extends Component {
       />
     );
     let position = 'left';
+    console.log('Overview mode', this.state.overviewMode, this.props.entity.id);
     if (this.cardRef && this.state.overviewMode) {
       let cardDimension = this.cardRef.getBoundingClientRect();
       let parentDimension = this.cardRef.parentElement.getBoundingClientRect();

--- a/cdap-ui/app/cdap/components/EntityCard/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/index.js
@@ -101,7 +101,7 @@ export default class EntityCard extends Component {
       let spaceOnBottom = parentDimension.bottom - cardDimension.bottom;
       let maxSpace = Math.max(spaceOnLeft, spaceOnRight, spaceOnBottom, spaceOnTop);
       parentdimension = parentDimension;
-      if (maxSpace < 330) {
+      if (maxSpace < 400) {
         position = 'bottom';
       } else {
         if (spaceOnLeft === maxSpace) {

--- a/cdap-ui/app/cdap/components/EntityCard/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/index.js
@@ -25,12 +25,17 @@ import StreamMetrics from './StreamMetrics';
 import classnames from 'classnames';
 import FastActions from 'components/EntityCard/FastActions';
 import JumpButton from 'components/JumpButton';
+import AppOverview from 'components/AppOverview';
 
 require('./EntityCard.less');
 
 export default class EntityCard extends Component {
   constructor(props) {
     super(props);
+    this.state = {
+      overviewMode: false
+    };
+    this.cardRef = null;
   }
 
   renderEntityStatus() {
@@ -65,6 +70,15 @@ export default class EntityCard extends Component {
     );
   }
 
+  toggleOverviewMode() {
+    if (this.props.entity.type !== 'application') {
+      return;
+    }
+    this.setState({
+      overviewMode: !this.state.overviewMode
+    });
+  }
+
   render() {
     const header = (
       <EntityCardHeader
@@ -73,38 +87,74 @@ export default class EntityCard extends Component {
         systemTags={this.props.entity.metadata.metadata.SYSTEM.tags}
       />
     );
-
+    let position = 'left';
+    if (this.cardRef && this.state.overviewMode) {
+      let cardDimension = this.cardRef.getBoundingClientRect();
+      let parentDimension = this.cardRef.parentElement.getBoundingClientRect();
+      let spaceOnLeft = parentDimension.left - cardDimension.left;
+      let spaceOnRight = parentDimension.right - cardDimension.right;
+      let spaceOnTop = parentDimension.top - cardDimension.top;
+      let spaceOnBottom = parentDimension.bottom - cardDimension.bottom;
+      let maxSpace = Math.max(spaceOnLeft, spaceOnRight, spaceOnBottom, spaceOnTop);
+      if (spaceOnLeft === maxSpace) {
+        position = 'left';
+      }
+      if (spaceOnRight === maxSpace) {
+        position = 'right';
+      }
+      if (spaceOnBottom === maxSpace) {
+        position = 'bottom';
+      }
+      if (spaceOnTop === maxSpace) {
+        position = 'top';
+      }
+    }
     return (
-      <Card
-        header={header}
-        cardClass={`home-cards ${this.props.entity.type}`}
+      <div
+        className={classnames('home-cards', this.props.entity.type, this.props.className)}
+        onClick={this.toggleOverviewMode.bind(this)}
+        ref={(ref) => this.cardRef = ref}
       >
-        <div className="entity-information clearfix">
-          <div className="entity-id-container">
-            <h4
-              className={classnames({'with-version': this.props.entity.version})}
-            >
-              {this.props.entity.id}
-            </h4>
-            <small>{this.props.entity.version}</small>
+        <Card header={header} id={`home-cards-${this.props.entity.type}`}>
+          <div className="entity-information clearfix">
+            <div className="entity-id-container">
+              <h4
+                className={classnames({'with-version': this.props.entity.version})}
+              >
+                {this.props.entity.id}
+              </h4>
+              <small>{this.props.entity.version}</small>
+            </div>
+            {this.renderJumpButton()}
           </div>
-          {this.renderJumpButton()}
-        </div>
 
-        {this.renderEntityStatus()}
+          {this.renderEntityStatus()}
 
-        <div className="fast-actions-container">
-          <FastActions
-            entity={this.props.entity}
-            onUpdate={this.props.onUpdate}
-          />
-        </div>
-      </Card>
+          <div className="fast-actions-container">
+            <FastActions
+              entity={this.props.entity}
+              onUpdate={this.props.onUpdate}
+            />
+          </div>
+        </Card>
+        {
+          this.state.overviewMode ?
+            <AppOverview
+              isOpen={this.state.overviewMode}
+              position={position}
+              entity={this.props.entity}
+            />
+          :
+            null
+        }
+      </div>
     );
   }
 }
 
 EntityCard.propTypes = {
   entity: PropTypes.object,
-  onUpdate: PropTypes.func
+  onUpdate: PropTypes.func,
+  className: PropTypes.string,
+  onClick: PropTypes.func
 };

--- a/cdap-ui/app/cdap/components/FastAction/DeleteAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/DeleteAction/index.js
@@ -40,8 +40,9 @@ export default class DeleteAction extends Component {
     };
   }
 
-  toggleModal() {
+  toggleModal(event) {
     this.setState({modal: !this.state.modal});
+    event.stopPropagation();
   }
 
   action() {
@@ -68,6 +69,7 @@ export default class DeleteAction extends Component {
         api = MyStreamApi.delete;
         params.streamId = this.props.entity.id;
         break;
+
     }
 
     api(params)

--- a/cdap-ui/app/cdap/components/FastAction/StartStopAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/StartStopAction/index.js
@@ -47,7 +47,7 @@ export default class StartStopAction extends Component {
     this.statusPoll$.dispose();
   }
 
-  onClick() {
+  onClick(event) {
     let params = Object.assign({}, this.params);
     if (this.state.status === 'RUNNING' || this.state.status === 'STARTING') {
       params.action = 'stop';
@@ -61,6 +61,7 @@ export default class StartStopAction extends Component {
       .subscribe(this.props.onSuccess, (err) => {
         alert(err);
       });
+    event.stopPropagation();
   }
 
   render() {

--- a/cdap-ui/app/cdap/components/FastAction/TruncateAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/TruncateAction/index.js
@@ -37,8 +37,9 @@ export default class TruncateAction extends Component {
     };
   }
 
-  toggleModal() {
+  toggleModal(event) {
     this.setState({modal: !this.state.modal});
+    event.stopPropagation();
   }
 
   action() {

--- a/cdap-ui/app/cdap/components/Home/Home.less
+++ b/cdap-ui/app/cdap/components/Home/Home.less
@@ -61,60 +61,46 @@
  }
 
 
-.entities-container {
-  display: flex;
-  flex-wrap: wrap;
-  margin-top: 55px;
+.home-content {
+  height: ~"calc(100vh - 100px)";
+  height: ~"-moz-calc(100vh - 100px)";
+  height: ~"-webkit-calc(100vh - 100px)";
+  align-items: flex-start;
 
-  .entity-card-container {
-    margin: 5px;
-    -webkit-box-shadow: 0px 1px 10px 0 rgba(0,0,0,0.3);
-    -moz-box-shadow: 0px 1px 10px 0 rgba(0,0,0,0.3);
-    box-shadow: 0px 1px 10px 0 rgba(0,0,0,0.3);
-    width: 100%;
-    /*
-      width of each card = 100% - (padding of parent) - (combined margin of all cards in the row)
-      margin for each card is 5px (as mentioned above).
-      So the combined margin for all cards in say ,
-        4 column layout : 5px + (5px + 5px) + (5px + 5px) + 5px = (3 * 10px)
-        5 column layout : 5px + (5px + 5px) + (5px + 5px) + (5px + 5px) + 5px = (4 * 10px)
-        6 column layout : 5px + (5px + 5px) + (5px + 5px) + (5px + 5px) + (5px + 5px) + 5px = (5 * 10px)
-        n column layout : (n-1 * 10px);
-    */
-    @media (min-width: 1601px)  {
-      width: ~"calc((100% - 10px - (5 * 10px)) / 6)";
-    }
-    @media (min-width: 1201px) and (max-width: 1600px) {
-      width: ~"calc((100% - 10px - (3 * 10px)) / 4)";
-    }
-    @media (min-width: 993px) and (max-width: 1200px) {
-      width: ~"calc((100% - 10px - (2 * 10px)) / 3)";
-    }
-    @media(min-width: 768px) and (max-width: 992px) {
-      width: ~"calc((100% - 10px - 10px) / 2)";
+  .entities-container {
+    display: flex;
+    flex-wrap: wrap;
+    margin-top: 55px;
+
+    .entity-card-container {
+      margin: 5px;
+      -webkit-box-shadow: 0px 1px 10px 0 rgba(0,0,0,0.3);
+      -moz-box-shadow: 0px 1px 10px 0 rgba(0,0,0,0.3);
+      box-shadow: 0px 1px 10px 0 rgba(0,0,0,0.3);
+      width: 300px;
+
+      &.active {
+        -webkit-box-shadow: 0px 0px 8px 0 rgba(255,102,0,1);
+        -moz-box-shadow: 0px 0px 8px 0 rgba(255,102,0,1);
+        box-shadow: 0px 0px 8px 0 rgba(255,102,0,1);
+      }
     }
 
-
-    &.active {
-      -webkit-box-shadow: 0px 0px 8px 0 rgba(255,102,0,1);
-      -moz-box-shadow: 0px 0px 8px 0 rgba(255,102,0,1);
-      box-shadow: 0px 0px 8px 0 rgba(255,102,0,1);
-    }
+  }
+  .loading-spinner {
+    position: absolute;
+    top: 40%;
+    left: 50%;
+    transform: translate(-50%, -50%);  color: gray;
   }
 
-}
-.loading-spinner {
-  position: absolute;
-  top: 40%;
-  left: 50%;
-  transform: translate(-50%, -50%);  color: gray;
-}
+  .empty-message {
+     position: absolute;
+     top: 40%;
+     left: 50%;
+     transform: translate(-50%, -50%);
+     font-size: 20px;
+     font-weight: 500;
+  }
 
-.empty-message {
-   position: absolute;
-   top: 40%;
-   left: 50%;
-   transform: translate(-50%, -50%);
-   font-size: 20px;
-   font-weight: 500;
 }

--- a/cdap-ui/app/cdap/components/Home/Home.less
+++ b/cdap-ui/app/cdap/components/Home/Home.less
@@ -60,35 +60,61 @@
    }
  }
 
-.entity-list {
-  text-align: left;
-  margin-top: 55px; // height of home header
-  padding-bottom: 60px;
-}
 
+.entities-container {
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: 55px;
+
+  .entity-card-container {
+    margin: 5px;
+    -webkit-box-shadow: 0px 1px 10px 0 rgba(0,0,0,0.3);
+    -moz-box-shadow: 0px 1px 10px 0 rgba(0,0,0,0.3);
+    box-shadow: 0px 1px 10px 0 rgba(0,0,0,0.3);
+    width: 100%;
+    /*
+      width of each card = 100% - (padding of parent) - (combined margin of all cards in the row)
+      margin for each card is 5px (as mentioned above).
+      So the combined margin for all cards in say ,
+        4 column layout : 5px + (5px + 5px) + (5px + 5px) + 5px = (3 * 10px)
+        5 column layout : 5px + (5px + 5px) + (5px + 5px) + (5px + 5px) + 5px = (4 * 10px)
+        6 column layout : 5px + (5px + 5px) + (5px + 5px) + (5px + 5px) + (5px + 5px) + 5px = (5 * 10px)
+        n column layout : (n-1 * 10px);
+    */
+    @media (min-width: 1601px)  {
+      width: ~"calc((100% - 10px - (5 * 10px)) / 6)";
+    }
+    @media (min-width: 1201px) and (max-width: 1600px) {
+      width: ~"calc((100% - 10px - (3 * 10px)) / 4)";
+    }
+    @media (min-width: 993px) and (max-width: 1200px) {
+      width: ~"calc((100% - 10px - (2 * 10px)) / 3)";
+    }
+    @media(min-width: 768px) and (max-width: 992px) {
+      width: ~"calc((100% - 10px - 10px) / 2)";
+    }
+
+
+    &.active {
+      -webkit-box-shadow: 0px 0px 8px 0 rgba(255,102,0,1);
+      -moz-box-shadow: 0px 0px 8px 0 rgba(255,102,0,1);
+      box-shadow: 0px 0px 8px 0 rgba(255,102,0,1);
+    }
+  }
+
+}
 .loading-spinner {
   position: absolute;
-  top: 50%;
-  color: gray;
+  top: 40%;
+  left: 50%;
+  transform: translate(-50%, -50%);  color: gray;
 }
 
 .empty-message {
-   margin-top: 15%;
+   position: absolute;
+   top: 40%;
+   left: 50%;
+   transform: translate(-50%, -50%);
    font-size: 20px;
    font-weight: 500;
-}
-
-.entity-card-container {
-  width: 300px;
-  display: inline-block;
-  margin: 5px;
-  -webkit-box-shadow: 0px 1px 10px 0 rgba(0,0,0,0.3);
-  -moz-box-shadow: 0px 1px 10px 0 rgba(0,0,0,0.3);
-  box-shadow: 0px 1px 10px 0 rgba(0,0,0,0.3);
-
-  &.active {
-    -webkit-box-shadow: 0px 0px 8px 0 rgba(255,102,0,1);
-    -moz-box-shadow: 0px 0px 8px 0 rgba(255,102,0,1);
-    box-shadow: 0px 0px 8px 0 rgba(255,102,0,1);
-  }
 }

--- a/cdap-ui/app/cdap/components/Home/index.js
+++ b/cdap-ui/app/cdap/components/Home/index.js
@@ -372,27 +372,23 @@ class Home extends Component {
       entitiesToBeRendered = loading;
 
       bodyContent = (
-        <div className="entity-list">
-            <div className="entities-container">
-              <ReactCSSTransitionGroup
-                transitionName=""
-                transitionEnterTimeout={200}
-                transitionLeaveTimeout={200}
-              >
-                {entitiesToBeRendered}
-              </ReactCSSTransitionGroup>
-            </div>
-        </div>
+          <ReactCSSTransitionGroup
+            component="div"
+            className="entities-container"
+            transitionName=""
+            transitionEnterTimeout={200}
+            transitionLeaveTimeout={200}
+          >
+            {entitiesToBeRendered}
+          </ReactCSSTransitionGroup>
       );
 
     } else if(this.state.entities.length === 0 || this.state.entityErr) {
       entitiesToBeRendered = empty;
 
       bodyContent = (
-        <div className="entity-list">
-          <div className="entities-container">
-            {entitiesToBeRendered}
-          </div>
+        <div className="entities-container">
+          {entitiesToBeRendered}
         </div>
       );
 
@@ -419,17 +415,15 @@ class Home extends Component {
       );
 
       bodyContent = (
-        <div className="entity-list">
-            <div className="entities-container">
-              <ReactCSSTransitionGroup
-                transitionName={"entity-animation--" + this.state.animationDirection}
-                transitionEnterTimeout={400}
-                transitionLeaveTimeout={400}
-              >
-                {entitiesToBeRendered}
-              </ReactCSSTransitionGroup>
-            </div>
-        </div>
+        <ReactCSSTransitionGroup
+          component="div"
+          className="entities-container"
+          transitionName={"entity-animation--" + this.state.animationDirection}
+          transitionEnterTimeout={400}
+          transitionLeaveTimeout={400}
+        >
+          {entitiesToBeRendered}
+        </ReactCSSTransitionGroup>
       );
 
     }

--- a/cdap-ui/app/cdap/components/Home/index.js
+++ b/cdap-ui/app/cdap/components/Home/index.js
@@ -369,20 +369,7 @@ class Home extends Component {
     let bodyContent;
 
     if(this.state.loading){
-      entitiesToBeRendered = loading;
-
-      bodyContent = (
-          <ReactCSSTransitionGroup
-            component="div"
-            className="entities-container"
-            transitionName=""
-            transitionEnterTimeout={200}
-            transitionLeaveTimeout={200}
-          >
-            {entitiesToBeRendered}
-          </ReactCSSTransitionGroup>
-      );
-
+      bodyContent = loading;
     } else if(this.state.entities.length === 0 || this.state.entityErr) {
       entitiesToBeRendered = empty;
 
@@ -393,10 +380,10 @@ class Home extends Component {
       );
 
     } else {
-      entitiesToBeRendered = this.state.entities.map(
+      bodyContent = this.state.entities.map(
         (entity) => {
           return (
-            <div
+            <EntityCard
               className={
                 classNames('entity-card-container',
                   { active: entity.uniqueId === this.state.selectedEntity }
@@ -404,28 +391,12 @@ class Home extends Component {
               }
               key={entity.uniqueId}
               onClick={this.handleEntityClick.bind(this, entity.uniqueId)}
-            >
-              <EntityCard
-                entity={entity}
-                onUpdate={this.search.bind(this)}
-              />
-            </div>
+              entity={entity}
+              onUpdate={this.search.bind(this)}
+            />
           );
         }
       );
-
-      bodyContent = (
-        <ReactCSSTransitionGroup
-          component="div"
-          className="entities-container"
-          transitionName={"entity-animation--" + this.state.animationDirection}
-          transitionEnterTimeout={400}
-          transitionLeaveTimeout={400}
-        >
-          {entitiesToBeRendered}
-        </ReactCSSTransitionGroup>
-      );
-
     }
 
     return (
@@ -443,13 +414,22 @@ class Home extends Component {
           currentPage={this.state.currentPage}
           onPageChange={this.handlePageChange}
         />
-        <Pagination
-          setCurrentPage={this.handlePageChange}
-          currentPage={this.state.currentPage}
-          setDirection={this.setAnimationDirection}
-        >
-          {bodyContent}
-        </Pagination>
+          <Pagination
+            className="home-content"
+            setCurrentPage={this.handlePageChange}
+            currentPage={this.state.currentPage}
+            setDirection={this.setAnimationDirection}
+          >
+            <ReactCSSTransitionGroup
+              component="div"
+              className="entities-container"
+              transitionName={"entity-animation--" + this.state.animationDirection}
+              transitionEnterTimeout={400}
+              transitionLeaveTimeout={400}
+            >
+              {bodyContent}
+            </ReactCSSTransitionGroup>
+          </Pagination>
       </div>
     );
   }

--- a/cdap-ui/app/cdap/components/Home/index.js
+++ b/cdap-ui/app/cdap/components/Home/index.js
@@ -389,6 +389,7 @@ class Home extends Component {
                   { active: entity.uniqueId === this.state.selectedEntity }
                 )
               }
+              activeEntity={this.state.selectedEntity}
               key={entity.uniqueId}
               onClick={this.handleEntityClick.bind(this, entity.uniqueId)}
               entity={entity}

--- a/cdap-ui/app/cdap/components/JumpButton/index.js
+++ b/cdap-ui/app/cdap/components/JumpButton/index.js
@@ -116,7 +116,7 @@ export default class JumpButton extends Component {
             'fa-chevron-up': this.state.dropdownOpen
           })} />
         </DropdownToggle>
-        <DropdownMenu className="jump-button-dropdown">
+        <DropdownMenu className="jump-button-dropdown" right>
           {this.getJumpActions()}
         </DropdownMenu>
       </ButtonDropdown>

--- a/cdap-ui/app/cdap/components/JumpButton/index.js
+++ b/cdap-ui/app/cdap/components/JumpButton/index.js
@@ -36,10 +36,11 @@ export default class JumpButton extends Component {
     this.getJumpActions();
   }
 
-  toggle() {
+  toggle(event) {
     this.setState({
       dropdownOpen: !this.state.dropdownOpen
     });
+    event.stopPropagation();
   }
 
   viewInTrackerLink() {
@@ -108,8 +109,8 @@ export default class JumpButton extends Component {
 
   render() {
     return (
-      <ButtonDropdown isOpen={this.state.dropdownOpen} toggle={this.toggle}>
-        <DropdownToggle className="jump-button">
+      <ButtonDropdown isOpen={this.state.dropdownOpen} toggle={() => {}}>
+        <DropdownToggle className="jump-button" onClick={this.toggle}>
           <span>{T.translate('features.JumpButton.buttonLabel')}</span>
           <span className={classnames('fa pull-right', {
             'fa-chevron-down': !this.state.dropdownOpen,

--- a/cdap-ui/app/cdap/components/Pagination/index.js
+++ b/cdap-ui/app/cdap/components/Pagination/index.js
@@ -17,6 +17,8 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
 import Mousetrap from 'mousetrap';
+import classnames from 'classnames';
+
 require('./Pagination.less');
 
 export default class Pagination extends Component {
@@ -85,7 +87,7 @@ export default class Pagination extends Component {
     Mousetrap.bind('left', this.goToPrev);
 
     return (
-      <div className="pagination-container">
+      <div className={classnames("pagination-container", this.props.className)}>
         <div onClick={this.goToPrev}
           className={pageChangeLeftClass}
         >
@@ -112,5 +114,6 @@ Pagination.propTypes = {
   currentPage: PropTypes.number,
   children: PropTypes.node,
   setCurrentPage: PropTypes.func,
-  setDirection: PropTypes.func
+  setDirection: PropTypes.func,
+  className: PropTypes.string
 };

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import isObject from 'lodash/isObject';
+
+/*
+  Purpose: Query a json object or an array of json objects
+  Return: Returns undefined if property is not defined(never set) and
+          and a valid value (including null) if defined.
+  Usage:
+    var obj1 = [
+      {
+        p1: 'something',
+        p2: {
+          p21: 'angular',
+          p22: 21,
+          p23: {
+            p231: 'ember',
+            p232: null
+          }
+        },
+        p3: 1296,
+        p4: [1, 2, 3],
+        p5: null
+      },
+      {
+        p101: 'somethingelse'
+      }
+    ]
+    1. query(obj1, 0, 'p1') => 'something'
+    2. query(obj1, 0, 'p2', 'p22') => 21
+    3. query(obj1, 0, 'p2', 'p32') => { p231: 'ember'}
+    4. query(obj1, 0, 'notaproperty') => undefined
+    5. query(obj1, 0, 'p2', 'p32', 'somethingelse') => undefined
+    6. query(obj1, 1, 'p2', 'p32') => undefined
+    7. query(obj1, 0, 'p2', 'p23', 'p232') => null
+    8. query(obj1, 0, 'p5') => null
+ */
+
+function objectQuery(obj) {
+  if (!isObject(obj)) {
+    return null;
+  }
+  for (var i = 1; i < arguments.length; i++) {
+    if (!isObject(obj)) {
+      return undefined;
+    }
+    obj = obj[arguments[i]];
+  }
+  return obj;
+}
+
+export {
+  objectQuery
+};

--- a/cdap-ui/app/cdap/styles/variables.less
+++ b/cdap-ui/app/cdap/styles/variables.less
@@ -115,3 +115,10 @@
 @tracker-green: #35c853;
 @hydrator-blue: #098cf9;
 @navbar-bg: #464a56;
+
+@artifact-entity-header-bg: #bdc3c7;
+@application-entity-header-bg: #ff6600;
+@datasetinstance-entity-header-bg: #27ae60;
+@stream-entity-header-bg: #3498db;
+@streamview-entity-header-bg: #1abc9c;
+@program-entity-header-bg: #2c3e50;


### PR DESCRIPTION
- Adds initial implementation of overview popover to application entities in home page.
- Fixes home page (home page wrapper) layout to occupy viewport height (avoid un-necessary wrapping and have list view to be simple(errr..))
- Adds `AppOverview` component to handle the overview popover

Bamboo build: http://builds.cask.co/browse/CDAP-DRC4789-7

Note:
- Styling still pending. Not perfect
- Don't worry about hacks for popover positioning. We should eventually have a component (like react-dimension) or a utility library that will accept a parent and child and will provide the position & dimension for child under parent)
  This is happening in package view and now in overview popover. The sooner we clean this up the better it will be
- Will add unit tests soon in subsequent PR.
