### PR TITLE
Merge release/3.5 to release/3.6

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceEnsurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceEnsurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -50,7 +50,7 @@ public final class DefaultNamespaceEnsurer extends AbstractService {
             try {
               namespaceAdmin.create(NamespaceMeta.DEFAULT);
               // if there is no exception, assume successfully created and break
-              LOG.info("Created default namespace successfully.");
+              LOG.info("Successfully created namespace '{}'.", NamespaceMeta.DEFAULT);
               notifyStarted();
             } catch (AlreadyExistsException e) {
               // default namespace already exists

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/AppFabricServer.java
@@ -25,6 +25,7 @@ import co.cask.cdap.common.http.CommonNettyHttpServiceBuilder;
 import co.cask.cdap.common.logging.LoggingContextAccessor;
 import co.cask.cdap.common.logging.ServiceLoggingContext;
 import co.cask.cdap.common.metrics.MetricsReporterHook;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.data.stream.StreamCoordinatorClient;
 import co.cask.cdap.internal.app.namespace.DefaultNamespaceEnsurer;
 import co.cask.cdap.internal.app.runtime.artifact.SystemArtifactLoader;
@@ -73,11 +74,11 @@ public class AppFabricServer extends AbstractIdleService {
   private final Set<String> handlerHookNames;
   private final StreamCoordinatorClient streamCoordinatorClient;
   private final ProgramLifecycleService programLifecycleService;
-  private final DefaultNamespaceEnsurer defaultNamespaceEnsurer;
   private final SystemArtifactLoader systemArtifactLoader;
   private final PluginService pluginService;
   private final PrivilegesFetcherProxyService privilegesFetcherProxyService;
 
+  private DefaultNamespaceEnsurer defaultNamespaceEnsurer;
   private NettyHttpService httpService;
   private Set<HttpHandler> handlers;
   private MetricsCollectionService metricsCollectionService;
@@ -98,7 +99,7 @@ public class AppFabricServer extends AbstractIdleService {
                          StreamCoordinatorClient streamCoordinatorClient,
                          @Named("appfabric.services.names") Set<String> servicesNames,
                          @Named("appfabric.handler.hooks") Set<String> handlerHookNames,
-                         DefaultNamespaceEnsurer defaultNamespaceEnsurer,
+                         NamespaceAdmin namespaceAdmin,
                          SystemArtifactLoader systemArtifactLoader,
                          PluginService pluginService,
                          PrivilegesFetcherProxyService privilegesFetcherProxyService) {
@@ -115,10 +116,10 @@ public class AppFabricServer extends AbstractIdleService {
     this.applicationLifecycleService = applicationLifecycleService;
     this.streamCoordinatorClient = streamCoordinatorClient;
     this.programLifecycleService = programLifecycleService;
-    this.defaultNamespaceEnsurer = defaultNamespaceEnsurer;
     this.systemArtifactLoader = systemArtifactLoader;
     this.pluginService = pluginService;
     this.privilegesFetcherProxyService = privilegesFetcherProxyService;
+    this.defaultNamespaceEnsurer = new DefaultNamespaceEnsurer(namespaceAdmin);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/StandaloneAppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/StandaloneAppFabricServer.java
@@ -21,8 +21,8 @@ import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.app.runtime.ProgramRuntimeService;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.data.stream.StreamCoordinatorClient;
-import co.cask.cdap.internal.app.namespace.DefaultNamespaceEnsurer;
 import co.cask.cdap.internal.app.runtime.artifact.SystemArtifactLoader;
 import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
 import co.cask.cdap.internal.app.runtime.plugin.PluginService;
@@ -62,14 +62,14 @@ public class StandaloneAppFabricServer extends AppFabricServer {
                                    StreamCoordinatorClient streamCoordinatorClient,
                                    @Named("appfabric.services.names") Set<String> servicesNames,
                                    @Named("appfabric.handler.hooks") Set<String> handlerHookNames,
-                                   DefaultNamespaceEnsurer defaultNamespaceEnsurer,
+                                   NamespaceAdmin namespaceAdmin,
                                    MetricStore metricStore,
                                    SystemArtifactLoader systemArtifactLoader,
                                    PluginService pluginService,
                                    PrivilegesFetcherProxyService privilegesFetcherProxyService) {
     super(configuration, discoveryService, schedulerService, notificationService, hostname, handlers,
           metricsCollectionService, programRuntimeService, applicationLifecycleService,
-          programLifecycleService, streamCoordinatorClient, servicesNames, handlerHookNames, defaultNamespaceEnsurer,
+          programLifecycleService, streamCoordinatorClient, servicesNames, handlerHookNames, namespaceAdmin,
           systemArtifactLoader, pluginService, privilegesFetcherProxyService);
     this.metricStore = metricStore;
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AuthorizationBootstrapperTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AuthorizationBootstrapperTest.java
@@ -116,8 +116,10 @@ public class AuthorizationBootstrapperTest {
     File systemArtifactsDir = TMP_FOLDER.newFolder();
     cConf.set(Constants.AppFabric.SYSTEM_ARTIFACTS_DIR, systemArtifactsDir.getAbsolutePath());
     createSystemArtifact(systemArtifactsDir);
-    Injector injector =  Guice.createInjector(new AppFabricTestModule(cConf));
-    defaultNamespaceEnsurer = injector.getInstance(DefaultNamespaceEnsurer.class);
+    Injector injector = Guice.createInjector(new AppFabricTestModule(cConf));
+    namespaceQueryAdmin = injector.getInstance(NamespaceQueryAdmin.class);
+    namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
+    defaultNamespaceEnsurer = new DefaultNamespaceEnsurer(namespaceAdmin);
     discoveryServiceClient = injector.getInstance(DiscoveryServiceClient.class);
     txManager = injector.getInstance(TransactionManager.class);
     datasetService = injector.getInstance(DatasetService.class);
@@ -125,8 +127,6 @@ public class AuthorizationBootstrapperTest {
     authorizationEnforcementService.startAndWait();
     systemArtifactLoader = injector.getInstance(SystemArtifactLoader.class);
     authorizationBootstrapper = injector.getInstance(AuthorizationBootstrapper.class);
-    namespaceQueryAdmin = injector.getInstance(NamespaceQueryAdmin.class);
-    namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
     artifactRepository = injector.getInstance(ArtifactRepository.class);
     dsFramework = injector.getInstance(DatasetFramework.class);
   }


### PR DESCRIPTION
Merging release/3.5 to release/3.6.
There was a conflict due to both RouteConfig and DefaultNamespaceEnsurer being inserted/removed from AppFabricServer's constructor. It was simple to resolve.

![image](https://cloud.githubusercontent.com/assets/2440977/20190491/7adae9e6-a736-11e6-845e-e1ccb2b14a46.png)
