### PR TITLE
CDAP-7659 Allow selecting hive execution engine dynamically

### DIFF
--- a/cdap-docs/developers-manual/source/data-exploration/hive-execution-engines.rst
+++ b/cdap-docs/developers-manual/source/data-exploration/hive-execution-engines.rst
@@ -47,7 +47,7 @@ This feature is currently experimental in CDAP due to these limitations:
 - It requires Spark to be installed on all cluster nodes.
 - Currently, CDAP Explore launches a new Spark job for every query. Starting a new Spark job for every query may bring
   a significant overhead.
-- Users cannot dynamically select the execution engine, or adjust memory for containers created for the query.
+- Users cannot dynamically adjust memory for containers created for the query.
 
 .. _hive-execution-engines-hive-on-tez:
 

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreServiceUtils.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/ExploreServiceUtils.java
@@ -43,6 +43,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Enumeration;
+import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
@@ -57,6 +58,7 @@ public class ExploreServiceUtils {
   private static final Logger LOG = LoggerFactory.getLogger(ExploreServiceUtils.class);
 
   private static final String HIVE_AUTHFACTORY_CLASS_NAME = "org.apache.hive.service.auth.HiveAuthFactory";
+  private static final String HIVE_EXECUTION_ENGINE = "hive.execution.engine";
 
   /**
    * Hive support enum.
@@ -234,16 +236,21 @@ public class ExploreServiceUtils {
     }
   }
 
-  public static boolean isSparkEngine(HiveConf hiveConf) {
-    // We don't support setting engine through session configuration now
-    String engine = hiveConf.get("hive.execution.engine");
-    return "spark".equals(engine);
+  // Determines whether the execution engine is spark, by checking the SessionConf (if provided) and then the HiveConf.
+  public static boolean isSparkEngine(HiveConf hiveConf, @Nullable Map<String, String> sessionConf) {
+    return "spark".equals(getEngine(hiveConf, sessionConf));
   }
 
-  public static boolean isTezEngine(HiveConf hiveConf) {
-    // We don't support setting engine through session configuration now
-    String engine = hiveConf.get("hive.execution.engine");
-    return "tez".equals(engine);
+  // Determines whether the execution engine is tez, by checking the SessionConf (if provided) and then the HiveConf.
+  public static boolean isTezEngine(HiveConf hiveConf, @Nullable Map<String, String> sessionConf) {
+    return "tez".equals(getEngine(hiveConf, sessionConf));
   }
 
+  private static String getEngine(HiveConf hiveConf, @Nullable Map<String, String> sessionConf) {
+    // sessionConf overrides hiveConf
+    if (sessionConf != null && sessionConf.containsKey(HIVE_EXECUTION_ENGINE)) {
+      return sessionConf.get(HIVE_EXECUTION_ENGINE);
+    }
+    return hiveConf.get(HIVE_EXECUTION_ENGINE);
+  }
 }

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -290,10 +290,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
     LOG.info("Starting {}...", BaseHiveExploreService.class.getSimpleName());
 
     HiveConf hiveConf = getHiveConf();
-    if (ExploreServiceUtils.isSparkEngine(hiveConf)) {
-      LOG.info("Engine is spark");
-      setupSparkConf();
-    }
+    setupSparkConf();
 
     authorizationEnforcementService.startAndWait();
     cliService.init(hiveConf);
@@ -1285,7 +1282,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
 
 
     HiveConf hiveConf = getHiveConf();
-    if (ExploreServiceUtils.isSparkEngine(hiveConf)) {
+    if (ExploreServiceUtils.isSparkEngine(hiveConf, additionalSessionConf)) {
       sessionConf.putAll(sparkConf);
     }
 
@@ -1305,7 +1302,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
 
       sessionConf.put(HiveConf.ConfVars.SUBMITLOCALTASKVIACHILD.toString(), Boolean.FALSE.toString());
       sessionConf.put(HiveConf.ConfVars.SUBMITVIACHILD.toString(), Boolean.FALSE.toString());
-      if (ExploreServiceUtils.isTezEngine(hiveConf)) {
+      if (ExploreServiceUtils.isTezEngine(hiveConf, additionalSessionConf)) {
         // Add token file location property for tez if engine is tez
         sessionConf.put("tez.credentials.path", credentialsFilePath);
       }


### PR DESCRIPTION
Allow selecting hive execution engine dynamically (via session configuration, instead of via hive-site.xml).

https://issues.cask.co/browse/CDAP-7659
http://builds.cask.co/browse/CDAP-DUT5102