### PR TITLE
Introduce TopicMetadata class

### DIFF
--- a/cdap-tms-tests/pom.xml
+++ b/cdap-tms-tests/pom.xml
@@ -93,6 +93,14 @@
       <type>test-jar</type>
     </dependency>
     <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-common</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-minicluster</artifactId>
     </dependency>

--- a/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseMetadataTableTest.java
+++ b/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseMetadataTableTest.java
@@ -19,11 +19,14 @@ package co.cask.cdap.messaging.store.hbase;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data.hbase.HBaseTestBase;
 import co.cask.cdap.data.hbase.HBaseTestFactory;
+import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
 import co.cask.cdap.messaging.store.MetadataTable;
 import co.cask.cdap.messaging.store.MetadataTableTest;
 import co.cask.cdap.proto.id.NamespaceId;
+import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -58,6 +61,11 @@ public class HBaseMetadataTableTest extends MetadataTableTest {
 
   @Override
   protected MetadataTable getTable() throws Exception {
-    return new HBaseMetadataTable(hBaseAdmin.getConfiguration(), tableUtil, "metadata");
+    byte[] columnFamily = {'d'};
+    TableId tableId = tableUtil.createHTableId(NamespaceId.CDAP, "metadata");
+    HColumnDescriptor hcd = new HColumnDescriptor(columnFamily);
+    HTableDescriptorBuilder htd = tableUtil.buildHTableDescriptor(tableId).addFamily(hcd);
+    tableUtil.createTableIfNotExists(hBaseAdmin, tableId, htd.build());
+    return new HBaseMetadataTable(hBaseAdmin.getConfiguration(), tableUtil, tableId, columnFamily);
   }
 }

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/TopicMetadata.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/TopicMetadata.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.messaging;
+
+import co.cask.cdap.proto.id.TopicId;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents metadata about a messaging topic.
+ */
+public class TopicMetadata {
+
+  private static final String TTL_KEY = "ttl";
+
+  private final TopicId topicId;
+  private final Map<String, String> properties;
+
+  /**
+   * Creates a new instance for the given topic with the associated properties.
+   */
+  public TopicMetadata(TopicId topicId, Map<String, String> properties) {
+    validateProperties(topicId, properties);
+
+    this.topicId = topicId;
+    this.properties = ImmutableMap.copyOf(properties);
+  }
+
+  /**
+   * Creates a new instance for the given topic with the associated properties.
+   *
+   * @param topicId topic id
+   * @param properties a list of key/value pairs that will get converted into a {@link Map}.
+   */
+  @VisibleForTesting
+  public TopicMetadata(TopicId topicId, Object...properties) {
+    this(topicId, toMap(properties));
+  }
+
+  /**
+   * Returns the topic id that this metadata is associated with.
+   */
+  public TopicId getTopicId() {
+    return topicId;
+  }
+
+  /**
+   * Returns the raw properties for the topic.
+   */
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  /**
+   * Returns the time-to-live in seconds property of the topic.
+   */
+  public long getTTL() {
+    return Integer.parseInt(properties.get(TTL_KEY));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TopicMetadata that = (TopicMetadata) o;
+    return Objects.equals(topicId, that.topicId) && Objects.equals(properties, that.properties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(topicId, properties);
+  }
+
+  /**
+   * Validates all the required properties of the given topic.
+   *
+   * @throws IllegalArgumentException if any required properties is missing or having invalid values
+   */
+  private void validateProperties(TopicId topicId, Map<String, String> properties) {
+    validateTTL(topicId, properties);
+  }
+
+  /**
+   * Validates the "ttl" property of the given topic.
+   *
+   * @throws IllegalArgumentException if the ttl value is missing, not a number or <= 0.
+   */
+  private void validateTTL(TopicId topicId, Map<String, String> properties) {
+    String ttl = properties.get(TTL_KEY);
+    if (ttl == null) {
+      throw new IllegalArgumentException("Missing ttl property from the metadata of topic " + topicId);
+    }
+    try {
+      if (Integer.parseInt(ttl) <= 0) {
+        throw new IllegalArgumentException("The ttl property must be greater than zero for topic " + topicId);
+      }
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("The ttl property must be a number greater than zero for topic " + topicId, e);
+    }
+  }
+
+  /**
+   * Turns a list of {@link Object} into a {@link Map} by using even index objects as keys and the following odd index
+   * objects as values. The {@link Object#toString()} method will be used to convert {@link Object} to {@link String}.
+   */
+  private static Map<String, String> toMap(Object...properties) {
+    if (properties.length % 2 != 0) {
+      throw new IllegalArgumentException("The properties size should be even as it should contain key-value pairs");
+    }
+
+    Map<String, String> map = new HashMap<>();
+    for (int i = 0; i < properties.length; i += 2) {
+      map.put(properties[i].toString(), properties[i + 1].toString());
+    }
+    return map;
+  }
+}

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/MetadataTable.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/MetadataTable.java
@@ -16,14 +16,14 @@
 
 package co.cask.cdap.messaging.store;
 
+import co.cask.cdap.messaging.TopicMetadata;
+import co.cask.cdap.messaging.TopicNotFoundException;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.TopicId;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
-import javax.annotation.Nullable;
 
 /**
  * Table to store information about the topics and their properties.
@@ -31,31 +31,25 @@ import javax.annotation.Nullable;
 public interface MetadataTable extends Closeable {
 
   /**
-   * Create Metadata Table.
-   *
-   * @throws IOException
-   */
-  void createTableIfNotExists() throws IOException;
-
-  /**
-   * Fetch the properties of the {@link TopicId}.
+   * Fetch the metadata of the {@link TopicId}.
    *
    * @param topicId message topic
-   * @return properties of the {@link TopicId} or null if the topic is not present
+   * @return metadata of the {@link TopicId}
+   * @throws TopicNotFoundException if the topic doesn't exist
+   * @throws IOException if failed to retrieve metadata
    */
-  @Nullable
-  Map<String, String> getProperties(TopicId topicId) throws IOException;
+  TopicMetadata getMetadata(TopicId topicId) throws TopicNotFoundException, IOException;
 
   /**
    * Create a topic with properties.
    *
-   * @param topicId message topic
-   * @param properties properties of the {@link TopicId}
+   * @param topicMetadata metadata of the topic
+   * @throws IOException if failed to create topic
    */
-  void createTopic(TopicId topicId, @Nullable Map<String, String> properties) throws IOException;
+  void createTopic(TopicMetadata topicMetadata) throws IOException;
 
   /**
-   * Delete a topic.
+   * Delete a topic if it exists. If the topic doesn't exist, the deletion is an no-op.
    *
    * @param topicId message topic
    */
@@ -66,6 +60,15 @@ public interface MetadataTable extends Closeable {
    *
    * @param namespaceId namespace
    * @return {@link List} of topics in that namespace
+   * @throws IOException if failed to retrieve topics
    */
   List<TopicId> listTopics(NamespaceId namespaceId) throws IOException;
+
+  /**
+   * List all topics in the messaging system.
+   *
+   * @return {@link List} of all topics.
+   * @throws IOException if failed to retrieve topics
+   */
+  List<TopicId> listTopics() throws IOException;
 }

--- a/cdap-tms/src/test/java/co/cask/cdap/messaging/store/MetadataTableTest.java
+++ b/cdap-tms/src/test/java/co/cask/cdap/messaging/store/MetadataTableTest.java
@@ -16,12 +16,11 @@
 
 package co.cask.cdap.messaging.store;
 
+import co.cask.cdap.messaging.TopicMetadata;
+import co.cask.cdap.messaging.TopicNotFoundException;
 import co.cask.cdap.proto.id.NamespaceId;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.Map;
 
 /**
  * Base class for Metadata Table tests.
@@ -31,19 +30,49 @@ public abstract class MetadataTableTest {
   @Test
   public void testTopicManagement() throws Exception {
     try (MetadataTable table = getTable()) {
-      table.createTableIfNotExists();
+      Assert.assertTrue(table.listTopics().isEmpty());
       Assert.assertTrue(table.listTopics(NamespaceId.DEFAULT).isEmpty());
-      Assert.assertNull(table.getProperties(NamespaceId.DEFAULT.topic("t1")));
-      table.createTopic(NamespaceId.DEFAULT.topic("t1"), null);
+
+      try {
+        table.getMetadata(NamespaceId.DEFAULT.topic("t1"));
+        Assert.fail("Expected exception on topic that doesn't exist");
+      } catch (TopicNotFoundException e) {
+        // expected
+      }
+
+      // Create topic default:t1
+      table.createTopic(new TopicMetadata(NamespaceId.DEFAULT.topic("t1"), "ttl", 10));
       Assert.assertEquals(1, table.listTopics(NamespaceId.DEFAULT).size());
-      Map<String, String> props = ImmutableMap.of("k1", "v1");
-      table.createTopic(NamespaceId.DEFAULT.topic("t2"), props);
-      Assert.assertEquals(props, table.getProperties(NamespaceId.DEFAULT.topic("t2")));
+
+      // Create topic default:t2
+      TopicMetadata topicMetadata = new TopicMetadata(NamespaceId.DEFAULT.topic("t2"), "ttl", 20);
+      table.createTopic(topicMetadata);
+      Assert.assertEquals(topicMetadata, table.getMetadata(NamespaceId.DEFAULT.topic("t2")));
+
+      // Create topic system:t3
+      table.createTopic(new TopicMetadata(NamespaceId.SYSTEM.topic("t3"), "ttl", 30));
+
+      // List default namespace, should get 2
       Assert.assertEquals(2, table.listTopics(NamespaceId.DEFAULT).size());
+
+      // List all topics, should get 3
+      Assert.assertEquals(3, table.listTopics().size());
+
+      // Delete t1
       table.deleteTopic(NamespaceId.DEFAULT.topic("t1"));
       Assert.assertEquals(1, table.listTopics(NamespaceId.DEFAULT).size());
+      Assert.assertEquals(2, table.listTopics().size());
+
+      // Delete t2
       table.deleteTopic(NamespaceId.DEFAULT.topic("t2"));
       Assert.assertTrue(table.listTopics(NamespaceId.DEFAULT).isEmpty());
+      Assert.assertEquals(1, table.listTopics(NamespaceId.SYSTEM).size());
+
+      // Delete t3
+      table.deleteTopic(NamespaceId.SYSTEM.topic("t3"));
+      Assert.assertTrue(table.listTopics(NamespaceId.DEFAULT).isEmpty());
+      Assert.assertTrue(table.listTopics(NamespaceId.SYSTEM).isEmpty());
+      Assert.assertTrue(table.listTopics().isEmpty());
     }
   }
 

--- a/cdap-tms/src/test/java/co/cask/cdap/messaging/store/leveldb/LevelDBMetadataTableTest.java
+++ b/cdap-tms/src/test/java/co/cask/cdap/messaging/store/leveldb/LevelDBMetadataTableTest.java
@@ -44,6 +44,7 @@ public class LevelDBMetadataTableTest extends MetadataTableTest {
 
   @Override
   protected MetadataTable getTable() throws Exception {
+    service.ensureTableExists("metadata");
     return new LevelDBMetadataTable(service, "metadata");
   }
 }


### PR DESCRIPTION
Note: This is not merging to develop. It's branch merges between TMS (Transactional Messaging System) branches.

- Refactored MetadataTable
  - Remove the table create method
    - It should be done outside of the Table, something like the messaging service itself.
  - Use TopicMetadata instead of raw Map
  - throws TopicNotFoundException
  - Introduce a method to list all topics in all namespaces