### PR TITLE
[CDAP-7638] Validate transaction timeout at system and program startup

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/common/RuntimeArguments.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/common/RuntimeArguments.java
@@ -138,6 +138,7 @@ public final class RuntimeArguments {
 
   /**
    * Add a scope prefix to all arguments.
+   *
    * @param scope The type of the scope
    * @param name The name of the scope, e.g. "myTable"
    * @param arguments the runtime arguments to be scoped
@@ -147,12 +148,33 @@ public final class RuntimeArguments {
     if (arguments == null || arguments.isEmpty()) {
       return arguments;
     }
-    final String prefix = scope + "." + name + ".";
     Map<String, String> result = new HashMap<>();
     for (Map.Entry<String, String> entry : arguments.entrySet()) {
-        result.put(prefix + entry.getKey(), entry.getValue());
+        result.put(addScope(scope, name, entry.getKey()), entry.getValue());
     }
     return result;
+  }
+
+  /**
+   * Add a scope prefix to an argument name.
+   *
+   * @param scope The type of the scope
+   * @param name The name of the scope, e.g. "myTable"
+   * @param argument the runtime argument to be scoped
+   */
+  public static String addScope(Scope scope, String name, String argument) {
+    return addScope(scope.toString(), name, argument);
+  }
+
+  /**
+   * Add a scope prefix to an argument name.
+   *
+   * @param scope The type of the scope
+   * @param name The name of the scope, e.g. "myTable"
+   * @param argument the runtime argument to be scoped
+   */
+  public static String addScope(String scope, String name, String argument) {
+    return scope + "." + name + "." + argument;
   }
 
 }

--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRunnerTxTimeoutTest.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/runtime/distributed/DistributedProgramRunnerTxTimeoutTest.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.distributed;
+
+import co.cask.cdap.api.Config;
+import co.cask.cdap.api.annotation.ProcessInput;
+import co.cask.cdap.api.annotation.Tick;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.app.Application;
+import co.cask.cdap.api.app.ApplicationContext;
+import co.cask.cdap.api.app.ApplicationSpecification;
+import co.cask.cdap.api.artifact.ArtifactVersion;
+import co.cask.cdap.api.common.RuntimeArguments;
+import co.cask.cdap.api.customaction.AbstractCustomAction;
+import co.cask.cdap.api.flow.AbstractFlow;
+import co.cask.cdap.api.flow.flowlet.AbstractFlowlet;
+import co.cask.cdap.api.flow.flowlet.OutputEmitter;
+import co.cask.cdap.api.mapreduce.AbstractMapReduce;
+import co.cask.cdap.api.service.AbstractService;
+import co.cask.cdap.api.service.http.AbstractHttpServiceHandler;
+import co.cask.cdap.api.spark.AbstractSpark;
+import co.cask.cdap.api.worker.AbstractWorker;
+import co.cask.cdap.api.workflow.AbstractWorkflow;
+import co.cask.cdap.app.DefaultAppConfigurer;
+import co.cask.cdap.app.program.Program;
+import co.cask.cdap.app.runtime.ProgramOptions;
+import co.cask.cdap.app.runtime.spark.distributed.DistributedSparkProgramRunner;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.internal.app.runtime.BasicArguments;
+import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
+import co.cask.cdap.internal.app.runtime.SystemArguments;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ProgramId;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.tephra.TxConstants;
+import org.apache.twill.filesystem.Location;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+public class DistributedProgramRunnerTxTimeoutTest {
+
+  private static ApplicationSpecification appSpec;
+  private static CConfiguration cConf = CConfiguration.create();
+  private static YarnConfiguration yConf = new YarnConfiguration();
+
+  private static Program flow = createProgram(ProgramType.FLOW, "flow");
+  private static Program service = createProgram(ProgramType.SERVICE, "service");
+  private static Program worker = createProgram(ProgramType.WORKER, "worker");
+  private static Program mapreduce = createProgram(ProgramType.MAPREDUCE, "mapreduce");
+  private static Program spark = createProgram(ProgramType.SPARK, "spark");
+  private static Program workflow = createProgram(ProgramType.WORKER, "workflow");
+
+  private static AbstractDistributedProgramRunner flowRunner =
+    new DistributedFlowProgramRunner(null, null, cConf, null, null, null, null, null);
+  private static AbstractDistributedProgramRunner serviceRunner =
+    new DistributedServiceProgramRunner(null, null, cConf, null, null);
+  private static AbstractDistributedProgramRunner workerRunner =
+    new DistributedWorkerProgramRunner(null, null, cConf, null, null);
+  private static AbstractDistributedProgramRunner mapreduceRunner =
+    new DistributedMapReduceProgramRunner(null, null, cConf, null, null);
+  private static AbstractDistributedProgramRunner sparkRunner =
+    new DistributedSparkProgramRunner(null, yConf, cConf, null, null);
+  private static AbstractDistributedProgramRunner workflowRunner =
+    new DistributedWorkflowProgramRunner(null, yConf, cConf, null, null, null);
+
+  @BeforeClass
+  public static void setup() {
+    Application app = new AppWithAllProgramTypes();
+    DefaultAppConfigurer configurer = new DefaultAppConfigurer(
+      Id.Namespace.DEFAULT, new Id.Artifact(Id.Namespace.DEFAULT, "artifact", new ArtifactVersion("0.1")), app);
+    app.configure(configurer, new ApplicationContext() {
+      @Override
+      public Config getConfig() {
+        return null;
+      }
+    });
+    appSpec = configurer.createSpecification("app", "1.0");
+    // System.out.println(new GsonBuilder().setPrettyPrinting().create().toJson(appSpec));
+
+    cConf.setInt(TxConstants.Manager.CFG_TX_MAX_TIMEOUT, 60);
+  }
+
+  @Test
+  public void testValid() {
+    flowRunner.validateOptions(flow, createOptions(flow));
+    flowRunner.validateOptions(flow, createOptions(flow, 30));
+    flowRunner.validateOptions(flow, createOptions(flow, 1000, "flowlet", "nosuch"));
+
+    serviceRunner.validateOptions(service, createOptions(service));
+    serviceRunner.validateOptions(service, createOptions(service, 30));
+
+    workerRunner.validateOptions(worker, createOptions(worker));
+    workerRunner.validateOptions(worker, createOptions(worker, 30));
+
+    mapreduceRunner.validateOptions(mapreduce, createOptions(mapreduce));
+    mapreduceRunner.validateOptions(mapreduce, createOptions(mapreduce, 30));
+
+    sparkRunner.validateOptions(spark, createOptions(spark));
+    sparkRunner.validateOptions(spark, createOptions(spark, 30));
+
+    workflowRunner.validateOptions(workflow, createOptions(workflow));
+    workflowRunner.validateOptions(workflow, createOptions(workflow, 30));
+    workflowRunner.validateOptions(workflow, createOptions(workflow, 30, "action", "nosuch"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidFlow() {
+    flowRunner.validateOptions(flow, createOptions(flow, 61));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidFlowlet() {
+    flowRunner.validateOptions(flow, createOptions(flow, 61, "flowlet", "ticker"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidService() {
+    serviceRunner.validateOptions(service, createOptions(service, 61));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidMapreduce() {
+    mapreduceRunner.validateOptions(mapreduce, createOptions(mapreduce, 61));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidSpark() {
+    sparkRunner.validateOptions(spark, createOptions(spark, 61));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidWorker() {
+    workerRunner.validateOptions(worker, createOptions(worker, 61));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidWorkflow() {
+    workflowRunner.validateOptions(workflow, createOptions(workflow, 61));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidAction() {
+    workflowRunner.validateOptions(workflow, createOptions(workflow, 61, "action", "noop"));
+  }
+
+  private static ProgramOptions createOptions(Program program) {
+    return new SimpleProgramOptions(program.getId());
+  }
+
+  private static ProgramOptions createOptions(Program program, int timeout) {
+    return new SimpleProgramOptions(program.getId().getProgram(),
+                                    new BasicArguments(Collections.<String, String>emptyMap()),
+                                    new BasicArguments(Collections.singletonMap(SystemArguments.TRANSACTION_TIMEOUT,
+                                                                                String.valueOf(timeout))));
+  }
+
+  private static ProgramOptions createOptions(Program program, int timeout, String scope, String name) {
+    return new SimpleProgramOptions(program.getId().getProgram(),
+                                    new BasicArguments(Collections.<String, String>emptyMap()),
+                                    new BasicArguments(Collections.singletonMap(
+                                      RuntimeArguments.addScope(scope, name, SystemArguments.TRANSACTION_TIMEOUT),
+                                      String.valueOf(timeout))));
+  }
+
+  private static Program createProgram(final ProgramType type, final String name) {
+    return new Program() {
+      @Override
+      public String getMainClassName() {
+        return null;
+      }
+      @Override
+      public <T> Class<T> getMainClass() throws ClassNotFoundException {
+        return null;
+      }
+      @Override
+      public ProgramType getType() {
+        return type;
+      }
+      @Override
+      public ProgramId getId() {
+        return new ProgramId(getNamespaceId(), getApplicationId(), getType(), getName());
+      }
+      @Override
+      public String getName() {
+        return name;
+      }
+      @Override
+      public String getNamespaceId() {
+        return Id.Namespace.DEFAULT.getId();
+      }
+      @Override
+      public String getApplicationId() {
+        return appSpec.getName();
+      }
+      @Override
+      public ApplicationSpecification getApplicationSpecification() {
+        return appSpec;
+      }
+      @Override
+      public Location getJarLocation() {
+        return null;
+      }
+      @Override
+      public ClassLoader getClassLoader() {
+        return null;
+      }
+      @Override
+      public void close() throws IOException {
+      }
+    };
+  }
+
+  public static class AppWithAllProgramTypes extends AbstractApplication {
+    @Override
+    public void configure() {
+      setName("app");
+      addFlow(new AbstractFlow() {
+        @Override
+        protected void configure() {
+          setName("flow");
+          addFlowlet(new Ticker());
+          addFlowlet(new Counter());
+          connect("ticker", "counter");
+        }
+      });
+      addWorker(new AbstractWorker() {
+        @Override
+        public void configure() {
+          setName("worker");
+        }
+        @Override
+        public void run() {
+          // no-op
+        }
+      });
+      addService(new AbstractService() {
+        @Override
+        protected void configure() {
+          setName("service");
+          addHandler(new AbstractHttpServiceHandler() {
+            @Override
+            public void configure() {
+              setName("handler");
+            }
+          });
+        }
+      });
+      addMapReduce(new AbstractMapReduce() {
+        @Override
+        protected void configure() {
+          setName("mapreduce");
+        }
+      });
+      addSpark(new AbstractSpark() {
+        @Override
+        protected void configure() {
+          setName("spark");
+          setMainClassName("mainclass");
+        }
+      });
+      addWorkflow(new AbstractWorkflow() {
+        @Override
+        protected void configure() {
+          setName("workflow");
+          addAction(new AbstractCustomAction("noop") {
+            @Override
+            public void run() throws Exception {
+              // no-op
+            }
+          });
+        }
+      });
+    }
+  }
+
+  public static class Ticker extends AbstractFlowlet {
+    private OutputEmitter<Integer> out;
+    @Override
+    protected void configure() {
+      setName("ticker");
+    }
+    @Tick(delay = 100)
+    public void tick() {
+      out.emit(1);
+    }
+  }
+
+  public static class Counter extends AbstractFlowlet {
+    @Override
+    protected void configure() {
+      setName("counter");
+    }
+    @ProcessInput
+    public void process(int i) {
+      // no-op
+    }
+  }
+}
+

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/SystemArguments.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/SystemArguments.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app.runtime;
 
 import co.cask.cdap.api.Resources;
+import co.cask.cdap.api.common.RuntimeArguments;
 import co.cask.cdap.app.runtime.Arguments;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.logging.appender.LogAppenderInitializer;
@@ -82,10 +83,55 @@ public final class SystemArguments {
    *
    * @returns the integer value of the argument system.data.tx.timeout, or if that is not given in the arguments,
    *          the value for data.tx.timeout from the CConfiguration.
+   * @throws IllegalArgumentException if the transaction timeout exceeds the transaction timeout limit given in the
+   *         CConfiguratuion.
    */
   public static int getTransactionTimeout(Map<String, String> args, CConfiguration cConf) {
     Integer timeout = getPositiveInt(args, TRANSACTION_TIMEOUT, "transaction timeout");
-    return timeout != null ? timeout : cConf.getInt(TxConstants.Manager.CFG_TX_TIMEOUT);
+    if (timeout == null) {
+      return cConf.getInt(TxConstants.Manager.CFG_TX_TIMEOUT);
+    }
+    int maxTimeout = cConf.getInt(TxConstants.Manager.CFG_TX_MAX_TIMEOUT);
+    if (timeout > maxTimeout) {
+      throw new IllegalArgumentException(String.format(
+        "Transaction timeout (%s) of %d seconds must not exceed the transaction timeout limit (%s) of %d",
+        TRANSACTION_TIMEOUT, timeout, TxConstants.Manager.CFG_TX_MAX_TIMEOUT, maxTimeout));
+    }
+    return timeout;
+  }
+
+  /**
+   * Validates the custom transaction timeout, if specified in the given arguments.
+   *
+   * @throws IllegalArgumentException if the transaction timeout exceeds the transaction timeout limit given in the
+   *         CConfiguration.
+   */
+  public static void validateTransactionTimeout(Map<String, String> args, CConfiguration cConf) {
+    validateTransactionTimeout(args, cConf, null, null);
+  }
+
+  /**
+   * Validates the custom transaction timeout, if specified in the given arguments. If scope and name are not null,
+   * validates only for that given scope (for example, flowlet.myFlowlet).
+   *
+   * @throws IllegalArgumentException if the transaction timeout exceeds the transaction timeout limit given in the
+   *         CConfiguration.
+   */
+  public static void validateTransactionTimeout(Map<String, String> args, CConfiguration cConf,
+                                                @Nullable String scope, @Nullable String name) {
+    String argName = TRANSACTION_TIMEOUT;
+    if (scope != null && name != null) {
+      argName = RuntimeArguments.addScope(scope, name, TRANSACTION_TIMEOUT);
+    }
+    Integer timeout = getPositiveInt(args, argName, "transaction timeout");
+    if (timeout != null) {
+      int maxTimeout = cConf.getInt(TxConstants.Manager.CFG_TX_MAX_TIMEOUT);
+      if (timeout > maxTimeout) {
+        throw new IllegalArgumentException(String.format(
+          "Transaction timeout (%s) of %d seconds must not exceed the transaction timeout limit (%s) of %d",
+          argName, timeout, TxConstants.Manager.CFG_TX_MAX_TIMEOUT, maxTimeout));
+      }
+    }
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
@@ -38,6 +38,7 @@ import co.cask.cdap.internal.app.runtime.BasicArguments;
 import co.cask.cdap.internal.app.runtime.LocalizationUtils;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
+import co.cask.cdap.internal.app.runtime.SystemArguments;
 import co.cask.cdap.internal.app.runtime.codec.ArgumentsCodec;
 import co.cask.cdap.internal.app.runtime.codec.ProgramOptionsCodec;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -172,8 +173,20 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner,
     return new AbortOnTimeoutEventHandler(cConf.getLong(Constants.CFG_TWILL_NO_CONTAINER_TIMEOUT, Long.MAX_VALUE));
   }
 
+  /**
+   * Validates the options for the program.
+   * Subclasses can override this to also validate the options for their sub-programs.
+   */
+  protected void validateOptions(Program program, ProgramOptions options) {
+    // this will throw an exception if the custom tx timeout is invalid
+    SystemArguments.validateTransactionTimeout(options.getUserArguments().asMap(), cConf);
+  }
+
   @Override
   public final ProgramController run(final Program program, final ProgramOptions oldOptions) {
+
+    validateOptions(program, oldOptions);
+
     final File tempDir = DirUtils.createTempDir(new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
                                                          cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile());
     try {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedFlowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedFlowProgramRunner.java
@@ -35,6 +35,7 @@ import co.cask.cdap.data2.transaction.queue.QueueAdmin;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.internal.app.queue.SimpleQueueSpecificationGenerator;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
+import co.cask.cdap.internal.app.runtime.SystemArguments;
 import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.ApplicationId;
@@ -83,6 +84,15 @@ public final class DistributedFlowProgramRunner extends AbstractDistributedProgr
     this.streamAdmin = streamAdmin;
     this.txExecutorFactory = txExecutorFactory;
     this.impersonator = impersonator;
+  }
+
+  @Override
+  protected void validateOptions(Program program, ProgramOptions options) {
+    super.validateOptions(program, options);
+    FlowSpecification spec = program.getApplicationSpecification().getFlows().get(program.getName());
+    for (String flowlet : spec.getFlowlets().keySet()) {
+      SystemArguments.validateTransactionTimeout(options.getUserArguments().asMap(), cConf, "flowlet", flowlet);
+    }
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
@@ -36,6 +36,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.security.Impersonator;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.ProgramRuntimeProviderLoader;
+import co.cask.cdap.internal.app.runtime.SystemArguments;
 import co.cask.cdap.internal.app.runtime.batch.distributed.MapReduceContainerHelper;
 import co.cask.cdap.internal.app.runtime.spark.SparkUtils;
 import co.cask.cdap.proto.ProgramType;
@@ -76,6 +77,17 @@ public final class DistributedWorkflowProgramRunner extends AbstractDistributedP
     this.runtimeProviderLoader = runtimeProviderLoader;
   }
 
+  @Override
+  protected void validateOptions(Program program, ProgramOptions options) {
+    super.validateOptions(program, options);
+    WorkflowSpecification spec = program.getApplicationSpecification().getWorkflows().get(program.getName());
+    for (WorkflowNode node : spec.getNodes()) {
+      if (node.getType().equals(WorkflowNodeType.ACTION)) {
+        SystemArguments.validateTransactionTimeout(options.getUserArguments().asMap(),
+                                                   cConf, "action", node.getNodeId());
+      }
+    }
+  }
 
   @Override
   public ProgramController createProgramController(TwillController twillController,

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -109,7 +109,7 @@
 
   <property>
     <name>master.startup.checks.packages</name>
-    <value>co.cask.cdap.master.startup</value>
+    <value>co.cask.cdap.master.startup,co.cask.cdap.data.startup</value>
     <description>
       Comma-separated list of packages containing checks that will be run
       before the CDAP Master starts up. If any of the checks fails, the CDAP

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/startup/TransactionServiceCheck.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/startup/TransactionServiceCheck.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.startup;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.startup.Check;
+import com.google.inject.Inject;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.tephra.TxConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Startup check that validates the configuration of the transaction service.
+ */
+public class TransactionServiceCheck extends Check {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TransactionServiceCheck.class);
+
+  private final CConfiguration cConf;
+  private final Configuration hConf;
+
+  @Inject
+  public TransactionServiceCheck(CConfiguration cConf) {
+    this.cConf = cConf;
+    this.hConf = null;
+  }
+
+  public TransactionServiceCheck(Configuration hConf) {
+    this.cConf = null;
+    this.hConf = hConf;
+  }
+
+  @Override
+  public void run() throws Exception {
+    LOG.info("Validating transaction service configuration.");
+    int defaultTxTimeout = getConfiguredInteger(TxConstants.Manager.CFG_TX_TIMEOUT, "Default transaction timeout");
+    int maxTxTimeout =  getConfiguredInteger(TxConstants.Manager.CFG_TX_MAX_TIMEOUT, "Transaction timeout limit");
+    if (defaultTxTimeout > maxTxTimeout) {
+      throw new IllegalArgumentException(String.format(
+        "Default transaction timeout (%s) of %d seconds must not exceed the transaction timeout limit (%s) of %d",
+        TxConstants.Manager.CFG_TX_TIMEOUT, defaultTxTimeout, TxConstants.Manager.CFG_TX_MAX_TIMEOUT, maxTxTimeout));
+    }
+    LOG.info("Transaction service configuration successfully validated.");
+  }
+
+  private int getConfiguredInteger(String propertyName, String description) {
+    try {
+      return getConfiguredInteger(propertyName);
+    } catch (NullPointerException e) {
+      throw new IllegalArgumentException(String.format("%s (%s) is not configured.", description, propertyName));
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(String.format("%s (%s) is not a number.", description, propertyName), e);
+    }
+  }
+
+  private int getConfiguredInteger(String propertyName) {
+    if (cConf != null) {
+      return cConf.getInt(propertyName);
+    } else if (hConf != null) {
+      if (hConf.get(propertyName) != null) {
+        return hConf.getInt(propertyName, 0);
+      }
+      throw new NullPointerException();
+    }
+    // this should never happen because the constructors ensure either cConf or hConf is not null
+    throw new NullPointerException();
+  }
+
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/startup/TransactionServiceCheckTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/startup/TransactionServiceCheckTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.startup;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import org.apache.tephra.TxConstants;
+import org.junit.Test;
+
+public class TransactionServiceCheckTest {
+
+  protected void run(CConfiguration cConf) throws Exception {
+    new TransactionServiceCheck(cConf).run();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testDefaultNotConfigured() throws Exception {
+    CConfiguration cConfiguration = CConfiguration.create();
+    cConfiguration.unset(TxConstants.Manager.CFG_TX_TIMEOUT);
+    run(cConfiguration);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testDefaultNotInteger() throws Exception {
+    CConfiguration cConfiguration = CConfiguration.create();
+    cConfiguration.set(TxConstants.Manager.CFG_TX_TIMEOUT, "NaN");
+    run(cConfiguration);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMaxNotConfigured() throws Exception {
+    CConfiguration cConfiguration = CConfiguration.create();
+    cConfiguration.unset(TxConstants.Manager.CFG_TX_MAX_TIMEOUT);
+    run(cConfiguration);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMaxNotInteger() throws Exception {
+    CConfiguration cConfiguration = CConfiguration.create();
+    cConfiguration.set(TxConstants.Manager.CFG_TX_MAX_TIMEOUT, "NaN");
+    run(cConfiguration);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testDefaultExceedsMax() throws Exception {
+    CConfiguration cConfiguration = CConfiguration.create();
+    cConfiguration.setInt(TxConstants.Manager.CFG_TX_TIMEOUT,
+                          cConfiguration.getInt(TxConstants.Manager.CFG_TX_MAX_TIMEOUT) + 5);
+    run(cConfiguration);
+  }
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data/startup/TransactionServiceCheckWithHConfTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data/startup/TransactionServiceCheckWithHConfTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.startup;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import org.apache.hadoop.conf.Configuration;
+
+import java.util.Map;
+
+public class TransactionServiceCheckWithHConfTest extends TransactionServiceCheckTest {
+
+  protected void run(CConfiguration cConf) throws Exception {
+    Configuration hConf = new Configuration();
+    for (Map.Entry<String, String> entry : cConf) {
+      hConf.set(entry.getKey(), entry.getValue());
+    }
+    new TransactionServiceCheck(hConf).run();
+  }
+}

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
@@ -38,6 +38,7 @@ import co.cask.cdap.internal.app.runtime.spark.SparkUtils;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.security.TokenSecureStoreUpdater;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -61,9 +62,10 @@ public final class DistributedSparkProgramRunner extends AbstractDistributedProg
   private static final Logger LOG = LoggerFactory.getLogger(DistributedSparkProgramRunner.class);
 
   @Inject
-  DistributedSparkProgramRunner(TwillRunner twillRunner, YarnConfiguration hConf, CConfiguration cConf,
-                                TokenSecureStoreUpdater tokenSecureStoreUpdater,
-                                Impersonator impersonator) {
+  @VisibleForTesting
+  public DistributedSparkProgramRunner(TwillRunner twillRunner, YarnConfiguration hConf, CConfiguration cConf,
+                                       TokenSecureStoreUpdater tokenSecureStoreUpdater,
+                                       Impersonator impersonator) {
     super(twillRunner, createConfiguration(hConf, cConf, tokenSecureStoreUpdater),
           cConf, tokenSecureStoreUpdater, impersonator);
   }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -1199,8 +1199,16 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
     ApplicationManager appManager = deployApplication(testSpace, AppWithCustomTx.class);
     try {
-      getStreamManager(testSpace, AppWithCustomTx.INPUT).send("hello");
+      // attempt to start with a tx timeout that exceeds the max tx timeout
+      try {
+        appManager.getServiceManager(AppWithCustomTx.SERVICE)
+          .start(txTimeoutArguments(100000));
+      } catch (IllegalArgumentException e) {
+        //expected
+      }
 
+      // now start all the programs with valid tx timeouts
+      getStreamManager(testSpace, AppWithCustomTx.INPUT).send("hello");
       ServiceManager serviceManager = appManager.getServiceManager(AppWithCustomTx.SERVICE)
         .start(txTimeoutArguments(txDefaulTimeoutService));
       WorkerManager notxWorkerManager = appManager.getWorkerManager(AppWithCustomTx.WORKER_NOTX)


### PR DESCRIPTION
Because master startup test are not run in unit tests, I did some manual testing. 

Master startup without issues:
```
2016-11-15 21:14:14,913 - INFO  [main:c.c.c.m.s.ConfigurationCheck@53] - Checking that config settings are valid.
2016-11-15 21:14:15,183 - INFO  [main:c.c.c.m.s.ConfigurationCheck@64] -   Configuration successfully verified.
2016-11-15 21:14:15,183 - INFO  [main:c.c.c.d.s.TransactionServiceCheck@50] - Validating transaction service configuration.
2016-11-15 21:14:15,183 - INFO  [main:c.c.c.d.s.TransactionServiceCheck@58] - Transaction service configuration successfully validated.
2016-11-15 21:14:15,183 - INFO  [main:c.c.c.m.s.HBaseCheck@45] - Checking HBase availability.
2016-11-15 21:14:15,911 - INFO  [main:c.c.c.m.s.HBaseCheck@48] -   HBase availability successfully verified.
```

Master startup with data.tx.timeout too long:
```
2016-11-15 21:11:36,130 - ERROR [main:c.c.c.m.s.MasterStartupTool@103] - TransactionServiceCheck failed: Default transaction timeout (data.tx.timeout) of 180 seconds must not exceed the transaction timeou
t limit (data.tx.max.timeout) of 150
2016-11-15 21:11:36,130 - ERROR [main:c.c.c.m.s.MasterStartupTool@108] - Errors detected while starting up master. Please check the logs, address all errors, then try again.
```

In SDK:
```
2016-11-15 14:31:26,403 - INFO  [main:c.c.c.d.s.TransactionServiceCheck@50] - Validating transaction service configuration.
2016-11-15 14:31:26,409 - ERROR [main:o.a.t.i.InMemoryTransactionService@109] - Transaction service validation failed
java.lang.IllegalArgumentException: Default transaction timeout (data.tx.timeout) of 300 seconds must not exceed the transaction timeout limit (data.tx.max.timeout) of 180
```

Starting a program in SDK with excessive system.data.tx.timeout:
```
cdap (http://Andreass-MacBook-Pro-2.local:11015/namespace:default)> start service HelloWorld.Greeting system.data.tx.timeout=1000
Error: 500: Transaction timeout (system.data.tx.timeout) of 1000 seconds must not exceed the transaction timeout limit (data.tx.max.timeout) of 180
```
Starting program in distributed mode:
```
cdap (http://tx15723-1000.dev.continuuity.net:11015/namespace:default)> start flow HelloWorld.WhoFlow system.data.tx.timeout=10000
Error: 500: Transaction timeout (system.data.tx.timeout) of 10000 seconds must not exceed the transaction timeout limit (data.tx.max.timeout) of 600

cdap (http://tx15723-1000.dev.continuuity.net:11015/namespace:default)> start flow HelloWorld.WhoFlow flowlet.saver.system.data.tx.timeout=10000
Error: 500: Transaction timeout (flowlet.saver.system.data.tx.timeout) of 10000 seconds must not exceed the transaction timeout limit (data.tx.max.timeout) of 600
```
