### PR TITLE
Issuing restart should start service, even if stopped

### DIFF
--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -522,7 +522,7 @@ cdap_service() {
           cdap_stop_pidfile ${__pidfile} "CDAP ${__name}" && \
           cdap_${__svc} ${__action} ${__args}
       elif [[ ${__action} == restart ]]; then
-          cdap_stop_pidfile ${__pidfile} "CDAP ${__name}" && \
+          cdap_stop_pidfile ${__pidfile} "CDAP ${__name}" ; \
           cdap_${__svc} ${__action} ${__args}
       else
           cdap_${__svc} ${__action} ${__args}


### PR DESCRIPTION
The `start` should run unconditionally, because any failure in the `stop` means any processes are outside the script's knowledge.