### PR TITLE
[CDAP-7629] Fix TableTest

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/TableProperties.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/TableProperties.java
@@ -62,7 +62,7 @@ public class TableProperties {
    * @throws IllegalArgumentException if the property value is not a valid conflict detection level.
    */
   @Nullable
-  static ConflictDetection getConflictDetectionLevel(Map<String, String> props, ConflictDetection defaultLevel) {
+  public static ConflictDetection getConflictDetectionLevel(Map<String, String> props, ConflictDetection defaultLevel) {
     String value = props.get(Table.PROPERTY_CONFLICT_LEVEL);
     if (value == null) {
       return defaultLevel;

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/BufferingTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/BufferingTableTest.java
@@ -18,6 +18,7 @@ package co.cask.cdap.data2.dataset2.lib.table;
 
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.DatasetAdmin;
+import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.table.Get;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scan;
@@ -196,12 +197,14 @@ public abstract class BufferingTableTest<T extends BufferingTable> extends Table
     // The test verifies that one can re-use byte arrays passed as parameters to write methods of a table without
     // affecting the stored data.
     // Also, one can re-use (modify) returned data from the table without affecting the stored data.
-    DatasetAdmin admin = getTableAdmin(CONTEXT1, MY_TABLE);
+    DatasetProperties props = DatasetProperties.builder().add(
+      Table.PROPERTY_READLESS_INCREMENT, String.valueOf(isReadlessIncrementSupported())).build();
+    DatasetAdmin admin = getTableAdmin(CONTEXT1, MY_TABLE, props);
     admin.create();
     try {
       // writing some data: we'll need it to test delete later
       Transaction tx = txClient.startShort();
-      BufferingTable table = getTable(CONTEXT1, MY_TABLE);
+      BufferingTable table = getTable(CONTEXT1, MY_TABLE, props);
       table.startTx(tx);
 
       table.put(new byte[] {0}, new byte[] {9}, new byte[] {8});

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryTableTest.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.table.ConflictDetection;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.dataset2.lib.table.BufferingTableTest;
+import co.cask.cdap.data2.dataset2.lib.table.TableProperties;
 
 /**
  *
@@ -32,8 +33,10 @@ public class InMemoryTableTest extends BufferingTableTest<InMemoryTable> {
 
   @Override
   protected InMemoryTable getTable(DatasetContext datasetContext, String name,
-                                   ConflictDetection conflictLevel) throws Exception {
-    return new InMemoryTable(datasetContext, name, ConflictDetection.valueOf(conflictLevel.name()), cConf);
+                                   DatasetProperties props) throws Exception {
+    ConflictDetection conflictLevel =
+      TableProperties.getConflictDetectionLevel(props.getProperties(), ConflictDetection.ROW);
+    return new InMemoryTable(datasetContext, name, conflictLevel, cConf);
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableTest.java
@@ -19,8 +19,6 @@ package co.cask.cdap.data2.dataset2.lib.table.leveldb;
 import co.cask.cdap.api.dataset.DatasetContext;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
-import co.cask.cdap.api.dataset.table.ConflictDetection;
-import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
@@ -47,6 +45,8 @@ import java.io.IOException;
  * test for LevelDB tables.
  */
 public class LevelDBTableTest extends BufferingTableTest<LevelDBTable> {
+
+  private static final LevelDBTableDefinition TABLE_DEFINITION = new LevelDBTableDefinition("foo");
 
   @ClassRule
   public static TemporaryFolder tmpFolder = new TemporaryFolder();
@@ -75,18 +75,15 @@ public class LevelDBTableTest extends BufferingTableTest<LevelDBTable> {
 
   @Override
   protected LevelDBTable getTable(DatasetContext datasetContext, String name,
-                                  ConflictDetection level) throws IOException {
-    DatasetSpecification spec = DatasetSpecification
-      .builder(name, "table")
-      .property(Table.PROPERTY_CONFLICT_LEVEL, level.name())
-      .build();
+                                  DatasetProperties props) throws Exception {
+    DatasetSpecification spec = DatasetSpecification.builder(name, "table").properties(props.getProperties()).build();
     return new LevelDBTable(datasetContext, name, service, cConf, spec);
   }
 
   @Override
   protected LevelDBTableAdmin getTableAdmin(DatasetContext datasetContext, String name,
-                                            DatasetProperties ignored) throws IOException {
-    DatasetSpecification spec = new LevelDBTableDefinition("foo").configure(name, DatasetProperties.EMPTY);
+                                            DatasetProperties props) throws IOException {
+    DatasetSpecification spec = TABLE_DEFINITION.configure(name, props);
     return new LevelDBTableAdmin(datasetContext, spec, service, cConf);
   }
 


### PR DESCRIPTION
- instantiate table with same properties that they are created with; 
- test both with and without readless increments enabled; 
- consolidate code duplication