### PR TITLE
CDAP-4121 Remove deprecated Id class from NamespaceAdmin

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/scheduler/SchedulerQueueResolver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/scheduler/SchedulerQueueResolver.java
@@ -63,7 +63,7 @@ public class SchedulerQueueResolver {
   public String getQueue(Id.Namespace namespaceId) throws IOException, NamespaceNotFoundException {
     NamespaceMeta meta;
     try {
-      meta = namespaceQueryAdmin.get(namespaceId);
+      meta = namespaceQueryAdmin.get(namespaceId.toEntityId());
     } catch (NamespaceNotFoundException e) {
       throw e;
     } catch (Exception e) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -509,7 +509,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     }
 
     try {
-      namespaceQueryAdmin.get(namespace.toId());
+      namespaceQueryAdmin.get(namespace);
     } catch (NamespaceNotFoundException e) {
       throw e;
     } catch (Exception e) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
@@ -721,7 +721,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
     throws NamespaceNotFoundException {
 
     try {
-      namespaceQueryAdmin.get(namespace.toId());
+      namespaceQueryAdmin.get(namespace);
     } catch (NamespaceNotFoundException e) {
       throw e;
     } catch (Exception e) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/NamespaceHttpHandler.java
@@ -24,6 +24,7 @@ import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.http.HttpHandler;
 import co.cask.http.HttpResponder;
 import com.google.gson.JsonSyntaxException;
@@ -65,7 +66,7 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/namespaces/{namespace-id}")
   public void getNamespace(HttpRequest request, HttpResponder responder,
                            @PathParam("namespace-id") String namespaceId) throws Exception {
-    NamespaceMeta ns = namespaceAdmin.get(Id.Namespace.from(namespaceId));
+    NamespaceMeta ns = namespaceAdmin.get(new NamespaceId(namespaceId));
     responder.sendJson(HttpResponseStatus.OK, ns);
   }
 
@@ -75,7 +76,7 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
   public void updateNamespaceProperties(HttpRequest request, HttpResponder responder,
                                         @PathParam("namespace-id") String namespaceId) throws Exception {
     NamespaceMeta meta = parseBody(request, NamespaceMeta.class);
-    namespaceAdmin.updateProperties(Id.Namespace.from(namespaceId), meta);
+    namespaceAdmin.updateProperties(new NamespaceId(namespaceId), meta);
     responder.sendString(HttpResponseStatus.OK, String.format("Updated properties for namespace '%s'.", namespaceId));
   }
 
@@ -141,7 +142,7 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
                                          namespace, Constants.Dangerous.UNRECOVERABLE_RESET));
       return;
     }
-    Id.Namespace namespaceId = Id.Namespace.from(namespace);
+    NamespaceId namespaceId = new NamespaceId(namespace);
     namespaceAdmin.delete(namespaceId);
     responder.sendStatus(HttpResponseStatus.OK);
   }
@@ -157,7 +158,7 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
                                          namespace, Constants.Dangerous.UNRECOVERABLE_RESET));
       return;
     }
-    Id.Namespace namespaceId = Id.Namespace.from(namespace);
+    NamespaceId namespaceId = new NamespaceId(namespace);
     namespaceAdmin.deleteDatasets(namespaceId);
     responder.sendStatus(HttpResponseStatus.OK);
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/AbstractStorageProviderNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/AbstractStorageProviderNamespaceAdmin.java
@@ -106,7 +106,7 @@ abstract class AbstractStorageProviderNamespaceAdmin implements StorageProviderN
     // TODO: CDAP-1581: Implement soft delete
     Location namespaceHome = namespacedLocationFactory.get(namespaceId.toId());
     try {
-      if (hasCustomLocation(namespaceQueryAdmin.get(namespaceId.toId()))) {
+      if (hasCustomLocation(namespaceQueryAdmin.get(namespaceId))) {
         LOG.debug("Custom location mapping {} was found while deleting namespace {}. Deleting all data inside it but" +
                     "skipping namespace home directory delete.", namespaceHome, namespaceId);
         // delete everything inside the namespace home but not the namespace home as its user owned directory

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DistributedStorageProviderNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DistributedStorageProviderNamespaceAdmin.java
@@ -101,7 +101,7 @@ public final class DistributedStorageProviderNamespaceAdmin extends AbstractStor
     // delete HBase namespace
     NamespaceConfig namespaceConfig;
     try {
-      namespaceConfig = namespaceQueryAdmin.get(namespaceId.toId()).getConfig();
+      namespaceConfig = namespaceQueryAdmin.get(namespaceId).getConfig();
     } catch (Exception ex) {
       throw new IOException("Could not fetch custom HBase mapping.", ex);
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/NamespaceExistenceVerifier.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/NamespaceExistenceVerifier.java
@@ -42,7 +42,7 @@ public class NamespaceExistenceVerifier implements EntityExistenceVerifier<Names
     if (!NamespaceId.SYSTEM.equals(namespaceId)) {
       boolean exists = false;
       try {
-        exists = namespaceQueryAdmin.exists(namespaceId.toId());
+        exists = namespaceQueryAdmin.exists(namespaceId);
       } catch (Exception e) {
         throw Throwables.propagate(e);
       }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/ScheduleTaskRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/ScheduleTaskRunner.java
@@ -32,7 +32,6 @@ import co.cask.cdap.internal.app.runtime.AbstractListener;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.services.ProgramLifecycleService;
 import co.cask.cdap.internal.app.services.PropertiesResolver;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import com.google.common.collect.Maps;
@@ -127,7 +126,7 @@ public final class ScheduleTaskRunner {
     try {
       // if the program has a namespace user configured then set that user in the security request context.
       // See: CDAP-7396
-      String nsPrincipal = namespaceQueryAdmin.get(id.getNamespaceId().toId()).getConfig().getPrincipal();
+      String nsPrincipal = namespaceQueryAdmin.get(id.getNamespaceId()).getConfig().getPrincipal();
       if (nsPrincipal != null && SecurityUtil.isKerberosEnabled(cConf)) {
         SecurityRequestContext.setUserId(new KerberosName(nsPrincipal).getServiceName());
       }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/PropertiesResolver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/PropertiesResolver.java
@@ -61,7 +61,8 @@ public class PropertiesResolver {
     Map<String, String> systemArgs = Maps.newHashMap();
     systemArgs.put(Constants.AppFabric.APP_SCHEDULER_QUEUE, queueResolver.getQueue(id.getNamespace()));
     if (SecurityUtil.isKerberosEnabled(cConf)) {
-      ImpersonationInfo impersonationInfo = new ImpersonationInfo(namespaceQueryAdmin.get(id.getNamespace()), cConf);
+      ImpersonationInfo impersonationInfo = new ImpersonationInfo(
+        namespaceQueryAdmin.get(id.toEntityId().getNamespaceId()), cConf);
       systemArgs.put(ProgramOptionConstants.PRINCIPAL, impersonationInfo.getPrincipal());
       systemArgs.put(ProgramOptionConstants.KEYTAB_URI, impersonationInfo.getKeytabURI());
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
@@ -155,12 +155,12 @@ public class AppFabricTestHelper {
   private static void ensureNamespaceExists(Id.Namespace namespace, CConfiguration cConf) throws Exception {
     NamespaceAdmin namespaceAdmin = getInjector(cConf).getInstance(NamespaceAdmin.class);
     try {
-      if (!namespaceAdmin.exists(namespace)) {
+      if (!namespaceAdmin.exists(namespace.toEntityId())) {
         namespaceAdmin.create(new NamespaceMeta.Builder().setName(namespace).build());
       }
     } catch (NamespaceAlreadyExistsException e) {
       // There can be race between exists() and create() call.
-      if (!namespaceAdmin.exists(namespace)) {
+      if (!namespaceAdmin.exists(namespace.toEntityId())) {
         throw new IllegalStateException("Failed to create namespace " + namespace, e);
       }
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricTestHelper.java
@@ -57,6 +57,7 @@ import co.cask.cdap.internal.guice.AppFabricTestModule;
 import co.cask.cdap.notifications.service.NotificationService;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.security.authorization.AuthorizationBootstrapper;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
@@ -148,27 +149,27 @@ public class AppFabricTestHelper {
     });
   }
 
-  public static void ensureNamespaceExists(Id.Namespace namespace) throws Exception {
-    ensureNamespaceExists(namespace, CConfiguration.create());
+  public static void ensureNamespaceExists(NamespaceId namespaceId) throws Exception {
+    ensureNamespaceExists(namespaceId, CConfiguration.create());
   }
 
-  private static void ensureNamespaceExists(Id.Namespace namespace, CConfiguration cConf) throws Exception {
+  private static void ensureNamespaceExists(NamespaceId namespaceId, CConfiguration cConf) throws Exception {
     NamespaceAdmin namespaceAdmin = getInjector(cConf).getInstance(NamespaceAdmin.class);
     try {
-      if (!namespaceAdmin.exists(namespace.toEntityId())) {
-        namespaceAdmin.create(new NamespaceMeta.Builder().setName(namespace).build());
+      if (!namespaceAdmin.exists(namespaceId)) {
+        namespaceAdmin.create(new NamespaceMeta.Builder().setName(namespaceId).build());
       }
     } catch (NamespaceAlreadyExistsException e) {
       // There can be race between exists() and create() call.
-      if (!namespaceAdmin.exists(namespace.toEntityId())) {
-        throw new IllegalStateException("Failed to create namespace " + namespace, e);
+      if (!namespaceAdmin.exists(namespaceId)) {
+        throw new IllegalStateException("Failed to create namespace " + namespaceId.getNamespace(), e);
       }
     }
   }
 
   public static void deployApplication(Id.Namespace namespace, Class<?> applicationClz,
                                        @Nullable String config, CConfiguration cConf) throws Exception {
-    ensureNamespaceExists(namespace, cConf);
+    ensureNamespaceExists(namespace.toEntityId(), cConf);
     AppFabricClient appFabricClient = getInjector(cConf).getInstance(AppFabricClient.class);
     Location deployedJar = appFabricClient.deployApplication(namespace, applicationClz, config);
     deployedJar.delete(true);
@@ -182,7 +183,7 @@ public class AppFabricTestHelper {
 
   public static ApplicationWithPrograms deployApplicationWithManager(Id.Namespace namespace, Class<?> appClass,
                                                                      Supplier<File> folderSupplier) throws Exception {
-    ensureNamespaceExists(namespace);
+    ensureNamespaceExists(namespace.toEntityId());
     Location deployedJar = createAppJar(appClass, folderSupplier);
     ArtifactVersion artifactVersion = new ArtifactVersion(String.format("1.0.%d", System.currentTimeMillis()));
     ArtifactId artifactId = new ArtifactId(appClass.getSimpleName(), artifactVersion, ArtifactScope.USER);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/SystemArtifactsAuthorizationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/SystemArtifactsAuthorizationTest.java
@@ -156,7 +156,7 @@ public class SystemArtifactsAuthorizationTest {
     Assert.assertEquals(SYSTEM_ARTIFACT.getVersion(), artifactId.getVersion().getVersion());
     Assert.assertEquals(SYSTEM_ARTIFACT.getNamespace(), artifactId.getScope().name().toLowerCase());
 
-    namespaceAdmin.delete(namespaceId.toId());
+    namespaceAdmin.delete(namespaceId);
     authorizer.enforce(SYSTEM_ARTIFACT, ALICE, EnumSet.allOf(Action.class));
     authorizer.enforce(NamespaceId.SYSTEM, ALICE, Action.WRITE);
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerServiceTest.java
@@ -30,10 +30,9 @@ import co.cask.cdap.internal.app.DefaultApplicationSpecification;
 import co.cask.cdap.internal.schedule.TimeSchedule;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
-import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.ScheduledRuntime;
 import co.cask.cdap.proto.id.ApplicationId;
-import co.cask.cdap.proto.id.Ids;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
 import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
@@ -121,8 +120,8 @@ public class SchedulerServiceTest {
 
   @AfterClass
   public static void finish() throws Exception {
-    namespaceAdmin.delete(namespace);
-    namespaceAdmin.deleteDatasets(Id.Namespace.DEFAULT);
+    namespaceAdmin.delete(namespace.toEntityId());
+    namespaceAdmin.deleteDatasets(NamespaceId.DEFAULT);
     schedulerService.stopAndWait();
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerTestBase.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/SchedulerTestBase.java
@@ -169,7 +169,7 @@ public abstract class SchedulerTestBase {
 
   @AfterClass
   public static void tearDown() throws Exception {
-    namespaceAdmin.delete(Id.Namespace.DEFAULT);
+    namespaceAdmin.delete(NamespaceId.DEFAULT);
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/DefaultSecureStoreServiceTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/DefaultSecureStoreServiceTest.java
@@ -27,7 +27,6 @@ import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.test.AppJarHelper;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.internal.AppFabricTestHelper;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.SecureKeyId;
@@ -102,7 +101,7 @@ public class DefaultSecureStoreServiceTest {
     Tasks.waitFor(true, new Callable<Boolean>() {
       @Override
       public Boolean call() throws Exception {
-        return injector.getInstance(NamespaceAdmin.class).exists(Id.Namespace.DEFAULT);
+        return injector.getInstance(NamespaceAdmin.class).exists(NamespaceId.DEFAULT);
       }
     }, 5, TimeUnit.SECONDS);
     authorizer.revoke(NamespaceId.DEFAULT, ALICE, Collections.singleton(Action.READ));

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AuthorizationBootstrapperTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AuthorizationBootstrapperTest.java
@@ -167,7 +167,7 @@ public class AuthorizationBootstrapperTest {
       @Override
       public Boolean call() throws Exception {
         try {
-          return namespaceQueryAdmin.exists(NamespaceId.DEFAULT.toId());
+          return namespaceQueryAdmin.exists(NamespaceId.DEFAULT);
         } catch (Exception e) {
           return false;
         }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
@@ -34,6 +34,7 @@ import co.cask.cdap.proto.NamespaceConfig;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.StreamId;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -375,18 +376,18 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
                                                             TEST_NAMESPACE_META2);
     Assert.assertEquals(expectedNamespaces, Sets.newHashSet(namespaces));
 
-    NamespaceMeta namespaceMeta = namespaceClient.get(Id.Namespace.from(TEST_NAMESPACE1));
+    NamespaceMeta namespaceMeta = namespaceClient.get(new NamespaceId(TEST_NAMESPACE1));
     Assert.assertEquals(TEST_NAMESPACE_META1, namespaceMeta);
 
     try {
-      namespaceClient.get(Id.Namespace.from("nonExistentNamespace"));
+      namespaceClient.get(new NamespaceId("nonExistentNamespace"));
       Assert.fail("Did not expect namespace 'nonExistentNamespace' to exist.");
     } catch (NotFoundException expected) {
       // expected
     }
 
     // test create and get
-    Id.Namespace fooNamespace = Id.Namespace.from("fooNamespace");
+    NamespaceId fooNamespace = new NamespaceId("fooNamespace");
     NamespaceMeta toCreate = new NamespaceMeta.Builder().setName(fooNamespace).build();
     namespaceClient.create(toCreate);
     NamespaceMeta receivedMeta = namespaceClient.get(fooNamespace);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/AppMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/AppMetadataStoreTest.java
@@ -63,7 +63,7 @@ public class AppMetadataStoreTest {
   @BeforeClass
   public static void beforeClass() throws Exception {
     Injector injector = AppFabricTestHelper.getInjector();
-    AppFabricTestHelper.ensureNamespaceExists(NamespaceId.DEFAULT.toId());
+    AppFabricTestHelper.ensureNamespaceExists(NamespaceId.DEFAULT);
     datasetFramework = injector.getInstance(DatasetFramework.class);
     txExecutorFactory = injector.getInstance(TransactionExecutorFactory.class);
     cConf = injector.getInstance(CConfiguration.class);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemoteNamespaceQueryTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/store/remote/RemoteNamespaceQueryTest.java
@@ -114,11 +114,11 @@ public class RemoteNamespaceQueryTest {
     nsLocation.mkdirs();
     namespaceAdmin.create(meta);
     NamespaceId namespaceId = new NamespaceId(cdapNamespace);
-    Assert.assertTrue(queryClient.exists(namespaceId.toId()));
-    NamespaceMeta resultMeta = queryClient.get(namespaceId.toId());
+    Assert.assertTrue(queryClient.exists(namespaceId));
+    NamespaceMeta resultMeta = queryClient.get(namespaceId);
     Assert.assertEquals(namespaceConfig, resultMeta.getConfig());
 
-    namespaceAdmin.delete(namespaceId.toId());
-    Assert.assertTrue(!queryClient.exists(namespaceId.toId()));
+    namespaceAdmin.delete(namespaceId);
+    Assert.assertTrue(!queryClient.exists(namespaceId));
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/SystemMetadataAuditPublishTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/SystemMetadataAuditPublishTest.java
@@ -30,6 +30,7 @@ import co.cask.cdap.proto.audit.AuditMessage;
 import co.cask.cdap.proto.audit.AuditPayload;
 import co.cask.cdap.proto.audit.AuditType;
 import co.cask.cdap.proto.audit.payload.metadata.MetadataPayload;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.metadata.Metadata;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import com.google.common.base.Predicate;
@@ -73,7 +74,7 @@ public class SystemMetadataAuditPublishTest {
     AppFabricTestHelper.deployApplication(Id.Namespace.DEFAULT, AllProgramsApp.class, null, cConf);
     Set<String> addedMetadata = getAllSystemMetadata();
     Assert.assertFalse(addedMetadata.isEmpty());
-    namespaceAdmin.delete(Id.Namespace.DEFAULT);
+    namespaceAdmin.delete(NamespaceId.DEFAULT);
     Set<String> removedMetadata = getAllSystemMetadata();
     Assert.assertFalse(removedMetadata.isEmpty());
     // Assert that the exact same system properties and tags got added upon app deployment and removed upon deletion

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteNamespaceCommand.java
@@ -57,7 +57,7 @@ public class DeleteNamespaceCommand extends AbstractCommand {
                                     namespaceId.getNamespace());
       String userConfirm = consoleReader.readLine(prompt);
       if ("y".equalsIgnoreCase(userConfirm)) {
-        namespaceClient.delete(namespaceId.toId());
+        namespaceClient.delete(namespaceId);
         out.printf("Contents of namespace '%s' were deleted successfully", namespaceId.getNamespace());
         out.println();
       }
@@ -67,7 +67,7 @@ public class DeleteNamespaceCommand extends AbstractCommand {
                                     namespaceId.getNamespace());
       String userConfirm = consoleReader.readLine(prompt);
       if ("y".equalsIgnoreCase(userConfirm)) {
-        namespaceClient.delete(namespaceId.toId());
+        namespaceClient.delete(namespaceId);
         out.println(String.format(SUCCESS_MSG, namespaceId));
         if (cliConfig.getCurrentNamespace().equals(namespaceId)) {
           cliConfig.setNamespace(NamespaceId.DEFAULT);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeNamespaceCommand.java
@@ -51,7 +51,7 @@ public class DescribeNamespaceCommand extends AbstractCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     NamespaceId namespace = new NamespaceId(arguments.get(ArgumentName.NAMESPACE_NAME.getName()));
-    NamespaceMeta namespaceMeta = namespaceClient.get(namespace.toId());
+    NamespaceMeta namespaceMeta = namespaceClient.get(namespace);
     Table table = Table.builder()
       .setHeader("name", "description", "config")
       .setRows(Lists.newArrayList(namespaceMeta), new RowMaker<NamespaceMeta>() {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/UseNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/UseNamespaceCommand.java
@@ -47,7 +47,7 @@ public class UseNamespaceCommand extends AbstractAuthCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     NamespaceId namespace = new NamespaceId(arguments.get(ArgumentName.NAMESPACE_NAME.toString()));
     // Check if namespace exists; throws exception if namespace doesn't exist.
-    namespaceClient.get(namespace.toId());
+    namespaceClient.get(namespace);
     cliConfig.setNamespace(namespace);
     output.printf("Now using namespace '%s'\n", namespace.getNamespace());
   }

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/DatasetClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/DatasetClientTestRun.java
@@ -82,8 +82,8 @@ public class DatasetClientTestRun extends ClientTestBase {
   @After
   public void tearDown() throws Exception {
     NamespaceClient namespaceClient = new NamespaceClient(clientConfig);
-    namespaceClient.delete(TEST_NAMESPACE);
-    namespaceClient.delete(OTHER_NAMESPACE);
+    namespaceClient.delete(TEST_NAMESPACE.toEntityId());
+    namespaceClient.delete(OTHER_NAMESPACE.toEntityId());
   }
 
   @Test

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/LineageTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/LineageTestRun.java
@@ -189,7 +189,7 @@ public class LineageTestRun extends MetadataTestBase {
       // Test non-existent run
       assertRunMetadataNotFound(flow.run(RunIds.generate(1000).getId()));
     } finally {
-      namespaceClient.delete(namespace.toId());
+      namespaceClient.delete(namespace);
     }
   }
 
@@ -324,7 +324,7 @@ public class LineageTestRun extends MetadataTestBase {
                                 new MetadataRecord(stream, MetadataScope.USER, emptyMap(), emptySet())),
                           fetchRunMetadata(spark.run(sparkRunId.getId())));
     } finally {
-      namespaceClient.delete(namespace.toId());
+      namespaceClient.delete(namespace);
     }
   }
 

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataHttpHandlerTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataHttpHandlerTestRun.java
@@ -115,7 +115,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
   public void after() throws Exception {
     appClient.delete(application.toId());
     artifactClient.delete(artifactId.toId());
-    namespaceClient.delete(NamespaceId.DEFAULT.toId());
+    namespaceClient.delete(NamespaceId.DEFAULT);
   }
 
   @Test
@@ -1134,7 +1134,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
                         searchMetadata(namespace, "tag1"));
 
     // Delete namespace
-    namespaceClient.delete(namespace.toId());
+    namespaceClient.delete(namespace);
 
     // Assert no metadata
     Assert.assertEquals(ImmutableSet.of(), searchMetadata(namespace, "text"));

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/NamespaceClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/NamespaceClientTestRun.java
@@ -23,6 +23,7 @@ import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.NamespaceId;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,10 +38,10 @@ import java.util.concurrent.TimeUnit;
 public class NamespaceClientTestRun extends ClientTestBase {
   private NamespaceClient namespaceClient;
 
-  private static final Id.Namespace DOES_NOT_EXIST = Id.Namespace.from("doesnotexist");
-  private static final Id.Namespace TEST_NAMESPACE_NAME = Id.Namespace.from("testnamespace");
+  private static final NamespaceId DOES_NOT_EXIST = new NamespaceId("doesnotexist");
+  private static final NamespaceId TEST_NAMESPACE_NAME = new NamespaceId("testnamespace");
   private static final String TEST_DESCRIPTION = "testdescription";
-  private static final Id.Namespace TEST_DEFAULT_FIELDS = Id.Namespace.from("testdefaultfields");
+  private static final NamespaceId TEST_DEFAULT_FIELDS = new NamespaceId("testdefaultfields");
 
   @Before
   public void setup() {
@@ -67,7 +68,7 @@ public class NamespaceClientTestRun extends ClientTestBase {
     namespaces = namespaceClient.list();
     Assert.assertEquals(initialNamespaceCount + 1, namespaces.size());
     NamespaceMeta meta = namespaceClient.get(TEST_NAMESPACE_NAME);
-    Assert.assertEquals(TEST_NAMESPACE_NAME.getId(), meta.getName());
+    Assert.assertEquals(TEST_NAMESPACE_NAME.getNamespace(), meta.getName());
     Assert.assertEquals(TEST_DESCRIPTION, meta.getDescription());
 
     // try creating a namespace with the same id again
@@ -80,7 +81,7 @@ public class NamespaceClientTestRun extends ClientTestBase {
     }
     // verify that the existing namespace was not updated
     meta = namespaceClient.get(TEST_NAMESPACE_NAME);
-    Assert.assertEquals(TEST_NAMESPACE_NAME.getId(), meta.getName());
+    Assert.assertEquals(TEST_NAMESPACE_NAME.getNamespace(), meta.getName());
     Assert.assertEquals(TEST_DESCRIPTION, meta.getDescription());
 
     // create and verify namespace without name and description
@@ -90,7 +91,7 @@ public class NamespaceClientTestRun extends ClientTestBase {
     namespaces = namespaceClient.list();
     Assert.assertEquals(initialNamespaceCount + 2, namespaces.size());
     meta = namespaceClient.get(TEST_DEFAULT_FIELDS);
-    Assert.assertEquals(TEST_DEFAULT_FIELDS.getId(), meta.getName());
+    Assert.assertEquals(TEST_DEFAULT_FIELDS.getNamespace(), meta.getName());
     Assert.assertEquals("", meta.getDescription());
 
     // cleanup
@@ -143,17 +144,17 @@ public class NamespaceClientTestRun extends ClientTestBase {
   private void verifyReservedDelete() throws Exception {
     // For the purposes of NamespaceClientTestRun, deleting default namespace has no effect.
     // Its lifecycle is already tested in NamespaceHttpHandlerTest
-    namespaceClient.delete(Id.Namespace.DEFAULT);
-    namespaceClient.get(Id.Namespace.DEFAULT);
+    namespaceClient.delete(NamespaceId.DEFAULT);
+    namespaceClient.get(NamespaceId.DEFAULT);
     try {
-      namespaceClient.delete(Id.Namespace.SYSTEM);
-      Assert.fail(String.format("'%s' namespace must not exist", Id.Namespace.SYSTEM.getId()));
+      namespaceClient.delete(NamespaceId.SYSTEM);
+      Assert.fail(String.format("'%s' namespace must not exist", NamespaceId.SYSTEM.getNamespace()));
     } catch (NotFoundException e) {
       // expected
     }
   }
 
-  private void waitForNamespaceCreation(Id.Namespace namespace) throws IOException, UnauthenticatedException,
+  private void waitForNamespaceCreation(NamespaceId namespace) throws IOException, UnauthenticatedException,
     InterruptedException {
     int count = 0;
     while (count < 10) {

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/PreferencesClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/PreferencesClientTestRun.java
@@ -25,6 +25,7 @@ import co.cask.cdap.common.ProgramNotFoundException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.XSlowTests;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
@@ -252,7 +253,7 @@ public class PreferencesClientTestRun extends ClientTestBase {
       } catch (ApplicationNotFoundException e) {
         // ok if this happens, means its already deleted.
       }
-      namespaceClient.delete(invalidNamespace);
+      namespaceClient.delete(invalidNamespace.toEntityId());
     }
   }
 
@@ -261,17 +262,17 @@ public class PreferencesClientTestRun extends ClientTestBase {
     Map<String, String> propMap = Maps.newHashMap();
     propMap.put("k1", "namespace");
 
-    Id.Namespace myspace = Id.Namespace.from("myspace");
-    namespaceClient.create(new NamespaceMeta.Builder().setName(myspace.getId()).build());
+    NamespaceId myspace = new NamespaceId("myspace");
+    namespaceClient.create(new NamespaceMeta.Builder().setName(myspace).build());
 
-    client.setNamespacePreferences(myspace, propMap);
-    Assert.assertEquals(propMap, client.getNamespacePreferences(myspace, false));
-    Assert.assertEquals(propMap, client.getNamespacePreferences(myspace, true));
+    client.setNamespacePreferences(myspace.toId(), propMap);
+    Assert.assertEquals(propMap, client.getNamespacePreferences(myspace.toId(), false));
+    Assert.assertEquals(propMap, client.getNamespacePreferences(myspace.toId(), true));
 
     namespaceClient.delete(myspace);
-    namespaceClient.create(new NamespaceMeta.Builder().setName(myspace.getId()).build());
-    Assert.assertTrue(client.getNamespacePreferences(myspace, false).isEmpty());
-    Assert.assertTrue(client.getNamespacePreferences(myspace, true).isEmpty());
+    namespaceClient.create(new NamespaceMeta.Builder().setName(myspace).build());
+    Assert.assertTrue(client.getNamespacePreferences(myspace.toId(), false).isEmpty());
+    Assert.assertTrue(client.getNamespacePreferences(myspace.toId(), true).isEmpty());
 
     namespaceClient.delete(myspace);
   }

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/StreamClientTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/StreamClientTestRun.java
@@ -27,6 +27,7 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.StreamProperties;
 import co.cask.cdap.proto.ViewSpecification;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.cdap.test.XSlowTests;
 import com.google.common.base.Charsets;
@@ -263,7 +264,7 @@ public class StreamClientTestRun extends ClientTestBase {
     streamClient.getConfig(testStream);
     Assert.assertTrue(streamViewClient.createOrUpdate(testView, testViewSpec));
     // test that namespace deletion succeeds
-    namespaceClient.delete(Id.Namespace.DEFAULT);
+    namespaceClient.delete(NamespaceId.DEFAULT);
   }
 
 
@@ -296,6 +297,6 @@ public class StreamClientTestRun extends ClientTestBase {
 
   @After
   public void tearDown() throws Exception {
-    namespaceClient.delete(namespaceId);
+    namespaceClient.delete(namespaceId.toEntityId());
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/AbstractNamespaceQueryClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/AbstractNamespaceQueryClient.java
@@ -18,8 +18,8 @@ package co.cask.cdap.common.namespace;
 
 import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.UnauthenticatedException;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpResponse;
@@ -58,11 +58,11 @@ public abstract class AbstractNamespaceQueryClient implements NamespaceQueryAdmi
   }
 
   @Override
-  public NamespaceMeta get(Id.Namespace namespaceId) throws Exception {
+  public NamespaceMeta get(NamespaceId namespaceId) throws Exception {
     HttpResponse response =
-      execute(HttpRequest.get(resolve(String.format("namespaces/%s", namespaceId.getId()))).build());
+      execute(HttpRequest.get(resolve(String.format("namespaces/%s", namespaceId.getNamespace()))).build());
     if (response.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
-      throw new NamespaceNotFoundException(namespaceId.toEntityId());
+      throw new NamespaceNotFoundException(namespaceId);
     } else if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return ObjectResponse.fromJsonBody(response, NamespaceMeta.class).getResponseObject();
     }
@@ -71,7 +71,7 @@ public abstract class AbstractNamespaceQueryClient implements NamespaceQueryAdmi
   }
 
   @Override
-  public boolean exists(Id.Namespace namespaceId) throws Exception {
+  public boolean exists(NamespaceId namespaceId) throws Exception {
     try {
       get(namespaceId);
     } catch (NamespaceNotFoundException e) {

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/DefaultNamespacedLocationFactory.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/DefaultNamespacedLocationFactory.java
@@ -85,7 +85,7 @@ public class DefaultNamespacedLocationFactory implements NamespacedLocationFacto
       // since this is not a cdap reserved namespace we look up meta if there is a custom mapping
       NamespaceMeta namespaceMeta;
       try {
-        namespaceMeta = namespaceQueryAdmin.get(namespaceId);
+        namespaceMeta = namespaceQueryAdmin.get(namespaceId.toEntityId());
       } catch (Exception e) {
         throw new IOException(String.format("Failed to get namespace meta for namespace %s", namespaceId), e);
       }

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/InMemoryNamespaceClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/InMemoryNamespaceClient.java
@@ -18,8 +18,8 @@ package co.cask.cdap.common.namespace;
 
 import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.UnauthenticatedException;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpResponse;
 import com.google.common.base.Predicate;
@@ -49,15 +49,15 @@ public class InMemoryNamespaceClient extends AbstractNamespaceClient {
   }
 
   @Override
-  public NamespaceMeta get(final Id.Namespace namespaceId) throws Exception {
+  public NamespaceMeta get(final NamespaceId namespaceId) throws Exception {
     Iterable<NamespaceMeta> filtered = Iterables.filter(namespaces, new Predicate<NamespaceMeta>() {
       @Override
       public boolean apply(NamespaceMeta input) {
-        return input.getName().equals(namespaceId.getId());
+        return input.getName().equals(namespaceId.getNamespace());
       }
     });
     if (Iterables.size(filtered) == 0) {
-      throw new NamespaceNotFoundException(namespaceId.toEntityId());
+      throw new NamespaceNotFoundException(namespaceId);
     }
     return filtered.iterator().next();
   }
@@ -68,22 +68,22 @@ public class InMemoryNamespaceClient extends AbstractNamespaceClient {
   }
 
   @Override
-  public void delete(final Id.Namespace namespaceId) throws Exception {
+  public void delete(final NamespaceId namespaceId) throws Exception {
     Iterables.removeIf(namespaces, new Predicate<NamespaceMeta>() {
       @Override
       public boolean apply(NamespaceMeta input) {
-        return input.getName().equals(namespaceId.getId());
+        return input.getName().equals(namespaceId.getNamespace());
       }
     });
   }
 
   @Override
-  public void deleteDatasets(Id.Namespace namespaceId) throws Exception {
+  public void deleteDatasets(NamespaceId namespaceId) throws Exception {
     // No-op, we're not managing apps and datasets within InMemoryNamespaceAdmin yet
   }
 
   @Override
-  public void updateProperties(Id.Namespace namespaceId, NamespaceMeta namespaceMeta) throws Exception {
+  public void updateProperties(NamespaceId namespaceId, NamespaceMeta namespaceMeta) throws Exception {
     delete(namespaceId);
     create(namespaceMeta);
   }

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/LocalNamespaceClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/LocalNamespaceClient.java
@@ -17,8 +17,8 @@
 package co.cask.cdap.common.namespace;
 
 import co.cask.cdap.common.UnauthenticatedException;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpResponse;
 import com.google.inject.Inject;
@@ -45,12 +45,12 @@ public class LocalNamespaceClient extends AbstractNamespaceClient {
   }
 
   @Override
-  public NamespaceMeta get(Id.Namespace namespaceId) throws Exception {
+  public NamespaceMeta get(NamespaceId namespaceId) throws Exception {
     return namespaceAdmin.get(namespaceId);
   }
 
   @Override
-  public void delete(Id.Namespace namespaceId) throws Exception {
+  public void delete(NamespaceId namespaceId) throws Exception {
     namespaceAdmin.delete(namespaceId);
   }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/NamespaceAdmin.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/NamespaceAdmin.java
@@ -21,8 +21,8 @@ import co.cask.cdap.common.NamespaceCannotBeCreatedException;
 import co.cask.cdap.common.NamespaceCannotBeDeletedException;
 import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.NamespaceId;
 
 /**
  * Admin class for managing a namespace's lifecycle
@@ -41,27 +41,27 @@ public interface NamespaceAdmin extends NamespaceQueryAdmin {
   /**
    * Deletes the specified namespace.
    *
-   * @param namespaceId the {@link Id.Namespace} of the specified namespace
+   * @param namespaceId the {@link NamespaceId} of the specified namespace
    * @throws NamespaceNotFoundException if the specified namespace does not exist
    * @throws NamespaceCannotBeDeletedException if the deletion operation was unsuccessful
    */
-  void delete(Id.Namespace namespaceId) throws Exception;
+  void delete(NamespaceId namespaceId) throws Exception;
 
   /**
    * Deletes all datasets in the specified namespace.
    *
-   * @param namespaceId the {@link Id.Namespace} of the specified namespace
+   * @param namespaceId the {@link NamespaceId} of the specified namespace
    * @throws NotFoundException if the specified namespace does not exist
    * @throws NamespaceCannotBeDeletedException if the deletion operation was unsuccessful
    */
-  void deleteDatasets(Id.Namespace namespaceId) throws Exception;
+  void deleteDatasets(NamespaceId namespaceId) throws Exception;
 
   /**
    * Update namespace properties for a given namespace.
    *
-   * @param namespaceId  the {@link Id.Namespace} of the namespace to be updated
-   * @param namespaceMeta namespacemeta to update
+   * @param namespaceId  the {@link NamespaceId} of the namespace to be updated
+   * @param namespaceMeta namespace meta to update
    * @throws NotFoundException if the specified namespace is not found
    */
-  void updateProperties(Id.Namespace namespaceId, NamespaceMeta namespaceMeta) throws Exception;
+  void updateProperties(NamespaceId namespaceId, NamespaceMeta namespaceMeta) throws Exception;
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/namespace/NamespaceQueryAdmin.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/namespace/NamespaceQueryAdmin.java
@@ -19,6 +19,7 @@ package co.cask.cdap.common.namespace;
 import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.NamespaceId;
 
 import java.util.List;
 
@@ -40,7 +41,7 @@ public interface NamespaceQueryAdmin {
    * @return the {@link NamespaceMeta} of the requested namespace
    * @throws NamespaceNotFoundException if the requested namespace is not found
    */
-  NamespaceMeta get(Id.Namespace namespaceId) throws Exception;
+  NamespaceMeta get(NamespaceId namespaceId) throws Exception;
 
   /**
    * Checks if the specified namespace exists.
@@ -48,5 +49,5 @@ public interface NamespaceQueryAdmin {
    * @param namespaceId the {@link Id.Namespace} to check for existence
    * @return true, if the specifed namespace exists, false otherwise
    */
-  boolean exists(Id.Namespace namespaceId) throws Exception;
+  boolean exists(NamespaceId namespaceId) throws Exception;
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/security/DefaultImpersonator.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/security/DefaultImpersonator.java
@@ -71,7 +71,7 @@ public class DefaultImpersonator implements Impersonator {
       return UserGroupInformation.getCurrentUser();
     }
     try {
-      return getUGI(namespaceQueryAdmin.get(namespaceId.toId()));
+      return getUGI(namespaceQueryAdmin.get(namespaceId));
     } catch (Exception e) {
       Throwables.propagateIfInstanceOf(e, IOException.class);
       throw Throwables.propagate(e);

--- a/cdap-common/src/test/java/co/cask/cdap/common/namespace/SimpleNamespaceQueryAdmin.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/namespace/SimpleNamespaceQueryAdmin.java
@@ -16,9 +16,9 @@
 
 package co.cask.cdap.common.namespace;
 
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceConfig;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.List;
@@ -46,13 +46,13 @@ public class SimpleNamespaceQueryAdmin implements NamespaceQueryAdmin {
   }
 
   @Override
-  public NamespaceMeta get(Id.Namespace namespaceId) throws Exception {
-    return customNSMap.containsKey(namespaceId.getId()) ? customNSMap.get(namespaceId.getId()) :
-      new NamespaceMeta.Builder().setName(namespaceId.getId()).build();
+  public NamespaceMeta get(NamespaceId namespaceId) throws Exception {
+    return customNSMap.containsKey(namespaceId.getNamespace()) ? customNSMap.get(namespaceId.getNamespace()) :
+      new NamespaceMeta.Builder().setName(namespaceId.getNamespace()).build();
   }
 
   @Override
-  public boolean exists(Id.Namespace namespaceId) throws Exception {
+  public boolean exists(NamespaceId namespaceId) throws Exception {
     // We always return true here since this query admin is only for tests classes where we want to work with
     // namespaces without actually creating the namespace. This is why the get of this method always return a meta so
     // we always return true here.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
@@ -186,7 +186,7 @@ public final class StreamHandler extends AbstractHttpHandler {
   public void listStreams(HttpRequest request, HttpResponder responder,
                           @PathParam("namespace-id") String namespaceId) throws Exception {
     // Check for namespace existence. Throws NotFoundException if namespace doesn't exist
-    namespaceQueryAdmin.get(new NamespaceId(namespaceId).toId());
+    namespaceQueryAdmin.get(new NamespaceId(namespaceId));
     List<StreamSpecification> specifications = streamAdmin.listStreams(new NamespaceId(namespaceId));
     List<StreamDetail> streamDetails = new ArrayList<>(specifications.size());
     for (StreamSpecification specification : specifications) {
@@ -212,7 +212,7 @@ public final class StreamHandler extends AbstractHttpHandler {
                      @PathParam("namespace-id") String namespaceId,
                      @PathParam("stream") String stream) throws Exception {
     // Check for namespace existence. Throws NotFoundException if namespace doesn't exist
-    namespaceQueryAdmin.get(new NamespaceId(namespaceId).toId());
+    namespaceQueryAdmin.get(new NamespaceId(namespaceId));
 
     StreamId streamId = validateAndGetStreamId(namespaceId, stream);
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
@@ -510,10 +510,10 @@ public class DatasetInstanceService {
   /**
    * Throws an exception if the specified namespace is not the system namespace and does not exist
    */
-  private void ensureNamespaceExists(NamespaceId namespace) throws Exception {
-    if (!NamespaceId.SYSTEM.equals(namespace)) {
-      if (!namespaceQueryAdmin.exists(namespace.toId())) {
-        throw new NamespaceNotFoundException(namespace);
+  private void ensureNamespaceExists(NamespaceId namespaceId) throws Exception {
+    if (!NamespaceId.SYSTEM.equals(namespaceId)) {
+      if (!namespaceQueryAdmin.exists(namespaceId)) {
+        throw new NamespaceNotFoundException(namespaceId);
       }
     }
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetTypeService.java
@@ -567,7 +567,7 @@ public class DatasetTypeService extends AbstractIdleService {
    */
   private void ensureNamespaceExists(NamespaceId namespaceId) throws Exception {
     if (!NamespaceId.SYSTEM.equals(namespaceId)) {
-      if (!namespaceQueryAdmin.exists(namespaceId.toId())) {
+      if (!namespaceQueryAdmin.exists(namespaceId)) {
         throw new NamespaceNotFoundException(namespaceId);
       }
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
@@ -162,14 +162,14 @@ public abstract class HBaseTableUtil {
 
     if (namespaceQueryAdmin == null) {
       throw new IOException(String.format("NamespaceQueryAdmin is not set and a non-reserved namespace " +
-                                            "lookup is requested. Namespace %s", namespaceId));
+                                            "lookup is requested. Namespace %s", namespaceId.getNamespace()));
     }
 
     try {
       return getHBaseNamespace(namespaceQueryAdmin.get(namespaceId));
     } catch (Exception ex) {
       throw new IOException(String.format("NamespaceQueryAdmin lookup to get NamespaceMeta failed. " +
-                                            "Can't find mapping for %s", namespaceId), ex);
+                                            "Can't find mapping for %s", namespaceId.getNamespace()), ex);
     }
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
@@ -153,23 +153,23 @@ public abstract class HBaseTableUtil {
     return ImmutableMap.copyOf(reverseMap);
   }
 
-  public String getHBaseNamespace(NamespaceId namespace) throws IOException {
+  public String getHBaseNamespace(NamespaceId namespaceId) throws IOException {
     // Convert CDAP Namespace to HBase namespace
-    if (NamespaceId.SYSTEM.equals(namespace) || NamespaceId.CDAP.equals(namespace) ||
-      NamespaceId.DEFAULT.equals(namespace)) {
-      return toCDAPManagedHBaseNamespace(namespace);
+    if (NamespaceId.SYSTEM.equals(namespaceId) || NamespaceId.CDAP.equals(namespaceId) ||
+      NamespaceId.DEFAULT.equals(namespaceId)) {
+      return toCDAPManagedHBaseNamespace(namespaceId);
     }
 
     if (namespaceQueryAdmin == null) {
       throw new IOException(String.format("NamespaceQueryAdmin is not set and a non-reserved namespace " +
-                                            "lookup is requested. Namespace %s", namespace));
+                                            "lookup is requested. Namespace %s", namespaceId));
     }
 
     try {
-      return getHBaseNamespace(namespaceQueryAdmin.get(namespace.toId()));
+      return getHBaseNamespace(namespaceQueryAdmin.get(namespaceId));
     } catch (Exception ex) {
       throw new IOException(String.format("NamespaceQueryAdmin lookup to get NamespaceMeta failed. " +
-                                            "Can't find mapping for %s", namespace), ex);
+                                            "Can't find mapping for %s", namespaceId), ex);
     }
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -239,7 +239,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
   private void deleteNamespace (NamespaceId namespaceId) throws Exception {
     // since the namespace admin here is an in memory one we need to delete the location explicitly
     namespacedLocationFactory.get(namespaceId.toId()).delete(true);
-    namespaceAdmin.delete(namespaceId.toId());
+    namespaceAdmin.delete(namespaceId);
   }
 
   @After

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -145,7 +145,7 @@ public abstract class DatasetServiceTestBase {
   @AfterClass
   public static void tearDown() throws Exception {
     Services.chainStop(service, opExecutorService, txManager, authEnforcementService);
-    namespaceAdmin.delete(NamespaceId.DEFAULT.toId());
+    namespaceAdmin.delete(NamespaceId.DEFAULT);
     Locations.deleteQuietly(locationFactory.create(NamespaceId.DEFAULT.getNamespace()));
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorServiceTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorServiceTest.java
@@ -160,8 +160,8 @@ public class DatasetOpExecutorServiceTest {
     managerService.stopAndWait();
     managerService = null;
 
-    namespaceAdmin.delete(NamespaceId.DEFAULT.toId());
-    namespaceAdmin.delete(bob.getParent().toId());
+    namespaceAdmin.delete(NamespaceId.DEFAULT);
+    namespaceAdmin.delete(bob.getParent());
   }
 
   @Test

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -40,7 +40,6 @@ import co.cask.cdap.hive.context.TxnCodec;
 import co.cask.cdap.hive.datasets.DatasetStorageHandler;
 import co.cask.cdap.hive.stream.StreamStorageHandler;
 import co.cask.cdap.proto.ColumnDesc;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.QueryHandle;
 import co.cask.cdap.proto.QueryInfo;
@@ -807,7 +806,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     startAndWait();
     String customHiveDatabase;
     try {
-      customHiveDatabase = namespaceQueryAdmin.get(namespace.toId()).getConfig().getHiveDatabase();
+      customHiveDatabase = namespaceQueryAdmin.get(namespace).getConfig().getHiveDatabase();
     } catch (Exception e) {
       throw new ExploreException(String.format("Failed to get namespace meta for the namespace %s", namespace));
     }
@@ -1235,7 +1234,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
       return namespace;
     }
     try {
-      String customHiveDb = namespaceQueryAdmin.get(Id.Namespace.from(namespace)).getConfig().getHiveDatabase();
+      String customHiveDb = namespaceQueryAdmin.get(new NamespaceId(namespace)).getConfig().getHiveDatabase();
       if (!Strings.isNullOrEmpty(customHiveDb)) {
         return customHiveDb;
       }

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
@@ -278,7 +278,7 @@ public class BaseHiveExploreServiceTest {
     if (!NamespaceId.DEFAULT.equals(namespaceId)) {
       exploreService.deleteNamespace(namespaceId);
     }
-    namespaceAdmin.delete(namespaceId.toId());
+    namespaceAdmin.delete(namespaceId);
   }
 
   protected static String getDatasetHiveName(DatasetId datasetID) {

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
@@ -122,7 +122,7 @@ public class ExploreDisabledTest {
   @AfterClass
   public static void stop() throws Exception {
     exploreClient.removeNamespace(namespaceId.toId());
-    namespaceAdmin.delete(namespaceId.toId());
+    namespaceAdmin.delete(namespaceId);
     exploreClient.close();
     datasetService.stopAndWait();
     dsOpExecutor.stopAndWait();

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/GatewayTestBase.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/GatewayTestBase.java
@@ -41,8 +41,8 @@ import co.cask.cdap.logging.read.LogReader;
 import co.cask.cdap.metrics.query.MetricsQueryService;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.notifications.service.NotificationService;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.guice.InMemorySecurityModule;
 import co.cask.cdap.security.spi.authorization.NoOpAuthorizer;
 import co.cask.cdap.security.spi.authorization.PrivilegesManager;
@@ -214,9 +214,9 @@ public abstract class GatewayTestBase {
   }
 
   public static void stopGateway(CConfiguration conf) throws Exception {
-    namespaceAdmin.delete(Id.Namespace.from(TEST_NAMESPACE1));
-    namespaceAdmin.delete(Id.Namespace.from(TEST_NAMESPACE2));
-    namespaceAdmin.delete(Id.Namespace.DEFAULT);
+    namespaceAdmin.delete(new NamespaceId(TEST_NAMESPACE1));
+    namespaceAdmin.delete(new NamespaceId(TEST_NAMESPACE2));
+    namespaceAdmin.delete(NamespaceId.DEFAULT);
     streamService.stopAndWait();
     notificationService.stopAndWait();
     appFabricServer.stopAndWait();

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
@@ -102,7 +102,7 @@ public abstract class IntegrationTestBase {
     assertUnrecoverableResetEnabled();
 
     boolean deleteUponTeardown = false;
-    if (!getNamespaceClient().exists(configuredNamespace.toId())) {
+    if (!getNamespaceClient().exists(configuredNamespace)) {
       getNamespaceClient().create(new NamespaceMeta.Builder().setName(configuredNamespace.toId()).build());
       // if we created the configured namespace, delete it upon teardown
       deleteUponTeardown = true;
@@ -120,7 +120,7 @@ public abstract class IntegrationTestBase {
     for (Map.Entry<NamespaceId, Boolean> namespaceEntry : registeredNamespaces.entrySet()) {
       // there could be a race condition that test case registers the namespace, but fails before
       // creating the actual namespace, so check existence before clearing/deleting the namespace
-      if (!getNamespaceClient().exists(namespaceEntry.getKey().toId())) {
+      if (!getNamespaceClient().exists(namespaceEntry.getKey())) {
         continue;
       }
       Boolean deleteUponTeardown = namespaceEntry.getValue();
@@ -387,7 +387,7 @@ public abstract class IntegrationTestBase {
     getProgramClient().stopAll(namespace.toId());
 
     if (deleteNamespace) {
-      getNamespaceClient().delete(namespace.toId());
+      getNamespaceClient().delete(namespace);
       return;
     }
 

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestManager.java
@@ -451,7 +451,7 @@ public class IntegrationTestManager implements TestManager {
 
   @Override
   public void deleteNamespace(Id.Namespace namespace) throws Exception {
-    namespaceClient.delete(namespace);
+    namespaceClient.delete(namespace.toEntityId());
   }
 
   @Override

--- a/cdap-kms/src/main/java/co/cask/cdap/security/store/KMSSecureStore.java
+++ b/cdap-kms/src/main/java/co/cask/cdap/security/store/KMSSecureStore.java
@@ -236,7 +236,7 @@ public class KMSSecureStore implements SecureStore, SecureStoreManager, Delegati
 
   private void checkNamespaceExists(String namespace) throws Exception {
     NamespaceId namespaceId = new NamespaceId(namespace);
-    if (!namespaceQueryAdmin.exists(namespaceId.toId())) {
+    if (!namespaceQueryAdmin.exists(namespaceId)) {
       throw new NamespaceNotFoundException(namespaceId);
     }
   }

--- a/cdap-notifications/src/test/java/co/cask/cdap/notifications/NotificationTest.java
+++ b/cdap-notifications/src/test/java/co/cask/cdap/notifications/NotificationTest.java
@@ -189,7 +189,7 @@ public abstract class NotificationTest {
     // clear the feeds
     feedManager.deleteFeed(FEED1);
     feedManager.deleteFeed(FEED2);
-    namespaceAdmin.delete(namespace.toId());
+    namespaceAdmin.delete(namespace);
     Assert.assertEquals(0, feedManager.listFeeds(namespace.toId()).size());
   }
 
@@ -266,7 +266,7 @@ public abstract class NotificationTest {
     } finally {
       dsFramework.deleteInstance(myTableInstance);
       feedManager.deleteFeed(FEED1);
-      namespaceAdmin.delete(namespace.toId());
+      namespaceAdmin.delete(namespace);
     }
   }
 

--- a/cdap-security/src/main/java/co/cask/cdap/security/store/FileSecureStore.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/store/FileSecureStore.java
@@ -243,7 +243,7 @@ public class FileSecureStore implements SecureStore, SecureStoreManager {
 
   private void checkNamespaceExists(String namespace) throws Exception {
     NamespaceId namespaceId = new NamespaceId(namespace);
-    if (!namespaceQueryAdmin.exists(namespaceId.toId())) {
+    if (!namespaceQueryAdmin.exists(namespaceId)) {
       throw new NamespaceNotFoundException(namespaceId);
     }
   }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -448,7 +448,7 @@ public class TestBase {
       authorizerInstantiator.get().grant(NamespaceId.DEFAULT, principal, ImmutableSet.of(Action.ADMIN));
     }
 
-    namespaceAdmin.delete(Id.Namespace.DEFAULT);
+    namespaceAdmin.delete(NamespaceId.DEFAULT);
     authorizerInstantiator.close();
     streamCoordinatorClient.stopAndWait();
     metricsQueryService.stopAndWait();

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/UnitTestManager.java
@@ -473,7 +473,7 @@ public class UnitTestManager implements TestManager {
 
   @Override
   public void deleteNamespace(Id.Namespace namespace) throws Exception {
-    namespaceAdmin.delete(namespace);
+    namespaceAdmin.delete(namespace.toEntityId());
   }
 
   @Override

--- a/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
@@ -193,11 +193,11 @@ public class AuthorizationTest extends TestBase {
     createAuthNamespace();
     // No authorization currently for listing and retrieving namespace
     namespaceAdmin.list();
-    namespaceAdmin.get(AUTH_NAMESPACE.toId());
+    namespaceAdmin.get(AUTH_NAMESPACE);
     // revoke privileges
     revokeAndAssertSuccess(AUTH_NAMESPACE);
     try {
-      namespaceAdmin.deleteDatasets(AUTH_NAMESPACE.toId());
+      namespaceAdmin.deleteDatasets(AUTH_NAMESPACE);
       Assert.fail("Namespace delete datasets should have failed because alice's privileges on the namespace have " +
                     "been revoked");
     } catch (UnauthorizedException expected) {
@@ -205,14 +205,14 @@ public class AuthorizationTest extends TestBase {
     }
     // grant privileges again
     grantAndAssertSuccess(AUTH_NAMESPACE, ALICE, ImmutableSet.of(Action.ADMIN));
-    namespaceAdmin.deleteDatasets(AUTH_NAMESPACE.toId());
+    namespaceAdmin.deleteDatasets(AUTH_NAMESPACE);
     // deleting datasets does not revoke privileges.
     Assert.assertEquals(
       ImmutableSet.of(new Privilege(instance, Action.ADMIN), new Privilege(AUTH_NAMESPACE, Action.ADMIN)),
       authorizer.listPrivileges(ALICE)
     );
     NamespaceMeta updated = new NamespaceMeta.Builder(AUTH_NAMESPACE_META).setDescription("new desc").build();
-    namespaceAdmin.updateProperties(AUTH_NAMESPACE.toId(), updated);
+    namespaceAdmin.updateProperties(AUTH_NAMESPACE, updated);
   }
 
   @Test
@@ -896,7 +896,7 @@ public class AuthorizationTest extends TestBase {
       Assert.assertArrayEquals(key, results.read(key));
     }
     flowManager.stop();
-    getNamespaceAdmin().delete(outputDatasetNS.getNamespaceId().toId());
+    getNamespaceAdmin().delete(outputDatasetNS.getNamespaceId());
   }
 
   @Test
@@ -960,7 +960,7 @@ public class AuthorizationTest extends TestBase {
     // cleanup
     deleteDatasetInstance(NamespaceId.SYSTEM, "table1");
     deleteDatasetInstance(NamespaceId.SYSTEM, "table2");
-    getNamespaceAdmin().delete(otherNS.getNamespaceId().toId());
+    getNamespaceAdmin().delete(otherNS.getNamespaceId());
   }
 
   private void testCrossNSDatasetAccessWithAuthMapReduce(MapReduceManager mrManager) throws Exception {
@@ -1013,8 +1013,8 @@ public class AuthorizationTest extends TestBase {
     // Verify results as alice
     SecurityRequestContext.setUserId(ALICE.getName());
     verifyDummyData(outputDatasetNS.getNamespaceId(), "table2");
-    getNamespaceAdmin().delete(inputDatasetNS.getNamespaceId().toId());
-    getNamespaceAdmin().delete(outputDatasetNS.getNamespaceId().toId());
+    getNamespaceAdmin().delete(inputDatasetNS.getNamespaceId());
+    getNamespaceAdmin().delete(outputDatasetNS.getNamespaceId());
   }
 
   @Test
@@ -1161,7 +1161,7 @@ public class AuthorizationTest extends TestBase {
     // cleanup
     deleteDatasetInstance(NamespaceId.SYSTEM, "table1");
     deleteDatasetInstance(NamespaceId.SYSTEM, "table2");
-    getNamespaceAdmin().delete(otherNS.getNamespaceId().toId());
+    getNamespaceAdmin().delete(otherNS.getNamespaceId());
   }
 
   private void testCrossNSDatasetAccessWithAuthSpark(SparkManager sparkManager) throws Exception {
@@ -1217,8 +1217,8 @@ public class AuthorizationTest extends TestBase {
     // Verify the results as alice
     SecurityRequestContext.setUserId(ALICE.getName());
     verifyDummyData(outputDatasetNSMeta.getNamespaceId(), "output");
-    getNamespaceAdmin().delete(inputDatasetNSMeta.getNamespaceId().toId());
-    getNamespaceAdmin().delete(outputDatasetNSMeta.getNamespaceId().toId());
+    getNamespaceAdmin().delete(inputDatasetNSMeta.getNamespaceId());
+    getNamespaceAdmin().delete(outputDatasetNSMeta.getNamespaceId());
   }
 
   @Test
@@ -1280,7 +1280,7 @@ public class AuthorizationTest extends TestBase {
 
     grantAndAssertSuccess(AUTH_NAMESPACE, SecurityRequestContext.toPrincipal(), EnumSet.allOf(Action.class));
     // clean up. remove the namespace. all privileges on the namespace should be revoked
-    getNamespaceAdmin().delete(AUTH_NAMESPACE.toId());
+    getNamespaceAdmin().delete(AUTH_NAMESPACE);
     Assert.assertEquals(ImmutableSet.of(new Privilege(instance, Action.ADMIN)), authorizer.listPrivileges(ALICE));
     // revoke privileges on the instance
     revokeAndAssertSuccess(instance);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestSQLQueryTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestSQLQueryTestRun.java
@@ -19,8 +19,8 @@ package co.cask.cdap.test.app;
 import co.cask.cdap.common.NamespaceCannotBeCreatedException;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.explore.service.ExploreException;
-import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.base.TestFrameworkTestBase;
 import org.junit.Assert;
@@ -35,7 +35,7 @@ import java.sql.ResultSet;
  */
 public class TestSQLQueryTestRun extends TestFrameworkTestBase {
 
-  private final Id.Namespace testSpace = Id.Namespace.from("testspace");
+  private final NamespaceId testSpace = new NamespaceId("testspace");
   private static NamespaceAdmin namespaceAdmin;
 
   @BeforeClass
@@ -110,11 +110,11 @@ public class TestSQLQueryTestRun extends TestFrameworkTestBase {
 
   private void testSQLQuery() throws Exception {
     // Deploying app makes sure that the default namespace is available.
-    deployApplication(testSpace, DummyApp.class);
-    deployDatasetModule(testSpace, "my-kv", AppsWithDataset.KeyValueTableDefinition.Module.class);
-    deployApplication(testSpace, AppsWithDataset.AppWithAutoCreate.class);
+    deployApplication(testSpace.toId(), DummyApp.class);
+    deployDatasetModule(testSpace.toId(), "my-kv", AppsWithDataset.KeyValueTableDefinition.Module.class);
+    deployApplication(testSpace.toId(), AppsWithDataset.AppWithAutoCreate.class);
     DataSetManager<AppsWithDataset.KeyValueTableDefinition.KeyValueTable> myTableManager =
-      getDataset(testSpace, "myTable");
+      getDataset(testSpace.toId(), "myTable");
     AppsWithDataset.KeyValueTableDefinition.KeyValueTable kvTable = myTableManager.get();
     kvTable.put("a", "1");
     kvTable.put("b", "2");
@@ -122,7 +122,7 @@ public class TestSQLQueryTestRun extends TestFrameworkTestBase {
     myTableManager.flush();
 
     try (
-      Connection connection = getQueryClient(testSpace);
+      Connection connection = getQueryClient(testSpace.toId());
       ResultSet results = connection.prepareStatement("select first from dataset_mytable where second = '1'")
         .executeQuery()
     ) {


### PR DESCRIPTION
Removed the deprecated Id.Namespace from NamespaceAdmin interface and all its usage.

Issue: https://issues.cask.co/browse/CDAP-4121
Build: http://builds.cask.co/browse/CDAP-DUT5041-3
ITM: http://builds.cask.co/browse/CDAP-ITM-60