### PR TITLE
CDAP-7663 Trim 'yarn.application.classpath' before using it.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
@@ -292,8 +292,8 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner,
                 getKMSSecureStore(cConf), extraDependencies);
 
               Iterable<String> yarnAppClassPath = Arrays.asList(
-                hConf.getStrings(YarnConfiguration.YARN_APPLICATION_CLASSPATH,
-                                 YarnConfiguration.DEFAULT_YARN_APPLICATION_CLASSPATH));
+                hConf.getTrimmedStrings(YarnConfiguration.YARN_APPLICATION_CLASSPATH,
+                                        YarnConfiguration.DEFAULT_YARN_APPLICATION_CLASSPATH));
 
               twillPreparer
                 .withDependencies(dependencies)


### PR DESCRIPTION
On EMR, the yarn.application.classpath has whitespace in it, which messes with how we (twill) constructs the classpath. 
See https://issues.cask.co/browse/CDAP-7663

Effectively reverting the few line changes around https://github.com/caskdata/cdap/commit/f452d914eabd56908acf4979211ca755a42b5eb4#diff-6578ed5e516b6ce7c5648c98afe1c51dR273

http://builds.cask.co/browse/CDAP-DUT5083-3