### PR TITLE
CDAP-4322 Make input PartitionKey available to Mappers.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/InputContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/InputContext.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.data.batch;
+
+/**
+ * Exposes information about the input configured for this task.
+ */
+public interface InputContext {
+
+  /**
+   * Returns the name of the input configured for this task.
+   */
+  String getInputName();
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/data/batch/PartitionedFileSetInputContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/data/batch/PartitionedFileSetInputContext.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.data.batch;
+
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+
+/**
+ * Exposes information about the {@link PartitionedFileSet} input configured for this task.
+ */
+public interface PartitionedFileSetInputContext extends InputContext {
+
+  /**
+   * Returns the {@link PartitionKey} of the input configured for this task.
+   */
+  PartitionKey getInputPartitionKey();
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceTaskContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceTaskContext.java
@@ -1,7 +1,5 @@
-package co.cask.cdap.api.mapreduce;
-
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,11 +14,15 @@ package co.cask.cdap.api.mapreduce;
  * the License.
  */
 
+package co.cask.cdap.api.mapreduce;
+
 import co.cask.cdap.api.RuntimeContext;
 import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.TaskLocalizationContext;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.data.batch.InputContext;
+import co.cask.cdap.api.data.batch.PartitionedFileSetInputContext;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.workflow.Workflow;
@@ -96,7 +98,17 @@ public interface MapReduceTaskContext<KEYOUT, VALUEOUT> extends RuntimeContext, 
   /**
    * Returns the name of the input configured for this task.
    * Returns null, if this task is a Reducer or no inputs were configured through CDAP APIs.
+   *
+   * @deprecated Instead, use {@link #getInputContext()}.
    */
+  @Deprecated
   @Nullable
   String getInputName();
+
+  /**
+   * Returns an {@link InputContext} of the input configured for this task. The returned object will be a
+   * {@link PartitionedFileSetInputContext} if the input for this task was configured from the PartitionedFileSet APIs.
+   * Returns null, if this task is a Reducer or no inputs were configured through CDAP APIs.
+   */
+  InputContext getInputContext();
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.TaskLocalizationContext;
 import co.cask.cdap.api.data.DatasetInstantiationException;
 import co.cask.cdap.api.data.batch.BatchReadable;
 import co.cask.cdap.api.data.batch.BatchWritable;
+import co.cask.cdap.api.data.batch.InputContext;
 import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.data.batch.SplitReader;
 import co.cask.cdap.api.dataset.Dataset;
@@ -86,7 +87,7 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
 
   private MultipleOutputs multipleOutputs;
   private TaskInputOutputContext<?, ?, KEYOUT, VALUEOUT> context;
-  private String inputName;
+  private InputContext inputContext;
 
   // keeps track of all tx-aware datasets to perform the transaction lifecycle for them. Note that
   // the transaction is already started, and it will be committed or aborted outside of this task.
@@ -156,8 +157,8 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
     this.context = context;
   }
 
-  public void setInputName(String inputName) {
-    this.inputName = inputName;
+  public void setInputContext(InputContext inputContext) {
+    this.inputContext = inputContext;
   }
 
   /**
@@ -220,7 +221,15 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
   @Nullable
   @Override
   public String getInputName() {
-    return inputName;
+    if (inputContext == null) {
+      return null;
+    }
+    return inputContext.getInputName();
+  }
+
+  @Override
+  public InputContext getInputContext() {
+    return inputContext;
   }
 
   private static Map<String, String> createMetricsTags(@Nullable String taskId,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
@@ -1,5 +1,3 @@
-package co.cask.cdap.internal.app.runtime.batch;
-
 /*
  * Copyright © 2015-2016 Cask Data, Inc.
  *
@@ -16,6 +14,8 @@ package co.cask.cdap.internal.app.runtime.batch;
  * the License.
  */
 
+package co.cask.cdap.internal.app.runtime.batch;
+
 import co.cask.cdap.api.Admin;
 import co.cask.cdap.api.ProgramState;
 import co.cask.cdap.api.ProgramStatus;
@@ -23,6 +23,7 @@ import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.data.DatasetInstantiationException;
 import co.cask.cdap.api.data.batch.Input;
+import co.cask.cdap.api.data.batch.InputContext;
 import co.cask.cdap.api.data.batch.InputFormatProvider;
 import co.cask.cdap.api.data.batch.Output;
 import co.cask.cdap.api.data.batch.OutputFormatProvider;
@@ -107,6 +108,11 @@ public class MapReduceLifecycleContext<KEY, VALUE> implements MapReduceTaskConte
   @Override
   public String getInputName() {
     return delegate.getInputName();
+  }
+
+  @Override
+  public InputContext getInputContext() {
+    return delegate.getInputContext();
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/BasicInputContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/BasicInputContext.java
@@ -16,16 +16,20 @@
 
 package co.cask.cdap.internal.app.runtime.batch.dataset.input;
 
-import org.apache.hadoop.mapreduce.Job;
-import org.apache.hadoop.mapreduce.Mapper;
-
-import java.util.Map;
+import co.cask.cdap.api.data.batch.InputContext;
 
 /**
- * A placeholder class that will be set on the {@link Job} when multiple mappers are to be used.
- *
- * @see MultipleInputs#addInput(Job, String, String, Map, Class)
+ * A basic implementation of {@link InputContext}.
  */
-public class DelegatingMapper extends Mapper {
+class BasicInputContext implements InputContext {
+  private final String inputName;
 
+  BasicInputContext(String inputName) {
+    this.inputName = inputName;
+  }
+
+  @Override
+  public String getInputName() {
+    return inputName;
+  }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/BasicPartitionedFileSetInputContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/BasicPartitionedFileSetInputContext.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.input;
+
+import co.cask.cdap.api.data.batch.PartitionedFileSetInputContext;
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.api.dataset.lib.partitioned.PartitionKeyCodec;
+import co.cask.cdap.data2.dataset2.lib.partitioned.PartitionedFileSetDataset;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A basic implementation of {@link PartitionedFileSetInputContext}.
+ */
+class BasicPartitionedFileSetInputContext extends BasicInputContext implements PartitionedFileSetInputContext {
+
+  private static final Gson GSON =
+    new GsonBuilder().registerTypeAdapter(PartitionKey.class, new PartitionKeyCodec()).create();
+
+  private static final Type STRING_PARTITION_KEY_MAP_TYPE = new TypeToken<Map<String, PartitionKey>>() { }.getType();
+
+  private final Path inputPath;
+  private final String mappingString;
+
+  private PartitionKey partitionKey;
+
+  BasicPartitionedFileSetInputContext(MultiInputTaggedSplit multiInputTaggedSplit) {
+    super(multiInputTaggedSplit.getName());
+
+    InputSplit inputSplit = multiInputTaggedSplit.getInputSplit();
+    if (!(inputSplit instanceof FileSplit)) {
+      throw new IllegalArgumentException(String.format("Expected a '%s', but got '%s'.",
+                                                       FileSplit.class.getName(), inputSplit.getClass().getName()));
+    }
+    this.inputPath = ((FileSplit) inputSplit).getPath();
+    this.mappingString = multiInputTaggedSplit.getConf().get(PartitionedFileSetDataset.PATH_TO_PARTITIONING_MAPPING);
+  }
+
+  @Override
+  public PartitionKey getInputPartitionKey() {
+    if (partitionKey == null) {
+      partitionKey = getPartitionKey(inputPath.toUri());
+    }
+    return partitionKey;
+  }
+
+  private PartitionKey getPartitionKey(URI inputPathURI) {
+    Map<String, PartitionKey> pathToPartitionMapping =
+      GSON.fromJson(Objects.requireNonNull(mappingString), STRING_PARTITION_KEY_MAP_TYPE);
+    if (pathToPartitionMapping.containsKey(inputPathURI.toString())) {
+      return pathToPartitionMapping.get(inputPathURI.toString());
+    }
+    for (Map.Entry<String, PartitionKey> pathEntry : pathToPartitionMapping.entrySet()) {
+      if (isParentOrEquals(URI.create(pathEntry.getKey()), inputPathURI)) {
+        return pathEntry.getValue();
+      }
+    }
+    throw new IllegalArgumentException(
+      String.format("Failed to derive PartitionKey from input path '%s' and path to key mapping '%s'.",
+                    inputPath, pathToPartitionMapping));
+  }
+
+  // compares only the paths of the URI, ignoring the scheme, host, port, etc. of the URIs.
+  private boolean isParentOrEquals(URI potentialParent, URI potentialChild) {
+    return potentialChild.normalize().getPath().startsWith(potentialParent.normalize().getPath());
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/InputContexts.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/InputContexts.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.input;
+
+import co.cask.cdap.api.data.batch.InputContext;
+import co.cask.cdap.data2.dataset2.lib.partitioned.PartitionedFileSetDataset;
+
+/**
+ * Utility class that helps determine the {@link InputContext} to be used.
+ */
+public final class InputContexts {
+
+  private InputContexts() { }
+
+  /**
+   * @param multiInputTaggedSplit the split given to this mapper task
+   * @return an {@link InputContext} representing the input that this mapper task is processing
+   */
+  public static InputContext create(MultiInputTaggedSplit multiInputTaggedSplit) {
+    String mappingString = multiInputTaggedSplit.getConf().get(PartitionedFileSetDataset.PATH_TO_PARTITIONING_MAPPING);
+    if (mappingString != null) {
+      return new BasicPartitionedFileSetInputContext(multiInputTaggedSplit);
+    }
+    return new BasicInputContext(multiInputTaggedSplit.getName());
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/MultiInputTaggedSplit.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/MultiInputTaggedSplit.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.batch.dataset.input;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.InputSplit;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/**
+ * A {@link TaggedInputSplit} that is tagged with extra data for use by {@link MultiInputFormat}s.
+ */
+public class MultiInputTaggedSplit extends TaggedInputSplit {
+
+  private static final Type STRING_STRING_MAP_TYPE = new TypeToken<Map<String, String>>() { }.getType();
+  private static final Gson GSON = new Gson();
+
+  private String name;
+  private Map<String, String> inputConfigs;
+  private String mapperClassName;
+
+  private Class<? extends InputFormat<?, ?>> inputFormatClass;
+
+  MultiInputTaggedSplit() { }
+
+  /**
+   * Creates a new MultiInputTaggedSplit.
+   *
+   * @param inputSplit The InputSplit to be tagged
+   * @param conf The configuration to use
+   * @param name name of the input to which this InputSplit belongs
+   * @param inputConfigs configurations to use for the InputFormat
+   * @param inputFormatClass The InputFormat class to use for this job
+   * @param mapperClassName The name of the Mapper class to use for this job
+   */
+  @SuppressWarnings("unchecked")
+  MultiInputTaggedSplit(InputSplit inputSplit, Configuration conf,
+                        String name,
+                        Map<String, String> inputConfigs,
+                        Class<? extends InputFormat> inputFormatClass,
+                        String mapperClassName) {
+    super(inputSplit, conf);
+    this.name = name;
+    this.inputConfigs = inputConfigs;
+    this.mapperClassName = mapperClassName;
+    this.inputFormatClass = (Class<? extends InputFormat<?, ?>>) inputFormatClass;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  protected void readAdditionalFields(DataInput in) throws IOException {
+    name = Text.readString(in);
+    mapperClassName = Text.readString(in);
+    inputConfigs = GSON.fromJson(Text.readString(in), STRING_STRING_MAP_TYPE);
+    inputFormatClass = (Class<? extends InputFormat<?, ?>>) readClass(in);
+  }
+
+  @Override
+  protected void writeAdditionalFields(DataOutput out) throws IOException {
+    Text.writeString(out, name);
+    Text.writeString(out, mapperClassName);
+    Text.writeString(out, GSON.toJson(inputConfigs));
+    Text.writeString(out, inputFormatClass.getName());
+  }
+
+  /**
+   * Retrieves the name of this MultiInputTaggedSplit.
+   *
+   * @return name of the MultiInputTaggedSplit
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Retrieves the name of the Mapper class to use for this split.
+   *
+   * @return The name of the Mapper class to use
+   */
+  public String getMapperClassName() {
+    return mapperClassName;
+  }
+
+  Map<String, String> getInputConfigs() {
+    return inputConfigs;
+  }
+
+  /**
+   * Retrieves the InputFormat class to use for this split.
+   *
+   * @return The InputFormat class to use
+   */
+  public Class<? extends InputFormat<?, ?>> getInputFormatClass() {
+    return inputFormatClass;
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/MultipleInputs.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/MultipleInputs.java
@@ -65,7 +65,7 @@ public final class MultipleInputs {
     map.put(namedInput, new MapperInput(inputFormatClass, inputConfigs, mapperClass));
     conf.set(INPUT_CONFIGS, GSON.toJson(map));
 
-    job.setInputFormatClass(DelegatingInputFormat.class);
+    job.setInputFormatClass(MultiInputFormat.class);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/DynamicPartitionerWriterWrapper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/DynamicPartitionerWriterWrapper.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
+import org.apache.hadoop.util.ReflectionUtils;
 
 import java.io.IOException;
 
@@ -110,7 +111,7 @@ abstract class DynamicPartitionerWriterWrapper<K, V> extends RecordWriter<K, V> 
 
       @SuppressWarnings("unchecked")
       FileOutputFormat<K, V> fileOutputFormat =
-        new InstantiatorFactory(false).get(TypeToken.of(delegateOutputFormat)).create();
+        ReflectionUtils.newInstance(delegateOutputFormat, job.getConfiguration());
       this.fileOutputFormat = fileOutputFormat;
     }
     return fileOutputFormat;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/DynamicPartitioningOutputFormat.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/DynamicPartitioningOutputFormat.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.internal.app.runtime.batch.dataset.partitioned;
 
 import co.cask.cdap.api.dataset.lib.DynamicPartitioner;
-import co.cask.cdap.api.dataset.lib.PartitionKey;
 import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.lib.partitioned.PartitionedFileSetDataset;
@@ -31,11 +30,8 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.security.TokenCache;
-import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
 
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * This class extends the FileOutputFormat and allows writing dynamically to multiple partitions of a PartitionedFileSet

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceWithPartitionedTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceWithPartitionedTest.java
@@ -49,13 +49,13 @@ import java.util.concurrent.TimeUnit;
 import static co.cask.cdap.internal.app.runtime.batch.AppWithPartitionedFileSet.PARTITIONED;
 import static co.cask.cdap.internal.app.runtime.batch.AppWithTimePartitionedFileSet.TIME_PARTITIONED;
 
-@Category(XSlowTests.class)
 /**
  * This tests that we can read and write time-partitioned file sets with map/reduce, using the partition
  * time to specify input and output partitions. It does not test that the dataset is queryable with Hive,
  * or that its partitions are registered correctly in the Hive meta store. That is because here in the
  * app-fabric tests, explore is disabled.
  */
+@Category(XSlowTests.class)
 public class MapReduceWithPartitionedTest extends MapReduceRunnerTestBase {
 
   static final DateFormat DATE_FORMAT = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT, Locale.US);
@@ -88,7 +88,8 @@ public class MapReduceWithPartitionedTest extends MapReduceRunnerTestBase {
                                                                           "data.source.type", "table");
     TimePartitionedFileSetArguments.setOutputPartitionMetadata(outputArgs, assignedMetadata);
     runtimeArguments.putAll(RuntimeArguments.addScope(Scope.DATASET, TIME_PARTITIONED, outputArgs));
-    runProgram(app, AppWithTimePartitionedFileSet.PartitionWriter.class, new BasicArguments(runtimeArguments));
+    Assert.assertTrue(
+      runProgram(app, AppWithTimePartitionedFileSet.PartitionWriter.class, new BasicArguments(runtimeArguments)));
 
     // this should have created a partition in the tpfs
     final TimePartitionedFileSet tpfs = datasetCache.getDataset(TIME_PARTITIONED);
@@ -120,7 +121,8 @@ public class MapReduceWithPartitionedTest extends MapReduceRunnerTestBase {
     runtimeArguments.putAll(RuntimeArguments.addScope(Scope.DATASET, TIME_PARTITIONED, outputArgs));
     // make the mapreduce add the partition in destroy, to validate that this does not fail the job
     runtimeArguments.put(AppWithTimePartitionedFileSet.COMPAT_ADD_PARTITION, "true");
-    runProgram(app, AppWithTimePartitionedFileSet.PartitionWriter.class, new BasicArguments(runtimeArguments));
+    Assert.assertTrue(
+      runProgram(app, AppWithTimePartitionedFileSet.PartitionWriter.class, new BasicArguments(runtimeArguments)));
 
     // this should have created a partition in the tpfs
     Transactions.createTransactionExecutor(txExecutorFactory, (TransactionAware) tpfs).execute(
@@ -142,7 +144,8 @@ public class MapReduceWithPartitionedTest extends MapReduceRunnerTestBase {
     TimePartitionedFileSetArguments.setInputEndTime(inputArgs, time5 + TimeUnit.MINUTES.toMillis(5));
     runtimeArguments.putAll(RuntimeArguments.addScope(Scope.DATASET, TIME_PARTITIONED, inputArgs));
     runtimeArguments.put(AppWithTimePartitionedFileSet.ROW_TO_WRITE, "a");
-    runProgram(app, AppWithTimePartitionedFileSet.PartitionReader.class, new BasicArguments(runtimeArguments));
+    Assert.assertTrue(
+      runProgram(app, AppWithTimePartitionedFileSet.PartitionReader.class, new BasicArguments(runtimeArguments)));
 
     // this should have read both partitions - and written both x and y to row a
     final Table output = datasetCache.getDataset(AppWithTimePartitionedFileSet.OUTPUT);
@@ -161,7 +164,8 @@ public class MapReduceWithPartitionedTest extends MapReduceRunnerTestBase {
     TimePartitionedFileSetArguments.setInputEndTime(inputArgs, time + TimeUnit.MINUTES.toMillis(2));
     runtimeArguments.putAll(RuntimeArguments.addScope(Scope.DATASET, TIME_PARTITIONED, inputArgs));
     runtimeArguments.put(AppWithTimePartitionedFileSet.ROW_TO_WRITE, "b");
-    runProgram(app, AppWithTimePartitionedFileSet.PartitionReader.class, new BasicArguments(runtimeArguments));
+    Assert.assertTrue(
+      runProgram(app, AppWithTimePartitionedFileSet.PartitionReader.class, new BasicArguments(runtimeArguments)));
 
     // this should have read the first partition only - and written only x to row b
     Transactions.createTransactionExecutor(txExecutorFactory, (TransactionAware) output).execute(
@@ -179,7 +183,8 @@ public class MapReduceWithPartitionedTest extends MapReduceRunnerTestBase {
     TimePartitionedFileSetArguments.setInputEndTime(inputArgs, time - TimeUnit.MINUTES.toMillis(9));
     runtimeArguments.putAll(RuntimeArguments.addScope(Scope.DATASET, TIME_PARTITIONED, inputArgs));
     runtimeArguments.put(AppWithTimePartitionedFileSet.ROW_TO_WRITE, "n");
-    runProgram(app, AppWithTimePartitionedFileSet.PartitionReader.class, new BasicArguments(runtimeArguments));
+    Assert.assertTrue(
+      runProgram(app, AppWithTimePartitionedFileSet.PartitionReader.class, new BasicArguments(runtimeArguments)));
 
     // this should have read no partitions - and written nothing to row n
     Transactions.createTransactionExecutor(txExecutorFactory, (TransactionAware) output).execute(
@@ -218,7 +223,8 @@ public class MapReduceWithPartitionedTest extends MapReduceRunnerTestBase {
     Map<String, String> outputArgs = Maps.newHashMap();
     PartitionedFileSetArguments.setOutputPartitionKey(outputArgs, keyX);
     runtimeArguments.putAll(RuntimeArguments.addScope(Scope.DATASET, PARTITIONED, outputArgs));
-    runProgram(app, AppWithPartitionedFileSet.PartitionWriter.class, new BasicArguments(runtimeArguments));
+    Assert.assertTrue(
+      runProgram(app, AppWithPartitionedFileSet.PartitionWriter.class, new BasicArguments(runtimeArguments)));
 
     // this should have created a partition in the tpfs
     final PartitionedFileSet dataset = datasetCache.getDataset(PARTITIONED);
@@ -253,7 +259,8 @@ public class MapReduceWithPartitionedTest extends MapReduceRunnerTestBase {
     // now run the m/r again with a new partition time, say 5 minutes later
     PartitionedFileSetArguments.setOutputPartitionKey(outputArgs, keyY);
     runtimeArguments.putAll(RuntimeArguments.addScope(Scope.DATASET, PARTITIONED, outputArgs));
-    runProgram(app, AppWithPartitionedFileSet.PartitionWriter.class, new BasicArguments(runtimeArguments));
+    Assert.assertTrue(
+      runProgram(app, AppWithPartitionedFileSet.PartitionWriter.class, new BasicArguments(runtimeArguments)));
 
     // this should have created a partition in the tpfs
     Transactions.createTransactionExecutor(txExecutorFactory, (TransactionAware) dataset).execute(
@@ -280,7 +287,8 @@ public class MapReduceWithPartitionedTest extends MapReduceRunnerTestBase {
     PartitionedFileSetArguments.setInputPartitionFilter(inputArgs, filterXY);
     runtimeArguments.putAll(RuntimeArguments.addScope(Scope.DATASET, PARTITIONED, inputArgs));
     runtimeArguments.put(AppWithPartitionedFileSet.ROW_TO_WRITE, "a");
-    runProgram(app, AppWithPartitionedFileSet.PartitionReader.class, new BasicArguments(runtimeArguments));
+    Assert.assertTrue(
+      runProgram(app, AppWithPartitionedFileSet.PartitionReader.class, new BasicArguments(runtimeArguments)));
 
     // this should have read both partitions - and written both x and y to row a
     final Table output = datasetCache.getDataset(AppWithPartitionedFileSet.OUTPUT);
@@ -305,7 +313,8 @@ public class MapReduceWithPartitionedTest extends MapReduceRunnerTestBase {
     PartitionedFileSetArguments.setInputPartitionFilter(inputArgs, filterX);
     runtimeArguments.putAll(RuntimeArguments.addScope(Scope.DATASET, PARTITIONED, inputArgs));
     runtimeArguments.put(AppWithPartitionedFileSet.ROW_TO_WRITE, "b");
-    runProgram(app, AppWithPartitionedFileSet.PartitionReader.class, new BasicArguments(runtimeArguments));
+    Assert.assertTrue(
+      runProgram(app, AppWithPartitionedFileSet.PartitionReader.class, new BasicArguments(runtimeArguments)));
 
     // this should have read the first partition only - and written only x to row b
     Transactions.createTransactionExecutor(txExecutorFactory, (TransactionAware) output).execute(
@@ -328,7 +337,8 @@ public class MapReduceWithPartitionedTest extends MapReduceRunnerTestBase {
     PartitionedFileSetArguments.setInputPartitionFilter(inputArgs, filterMT);
     runtimeArguments.putAll(RuntimeArguments.addScope(Scope.DATASET, PARTITIONED, inputArgs));
     runtimeArguments.put(AppWithPartitionedFileSet.ROW_TO_WRITE, "n");
-    runProgram(app, AppWithPartitionedFileSet.PartitionReader.class, new BasicArguments(runtimeArguments));
+    Assert.assertTrue(
+      runProgram(app, AppWithPartitionedFileSet.PartitionReader.class, new BasicArguments(runtimeArguments)));
 
     // this should have read no partitions - and written nothing to row n
     Transactions.createTransactionExecutor(txExecutorFactory, (TransactionAware) output).execute(

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/MultipleInputsTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/dataset/input/MultipleInputsTest.java
@@ -49,7 +49,7 @@ public class MultipleInputsTest {
     Assert.assertEquals(inputFormatConfigs1, Iterables.getOnlyElement(map.values()).getInputFormatConfiguration());
     Assert.assertEquals(job.getMapperClass().getName(), Iterables.getOnlyElement(map.values()).getMapperClassName());
 
-    Assert.assertEquals(DelegatingInputFormat.class, job.getInputFormatClass());
+    Assert.assertEquals(MultiInputFormat.class, job.getInputFormatClass());
 
     // now, test with two inputs in the configuration
     String inputName2 = "inputName2";

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/TransformRunner.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/TransformRunner.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.etl.batch.mapreduce;
 
+import co.cask.cdap.api.data.batch.InputContext;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
@@ -90,9 +91,9 @@ public class TransformRunner<KEY, VALUE> {
     // input alias name -> stage name mapping
     Map<String, String> inputAliasToStage = GSON.fromJson(hConf.get(ETLMapReduce.INPUT_ALIAS_KEY),
                                                           ETLMapReduce.INPUT_ALIAS_TYPE);
-    String inputAliasName = context.getInputName();
-    // inputAliasName can be null (in case of reducers)
-    String sourceStage = (inputAliasName != null) ? inputAliasToStage.get(inputAliasName) : null;
+    InputContext inputContext = context.getInputContext();
+    // inputContext can be null (in case of reducers)
+    String sourceStage = (inputContext != null) ? inputAliasToStage.get(inputContext.getInputName()) : null;
 
     PipelinePhase phase = phaseSpec.getPhase();
     Set<StageInfo> reducers = phase.getStagesOfType(BatchAggregator.PLUGIN_TYPE, BatchJoiner.PLUGIN_TYPE);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetDataset.java
@@ -41,6 +41,7 @@ import com.google.inject.Provider;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -129,17 +130,17 @@ public class TimePartitionedFileSetDataset extends PartitionedFileSetDataset imp
     return partitions;
   }
 
-  private Collection<String> getPartitionPathsByTime(long startTime, long endTime) {
-    final Set<String> paths = Sets.newHashSet();
+  private Collection<PartitionKey> getPartitionPathsByTime(long startTime, long endTime) {
+    final Set<PartitionKey> partitionKeys = new HashSet<>();
     for (PartitionFilter filter : partitionFiltersForTimeRange(startTime, endTime)) {
       super.getPartitions(filter, new PartitionedFileSetDataset.PartitionConsumer() {
         @Override
         public void consume(PartitionKey key, String path, @Nullable PartitionMetadata metadata) {
-          paths.add(path);
+          partitionKeys.add(key);
         }
       });
     }
-    return paths;
+    return partitionKeys;
   }
 
   @Override
@@ -154,12 +155,12 @@ public class TimePartitionedFileSetDataset extends PartitionedFileSetDataset imp
 
   @Override
   @Nullable
-  protected Collection<String> computeFilterInputPaths() {
+  protected Collection<PartitionKey> computeInputKeys() {
     Long startTime = TimePartitionedFileSetArguments.getInputStartTime(getRuntimeArguments());
     Long endTime = TimePartitionedFileSetArguments.getInputEndTime(getRuntimeArguments());
     if (startTime == null && endTime == null) {
       // no times specified; perhaps a partition filter was specified. super will deal with that
-      return super.computeFilterInputPaths();
+      return super.computeInputKeys();
     }
     if (startTime == null) {
       throw new DataSetException("Start time for input time range must be given as argument.");


### PR DESCRIPTION
CDAP-4322 Make input PartitionKey available to Mappers.

- Use `ReflectionUtils.newInstance` instead of `InstantiatorFactory`, so that the object's `setConf` is called, in case it implements `Configurable`.
- Modify `TaggedInputSplit` to make it more generic. This isn't strictly necessary for this feature.
- Pass a mapping of Path to PartitionKey, for looking up which PartitionKey a given FileSplit's Path is for, and exposing access to this PartitionKey through a PartitionedFileSetInputContext, accessible from the MapReduceTaskContext, by casting down the result of `getInputContext`.

https://issues.cask.co/browse/CDAP-4322
http://builds.cask.co/browse/CDAP-RUT268-6

Note: This also fixes https://issues.cask.co/browse/CDAP-2945.