### PR TITLE
Etl change to use DataTracer in hydrator pipeline

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/SmartWorkflow.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/SmartWorkflow.java
@@ -182,6 +182,9 @@ public class SmartWorkflow extends AbstractWorkflow {
   @Override
   public void destroy() {
     WorkflowContext workflowContext = getContext();
+    if (workflowContext.getDataTracer(PostAction.PLUGIN_TYPE).isEnabled()) {
+      return;
+    }
     LookupProvider lookupProvider = new DatasetContextLookupProvider(workflowContext);
     Map<String, String> runtimeArgs = workflowContext.getRuntimeArguments();
     long logicalStartTime = workflowContext.getLogicalStartTime();

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineRunner.java
@@ -78,7 +78,8 @@ public class SparkStreamingPipelineRunner extends SparkPipelineRunner {
 
     StreamingContext sourceContext = new DefaultStreamingContext(stageInfo.getName(), sec, streamingContext);
     JavaDStream<Object> javaDStream = source.getStream(sourceContext)
-      .transform(new CountingTranformFunction<>(stageInfo.getName(), sec.getMetrics(), "records.out"));
+      .transform(new CountingTranformFunction<>(stageInfo.getName(), sec.getMetrics(), "records.out",
+                                                sec.getDataTracer(stageInfo.getName())));
     return new DStreamCollection<>(sec, javaDStream);
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/ETLWorkflow.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/ETLWorkflow.java
@@ -98,6 +98,9 @@ public class ETLWorkflow extends AbstractWorkflow {
   @Override
   public void destroy() {
     WorkflowContext workflowContext = getContext();
+    if (workflowContext.getDataTracer(PostAction.PLUGIN_TYPE).isEnabled()) {
+      return;
+    }
     LookupProvider lookupProvider = new DatasetContextLookupProvider(workflowContext);
     Map<String, String> runtimeArgs = workflowContext.getRuntimeArguments();
     long logicalStartTime = workflowContext.getLogicalStartTime();

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/customaction/PipelineAction.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/customaction/PipelineAction.java
@@ -81,7 +81,9 @@ public class PipelineAction extends AbstractCustomAction {
                                                           context,
                                                           context.getNamespace()));
     ActionContext actionContext = new BasicActionContext(context, metrics, stageInfo.getName());
-    action.run(actionContext);
+    if (!context.getDataTracer(stageInfo.getName()).isEnabled()) {
+      action.run(actionContext);
+    }
     WorkflowToken token = context.getWorkflowToken();
     if (token == null) {
       throw new IllegalStateException("WorkflowToken cannot be null when action is executed through Workflow.");

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/common/TransformExecutorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/common/TransformExecutorTest.java
@@ -16,9 +16,11 @@
 
 package co.cask.cdap.etl.common;
 
+import co.cask.cdap.app.preview.DataTracerFactory;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.InvalidEntry;
 import co.cask.cdap.etl.api.Transform;
+import co.cask.cdap.internal.app.preview.NoopDataTracerFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -33,6 +35,8 @@ import java.util.Map;
 /**
  */
 public class TransformExecutorTest {
+
+  private final DataTracerFactory dataTracerFactory = new NoopDataTracerFactory();
 
   @Test
   public void testEmptyTransforms() throws Exception {
@@ -61,25 +65,29 @@ public class TransformExecutorTest {
     transformationMap.put("transform1",
                           new TransformDetail(
                             new TrackedTransform<>(new IntToDouble(),
-                                                   new DefaultStageMetrics(mockMetrics, "transform1")),
+                                                   new DefaultStageMetrics(mockMetrics, "transform1"),
+                                                   dataTracerFactory.getDataTracer(null, "transform1")),
                             ImmutableList.of("transform2", "sink1")));
 
     transformationMap.put("transform2",
                           new TransformDetail(
                             new TrackedTransform<>(new Filter(100d, Threshold.LOWER),
-                                                   new DefaultStageMetrics(mockMetrics, "transform2")),
+                                                   new DefaultStageMetrics(mockMetrics, "transform2"),
+                                                   dataTracerFactory.getDataTracer(null, "transform2")),
                             ImmutableList.of("sink2")));
 
     transformationMap.put("sink1",
                           new TransformDetail(
                             new TrackedTransform<>(new DoubleToString(),
-                                                   new DefaultStageMetrics(mockMetrics, "sink1")),
+                                                   new DefaultStageMetrics(mockMetrics, "sink1"),
+                                                   dataTracerFactory.getDataTracer(null, "sink1")),
                             ImmutableList.<String>of()));
 
     transformationMap.put("sink2",
                           new TransformDetail(
                             new TrackedTransform<>(new DoubleToString(),
-                                                   new DefaultStageMetrics(mockMetrics, "sink2")),
+                                                   new DefaultStageMetrics(mockMetrics, "sink2"),
+                                                   dataTracerFactory.getDataTracer(null, "sink2")),
                             ImmutableList.<String>of()));
 
     TransformExecutor<Integer> executor = new TransformExecutor<>(transformationMap, ImmutableSet.of("transform1"));
@@ -144,44 +152,51 @@ public class TransformExecutorTest {
     transformationMap.put("conversion",
                           new TransformDetail(
                             new TrackedTransform<>(new IntToDouble(),
-                                                   new DefaultStageMetrics(mockMetrics, "conversion")),
+                                                   new DefaultStageMetrics(mockMetrics, "conversion"),
+                                                   dataTracerFactory.getDataTracer(null, "conversion")),
                             ImmutableList.of("filter1", "filter2")));
 
     transformationMap.put("filter1",
                           new TransformDetail(
                             new TrackedTransform<>(new Filter(100d, Threshold.LOWER),
-                                                   new DefaultStageMetrics(mockMetrics, "filter1")),
+                                                   new DefaultStageMetrics(mockMetrics, "filter1"),
+                                                   dataTracerFactory.getDataTracer(null, "filter1")),
                             ImmutableList.of("limiter1", "sink1")));
 
     transformationMap.put("filter2",
                           new TransformDetail(
                             new TrackedTransform<>(new Filter(1000d, Threshold.LOWER),
-                                                   new DefaultStageMetrics(mockMetrics, "filter2")),
+                                                   new DefaultStageMetrics(mockMetrics, "filter2"),
+                                                   dataTracerFactory.getDataTracer(null, "filter2")),
                             ImmutableList.of("limiter1", "sink2")));
 
 
     transformationMap.put("limiter1",
                           new TransformDetail(
                             new TrackedTransform<>(new Filter(5000d, Threshold.UPPER),
-                                                   new DefaultStageMetrics(mockMetrics, "limiter1")),
+                                                   new DefaultStageMetrics(mockMetrics, "limiter1"),
+                                                   dataTracerFactory.getDataTracer(null, "limiter1")),
                             ImmutableList.of("sink3")));
 
     transformationMap.put("sink1",
                           new TransformDetail(
                             new TrackedTransform<>(new DoubleToString(),
-                                                   new DefaultStageMetrics(mockMetrics, "sink1")),
+                                                   new DefaultStageMetrics(mockMetrics, "sink1"),
+                                                   dataTracerFactory.getDataTracer(null, "sink1")),
                             ImmutableList.<String>of()));
 
     transformationMap.put("sink2",
                           new TransformDetail(
                             new TrackedTransform<>(new DoubleToString(),
-                                                   new DefaultStageMetrics(mockMetrics, "sink2")),
+                                                   new DefaultStageMetrics(mockMetrics, "sink2"),
+                                                   dataTracerFactory.getDataTracer(null, "sink2")),
                             ImmutableList.<String>of()));
 
     transformationMap.put("sink3",
                           new TransformDetail(
                             new TrackedTransform<>(new DoubleToString(),
-                                                   new DefaultStageMetrics(mockMetrics, "sink3")),
+                                                   new DefaultStageMetrics(mockMetrics, "sink3"),
+                                                   dataTracerFactory.getDataTracer(null, "sink3")),
                             ImmutableList.<String>of()));
 
 
@@ -215,38 +230,44 @@ public class TransformExecutorTest {
     transformationMap.put("filter1",
                           new TransformDetail(
                             new TrackedTransform<>(new Filter(100d, Threshold.LOWER),
-                                                   new DefaultStageMetrics(mockMetrics, "filter1")),
+                                                   new DefaultStageMetrics(mockMetrics, "filter1"),
+                                                   dataTracerFactory.getDataTracer(null, "filter1")),
                             ImmutableList.of("limiter1", "sink1")));
 
     transformationMap.put("filter2",
                           new TransformDetail(
                             new TrackedTransform<>(new Filter(1000d, Threshold.LOWER),
-                                                   new DefaultStageMetrics(mockMetrics, "filter2")),
+                                                   new DefaultStageMetrics(mockMetrics, "filter2"),
+                                                   dataTracerFactory.getDataTracer(null, "filter2")),
                             ImmutableList.of("limiter1", "sink2")));
 
 
     transformationMap.put("limiter1",
                           new TransformDetail(
                             new TrackedTransform<>(new Filter(5000d, Threshold.UPPER),
-                                                   new DefaultStageMetrics(mockMetrics, "limiter1")),
+                                                   new DefaultStageMetrics(mockMetrics, "limiter1"),
+                                                   dataTracerFactory.getDataTracer(null, "limiter1")),
                             ImmutableList.of("sink3")));
 
     transformationMap.put("sink1",
                           new TransformDetail(
                             new TrackedTransform<>(new DoubleToString(),
-                                                   new DefaultStageMetrics(mockMetrics, "sink1")),
+                                                   new DefaultStageMetrics(mockMetrics, "sink1"),
+                                                   dataTracerFactory.getDataTracer(null, "sink1")),
                             ImmutableList.<String>of()));
 
     transformationMap.put("sink2",
                           new TransformDetail(
                             new TrackedTransform<>(new DoubleToString(),
-                                                   new DefaultStageMetrics(mockMetrics, "sink2")),
+                                                   new DefaultStageMetrics(mockMetrics, "sink2"),
+                                                   dataTracerFactory.getDataTracer(null, "sink2")),
                             ImmutableList.<String>of()));
 
     transformationMap.put("sink3",
                           new TransformDetail(
                             new TrackedTransform<>(new DoubleToString(),
-                                                   new DefaultStageMetrics(mockMetrics, "sink3")),
+                                                   new DefaultStageMetrics(mockMetrics, "sink3"),
+                                                   dataTracerFactory.getDataTracer(null, "sink3")),
                             ImmutableList.<String>of()));
 
     TransformExecutor<Double> executor = new TransformExecutor<>(transformationMap,

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/RDDCollection.java
@@ -111,10 +111,12 @@ public class RDDCollection<T> implements SparkCollection<T> {
       new BasicSparkExecutionPluginContext(sec, jsc, datasetContext, stageName);
     compute.initialize(sparkPluginContext);
 
-    JavaRDD<T> countedInput = rdd.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in")).cache();
+    JavaRDD<T> countedInput = rdd.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in",
+                                                              sec.getDataTracer(stageName))).cache();
 
     return wrap(compute.transform(sparkPluginContext, countedInput)
-                  .map(new CountingFunction<U>(stageName, sec.getMetrics(), "records.out")));
+                  .map(new CountingFunction<U>(stageName, sec.getMetrics(), "records.out",
+                                               sec.getDataTracer(stageName))));
   }
 
   @Override
@@ -129,7 +131,8 @@ public class RDDCollection<T> implements SparkCollection<T> {
     SparkExecutionPluginContext sparkPluginContext =
       new BasicSparkExecutionPluginContext(sec, jsc, datasetContext, stageName);
 
-    JavaRDD<T> countedRDD = rdd.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in")).cache();
+    JavaRDD<T> countedRDD = rdd.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in",
+                                                            sec.getDataTracer(stageName))).cache();
     sink.run(sparkPluginContext, countedRDD);
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/AggregatorAggregateFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/AggregatorAggregateFunction.java
@@ -50,7 +50,8 @@ public class AggregatorAggregateFunction<GROUP_KEY, GROUP_VAL, OUT>
       aggregateTransform = new TrackedTransform<>(new AggregateTransform<>(aggregator),
                                                   pluginFunctionContext.createStageMetrics(),
                                                   "aggregator.groups",
-                                                  TrackedTransform.RECORDS_OUT);
+                                                  TrackedTransform.RECORDS_OUT, pluginFunctionContext.getDataTracer(),
+                                                  null);
       emitter = new DefaultEmitter<>();
     }
     emitter.reset();

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/AggregatorGroupByFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/AggregatorGroupByFunction.java
@@ -49,7 +49,8 @@ public class AggregatorGroupByFunction<GROUP_KEY, GROUP_VAL>
       groupByFunction = new TrackedTransform<>(new GroupByTransform<>(aggregator),
                                                pluginFunctionContext.createStageMetrics(),
                                                TrackedTransform.RECORDS_IN,
-                                               null);
+                                               null, pluginFunctionContext.getDataTracer(),
+                                               TrackedTransform.RECORDS_IN);
       emitter = new DefaultEmitter<>();
     }
     emitter.reset();

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/BatchSinkFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/BatchSinkFunction.java
@@ -42,7 +42,8 @@ public class BatchSinkFunction implements PairFlatMapFunction<Object, Object, Ob
     if (transform == null) {
       BatchSink<Object, Object, Object> batchSink = pluginFunctionContext.createPlugin();
       batchSink.initialize(pluginFunctionContext.createBatchRuntimeContext());
-      transform = new TrackedTransform<>(batchSink, pluginFunctionContext.createStageMetrics());
+      transform = new TrackedTransform<>(batchSink, pluginFunctionContext.createStageMetrics(),
+                                         pluginFunctionContext.getDataTracer());
       emitter = new TransformingEmitter<>(new Function<KeyValue<Object, Object>, Tuple2<Object, Object>>() {
         @Override
         public Tuple2<Object, Object> apply(KeyValue<Object, Object> input) {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/BatchSourceFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/BatchSourceFunction.java
@@ -41,7 +41,8 @@ public class BatchSourceFunction implements FlatMapFunction<Tuple2<Object, Objec
     if (transform == null) {
       BatchSource<Object, Object, Object> batchSource = pluginFunctionContext.createPlugin();
       batchSource.initialize(pluginFunctionContext.createBatchRuntimeContext());
-      transform = new TrackedTransform<>(batchSource, pluginFunctionContext.createStageMetrics());
+      transform = new TrackedTransform<>(batchSource, pluginFunctionContext.createStageMetrics(),
+                                         pluginFunctionContext.getDataTracer());
       emitter = new DefaultEmitter<>();
     }
     emitter.reset();

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/CountingFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/CountingFunction.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.etl.spark.function;
 
 import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.api.preview.DataTracer;
 import co.cask.cdap.etl.api.StageMetrics;
 import co.cask.cdap.etl.common.DefaultStageMetrics;
 import org.apache.spark.api.java.function.Function;
@@ -30,18 +31,23 @@ public class CountingFunction<T> implements Function<T, T> {
   private final String stageName;
   private final Metrics metrics;
   private final String metricName;
+  private final DataTracer dataTracer;
   private transient StageMetrics stageMetrics;
 
-  public CountingFunction(String stageName, Metrics metrics, String metricName) {
+  public CountingFunction(String stageName, Metrics metrics, String metricName, DataTracer dataTracer) {
     this.stageName = stageName;
     this.metrics = metrics;
     this.metricName = metricName;
+    this.dataTracer = dataTracer;
   }
 
   @Override
   public T call(T in) throws Exception {
     if (stageMetrics == null) {
       stageMetrics = new DefaultStageMetrics(metrics, stageName);
+    }
+    if (dataTracer.isEnabled()) {
+      dataTracer.info(metricName, in);
     }
     stageMetrics.count(metricName, 1);
     return in;

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/JoinMergeFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/JoinMergeFunction.java
@@ -55,7 +55,7 @@ public class JoinMergeFunction<JOIN_KEY, INPUT_RECORD, OUT>
       joinFunction = new TrackedTransform<>(new JoinOnTransform<>(joiner),
                                             pluginFunctionContext.createStageMetrics(),
                                             "joiner.keys",
-                                            TrackedTransform.RECORDS_OUT);
+                                            TrackedTransform.RECORDS_OUT, pluginFunctionContext.getDataTracer(), null);
       emitter = new DefaultEmitter<>();
     }
     emitter.reset();

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/JoinOnFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/JoinOnFunction.java
@@ -54,7 +54,8 @@ public class JoinOnFunction<JOIN_KEY, INPUT_RECORD>
       joinFunction = new TrackedTransform<>(new JoinOnTransform<>(joiner, inputStageName),
                                                pluginFunctionContext.createStageMetrics(),
                                                TrackedTransform.RECORDS_IN,
-                                               null);
+                                               null, pluginFunctionContext.getDataTracer(),
+                                               TrackedTransform.RECORDS_IN);
       emitter = new DefaultEmitter<>();
     }
     emitter.reset();

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/PluginFunctionContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/PluginFunctionContext.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.macro.MacroEvaluator;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginContext;
+import co.cask.cdap.api.preview.DataTracer;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.spark.JavaSparkExecutionContext;
 import co.cask.cdap.api.workflow.WorkflowToken;
@@ -52,6 +53,7 @@ public class PluginFunctionContext implements Serializable {
   private final PluginContext pluginContext;
   private final Metrics metrics;
   private final SecureStore secureStore;
+  private final DataTracer dataTracer;
 
   public PluginFunctionContext(StageInfo stageInfo, JavaSparkExecutionContext sec) {
     this(stageInfo.getName(), sec, stageInfo.getInputSchemas(), stageInfo.getOutputSchema());
@@ -76,6 +78,7 @@ public class PluginFunctionContext implements Serializable {
     this.pluginContext = sec.getPluginContext();
     this.metrics = sec.getMetrics();
     this.secureStore = sec.getSecureStore();
+    this.dataTracer = sec.getDataTracer(stageName);
   }
 
   public <T> T createPlugin() throws Exception {
@@ -98,5 +101,9 @@ public class PluginFunctionContext implements Serializable {
   public BatchJoinerRuntimeContext createJoinerRuntimeContext() {
     return new SparkJoinerRuntimeContext(pluginContext, metrics, logicalStartTime, arguments,
                                          stageName, inputSchemas, outputSchema);
+  }
+
+  public DataTracer getDataTracer() {
+    return dataTracer;
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/TransformFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/TransformFunction.java
@@ -42,7 +42,8 @@ public class TransformFunction<T, U> implements FlatMapFunction<T, U> {
     if (transform == null) {
       Transform<T, U> plugin = pluginFunctionContext.createPlugin();
       plugin.initialize(pluginFunctionContext.createBatchRuntimeContext());
-      transform = new TrackedTransform<>(plugin, pluginFunctionContext.createStageMetrics());
+      transform = new TrackedTransform<>(plugin, pluginFunctionContext.createStageMetrics(),
+                                         pluginFunctionContext.getDataTracer());
       emitter = new DefaultEmitter<>();
     }
     emitter.reset();

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/DStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/DStreamCollection.java
@@ -128,9 +128,11 @@ public class DStreamCollection<T> implements SparkCollection<T> {
   @Override
   public SparkCollection<T> window(StageInfo stageInfo, Windower windower) {
     String stageName = stageInfo.getName();
-    return wrap(stream.transform(new CountingTranformFunction<T>(stageName, sec.getMetrics(), "records.in"))
+    return wrap(stream.transform(new CountingTranformFunction<T>(stageName, sec.getMetrics(), "records.in",
+                                                                 sec.getDataTracer(stageName)))
                   .window(Durations.seconds(windower.getWidth()), Durations.seconds(windower.getSlideInterval()))
-                  .transform(new CountingTranformFunction<T>(stageName, sec.getMetrics(), "records.out")));
+                  .transform(new CountingTranformFunction<T>(stageName, sec.getMetrics(), "records.out",
+                                                             sec.getDataTracer(stageName))));
   }
 
   private <U> SparkCollection<U> wrap(JavaDStream<U> stream) {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/ComputeTransformFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/ComputeTransformFunction.java
@@ -50,8 +50,8 @@ public class ComputeTransformFunction<T, U> implements Function2<JavaRDD<T>, Tim
       new SparkStreamingExecutionContext(sec, JavaSparkContext.fromSparkContext(data.context()),
                                          stageName, batchTime.milliseconds());
 
-    data = data.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in"));
+    data = data.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in", sec.getDataTracer(stageName)));
     return compute.transform(sparkPluginContext, data)
-      .map(new CountingFunction<U>(stageName, sec.getMetrics(), "records.out"));
+      .map(new CountingFunction<U>(stageName, sec.getMetrics(), "records.out", sec.getDataTracer(stageName)));
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/CountingTranformFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/CountingTranformFunction.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.etl.spark.streaming.function;
 
 import co.cask.cdap.api.metrics.Metrics;
+import co.cask.cdap.api.preview.DataTracer;
 import co.cask.cdap.etl.spark.function.CountingFunction;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.Function;
@@ -30,15 +31,17 @@ public class CountingTranformFunction<T> implements Function<JavaRDD<T>, JavaRDD
   private final Metrics metrics;
   private final String stageName;
   private final String metricName;
+  private final DataTracer dataTracer;
 
-  public CountingTranformFunction(String stageName, Metrics metrics, String metricName) {
+  public CountingTranformFunction(String stageName, Metrics metrics, String metricName, DataTracer dataTracer) {
     this.metrics = metrics;
     this.stageName = stageName;
     this.metricName = metricName;
+    this.dataTracer = dataTracer;
   }
 
   @Override
   public JavaRDD<T> call(JavaRDD<T> in) throws Exception {
-    return in.map(new CountingFunction<T>(stageName, metrics, metricName));
+    return in.map(new CountingFunction<T>(stageName, metrics, metricName, dataTracer));
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/StreamingBatchSinkFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/StreamingBatchSinkFunction.java
@@ -76,7 +76,7 @@ public class StreamingBatchSinkFunction<T> implements Function2<JavaRDD<T>, Time
       });
       isPrepared = true;
 
-      data = data.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in"));
+      data = data.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in", sec.getDataTracer(stageName)));
       sinkFactory.writeFromRDD(data.flatMapToPair(sinkFunction), sec, stageName, Object.class, Object.class);
       isDone = true;
       sec.execute(new TxRunnable() {


### PR DESCRIPTION
Changes to use DataTracer for hydrator pipelines. Let the `TrackedTransform` and `TrackedEmitter` have `DataTracer` instance, trace the data using the `DataTracer` for input, output, and error records. Also, disable action in preview mode. 
JIRA: https://issues.cask.co/browse/HYDRATOR-1092
Build: http://builds.cask.co/browse/CDAP-DUT5063-1