### PR TITLE
(CDAP-7670) Implemented backend for collecting and reporting operatio…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -53,6 +53,7 @@ import co.cask.cdap.gateway.handlers.ImpersonationHandler;
 import co.cask.cdap.gateway.handlers.MonitorHandler;
 import co.cask.cdap.gateway.handlers.NamespaceHttpHandler;
 import co.cask.cdap.gateway.handlers.NotificationFeedHttpHandler;
+import co.cask.cdap.gateway.handlers.OperationalStatsHttpHandler;
 import co.cask.cdap.gateway.handlers.PreferencesHttpHandler;
 import co.cask.cdap.gateway.handlers.ProgramLifecycleHttpHandler;
 import co.cask.cdap.gateway.handlers.RouteConfigHttpHandler;
@@ -355,6 +356,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       handlerBinder.addBinding().to(SecureStoreHandler.class);
       handlerBinder.addBinding().to(RemotePrivilegesHandler.class);
       handlerBinder.addBinding().to(RouteConfigHttpHandler.class);
+      handlerBinder.addBinding().to(OperationalStatsHttpHandler.class);
 
       for (Class<? extends HttpHandler> handlerClass : handlerClasses) {
         handlerBinder.addBinding().to(handlerClass);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/OperationalStatsHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/OperationalStatsHttpHandler.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.handlers;
+
+import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.operations.OperationalStats;
+import co.cask.cdap.operations.OperationalStatsUtils;
+import co.cask.http.AbstractHttpHandler;
+import co.cask.http.HttpResponder;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.management.ManagementFactory;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * {@link co.cask.http.HttpHandler} for service provider statistics.
+ */
+@Path(Constants.Gateway.API_VERSION_3 + "/system/serviceproviders")
+public class OperationalStatsHttpHandler extends AbstractHttpHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(OperationalStatsHttpHandler.class);
+
+  @GET
+  @Path("/")
+  public void getServiceProviders(HttpRequest request, HttpResponder responder) throws Exception {
+    // we want to fetch stats with the stat type 'info' grouped by the service name
+    responder.sendJson(
+      HttpResponseStatus.OK,
+      getStats(OperationalStatsUtils.STAT_TYPE_KEY, OperationalStatsUtils.STAT_TYPE_INFO,
+               OperationalStatsUtils.SERVICE_NAME_KEY)
+    );
+  }
+
+  @GET
+  @Path("/{service-provider}/stats")
+  public void getServiceProviderStats(HttpRequest request, HttpResponder responder,
+                                      @PathParam("service-provider") String serviceProvider) throws Exception {
+    // we want to fetch stats with the specified service name grouped by the stat type
+    Map<String, Map<String, Object>> stats =
+      getStats(OperationalStatsUtils.SERVICE_NAME_KEY, serviceProvider, OperationalStatsUtils.STAT_TYPE_KEY);
+    if (stats.isEmpty()) {
+      throw new NotFoundException(String.format("Service provider %s not found", serviceProvider));
+    }
+    // info is only needed in the list API, not in the stats API
+    stats.remove(OperationalStatsUtils.STAT_TYPE_INFO);
+    responder.sendJson(HttpResponseStatus.OK, stats);
+  }
+
+  /**
+   * Reads operational stats collected using the {@link OperationalStats} extension mechanism with the specified
+   * property key and value, grouped by the specified groupByKey.
+   *
+   * @param propertyKey the key that must be contained with the specified value in the stat to be returned
+   * @param propertyValue the value that the specified key must have in the stat to be returned
+   * @param groupByKey an additional key in the stat's property to group the stats by
+   * @return a {@link Map} of the group to a {@link Map} of stats of that group
+   * @throws Exception when there are errors reading stats using JMX
+   */
+  @VisibleForTesting
+  Map<String, Map<String, Object>> getStats(String propertyKey, String propertyValue,
+                                            String groupByKey) throws Exception {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(propertyKey), "Property should not be null or empty.");
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(propertyValue), "Property value should not be null or empty.");
+    Hashtable<String, String> properties = new Hashtable<>();
+    // we want stats with the specified value for the specified key, so set them in the properties
+    properties.put(propertyKey, propertyValue);
+    // since we want to group by the groupKey, we want to fetch all groups
+    properties.put(groupByKey, "*");
+    ObjectName objectName = new ObjectName(OperationalStatsUtils.JMX_DOMAIN, properties);
+    Map<String, Map<String, Object>> result = new HashMap<>();
+    MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+    for (ObjectName name : mbs.queryNames(objectName, null)) {
+      String group = name.getKeyProperty(groupByKey);
+      MBeanInfo mBeanInfo = mbs.getMBeanInfo(name);
+      Map<String, Object> stats = new HashMap<>();
+      for (MBeanAttributeInfo attributeInfo : mBeanInfo.getAttributes()) {
+        stats.put(attributeInfo.getName().toLowerCase(), mbs.getAttribute(name, attributeInfo.getName()));
+      }
+      result.put(group, stats);
+      LOG.trace("Found stats of group {} as {}", group, stats);
+    }
+    return result;
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/operations/OperationalExtensionId.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/operations/OperationalExtensionId.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.operations;
+
+import java.util.Objects;
+
+/**
+ * Uniquely identifies an operational extension.
+ */
+public class OperationalExtensionId {
+  private final String serviceName;
+  private final String statType;
+
+  public OperationalExtensionId(String serviceName, String statType) {
+    this.serviceName = serviceName;
+    this.statType = statType;
+  }
+
+  public String getServiceName() {
+    return serviceName;
+  }
+
+  public String getStatType() {
+    return statType;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    OperationalExtensionId that = (OperationalExtensionId) o;
+
+    return Objects.equals(serviceName, that.serviceName) &&
+      Objects.equals(statType, that.statType);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(serviceName, statType);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/operations/OperationalStats.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/operations/OperationalStats.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.operations;
+
+import java.io.IOException;
+import javax.management.MBeanServer;
+import javax.management.MXBean;
+
+/**
+ * Interface for all operational stats emitted using the operational stats extension framework.
+ *
+ * To emit stats using this framework, create JMX {@link MXBean} interfaces, then have the implementations of those
+ * interfaces extend this class. At runtime, all sub-classes of this class will be registered with the
+ * {@link MBeanServer} with the <i>name</i> property determined by {@link #getServiceName()} and the <i>type</i>
+ * property determined by {@link #getStatType()}.
+ */
+public interface OperationalStats {
+  /**
+   * Returns the service name for which this operational stat is emitted. Service names are case-insensitive, and will
+   * be converted to lower case.
+   */
+  String getServiceName();
+
+  /**
+   * Returns the type of the stat. Stat types are case-insensitive, and will be converted to lower case.
+   */
+  String getStatType();
+
+  /**
+   * Collects the stats that are reported by this object.
+   */
+  void collect() throws IOException;
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/operations/OperationalStatsLoader.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/operations/OperationalStatsLoader.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.operations;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.extension.AbstractExtensionLoader;
+import com.google.inject.Inject;
+
+import java.util.Collections;
+import java.util.ServiceLoader;
+import java.util.Set;
+import javax.management.MXBean;
+
+/**
+ * Class that registers {@link MXBean MXBeans} for reporting operational stats. To be loaded by this class, the
+ * class that implements an {@link MXBean} should also additionally implement {@link OperationalStats}. This class loads
+ * implementations of {@link OperationalStats} using the Java {@link ServiceLoader} architecture.
+ */
+public class OperationalStatsLoader extends AbstractExtensionLoader<OperationalExtensionId, OperationalStats> {
+
+  @Inject
+  OperationalStatsLoader(CConfiguration cConf) {
+    super(cConf.get(Constants.OperationalStats.EXTENSIONS_DIR, ""));
+  }
+
+  @Override
+  public Set<OperationalExtensionId> getSupportedTypesForProvider(OperationalStats operationalStats) {
+    OperationalExtensionId operationalExtensionId = OperationalStatsUtils.getOperationalExtensionId(operationalStats);
+    return operationalExtensionId == null ?
+      Collections.<OperationalExtensionId>emptySet() :
+      Collections.singleton(operationalExtensionId);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/operations/OperationalStatsService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/operations/OperationalStatsService.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.operations;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.inject.Inject;
+import org.apache.twill.common.Threads;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanRegistrationException;
+import javax.management.MBeanServer;
+import javax.management.MXBean;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+/**
+ * A service that registers {@link OperationalStats} extensions as JMX Beans. The Beans are registered with the JMX
+ * domain {@link OperationalStatsUtils#JMX_DOMAIN} with the following properties:
+ * <ol>
+ *   <li>{@link OperationalStatsUtils#SERVICE_NAME_KEY} = name of the service, as defined by
+ *   {@link OperationalStats#getServiceName()};</li>
+ *   <li>{@link OperationalStatsUtils#STAT_TYPE_KEY} = type of the stat; as defined by
+ *   {@link OperationalStats#getStatType()}</li>
+ * </ol>
+ *
+ * It also updates the Beans periodically by calling their {@link OperationalStats#collect()} method.
+ */
+public class OperationalStatsService extends AbstractScheduledService {
+  private static final Logger LOG = LoggerFactory.getLogger(OperationalStatsService.class);
+
+  private final OperationalStatsLoader operationalStatsLoader;
+  private final int statsRefreshInterval;
+
+  private ScheduledExecutorService executor;
+
+  @Inject
+  OperationalStatsService(OperationalStatsLoader operationalStatsLoader, CConfiguration cConf) {
+    this.operationalStatsLoader = operationalStatsLoader;
+    this.statsRefreshInterval = cConf.getInt(Constants.OperationalStats.REFRESH_INTERVAL_SECS);
+  }
+
+  /**
+   * Registers all JMX {@link MXBean MXBeans} from {@link OperationalStats} extensions in the extensions directory.
+   */
+  @Override
+  protected void startUp() throws Exception {
+    LOG.info("Starting Operational Stats Service...");
+    MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+    for (Map.Entry<OperationalExtensionId, OperationalStats> entry : operationalStatsLoader.getAll().entrySet()) {
+      ObjectName objectName = getObjectName(entry.getValue());
+      if (objectName == null) {
+        LOG.warn("Found an operational extension with null service name and stat type - {}. Ignoring this extension.",
+                 OperationalStats.class.getName());
+        continue;
+      }
+      LOG.debug("Registering operational extension: {}", entry.getValue());
+      // register MBean
+      mbs.registerMBean(entry.getValue(), objectName);
+    }
+  }
+
+  /**
+   * Also schedules asynchronous stats collection for all {@link MXBean MXBeans} by calling the
+   * {@link OperationalStats#collect()} method.
+   */
+  @Override
+  protected void runOneIteration() throws Exception {
+    LOG.debug("Running operational stats extension service iteration");
+    for (Map.Entry<OperationalExtensionId, OperationalStats> entry : operationalStatsLoader.getAll().entrySet()) {
+      LOG.debug("Collecting {] stats for service {}", entry.getValue().getStatType(),
+                entry.getValue().getServiceName());
+      try {
+        entry.getValue().collect();
+      } catch (IOException e) {
+        LOG.warn("Exception while collecting stats for service: {}; type: {}", entry.getValue().getServiceName(),
+                 entry.getValue().getStatType(), e);
+      }
+    }
+  }
+
+  @Override
+  protected Scheduler scheduler() {
+    return Scheduler.newFixedDelaySchedule(0, statsRefreshInterval, TimeUnit.SECONDS);
+  }
+
+  @Override
+  protected ScheduledExecutorService executor() {
+    executor = Executors.newSingleThreadScheduledExecutor(
+      Threads.createDaemonThreadFactory("operational-stats-collector-%d"));
+    return executor;
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+    for (Map.Entry<OperationalExtensionId, OperationalStats> entry : operationalStatsLoader.getAll().entrySet()) {
+      ObjectName objectName = getObjectName(entry.getValue());
+      if (objectName == null) {
+        LOG.warn("Found an operational extension with null service name and stat type while unregistering - {}. " +
+                   "Ignoring this extension.", entry.getValue().getClass().getName());
+        continue;
+      }
+      try {
+        mbs.unregisterMBean(objectName);
+      } catch (InstanceNotFoundException e) {
+        LOG.debug("MBean {} not found while un-registering. Ignoring.", objectName);
+      } catch (MBeanRegistrationException e) {
+        LOG.warn("Error while un-registering MBean {}.", e);
+      }
+    }
+    if (executor != null) {
+      executor.shutdownNow();
+    }
+    LOG.info("Successfully shutdown operational stats service.");
+  }
+
+  @Nullable
+  private ObjectName getObjectName(OperationalStats operationalStats) {
+    OperationalExtensionId operationalExtensionId = OperationalStatsUtils.getOperationalExtensionId(operationalStats);
+    if (operationalExtensionId == null) {
+      return null;
+    }
+    Hashtable<String, String> properties = new Hashtable<>();
+    properties.put(OperationalStatsUtils.SERVICE_NAME_KEY, operationalExtensionId.getServiceName());
+    properties.put(OperationalStatsUtils.STAT_TYPE_KEY, operationalExtensionId.getStatType());
+    try {
+      return new ObjectName(OperationalStatsUtils.JMX_DOMAIN, properties);
+    } catch (MalformedObjectNameException e) {
+      // should never happen, since we're constructing a valid domain name, and properties is non-empty
+      throw Throwables.propagate(e);
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/operations/OperationalStatsUtils.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/operations/OperationalStatsUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.operations;
+
+import com.google.common.base.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+/**
+ * Utilities for use in collection and retrieval of {@link OperationalStats}.
+ */
+public final class OperationalStatsUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(OperationalStatsUtils.class);
+
+  public static final String JMX_DOMAIN = "co.cask.cdap.operations";
+  public static final String SERVICE_NAME_KEY = "name";
+  public static final String STAT_TYPE_KEY = "type";
+  public static final String STAT_TYPE_INFO = "info";
+
+  @Nullable
+  static OperationalExtensionId getOperationalExtensionId(OperationalStats operationalStats) {
+    String serviceName = operationalStats.getServiceName();
+    String statType = operationalStats.getStatType();
+    if (Strings.isNullOrEmpty(serviceName) && Strings.isNullOrEmpty(statType)) {
+      return null;
+    }
+    if (!Strings.isNullOrEmpty(serviceName)) {
+      serviceName = serviceName.toLowerCase();
+    } else {
+      LOG.warn("Found operational stat without service name - {}. This stat will not be discovered by service name.",
+               operationalStats.getClass().getName());
+    }
+    if (!Strings.isNullOrEmpty(statType)) {
+      statType = statType.toLowerCase();
+    } else {
+      LOG.warn("Found operational stat without stat type - {}. This stat will not be discovered by stat type.",
+               operationalStats.getClass().getName());
+    }
+    return new OperationalExtensionId(serviceName, statType);
+  }
+
+  private OperationalStatsUtils() {
+    // prevent instantiation.
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/OperationalStatsHttpHanderTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/OperationalStatsHttpHanderTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.gateway.handlers;
+
+import co.cask.cdap.operations.OperationalStatsUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.lang.management.ManagementFactory;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+/**
+ * Tests for {@link OperationalStatsUtils}.
+ */
+public class OperationalStatsHttpHanderTest {
+
+  private final  OperationalStatsHttpHandler handler = new OperationalStatsHttpHandler();
+
+  @BeforeClass
+  public static void setup() throws Exception {
+   registerBean("one", "string", new OneString());
+   registerBean("one", "int", new OneInt());
+   registerBean("one", "float", new OneFloat());
+   registerBean("two", "string", new TwoString());
+   registerBean("two", "int", new TwoInt());
+   registerBean("two", "float", new TwoFloat());
+  }
+
+  @Test
+  public void testReadByName() throws Exception {
+    Map<String, Map<String, Object>> expected = new HashMap<>();
+    Map<String, Object> inner = new HashMap<>();
+    inner.put("onestring", "one");
+    expected.put("string", inner);
+    inner = new HashMap<>();
+    inner.put("oneint", 1);
+    expected.put("int", inner);
+    inner = new HashMap<>();
+    inner.put("onefloat", 1.0F);
+    expected.put("float", inner);
+    Assert.assertEquals(expected, handler.getStats("name", "one", "type"));
+    expected = new HashMap<>();
+    inner = new HashMap<>();
+    inner.put("twostring", "two");
+    expected.put("string", inner);
+    inner = new HashMap<>();
+    inner.put("twoint", 2);
+    expected.put("int", inner);
+    inner = new HashMap<>();
+    inner.put("twofloat", 2.0F);
+    expected.put("float", inner);
+    Assert.assertEquals(expected, handler.getStats("name", "two", "type"));
+  }
+
+  @Test
+  public void testReadByType() throws Exception {
+    Map<String, Map<String, Object>> expected = new HashMap<>();
+    Map<String, Object> inner = new HashMap<>();
+    inner.put("onestring", "one");
+    expected.put("one", inner);
+    inner = new HashMap<>();
+    inner.put("twostring", "two");
+    expected.put("two", inner);
+    Assert.assertEquals(expected, handler.getStats("type", "string", "name"));
+    expected = new HashMap<>();
+    inner = new HashMap<>();
+    inner.put("oneint", 1);
+    expected.put("one", inner);
+    inner = new HashMap<>();
+    inner.put("twoint", 2);
+    expected.put("two", inner);
+    Assert.assertEquals(expected, handler.getStats("type", "int", "name"));
+    expected = new HashMap<>();
+    inner = new HashMap<>();
+    inner.put("onefloat", 1.0F);
+    expected.put("one", inner);
+    inner = new HashMap<>();
+    inner.put("twofloat", 2.0F);
+    expected.put("two", inner);
+    Assert.assertEquals(expected, handler.getStats("type", "float", "name"));
+  }
+
+  @Test
+  public void testInvalid() throws Exception {
+    try {
+      handler.getStats(null, "foo", "don'tcare");
+      Assert.fail();
+    } catch (IllegalArgumentException expected) {
+      // expected
+    }
+
+    try {
+      handler.getStats("bar", null, "don'tcare");
+      Assert.fail();
+    } catch (IllegalArgumentException expected) {
+      // expected
+    }
+  }
+
+  private static void registerBean(String name, String type, Object bean) throws Exception {
+    MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+    Hashtable<String, String> properties = new Hashtable<>();
+    properties.put("name", name);
+    properties.put("type", type);
+    mbs.registerMBean(bean, new ObjectName(OperationalStatsUtils.JMX_DOMAIN, properties));
+  }
+
+  public interface OneStringMXBean {
+    @SuppressWarnings("unused")
+    String getOneString();
+  }
+
+  public static class OneString implements OneStringMXBean {
+    @Override
+    public String getOneString() {
+      return "one";
+    }
+  }
+
+  public interface OneIntMXBean {
+    @SuppressWarnings("unused")
+    int getOneInt();
+  }
+
+  public static class OneInt implements OneIntMXBean {
+    @Override
+    public int getOneInt() {
+      return 1;
+    }
+  }
+
+  public interface OneFloatMXBean {
+    @SuppressWarnings("unused")
+    float getOneFloat();
+  }
+
+  public static class OneFloat implements OneFloatMXBean {
+    @Override
+    public float getOneFloat() {
+      return 1.0F;
+    }
+  }
+
+  public interface TwoStringMXBean {
+    @SuppressWarnings("unused")
+    String getTwoString();
+  }
+
+  public static class TwoString implements TwoStringMXBean {
+    @Override
+    public String getTwoString() {
+      return "two";
+    }
+  }
+
+  public interface TwoIntMXBean {
+    @SuppressWarnings("unused")
+    int getTwoInt();
+  }
+
+  public static class TwoInt implements TwoIntMXBean {
+    @Override
+    public int getTwoInt() {
+      return 2;
+    }
+  }
+
+  public interface TwoFloatMXBean {
+    @SuppressWarnings("unused")
+    float getTwoFloat();
+  }
+
+  public static class TwoFloat implements TwoFloatMXBean {
+    @Override
+    public float getTwoFloat() {
+      return 2.0F;
+    }
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -1062,4 +1062,12 @@ public final class Constants {
     // The name of the HBase table attribute to store the bucket size being used by the RowKeyDistributor
     public static final String KEY_DISTRIBUTOR_BUCKETS_ATTR = "cdap.messaging.key.distributor.buckets";
   }
+
+  /**
+   * Constants for operational stats
+   */
+  public static final class OperationalStats {
+    public static final String EXTENSIONS_DIR = "operational.stats.extensions.dir";
+    public static final String REFRESH_INTERVAL_SECS = "operational.stats.refresh.interval.secs";
+  }
 }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1393,6 +1393,26 @@
     </description>
   </property>
 
+  
+  <!-- Operational Statistics Configuration -->
+  
+  <property>
+    <name>operational.stats.extensions.dir</name>
+    <value>/opt/cdap/master/ext/operations</value>
+    <description>
+      Semicolon-separated list of local directories on the CDAP Master
+      that are scanned for operational statistics extensions
+    </description>
+  </property>
+
+  <property>
+    <name>operational.stats.refresh.interval.secs</name>
+    <value>60</value>
+    <description>
+      Number of seconds after which operational statistics should be refreshed
+    </description>
+  </property>
+
 
   <!-- Queue Configuration -->
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="4b8ae57282a51734462b31235fe47213"
+DEFAULT_XML_MD5_HASH="98acec132154e462f335761c059b6443"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterPathLookup.java
@@ -130,6 +130,8 @@ public final class RouterPathLookup extends AbstractHttpHandler {
       return APP_FABRIC_HTTP;
     } else if (matches(uriParts, "v3", "namespaces", null, "previews")) {
       return PREVIEW_HTTP;
+    } else if (matches(uriParts, "v3", "system", "serviceproviders")) {
+      return APP_FABRIC_HTTP;
     } else if ((uriParts.length >= 4) && uriParts[1].equals("namespaces") && uriParts[3].equals("streams")) {
       return STREAMS_SERVICE;
     } else if ((uriParts.length >= 8 && uriParts[7].equals("logs")) ||

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterPathTest.java
@@ -433,6 +433,13 @@ public class RouterPathTest {
     assertRouting("/v3/namespaces/default/previews/preview123/metrics", RouterPathLookup.PREVIEW_HTTP);
   }
 
+  @Test
+  public void testServiceProviderStatsPaths() {
+    assertRouting("/v3/system/////serviceproviders", RouterPathLookup.APP_FABRIC_HTTP);
+    assertRouting("/v3/system/////serviceproviders/serviceprovider/stats", RouterPathLookup.APP_FABRIC_HTTP);
+    assertRouting("/v3/system/////serviceproviders///////", RouterPathLookup.APP_FABRIC_HTTP);
+  }
+
   private void assertRouting(String path, RouteDestination destination) {
     for (HttpMethod method : ImmutableList.of(HttpMethod.GET, HttpMethod.POST, HttpMethod.DELETE)) {
       HttpRequest httpRequest = new DefaultHttpRequest(VERSION, method, path);

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -213,6 +213,7 @@
         <stage.artifacts.dir>${stage.opt.dir}/artifacts</stage.artifacts.dir>
         <stage.runtime.ext.dir>${stage.opt.dir}/ext/runtimes</stage.runtime.ext.dir>
         <stage.security.ext.dir>${stage.opt.dir}/ext/security</stage.security.ext.dir>
+        <stage.operations.ext.dir>${stage.opt.dir}/ext/operations</stage.operations.ext.dir>
         <additional.artifacts.jar.pattern>**/target/*.jar</additional.artifacts.jar.pattern>
         <additional.artifacts.config.pattern>**/target/*.json</additional.artifacts.config.pattern>
         <additional.artifacts.exclude.pattern>**/target/*-tests.jar</additional.artifacts.exclude.pattern>
@@ -234,6 +235,12 @@
         <dependency>
           <groupId>co.cask.cdap</groupId>
           <artifactId>cdap-spark-core</artifactId>
+          <version>${project.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>co.cask.cdap</groupId>
+          <artifactId>cdap-operational-stats-core</artifactId>
           <version>${project.version}</version>
           <scope>provided</scope>
         </dependency>
@@ -381,6 +388,28 @@
                       <includes>
                         <include>co.cask.cdap.cdap-api-spark*.jar</include>
                         <include>co.cask.cdap.cdap-spark-core*.jar</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+
+              <!-- Copy operations extensions -->
+              <execution>
+                <id>copy-operations-extensions</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration combine.self="override">
+                  <outputDirectory>${stage.operations.ext.dir}/core</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>
+                        ${project.parent.basedir}/cdap-operational-stats-core/target/
+                      </directory>
+                      <includes>
+                        <include>co.cask.cdap.cdap-operational-stats-core-${project.version}.jar</include>
                       </includes>
                     </resource>
                   </resources>

--- a/cdap-operational-stats-core/pom.xml
+++ b/cdap-operational-stats-core/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 2016 Cask Data, Inc.
+  
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+  
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>cdap</artifactId>
+    <groupId>co.cask.cdap</groupId>
+    <version>4.0.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>cdap-operational-stats-core</artifactId>
+  <name>CDAP Operational Stats Core</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-app-fabric</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+      <version>${hadoop.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+      <version>${hadoop.version}</version>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>dist</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>2.4</version>
+            <executions>
+              <execution>
+                <id>jar</id>
+                <phase>prepare-package</phase>
+                <configuration combine.self="override">
+                  <outputDirectory>${project.build.directory}</outputDirectory>
+                  <finalName>${project.groupId}.${project.build.finalName}</finalName>
+                </configuration>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>
+

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/hdfs/AbstractHDFSStats.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/hdfs/AbstractHDFSStats.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.operations.hdfs;
+
+import co.cask.cdap.operations.OperationalStats;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+
+import java.io.IOException;
+
+/**
+ * Base class for {@link OperationalStats} for HDFS
+ */
+public abstract class AbstractHDFSStats implements OperationalStats {
+  @VisibleForTesting
+  static final String SERVICE_NAME = "HDFS";
+
+  protected final Configuration conf;
+
+  protected AbstractHDFSStats() {
+    this.conf = new Configuration();
+  }
+
+  protected DistributedFileSystem createDFS() throws IOException {
+    FileSystem fs = FileSystem.get(conf);
+    Preconditions.checkArgument(fs instanceof DistributedFileSystem, "Expected Distributed Filesystem to be the " +
+      "configured file system, but found %s", fs.getClass().getName());
+    return (DistributedFileSystem) fs;
+  }
+
+  @Override
+  public String getServiceName() {
+    return SERVICE_NAME;
+  }
+}

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/hdfs/HDFSInfo.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/hdfs/HDFSInfo.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.operations.hdfs;
+
+import co.cask.cdap.operations.OperationalStats;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Iterables;
+import org.apache.hadoop.ha.HAServiceProtocol;
+import org.apache.hadoop.ha.HAServiceStatus;
+import org.apache.hadoop.ha.HAServiceTarget;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.DFSUtil;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.HAUtil;
+import org.apache.hadoop.hdfs.tools.NNHAServiceTarget;
+import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.util.VersionInfo;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.Collection;
+import javax.annotation.Nullable;
+
+/**
+ * {@link OperationalStats} representing HDFS information.
+ */
+@SuppressWarnings("unused")
+public class HDFSInfo extends AbstractHDFSStats implements HDFSInfoMXBean {
+  @VisibleForTesting
+  static final String STAT_TYPE = "info";
+
+  @Override
+  public String getStatType() {
+    return STAT_TYPE;
+  }
+
+  @Override
+  public String getVersion() {
+    return VersionInfo.getVersion();
+  }
+
+  @Override
+  public String getWebURL() throws IOException {
+    if (HAUtil.isHAEnabled(conf, getNameService())) {
+      return getHAWebURL().toString();
+    }
+    try (DistributedFileSystem dfs = createDFS()) {
+      return rpcToHttpAddress(dfs.getUri()).toString();
+    }
+  }
+
+  @Override
+  public String getLogsURL() throws IOException {
+    return getWebURL() + "/logs";
+  }
+
+  @Override
+  public void collect() throws IOException {
+    // TODO: no need to refresh, but need to figure out a way to not spawn a new thread for such stats
+  }
+
+  @Nullable
+  private String getNameService() {
+    Collection<String> nameservices = conf.getTrimmedStringCollection(DFSConfigKeys.DFS_NAMESERVICES);
+    if (nameservices.isEmpty()) {
+      // we want to return null from this method if nameservices are not configured, so it can be used in methods like
+      // HAUtil.isHAEnabled()
+      return null;
+    }
+    if (1 == nameservices.size()) {
+      return Iterables.getOnlyElement(nameservices);
+    }
+    throw new IllegalStateException("Found multiple nameservices configured in HDFS. CDAP currently does not support " +
+                                      "HDFS Federation.");
+  }
+
+  private URL getHAWebURL() throws IOException {
+    String activeNamenode = null;
+    String nameService = getNameService();
+    for (String nnId : DFSUtil.getNameNodeIds(conf, nameService)) {
+      HAServiceTarget haServiceTarget = new NNHAServiceTarget(conf, nameService, nnId);
+      HAServiceProtocol proxy = haServiceTarget.getProxy(conf, 10000);
+      HAServiceStatus serviceStatus = proxy.getServiceStatus();
+      if (HAServiceProtocol.HAServiceState.ACTIVE != serviceStatus.getState()) {
+        continue;
+      }
+      activeNamenode = DFSUtil.getNamenodeServiceAddr(conf, nameService, nnId);
+    }
+    if (activeNamenode == null) {
+      throw new IllegalStateException("Could not find an active namenode");
+    }
+    return rpcToHttpAddress(URI.create(activeNamenode));
+  }
+
+  private URL rpcToHttpAddress(URI rpcURI) throws MalformedURLException {
+    String host = rpcURI.getHost();
+    boolean httpsEnabled = conf.getBoolean(DFSConfigKeys.DFS_HTTPS_ENABLE_KEY, DFSConfigKeys.DFS_HTTPS_ENABLE_DEFAULT);
+    String namenodeWebAddress = httpsEnabled ?
+      conf.get(DFSConfigKeys.DFS_NAMENODE_HTTPS_ADDRESS_KEY, DFSConfigKeys.DFS_NAMENODE_HTTPS_ADDRESS_DEFAULT) :
+      conf.get(DFSConfigKeys.DFS_NAMENODE_HTTP_ADDRESS_KEY, DFSConfigKeys.DFS_NAMENODE_HTTP_ADDRESS_DEFAULT);
+    InetSocketAddress socketAddress = NetUtils.createSocketAddr(namenodeWebAddress);
+    int namenodeWebPort = socketAddress.getPort();
+    String protocol = httpsEnabled ? "https" : "http";
+    return new URL(protocol, host, namenodeWebPort, "");
+  }
+}

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/hdfs/HDFSInfoMXBean.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/hdfs/HDFSInfoMXBean.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.operations.hdfs;
+
+import java.io.IOException;
+import java.net.URL;
+import javax.management.MXBean;
+
+/**
+ * {@link MXBean} representing HDFS information.
+ */
+public interface HDFSInfoMXBean {
+  /**
+   * Returns HDFS Version;
+   */
+  String getVersion();
+
+  /**
+   * Returns the web URL of the HDFS Namenode
+   */
+  String getWebURL() throws IOException;
+
+  /**
+   * Returns the URL for the logs of the HDFS Namenode
+   */
+  String getLogsURL() throws IOException;
+}

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/hdfs/HDFSNodes.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/hdfs/HDFSNodes.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.operations.hdfs;
+
+import co.cask.cdap.operations.OperationalStats;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Iterables;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
+import org.apache.hadoop.hdfs.DFSUtil;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.HAUtil;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * {@link OperationalStats} for HDFS nodes.
+ */
+@SuppressWarnings("unused")
+public class HDFSNodes extends AbstractHDFSStats implements HDFSNodesMXBean {
+  @VisibleForTesting
+  static final String STAT_TYPE = "nodes";
+
+  private final int namenodes;
+
+  public HDFSNodes() throws IOException {
+    super();
+    this.namenodes = getNameNodes().size();
+  }
+
+  @Override
+  public String getStatType() {
+    return "nodes";
+  }
+
+  @Override
+  public int getNamenodes() {
+    return namenodes;
+  }
+
+  @Override
+  public void collect() throws IOException {
+    // no need to refresh right now, but need to figure out a way to not spawn a new thread for such stats
+  }
+
+  private List<String> getNameNodes() throws IOException {
+    List<String> namenodes = new ArrayList<>();
+    if (!HAUtil.isHAEnabled(conf, getNameService())) {
+      try (DistributedFileSystem dfs = createDFS()) {
+        return Collections.singletonList(dfs.getUri().toString());
+      }
+    }
+    String nameService = getNameService();
+    for (String nnId : DFSUtil.getNameNodeIds(conf, nameService)) {
+      namenodes.add(DFSUtil.getNamenodeServiceAddr(conf, nameService, nnId));
+    }
+    return namenodes;
+  }
+
+  @Nullable
+  private String getNameService() {
+    Collection<String> nameservices = conf.getTrimmedStringCollection(DFSConfigKeys.DFS_NAMESERVICES);
+    if (nameservices.isEmpty()) {
+      return null;
+    }
+    if (1 == nameservices.size()) {
+      return Iterables.getOnlyElement(nameservices);
+    }
+    throw new IllegalStateException("Found multiple nameservices configured in HDFS. CDAP currently does not support " +
+                                      "HDFS Federation.");
+  }
+}

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/hdfs/HDFSNodesMXBean.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/hdfs/HDFSNodesMXBean.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.operations.hdfs;
+
+import javax.management.MXBean;
+
+/**
+ * {@link MXBean} for HDFS node statistics
+ */
+public interface HDFSNodesMXBean {
+  /**
+   * Returns number of namenodes
+   */
+  int getNamenodes();
+}

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/hdfs/HDFSStorage.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/hdfs/HDFSStorage.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.operations.hdfs;
+
+import co.cask.cdap.operations.OperationalStats;
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.fs.FsStatus;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+
+import java.io.IOException;
+
+/**
+ * {@link OperationalStats} for HDFS.
+ */
+@SuppressWarnings("unused")
+public class HDFSStorage extends AbstractHDFSStats implements HDFSStorageMXBean {
+  @VisibleForTesting
+  static final String STAT_TYPE = "storage";
+
+  private long totalBytes;
+  private long usedBytes;
+  private long availableBytes;
+  private long missingBlocks;
+  private long underReplicatedBlocks;
+  private long corruptBlocks;
+
+  @Override
+  public String getStatType() {
+    return STAT_TYPE;
+  }
+
+  @Override
+  public long getTotalBytes() {
+    return totalBytes;
+  }
+
+  @Override
+  public long getUsedBytes() {
+    return usedBytes;
+  }
+
+  @Override
+  public long getRemainingBytes() {
+    return availableBytes;
+  }
+
+  @Override
+  public long getMissingBlocks() {
+    return missingBlocks;
+  }
+
+  @Override
+  public long getUnderReplicatedBlocks() {
+    return underReplicatedBlocks;
+  }
+
+  @Override
+  public long getCorruptBlocks() {
+    return corruptBlocks;
+  }
+
+  @Override
+  public synchronized void collect() throws IOException {
+    try (DistributedFileSystem dfs = createDFS()) {
+      FsStatus status = dfs.getStatus();
+      this.totalBytes = status.getCapacity();
+      this.availableBytes = status.getRemaining();
+      this.usedBytes = status.getUsed();
+      this.missingBlocks = dfs.getMissingBlocksCount();
+      this.underReplicatedBlocks = dfs.getUnderReplicatedBlocksCount();
+      this.corruptBlocks = dfs.getCorruptBlocksCount();
+    }
+  }
+}

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/hdfs/HDFSStorageMXBean.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/hdfs/HDFSStorageMXBean.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.operations.hdfs;
+
+import java.io.IOException;
+import javax.management.MXBean;
+
+/**
+ * {@link MXBean} representing HDFS Storage statistics.
+ */
+public interface HDFSStorageMXBean {
+  /**
+   * Return the total number of bytes in HDFS.
+   */
+  long getTotalBytes();
+
+  /**
+   * Return the used bytes in HDFS.
+   */
+  long getUsedBytes();
+
+  /**
+   * Return the free bytes in HDFS.
+   */
+  long getRemainingBytes();
+
+  /**
+   * Return the number of missing blocks in HDFS.
+   */
+  long getMissingBlocks();
+
+  /**
+   * Return the number of under replicated blocks in HDFS.
+   */
+  long getUnderReplicatedBlocks();
+
+  /**
+   * Return the number of corrupt blocks in HDFS.
+   */
+  long getCorruptBlocks();
+}

--- a/cdap-operational-stats-core/src/main/resources/META-INF/services/co.cask.cdap.operations.OperationalStats
+++ b/cdap-operational-stats-core/src/main/resources/META-INF/services/co.cask.cdap.operations.OperationalStats
@@ -1,0 +1,19 @@
+#
+# Copyright © 2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+co.cask.cdap.operations.hdfs.HDFSInfo
+co.cask.cdap.operations.hdfs.HDFSStorage
+co.cask.cdap.operations.hdfs.HDFSNodes

--- a/cdap-operational-stats-core/src/test/java/co/cask/cdap/operations/hdfs/HDFSOperationalStatsTest.java
+++ b/cdap-operational-stats-core/src/test/java/co/cask/cdap/operations/hdfs/HDFSOperationalStatsTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.operations.hdfs;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * Tests for HDFS Operational Stats.
+ */
+public class HDFSOperationalStatsTest {
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+  private static MiniDFSCluster dfsCluster;
+
+  @BeforeClass
+  public static void setup() throws IOException {
+    Configuration hConf = new Configuration();
+    hConf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, TMP_FOLDER.newFolder().getAbsolutePath());
+    dfsCluster = new MiniDFSCluster.Builder(hConf).numDataNodes(2).build();
+    dfsCluster.waitClusterUp();
+  }
+
+  @AfterClass
+  public static void teardown() {
+    dfsCluster.shutdown();
+  }
+
+  @Test
+  public void test() throws IOException {
+    final DistributedFileSystem dfs = dfsCluster.getFileSystem();
+    HDFSInfo hdfsInfo = new HDFSInfo() {
+      @Override
+      protected DistributedFileSystem createDFS() throws IOException {
+        return dfs;
+      }
+    };
+    Assert.assertEquals(AbstractHDFSStats.SERVICE_NAME, hdfsInfo.getServiceName());
+    Assert.assertEquals(HDFSInfo.STAT_TYPE, hdfsInfo.getStatType());
+    Assert.assertNotNull(hdfsInfo.getVersion());
+    URL webURL = new URL(hdfsInfo.getWebURL());
+    URL logsURL = new URL(hdfsInfo.getLogsURL());
+    Assert.assertNotNull(logsURL);
+    Assert.assertEquals(webURL.getProtocol(), logsURL.getProtocol());
+    Assert.assertEquals(webURL.getHost(), logsURL.getHost());
+    Assert.assertEquals(webURL.getPort(), logsURL.getPort());
+    Assert.assertEquals("/logs", logsURL.getPath());
+    HDFSNodes hdfsNodes = new HDFSNodes() {
+      @Override
+      protected DistributedFileSystem createDFS() throws IOException {
+        return dfs;
+      }
+    };
+    Assert.assertEquals(AbstractHDFSStats.SERVICE_NAME, hdfsNodes.getServiceName());
+    Assert.assertEquals(HDFSNodes.STAT_TYPE, hdfsNodes.getStatType());
+    Assert.assertEquals(1, hdfsNodes.getNamenodes());
+    HDFSStorage hdfsStorage = new HDFSStorage() {
+      @Override
+      protected DistributedFileSystem createDFS() throws IOException {
+        return dfs;
+      }
+    };
+    Assert.assertEquals(AbstractHDFSStats.SERVICE_NAME, hdfsStorage.getServiceName());
+    Assert.assertEquals(HDFSStorage.STAT_TYPE, hdfsStorage.getStatType());
+    Assert.assertEquals(0, hdfsStorage.getCorruptBlocks());
+    Assert.assertEquals(0, hdfsStorage.getMissingBlocks());
+    Assert.assertEquals(0, hdfsStorage.getUnderReplicatedBlocks());
+    hdfsStorage.collect();
+    Assert.assertEquals(0, hdfsStorage.getMissingBlocks());
+    Assert.assertEquals(0, hdfsStorage.getUnderReplicatedBlocks());
+    Assert.assertEquals(0, hdfsStorage.getCorruptBlocks());
+    Assert.assertTrue(hdfsStorage.getTotalBytes() > hdfsStorage.getRemainingBytes());
+    Assert.assertTrue(hdfsStorage.getTotalBytes() > hdfsStorage.getUsedBytes());
+    Assert.assertTrue(hdfsStorage.getRemainingBytes() > 0);
+    Assert.assertTrue(hdfsStorage.getUsedBytes() > 0);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -2521,6 +2521,7 @@
         <module>cdap-proto</module>
         <module>cdap-notifications</module>
         <module>cdap-notifications-api</module>
+        <module>cdap-operational-stats-core</module>
         <module>cdap-client</module>
         <module>cdap-cli</module>
         <module>cdap-standalone</module>


### PR DESCRIPTION
…nal stats using JMX

- Added a new cdap-operational-stats-core module
- Classes from cdap-operational-stats-core that implement OperationalStats will be loaded as extensions using the Java ServiceLoader architecture, and be registered as JMX Beans
- As initial integration, added operational stats for HDFS
- Also added REST APIs and JMX Reader for reporting JMX stats

Jira: [CDAP-7670](https://issues.cask.co/browse/CDAP-7670)
Build: http://builds.cask.co/browse/CDAP-DUT5085

There are no tests in this PR yet, but wanted to get an initial review done first, since the PR was becoming large. Tested this to work on a cluster for HDFS.