### PR TITLE
Retain the case of property keys reported by JMX instead of convertin…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/OperationalStatsHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/OperationalStatsHttpHandler.java
@@ -103,7 +103,7 @@ public class OperationalStatsHttpHandler extends AbstractHttpHandler {
       MBeanInfo mBeanInfo = mbs.getMBeanInfo(name);
       Map<String, Object> stats = new HashMap<>();
       for (MBeanAttributeInfo attributeInfo : mBeanInfo.getAttributes()) {
-        stats.put(attributeInfo.getName().toLowerCase(), mbs.getAttribute(name, attributeInfo.getName()));
+        stats.put(attributeInfo.getName(), mbs.getAttribute(name, attributeInfo.getName()));
       }
       result.put(group, stats);
       LOG.trace("Found stats of group {} as {}", group, stats);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/OperationalStatsHttpHanderTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/OperationalStatsHttpHanderTest.java
@@ -29,7 +29,7 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
 /**
- * Tests for {@link OperationalStatsUtils}.
+ * Tests for {@link OperationalStatsHttpHandler}.
  */
 public class OperationalStatsHttpHanderTest {
 
@@ -49,24 +49,24 @@ public class OperationalStatsHttpHanderTest {
   public void testReadByName() throws Exception {
     Map<String, Map<String, Object>> expected = new HashMap<>();
     Map<String, Object> inner = new HashMap<>();
-    inner.put("onestring", "one");
+    inner.put("OneString", "one");
     expected.put("string", inner);
     inner = new HashMap<>();
-    inner.put("oneint", 1);
+    inner.put("OneInt", 1);
     expected.put("int", inner);
     inner = new HashMap<>();
-    inner.put("onefloat", 1.0F);
+    inner.put("OneFloat", 1.0F);
     expected.put("float", inner);
     Assert.assertEquals(expected, handler.getStats("name", "one", "type"));
     expected = new HashMap<>();
     inner = new HashMap<>();
-    inner.put("twostring", "two");
+    inner.put("TwoString", "two");
     expected.put("string", inner);
     inner = new HashMap<>();
-    inner.put("twoint", 2);
+    inner.put("TwoInt", 2);
     expected.put("int", inner);
     inner = new HashMap<>();
-    inner.put("twofloat", 2.0F);
+    inner.put("TwoFloat", 2.0F);
     expected.put("float", inner);
     Assert.assertEquals(expected, handler.getStats("name", "two", "type"));
   }
@@ -75,26 +75,26 @@ public class OperationalStatsHttpHanderTest {
   public void testReadByType() throws Exception {
     Map<String, Map<String, Object>> expected = new HashMap<>();
     Map<String, Object> inner = new HashMap<>();
-    inner.put("onestring", "one");
+    inner.put("OneString", "one");
     expected.put("one", inner);
     inner = new HashMap<>();
-    inner.put("twostring", "two");
+    inner.put("TwoString", "two");
     expected.put("two", inner);
     Assert.assertEquals(expected, handler.getStats("type", "string", "name"));
     expected = new HashMap<>();
     inner = new HashMap<>();
-    inner.put("oneint", 1);
+    inner.put("OneInt", 1);
     expected.put("one", inner);
     inner = new HashMap<>();
-    inner.put("twoint", 2);
+    inner.put("TwoInt", 2);
     expected.put("two", inner);
     Assert.assertEquals(expected, handler.getStats("type", "int", "name"));
     expected = new HashMap<>();
     inner = new HashMap<>();
-    inner.put("onefloat", 1.0F);
+    inner.put("OneFloat", 1.0F);
     expected.put("one", inner);
     inner = new HashMap<>();
-    inner.put("twofloat", 2.0F);
+    inner.put("TwoFloat", 2.0F);
     expected.put("two", inner);
     Assert.assertEquals(expected, handler.getStats("type", "float", "name"));
   }


### PR DESCRIPTION
…g them to lowercase.

- If extensions want to report keys with a lower case (or just with lower case first character), they can do so by naming the accessor methods of their MXBeans appropriately.
- CDAP should not enforce case, other than for service name and stat type which are case-insensitive

Build: http://builds.cask.co/browse/CDAP-DUT5106