### PR TITLE
Skip Compat module tests

### DIFF
--- a/BUILD.rst
+++ b/BUILD.rst
@@ -21,6 +21,9 @@ Standalone and Distributed CDAP
 - Run all tests, fail at the end::
 
     MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn test -fae
+
+- Run tests skipping repeated compat module tests:: 
+    MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn test -Pskip-hbase-compat-tests -fae
     
 - Build all modules::
 

--- a/cdap-hbase-compat-0.96/pom.xml
+++ b/cdap-hbase-compat-0.96/pom.xml
@@ -358,6 +358,21 @@
         </plugins>
       </build>
     </profile>
+    <profile> 
+      <id>skip-hbase-compat-tests</id>
+      <build> 
+         <plugins> 
+           <plugin>
+             <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <version>2.4.2</version>
+              <configuration>
+                <skipTests>true</skipTests>
+              </configuration>
+           </plugin>
+         </plugins>
+      </build>
+    </profile>
 
   </profiles>
 

--- a/cdap-hbase-compat-0.98/pom.xml
+++ b/cdap-hbase-compat-0.98/pom.xml
@@ -358,6 +358,22 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>skip-hbase-compat-tests</id>
+      <build>
+         <plugins>
+           <plugin>
+             <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <version>2.4.2</version>
+              <configuration>
+                <skipTests>true</skipTests>
+              </configuration>
+           </plugin>
+         </plugins>
+      </build>
+    </profile>
+
 
   </profiles>
 

--- a/cdap-hbase-compat-1.0-cdh/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh/pom.xml
@@ -379,6 +379,21 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>skip-hbase-compat-tests</id>
+      <build>
+         <plugins>
+           <plugin>
+             <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <version>2.4.2</version>
+              <configuration>
+                <skipTests>true</skipTests>
+              </configuration>
+           </plugin>
+         </plugins>
+      </build>
+    </profile>
 
   </profiles>
 

--- a/cdap-hbase-compat-1.0-cdh5.5.0/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/pom.xml
@@ -379,6 +379,21 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>skip-hbase-compat-tests</id>
+      <build>
+         <plugins>
+           <plugin>
+             <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <version>2.4.2</version>
+              <configuration>
+                <skipTests>true</skipTests>
+              </configuration>
+           </plugin>
+         </plugins>
+      </build>
+    </profile>
 
   </profiles>
 

--- a/cdap-hbase-compat-1.0/pom.xml
+++ b/cdap-hbase-compat-1.0/pom.xml
@@ -365,6 +365,21 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>skip-hbase-compat-tests</id>
+      <build>
+         <plugins>
+           <plugin>
+             <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <version>2.4.2</version>
+              <configuration>
+                <skipTests>true</skipTests>
+              </configuration>
+           </plugin>
+         </plugins>
+      </build>
+    </profile>
 
   </profiles>
 

--- a/cdap-hbase-compat-1.1/pom.xml
+++ b/cdap-hbase-compat-1.1/pom.xml
@@ -365,6 +365,21 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>skip-hbase-compat-tests</id>
+      <build>
+         <plugins>
+           <plugin>
+             <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <version>2.4.2</version>
+              <configuration>
+                <skipTests>true</skipTests>
+              </configuration>
+           </plugin>
+         </plugins>
+      </build>
+    </profile>
 
   </profiles>
 


### PR DESCRIPTION
* Motivation: There are seven compat module tests which run for 5-10 mins and each of the tests are running the same suite of tests. Inorder to cut the build time introducing an option to optionally skip *all but one* compat module tests.  
* Solution:  Add a build profile that will skip the tests and which can be enabled in the command line.
  * ```mvn test -Pskip-hbase-compat-tests``` will run one compat module, if the skip-hbase-compat-tests profile is not enabled then tests on all compat modules will run. 
* Build: http://builds.cask.co/browse/CDAP-DUT5054