### PR TITLE
Cherry-pick Spark Controller fix from #7096

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/AbstractProgramRuntimeService.java
@@ -40,7 +40,6 @@ import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.ProgramId;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
 import com.google.common.collect.HashBasedTable;
@@ -103,8 +102,6 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
     ProgramId programId = programDescriptor.getProgramId();
 
     ProgramRunner runner = programRunnerFactory.create(programId.getType());
-    Preconditions.checkNotNull(runner, "Fail to get ProgramRunner for type " + programId.getType());
-
     RunId runId = RunIds.generate();
     File tempDir = createTempDirectory(programId, runId);
     Runnable cleanUpTask = createCleanupTask(tempDir, runner);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/distributed/DistributedProgramControllerFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/distributed/DistributedProgramControllerFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.distributed;
+
+import co.cask.cdap.app.program.ProgramDescriptor;
+import co.cask.cdap.app.runtime.ProgramController;
+import org.apache.twill.api.RunId;
+import org.apache.twill.api.TwillController;
+
+/**
+ * Provides method to create {@link ProgramController} in distributed mode.
+ */
+public interface DistributedProgramControllerFactory {
+
+  /**
+   * Creates a {@link ProgramController} for the given program that was launched as a Twill application.
+   *
+   * @param twillController the {@link TwillController} to interact with the twill application
+   * @param programDescriptor information for the Program being launched
+   * @param runId the run id of the particular execution
+   * @return a new instance of {@link ProgramController}.
+   */
+  ProgramController createProgramController(TwillController twillController,
+                                            ProgramDescriptor programDescriptor, RunId runId);
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
@@ -21,6 +21,7 @@ import co.cask.cdap.app.runtime.Arguments;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
+import co.cask.cdap.app.runtime.distributed.DistributedProgramControllerFactory;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.CConfigurationUtil;
 import co.cask.cdap.common.conf.Constants;
@@ -92,7 +93,7 @@ import javax.annotation.Nullable;
 /**
  * Defines the base framework for starting {@link Program} in the cluster.
  */
-public abstract class AbstractDistributedProgramRunner implements ProgramRunner {
+public abstract class AbstractDistributedProgramRunner implements ProgramRunner, DistributedProgramControllerFactory {
 
   private static final Logger LOG = LoggerFactory.getLogger(AbstractDistributedProgramRunner.class);
   private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder())

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedFlowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedFlowProgramRunner.java
@@ -18,7 +18,11 @@ package co.cask.cdap.internal.app.runtime.distributed;
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.flow.Flow;
 import co.cask.cdap.api.flow.FlowSpecification;
+import co.cask.cdap.api.flow.FlowletDefinition;
 import co.cask.cdap.app.program.Program;
+import co.cask.cdap.app.program.ProgramDescriptor;
+import co.cask.cdap.app.queue.QueueSpecification;
+import co.cask.cdap.app.queue.QueueSpecificationGenerator;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
@@ -29,13 +33,19 @@ import co.cask.cdap.common.security.Impersonator;
 import co.cask.cdap.common.twill.AbortOnTimeoutEventHandler;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
+import co.cask.cdap.internal.app.queue.SimpleQueueSpecificationGenerator;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.security.TokenSecureStoreUpdater;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Table;
 import com.google.inject.Inject;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.tephra.TransactionExecutorFactory;
@@ -48,6 +58,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A {@link ProgramRunner} to start a {@link Flow} program in distributed mode.
@@ -72,6 +83,23 @@ public final class DistributedFlowProgramRunner extends AbstractDistributedProgr
     this.streamAdmin = streamAdmin;
     this.txExecutorFactory = txExecutorFactory;
     this.impersonator = impersonator;
+  }
+
+  @Override
+  public ProgramController createProgramController(TwillController twillController,
+                                                   ProgramDescriptor programDescriptor, RunId runId) {
+    FlowSpecification flowSpec = programDescriptor.getSpecification();
+    DistributedFlowletInstanceUpdater instanceUpdater = new DistributedFlowletInstanceUpdater(
+      programDescriptor.getProgramId(), twillController, queueAdmin, streamAdmin,
+      getFlowletQueues(programDescriptor.getProgramId().getParent(), flowSpec),
+      txExecutorFactory, impersonator
+    );
+    return createProgramController(twillController, programDescriptor.getProgramId(), runId, instanceUpdater);
+  }
+
+  private ProgramController createProgramController(TwillController twillController, ProgramId programId, RunId runId,
+                                                    DistributedFlowletInstanceUpdater instanceUpdater) {
+    return new FlowTwillProgramController(programId.toId(), twillController, instanceUpdater, runId).startListen();
   }
 
   @Override
@@ -102,8 +130,9 @@ public final class DistributedFlowProgramRunner extends AbstractDistributedProgr
       DistributedFlowletInstanceUpdater instanceUpdater =
         new DistributedFlowletInstanceUpdater(program.getId().toEntityId(), controller, queueAdmin,
                                               streamAdmin, flowletQueues, txExecutorFactory, impersonator);
-      RunId runId = ProgramRunners.getRunId(options);
-      return new FlowTwillProgramController(program.getId(), controller, instanceUpdater, runId).startListen();
+
+      return createProgramController(controller, program.getId().toEntityId(),
+                                     ProgramRunners.getRunId(options), instanceUpdater);
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }
@@ -113,5 +142,27 @@ public final class DistributedFlowProgramRunner extends AbstractDistributedProgr
   protected EventHandler createEventHandler(CConfiguration cConf) {
     return new AbortOnTimeoutEventHandler(
       cConf.getLong(Constants.CFG_TWILL_NO_CONTAINER_TIMEOUT, Long.MAX_VALUE), true);
+  }
+
+  /**
+   * Gets the queue configuration of the Flow based on the connections in the given {@link FlowSpecification}.
+   */
+  private Multimap<String, QueueName> getFlowletQueues(ApplicationId appId, FlowSpecification flowSpec) {
+    // Generate all queues specifications
+    Table<QueueSpecificationGenerator.Node, String, Set<QueueSpecification>> queueSpecs
+      = new SimpleQueueSpecificationGenerator(appId.toId()).create(flowSpec);
+
+    // For storing result from flowletId to queue.
+    ImmutableSetMultimap.Builder<String, QueueName> resultBuilder = ImmutableSetMultimap.builder();
+
+    // Loop through each flowlet
+    for (Map.Entry<String, FlowletDefinition> entry : flowSpec.getFlowlets().entrySet()) {
+      String flowletId = entry.getKey();
+      // For each queue that the flowlet is a consumer, store the number of instances for this flowlet
+      for (QueueSpecification queueSpec : Iterables.concat(queueSpecs.column(flowletId).values())) {
+        resultBuilder.put(flowletId, queueSpec.getQueueName());
+      }
+    }
+    return resultBuilder.build();
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedMapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedMapReduceProgramRunner.java
@@ -18,6 +18,7 @@ package co.cask.cdap.internal.app.runtime.distributed;
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
 import co.cask.cdap.app.program.Program;
+import co.cask.cdap.app.program.ProgramDescriptor;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.conf.CConfiguration;
@@ -25,6 +26,7 @@ import co.cask.cdap.common.security.Impersonator;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.batch.distributed.MapReduceContainerHelper;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.security.TokenSecureStoreUpdater;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
@@ -56,6 +58,16 @@ public final class DistributedMapReduceProgramRunner extends AbstractDistributed
   }
 
   @Override
+  public ProgramController createProgramController(TwillController twillController,
+                                                   ProgramDescriptor programDescriptor, RunId runId) {
+    return createProgramController(twillController, programDescriptor.getProgramId(), runId);
+  }
+
+  private ProgramController createProgramController(TwillController twillController, ProgramId programId, RunId runId) {
+    return new MapReduceTwillProgramController(programId.toId(), twillController, runId).startListen();
+  }
+
+  @Override
   protected ProgramController launch(Program program, ProgramOptions options,
                                      Map<String, LocalizeResource> localizeResources,
                                      File tempDir, final ApplicationLauncher launcher) {
@@ -77,7 +89,6 @@ public final class DistributedMapReduceProgramRunner extends AbstractDistributed
       new MapReduceTwillApplication(program, options.getUserArguments(), spec, localizeResources, eventHandler),
       extraClassPaths, Collections.singletonList(YarnClientProtocolProvider.class));
 
-    RunId runId = ProgramRunners.getRunId(options);
-    return new MapReduceTwillProgramController(program.getId(), controller, runId).startListen();
+    return createProgramController(controller, program.getId().toEntityId(), ProgramRunners.getRunId(options));
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
@@ -16,28 +16,22 @@
 
 package co.cask.cdap.internal.app.runtime.distributed;
 
-import co.cask.cdap.api.flow.FlowSpecification;
-import co.cask.cdap.api.flow.FlowletDefinition;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.app.program.ProgramDescriptor;
-import co.cask.cdap.app.queue.QueueSpecification;
-import co.cask.cdap.app.queue.QueueSpecificationGenerator;
 import co.cask.cdap.app.runtime.AbstractProgramRuntimeService;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramResourceReporter;
+import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.app.runtime.ProgramRunnerFactory;
+import co.cask.cdap.app.runtime.distributed.DistributedProgramControllerFactory;
 import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.Locations;
-import co.cask.cdap.common.queue.QueueName;
 import co.cask.cdap.common.security.Impersonator;
-import co.cask.cdap.data2.transaction.queue.QueueAdmin;
-import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.internal.app.program.ProgramTypeMetricTag;
-import co.cask.cdap.internal.app.queue.SimpleQueueSpecificationGenerator;
 import co.cask.cdap.internal.app.runtime.AbstractResourceReporter;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactDetail;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
@@ -50,17 +44,13 @@ import co.cask.cdap.proto.NotRunningProgramLiveInfo;
 import co.cask.cdap.proto.ProgramLiveInfo;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
-import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.ProgramId;
 import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Multimap;
 import com.google.common.collect.Table;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
@@ -68,7 +58,6 @@ import org.apache.hadoop.yarn.api.records.NodeReport;
 import org.apache.hadoop.yarn.api.records.NodeState;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.client.api.YarnClient;
-import org.apache.tephra.TransactionExecutorFactory;
 import org.apache.twill.api.ResourceReport;
 import org.apache.twill.api.RunId;
 import org.apache.twill.api.TwillController;
@@ -102,26 +91,20 @@ public final class DistributedProgramRuntimeService extends AbstractProgramRunti
 
   // TODO (terence): Injection of Store and QueueAdmin is a hack for queue reconfiguration.
   // Need to remove it when FlowProgramRunner can runs inside Twill AM.
+  private final ProgramRunnerFactory programRunnerFactory;
   private final Store store;
-  private final QueueAdmin queueAdmin;
-  private final StreamAdmin streamAdmin;
-  private final TransactionExecutorFactory txExecutorFactory;
   private final ProgramResourceReporter resourceReporter;
   private final Impersonator impersonator;
 
   @Inject
-  DistributedProgramRuntimeService(ProgramRunnerFactory programRunnerFactory, TwillRunner twillRunner,
-                                   Store store, QueueAdmin queueAdmin, StreamAdmin streamAdmin,
+  DistributedProgramRuntimeService(ProgramRunnerFactory programRunnerFactory, TwillRunner twillRunner, Store store,
                                    MetricsCollectionService metricsCollectionService,
                                    Configuration hConf, CConfiguration cConf,
-                                   TransactionExecutorFactory txExecutorFactory,
                                    ArtifactRepository artifactRepository, Impersonator impersonator) {
     super(cConf, programRunnerFactory, artifactRepository);
+    this.programRunnerFactory = programRunnerFactory;
     this.twillRunner = twillRunner;
     this.store = store;
-    this.queueAdmin = queueAdmin;
-    this.streamAdmin = streamAdmin;
-    this.txExecutorFactory = txExecutorFactory;
     this.resourceReporter = new ClusterResourceReporter(metricsCollectionService, hConf);
     this.impersonator = impersonator;
   }
@@ -254,7 +237,14 @@ public final class DistributedProgramRuntimeService extends AbstractProgramRunti
     });
 
     for (RunRecordMeta record : activeRunRecords) {
-      RunId twillRunIdFromRecord = org.apache.twill.internal.RunIds.fromString(record.getTwillRunId());
+      String twillRunId = record.getTwillRunId();
+      if (twillRunId == null) {
+        // This is unexpected. Just log and ignore the run record
+        LOG.warn("No twill runId for in run record {}.", record);
+        continue;
+      }
+
+      RunId twillRunIdFromRecord = org.apache.twill.internal.RunIds.fromString(twillRunId);
       // Get the CDAP RunId from RunRecord
       RunId runId = RunIds.fromString(record.getPid());
       // Get the Program and TwillController for the current twillRunId
@@ -290,58 +280,31 @@ public final class DistributedProgramRuntimeService extends AbstractProgramRunti
   @Nullable
   private ProgramController createController(ProgramDescriptor programDescriptor,
                                              TwillController controller, RunId runId) {
-    AbstractTwillProgramController programController = null;
     ProgramId programId = programDescriptor.getProgramId();
-
-    switch (programId.getType()) {
-      case FLOW: {
-        FlowSpecification flowSpec = programDescriptor.getSpecification();
-        DistributedFlowletInstanceUpdater instanceUpdater = new DistributedFlowletInstanceUpdater(
-          programDescriptor.getProgramId(), controller, queueAdmin, streamAdmin,
-          getFlowletQueues(programDescriptor.getProgramId().getParent(), flowSpec),
-          txExecutorFactory, impersonator
-        );
-        programController = new FlowTwillProgramController(programId.toId(), controller, instanceUpdater, runId);
-        break;
-      }
-      case MAPREDUCE:
-        programController = new MapReduceTwillProgramController(programId.toId(), controller, runId);
-        break;
-      case WORKFLOW:
-        programController = new WorkflowTwillProgramController(programId.toId(), controller, runId);
-        break;
-      case WEBAPP:
-        programController = new WebappTwillProgramController(programId.toId(), controller, runId);
-        break;
-      case SERVICE:
-        programController = new ServiceTwillProgramController(programId.toId(), controller, runId);
-        break;
-      case WORKER:
-        programController = new WorkerTwillProgramController(programId.toId(), controller, runId);
-        break;
+    ProgramRunner programRunner;
+    try {
+      programRunner = programRunnerFactory.create(programId.getType());
+    } catch (IllegalArgumentException e) {
+      // This shouldn't happen. If it happen, it means CDAP was incorrectly install such that some of the program
+      // type is not support (maybe due to version mismatch in upgrade).
+      LOG.error("Unsupported program type {} for program {}. " +
+                  "It is likely caused by incorrect CDAP installation or upgrade to incompatible CDAP version",
+                programId.getType(), programId);
+      return null;
     }
-    return programController == null ? null : programController.startListen();
-  }
 
-  // TODO (terence) : This method is part of the hack mentioned above. It should be removed when
-  // FlowProgramRunner moved to run in AM.
-  private Multimap<String, QueueName> getFlowletQueues(ApplicationId appId, FlowSpecification flowSpec) {
-    // Generate all queues specifications
-    Table<QueueSpecificationGenerator.Node, String, Set<QueueSpecification>> queueSpecs
-      = new SimpleQueueSpecificationGenerator(appId.toId()).create(flowSpec);
-
-    // For storing result from flowletId to queue.
-    ImmutableSetMultimap.Builder<String, QueueName> resultBuilder = ImmutableSetMultimap.builder();
-
-    // Loop through each flowlet
-    for (Map.Entry<String, FlowletDefinition> entry : flowSpec.getFlowlets().entrySet()) {
-      String flowletId = entry.getKey();
-      // For each queue that the flowlet is a consumer, store the number of instances for this flowlet
-      for (QueueSpecification queueSpec : Iterables.concat(queueSpecs.column(flowletId).values())) {
-        resultBuilder.put(flowletId, queueSpec.getQueueName());
-      }
+    if (!(programRunner instanceof DistributedProgramControllerFactory)) {
+      // This is also unexpected. If it happen, it means the CDAP core or the runtime provider extension was wrongly
+      // implemented
+      ResourceReport resourceReport = controller.getResourceReport();
+      LOG.error("Unable to create ProgramController for program {} for twill application {}. It is likely caused by " +
+                  "invalid CDAP program runtime extension.",
+                programId, resourceReport == null ? "'unknown twill application'" : resourceReport.getApplicationId());
+      return null;
     }
-    return resultBuilder.build();
+
+    return ((DistributedProgramControllerFactory) programRunner).createProgramController(controller,
+                                                                                         programDescriptor, runId);
   }
 
   @Override
@@ -478,14 +441,14 @@ public final class DistributedProgramRuntimeService extends AbstractProgramRunti
         return null;
       }
 
-      return getMetricsContext(programId.getType(), programId.toId());
+      return getMetricsContext(programId.getType(), programId);
     }
   }
 
-  private static Map<String, String> getMetricsContext(ProgramType type, Id.Program programId) {
-    return ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, programId.getNamespaceId(),
-                           Constants.Metrics.Tag.APP, programId.getApplicationId(),
-                           ProgramTypeMetricTag.getTagName(type), programId.getId());
+  private static Map<String, String> getMetricsContext(ProgramType type, ProgramId programId) {
+    return ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, programId.getNamespace(),
+                           Constants.Metrics.Tag.APP, programId.getApplication(),
+                           ProgramTypeMetricTag.getTagName(type), programId.getProgram());
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedServiceProgramRunner.java
@@ -19,6 +19,7 @@ package co.cask.cdap.internal.app.runtime.distributed;
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.service.ServiceSpecification;
 import co.cask.cdap.app.program.Program;
+import co.cask.cdap.app.program.ProgramDescriptor;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.conf.CConfiguration;
@@ -27,6 +28,7 @@ import co.cask.cdap.common.security.Impersonator;
 import co.cask.cdap.common.twill.AbortOnTimeoutEventHandler;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.security.TokenSecureStoreUpdater;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
@@ -56,6 +58,16 @@ public class DistributedServiceProgramRunner extends AbstractDistributedProgramR
   }
 
   @Override
+  public ProgramController createProgramController(TwillController twillController,
+                                                   ProgramDescriptor programDescriptor, RunId runId) {
+    return createProgramController(twillController, programDescriptor.getProgramId(), runId);
+  }
+
+  private ProgramController createProgramController(TwillController twillController, ProgramId programId, RunId runId) {
+    return new ServiceTwillProgramController(programId.toId(), twillController, runId).startListen();
+  }
+
+  @Override
   protected ProgramController launch(Program program, ProgramOptions options,
                                      Map<String, LocalizeResource> localizeResources,
                                      File tempDir, ApplicationLauncher launcher) {
@@ -76,8 +88,7 @@ public class DistributedServiceProgramRunner extends AbstractDistributedProgramR
     TwillController controller = launcher.launch(new ServiceTwillApplication(program, options.getUserArguments(),
                                                                              serviceSpec,
                                                                              localizeResources, eventHandler));
-    RunId runId = ProgramRunners.getRunId(options);
-    return new ServiceTwillProgramController(program.getId(), controller, runId).startListen();
+    return createProgramController(controller, program.getId().toEntityId(), ProgramRunners.getRunId(options));
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWebappProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWebappProgramRunner.java
@@ -17,12 +17,14 @@ package co.cask.cdap.internal.app.runtime.distributed;
 
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.app.program.Program;
+import co.cask.cdap.app.program.ProgramDescriptor;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.security.Impersonator;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.security.TokenSecureStoreUpdater;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
@@ -51,6 +53,16 @@ public final class DistributedWebappProgramRunner extends AbstractDistributedPro
   }
 
   @Override
+  public ProgramController createProgramController(TwillController twillController,
+                                                   ProgramDescriptor programDescriptor, RunId runId) {
+    return createProgramController(twillController, programDescriptor.getProgramId(), runId);
+  }
+
+  private ProgramController createProgramController(TwillController twillController, ProgramId programId, RunId runId) {
+    return new WebappTwillProgramController(programId.toId(), twillController, runId).startListen();
+  }
+
+  @Override
   protected ProgramController launch(Program program, ProgramOptions options,
                                      Map<String, LocalizeResource> localizeResources,
                                      File tempDir, ApplicationLauncher launcher) {
@@ -65,7 +77,6 @@ public final class DistributedWebappProgramRunner extends AbstractDistributedPro
     LOG.info("Launching distributed webapp: " + program.getName());
     TwillController controller = launcher.launch(new WebappTwillApplication(program, options.getUserArguments(),
                                                                             localizeResources, eventHandler));
-    RunId runId = ProgramRunners.getRunId(options);
-    return new WebappTwillProgramController(program.getId(), controller, runId).startListen();
+    return createProgramController(controller, program.getId().toEntityId(), ProgramRunners.getRunId(options));
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.worker.WorkerSpecification;
 import co.cask.cdap.app.program.Program;
+import co.cask.cdap.app.program.ProgramDescriptor;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.conf.CConfiguration;
@@ -29,6 +30,7 @@ import co.cask.cdap.common.twill.AbortOnTimeoutEventHandler;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.security.TokenSecureStoreUpdater;
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
@@ -57,6 +59,16 @@ public class DistributedWorkerProgramRunner extends AbstractDistributedProgramRu
                                  TokenSecureStoreUpdater tokenSecureStoreUpdater,
                                  Impersonator impersonator) {
     super(twillRunner, hConf, cConf, tokenSecureStoreUpdater, impersonator);
+  }
+
+  @Override
+  public ProgramController createProgramController(TwillController twillController,
+                                                   ProgramDescriptor programDescriptor, RunId runId) {
+    return createProgramController(twillController, programDescriptor.getProgramId(), runId);
+  }
+
+  private ProgramController createProgramController(TwillController twillController, ProgramId programId, RunId runId) {
+    return new WorkerTwillProgramController(programId.toId(), twillController, runId).startListen();
   }
 
   @Override
@@ -89,8 +101,7 @@ public class DistributedWorkerProgramRunner extends AbstractDistributedProgramRu
     TwillController controller = launcher.launch(new WorkerTwillApplication(program, options.getUserArguments(),
                                                                             newWorkerSpec,
                                                                             localizeResources, eventHandler));
-    RunId runId = ProgramRunners.getRunId(options);
-    return new WorkerTwillProgramController(program.getId(), controller, runId).startListen();
+    return createProgramController(controller, program.getId().toEntityId(), ProgramRunners.getRunId(options));
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
@@ -27,6 +27,7 @@ import co.cask.cdap.api.workflow.WorkflowNode;
 import co.cask.cdap.api.workflow.WorkflowNodeType;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
 import co.cask.cdap.app.program.Program;
+import co.cask.cdap.app.program.ProgramDescriptor;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.runtime.ProgramRunner;
@@ -38,6 +39,7 @@ import co.cask.cdap.internal.app.runtime.ProgramRuntimeProviderLoader;
 import co.cask.cdap.internal.app.runtime.batch.distributed.MapReduceContainerHelper;
 import co.cask.cdap.internal.app.runtime.spark.SparkUtils;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.security.TokenSecureStoreUpdater;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
@@ -72,6 +74,17 @@ public final class DistributedWorkflowProgramRunner extends AbstractDistributedP
                                    Impersonator impersonator) {
     super(twillRunner, createConfiguration(hConf), cConf, tokenSecureStoreUpdater, impersonator);
     this.runtimeProviderLoader = runtimeProviderLoader;
+  }
+
+
+  @Override
+  public ProgramController createProgramController(TwillController twillController,
+                                                   ProgramDescriptor programDescriptor, RunId runId) {
+    return createProgramController(twillController, programDescriptor.getProgramId(), runId);
+  }
+
+  private ProgramController createProgramController(TwillController twillController, ProgramId programId, RunId runId) {
+    return new WorkflowTwillProgramController(programId.toId(), twillController, runId).startListen();
   }
 
   @Override
@@ -134,8 +147,7 @@ public final class DistributedWorkflowProgramRunner extends AbstractDistributedP
                                    workflowSpec, localizeResources, eventHandler, driverMeta.resources),
       extraClassPaths, extraDependencies
     );
-    RunId runId = ProgramRunners.getRunId(options);
-    return new WorkflowTwillProgramController(program.getId(), controller, runId).startListen();
+    return createProgramController(controller, program.getId().toEntityId(), ProgramRunners.getRunId(options));
   }
 
   private static YarnConfiguration createConfiguration(YarnConfiguration hConf) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
@@ -444,7 +444,7 @@ public class ProgramLifecycleService extends AbstractIdleService {
 
   private boolean isConcurrentRunsAllowed(ProgramType type) {
     // Concurrent runs are only allowed for the Workflow and MapReduce
-    return EnumSet.of(ProgramType.WORKFLOW, ProgramType.MAPREDUCE).contains(type);
+    return EnumSet.of(ProgramType.WORKFLOW, ProgramType.MAPREDUCE, ProgramType.SPARK).contains(type);
   }
 
   @Nullable

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRunnerClassLoader.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRunnerClassLoader.java
@@ -90,7 +90,6 @@ public final class SparkRunnerClassLoader extends URLClassLoader {
   private static final Set<String> API_CLASSES;
 
   private final boolean rewriteYarnClient;
-  private final boolean rewriteDStreamGraph;
 
   static {
     Set<String> apiClasses = new HashSet<>();
@@ -122,16 +121,13 @@ public final class SparkRunnerClassLoader extends URLClassLoader {
     return urls.toArray(new URL[urls.size()]);
   }
 
-  public SparkRunnerClassLoader(ClassLoader parent,
-                                boolean rewriteYarnClient, boolean rewriteDStreamGraph) throws IOException {
-    this(getClassloaderURLs(parent), parent, rewriteYarnClient, rewriteDStreamGraph);
+  public SparkRunnerClassLoader(ClassLoader parent, boolean rewriteYarnClient) throws IOException {
+    this(getClassloaderURLs(parent), parent, rewriteYarnClient);
   }
 
-  public SparkRunnerClassLoader(URL[] urls, @Nullable ClassLoader parent,
-                                boolean rewriteYarnClient, boolean rewriteDStreamGraph) {
+  public SparkRunnerClassLoader(URL[] urls, @Nullable ClassLoader parent, boolean rewriteYarnClient) {
     super(urls, parent);
     this.rewriteYarnClient = rewriteYarnClient;
-    this.rewriteDStreamGraph = rewriteDStreamGraph;
   }
 
   @Override
@@ -179,7 +175,7 @@ public final class SparkRunnerClassLoader extends URLClassLoader {
       } else if (name.equals(SPARK_YARN_CLIENT_TYPE.getClassName()) && rewriteYarnClient) {
         // Rewrite YarnClient for workaround SPARK-13441.
         cls = defineClient(name, is);
-      } else if (name.equals(SPARK_DSTREAM_GRAPH_TYPE.getClassName()) && rewriteDStreamGraph) {
+      } else if (name.equals(SPARK_DSTREAM_GRAPH_TYPE.getClassName())) {
         // Rewrite DStreamGraph to set TaskSupport on parallel array usage to avoid Thread leak
         cls = defineDStreamGraph(name, is);
       } else if (name.equals(AKKA_REMOTING_TYPE.getClassName())) {

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.spark.Spark;
 import co.cask.cdap.api.spark.SparkSpecification;
 import co.cask.cdap.app.program.Program;
+import co.cask.cdap.app.program.ProgramDescriptor;
 import co.cask.cdap.app.runtime.ProgramClassLoaderProvider;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.app.runtime.ProgramOptions;
@@ -35,6 +36,7 @@ import co.cask.cdap.internal.app.runtime.distributed.AbstractDistributedProgramR
 import co.cask.cdap.internal.app.runtime.distributed.LocalizeResource;
 import co.cask.cdap.internal.app.runtime.spark.SparkUtils;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.security.TokenSecureStoreUpdater;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
@@ -67,6 +69,16 @@ public final class DistributedSparkProgramRunner extends AbstractDistributedProg
   }
 
   @Override
+  public ProgramController createProgramController(TwillController twillController,
+                                                   ProgramDescriptor programDescriptor, RunId runId) {
+    return createProgramController(twillController, programDescriptor.getProgramId(), runId);
+  }
+
+  private ProgramController createProgramController(TwillController twillController, ProgramId programId, RunId runId) {
+    return new SparkTwillProgramController(programId, twillController, runId).startListen();
+  }
+
+  @Override
   protected ProgramController launch(Program program, ProgramOptions options,
                                      Map<String, LocalizeResource> localizeResources,
                                      File tempDir, AbstractDistributedProgramRunner.ApplicationLauncher launcher) {
@@ -91,8 +103,7 @@ public final class DistributedSparkProgramRunner extends AbstractDistributedProg
       new SparkTwillApplication(program, options.getUserArguments(),
                                 spec, localizeResources, eventHandler), sparkAssemblyJarName);
 
-    RunId runId = ProgramRunners.getRunId(options);
-    return new SparkTwillProgramController(program.getId().toEntityId(), controller, runId).startListen();
+    return createProgramController(controller, program.getId().toEntityId(), ProgramRunners.getRunId(options));
   }
 
   private static YarnConfiguration createConfiguration(YarnConfiguration hConf, CConfiguration cConf,

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/SparkContainerLauncher.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/SparkContainerLauncher.java
@@ -67,7 +67,7 @@ public final class SparkContainerLauncher {
     // Spark classes are in the system classloader which we want to rewrite.
     URL[] classLoaderUrls = urls.toArray(new URL[urls.size()]);
     ClassLoader classLoader = new SparkRunnerClassLoader(
-      classLoaderUrls, new MainClassLoader(classLoaderUrls, systemClassLoader.getParent()), false, false);
+      classLoaderUrls, new MainClassLoader(classLoaderUrls, systemClassLoader.getParent()), false);
 
     // Sets the context classloader and launch the actual Spark main class.
     Thread.currentThread().setContextClassLoader(classLoader);

--- a/cdap-spark-core/src/test/java/co/cask/cdap/app/runtime/spark/SparkRunnerClassLoaderTest.java
+++ b/cdap-spark-core/src/test/java/co/cask/cdap/app/runtime/spark/SparkRunnerClassLoaderTest.java
@@ -41,7 +41,7 @@ public class SparkRunnerClassLoaderTest {
       final URL[] urlArray = urls.toArray(new URL[urls.size()]);
 
       SparkRunnerClassLoader firstCL = new SparkRunnerClassLoader(urlArray,
-                                                                  getClass().getClassLoader(), false, false);
+                                                                  getClass().getClassLoader(), false);
       // Load a class from the first CL.
       firstCL.loadClass("org.apache.spark.SparkContext");
 
@@ -52,7 +52,7 @@ public class SparkRunnerClassLoaderTest {
         @Override
         public void run() {
           SparkRunnerClassLoader secondCL = new SparkRunnerClassLoader(urlArray,
-                                                                       getClass().getClassLoader(), false, false);
+                                                                       getClass().getClassLoader(), false);
           try {
             latch.countDown();
             secondCL.loadClass("org.apache.spark.SparkContext");


### PR DESCRIPTION
(CDAP-7612) Makes ProgramController creation done by corresponding ProgramRunner

- This allows program runtime extension to provide ProgramController instance
- Don’t create new SparkRunnerClassLoader for DistributedSparkProgramRunner
  -	memorize the SparkRunnerClassLoader created for DistributedSparkProgramRunner
  - This avoid consuming permgen proportion to number of active Spark jobs

(CDAP-6885) Supports concurrent runs of Spark program