### PR TITLE
Create CDAP SDK AMI using Packer

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -40,11 +40,27 @@
       ],
       "vm_name": "cdap-standalone-vm-{{user `sdk_version`}}",
       "name": "cdap-sdk-vm"
+    },
+    {
+      "type": "amazon-ebs",
+      "ami_name": "CDAP SDK {{user `sdk_version`}} ({{timestamp}})",
+      "instance_type": "m1.medium",
+      "region": "us-east-1",
+      "source_ami": "ami-a488dbb3",
+      "ami_groups": ["all"],
+      "ami_regions": [
+        "us-east-1",
+        "us-west-1",
+        "us-west-2"
+      ],
+      "ssh_username": "ubuntu",
+      "name": "cdap-sdk-ami"
     }
   ],
   "provisioners": [
     {
       "type": "shell",
+      "execute_command": "sudo bash -c '{{ .Vars }} {{ .Path }}'",
       "scripts": [
         "scripts/apt-setup.sh",
         "scripts/cookbook-dir.sh"
@@ -66,6 +82,7 @@
     },
     {
       "type": "shell",
+      "execute_command": "sudo bash -c '{{ .Vars }} {{ .Path }}'",
       "scripts": "scripts/cookbook-setup.sh"
     },
     {
@@ -123,8 +140,7 @@
     {
       "type": "file",
       "source": "files/cdap-sdk.zip",
-      "destination": "/tmp/cdap-sdk.zip",
-      "only": ["cdap-sdk-vm"]
+      "destination": "/tmp/cdap-sdk.zip"
     },
     {
       "type": "file",
@@ -136,7 +152,6 @@
       "type": "chef-solo",
       "remote_cookbook_paths": "/var/chef/cookbooks",
       "run_list": "recipe[cdap::sdk]",
-      "prevent_sudo": true,
       "skip_install": true,
       "json": {
         "cdap": {
@@ -163,20 +178,24 @@
     },
     {
       "type": "shell",
+      "execute_command": "sudo bash -c '{{ .Vars }} {{ .Path }}'",
       "scripts": [
         "scripts/remove-chef.sh",
         "scripts/sdk-cleanup.sh",
         "scripts/network-cleanup.sh",
-        "scripts/apt-cleanup.sh"
+        "scripts/apt-cleanup.sh",
+        "scripts/random-root-password.sh"
       ]
     },
     {
       "type": "shell",
-      "scripts": [
-        "scripts/random-root-password.sh",
-        "scripts/zero-disk.sh"
-      ],
+      "scripts": "scripts/zero-disk.sh",
       "only": ["cdap-sdk-vm"]
+    },
+    {
+      "type": "shell",
+      "execute_command": "sudo bash -c '{{ .Vars }} {{ .Path }}'",
+      "scripts": "scripts/ssh-cleanup.sh"
     }
   ]
 }

--- a/cdap-distributions/src/packer/scripts/cookbook-setup.sh
+++ b/cdap-distributions/src/packer/scripts/cookbook-setup.sh
@@ -21,7 +21,7 @@
 die() { echo $*; exit 1; }
 
 # Grab cookbooks using knife
-for cb in hadoop idea maven nodejs cdap ; do
+for cb in cdap hadoop idea maven nodejs; do
   knife cookbook site install $cb || die "Cannot fetch cookbook $cb"
 done
 

--- a/cdap-distributions/src/packer/scripts/network-cleanup.sh
+++ b/cdap-distributions/src/packer/scripts/network-cleanup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -22,11 +22,15 @@ rm -f /lib/udev/rules.d/75-persistent-net-generator.rules
 rm -rf /dev/.udev/ /var/lib/dhcp/*
 
 # Remove HWADDR/UUID from ifcfg-* files (RHEL-compatable)
-for ndev in /etc/sysconfig/network-scripts/ifcfg-*; do
+for ndev in $(ls -1 /etc/sysconfig/network-scripts/ifcfg-* 2>/dev/null); do
   [[ "${ndev##*/}" != "ifcfg-lo" ]] && sed -i '/^HWADDR/d;/^UUID/d' ${ndev}
 done
 
 # Adding a 2 sec delay to the interface up, to make the dhclient happy
-echo "pre-up sleep 2" >> /etc/network/interfaces
+if [[ -e /etc/network/interfaces.d/eth0.cfg ]]; then
+  echo "pre-up sleep 2" >> /etc/network/interfaces.d/eth0.cfg
+else
+  echo "pre-up sleep 2" >> /etc/network/interfaces
+fi
 
 exit 0

--- a/cdap-distributions/src/packer/scripts/ssh-cleanup.sh
+++ b/cdap-distributions/src/packer/scripts/ssh-cleanup.sh
@@ -14,24 +14,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-#
-# Sets up Chef cookbook directory for "knife cookbook site install"
-#
-
-# Create directory
-mkdir -p /var/chef/cookbooks
-cd /var/chef/cookbooks
-
-# Initialize Git repository
-touch .gitignore
-
-if [[ $(which apt-get 2>/dev/null) ]]; then
-  apt-get install -y --no-install-recommends git || exit 1
-else
-  yum install -y git || exit 1
-fi
-git init || exit 1
-git add .gitignore
-git commit -m 'Initial commit'
+# Delete SSH keys
+rm -f /etc/ssh/*_key /etc/ssh/*_key.pub
+rm -f /root/.ssh/authorized_keys* /home/*/.ssh/authorized_keys*
 
 exit 0


### PR DESCRIPTION
This uses Packer to create a CDAP SDK AMI in `us-east-1`, `us-west-1`, and `us-west-2` regions. This creates an EBS-backed Ubuntu 12.04 AMI with the CDAP SDK on it. The SDK is sourced from `cdap-distributions/src/packer/files` as `cdap-sdk.zip` so it is up to the build to put the file into place, just like the VM build.