### PR TITLE
Several EMR use case script fixes

### DIFF
--- a/cdap-distributions/src/debian/init.d/cdap-service
+++ b/cdap-distributions/src/debian/init.d/cdap-service
@@ -45,8 +45,7 @@ fi
 
 CDAP_USER=${CDAP_USER:-cdap}
 
-# drop permissions to cdap user and run service script
-
+# drop permissions to CDAP_USER and run service script
 if [[ ${UID} -eq 0 ]]; then
   su - ${CDAP_USER} -c "${SVC_COMMAND}"
   ret=$?
@@ -55,6 +54,6 @@ elif [[ ${USER} == ${CDAP_USER} ]]; then
   ret=$?
 else
   echo "ERROR: Must run this script as root or ${CDAP_USER}!"
-  exit 1
+  ret=1
 fi
 exit $ret

--- a/cdap-distributions/src/emr/cdap-conf.json
+++ b/cdap-distributions/src/emr/cdap-conf.json
@@ -2,37 +2,36 @@
   "cdap": {
     "cdap_site": {
       "dashboard.bind.port": "11011",
-      "dataset.executor.container.memory.mb": "1536",
       "explore.enabled": "{{EXPLORE_ENABLED}}",
-      "explore.executor.container.memory.mb": "2304",
       "http.client.read.timeout.ms": "120000",
       "kafka.log.dir": "/mnt/cdap/kafka-logs",
-      "log.saver.run.memory.megs": "1536",
-      "master.service.memory.mb": "1536",
       "master.startup.checks.enabled": "false",
-      "metrics.memory.mb": "1536",
-      "metrics.processor.memory.mb": "1536",
+      "enable.unrecoverable.reset": "true",
       "router.bind.port": "11015",
-      "stream.container.memory.mb": "1536",
-      "twill.java.reserved.memory.mb": "350",
-      "router.server.address": "{{ROUTER_IP_ADDRESS}}",
-      "zookeeper.quorum": "{{ZK_QUORUM}}"
+      "router.server.address": "{{ROUTER_IP_ADDRESS}}"
     },
     "cdap_env": {
       "explore_enabled": "true",
       "kerberos_enabled": "false",
       "hadoop_conf_dir": "/etc/hadoop/conf",
       "hadoop_home_warn_suppress": "$(hadoop dfsadmin -safemode wait >/dev/null 2>&1; sleep 1; [[ ${UID} -eq 0 ]] && su - hdfs -c 'for d in /cdap /user/cdap; do hdfs dfs -mkdir -p ${d} ; hdfs dfs -chown cdap ${d}; done' >/dev/null 2>&1; echo true)",
-      "hive_home": "/usr/lib/hive",
+      "hbase_home": "$(until $(which hbase &>/dev/null); do sleep 5; done; echo /usr/lib/hbase)",
+      "hive_home": "$(until $(which hive &>/dev/null); do sleep 5; done; echo /usr/lib/hive)",
       "hive_conf_dir": "/etc/hive/conf",
-      "hive_classpath": "{{HIVE_CLASSPATH}}",
-      "hive_exec_engine": "{{HIVE_EXEC_ENGINE}}",
+      "hive_classpath": "$(until $(which hive &>/dev/null); do sleep 5; done)${HIVE_CLASSPATH:-/etc/hive/conf:$(ls -1 /usr/lib/hive/lib/*.jar | tr '\\n' ':')$(if [[ -r /etc/hive/conf/hive-env.sh ]]; then source /etc/hive/conf/hive-env.sh ; fi ; if [[ -d ${HIVE_AUX_JARS_PATH} ]]; then ls -1 ${HIVE_AUX_JARS_PATH}/*.jar | tr '\\n' ':'; else echo ${HIVE_AUX_JARS_PATH} | tr ',' ':'; fi)$(ls -1 /usr/lib/hive/auxlib/*.jar 2>/dev/null | tr '\\n' ':')}",
+      "hive_exec_engine": "mr",
       "spark_home": "/usr/lib/spark",
       "tez_home": "/usr/lib/tez",
-      "tez_conf_dir": "/etc/tez/conf"
+      "tez_conf_dir": "/etc/tez/conf",
+      "zookeeper_home": "$(until $(which zookeeper-client &>/dev/null); do sleep 5; done; echo /usr/lib/zookeeper)"
+    },
+    "repo": {
+      "yum_repo_url": "{{CDAP_YUM_REPO_URL}}"
     },
     "skip_prerequisites": "true",
-    "yum_repo_url": "{{CDAP_YUM_REPO_URL}}",
     "version": "{{CDAP_VERSION}}"
+  },
+  "hadoop": {
+    "distribution": "bigtop"
   }
 }

--- a/cdap-distributions/src/emr/install.sh
+++ b/cdap-distributions/src/emr/install.sh
@@ -29,6 +29,8 @@ CDAP_VERSION=${CDAP_VERSION:-4.0.0-1}
 CHEF_VERSION=${CHEF_VERSION:-12.10.24}
 # cdap-site.xml configuration parameters
 EXPLORE_ENABLED='true'
+# Sleep delay before starting services (in seconds)
+SERVICE_DELAY=${SERVICE_DELAY:-240}
 
 __tmpdir="/tmp/cdap_install.$$.$(date +%s)"
 __gitdir="${__tmpdir}/cdap"
@@ -95,13 +97,14 @@ __create_tmpdir() { mkdir -p ${__tmpdir}; };
 # Begin CDAP Prep/Install
 
 # Install git
-yum install --yes git || die "Failed to install git"
+sudo yum install -y git || die "Failed to install git"
 
 # Install chef
 curl -L https://www.chef.io/chef/install.sh | sudo bash -s -- -v ${CHEF_VERSION} || die "Failed to install chef"
 
 # Clone CDAP repo
 __create_tmpdir
+echo "INFO: Checking out CDAP_BRANCH ${CDAP_BRANCH}"
 git clone --depth 1 --branch ${CDAP_BRANCH} https://github.com/caskdata/cdap.git ${__gitdir}
 
 # Check out to specific tag if specified
@@ -110,55 +113,40 @@ if [ -n "${CDAP_TAG}" ]; then
 fi
 
 # Setup cookbook repo
-test -d /var/chef/cookbooks && rm -rf /var/chef/cookbooks
-${__packerdir}/cookbook-dir.sh || die "Failed to setup cookbook dir"
+test -d /var/chef/cookbooks && sudo rm -rf /var/chef/cookbooks
+sudo ${__packerdir}/cookbook-dir.sh || die "Failed to setup cookbook dir"
 
 # Install cookbooks via knife
-${__packerdir}/cookbook-setup.sh || die "Failed to install cookbooks"
-
-# CDAP cli install, ensures package dependencies are present
-# We must specify the cdap version
-echo "{\"cdap\": {\"version\": \"${CDAP_VERSION}\"}}" > ${__tmpdir}/cli-conf.json
-chef-solo -o 'recipe[cdap::cli]' -j ${__tmpdir}/cli-conf.json
-
-source ${__gitdir}/cdap-common/bin/functions.sh || die "Cannot source CDAP functions script"
-
-# Read zookeeper quorum from hbase-site.xml, using sourced init script function
-__zk_quorum=$(cdap_get_conf 'hbase.zookeeper.quorum' '/etc/hbase/conf/hbase-site.xml') || die "Cannot determine zookeeper quorum"
-
-# Derive hive classpath using same method as Hive
-__hive_classpath=/etc/hive/conf:
-__hive_classpath+=$(ls -1 ${HIVE_HOME}/lib/*.jar | tr '\n' ':')
-__hive_classpath+=$(if [[ -d ${HIVE_AUX_JARS_PATH} ]]; then ls -1 ${HIVE_AUX_JARS_PATH}/*.jar | tr '\n' ':'; else echo ${HIVE_AUX_JARS_PATH} | tr ',' ':'; fi)
-__hive_classpath+=$(ls -1 ${HIVE_HOME}/auxlib/*.jar 2>/dev/null | tr '\n' ':')
-
-# Read hive exec engine
-__hive_exec_engine=$(cdap_get_conf 'hive.execution.engine' '/etc/hive/conf/hive-site.xml' 'mr') || die "Cannot get Hive Exec Engine"
+sudo ${__packerdir}/cookbook-setup.sh || die "Failed to install cookbooks"
 
 # Get IP
 __ipaddr=$(ifconfig eth0 | grep addr: | cut -d: -f2 | head -n 1 | awk '{print $1}')
 
 # Create chef json configuration
 sed \
-  -e "s/{{ZK_QUORUM}}/${__zk_quorum}/" \
-  -e "s/{{CDAP_VERSION}}/${CDAP_VERSION}/" \
-  -e "s/{{CDAP_YUM_REPO_URL}}/${CDAP_YUM_REPO_URL}/" \
-  -e "s/{{EXPLORE_ENABLED}}/${EXPLORE_ENABLED}/" \
-  -e "s/{{HIVE_CLASSPATH}}/${__hive_classpath}/" \
-  -e "s/{{HIVE_EXEC_ENGINE}}/${__hive_exec_engine}/" \
-  -e "s/{{ROUTER_IP_ADDRESS}}/${__ipaddr}/" \
+  -e "s#{{CDAP_VERSION}}#${CDAP_VERSION}#" \
+  -e "s#{{CDAP_YUM_REPO_URL}}#${CDAP_YUM_REPO_URL}#" \
+  -e "s#{{EXPLORE_ENABLED}}#${EXPLORE_ENABLED}#" \
+  -e "s#{{ROUTER_IP_ADDRESS}}#${__ipaddr}#" \
   ${__cdap_site_template} > ${__tmpdir}/generated-conf.json
 
 # Install/Configure CDAP
-chef-solo -o 'recipe[cdap::fullstack]' -j ${__tmpdir}/generated-conf.json
+sudo chef-solo -o 'recipe[cdap::fullstack]' -j ${__tmpdir}/generated-conf.json || die 'Failed during Chef run'
 
-# Temporary Hack to workaround CDAP-4089
-rm -f /opt/cdap/kafka/lib/log4j.log4j-1.2.14.jar
+### TODO: Temporary Hack to workaround CDAP-4089
+sudo rm -f /opt/cdap/kafka/lib/log4j.log4j-1.2.14.jar
+
+### TODO: Ensure Kafka directory is available until caskdata/cdap_cookbook#187 is merged and released
+sudo su - -c "mkdir -p /mnt/cdap/kafka-logs && chown -R cdap /mnt/cdap"
+
+### TODO: Temporary Hack to workaround CDAP-7648
+sudo rm -f /opt/cdap/master/lib/org.apache.httpcomponents.httpc*.jar
 
 # Start CDAP Services
 for i in /etc/init.d/cdap-*; do
   __svc=$(basename ${i})
-  chkconfig ${__svc}) on || die "Failed to enable ${__svc}"
+  sudo chkconfig ${__svc} on || die "Failed to enable ${__svc}"
+  nohup sudo su - -c "sleep ${SERVICE_DELAY}; service ${__svc} start" &
 done
 
 __cleanup_tmpdir

--- a/cdap-distributions/src/rpm/init.d/cdap-service
+++ b/cdap-distributions/src/rpm/init.d/cdap-service
@@ -45,8 +45,7 @@ fi
 
 CDAP_USER=${CDAP_USER:-cdap}
 
-# drop permissions to cdap user and run service script
-
+# drop permissions to CDAP_USER and run service script
 if [[ ${UID} -eq 0 ]]; then
   su - ${CDAP_USER} -c "${SVC_COMMAND}"
   ret=$?
@@ -55,6 +54,6 @@ elif [[ ${USER} == ${CDAP_USER} ]]; then
   ret=$?
 else
   echo "ERROR: Must run this script as root or ${CDAP_USER}!"
-  exit 1
+  ret=1
 fi
 exit $ret


### PR DESCRIPTION
This includes several small fixes.

- [x] Skip CDAP Master startup checks
  - [x] Skip if configured in `cdap-site.xml`
  - [x] Skip if `CDAP_STARTUP_CHECKS=false` for cases where we know the answer and don't want to do XML parsing (cannot control dependencies, for example)
- [x] Minor edits to init script templates
- [x] Move processing HIVE_CLASSPATH to `cdap-env.sh` so it gets executed at runtime
- [x] Fix custom YUM repo urls
- [x] Fix `git` install
- [x] Start services

This is all (except for the minor init script cleanup) in code introduced in CDAP 4.0 and still in progress, so no associated JIRA.