### PR TITLE
Updates for EMR install

### DIFF
--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -402,7 +402,7 @@ cdap_set_hbase() {
 cdap_set_hive_classpath() {
   local __explore=${EXPLORE_ENABLED:-$(cdap_get_conf "explore.enabled" "${CDAP_CONF}"/cdap-site.xml true)}
   if [[ ${__explore} == true ]]; then
-    if [[ -z ${HIVE_HOME} ]] || [[ -z ${HIVE_CONF_DIR} ]] || [[ -z ${HADOOP_CONF_DIR} ]]; then
+    if [[ -z ${HIVE_HOME} ]] || [[ -z ${HIVE_CONF_DIR} ]] || [[ -z ${HADOOP_CONF_DIR} ]] || [[ -z ${HIVE_EXEC_ENGINE} ]] || [[ -z ${HIVE_CLASSPATH} ]]; then
       __secure=${KERBEROS_ENABLED:-$(cdap_get_conf "kerberos.auth.enabled" "${CDAP_CONF}"/cdap-site.xml false)}
       if [[ ${__secure} == true ]]; then
         cdap_kinit || return 1
@@ -433,15 +433,15 @@ cdap_set_hive_classpath() {
         HIVE_HOME=${HIVE_HOME:-$(echo -e "${HIVE_VARS}" | grep '^env:HIVE_HOME=' | cut -d= -f2)}
         HIVE_CONF_DIR=${HIVE_CONF_DIR:-$(echo -e "${HIVE_VARS}" | grep '^env:HIVE_CONF_DIR=' | cut -d= -f2)}
         HADOOP_CONF_DIR=${HADOOP_CONF_DIR:-$(echo -e "${HIVE_VARS}" | grep '^env:HADOOP_CONF_DIR=' | cut -d= -f2)}
+        HIVE_CLASSPATH=${HIVE_CLASSPATH:-$(echo -e "${HIVE_VARS}" | grep '^env:CLASSPATH=' | cut -d= -f2)}
         HIVE_EXEC_ENGINE=${HIVE_EXEC_ENGINE:-$(echo -e "${HIVE_VARS}" | grep '^hive.execution.engine=' | cut -d= -f2)}
       fi
     fi
 
     # If Hive classpath is successfully determined, derive explore
     # classpath from it and export it to use it in the launch command
-    if [[ -n ${HIVE_HOME} ]] && [[ -n ${HIVE_CONF_DIR} ]] && [[ -n ${HADOOP_CONF_DIR} ]]; then
+    if [[ -n ${HIVE_HOME} ]] && [[ -n ${HIVE_CONF_DIR} ]] && [[ -n ${HADOOP_CONF_DIR} ]] && [[ -n ${HIVE_CLASSPATH} ]]; then
       EXPLORE_CONF_DIRS="${HIVE_CONF_DIR}:${HADOOP_CONF_DIR}"
-      HIVE_CLASSPATH=${HIVE_CLASSPATH:-$(echo -e "${HIVE_VARS}" | grep '^env:CLASSPATH=' | cut -d= -f2)}
       EXPLORE_CLASSPATH=${HIVE_CLASSPATH}
       if [[ -n ${TEZ_HOME} ]] && [[ -n ${TEZ_CONF_DIR} ]]; then
         # tez-site.xml also need to be passed to explore service

--- a/cdap-distributions/src/emr/cdap-conf.json
+++ b/cdap-distributions/src/emr/cdap-conf.json
@@ -15,14 +15,14 @@
       "router.bind.port": "11015",
       "stream.container.memory.mb": "1536",
       "twill.java.reserved.memory.mb": "350",
-      "router.server.address": "{{ROUTER-HOST-IP}}",
+      "router.server.address": "{{ROUTER_IP_ADDRESS}}",
       "zookeeper.quorum": "{{ZK_QUORUM}}"
     },
     "cdap_env": {
       "explore_enabled": "true",
       "kerberos_enabled": "false",
       "hadoop_conf_dir": "/etc/hadoop/conf",
-      "hadoop_home_warn_suppress": "$(hadoop dfsadmin -safemode wait 2>/dev/null; echo true)",
+      "hadoop_home_warn_suppress": "$(hadoop dfsadmin -safemode wait >/dev/null 2>&1; sleep 1; [[ ${UID} -eq 0 ]] && su - hdfs -c 'for d in /cdap /user/cdap; do hdfs dfs -mkdir -p ${d} ; hdfs dfs -chown cdap ${d}; done' >/dev/null 2>&1; echo true)",
       "hive_home": "/usr/lib/hive",
       "hive_conf_dir": "/etc/hive/conf",
       "hive_classpath": "{{HIVE_CLASSPATH}}",

--- a/cdap-distributions/src/emr/cdap-conf.json
+++ b/cdap-distributions/src/emr/cdap-conf.json
@@ -1,0 +1,38 @@
+{
+  "cdap": {
+    "cdap_site": {
+      "dashboard.bind.port": "11011",
+      "dataset.executor.container.memory.mb": "1536",
+      "explore.enabled": "{{EXPLORE_ENABLED}}",
+      "explore.executor.container.memory.mb": "2304",
+      "http.client.read.timeout.ms": "120000",
+      "kafka.log.dir": "/mnt/cdap/kafka-logs",
+      "log.saver.run.memory.megs": "1536",
+      "master.service.memory.mb": "1536",
+      "master.startup.checks.enabled": "false",
+      "metrics.memory.mb": "1536",
+      "metrics.processor.memory.mb": "1536",
+      "router.bind.port": "11015",
+      "stream.container.memory.mb": "1536",
+      "twill.java.reserved.memory.mb": "350",
+      "router.server.address": "{{ROUTER-HOST-IP}}",
+      "zookeeper.quorum": "{{ZK_QUORUM}}"
+    },
+    "cdap_env": {
+      "explore_enabled": "true",
+      "kerberos_enabled": "false",
+      "hadoop_conf_dir": "/etc/hadoop/conf",
+      "hadoop_home_warn_suppress": "$(hadoop dfsadmin -safemode wait 2>/dev/null; echo true)",
+      "hive_home": "/usr/lib/hive",
+      "hive_conf_dir": "/etc/hive/conf",
+      "hive_classpath": "{{HIVE_CLASSPATH}}",
+      "hive_exec_engine": "{{HIVE_EXEC_ENGINE}}",
+      "spark_home": "/usr/lib/spark",
+      "tez_home": "/usr/lib/tez",
+      "tez_conf_dir": "/etc/tez/conf"
+    },
+    "skip_prerequisites": "true",
+    "yum_repo_url": "{{CDAP_YUM_REPO_URL}}",
+    "version": "{{CDAP_VERSION}}"
+  }
+}

--- a/cdap-distributions/src/emr/install.sh
+++ b/cdap-distributions/src/emr/install.sh
@@ -15,16 +15,32 @@
 # the License.
 
 #
-# Install CDAP for EMR
+# Install CDAP for Amazon Elastic MapReduce (EMR) AMI 4.6.0+ using Amazon Hadoop
 #
+
+# CDAP config
+# The git branch to clone
+CDAP_BRANCH=${CDAP_BRANCH:-develop}
+# Optional tag to checkout - All released versions of this script should set this
+CDAP_TAG=''
+# The CDAP package version passed to Chef
+CDAP_VERSION=${CDAP_VERSION:-4.0.0-1}
+# The version of Chef to install
+CHEF_VERSION=${CHEF_VERSION:-12.10.24}
+# cdap-site.xml configuration parameters
+EXPLORE_ENABLED='true'
+
+__tmpdir="/tmp/cdap_install.$$.$(date +%s)"
+__gitdir="${__tmpdir}/cdap"
+
+__packerdir="${__gitdir}/cdap-distributions/src/packer/scripts"
+__cdap_site_template="${__gitdir}/cdap-distributions/src/emr/cdap-conf.json"
+
+__repo_url=${CDAP_YUM_REPO_URL:-http://repository.cask.co/centos/6/x86_64/cdap/MAJ_MIN}
 
 die() { echo "ERROR: ${*}"; exit 1; };
 
-# This should return the latest released CDAP version... do not put -SNAPSHOT here
-export CDAP_VERSION=${CDAP_VERSION:-4.0.0-1}
-
-__repo_url=${CDAP_REPO_URL:-http://repository.cask.co/centos/6/x86_64/cdap/MAJ_MIN}
-
+# Parse any command line options
 while [[ ${#} -gt 0 ]]; do
   case ${1} in
     --cdap-version*)
@@ -51,74 +67,99 @@ while [[ ${#} -gt 0 ]]; do
       if [[ ${__tmp} =~ ^- ]]; then # maybe url is next argument?
         __arg=${1}
         if [[ ${__arg} =~ ^- ]]; then
-          __maj_min=$(echo ${CDAP_VERSION} | cut -d. -f1,2)
+          __maj_min=${CDAP_VERSION%.*-*}
           echo "WARNING: --cdap-repo-url should specify a URL afterwards, using default ${__repo_url/MAJ_MIN/${__maj_min}}"
           continue
         else
-          CDAP_REPO_URL=${__arg}
-          echo "INFO: Setting CDAP repository URL to ${CDAP_REPO_URL}"
+          CDAP_YUM_REPO_URL=${__arg}
+          echo "INFO: Setting CDAP repository URL to ${CDAP_YUM_REPO_URL}"
           shift
         fi
       else
-        CDAP_REPO_URL=${__tmp}
-        echo "INFO: Setting CDAP repository URL to ${CDAP_REPO_URL}"
+        CDAP_YUM_REPO_URL=${__tmp}
+        echo "INFO: Setting CDAP repository URL to ${CDAP_YUM_REPO_URL}"
       fi
       ;;
     *) break ;;
   esac
 done
 
-# Get major/minor from CDAP version
-__maj_min=$(echo ${CDAP_VERSION} | cut -d. -f1,2)
+__maj_min=${CDAP_VERSION%.*-*}
 
-# One last sed-fu, if we're using the default CDAP_REPO_URL, in case version's been updated
-CDAP_REPO_URL=${CDAP_REPO_URL:-${__repo_url/MAJ_MIN/${__maj_min}}}
+# One last sed-fu, if we're using the default CDAP_YUM_REPO_URL, in case version's been updated
+CDAP_YUM_REPO_URL=${CDAP_YUM_REPO_URL:-${__repo_url/MAJ_MIN/${__maj_min}}}
 
-# echo "CDAP_VERSION:  $CDAP_VERSION"
-# echo "CDAP_REPO_URL: $CDAP_REPO_URL"
+__cleanup_tmpdir() { test -d ${__tmpdir} && rm -rf ${__tmpdir}; };
+__create_tmpdir() { mkdir -p ${__tmpdir}; };
 
-# Create YUM repo file
-__repo_file=/etc/yum.repos.d/cdap-${__maj_min}.repo
-echo "[CDAP-${__maj_min}]" > ${__repo_file}
-echo "name=CDAP ${__maj_min}" >> ${__repo_file}
-echo "baseurl=${CDAP_REPO_URL}" >> ${__repo_file}
-echo "enabled=1" >> ${__repo_file}
+# Begin CDAP Prep/Install
 
-# Do GPG check on official repos
-if [[ ${CDAP_REPO_URL} == ${__repo_url/MAJ_MIN/${__maj_min}} ]]; then
-  echo "gpgcheck=1" >> ${__repo_file}
-  rpm --import ${CDAP_REPO_URL}/pubkey.gpg || die "Cannot import GPG key from repo"
+# Install git
+yum install --yes git || die "Failed to install git"
+
+# Install chef
+curl -L https://www.chef.io/chef/install.sh | sudo bash -s -- -v ${CHEF_VERSION} || die "Failed to install chef"
+
+# Clone CDAP repo
+__create_tmpdir
+git clone --depth 1 --branch ${CDAP_BRANCH} https://github.com/caskdata/cdap.git ${__gitdir}
+
+# Check out to specific tag if specified
+if [ -n "${CDAP_TAG}" ]; then
+  git -C ${__gitdir} checkout tags/${CDAP_TAG}
 fi
 
-yum makecache
-yum install cdap-{cli,gateway,kafka,master,security,ui} -y || die "Failed installing packages"
+# Setup cookbook repo
+test -d /var/chef/cookbooks && rm -rf /var/chef/cookbooks
+${__packerdir}/cookbook-dir.sh || die "Failed to setup cookbook dir"
 
-mkdir -p /mnt/cdap/kafka-logs
-chown -R cdap:cdap /mnt/cdap/kafka-logs
+# Install cookbooks via knife
+${__packerdir}/cookbook-setup.sh || die "Failed to install cookbooks"
 
-# Configure CDAP
-__ipaddr=`ifconfig eth0 | grep addr: | cut -d: -f2 | head -n 1 | awk '{print $1}'`
+# CDAP cli install, ensures package dependencies are present
+# We must specify the cdap version
+echo "{\"cdap\": {\"version\": \"${CDAP_VERSION}\"}}" > ${__tmpdir}/cli-conf.json
+chef-solo -o 'recipe[cdap::cli]' -j ${__tmpdir}/cli-conf.json
+
+source ${__gitdir}/cdap-common/bin/functions.sh || die "Cannot source CDAP functions script"
+
+# Read zookeeper quorum from hbase-site.xml, using sourced init script function
+__zk_quorum=$(cdap_get_conf 'hbase.zookeeper.quorum' '/etc/hbase/conf/hbase-site.xml') || die "Cannot determine zookeeper quorum"
+
+# Derive hive classpath using same method as Hive
+__hive_classpath=/etc/hive/conf:
+__hive_classpath+=$(ls -1 ${HIVE_HOME}/lib/*.jar | tr '\n' ':')
+__hive_classpath+=$(if [[ -d ${HIVE_AUX_JARS_PATH} ]]; then ls -1 ${HIVE_AUX_JARS_PATH}/*.jar | tr '\n' ':'; else echo ${HIVE_AUX_JARS_PATH} | tr ',' ':'; fi)
+__hive_classpath+=$(ls -1 ${HIVE_HOME}/auxlib/*.jar 2>/dev/null | tr '\n' ':')
+
+# Read hive exec engine
+__hive_exec_engine=$(cdap_get_conf 'hive.execution.engine' '/etc/hive/conf/hive-site.xml' 'mr') || die "Cannot get Hive Exec Engine"
+
+# Get IP
+__ipaddr=$(ifconfig eth0 | grep addr: | cut -d: -f2 | head -n 1 | awk '{print $1}')
+
+# Create chef json configuration
 sed \
-  -e "s/FQDN1:2181,FQDN2/${__ipaddr}/" \
-  -e 's:/data/cdap/kafka-logs:/mnt/cdap/kafka-logs:' \
-  -e "s/FQDN1:9092,FQDN2:9092/${__ipaddr}:9092/" \
-  -e "s/LOCAL-ROUTER-IP/${__ipaddr}/" \
-  -e 's/LOCAL-APP-FABRIC-IP//' \
-  -e 's/LOCAL-DATA-FABRIC-IP//' \
-  -e 's/LOCAL-WATCHDOG-IP//' \
-  -e "s/ROUTER-HOST-IP/${__ipaddr}/" \
-  /etc/cdap/conf/cdap-site.xml.example > /etc/cdap/conf/cdap-site.xml
+  -e "s/{{ZK_QUORUM}}/${__zk_quorum}/" \
+  -e "s/{{CDAP_VERSION}}/${CDAP_VERSION}/" \
+  -e "s/{{CDAP_YUM_REPO_URL}}/${CDAP_YUM_REPO_URL}/" \
+  -e "s/{{EXPLORE_ENABLED}}/${EXPLORE_ENABLED}/" \
+  -e "s/{{HIVE_CLASSPATH}}/${__hive_classpath}/" \
+  -e "s/{{HIVE_EXEC_ENGINE}}/${__hive_exec_engine}/" \
+  -e "s/{{ROUTER_IP_ADDRESS}}/${__ipaddr}/" \
+  ${__cdap_site_template} > ${__tmpdir}/generated-conf.json
+
+# Install/Configure CDAP
+chef-solo -o 'recipe[cdap::fullstack]' -j ${__tmpdir}/generated-conf.json
 
 # Temporary Hack to workaround CDAP-4089
 rm -f /opt/cdap/kafka/lib/log4j.log4j-1.2.14.jar
 
-# Setup HDFS directories
-su - hdfs -c 'for d in /cdap /user/cdap; do hdfs dfs -mkdir -p ${d} ; hdfs dfs -chown cdap ${d}; done'
-
 # Start CDAP Services
-for i in /etc/init.d/cdap-*
-do
-  ${i} start || die "Failed to start ${i}"
+for i in /etc/init.d/cdap-*; do
+  __svc=$(basename ${i})
+  chkconfig ${__svc}) on || die "Failed to enable ${__svc}"
 done
 
+__cleanup_tmpdir
 exit 0


### PR DESCRIPTION
This generally ports the HDInsight script for EMR usage. This allows us to reuse the scripts and cookbooks for CDAP and simplify maintenance.

Older versions of EMR (3.x) would run the custom bootstrap options after starting Hadoop. This worked fine with older CDAP versions, before live-querying services was introduced, such as getting variables for CDAP's Explore service. CDAP also ran as the same user as the EMR services, so it was a Hadoop superuser, meaning there was no need for us to initialize any directories in HDFS before startup. However, newer EMR starts up the Hadoop services *after* bootstrap tasks are run, so we're unable to ensure they're up and running prior to CDAP starting. Since the bootstrap will not continue if our script is still running, we need to wait at startup. This is hacked into the `cdap-env.sh` script, along with the init.

**NOTE:**
- The config hasn't been vetted (memory, etc.)
- This needs deployment before testing, so it may need adjustment afterwards