### PR TITLE
CDAP-5395 Disable escaping HTML for fetching logs from ProgramClient

### DIFF
--- a/cdap-client/src/main/java/co/cask/cdap/client/ProgramClient.java
+++ b/cdap-client/src/main/java/co/cask/cdap/client/ProgramClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -584,7 +584,7 @@ public class ProgramClient {
   public String getProgramLogs(Id.Program program, long start, long stop)
     throws IOException, NotFoundException, UnauthenticatedException, UnauthorizedException {
 
-    String path = String.format("apps/%s/%s/%s/logs?start=%d&stop=%d",
+    String path = String.format("apps/%s/%s/%s/logs?start=%d&stop=%d&escape=false",
                                 program.getApplicationId(), program.getType().getCategoryName(),
                                 program.getId(), start, stop);
     URL url = config.resolveNamespacedURLV3(program.getNamespace(), path);


### PR DESCRIPTION
CDAP-5395 Disable escaping HTML for fetching logs from ProgramClient (used by 'get <program-type> logs ...' command).
(similar to https://github.com/caskdata/cdap/pull/7004).

https://issues.cask.co/browse/CDAP-5395
http://builds.cask.co/browse/CDAP-RUT271-1