### PR TITLE
CDAP-7612 create a twill program controller for spark

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
@@ -320,6 +320,9 @@ public final class DistributedProgramRuntimeService extends AbstractProgramRunti
       case WORKER:
         programController = new WorkerTwillProgramController(programId, controller, runId);
         break;
+      case SPARK:
+        programController = new SparkTwillProgramController(programId, controller, runId);
+        break;
     }
     return programController == null ? null : programController.startListen();
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/SparkTwillProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/SparkTwillProgramController.java
@@ -14,11 +14,10 @@
  * the License.
  */
 
-package co.cask.cdap.app.runtime.spark.distributed;
+package co.cask.cdap.internal.app.runtime.distributed;
 
 import co.cask.cdap.api.spark.Spark;
 import co.cask.cdap.app.runtime.ProgramController;
-import co.cask.cdap.internal.app.runtime.distributed.AbstractTwillProgramController;
 import co.cask.cdap.proto.id.ProgramId;
 import org.apache.twill.api.RunId;
 import org.apache.twill.api.TwillController;
@@ -28,11 +27,11 @@ import org.slf4j.LoggerFactory;
 /**
  * A {@link ProgramController} for {@link Spark} program in distributed mode.
  */
-final class SparkTwillProgramController extends AbstractTwillProgramController {
+public final class SparkTwillProgramController extends AbstractTwillProgramController {
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkTwillProgramController.class);
 
-  SparkTwillProgramController(ProgramId programId, TwillController controller, RunId runId) {
+  public SparkTwillProgramController(ProgramId programId, TwillController controller, RunId runId) {
     super(programId, controller, runId);
   }
 

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
@@ -33,6 +33,7 @@ import co.cask.cdap.common.security.Impersonator;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.distributed.AbstractDistributedProgramRunner;
 import co.cask.cdap.internal.app.runtime.distributed.LocalizeResource;
+import co.cask.cdap.internal.app.runtime.distributed.SparkTwillProgramController;
 import co.cask.cdap.internal.app.runtime.spark.SparkUtils;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.security.TokenSecureStoreUpdater;


### PR DESCRIPTION
Fixes a bug where a program controller would not be created for
spark programs when the controller is built from a TwillRunner.
This happens when the cdap master that stops a spark program
is no the same process that started it, due to restart or
failover.