### PR TITLE
Fix Documentation Build and Deployment

### DIFF
--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -475,9 +475,16 @@ function rewrite() {
     echo "    $sub_string"
     if [[ $(uname) == "Darwin" ]]; then
       sed -i ".bak" "${sub_string}" ${rewrite_source}
-      rm ${rewrite_source}.bak
     else
       sed -i "${sub_string}" ${rewrite_source}
+    fi
+    errors=$?
+    if [[ ${errors} -ne 0 ]]; then
+        echo "Could not sed ${sub_string} ${rewrite_source}"
+        return ${errors}   
+    fi
+    if [[ $(uname) == "Darwin" ]]; then
+      rm ${rewrite_source}.bak
     fi
   elif [[ -z ${4} ]]; then
     local sub_string=${2}
@@ -485,9 +492,16 @@ function rewrite() {
     echo "    ${sub_string} -> ${new_sub_string} "
     if [[ $(uname) == "Darwin" ]]; then
       sed -i ".bak" "s|${sub_string}|${new_sub_string}|g" ${rewrite_source}
-      rm ${rewrite_source}.bak
     else
       sed -i "s|${sub_string}|${new_sub_string}|g" ${rewrite_source}
+    fi
+    errors=$?
+    if [[ ${errors} -ne 0 ]]; then
+        echo "Could not sed ${sub_string} ${rewrite_source}"
+        return ${errors}   
+    fi
+    if [[ $(uname) == "Darwin" ]]; then
+      rm ${rewrite_source}.bak
     fi
   else
     local rewrite_target=${2}
@@ -497,6 +511,11 @@ function rewrite() {
     echo "    ${rewrite_target}"
     echo "    ${sub_string} -> ${new_sub_string} "
     sed -e "s|${sub_string}|${new_sub_string}|g" ${rewrite_source} > ${rewrite_target}
+    errors=$?
+    if [[ ${errors} -ne 0 ]]; then
+        echo "Could not sed ${sub_string} ${rewrite_source} ${rewrite_target}"
+        return ${errors}   
+    fi
   fi
   popd  > /dev/null
 }

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -319,6 +319,13 @@ function build_docs_package() {
       echo "Could not add redirect file"
       return ${errors}   
   fi
+  echo "Adding .htaccess file (404 file)"
+  rewrite ${SCRIPT_PATH}/${COMMON_SOURCE}/htaccess ${TARGET_PATH}/${PROJECT_VERSION}/.htaccess "<version>" "${PROJECT_VERSION}"
+  errors=$?
+  if [[ ${errors} -ne 0 ]]; then
+      echo "Could not create a .htaccess file"
+      return ${errors}   
+  fi
   echo "Canonical numbered version ${zip_dir_name}"
   python ${docs_change_py} ${TARGET_PATH}/${PROJECT_VERSION}
   errors=$?
@@ -327,7 +334,7 @@ function build_docs_package() {
       return ${errors}   
   fi
   echo "Creating zip ${zip_dir_name}"
-  zip -qr ${zip_dir_name}.zip ${PROJECT_VERSION}/* --exclude *.DS_Store* *.buildinfo*
+  zip -qr ${zip_dir_name}.zip ${PROJECT_VERSION}/* ${PROJECT_VERSION}/.htaccess --exclude *.DS_Store* *.buildinfo*
   errors=$?
   if [[ ${errors} -ne 0 ]]; then
       echo "Could not create zipped doc set ${TARGET_PATH}/${PROJECT_VERSION}"


### PR DESCRIPTION
The current web servers use `.htaccess` files to perform 404 redirection. Amazon S3 does not use them. In preparation for the move to S3, this file was removed from the build. However, the deployment code tries to sync them to the current web servers, and fails when it can't find them. 

This PR adds back the missing files, .htaccess file, and add better error-handling to common function "rewrite".

Passes a Docs Develop Build: http://builds.cask.co/browse/CDAP-DDB50-1