### PR TITLE
Minor Documentation Typos

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -482,7 +482,7 @@
     <name>data.tx.num.cores</name>
     <value>${master.service.num.cores}</value>
     <description>
-      Number of cores for the transaction service
+      Number of virtual cores for the transaction service
     </description>
   </property>
 
@@ -836,8 +836,8 @@
     <name>kafka.server.log.flush.interval.messages</name>
     <value>10000</value>
     <description>
-      The interval length at which will force an fsync of data written to
-      the log
+      The interval length (in number of messages) at which to force an fsync of data
+      written to the log
     </description>
   </property>
 
@@ -870,7 +870,7 @@
     <value>1000000</value>
     <description>
       Maximum time in milliseconds that the client will wait to
-      establish a connection to Zookeeper
+      establish a connection to ZooKeeper
     </description>
   </property>
 
@@ -963,7 +963,7 @@
     <name>log.saver.container.num.cores</name>
     <value>2</value>
     <description>
-      Number of cores for each log saver instance in YARN
+      Number of virtual cores for each log saver instance in YARN
     </description>
   </property>
 
@@ -1049,7 +1049,7 @@
     <name>master.service.num.cores</name>
     <value>2</value>
     <description>
-      Number of cores for master service instance
+      Number of virtual cores for each master service instance
     </description>
   </property>
 
@@ -1071,7 +1071,7 @@
   <property>
     <name>master.services.scheduler.queue</name>
     <value></value>
-    <description>Scheduler queue for CDAP Master Services</description>
+    <description>Scheduler queue for CDAP master services</description>
   </property>
 
 
@@ -1264,7 +1264,7 @@
     <name>metrics.processor.num.cores</name>
     <value>1</value>
     <description>
-      Number of cores for metrics processor service Apache Twill runnable
+      Number of virtual cores for metrics processor service Apache Twill runnable
     </description>
   </property>
 
@@ -1912,7 +1912,7 @@
     <name>stream.container.num.cores</name>
     <value>2</value>
     <description>
-      Number of virtual core for the YARN container that runs the stream
+      Number of virtual cores for the YARN container that runs the stream
       handler
     </description>
   </property>

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="638883c2cdb8576c0a30a1b6a5c6bedd"
+DEFAULT_XML_MD5_HASH="4af52a9f54f3fcd2f9ce9d24cfceb65a"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
A number of minor errors in the `cdap-site.xml` documentation.