### PR TITLE
[CDAP-7408] Configure a limit for the transaction timeout

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -577,6 +577,15 @@
   </property>
 
   <property>
+    <name>data.tx.max.timeout</name>
+    <value>600</value>
+    <description>
+      The limit for the allowed transaction timeout, in seconds. Attempts to
+      start a transaction with a longer timeout will fail.
+    </description>
+  </property>
+
+  <property>
     <name>dataset.data.dir</name>
     <value>data</value>
     <description>

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
@@ -56,7 +56,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
@@ -182,16 +181,14 @@ public class TransactionServiceClientTest extends TransactionSystemTest {
   }
 
   @Test
-  @Ignore
   @Override
   public void testNegativeTimeout() throws Exception {
-    // TODO bring this test back as part of CDAP-7408 once TEPHRA-194 is fixed
+    super.testNegativeTimeout();
   }
 
   @Test
-  @Ignore
   @Override
   public void testExcessiveTimeout() throws Exception {
-    // TODO bring this test back as part of CDAP-7408 once TEPHRA-194 is fixed
+    super.testExcessiveTimeout();
   }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueTest.java
@@ -148,6 +148,7 @@ public abstract class HBaseQueueTest extends QueueTest {
     // Fewer splits make the forceEvict runs faster, which makes all queue tests run faster
     cConf.setInt(QueueConstants.ConfigKeys.QUEUE_TABLE_PRESPLITS, 4);
     cConf.setLong(TxConstants.Manager.CFG_TX_TIMEOUT, 100000000L);
+    cConf.setLong(TxConstants.Manager.CFG_TX_MAX_TIMEOUT, 100000000L);
 
     injector = Guice.createInjector(
       new DataFabricDistributedModule(),


### PR DESCRIPTION
This is implemented in Tephra, we only need to configure it.
- add property  in cdap-default.xml
-  bring back test case inherited from Tephra

