### PR TITLE
[CDAP-7064] Homepage bug fixes

### DIFF
--- a/cdap-ui/app/cdap/components/AppOverview/AppOverview.less
+++ b/cdap-ui/app/cdap/components/AppOverview/AppOverview.less
@@ -19,6 +19,7 @@
   position: absolute;
   z-index: 1;
   background: white;
+  max-width: 700px;
 
   &.right,
   &.left {

--- a/cdap-ui/app/cdap/components/AppOverview/index.js
+++ b/cdap-ui/app/cdap/components/AppOverview/index.js
@@ -23,6 +23,8 @@ import OverviewTabConfig from './OverviewTabConfig';
 import ConfigurableTab from 'components/ConfigurableTab';
 import ApplicationMetrics from 'components/EntityCard/ApplicationMetrics';
 import shortid from 'shortid';
+import Rx from 'rx';
+import {isDescendant} from 'services/helpers';
 
 export default class AppOverview extends Component {
   constructor(props) {
@@ -41,6 +43,15 @@ export default class AppOverview extends Component {
       },
       dimension: {}
     };
+    this.documentClickEventListener$ = Rx.Observable.fromEvent(document, 'click')
+      .subscribe((e) => {
+        if (isDescendant(this.overviewRef, e.target)) {
+          return;
+        }
+        if (this.props.onClose) {
+          this.props.onClose();
+        }
+      });
   }
   getChildContext() {
     return {
@@ -98,6 +109,9 @@ export default class AppOverview extends Component {
       .subscribe(entityDetail => {
         this.setState({ entityDetail });
       });
+  }
+  componentWillUnmount() {
+    this.documentClickEventListener$.dispose();
   }
   render() {
     let style={};

--- a/cdap-ui/app/cdap/components/ConfirmationModal/index.js
+++ b/cdap-ui/app/cdap/components/ConfirmationModal/index.js
@@ -111,8 +111,14 @@ ConfirmationModal.propTypes = {
   cancelButtonText: PropTypes.string,
   cancelFn: PropTypes.func,
   confirmationElem: PropTypes.element,
-  confirmationText: PropTypes.string,
   confirmButtonText: PropTypes.string,
+  confirmationText: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.node
+    ]))
+  ]),
   confirmFn: PropTypes.func,
   headerTitle: PropTypes.string,
   isOpen: PropTypes.bool,

--- a/cdap-ui/app/cdap/components/EntityCard/ApplicationMetrics/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/ApplicationMetrics/index.js
@@ -17,6 +17,7 @@
 import React, {Component, PropTypes} from 'react';
 import {MyAppApi} from '../../../api/app';
 import NamespaceStore from 'services/NamespaceStore';
+import {humanReadableNumber} from 'services/helpers';
 
 export default class ApplicationMetrics extends Component {
   constructor(props) {
@@ -71,15 +72,15 @@ export default class ApplicationMetrics extends Component {
       <div className="metrics-container">
         <div className="metric-item">
           <p className="metric-header">Programs</p>
-          <p>{this.state.loading ? loading : this.state.numPrograms}</p>
+          <p>{this.state.loading ? loading : humanReadableNumber(this.state.numPrograms)}</p>
         </div>
         <div className="metric-item">
           <p className="metric-header">Running</p>
-          <p>{this.state.loading ? loading : this.state.running}</p>
+          <p>{this.state.loading ? loading : humanReadableNumber(this.state.running)}</p>
         </div>
         <div className="metric-item">
           <p className="metric-header">Failed</p>
-          <p>{this.state.loading ? loading : this.state.failed}</p>
+          <p>{this.state.loading ? loading : humanReadableNumber(this.state.failed)}</p>
         </div>
       </div>
     );

--- a/cdap-ui/app/cdap/components/EntityCard/DatasetMetrics/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/DatasetMetrics/index.js
@@ -18,6 +18,7 @@ import React, {Component, PropTypes} from 'react';
 import {MyMetricApi} from '../../../api/metric';
 import {MyDatasetApi} from '../../../api/dataset';
 import NamespaceStore from 'services/NamespaceStore';
+import {humanReadableNumber} from 'services/helpers';
 
 export default class DatasetMetrics extends Component {
   constructor(props) {
@@ -73,15 +74,15 @@ export default class DatasetMetrics extends Component {
       <div className="metrics-container">
         <div className="metric-item">
           <p className="metric-header">Programs</p>
-          <p>{this.state.loading ? loading : this.state.programs}</p>
+          <p>{this.state.loading ? loading : humanReadableNumber(this.state.programs)}</p>
         </div>
         <div className="metric-item">
           <p className="metric-header">Operations</p>
-          <p>{this.state.loading ? loading : this.state.ops}</p>
+          <p>{this.state.loading ? loading : humanReadableNumber(this.state.ops)}</p>
         </div>
         <div className="metric-item">
           <p className="metric-header">Writes</p>
-          <p>{this.state.loading ? loading : this.state.writes}</p>
+          <p>{this.state.loading ? loading : humanReadableNumber(this.state.writes)}</p>
         </div>
       </div>
     );

--- a/cdap-ui/app/cdap/components/EntityCard/EntityCard.less
+++ b/cdap-ui/app/cdap/components/EntityCard/EntityCard.less
@@ -27,7 +27,6 @@
   .cask-card {
     padding: 0;
     .card-header {
-      border-bottom: @entity-card-border;
       color: white;
     }
     .card-body { padding: 0; }
@@ -44,7 +43,6 @@
 
   .jump-button-container {
     width: @jump-button-container-size;
-    border-left: @entity-card-border;
     height: 100%;
 
     .jump-button { margin-top: 3px; }
@@ -60,8 +58,11 @@
       font-weight: 500;
       font-size: 15px;
       margin: 0;
-      line-height: 35px;
       vertical-align: middle;
+      width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
 
       &.with-version { line-height: initial; }
     }
@@ -75,18 +76,16 @@
   }
 
   .metrics-container {
-    height: 50px;
-    border-bottom: @entity-card-border;
+    height: 40px;
     display: flex;
 
     .metric-item {
       flex-grow: 1;
       text-align: center;
-      padding: 5px 0;
+      padding: 0;
 
       p {
         margin-bottom: 5px;
-        font-size: 15px;
         color: #333333;
       }
       .metric-header {
@@ -109,7 +108,7 @@
 
     .btn-link {
       text-decoration: none;
-      font-size: 17px;
+      font-size: 13px;
       color: white;
       padding: 0;
       span { margin: 0 20px; }

--- a/cdap-ui/app/cdap/components/EntityCard/EntityCardHeader/EntityCardHeader.less
+++ b/cdap-ui/app/cdap/components/EntityCard/EntityCardHeader/EntityCardHeader.less
@@ -18,11 +18,11 @@
   padding-left: 10px;
   width: 100%;
   h4 {
-    line-height: 15px;
+    line-height: 16px;
     margin-top: 5px;
     margin-bottom: 5px;
     font-size: 13px;
-
+    font-weight: 500;
     span { vertical-align: middle; }
   }
 

--- a/cdap-ui/app/cdap/components/EntityCard/StreamMetrics/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/StreamMetrics/index.js
@@ -18,6 +18,7 @@ import React, {Component, PropTypes} from 'react';
 import {MyMetricApi} from '../../../api/metric';
 import {MyStreamApi} from '../../../api/stream';
 import NamespaceStore from 'services/NamespaceStore';
+import {humanReadableNumber, HUMANREADABLESTORAGE} from 'services/helpers';
 
 export default class StreamMetrics extends Component {
   constructor(props) {
@@ -50,9 +51,9 @@ export default class StreamMetrics extends Component {
         if (res[0].series.length > 0) {
           res[0].series.forEach((metric) => {
             if (metric.metricName === 'system.collect.events') {
-              events = metric.data[0].value;
+              events = humanReadableNumber(metric.data[0].value);
             } else if (metric.metricName === 'system.collect.bytes') {
-              bytes = metric.data[0].value;
+              bytes = humanReadableNumber(metric.data[0].value, HUMANREADABLESTORAGE);
             }
           });
         }

--- a/cdap-ui/app/cdap/components/EntityCard/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/index.js
@@ -145,7 +145,12 @@ export default class EntityCard extends Component {
               >
                 {this.props.entity.id}
               </h4>
-              <small>{this.props.entity.version}</small>
+              <small>{
+                  this.props.entity.version ?
+                    this.props.entity.version
+                  :
+                    '1.0.0'
+                }</small>
             </div>
             {this.renderJumpButton()}
           </div>

--- a/cdap-ui/app/cdap/components/FastAction/DeleteAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/DeleteAction/index.js
@@ -43,6 +43,7 @@ export default class DeleteAction extends Component {
   toggleModal(event) {
     this.setState({modal: !this.state.modal});
     event.stopPropagation();
+    event.nativeEvent.stopImmediatePropagation();
   }
 
   action() {
@@ -85,7 +86,6 @@ export default class DeleteAction extends Component {
   render() {
     const actionLabel = T.translate('features.FastAction.deleteLabel');
     const headerTitle = `${actionLabel} ${this.props.entity.type}`;
-
     return (
       <span>
         <FastActionButton

--- a/cdap-ui/app/cdap/components/FastAction/StartStopAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/StartStopAction/index.js
@@ -62,6 +62,7 @@ export default class StartStopAction extends Component {
         alert(err);
       });
     event.stopPropagation();
+    event.nativeEvent.stopImmediatePropagation();
   }
 
   render() {

--- a/cdap-ui/app/cdap/components/FastAction/TruncateAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/TruncateAction/index.js
@@ -40,6 +40,7 @@ export default class TruncateAction extends Component {
   toggleModal(event) {
     this.setState({modal: !this.state.modal});
     event.stopPropagation();
+    event.nativeEvent.stopImmediatePropagation();
   }
 
   action() {

--- a/cdap-ui/app/cdap/components/JumpButton/index.js
+++ b/cdap-ui/app/cdap/components/JumpButton/index.js
@@ -19,6 +19,7 @@ import { ButtonDropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reac
 import T from 'i18n-react';
 import classnames from 'classnames';
 import NamespaceStore from 'services/NamespaceStore';
+import Rx from 'rx';
 
 require('./JumpButton.less');
 
@@ -34,6 +35,18 @@ export default class JumpButton extends Component {
     };
 
     this.getJumpActions();
+    this.documentClickEventListener$ = Rx.Observable.fromEvent(document, 'click')
+      .subscribe(() => {
+        if (this.state.dropdownOpen) {
+          this.setState({
+            dropdownOpen: !this.state.dropdownOpen
+          });
+        }
+      });
+  }
+
+  componentWillUnmount() {
+    this.documentClickEventListener$.dispose();
   }
 
   toggle(event) {
@@ -41,6 +54,7 @@ export default class JumpButton extends Component {
       dropdownOpen: !this.state.dropdownOpen
     });
     event.stopPropagation();
+    event.nativeEvent.stopImmediatePropagation();
   }
 
   viewInTrackerLink() {

--- a/cdap-ui/app/cdap/components/RouteToNamespace/index.js
+++ b/cdap-ui/app/cdap/components/RouteToNamespace/index.js
@@ -57,7 +57,10 @@ export default class RouteToNamespace extends Component {
     //Check #1
     if(!selectedNamespace){
       defaultNamespace = localStorage.getItem('DefaultNamespace');
-      selectedNamespace = {name: defaultNamespace};
+      let defaultNsFromBackend = list.filter(ns => ns.name === defaultNamespace);
+      if (defaultNsFromBackend.length) {
+        selectedNamespace = defaultNsFromBackend[0];
+      }
     }
     //Check #2
     if(!selectedNamespace) {

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -15,6 +15,7 @@
  */
 
 import isObject from 'lodash/isObject';
+import numeral from 'numeral';
 
 /*
   Purpose: Query a json object or an array of json objects
@@ -62,7 +63,44 @@ function objectQuery(obj) {
   }
   return obj;
 }
+export const HUMANREADABLESTORAGE = 'STORAGE';
+function humanReadableNumber(num, type) {
+  if (typeof num !== 'number') {
+    return num;
+  }
+
+  switch(type) {
+    case HUMANREADABLESTORAGE:
+      return convertBytesToHumanReadable(num);
+    default:
+      return numeral(num).format('0,0');
+  }
+
+}
+
+function convertBytesToHumanReadable(bytes) {
+  if (!bytes || typeof bytes !== 'number') {
+    return bytes;
+  }
+  if (bytes < (1024 * 1024)) {
+    return numeral(bytes).format('0.000b');
+  }
+}
+
+function isDescendant(parent, child) {
+  var node = child.parentNode;
+  while (node != null) {
+    if (node == parent) {
+      return true;
+    }
+    node = node.parentNode;
+  }
+  return false;
+}
 
 export {
-  objectQuery
+  objectQuery,
+  convertBytesToHumanReadable,
+  humanReadableNumber,
+  isDescendant
 };

--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -72,7 +72,6 @@
     "webpack-livereload-plugin": "0.9.0"
   },
   "dependencies": {
-    "redux-thunk": "2.0.1",
     "angular": "1.5.8",
     "body-parser": "1.14.2",
     "bootstrap": "3.3.7",
@@ -91,6 +90,7 @@
     "mousetrap": "1.6.0",
     "ngreact": "0.3.0",
     "node-uuid": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+    "numeral": "1.5.3",
     "object-hash": "1.1.0",
     "q": "1.4.1",
     "react": "15.3.1",
@@ -107,6 +107,7 @@
     "react-youtube": "7.1.1",
     "reactstrap": "3.2.0",
     "redux": "https://registry.npmjs.org/redux/-/redux-3.5.2.tgz",
+    "redux-thunk": "2.0.1",
     "request": "2.69.0",
     "rx": "4.1.0",
     "serve-favicon": "2.3.0",


### PR DESCRIPTION

- Fixes styling in Entity cards in homepage
- Fixes numbers to be human readable (file sizes, plain number with commas)
- Fixes going to `/` to go to appropriate namespace (Right now we only go to Defaultnamespace in localstorage. Backend might not necessarily have it. Added an extra check to see if Defaultnamespace is available in backend before navigating to the same)
- Fixes `ConfirmationModal`'s `confirmationText` prop type. `T.translate('some string', {entityId: 'entity'})` returns an array of string + react node. `translate` is not supposed to string (https://github.com/alexdrel/i18n-react/blob/release/0.3.0/src/i18n-react.ts#L199) 
- Fixes clicking on `document` to close `AppOverview` popover + Jump button.


Bamboo build: http://builds.cask.co/browse/CDAP-DRC4820-3