### PR TITLE
Can create an Integration test manager by passing in client config an…

### DIFF
--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/IntegrationTestBase.java
@@ -268,8 +268,12 @@ public abstract class IntegrationTestBase {
   }
 
   protected TestManager getTestManager() {
+    return getTestManager(getClientConfig(), getRestClient());
+  }
+
+  protected TestManager getTestManager(ClientConfig clientConfig, RESTClient restClient) {
     try {
-      return new IntegrationTestManager(getClientConfig(), getRestClient(), TEMP_FOLDER.newFolder());
+      return new IntegrationTestManager(clientConfig, restClient, TEMP_FOLDER.newFolder());
     } catch (IOException e) {
       throw Throwables.propagate(e);
     }


### PR DESCRIPTION
…d rest client.

Used in integration tests for authorization to run things as different users.