### PR TITLE
CDAP-7663 Trim 'yarn.application.classpath' before using it.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
@@ -292,8 +292,8 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner,
                 getKMSSecureStore(cConf), extraDependencies);
 
               Iterable<String> yarnAppClassPath = Arrays.asList(
-                hConf.getStrings(YarnConfiguration.YARN_APPLICATION_CLASSPATH,
-                                 YarnConfiguration.DEFAULT_YARN_APPLICATION_CLASSPATH));
+                hConf.getTrimmedStrings(YarnConfiguration.YARN_APPLICATION_CLASSPATH,
+                                        YarnConfiguration.DEFAULT_YARN_APPLICATION_CLASSPATH));
 
               twillPreparer
                 .withDependencies(dependencies)


### PR DESCRIPTION
Cherry pick of https://github.com/caskdata/cdap/pull/7136, against release/3.6.