### PR TITLE
Update RemoteServiceManager to use ServiceId instead of Id.Service

### DIFF
--- a/cdap-client/src/main/java/co/cask/cdap/client/ServiceClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ServiceClient.java
@@ -196,7 +196,7 @@ public class ServiceClient {
    * @throws NotFoundException @throws NotFoundException if the app or service could not be found
    * @throws IOException if a network error occurred
    * @throws UnauthenticatedException if the request is not authorized successfully in the gateway server
-   * @deprecated since 4.0.0. Please use {@link #getServiceURL(ProgramId)}  instead
+   * @deprecated since 4.0.0. Please use {@link #getServiceURL(ServiceId)} instead
    */
   @Deprecated
   public URL getServiceURL(Id.Service service)
@@ -204,7 +204,7 @@ public class ServiceClient {
     return getServiceURL(service.toEntityId());
   }
 
-  public URL getServiceURL(ProgramId service)
+  public URL getServiceURL(ServiceId service)
     throws NotFoundException, IOException, UnauthenticatedException, UnauthorizedException {
     // Make sure the service actually exists
     get(service);

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteServiceManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteServiceManager.java
@@ -42,12 +42,12 @@ public class RemoteServiceManager extends AbstractProgramManager<ServiceManager>
   private final MetricsClient metricsClient;
   private final ProgramClient programClient;
   private final ServiceClient serviceClient;
-  private final Id.Service serviceId;
+  private final ServiceId serviceId;
 
-  public RemoteServiceManager(ServiceId programId, ClientConfig clientConfig, RESTClient restClient,
+  public RemoteServiceManager(ServiceId serviceId, ClientConfig clientConfig, RESTClient restClient,
                               RemoteApplicationManager remoteApplicationManager) {
-    super(programId, remoteApplicationManager);
-    this.serviceId = Id.Service.from(programId.getParent().toId(), programId.getProgram());
+    super(serviceId, remoteApplicationManager);
+    this.serviceId = serviceId;
     this.metricsClient = new MetricsClient(clientConfig, restClient);
     this.programClient = new ProgramClient(clientConfig, restClient);
     this.serviceClient = new ServiceClient(clientConfig, restClient);
@@ -56,7 +56,7 @@ public class RemoteServiceManager extends AbstractProgramManager<ServiceManager>
   @Override
   public void setInstances(int instances) {
     try {
-      programClient.setServiceInstances(serviceId, instances);
+      programClient.setServiceInstances(serviceId.toId(), instances);
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }
@@ -70,7 +70,7 @@ public class RemoteServiceManager extends AbstractProgramManager<ServiceManager>
   @Override
   public int getProvisionedInstances() {
     try {
-      return programClient.getServiceInstances(serviceId);
+      return programClient.getServiceInstances(serviceId.toId());
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/ServiceId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/ServiceId.java
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/id/WorkflowId.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/id/WorkflowId.java
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not


### PR DESCRIPTION
Update RemoteServiceManager to use ServiceId instead of Id.Service, so that it makes versioned API calls.

http://builds.cask.co/browse/CDAP-DUT5039-1