### PR TITLE
[HYDRATOR-968] - Deprecates the use of a String when processing runtime arguments in UI

### DIFF
--- a/cdap-ui/app/directives/key-value-widget/key-value-widget.html
+++ b/cdap-ui/app/directives/key-value-widget/key-value-widget.html
@@ -1,0 +1,39 @@
+<!--
+  Copyright © 2016 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<div class="key-val-directive-container">
+  <div ng-repeat="property in KeyValue.properties" class="row" ng-keypress="KeyValue.enter($event, $last)">
+    <div class="col-xs-10 col-lg-8">
+      <input type="text" class="form-control" ng-model="property.key" placeholder="{{ KeyValue.keyPlaceholder }}" my-focus-watch="KeyValue.property.newField" />
+      <input type="text" class="form-control" ng-model="property.value" placeholder="{{ KeyValue.valuePlaceholder }}" ng-if="!isDropdown" />
+    </div>
+    <div class="col-xs-2 col-lg-4">
+      <a href="" class="btn btn-danger" ng-click="KeyValue.removeProperty(property)">
+        <span class="fa fa-fw fa-trash"> </span>
+      </a>
+      <a class="btn btn-info btn-transparent" ng-click="KeyValue.addProperty()" ng-if="$last">
+        <span class="fa fa-fw fa-plus"></span>
+      </a>
+    </div>
+  </div>
+
+  <div ng-if="KeyValue.properties.length === 0" class="empty-container">
+    <a class="btn btn-blue" ng-click="KeyValue.addProperty()">
+      <span class="fa fa-fw fa-plus"></span>
+      <span>Add Property</span>
+    </a>
+  </div>
+</div>

--- a/cdap-ui/app/directives/key-value-widget/key-value-widget.js
+++ b/cdap-ui/app/directives/key-value-widget/key-value-widget.js
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name + '.commons')
+  .directive('keyValueWidget', function() {
+    return {
+      restrict: 'E',
+      scope: {
+        model: '=ngModel',
+        config: '=',
+        isDropdown: '='
+      },
+      templateUrl: 'key-value-widget/key-value-widget.html',
+      controller: KeyValueController,
+      controllerAs: 'KeyValue',
+      bindToController: true
+    };
+  });
+
+function KeyValueController(myHelpers, $scope) {
+  this.keyPlaceholder = myHelpers.objectQuery(this.config, 'widget-attributes', 'key-placeholder') || 'key';
+  this.valuePlaceholder = myHelpers.objectQuery(this.config, 'widget-attributes', 'value-placeholder') || 'value';
+
+  // initializing
+  function initialize() {
+    var map = this.model;
+    this.properties = [];
+
+    if (!map || Object.keys(map).length === 0) {
+      this.properties.push({
+        key: '',
+        value: ''
+      });
+      return;
+    }
+
+    Object.keys(map).forEach((key) => {
+      this.properties.push({
+        key: key,
+        value: map[key]
+      });
+    });
+  }
+
+  initialize.call(this);
+
+  $scope.$watch('KeyValue.properties', function() {
+
+    var map = {};
+
+    angular.forEach(this.properties, function(p) {
+      if(p.key.length > 0){
+        map[p.key] = p.value;
+      }
+    });
+    this.model = map;
+  }.bind(this), true);
+
+  this.addProperty = function() {
+    this.properties.push({
+      key: '',
+      value: '',
+      newField: 'add'
+    });
+  };
+
+  this.removeProperty = function(property) {
+    var index = this.properties.indexOf(property);
+    this.properties.splice(index, 1);
+  };
+
+  this.enter = function (event, last) {
+    if (last && event.keyCode === 13) {
+      this.addProperty();
+    }
+  };
+}

--- a/cdap-ui/app/directives/key-value-widget/key-value-widget.less
+++ b/cdap-ui/app/directives/key-value-widget/key-value-widget.less
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+@import "../../styles/variables.less";
+
+key-value-widget {
+
+  .key-val-directive-container {
+    background-color: @body-bg;
+    border: 1px solid #dddddd;
+    border-radius: @border-radius-base;
+    padding: 20px 10px;
+    .empty-container {
+      padding-left: 15px;
+    }
+  }
+  .row {
+    margin-bottom: 2px;
+    > div > input.form-control,
+    select.form-control {
+      display: inline-block;
+      width: 48%;
+    }
+  }
+  .labels {
+    [class*="col-"] {
+      margin-bottom: 10px;
+    }
+  }
+
+  .delimiter-label {
+    line-height: 26px;
+    padding-left: 17px;
+
+    > strong {
+      vertical-align: middle;
+    }
+  }
+}

--- a/cdap-ui/app/hydrator/templates/detail/top-panel.html
+++ b/cdap-ui/app/hydrator/templates/detail/top-panel.html
@@ -188,11 +188,10 @@
           <strong>Runtime Arguments</strong>
         </h5>
         <div class="arguments-container">
-          <div
-            data-model="TopPanelCtrl.macrosList"
-            data-myconfig="TopPanelCtrl.runTimeWidgetConfig"
-            widget-container
-          ></div>
+          <key-value-widget
+            ng-model="TopPanelCtrl.macrosMap"
+            data-config="TopPanelCtrl.runTimeWidgetConfig"
+          ></key-value-widget>
         </div>
         <div class="clearfix">
           <span ng-if="TopPanelCtrl.macroError" class="pull-left macro-error-container">

--- a/cdap-ui/app/hydrator/toppanel.less
+++ b/cdap-ui/app/hydrator/toppanel.less
@@ -173,8 +173,8 @@ body.theme-cdap {
         // key-value widget was specifically meant for hydrator plugin configuration
         // Tweaking it for run configuration is messy. Either fix keyvalue to occupy
         // max space available or build a new widget for hydrator run configuration.
-        my-key-value {
-          .keyvalue-container {
+        key-value-widget {
+          .key-val-directive-container {
             padding: 0;
             border: 0;
             .row {


### PR DESCRIPTION
- Adds map-widget directive to be used for runtime args instead 
- TopPanel now uses a javascript object instead of a string for storing keyvalue pairs 
- UI now accesses runtime arguments object instead of tokenizing string 

Bamboo Build:
http://builds.cask.co/browse/CDAP-DRC4892