### PR TITLE
CDAP-7634 First cut of AuthEnforce annotation and class rewrite

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AuthorizationBootstrapperTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/AuthorizationBootstrapperTest.java
@@ -29,6 +29,7 @@ import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.namespace.NamespaceAdmin;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.test.AppJarHelper;
+import co.cask.cdap.common.test.TestRunner;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
@@ -68,6 +69,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.io.IOException;
@@ -79,6 +81,7 @@ import java.util.jar.Manifest;
 /**
  * Tests authorization for default namespace, system artifacts, system datasets, etc
  */
+@RunWith(TestRunner.class)
 public class AuthorizationBootstrapperTest {
   @ClassRule
   public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();

--- a/cdap-common/src/main/java/co/cask/cdap/common/security/AuthEnforce.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/security/AuthEnforce.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.security;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.security.Action;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for a method that needs Authorization enforcement.
+ * <p>
+ * {@link AuthEnforce#entities()}: Specifies the entity on which authorization will be enforced.
+ * Method parameters and class variables which are needed as entities should be marked with {@link Name} annotation
+ * with a unique name and those names should be provided here.
+ * It can either be an EntityId or an array of Strings from which the EntityId on which enforcement is needed
+ * (specified through {@link AuthEnforce#enforceOn()}) can be constructed.
+ * This will first be looked up in method parameter and if not found it will be looked up in the class member variable.
+ * If a class member variable is marked with the same name as a method parameter then the method parameter will take
+ * precedence over the class member variable. If you you want the class member variable to be used then specify it
+ * with this.AnnotationName
+ * <p>
+ * {@link AuthEnforce#enforceOn()}: CDAP entities (see {@link EntityId}) class on which enforcement will be done. If
+ * you want to enforce on the parent of the entity specify that EntityId class here
+ * <p>
+ * {@link AuthEnforce#actions()}: An array of {@link Action} to be checked during enforcement
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface AuthEnforce {
+
+  /**
+   * Specifies the entity on which authorization will be enforced. Method parameters and class variables which are
+   * needed as entities should be marked with {@link Name} annotation with a unique name and those names should be
+   * provided here. It can either be an EntityId or an array of Strings from which the EntityId on which enforcement
+   * is needed (specified through {@link AuthEnforce#enforceOn()}) can be constructed. This will first be looked up
+   * in method parameter and if not found it will be looked up in the class member variable. If a class member
+   * variable is marked with the same name as a method parameter then the method parameter will take precedence over
+   * the class member variable. If you you want the class member variable to be used then specify it with
+   * this.AnnotationName
+   */
+  String[] entities();
+
+  /**
+   * CDAP entities (see {@link EntityId}) class on which enforcement will be done. If
+   * you want to enforce on the parent of the entity specify that EntityId class here
+   */
+  Class<? extends EntityId> enforceOn();
+
+  /**
+   * An array of {@link Action} to be checked during enforcement
+   */
+  Action[] actions();
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/security/AuthEnforceRewriter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/security/AuthEnforceRewriter.java
@@ -1,0 +1,575 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.security;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.common.lang.ClassRewriter;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.security.spi.authentication.AuthenticationContext;
+import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
+import com.google.common.base.Preconditions;
+import com.google.common.io.ByteStreams;
+import com.google.inject.Inject;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.AdviceAdapter;
+import org.objectweb.asm.commons.GeneratorAdapter;
+import org.objectweb.asm.commons.Method;
+import org.objectweb.asm.tree.AnnotationNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * <p>
+ * A {@link ClassRewriter} for rewriting bytecode of classes which needs Authorization Enforcement and uses
+ * {@link AuthEnforce} annotation.
+ * </p>
+ * <p>
+ * This class rewriter does two passes on the class:
+ * </p>
+ * <p>
+ * Pass 1: In first pass it visit all the classes skipping interfaces and looks for non-static methods which has
+ * {@link AuthEnforce} annotation. If an {@link AuthEnforce} annotation is found then it store all the
+ * {@link AuthEnforce} annotation details and also visits the parameter annotation and collects all the position of
+ * parameters with {@link Name} annotation. Note: No byte code modification of the class is done in this pass.
+ * </p>
+ * <p>
+ * Pass 2: This pass only happen if a method with {@link AuthEnforce} annotation is found in the class during the
+ * first pass. In this pass we rewrite the method which has {@link AuthEnforce} annotation. In the rewrite we
+ * generate a call to
+ * {@link AuthEnforceUtil#enforce(AuthorizationEnforcer, EntityId, AuthenticationContext, Set)} with
+ * all the annotation details collected in the first pass.
+ * </p>
+ * <p>
+ * Below is a sample of how a class containing a method annotation with {@link AuthEnforce} looks like before and
+ * after class rewrite.
+ * </p>
+ * <p>
+ * Before:
+ * <pre>
+ *     public class ValidAuthEnforceAnnotations {
+ *      &#064;AuthEnforce(entities = "namespaceId", enforceOn = NamespaceId.class, actions = Action.ADMIN)
+ *      public void testSingleAction(@Name("namespaceId") NamespaceId namespaceId) throws Exception {
+ *        System.out.println("Hello");
+ *      }
+ *     }
+ *   </pre>
+ * </p>
+ * <p>
+ * After:
+ * <pre>
+ *     public class ValidAuthEnforceAnnotations {
+ *      private final AuthorizationEnforcer _[timestamp]authorizationEnforcer;
+ *      private final AuthenticationContext _[timestamp]authenticationContext;
+ *
+ *      @Inject
+ *      public void set_[timestamp]authorizationEnforcer (AuthorizationEnforcer authorizationEnforcer) {
+ *        _[timestamp]authorizationEnforcer = authorizationEnforcer
+ *      }
+ *
+ *      @Inject
+ *      public void set_[timestamp]authenticationContext (AuthenticationContext authenticationContext) {
+ *        _[timestamp]authenticationContext = authenticationContext
+ *      }
+ *
+ *      public void testSingleAction(@Name("namespaceId") NamespaceId namespaceId) throws Exception {
+ *        AuthEnforceUtil.enforce(_[timestamp]authorizationEnforcer, namespaceId, _[timestamp]authenticationContext,
+ *                                              Set<Action.Admin>);
+ *        System.out.println("Hello");
+ *      }
+ *     }
+ *   </pre>
+ * </p>
+ */
+public class AuthEnforceRewriter implements ClassRewriter {
+
+  public static final String GENERATED_FIELD_PREFIX = "_";
+  public static final String GENERATED_SETTER_METHOD_PREFIX = "set";
+  public static final String AUTHORIZATION_ENFORCER_FIELD_NAME = AuthorizationEnforcer.class.getSimpleName();
+  public static final String AUTHENTICATION_CONTEXT_FIELD_NAME = AuthenticationContext.class.getSimpleName();
+
+  private static final Logger LOG = LoggerFactory.getLogger(AuthEnforceRewriter.class);
+
+  private static final Type AUTHORIZATION_ENFORCER_TYPE = Type.getType(AuthorizationEnforcer.class);
+  private static final Type AUTHENTICATION_CONTEXT_TYPE = Type.getType(AuthenticationContext.class);
+  private static final Type ACTION_TYPE = Type.getType(Action.class);
+  private static final Type AUTH_ENFORCE_UTIL_TYPE = Type.getType(AuthEnforceUtil.class);
+
+  @Override
+  public byte[] rewriteClass(String className, InputStream input) throws IOException {
+    byte[] classBytes = ByteStreams.toByteArray(input);
+    // First pass: Check the class to have a method with AuthEnforce annotation if found store the annotation details
+    // and parameters for the method for second pass in which class rewrite will be performed.
+    ClassReader cr = new ClassReader(classBytes);
+
+    // SKIP_CODE SKIP_DEBUG and SKIP_FRAMESto make the first pass faster since in the first pass we just want to
+    // process annotations to check if the class has any method with AuthEnforce annotation. If such method is found
+    // we also store the parameters which has the named annotations as specified in the entities field of the
+    // AuthEnforce.
+    AuthEnforceAnnotationVisitor classVisitor = new AuthEnforceAnnotationVisitor(className);
+    cr.accept(classVisitor, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
+
+    Map<Method, AnnotationDetail> methodAnnotations = classVisitor.getMethodAnnotations();
+    if (methodAnnotations.isEmpty()) {
+      // if no AuthEnforce annotation was found then return the original class bytes
+      return classBytes;
+    }
+    // We found some method which has AuthEnforce annotation so we need a second pass in to rewrite the class
+    // in second pass we COMPUTE_FRAMES and visit classes with EXPAND_FRAMES
+    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+    cr.accept(new AuthEnforceAnnotationRewriter(className, cw, classVisitor.getFieldDetails(), methodAnnotations),
+              ClassReader.EXPAND_FRAMES);
+    return cw.toByteArray();
+  }
+
+  /**
+   * A {@link ClassVisitor} which is used in the first pass of the {@link AuthEnforceRewriter} to detect and store
+   * method with {@link AuthEnforce} annotations. Note: This is a visitor, to know the order of in which the below
+   * overridden methods will be called and their overall responsibility please see {@link ClassVisitor} documentation.
+   */
+  private static final class AuthEnforceAnnotationVisitor extends ClassVisitor {
+
+    private final String className;
+    private final Map<Method, AnnotationDetail> methodAnnotations;
+    private final Map<String, Type> fieldDetails;
+    private boolean interfaceClass;
+
+    AuthEnforceAnnotationVisitor(String className) {
+      super(Opcodes.ASM5);
+      this.className = className;
+      this.methodAnnotations = new HashMap<>();
+      this.fieldDetails = new HashMap<>();
+    }
+
+    @Override
+    public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+      interfaceClass = Modifier.isInterface(access);
+    }
+
+    @Override
+    public FieldVisitor visitField(int access, final String fieldName, String desc, String signature, Object value) {
+      if (interfaceClass) {
+        return null;
+      }
+      fieldDetails.put(fieldName, Type.getType(desc));
+      return super.visitField(access, fieldName, desc, signature, value);
+    }
+
+    @Override
+    public MethodVisitor visitMethod(final int access, final String methodName, final String methodDesc,
+                                     final String signature, final String[] exceptions) {
+
+      // No need to visit the class to look for AuthEnforce annotation if this class is an interface or the method is
+      // static.
+      if (interfaceClass || Modifier.isStatic(access)) {
+        return null;
+      }
+
+      // Visit the annotations of the method to determine if it has AuthEnforce annotation. If it does then collect
+      // AuthEnforce annotation details and also sets a boolean flag hasEnforce which is used later in
+      // visitParameterAnnotation to visit the annotations on parameters of this method only if it had AuthEnforce
+      // annotation.
+      return new MethodVisitor(Opcodes.ASM5) {
+
+        final Map<Integer, AnnotationNode> parameterAnnotationNode = new HashMap<>();
+        AnnotationNode authEnforceAnnotationNode;
+
+        @Override
+        public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+
+          // If the annotation is not visible or its not AuthEnforce just skip
+          if (!(visible && AuthEnforce.class.getName().equals(Type.getType(desc).getClassName()))) {
+            return null;
+          }
+          authEnforceAnnotationNode = new AnnotationNode(desc);
+          return authEnforceAnnotationNode;
+        }
+
+        @Override
+        public AnnotationVisitor visitParameterAnnotation(int parameter, String desc, boolean visible) {
+          if (!(authEnforceAnnotationNode != null && visible &&
+            Name.class.getName().equals(Type.getType(desc).getClassName()))) {
+            return null;
+          }
+          // Since AuthEnforce annotation was used on this method then look for parameters with named annotation and
+          // store their position.
+          // TODO: Should also pick up names from QueryParam and PathParam annotations here as needed later and also
+          // decide on a precedence order.
+          AnnotationNode annotationNode = new AnnotationNode(desc);
+          // store the parameter position and its annotation detail
+          parameterAnnotationNode.put(parameter, annotationNode);
+          return annotationNode;
+        }
+
+        // This is called at the end of visiting method. Here if the method has AuthEnforce annotation then we
+        // process all the AnnotationNode information collected by visiting method annotation and parameter annotation.
+        // store for second pass in which we will perform class rewrite
+        @Override
+        public void visitEnd() {
+          if (authEnforceAnnotationNode == null) {
+            return;
+          }
+          AuthEnforceAnnotationNodeProcessor nodeProcessor =
+            new AuthEnforceAnnotationNodeProcessor(authEnforceAnnotationNode);
+          Map<String, Integer> paramAnnotation = processParameterAnnotationNode(parameterAnnotationNode);
+
+          List<EntityPartDetail> entityPartDetails = new ArrayList<>();
+          for (String name : nodeProcessor.getEntities()) {
+            // Make sure that the entities specified in the AuthEnforce annotation are found in method parameters
+            // or class fields. Its fine if they exist at both places in that case we will give preference to
+            // method parameters unless its been specified with this. in that case its always looked in class field.
+            EntityPartDetail entityPart;
+            // if the name starts with this we will give preference to class field since its possible to annotate a
+            // method parameter with this.something
+            if (name.startsWith("this.")) {
+              String fieldName = getFieldName(name);
+              fieldDetails.containsKey(fieldName);
+              entityPart = new EntityPartDetail(fieldName, true);
+            } else {
+              // preference to method parameters
+              if (paramAnnotation.containsKey(name)) {
+                entityPart = new EntityPartDetail(name, false);
+              } else if (fieldDetails.containsKey(name)) {
+                entityPart = new EntityPartDetail(name, true);
+              } else {
+                // Didn't find a named method parameter or class field for the given entity name
+                throw new IllegalArgumentException(String.format("No named method parameter or a class field found " +
+                                                                   "with name %s in class %s for method %s whereas " +
+                                                                   "it was specified in %s annotation", name,
+                                                                 className, methodName,
+                                                                 AuthEnforce.class.getSimpleName()));
+              }
+            }
+            entityPartDetails.add(entityPart);
+          }
+          // Store all the information properly for the second pass
+          methodAnnotations.put(new Method(methodName, methodDesc),
+                                new AnnotationDetail(entityPartDetails, nodeProcessor.getEnforceOn(),
+                                                     nodeProcessor.getActions(), paramAnnotation));
+        }
+      };
+    }
+
+    Map<Method, AnnotationDetail> getMethodAnnotations() {
+      return methodAnnotations;
+    }
+
+    Map<String, Type> getFieldDetails() {
+      return fieldDetails;
+    }
+  }
+
+  /**
+   * A {@link ClassVisitor} which is used in second pass of {@link AuthEnforceRewriter} to rewrite methods which has
+   * {@link AuthEnforce} annotation on it with the annotation details collected from the first pass. This is only
+   * called for classes which has at least one such method. This class does byte code rewrite to generate call to
+   * {@link AuthEnforceUtil#enforce(AuthorizationEnforcer, EntityId, AuthenticationContext, Set)}. To
+   * see an example of generated byte code please see the documentation for {@link AuthEnforceRewriter}
+   */
+  private final class AuthEnforceAnnotationRewriter extends ClassVisitor {
+
+    private final String className;
+    private final Type classType;
+    private final Map<Method, AnnotationDetail> methodAnnotations;
+    private final String authenticationContextFieldName;
+    private final String authorizationEnforcerFieldName;
+    private final Map<String, Type> fieldDetails;
+
+    AuthEnforceAnnotationRewriter(String className, ClassWriter cw, Map<String, Type> fieldDetails,
+                                  Map<Method, AnnotationDetail> methodAnnotations) {
+      super(Opcodes.ASM5, cw);
+      this.className = className;
+      this.classType = Type.getObjectType(className.replace(".", "/"));
+      this.fieldDetails = fieldDetails;
+      this.methodAnnotations = methodAnnotations;
+      this.authenticationContextFieldName = generateUniqueFieldName(AUTHENTICATION_CONTEXT_FIELD_NAME);
+      this.authorizationEnforcerFieldName = generateUniqueFieldName(AUTHORIZATION_ENFORCER_FIELD_NAME);
+    }
+
+    @Override
+    public MethodVisitor visitMethod(int access, final String methodName, final String methodDesc, String signature,
+                                     String[] exceptions) {
+      MethodVisitor mv = super.visitMethod(access, methodName, methodDesc, signature, exceptions);
+      // From the first pass we know the methods which has AuthEnforce annotation and needs to be rewritten
+      // if this method was not identified earlier as marked with AuthEnforce annotation just skip it
+      final AnnotationDetail annotationDetail = methodAnnotations.get(new Method(methodName, methodDesc));
+      if (annotationDetail == null) {
+        return mv;
+      }
+      return new AdviceAdapter(Opcodes.ASM5, mv, access, methodName, methodDesc) {
+        @Override
+        protected void onMethodEnter() {
+          LOG.trace("AuthEnforce annotation found in class {} on method {}. Authorization enforcement command will " +
+                      "be generated for Entities: {}, enforceOn: {}, actions: {}.", className, methodName,
+                    annotationDetail.getEntities(), annotationDetail.getEnforceOn(),
+                    annotationDetail.getActions());
+
+          // TODO: Remove this one we support AuthEnforce with multiple string parts
+          Preconditions.checkArgument(annotationDetail.getEntities().size() == 1,
+                                      "Currently Authorization annotation is only supported for EntityId from " +
+                                        "method parameter.");
+
+          // do class rewrite to generate the call to
+          // AuthEnforceUtil#enforce(AuthorizationEnforcer, EntityId, AuthenticationContext, Set)
+
+          // this.authorizationEnforcer
+          loadThis();
+          getField(classType, authorizationEnforcerFieldName, AUTHORIZATION_ENFORCER_TYPE);
+
+          // push the parameters of method call on to the stack
+
+          // pushed the entity id
+          //TODO: This is because currently we don't support multi-part
+          EntityPartDetail entityPart = annotationDetail.getEntities().get(0);
+          if (entityPart.isField()) {
+            // load class field
+            loadThis();
+            getField(classType, entityPart.getEntityName(), fieldDetails.get(entityPart.getEntityName()));
+          } else {
+            // load method parameter
+            loadArg(0);
+          }
+
+          // push the authentication context
+          // this.authenticationContext
+          loadThis();
+          getField(classType, authenticationContextFieldName, AUTHENTICATION_CONTEXT_TYPE);
+
+          // push all the actions on to the stack
+          List<Type> actionEnumSetParamTypes = new ArrayList<>();
+          for (Action action : annotationDetail.getActions()) {
+            getStatic(ACTION_TYPE, action.name().toUpperCase(), ACTION_TYPE);
+            // store the Type of Enum for all the action pushed on stack as it will later be used to generate a
+            // method call instruction
+            actionEnumSetParamTypes.add(Type.getType(Enum.class));
+          }
+
+          // create a EnumSet from the above actions
+          invokeStatic(Type.getType(EnumSet.class),
+                       new Method("of", Type.getMethodDescriptor(Type.getType(EnumSet.class),
+                                                                 actionEnumSetParamTypes.toArray(
+                                                                   new Type[actionEnumSetParamTypes.size()]))));
+
+          // generate a call to AuthEnforceUtil#enforce with the above parameters on the stack
+          invokeStatic(AUTH_ENFORCE_UTIL_TYPE,
+                       new Method("enforce", Type.getMethodDescriptor(Type.VOID_TYPE,
+                                                                      AUTHORIZATION_ENFORCER_TYPE,
+                                                                      Type.getType(EntityId.class),
+                                                                      AUTHENTICATION_CONTEXT_TYPE,
+                                                                      Type.getType(Set.class))));
+        }
+      };
+    }
+
+    private String generateUniqueFieldName(String fieldName) {
+      // pre-pend current system time to make it unique
+      return GENERATED_FIELD_PREFIX + System.currentTimeMillis() + fieldName;
+    }
+
+    private void generateFieldAndSetter(String name, Type type) {
+      String setterMethodName = GENERATED_SETTER_METHOD_PREFIX + name;
+      // add the field
+      super.visitField(Modifier.PRIVATE, name, type.getDescriptor(), null, null);
+      // get the setter method details
+      Method method = new Method(setterMethodName, Type.getMethodDescriptor(Type.VOID_TYPE, type));
+      // add the setter method
+      MethodVisitor methodVisitor = super.visitMethod(Modifier.PRIVATE, method.getName(), method.getDescriptor(),
+                                                      null, null);
+      // Put annotation on the the setter method
+      AnnotationVisitor annotationVisitor = methodVisitor.visitAnnotation(Type.getType(Inject.class).getDescriptor(),
+                                                                          true);
+      annotationVisitor.visitEnd();
+
+      // Code generation for the setter method
+      GeneratorAdapter generatorAdapter = new GeneratorAdapter(Modifier.PRIVATE, method, methodVisitor);
+      generatorAdapter.loadThis();
+      // the setter method has only one argument which is what we want the field to be set to
+      generatorAdapter.loadArg(0);
+      generatorAdapter.putField(classType, name, type);
+      generatorAdapter.returnValue();
+      generatorAdapter.endMethod();
+    }
+
+    @Override
+    public void visitEnd() {
+      // If this class had method annotation then we need to generate the authenticationContext and
+      // authorizationEnforcer field and their setters
+      generateFieldAndSetter(authorizationEnforcerFieldName, AUTHORIZATION_ENFORCER_TYPE);
+      generateFieldAndSetter(authenticationContextFieldName, AUTHENTICATION_CONTEXT_TYPE);
+      super.visitEnd();
+    }
+  }
+
+  /**
+   * Process {@link AnnotationNode} information collected on a method parameters
+   *
+   * @param parameterAnnotationNode a {@link Map} of parameter position and annotation details of that parameter
+   * @return a new {@link Map} where the key is the parameter name given in the annotation and value is the
+   * position of the parameter.
+   */
+  private static Map<String, Integer> processParameterAnnotationNode(Map<Integer, AnnotationNode>
+                                                                       parameterAnnotationNode) {
+    Map<String, Integer> parameterAnnotation = new HashMap<>();
+    for (Map.Entry<Integer, AnnotationNode> entry : parameterAnnotationNode.entrySet()) {
+      // the AnnotationNode of parameter will be an array of size 2 where 0 is "value" and 1 is the name provided in
+      // the annotation.
+      String paraName = (String) entry.getValue().values.get(1);
+      // We expect all parameters to have unique names to ensure that here
+      Preconditions.checkArgument(!parameterAnnotation.containsKey(paraName),
+                                  String.format("A parameter with name %s was already found at position %s." +
+                                                  " Please use unique names.", paraName,
+                                                parameterAnnotation.get(paraName)));
+      // store the parameter position with the unique name given to it
+      parameterAnnotation.put(paraName, entry.getKey());
+    }
+    return parameterAnnotation;
+  }
+
+  /**
+   * A class which can process {@link AuthEnforce} {@link AnnotationNode}
+   */
+  private static class AuthEnforceAnnotationNodeProcessor {
+
+    private final Set<Action> actions = new HashSet<>();
+    private Type enforceOn;
+    private List<String> entities;
+
+    AuthEnforceAnnotationNodeProcessor(AnnotationNode annotationNode) {
+      List values = annotationNode.values;
+      // AuthEnforce AnnotationNode will have 6 values: 3 field names and another 3 field containing their values.
+      Preconditions.checkArgument(values.size() == 6,
+                                  "AuthEnforce annotation has three field and with their values " +
+                                    "total elements should be 6 but found %s", values.size());
+      for (int i = 0; i < 6; i = i + 2) { // increment by 2 to go to next field
+        Object name = values.get(i);
+        if ("entities".equals(name)) {
+          entities = (List<String>) values.get(i + 1);
+        } else if ("enforceOn".equals(name)) {
+          enforceOn = (Type) values.get(i + 1);
+        } else if ("actions".equals(name)) {
+          // Actions is a ArrayList<String[]> where each String array is of size 2. String[0] is class name Action
+          // class and String[1] is the action which was specified in the annotation
+          List<String[]> actionWithClassName = (List<String[]>) values.get(i + 1);
+          for (String[] action : actionWithClassName) {
+            Preconditions.checkArgument(action.length == 2);
+            Preconditions.checkArgument(Type.getType(action[0]).equals(Type.getType(Action.class)));
+            actions.add(Action.valueOf(action[1]));
+          }
+        } else {
+          throw new RuntimeException(String.format("Found invalid entry %s while parsing AuthEnforce details " +
+                                                     "%s", name, values));
+        }
+      }
+    }
+
+    Type getEnforceOn() {
+      return enforceOn;
+    }
+
+    List<String> getEntities() {
+      return entities;
+    }
+
+    Set<Action> getActions() {
+      return actions;
+    }
+  }
+
+  /**
+   * A wrapper to store all the annotation details of method which has {@link AuthEnforce} annotation and parameters
+   * marked with {@link Name} annotation specifying the entities
+   */
+  private static final class AnnotationDetail {
+    private final List<EntityPartDetail> entityParts;
+    private final Type enforceOn;
+    private final Set<Action> actions;
+    private final Map<String, Integer> parameterAnnotation;
+
+    AnnotationDetail(List<EntityPartDetail> entityParts, Type enforceOn, Set<Action> actions,
+                     Map<String, Integer> parameterAnnotation) {
+      this.entityParts = entityParts;
+      this.enforceOn = enforceOn;
+      this.actions = actions;
+      this.parameterAnnotation = parameterAnnotation;
+    }
+
+    List<EntityPartDetail> getEntities() {
+      return entityParts;
+    }
+
+    Type getEnforceOn() {
+      return enforceOn;
+    }
+
+    Set<Action> getActions() {
+      return actions;
+    }
+
+    Map<String, Integer> getParameterAnnotation() {
+      return parameterAnnotation;
+    }
+  }
+
+  private static final class EntityPartDetail {
+    private final String entityName;
+    private final boolean isField;
+
+    EntityPartDetail(String entityName, boolean isField) {
+      this.entityName = entityName;
+      this.isField = isField;
+    }
+
+    String getEntityName() {
+      return entityName;
+    }
+
+    boolean isField() {
+      return isField;
+    }
+  }
+
+  /**
+   * Return the field name without "this." if the given field name starts with it
+   *
+   * @param fieldNameWithThis the field name which starts with this.
+   * @return the field name without this.
+   */
+  private static String getFieldName(String fieldNameWithThis) {
+    Preconditions.checkArgument(fieldNameWithThis.startsWith("this."), String.format("The given field name %s does " +
+                                                                                       "not start with 'this.'",
+                                                                                     fieldNameWithThis));
+    return fieldNameWithThis.substring(fieldNameWithThis.lastIndexOf(".") + 1);
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/security/AuthEnforceUtil.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/security/AuthEnforceUtil.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.security;
+
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.security.spi.authentication.AuthenticationContext;
+import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
+
+import java.util.Set;
+
+/**
+ * Class used by {@link AuthEnforceRewriter} to rewrite classes with {@link AuthEnforce} annotation and call
+ * enforcement methods in this class to perform authorization enforcement.
+ */
+// Note: Do no remove the public modifier of this class. This class is marked public even though its only usage is
+// from the package because after class rewrite AuthEnforce annotations are rewritten to make call to the methods
+// in this class and since AuthEnforce annotation can be in any package after class rewrite this class methods
+// might be being called from other packages.
+public final class AuthEnforceUtil {
+
+  private AuthEnforceUtil() {
+    // no-op
+  }
+
+  /**
+   * Performs authorization enforcement
+   *
+   * @param authorizationEnforcer the {@link AuthorizationEnforcer} to use for performing the enforcement
+   * @param entities the {@link EntityId} on which authorization is to be enforced
+   * @param authenticationContext the {@link AuthenticationContext}  of the user that performs the action
+   * @param actions the {@link Action}s being performed
+   * @throws Exception
+   */
+  public static void enforce(AuthorizationEnforcer authorizationEnforcer, EntityId entities,
+                             AuthenticationContext authenticationContext, Set<Action> actions) throws Exception {
+    authorizationEnforcer.enforce(entities, authenticationContext.getPrincipal(), actions);
+  }
+}

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthEnforceRewriterTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthEnforceRewriterTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.common.security.AuthEnforce;
+import co.cask.cdap.common.security.AuthEnforceRewriter;
+import co.cask.cdap.internal.asm.ByteCodeClassLoader;
+import co.cask.cdap.internal.asm.ClassDefinition;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.id.InstanceId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.security.auth.context.AuthenticationTestContext;
+import co.cask.cdap.security.spi.authentication.AuthenticationContext;
+import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
+import org.junit.Assert;
+import org.junit.Test;
+import org.objectweb.asm.Type;
+
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+
+/**
+ * Tests {@link AuthEnforceRewriter} class rewriting for methods annotated with {@link AuthEnforce}. Uses different
+ * possibilities of {@link AuthEnforce} annotation from {@link DummyAuthEnforce}.
+ */
+public class AuthEnforceRewriterTest {
+
+  @Test
+  public void test() throws Exception {
+    ByteCodeClassLoader classLoader = new ByteCodeClassLoader(getClass().getClassLoader());
+    classLoader.addClass(rewrite(DummyAuthEnforce.ValidAuthEnforceAnnotations.class));
+    classLoader.addClass(rewrite(DummyAuthEnforce.AnotherValidAuthEnforceAnnotations.class));
+    classLoader.addClass(rewrite(DummyAuthEnforce.ClassImplementingInterfaceWithAuthAnnotation.class));
+    classLoader.addClass(rewrite(DummyAuthEnforce.ClassWithoutAuthEnforce.class));
+    classLoader.addClass(rewrite(DummyAuthEnforce.ValidAuthEnforceWithFields.class));
+
+    // Need to invoke the method on the object created from the rewritten class in the classloader since trying to
+    // cast it here to DummyAuthEnforce will fail since the object is created from a class which was loaded from a
+    // different classloader.
+    Class<?> cls = classLoader.loadClass(DummyAuthEnforce.ValidAuthEnforceAnnotations.class.getName());
+    Object rewrittenObject = loadRewritten(classLoader, DummyAuthEnforce.class.getName(), cls.getName());
+    invokeSetters(cls, rewrittenObject);
+    // tests a valid AuthEnforce annotation which has single action
+    testRewrite(getMethod(cls, "testSingleAction", NamespaceId.class), rewrittenObject,
+                ExceptionAuthorizationEnforcer.ExpectedException.class, NamespaceId.DEFAULT);
+    // tests a valid AuthEnforce annotation which has multiple action
+    testRewrite(getMethod(cls, "testMultipleAction", NamespaceId.class), rewrittenObject,
+                ExceptionAuthorizationEnforcer.ExpectedException.class, NamespaceId.DEFAULT);
+    // test that the class rewrite did not affect other non annotated methods
+    testRewrite(getMethod(cls, "testNoAuthEnforceAnnotation", NamespaceId.class), rewrittenObject,
+                DummyAuthEnforce.EnforceNotCalledException.class, NamespaceId.DEFAULT);
+    // test that the class rewrite works for method whose signature does not specify throws exception
+    testRewrite(getMethod(cls, "testMethodWithoutException", NamespaceId.class), rewrittenObject,
+                ExceptionAuthorizationEnforcer.ExpectedException.class, NamespaceId.DEFAULT);
+
+    // tests that class rewriting does not happen if an interface has a method with AuthEnforce
+    cls = classLoader.loadClass(DummyAuthEnforce.ClassImplementingInterfaceWithAuthAnnotation.class.getName());
+    rewrittenObject = loadRewritten(classLoader, DummyAuthEnforce.class.getName(), cls.getName());
+    invokeSetters(cls, rewrittenObject);
+    testRewrite(getMethod(cls, "interfaceMethodWithAuthEnforce", NamespaceId.class), rewrittenObject,
+                DummyAuthEnforce.EnforceNotCalledException.class, NamespaceId.DEFAULT);
+
+    // test that class rewriting does not happen for classes which does not have AuthEnforce annotation on its method
+    cls = classLoader.loadClass(DummyAuthEnforce.ClassWithoutAuthEnforce.class.getName());
+    rewrittenObject = loadRewritten(classLoader, DummyAuthEnforce.class.getName(), cls.getName());
+    invokeSetters(cls, rewrittenObject);
+    testRewrite(getMethod(cls, "methodWithoutAuthEnforce", NamespaceId.class), rewrittenObject, DummyAuthEnforce
+      .EnforceNotCalledException.class, NamespaceId.DEFAULT);
+
+    // test that class rewriting works for a valid annotated method in another inner class and needs the
+    // invokeSetters to called independently for this
+    cls = classLoader.loadClass(DummyAuthEnforce.AnotherValidAuthEnforceAnnotations.class.getName());
+    rewrittenObject = loadRewritten(classLoader, DummyAuthEnforce.class.getName(), cls.getName());
+    invokeSetters(cls, rewrittenObject);
+    testRewrite(getMethod(cls, "testSomeOtherAction", NamespaceId.class), rewrittenObject,
+                ExceptionAuthorizationEnforcer.ExpectedException.class, NamespaceId.DEFAULT);
+
+    // test that class rewriting works for a valid annotation with field instances
+    cls = classLoader.loadClass(DummyAuthEnforce.ValidAuthEnforceWithFields.class.getName());
+    rewrittenObject = loadRewritten(classLoader, DummyAuthEnforce.class.getName(), cls.getName());
+    invokeSetters(cls, rewrittenObject);
+    testRewrite(getMethod(cls, "testNoParameters"), rewrittenObject,
+                ExceptionAuthorizationEnforcer.ExpectedException.class);
+    testRewrite(getMethod(cls, "testParaNameSameAsField", NamespaceId.class), rewrittenObject,
+                new NamespaceId("ns"), ExceptionAuthorizationEnforcer.ExpectedException.class, NamespaceId.DEFAULT);
+    testRewrite(getMethod(cls, "testParaPreference", InstanceId.class), rewrittenObject,
+                new InstanceId("i1"), ExceptionAuthorizationEnforcer.ExpectedException.class, new InstanceId("i1"));
+    testRewrite(getMethod(cls, "testThisClassPreference", NamespaceId.class), rewrittenObject,
+                new NamespaceId("ns"), ExceptionAuthorizationEnforcer.ExpectedException.class, NamespaceId.DEFAULT);
+  }
+
+  @Test
+  public void testInvalidEntity() throws Exception {
+    // tests that class rewrite fails if no parameters are found with a Name specified in the annotation entities field
+    testInvalidEntityHelper(DummyAuthEnforce.AbsentEntityName.class);
+    // tests that class rewrite fails if invalid parameters are found with a Name specified in the annotation entities
+    // field
+    testInvalidEntityHelper(DummyAuthEnforce.InvalidEntityName.class);
+    // test that the class rewrite fails if two parameters are found with the same Name annotation
+    testInvalidEntityHelper(DummyAuthEnforce.DuplicateEntityName.class);
+  }
+
+  private void testInvalidEntityHelper(Class cls) throws Exception {
+    try {
+      rewrite(cls);
+      Assert.fail("An IllegalArgumentException should have been thrown earlier.");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+
+  private Method getMethod(Class<?> cls, String methodName, Class<?>... parameterTypes) throws NoSuchMethodException {
+    return cls.getDeclaredMethod(methodName, parameterTypes);
+  }
+
+  private void testRewrite(Method method, Object rewrittenObject, EntityId entityId,
+                           Class<? extends Exception> expectedException, Object... args) throws NoSuchMethodException {
+    try {
+      method.invoke(rewrittenObject, args);
+    } catch (Exception e) {
+      // Since the above method is invoked through reflection any exception thrown will be wrapped in
+      // InvocationTargetException so verify that the root cause is the expected exception confirming that enforce
+      // was called successfully.
+      if (!(e instanceof InvocationTargetException && expectedException.isAssignableFrom(e.getCause().getClass()))) {
+
+        Assert.fail(String.format("Got exception %s while expecting %s%s%s", e.getCause(),
+                                  ExceptionAuthorizationEnforcer.ExpectedException.class.getName(),
+                                  System.lineSeparator(), getFormattedStackTrace(e.getStackTrace())));
+      }
+      if (entityId != null) {
+        if (!ExceptionAuthorizationEnforcer.ExpectedException.class.isAssignableFrom(e.getCause().getClass())) {
+          Assert.fail(String.format("Exception %s is not assignable from %s to match entity %s", e.getCause(),
+                                    ExceptionAuthorizationEnforcer.ExpectedException.class.getName(), entityId));
+
+        }
+        ExceptionAuthorizationEnforcer.ExpectedException exception =
+          (ExceptionAuthorizationEnforcer.ExpectedException) e.getCause();
+        if (!exception.getEntityId().equals(entityId)) {
+          Assert.fail(String.format("Expected %s with entity %s but found %s", ExceptionAuthorizationEnforcer
+            .ExpectedException.class.getSimpleName(), entityId, exception.getEntityId()));
+        }
+      }
+    }
+  }
+
+  private void testRewrite(Method method, Object rewrittenObject, Class<? extends Exception> expectedException,
+                           Object... args) throws NoSuchMethodException {
+    testRewrite(method, rewrittenObject, null, expectedException, args);
+  }
+
+  private void invokeSetters(Class<?> cls, Object rewrittenObject)
+    throws InvocationTargetException, IllegalAccessException {
+    Method[] declaredMethods = cls.getDeclaredMethods();
+    for (Method declaredMethod : declaredMethods) {
+      // if the method name starts with set_ then we know its an generated setter
+      if (declaredMethod.getName().startsWith(AuthEnforceRewriter.GENERATED_SETTER_METHOD_PREFIX +
+                                                AuthEnforceRewriter.GENERATED_FIELD_PREFIX)) {
+        declaredMethod.setAccessible(true); // since its setter it might be private
+        if (declaredMethod.getName().contains(AuthEnforceRewriter.AUTHENTICATION_CONTEXT_FIELD_NAME)) {
+          declaredMethod.invoke(rewrittenObject, new AuthenticationTestContext());
+        } else if (declaredMethod.getName().contains(AuthEnforceRewriter.AUTHORIZATION_ENFORCER_FIELD_NAME)) {
+          declaredMethod.invoke(rewrittenObject, new ExceptionAuthorizationEnforcer());
+        } else {
+          throw new IllegalStateException(String.format("Found an expected setter method with name %s. While trying " +
+                                                          "invoke setter for %s and %s",
+                                                        declaredMethod.getName(),
+                                                        AuthenticationContext.class.getSimpleName(),
+                                                        AuthorizationEnforcer.class.getSimpleName()));
+        }
+      }
+    }
+  }
+
+  private ClassDefinition rewrite(Class cls) throws Exception {
+    AuthEnforceRewriter rewriter = new AuthEnforceRewriter();
+    URL url = cls.getClassLoader().getResource(cls.getName().replace('.', '/') + ".class");
+    Assert.assertNotNull(url);
+    try (InputStream is = url.openStream()) {
+      return new ClassDefinition(rewriter.rewriteClass(cls.getName(), is), Type.getInternalName(cls));
+    }
+  }
+
+  private Object loadRewritten(ClassLoader classLoader, String outerClassName, String innerClassName)
+    throws ClassNotFoundException,
+    IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+    // the classes which we are loading from DummyAuthEnforce are inner classes so we need to instantiate the outer
+    // class to load them.
+    Class<?> outerClass = classLoader.loadClass(outerClassName);
+    Object outer = outerClass.newInstance();
+    return classLoader.loadClass(innerClassName).getDeclaredConstructor(outerClass).newInstance(outer);
+  }
+
+  private String getFormattedStackTrace(StackTraceElement[] stackTraceElements) {
+    StringBuilder stringBuilder = new StringBuilder();
+    for (StackTraceElement stackTraceElement : stackTraceElements) {
+      stringBuilder.append(stackTraceElement);
+      stringBuilder.append(System.lineSeparator());
+    }
+    return stringBuilder.toString();
+  }
+}

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/DummyAuthEnforce.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/DummyAuthEnforce.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.common.security.AuthEnforce;
+import co.cask.cdap.common.security.AuthEnforceRewriter;
+import co.cask.cdap.proto.id.InstanceId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.security.Action;
+
+/**
+ * A Dummy class which is just an wrapper and have different inner classes with {@link AuthEnforce} annotations.
+ * to test class rewrite done through {@link AuthEnforceRewriter} for the annotations. The different
+ * {@link AuthEnforce} annotations are in their own independent inner classes rather than just in one class as we
+ * want to test the rewrite of one annotation independent of other.
+ * <p>
+ * Please see tests in {@link AuthEnforceRewriterTest}
+ */
+public class DummyAuthEnforce {
+
+  /**
+   * Class which has different possible valid {@link AuthEnforce} annotations
+   */
+  public class ValidAuthEnforceAnnotations {
+
+    @AuthEnforce(entities = "namespaceId", enforceOn = NamespaceId.class, actions = Action.ADMIN)
+    public void testSingleAction(@Name("namespaceId") NamespaceId namespaceId) throws Exception {
+      // the above annotation will call enforce after class rewrite which should throw an exception.
+      // If the line below is reached it means that enforce was not called as it supposed to be
+      throw new EnforceNotCalledException();
+    }
+
+    @Deprecated // tests that the presence of other annotations does not affect class rewrite
+    @AuthEnforce(entities = "namespaceId", enforceOn = NamespaceId.class, actions = {Action.ADMIN, Action.READ})
+    public void testMultipleAction(@Name("namespaceId") NamespaceId namespaceId) throws Exception {
+      // the above annotation will call enforce after class rewrite which should throw an exception.
+      // If the line below is reached it means that enforce was not called as it supposed to be
+      throw new EnforceNotCalledException();
+    }
+
+    @AuthEnforce(entities = "namespaceId", enforceOn = NamespaceId.class, actions = Action.ADMIN)
+    public void testMethodWithoutException(@Name("namespaceId") NamespaceId namespaceId) {
+      // no-op
+      // After class rewrite we make a call to AuthorizationEnforcer.enforce which can throw UnauthorizedException.
+      // This tests that a method which does not specify throws Exception in its signature will be able to throw
+      // exception during enforcement
+    }
+
+    // to test that presence of a method with AuthEnforce in classs does not affect other methods which does have
+    // AuthEnforce annotation
+    public void testNoAuthEnforceAnnotation(@Name("namespaceId") NamespaceId namespaceId) throws Exception {
+      throw new EnforceNotCalledException();
+    }
+  }
+
+  /**
+   * Class which has different possible valid {@link AuthEnforce} annotations just like
+   * {@link ValidAuthEnforceAnnotations} just to test with two valid inner classes
+   */
+  public class AnotherValidAuthEnforceAnnotations {
+
+    @AuthEnforce(entities = "namespaceId", enforceOn = NamespaceId.class, actions = Action.ADMIN)
+    public void testSomeOtherAction(@Name("namespaceId") NamespaceId namespaceId) throws Exception {
+      // the above annotation will call enforce after class rewrite which should throw an exception.
+      // If the line below is reached it means that enforce was not called as it supposed to be
+      throw new EnforceNotCalledException();
+    }
+  }
+
+  /**
+   * Class which has {@link AuthEnforce} annotation and fields
+   */
+  public class ValidAuthEnforceWithFields {
+
+    public NamespaceId someEntity = new NamespaceId("ns");
+
+    // test when method has no parameters and enforcement is one field
+    @AuthEnforce(entities = "someEntity", enforceOn = NamespaceId.class, actions = Action.ADMIN)
+    public void testNoParameters() throws Exception {
+      // the above annotation will call enforce after class rewrite which should throw an exception.
+      // If the line below is reached it means that enforce was not called as it supposed to be
+      throw new EnforceNotCalledException();
+    }
+
+    // test that having a para name same as field name
+    @AuthEnforce(entities = "someEntity", enforceOn = NamespaceId.class, actions = Action.ADMIN)
+    public void testParaNameSameAsField(NamespaceId someEntity) throws Exception {
+      // the above annotation will call enforce after class rewrite which should throw an exception.
+      // If the line below is reached it means that enforce was not called as it supposed to be
+      throw new EnforceNotCalledException();
+    }
+
+    // tests that when a method parameter has Named annotation same as class field name and when specified in
+    // AuthEnforce entities method parameter gets prefernce
+    @AuthEnforce(entities = "someEntity", enforceOn = InstanceId.class, actions = Action.ADMIN)
+    public void testParaPreference(@Name("someEntity") InstanceId instanceId) throws Exception {
+      // the above annotation will call enforce after class rewrite which should throw an exception.
+      // If the line below is reached it means that enforce was not called as it supposed to be
+      throw new EnforceNotCalledException();
+    }
+
+    // tests that when parameter has same Name annotation as the one specified in AuthEnforce annotation saying
+    // this.name give preference to class field than the default method parameters
+    @AuthEnforce(entities = "this.someEntity", enforceOn = NamespaceId.class, actions = Action.ADMIN)
+    public void testThisClassPreference(@Name("someEntity") NamespaceId namespaceId) throws Exception {
+      // the above annotation will call enforce after class rewrite which should throw an exception.
+      // If the line below is reached it means that enforce was not called as it supposed to be
+      throw new EnforceNotCalledException();
+    }
+  }
+
+  /**
+   * Class which has {@link AuthEnforce} annotation without a {@link Name} annotated parameter
+   */
+  public class AbsentEntityName {
+
+    @AuthEnforce(entities = "namespaceId", enforceOn = NamespaceId.class, actions = {Action.ADMIN, Action.READ})
+    public void testEntityNameAbsence(NamespaceId namespaceId) throws Exception {
+      // no-op
+    }
+  }
+
+  /**
+   * Class which has {@link AuthEnforce} annotation without an invalid {@link Name} annotated parameter than the one
+   * specified in {@link AuthEnforce#entities()}
+   */
+  public class InvalidEntityName {
+
+    @AuthEnforce(entities = "namespaceId", enforceOn = NamespaceId.class, actions = {Action.ADMIN, Action.READ})
+    public void testWrongEntityName(@Name("wrongId") NamespaceId namespaceId) throws Exception {
+      // no-op
+    }
+  }
+
+  /**
+   * Class which has {@link AuthEnforce} annotation with multiple parameters with same {@link Name} annotation
+   */
+  public class DuplicateEntityName {
+
+    @AuthEnforce(entities = "duplicateName", enforceOn = NamespaceId.class, actions = {Action.ADMIN, Action.READ})
+    public void testDuplicatEntityName(@Name("duplicateName") NamespaceId namespaceId,
+                                       @Name("duplicateName") NamespaceId anotherNamespaceId) throws Exception {
+      // no-op
+    }
+  }
+
+  /**
+   * Class which does not have {@link AuthEnforce}
+   */
+  public class ClassWithoutAuthEnforce {
+
+    public void methodWithoutAuthEnforce(@Name("namespaceId") NamespaceId namespaceId) throws Exception {
+      throw new EnforceNotCalledException();
+    }
+  }
+
+  /**
+   * An interface which has {@link AuthEnforce} annotation
+   */
+  public interface InterfaceWithAuthAnnotation {
+
+    @AuthEnforce(entities = "namespaceId", enforceOn = NamespaceId.class, actions = Action.ADMIN)
+    void interfaceMethodWithAuthEnforce(@Name("namespaceId") NamespaceId namespaceId) throws Exception;
+  }
+
+  /**
+   * A class implementing an interface with {@link AuthEnforce} annotation
+   */
+  public class ClassImplementingInterfaceWithAuthAnnotation implements InterfaceWithAuthAnnotation {
+
+    @Override
+    public void interfaceMethodWithAuthEnforce(@Name("namespaceId") NamespaceId namespaceId) throws Exception {
+      throw new EnforceNotCalledException();
+    }
+  }
+
+  /**
+   * Just a dummy exception which is thrown is authorization enforcement was not done
+   */
+  public class EnforceNotCalledException extends Exception {
+
+  }
+}

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/ExceptionAuthorizationEnforcer.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/ExceptionAuthorizationEnforcer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.api.Predicate;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
+
+import java.util.Set;
+
+/**
+ * A dummy AuthorizationEnforcer which throws {@link ExpectedException} when enforce is called.
+ * This is used for testing as in {@link AuthEnforceRewriterTest} to ensure that enforce was successfully called after
+ * class rewrite.
+ */
+public class ExceptionAuthorizationEnforcer implements AuthorizationEnforcer {
+
+  @Override
+  public void enforce(EntityId entity, Principal principal, Action action) throws Exception {
+    throw new ExpectedException(entity);
+  }
+
+  @Override
+  public void enforce(EntityId entity, Principal principal, Set<Action> actions) throws Exception {
+    throw new ExpectedException(entity);
+  }
+
+  @Override
+  public Predicate<EntityId> createFilter(Principal principal) throws Exception {
+    return null;
+  }
+
+  class ExpectedException extends Exception {
+    // just a dummy exception for test which is thrown if authorization enforcement call was successful
+    private final EntityId entityId; // entity on which authorization enforcement is being performed
+
+    ExpectedException(EntityId entityId) {
+      this.entityId = entityId;
+    }
+
+    public EntityId getEntityId() {
+      return entityId;
+    }
+  }
+}


### PR DESCRIPTION
- First cut of AuthEnforce annotation and class rewrite to generate Authorization enforcement call.
- Currently, the rewrite supports only EntityId from method parameters and not multiple part string or looking into class fields. 
- One thing is which is different from the design is that in design we mentioned entity being specified in AuthEnforce annotation will be name of the variable from the method parameter or class field. Supporting this is not possible as after compilation method parameter names are lost and they are represented/accessed by position. So we expect use to mark parameters with Name annotation and give unique name to them. Will update the design to reflect this.
- Have added extensive unit-tests to cover all possible scenarios in which the AuthEnforce annotation can be used. Please provide comments if I have missed a case.

Design: https://wiki.cask.co/display/CE/Authorization+Improvements

Build: http://builds.cask.co/browse/CDAP-DUT5031-9
IT: