### PR TITLE
Feature/tms core tables4

### DIFF
--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/AbstractMessageTable.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/AbstractMessageTable.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.messaging.store;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.lib.AbstractCloseableIterator;
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.messaging.MessagingUtils;
+import co.cask.cdap.messaging.data.MessageId;
+import co.cask.cdap.proto.id.TopicId;
+import com.google.common.collect.AbstractIterator;
+import org.apache.tephra.Transaction;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import javax.annotation.Nullable;
+
+/**
+ * Contains common logic for implementation of {@link MessageTable}.
+ */
+public abstract class AbstractMessageTable implements MessageTable {
+  private StoreIterator storeIterator;
+  private long writeTimestamp;
+  private short seqId;
+
+  private enum Result {
+    ACCEPT,
+    SKIP,
+    HOLD
+  }
+
+  @Override
+  public CloseableIterator<Entry> fetch(TopicId topicId, long startTime, int limit,
+                                        @Nullable Transaction transaction) throws IOException {
+    byte[] topic = MessagingUtils.toRowKeyPrefix(topicId);
+    byte[] startRow = new byte[topic.length + Bytes.SIZEOF_LONG];
+    Bytes.putBytes(startRow, 0, topic, 0, topic.length);
+    Bytes.putLong(startRow, topic.length, startTime);
+    byte[] stopRow = Bytes.stopKeyForPrefix(topic);
+    final CloseableIterator<RawMessageTableEntry> scanner = read(startRow, stopRow);
+    return new MessageTableCloseableIterator(scanner, limit, transaction);
+  }
+
+  @Override
+  public CloseableIterator<Entry> fetch(TopicId topicId, MessageId messageId, boolean inclusive, final int limit,
+                                        @Nullable final Transaction transaction) throws IOException {
+    byte[] topic = MessagingUtils.toRowKeyPrefix(topicId);
+    byte[] startRow = new byte[topic.length + Bytes.SIZEOF_LONG + Bytes.SIZEOF_SHORT];
+    Bytes.putBytes(startRow, 0, topic, 0, topic.length);
+    Bytes.putLong(startRow, topic.length, messageId.getPublishTimestamp());
+    Bytes.putShort(startRow, topic.length + Bytes.SIZEOF_LONG, messageId.getSequenceId());
+    if (!inclusive) {
+      startRow = Bytes.incrementBytes(startRow, 1);
+    }
+    byte[] stopRow = Bytes.stopKeyForPrefix(topic);
+    final CloseableIterator<RawMessageTableEntry> scanner = read(startRow, stopRow);
+    return new MessageTableCloseableIterator(scanner, limit, transaction);
+  }
+
+  @Override
+  public void store(Iterator<Entry> entries) throws IOException {
+    long writeTs = System.currentTimeMillis();
+    if (writeTs != writeTimestamp) {
+      seqId = 0;
+      writeTimestamp = writeTs;
+    }
+
+    if (storeIterator == null) {
+      storeIterator = new StoreIterator(entries, writeTimestamp, seqId);
+    } else {
+      storeIterator.reset(entries, writeTimestamp, seqId);
+    }
+
+    persist(storeIterator);
+    seqId = storeIterator.getSequenceId();
+  }
+
+  @Override
+  public void delete(TopicId topicId, long transactionWritePointer) throws IOException {
+    byte[] targetTxBytes = Bytes.toBytes(transactionWritePointer);
+    byte[] startRow = MessagingUtils.toRowKeyPrefix(topicId);
+    byte[] stopRow = Bytes.stopKeyForPrefix(startRow);
+    delete(startRow, stopRow, targetTxBytes);
+  }
+
+  private static Result isVisible(@Nullable byte[] txPtr, @Nullable Transaction transaction) {
+    // No transaction info available, so accept this message (it must have been published non-transactionally)
+    if (transaction == null || txPtr == null) {
+      return Result.ACCEPT;
+    }
+
+    long txWritePtr = Bytes.toLong(txPtr);
+    // This transaction is visible to everyone, hence accept the message
+    if (transaction.isVisible(txWritePtr)) {
+      return Result.ACCEPT;
+    }
+
+    // This transaction is an invalid transaction, so skip the entry and proceed to the next
+    if (Arrays.binarySearch(transaction.getInvalids(), txWritePtr) >= 0) {
+      return Result.SKIP;
+    }
+
+    // This transaction has not yet been committed, hence hold to ensure ordering
+    return Result.HOLD;
+  }
+
+  protected abstract void persist(Iterator<RawMessageTableEntry> entries) throws IOException;
+
+  protected abstract void delete(byte[] startKey, byte[] stopKey, byte[] targetTxBytes) throws IOException;
+
+  protected abstract CloseableIterator<RawMessageTableEntry> read(byte[] startRow, byte[] stopRow) throws IOException;
+
+  private static class MessageTableCloseableIterator extends AbstractCloseableIterator<Entry> {
+    private final CloseableIterator<RawMessageTableEntry> scanner;
+    private final Transaction transaction;
+    private boolean closed = false;
+    private int maxLimit;
+
+    MessageTableCloseableIterator(CloseableIterator<RawMessageTableEntry> scanner, int limit,
+                                  @Nullable Transaction transaction) {
+      this.scanner = scanner;
+      this.transaction = transaction;
+      this.maxLimit = limit;
+    }
+
+    @Override
+    protected Entry computeNext() {
+      if (closed || (maxLimit <= 0)) {
+        return endOfData();
+      }
+
+      while (scanner.hasNext()) {
+        RawMessageTableEntry tableEntry = scanner.next();
+        Result status = isVisible(tableEntry.getTxPtr(), transaction);
+        if (status == Result.ACCEPT) {
+          maxLimit--;
+          return new DefaultMessageTableEntry(tableEntry.getKey(), tableEntry.getPayload(), tableEntry.getTxPtr());
+        }
+
+        if (status == Result.HOLD) {
+          break;
+        }
+      }
+      return endOfData();
+    }
+
+    @Override
+    public void close() {
+      try {
+        scanner.close();
+      } finally {
+        endOfData();
+        closed = true;
+      }
+    }
+  }
+
+  private static class StoreIterator extends AbstractIterator<RawMessageTableEntry> {
+    private final RawMessageTableEntry tableEntry;
+
+    private Iterator<Entry> entries;
+    private long writeTs;
+    private TopicId topicId;
+    private byte[] topic;
+    private byte[] rowKey;
+    private short sequenceId;
+
+    StoreIterator(Iterator<Entry> entries, long writeTs, short sequenceId) {
+      this.entries = entries;
+      this.tableEntry = new RawMessageTableEntry();
+      this.writeTs = writeTs;
+      this.sequenceId = sequenceId;
+    }
+
+    @Override
+    protected RawMessageTableEntry computeNext() {
+      if (entries.hasNext()) {
+        Entry entry = entries.next();
+        // Create new byte arrays only when the topicId is different. Else, reuse the byte arrays.
+        if (topicId == null || (!topicId.equals(entry.getTopicId()))) {
+          topicId = entry.getTopicId();
+          topic = MessagingUtils.toRowKeyPrefix(topicId);
+          rowKey = new byte[topic.length + Bytes.SIZEOF_LONG + Bytes.SIZEOF_SHORT];
+        }
+
+        Bytes.putBytes(rowKey, 0, topic, 0, topic.length);
+        Bytes.putLong(rowKey, topic.length, writeTs);
+        Bytes.putShort(rowKey, topic.length + Bytes.SIZEOF_LONG, sequenceId++);
+
+        byte[] txPtr = null;
+        if (entry.isTransactional()) {
+          txPtr = Bytes.toBytes(entry.getTransactionWritePointer());
+        }
+        return tableEntry.set(rowKey, txPtr, entry.getPayload());
+      }
+      return endOfData();
+    }
+
+    private short getSequenceId() {
+      return sequenceId;
+    }
+
+    private StoreIterator reset(Iterator<Entry> entries, long writeTs, short sequenceId) {
+      this.entries = entries;
+      this.writeTs = writeTs;
+      this.sequenceId = sequenceId;
+      return this;
+    }
+  }
+}

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/AbstractPayloadTable.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/AbstractPayloadTable.java
@@ -17,16 +17,21 @@
 package co.cask.cdap.messaging.store;
 
 import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.lib.AbstractCloseableIterator;
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
 import co.cask.cdap.messaging.MessagingUtils;
+import co.cask.cdap.messaging.data.MessageId;
 import co.cask.cdap.proto.id.TopicId;
+import com.google.common.collect.AbstractIterator;
 
 import java.io.IOException;
+import java.util.Iterator;
 
 /**
- * Contains common logic for implementation of {@link PayloadTable}
+ * Contains common logic for implementation of {@link PayloadTable}.
  */
 public abstract class AbstractPayloadTable implements PayloadTable {
-
+  private StoreIterator storeIterator;
   private long writeTimestamp;
   private short pSeqId;
 
@@ -37,8 +42,119 @@ public abstract class AbstractPayloadTable implements PayloadTable {
     Bytes.putBytes(startRow, 0, topic, 0, topic.length);
     Bytes.putLong(startRow, topic.length, transactionWritePointer);
     byte[] stopRow = Bytes.stopKeyForPrefix(startRow);
-    performDelete(startRow, stopRow);
+    delete(startRow, stopRow);
   }
 
-  protected abstract void performDelete(byte[] startRow, byte[] stopRow) throws IOException;
+  @Override
+  public void store(Iterator<Entry> entries) throws IOException {
+    long writeTs = System.currentTimeMillis();
+    if (writeTs != writeTimestamp) {
+      pSeqId = 0;
+      writeTimestamp = writeTs;
+    }
+
+    if (storeIterator == null) {
+      storeIterator = new StoreIterator(entries, writeTimestamp, pSeqId);
+    } else {
+      storeIterator.reset(entries, writeTimestamp, pSeqId);
+    }
+
+    persist(storeIterator);
+    pSeqId = storeIterator.getSequenceId();
+  }
+
+  @Override
+  public CloseableIterator<Entry> fetch(TopicId topicId, long transactionWritePointer, MessageId messageId,
+                                        boolean inclusive, int limit) throws IOException {
+    byte[] topic = MessagingUtils.toRowKeyPrefix(topicId);
+    byte[] startRow = new byte[topic.length + (2 * Bytes.SIZEOF_LONG) + Bytes.SIZEOF_SHORT];
+    Bytes.putBytes(startRow, 0, topic, 0, topic.length);
+    Bytes.putLong(startRow, topic.length, transactionWritePointer);
+    Bytes.putLong(startRow, topic.length + Bytes.SIZEOF_LONG, messageId.getWriteTimestamp());
+    Bytes.putShort(startRow, topic.length + (2 * Bytes.SIZEOF_LONG), messageId.getPayloadSequenceId());
+    if (!inclusive) {
+      startRow = Bytes.incrementBytes(startRow, 1);
+    }
+    byte[] stopRow = Bytes.stopKeyForPrefix(topic);
+
+    final CloseableIterator<RawPayloadTableEntry> scanner = read(startRow, stopRow, limit);
+    return new AbstractCloseableIterator<Entry>() {
+      private boolean closed = false;
+
+      @Override
+      protected Entry computeNext() {
+        if (closed || (!scanner.hasNext())) {
+          return endOfData();
+        }
+        RawPayloadTableEntry entry = scanner.next();
+        return new DefaultPayloadTableEntry(entry.getKey(), entry.getValue());
+      }
+
+      @Override
+      public void close() {
+        try {
+          scanner.close();
+        } finally {
+          endOfData();
+          closed = true;
+        }
+      }
+    };
+  }
+
+  protected abstract void delete(byte[] startRow, byte[] stopRow) throws IOException;
+
+  protected abstract void persist(Iterator<RawPayloadTableEntry> tableEntries) throws IOException;
+
+  protected abstract CloseableIterator<RawPayloadTableEntry> read(byte[] startRow, byte[] stopRow,
+                                                                  int limit) throws IOException;
+
+
+  private static class StoreIterator extends AbstractIterator<RawPayloadTableEntry> {
+    private final RawPayloadTableEntry tableEntry;
+
+    private Iterator<Entry> entries;
+    private long writeTs;
+    private TopicId topicId;
+    private byte[] topic;
+    private byte[] rowKey;
+    private short sequenceId;
+
+    StoreIterator(Iterator<Entry> entries, long writeTs, short sequenceId) {
+      this.entries = entries;
+      this.tableEntry = new RawPayloadTableEntry();
+      this.writeTs = writeTs;
+      this.sequenceId = sequenceId;
+    }
+
+    @Override
+    protected RawPayloadTableEntry computeNext() {
+      if (entries.hasNext()) {
+        Entry entry = entries.next();
+        if (topicId == null || (!topicId.equals(entry.getTopicId()))) {
+          topicId = entry.getTopicId();
+          topic = MessagingUtils.toRowKeyPrefix(topicId);
+          rowKey = new byte[topic.length + (2 * Bytes.SIZEOF_LONG) + Bytes.SIZEOF_SHORT];
+        }
+
+        Bytes.putBytes(rowKey, 0, topic, 0, topic.length);
+        Bytes.putLong(rowKey, topic.length, entry.getTransactionWritePointer());
+        Bytes.putLong(rowKey, topic.length + Bytes.SIZEOF_LONG, writeTs);
+        Bytes.putShort(rowKey, topic.length + (2 * Bytes.SIZEOF_LONG), sequenceId++);
+        return tableEntry.set(rowKey, entry.getPayload());
+      }
+      return endOfData();
+    }
+
+    private short getSequenceId() {
+      return sequenceId;
+    }
+
+    private StoreIterator reset(Iterator<Entry> entries, long writeTs, short sequenceId) {
+      this.entries = entries;
+      this.writeTs = writeTs;
+      this.sequenceId = sequenceId;
+      return this;
+    }
+  }
 }

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/RawMessageTableEntry.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/RawMessageTableEntry.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.messaging.store;
+
+import javax.annotation.Nullable;
+
+/**
+ * Container class that contains raw bytes corresponding to an entry in the Message Table.
+ */
+public class RawMessageTableEntry {
+  private byte[] key;
+  private byte[] txPtr;
+  private byte[] payload;
+
+  public RawMessageTableEntry set(byte[] key, @Nullable byte[] txPtr, @Nullable byte[] payload) {
+    this.key = key;
+    this.txPtr = txPtr;
+    this.payload = payload;
+    return this;
+  }
+
+  public byte[] getKey() {
+    return key;
+  }
+
+  @Nullable
+  public byte[] getTxPtr() {
+    return txPtr;
+  }
+
+  @Nullable
+  public byte[] getPayload() {
+    return payload;
+  }
+}

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/RawPayloadTableEntry.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/RawPayloadTableEntry.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.messaging.store;
+
+/**
+* Container class for raw bytes corresponding to key, value of the Payload Table.
+*/
+public class RawPayloadTableEntry {
+  private byte[] key;
+  private byte[] value;
+
+  public RawPayloadTableEntry set(byte[] key, byte[] value) {
+    this.key = key;
+    this.value = value;
+    return this;
+  }
+
+  public byte[] getKey() {
+    return key;
+  }
+
+  public byte[] getValue() {
+    return value;
+  }
+}

--- a/cdap-tms/src/test/java/co/cask/cdap/messaging/store/MessageTableTest.java
+++ b/cdap-tms/src/test/java/co/cask/cdap/messaging/store/MessageTableTest.java
@@ -81,6 +81,7 @@ public abstract class MessageTableTest {
       byte[] messageId = new byte[MessageId.RAW_ID_SIZE];
       MessageId.putRawId(0L, (short) 0, 0L, (short) 0, messageId, 0);
       CloseableIterator<MessageTable.Entry> iterator = table.fetch(id, new MessageId(messageId), true, 50, null);
+      Assert.assertTrue(iterator.hasNext());
       MessageTable.Entry entry = iterator.next();
       Assert.assertArrayEquals(payload, entry.getPayload());
       Assert.assertFalse(iterator.hasNext());

--- a/cdap-tms/src/test/java/co/cask/cdap/messaging/store/PayloadTableTest.java
+++ b/cdap-tms/src/test/java/co/cask/cdap/messaging/store/PayloadTableTest.java
@@ -69,6 +69,7 @@ public abstract class PayloadTableTest {
       byte[] messageId = new byte[MessageId.RAW_ID_SIZE];
       MessageId.putRawId(0L, (short) 0, 0L, (short) 0, messageId, 0);
       CloseableIterator<PayloadTable.Entry> iterator = table.fetch(id, writePtr, new MessageId(messageId), true, 50);
+      Assert.assertTrue(iterator.hasNext());
       PayloadTable.Entry entry = iterator.next();
       Assert.assertArrayEquals(payloadBytes, entry.getPayload());
       Assert.assertEquals(writePtr, entry.getTransactionWritePointer());


### PR DESCRIPTION
Note : This is an internal PR for Messaging work.

Commit 1 : Address PR comment about pulling out common parts of LevelDB and HBase implementation of PayloadTable into an AbstractPayloadTable class.
Commit 2 : Address PR comment about pulling out common parts of LevelDB and HBase implementation of MessageTable into an AbstractMessageTable class.
Commit 3 : Skip messages that correspond to an invalid transaction while fetching messages from MessageTable.

