### PR TITLE
(CDAP-7690) Fix exception handling in HDFS MXBean classes

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/extension/ExtensionLoaderTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/extension/ExtensionLoaderTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.extension;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Tests for {@link AbstractExtensionLoader}.
+ */
+public class ExtensionLoaderTest {
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+  @Test
+  public void testLoadingFailure() throws IOException {
+    ExtensionLoader loader = new ExtensionLoader(TMP_FOLDER.newFolder().getAbsolutePath());
+    // getting all extensions should just skip the one that throws an error while loading
+    Map<String, Extension> allExtensions = loader.getAll();
+    Assert.assertEquals(2, allExtensions.size());
+    Extension hiExtension = allExtensions.get("hi");
+    Assert.assertEquals("hi", hiExtension.echo());
+    Extension helloExtension = allExtensions.get("hello");
+    Assert.assertEquals("hello", helloExtension.echo());
+    // getting the extension that throws an error while loading should not propagate the exception
+    Assert.assertNull(loader.get("error"));
+  }
+
+  private static final class ExtensionLoader extends AbstractExtensionLoader<String, Extension> {
+
+    public ExtensionLoader(String extDirs) {
+      super(extDirs);
+    }
+
+    @Override
+    protected Set<String> getSupportedTypesForProvider(Extension extension) {
+      return extension.getSupported();
+    }
+  }
+
+  /**
+   * Test extension interface
+   */
+  public interface Extension {
+    Set<String> getSupported();
+    String echo();
+  }
+
+  /**
+   * Extension that echoes 'hi'
+   */
+  @SuppressWarnings("unused")
+  public static class HiExtension implements Extension {
+
+    @Override
+    public Set<String> getSupported() {
+      return Collections.singleton("hi");
+    }
+
+    @Override
+    public String echo() {
+      return "hi";
+    }
+  }
+
+  /**
+   * Extension that echoes hello
+   */
+  @SuppressWarnings("unused")
+  public static class HelloExtension implements Extension {
+
+    @Override
+    public Set<String> getSupported() {
+      return Collections.singleton("hello");
+    }
+
+    @Override
+    public String echo() {
+      return "hello";
+    }
+  }
+
+  /**
+   * Extension that errors while loading
+   */
+  @SuppressWarnings("unused")
+  public static class LoadingErrorExtension implements Extension {
+
+    public LoadingErrorExtension() {
+      throw new IllegalStateException("Failed to load");
+    }
+
+    @Override
+    public Set<String> getSupported() {
+      return Collections.singleton("error");
+    }
+
+    @Override
+    public String echo() {
+      return "error";
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/resources/META-INF/services/co.cask.cdap.extension.ExtensionLoaderTest$Extension
+++ b/cdap-app-fabric/src/test/resources/META-INF/services/co.cask.cdap.extension.ExtensionLoaderTest$Extension
@@ -1,0 +1,19 @@
+#
+# Copyright © 2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+co.cask.cdap.extension.ExtensionLoaderTest$HiExtension
+co.cask.cdap.extension.ExtensionLoaderTest$HelloExtension
+co.cask.cdap.extension.ExtensionLoaderTest$LoadingErrorExtension

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/hdfs/AbstractHDFSStats.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/hdfs/AbstractHDFSStats.java
@@ -18,12 +18,7 @@ package co.cask.cdap.operations.hdfs;
 
 import co.cask.cdap.operations.OperationalStats;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.hdfs.DistributedFileSystem;
-
-import java.io.IOException;
 
 /**
  * Base class for {@link OperationalStats} for HDFS
@@ -34,15 +29,9 @@ public abstract class AbstractHDFSStats implements OperationalStats {
 
   protected final Configuration conf;
 
-  protected AbstractHDFSStats() {
-    this.conf = new Configuration();
-  }
-
-  protected DistributedFileSystem createDFS() throws IOException {
-    FileSystem fs = FileSystem.get(conf);
-    Preconditions.checkArgument(fs instanceof DistributedFileSystem, "Expected Distributed Filesystem to be the " +
-      "configured file system, but found %s", fs.getClass().getName());
-    return (DistributedFileSystem) fs;
+  @VisibleForTesting
+  AbstractHDFSStats(Configuration conf) {
+    this.conf = conf;
   }
 
   @Override

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/hdfs/HDFSInfoMXBean.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/hdfs/HDFSInfoMXBean.java
@@ -16,8 +16,7 @@
 
 package co.cask.cdap.operations.hdfs;
 
-import java.io.IOException;
-import java.net.URL;
+import javax.annotation.Nullable;
 import javax.management.MXBean;
 
 /**
@@ -30,12 +29,14 @@ public interface HDFSInfoMXBean {
   String getVersion();
 
   /**
-   * Returns the web URL of the HDFS Namenode
+   * Returns the web URL of the HDFS Namenode, or {@code null} if the web URL cannot be determined.
    */
-  String getWebURL() throws IOException;
+  @Nullable
+  String getWebURL();
 
   /**
-   * Returns the URL for the logs of the HDFS Namenode
+   * Returns the URL for the logs of the HDFS Namenode, or {@code null} if the logs URL cannot be determined.
    */
-  String getLogsURL() throws IOException;
+  @Nullable
+  String getLogsURL();
 }

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/hdfs/HDFSStorageMXBean.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/hdfs/HDFSStorageMXBean.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.operations.hdfs;
 
-import java.io.IOException;
 import javax.management.MXBean;
 
 /**

--- a/cdap-operational-stats-core/src/test/java/co/cask/cdap/operations/hdfs/HDFSOperationalStatsTest.java
+++ b/cdap-operational-stats-core/src/test/java/co/cask/cdap/operations/hdfs/HDFSOperationalStatsTest.java
@@ -54,42 +54,33 @@ public class HDFSOperationalStatsTest {
   @Test
   public void test() throws IOException {
     final DistributedFileSystem dfs = dfsCluster.getFileSystem();
-    HDFSInfo hdfsInfo = new HDFSInfo() {
-      @Override
-      protected DistributedFileSystem createDFS() throws IOException {
-        return dfs;
-      }
-    };
+    HDFSInfo hdfsInfo = new HDFSInfo(dfs.getConf());
     Assert.assertEquals(AbstractHDFSStats.SERVICE_NAME, hdfsInfo.getServiceName());
     Assert.assertEquals(HDFSInfo.STAT_TYPE, hdfsInfo.getStatType());
     Assert.assertNotNull(hdfsInfo.getVersion());
-    URL webURL = new URL(hdfsInfo.getWebURL());
-    URL logsURL = new URL(hdfsInfo.getLogsURL());
+    String webAddress = hdfsInfo.getWebURL();
+    Assert.assertNotNull(webAddress);
+    String logsAddress = hdfsInfo.getLogsURL();
+    Assert.assertNotNull(logsAddress);
+    URL webURL = new URL(webAddress);
+    URL logsURL = new URL(logsAddress);
     Assert.assertNotNull(logsURL);
     Assert.assertEquals(webURL.getProtocol(), logsURL.getProtocol());
     Assert.assertEquals(webURL.getHost(), logsURL.getHost());
     Assert.assertEquals(webURL.getPort(), logsURL.getPort());
     Assert.assertEquals("/logs", logsURL.getPath());
-    HDFSNodes hdfsNodes = new HDFSNodes() {
-      @Override
-      protected DistributedFileSystem createDFS() throws IOException {
-        return dfs;
-      }
-    };
+    HDFSNodes hdfsNodes = new HDFSNodes(dfs.getConf());
     Assert.assertEquals(AbstractHDFSStats.SERVICE_NAME, hdfsNodes.getServiceName());
     Assert.assertEquals(HDFSNodes.STAT_TYPE, hdfsNodes.getStatType());
+    Assert.assertEquals(0, hdfsNodes.getNamenodes());
+    hdfsNodes.collect();
     Assert.assertEquals(1, hdfsNodes.getNamenodes());
-    HDFSStorage hdfsStorage = new HDFSStorage() {
-      @Override
-      protected DistributedFileSystem createDFS() throws IOException {
-        return dfs;
-      }
-    };
+    HDFSStorage hdfsStorage = new HDFSStorage(dfs.getConf());
     Assert.assertEquals(AbstractHDFSStats.SERVICE_NAME, hdfsStorage.getServiceName());
     Assert.assertEquals(HDFSStorage.STAT_TYPE, hdfsStorage.getStatType());
-    Assert.assertEquals(0, hdfsStorage.getCorruptBlocks());
-    Assert.assertEquals(0, hdfsStorage.getMissingBlocks());
-    Assert.assertEquals(0, hdfsStorage.getUnderReplicatedBlocks());
+    Assert.assertEquals(0, hdfsStorage.getTotalBytes());
+    Assert.assertEquals(0, hdfsStorage.getUsedBytes());
+    Assert.assertEquals(0, hdfsStorage.getRemainingBytes());
     hdfsStorage.collect();
     Assert.assertEquals(0, hdfsStorage.getMissingBlocks());
     Assert.assertEquals(0, hdfsStorage.getUnderReplicatedBlocks());


### PR DESCRIPTION
- Have getters not propagate exceptions
- Use DistributedFileSystem only when necessary, otherwise use FileSystem
- Refactor to allow injecting a Configuration object for testing instead of injecting DistributedFileSystem
- When the webURL for namenode is not available, return null instead of empty

Jira: [CDAP-7690](https://issues.cask.co/browse/CDAP-7690)
Build: http://builds.cask.co/browse/CDAP-DUT5109