### PR TITLE
(CDAP-7654) Refactor ProgramRuntimeProviderLoader to create a generic…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/extension/AbstractExtensionLoader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/extension/AbstractExtensionLoader.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.extension;
+
+import co.cask.cdap.common.utils.DirUtils;
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.base.Throwables;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.reflect.TypeToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+
+/**
+ * A class to load extensions for supported extension types from a configured extensions directory. It uses the Java
+ * {@link ServiceLoader} architecture to load extensions from the specified directory. It first tries to load
+ * extensions using a {@link URLClassLoader} consisting of all jars in the configured extensions directory. For unit
+ * tests, it loads extensions using the system classloader. If an extension is not found via the extensions classloader
+ * or the system classloader, it returns a default extension.
+ *
+ * The supported directory structure is:
+ * <pre>
+ *   [extensions-directory]/[extensions-module-directory-1]/
+ *   [extensions-directory]/[extensions-module-directory-1]/file-containing-extensions-1.jar
+ *   [extensions-directory]/[extensions-module-directory-1]/file-containing-dependencies-1.jar
+ *   [extensions-directory]/[extensions-module-directory-1]/file-containing-dependencies-2.jar
+ *   [extensions-directory]/[extensions-module-directory-2]/
+ *   [extensions-directory]/[extensions-module-directory-2]/file-containing-extensions-2.jar
+ *   [extensions-directory]/[extensions-module-directory-2]/file-containing-extensions-3.jar
+ *   [extensions-directory]/[extensions-module-directory-2]/file-containing-dependencies-3.jar
+ *   [extensions-directory]/[extensions-module-directory-2]/file-containing-dependencies-4.jar
+ *   ...
+ *   [extensions-directory]/[extensions-module-directory-n]/file-containing-extensions-n.jar
+ * </pre>
+ *
+ * Each extensions jar file above can contain multiple extensions.
+ *
+ * @param <EXTENSION_TYPE> the data type of the objects that a given extension can be used for. e.g. for a program
+ *                        runtime extension, the list of program types that the extension can be used for
+ * @param <EXTENSION> the data type of the extension
+ */
+public abstract class AbstractExtensionLoader<EXTENSION_TYPE, EXTENSION> {
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractExtensionLoader.class);
+
+  private final List<String> extDirs;
+  private final Class<EXTENSION> extensionClass;
+  // A ServiceLoader that loads extension implementation from the CDAP system classloader.
+  private final ServiceLoader<EXTENSION> systemExtensionLoader;
+  private final LoadingCache<EXTENSION_TYPE, AtomicReference<EXTENSION>> extensionsCache;
+  private final LoadingCache<File, ServiceLoader<EXTENSION>> serviceLoaderCache;
+  private Map<EXTENSION_TYPE, EXTENSION> allExtensions;
+
+  @SuppressWarnings("unchecked")
+  public AbstractExtensionLoader(String extDirs) {
+    this.extDirs = ImmutableList.copyOf(Splitter.on(';').omitEmptyStrings().trimResults().split(extDirs));
+    Type type = TypeToken.of(getClass()).getSupertype(AbstractExtensionLoader.class).getType();
+    // type should always be an instance of ParameterizedType
+    Preconditions.checkState(type instanceof ParameterizedType);
+    Type extensionType = ((ParameterizedType) type).getActualTypeArguments()[1];
+    // extensionType should always be an instance of Class
+    Preconditions.checkState(extensionType instanceof Class);
+    this.extensionClass = (Class<EXTENSION>) extensionType;
+    this.systemExtensionLoader = ServiceLoader.load(this.extensionClass);
+    this.serviceLoaderCache = createServiceLoaderCache();
+    this.extensionsCache = createExtensionsCache();
+  }
+
+  /**
+   * Returns the extension for the specified object if one is found, otherwise returns {@code null}.
+   */
+  @Nullable
+  public EXTENSION get(EXTENSION_TYPE type) {
+    return extensionsCache.getUnchecked(type).get();
+  }
+
+  /**
+   * Returns all the extensions from the extension directory.
+   *
+   * @return map of extension type to the first extension that supports the extension type
+   */
+  public synchronized Map<EXTENSION_TYPE, EXTENSION> getAll() {
+    if (allExtensions != null) {
+      return allExtensions;
+    }
+
+    Map<EXTENSION_TYPE, EXTENSION> result = new HashMap<>();
+
+    for (String dir : extDirs) {
+      File extDir = new File(dir);
+      if (!extDir.isDirectory()) {
+        continue;
+      }
+
+      // Each module would be under a directory of the extension directory
+      for (File moduleDir : DirUtils.listFiles(extDir)) {
+        if (!moduleDir.isDirectory()) {
+          continue;
+        }
+        // Try to find a provider that can support the given program type.
+        try {
+          putEntriesIfAbsent(result, getAllExtensions(serviceLoaderCache.getUnchecked(moduleDir)));
+        } catch (Exception e) {
+          LOG.warn("Exception raised when loading an extension from {}. Extension ignored.", moduleDir, e);
+        }
+      }
+    }
+
+    // Also put everything from system classloader
+    putEntriesIfAbsent(result, getAllExtensions(systemExtensionLoader));
+
+    allExtensions = result;
+    return allExtensions;
+  }
+
+  /**
+   * Returns the set of objects that the extension supports. Implementations should return the set of objects of type
+   * #EXTENSION_TYPE that the specified extension applies to. A given extension can then be loaded for the specified
+   * type by using the #getExtension method.
+   *
+   * @param extension the extension for which supported types are requested
+   * @return the set of objects that the specified extension supports.
+   */
+  protected abstract Set<EXTENSION_TYPE> getSupportedTypesForProvider(EXTENSION extension);
+
+  private void putEntriesIfAbsent(Map<EXTENSION_TYPE, EXTENSION> result, Map<EXTENSION_TYPE, EXTENSION> entries) {
+    for (Map.Entry<EXTENSION_TYPE, EXTENSION> entry : entries.entrySet()) {
+      if (!result.containsKey(entry.getKey())) {
+        result.put(entry.getKey(), entry.getValue());
+      }
+    }
+  }
+
+  private LoadingCache<EXTENSION_TYPE, AtomicReference<EXTENSION>> createExtensionsCache() {
+    return CacheBuilder.newBuilder().build(new CacheLoader<EXTENSION_TYPE, AtomicReference<EXTENSION>>() {
+      @Override
+      public AtomicReference<EXTENSION> load(EXTENSION_TYPE extensionType) throws Exception {
+        EXTENSION extension = null;
+        try {
+          extension = findExtension(extensionType);
+        } catch (Throwable t) {
+          LOG.warn("Failed to load extension for type {}.", extensionType);
+        }
+        return new AtomicReference<>(extension);
+      }
+    });
+  }
+
+  /**
+   * Finds the first extension from the given {@link ServiceLoader} that supports the specified key.
+   */
+  @Nullable
+  private EXTENSION findExtension(EXTENSION_TYPE type) {
+    for (String dir : extDirs) {
+      File extDir = new File(dir);
+      if (!extDir.isDirectory()) {
+        continue;
+      }
+
+      // Each module would be under a directory of the extension directory
+      for (File moduleDir : DirUtils.listFiles(extDir)) {
+        if (!moduleDir.isDirectory()) {
+          continue;
+        }
+        // Try to find a provider that can support the given program type.
+        try {
+          EXTENSION extension = getAllExtensions(serviceLoaderCache.getUnchecked(moduleDir)).get(type);
+          if (extension != null) {
+            return extension;
+          }
+        } catch (Exception e) {
+          LOG.warn("Exception raised when loading an extension from {}. Extension ignored.", moduleDir, e);
+        }
+      }
+    }
+    // For unit tests, try to load the extensions from the system classloader. This is because in unit tests,
+    // extensions are part of the test dependency, hence in the unit-test ClassLoader.
+    return getAllExtensions(systemExtensionLoader).get(type);
+  }
+
+  /**
+   * Returns all the extensions in the extensions directory using the specified {@link ServiceLoader}.
+   */
+  private Map<EXTENSION_TYPE, EXTENSION> getAllExtensions(ServiceLoader<EXTENSION> serviceLoader) {
+    Map<EXTENSION_TYPE, EXTENSION> extensions = new HashMap<>();
+    for (EXTENSION extension : serviceLoader) {
+      for (EXTENSION_TYPE type : getSupportedTypesForProvider(extension)) {
+        if (extensions.containsKey(type)) {
+          LOG.info("Ignoring extension {} for type {}", extension, type);
+        } else {
+          extensions.put(type, extension);
+        }
+      }
+    }
+    return extensions;
+  }
+
+  /**
+   * Creates a cache for caching extension directory to {@link ServiceLoader} of {@link EXTENSION}.
+   */
+  private LoadingCache<File, ServiceLoader<EXTENSION>> createServiceLoaderCache() {
+    return CacheBuilder.newBuilder().build(new CacheLoader<File, ServiceLoader<EXTENSION>>() {
+      @Override
+      public ServiceLoader<EXTENSION> load(File dir) throws Exception {
+        return createServiceLoader(dir);
+      }
+    });
+  }
+
+  /**
+   * Creates a {@link ServiceLoader} from the {@link ClassLoader} created by all jar files under the given directory.
+   */
+  private ServiceLoader<EXTENSION> createServiceLoader(File dir) {
+    List<File> files = new ArrayList<>(DirUtils.listFiles(dir, "jar"));
+    Collections.sort(files);
+
+    URL[] urls = Iterables.toArray(Iterables.transform(files, new Function<File, URL>() {
+      @Override
+      public URL apply(File input) {
+        try {
+          return input.toURI().toURL();
+        } catch (MalformedURLException e) {
+          // Shouldn't happen
+          throw Throwables.propagate(e);
+        }
+      }
+    }), URL.class);
+
+    URLClassLoader classLoader = new URLClassLoader(urls, getClass().getClassLoader());
+    return ServiceLoader.load(extensionClass, classLoader);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramRuntimeProviderLoader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramRuntimeProviderLoader.java
@@ -16,195 +16,37 @@
 
 package co.cask.cdap.internal.app.runtime;
 
-import co.cask.cdap.app.guice.DefaultProgramRunnerFactory;
-import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.app.runtime.ProgramRuntimeProvider;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.utils.DirUtils;
+import co.cask.cdap.extension.AbstractExtensionLoader;
 import co.cask.cdap.proto.ProgramType;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Function;
-import com.google.common.base.Objects;
-import com.google.common.base.Splitter;
-import com.google.common.base.Throwables;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
-import com.google.inject.Injector;
 import com.google.inject.Singleton;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.ServiceLoader;
-import javax.annotation.Nullable;
+import java.util.Set;
 
 /**
  * A singleton class for discovering {@link ProgramRuntimeProvider} through the runtime extension mechanism that uses
  * the Java {@link ServiceLoader} architecture.
  */
 @Singleton
-public class ProgramRuntimeProviderLoader {
-
-  private static final Logger LOG = LoggerFactory.getLogger(ProgramRuntimeProviderLoader.class);
-
-  // The ServiceLoader that loads ProgramRunnerProvider implementation from the CDAP system classloader.
-  private static final ServiceLoader<ProgramRuntimeProvider> SYSTEM_PROGRAM_RUNNER_PROVIDER_LOADER
-    = ServiceLoader.load(ProgramRuntimeProvider.class);
-
-  // The ProgramRunnerProvider serves as a tagging instance to indicate there is not
-  // provider supported for a given program type
-  private static final ProgramRuntimeProvider NOT_SUPPORTED_PROVIDER = new ProgramRuntimeProvider() {
-    @Override
-    public ProgramRunner createProgramRunner(ProgramType type, Mode mode, Injector injector) {
-      throw new UnsupportedOperationException();
-    }
-  };
-
-  private final LoadingCache<ProgramType, ProgramRuntimeProvider> programRunnerProviderCache;
+public class ProgramRuntimeProviderLoader extends AbstractExtensionLoader<ProgramType, ProgramRuntimeProvider> {
 
   @VisibleForTesting
   @Inject
   public ProgramRuntimeProviderLoader(CConfiguration cConf) {
-    this.programRunnerProviderCache = createProgramRunnerProviderCache(cConf);
+    super(cConf.get(Constants.AppFabric.RUNTIME_EXT_DIR, ""));
   }
 
-  /**
-   * Returns a {@link ProgramRuntimeProvider} if one is found for the given {@link ProgramType};
-   * otherwise {@code null} will be returned.
-   */
-  @Nullable
-  public ProgramRuntimeProvider get(ProgramType programType) {
-    try {
-      ProgramRuntimeProvider provider = programRunnerProviderCache.get(programType);
-      if (provider != NOT_SUPPORTED_PROVIDER) {
-        return provider;
-      }
-    } catch (Throwable t) {
-      LOG.warn("Failed to load ProgramRunnerProvider for {} program.", programType, t);
-    }
-    return null;
-  }
-
-  /**
-   * Creates a cache for caching {@link ProgramRuntimeProvider} for different {@link ProgramType}.
-   */
-  private LoadingCache<ProgramType, ProgramRuntimeProvider> createProgramRunnerProviderCache(CConfiguration cConf) {
-    // A LoadingCache from extension directory to ServiceLoader
-    final LoadingCache<File, ServiceLoader<ProgramRuntimeProvider>> serviceLoaderCache = createServiceLoaderCache();
-
-    // List of extension directories to scan
-    String extDirs = cConf.get(Constants.AppFabric.RUNTIME_EXT_DIR, "");
-    final List<String> dirs = ImmutableList.copyOf(Splitter.on(';').omitEmptyStrings().trimResults().split(extDirs));
-
-    return CacheBuilder.newBuilder().build(new CacheLoader<ProgramType, ProgramRuntimeProvider>() {
-      @Override
-      public ProgramRuntimeProvider load(ProgramType programType) throws Exception {
-        // Goes through all extension directory and see which service loader supports the give program type
-        for (String dir : dirs) {
-          File extDir = new File(dir);
-          if (!extDir.isDirectory()) {
-            continue;
-          }
-
-          // Each module would be under a directory of the extension directory
-          for (File moduleDir : DirUtils.listFiles(extDir)) {
-            if (!moduleDir.isDirectory()) {
-              continue;
-            }
-            // Try to find a provider that can support the given program type.
-            try {
-              ProgramRuntimeProvider provider = findProvider(serviceLoaderCache.getUnchecked(moduleDir), programType);
-              if (provider != null) {
-                return provider;
-              }
-            } catch (Exception e) {
-              LOG.warn("Exception raised when loading a ProgramRuntimeProvider from {}. Extension ignored.",
-                       moduleDir, e);
-            }
-          }
-        }
-
-        // If there is none found in the ext dir, try to look it up from the CDAP system class ClassLoader.
-        // This is for the unit-test case, which extensions are part of the test dependency, hence in the
-        // unit-test ClassLoader.
-        // If no provider was found, returns the NOT_SUPPORTED_PROVIDER so that we won't search again for
-        // this program type.
-        // Cannot use null because LoadingCache doesn't allow null value
-        return Objects.firstNonNull(findProvider(SYSTEM_PROGRAM_RUNNER_PROVIDER_LOADER, programType),
-                                    NOT_SUPPORTED_PROVIDER);
-      }
-    });
-  }
-
-  /**
-   * Creates a cache for caching extension directory to {@link ServiceLoader} of {@link ProgramRuntimeProvider}.
-   */
-  private LoadingCache<File, ServiceLoader<ProgramRuntimeProvider>> createServiceLoaderCache() {
-    return CacheBuilder.newBuilder().build(new CacheLoader<File, ServiceLoader<ProgramRuntimeProvider>>() {
-      @Override
-      public ServiceLoader<ProgramRuntimeProvider> load(File dir) throws Exception {
-        return createServiceLoader(dir);
-      }
-    });
-  }
-
-  /**
-   * Creates a {@link ServiceLoader} from the {@link ClassLoader} created by all jar files under the given directory.
-   */
-  private ServiceLoader<ProgramRuntimeProvider> createServiceLoader(File dir) {
-    List<File> files = new ArrayList<>(DirUtils.listFiles(dir, "jar"));
-    Collections.sort(files);
-
-    URL[] urls = Iterables.toArray(Iterables.transform(files, new Function<File, URL>() {
-      @Override
-      public URL apply(File input) {
-        try {
-          return input.toURI().toURL();
-        } catch (MalformedURLException e) {
-          // Shouldn't happen
-          throw Throwables.propagate(e);
-        }
-      }
-    }), URL.class);
-
-    URLClassLoader classLoader = new URLClassLoader(urls, DefaultProgramRunnerFactory.class.getClassLoader());
-    return ServiceLoader.load(ProgramRuntimeProvider.class, classLoader);
-  }
-
-  /**
-   * Finds a {@link ProgramRuntimeProvider} from the given {@link ServiceLoader} that can support the given
-   * {@link ProgramType}.
-   */
-  @Nullable
-  private ProgramRuntimeProvider findProvider(ServiceLoader<ProgramRuntimeProvider> serviceLoader,
-                                              ProgramType programType) {
-    for (ProgramRuntimeProvider provider : serviceLoader) {
-      Class<? extends ProgramRuntimeProvider> providerClass = provider.getClass();
-
-      // See if the provide supports the required program type
-      ProgramRuntimeProvider.SupportedProgramType supportedType =
-        providerClass.getAnnotation(ProgramRuntimeProvider.SupportedProgramType.class);
-      if (supportedType == null || !ImmutableSet.copyOf(supportedType.value()).contains(programType)) {
-        continue;
-      }
-
-      // Found the provider.
-      LOG.debug("ProgramRunnerProvider {} found for {} program.", provider, programType);
-      return provider;
-    }
-
-    return null;
+  @Override
+  public Set<ProgramType> getSupportedTypesForProvider(ProgramRuntimeProvider programRuntimeProvider) {
+    // See if the provide supports the required program type
+    ProgramRuntimeProvider.SupportedProgramType supportedTypes =
+      programRuntimeProvider.getClass().getAnnotation(ProgramRuntimeProvider.SupportedProgramType.class);
+    return supportedTypes == null ? ImmutableSet.<ProgramType>of() : ImmutableSet.copyOf(supportedTypes.value());
   }
 }


### PR DESCRIPTION
… ExtensionLoader that can be used to load extensions using the Java ServiceLoader architecture.


Jira: [CDAP-7654](https://issues.cask.co/browse/CDAP-7654)
Build: http://builds.cask.co/browse/CDAP-DUT5077

This is Part I for supporting operational extensions.