### PR TITLE
CDAP-7676 Custom log processor support in log saver 

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -673,6 +673,8 @@ public final class Constants {
 
     public static final String SERVICE_DESCRIPTION = "Service to collect and store logs.";
     public static final String MESSAGE_PROCESSOR_FACTORIES =  "log.saver.message.processor.factories";
+    public static final String LOG_PROCESSOR_EXTENSION_JAR_PATH =  "log.saver.processor.extension.jar";
+    public static final String EXTENSION_CONFIG_PREFIX = "log.saver.processor.extension.config.";
   }
 
   /**

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/ExtensionClassHelper.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/ExtensionClassHelper.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.lang;
+
+import co.cask.cdap.common.conf.CConfiguration;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Properties;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+/**
+ * Helper class to load and instantiate class from external jar and get extension properties.
+ */
+public final class ExtensionClassHelper {
+
+  private ExtensionClassHelper() {
+
+  }
+
+  /**
+   * Inspect the given extension jar to find the extension class contained in it.
+   *
+   * @param extensionJar the bundled jar file for the extension
+   * @param tmpDir temporary Directory
+   * @param interfaceNameInExceptionMessage name of the interface that extensions implement
+   * @param interfaceClassName name of the interface class that extensions implement
+   * @return name of the class defined as the MAIN_CLASS in the extension jar
+   * @throws IOException if there was an exception opening the jar file
+   */
+  private static String getExtensionClassName(File extensionJar, File tmpDir,
+                                              String interfaceNameInExceptionMessage, String interfaceClassName)
+    throws InvalidExtensionException, IOException {
+    File manifestFile = new File(tmpDir, JarFile.MANIFEST_NAME);
+    if (!manifestFile.isFile() && !manifestFile.exists()) {
+      throw new InvalidExtensionException(
+        String.format("No Manifest found in %s extension jar '%s'.", interfaceNameInExceptionMessage, extensionJar));
+    }
+    try (InputStream is = new FileInputStream(manifestFile)) {
+      Manifest manifest = new Manifest(is);
+      Attributes manifestAttributes = manifest.getMainAttributes();
+      if (manifestAttributes == null) {
+        throw new InvalidExtensionException(
+          String.format("No attributes found in %s extension jar '%s'.", interfaceNameInExceptionMessage,
+                        extensionJar));
+      }
+      if (!manifestAttributes.containsKey(Attributes.Name.MAIN_CLASS)) {
+        throw new InvalidExtensionException(
+          String.format("%s class not set in the manifest of the %s extension jar located at %s. " +
+                          "Please set the attribute %s to the fully qualified class name of the class that " +
+                          "implements %s in the extension jar's manifest.",
+                        interfaceNameInExceptionMessage, interfaceNameInExceptionMessage,
+                        extensionJar, Attributes.Name.MAIN_CLASS, interfaceClassName));
+      }
+      return manifestAttributes.getValue(Attributes.Name.MAIN_CLASS);
+    }
+  }
+
+  /**
+   * Checks if the extension jar exists and if its a valid file
+   * @param extensionJar extension jar file
+   * @param extensionDescription description used for interface extension implements in error messages
+   * @param extensionPathProperty property used to specify the extension jar path
+   * @throws InvalidExtensionException
+   */
+  public static void ensureValidExtensionJar(File extensionJar, String extensionDescription,
+                                             String extensionPathProperty) throws InvalidExtensionException {
+    if (!extensionJar.exists()) {
+      throw new InvalidExtensionException(
+        String.format("%s extension jar %s specified as %s does not exist.", extensionDescription, extensionJar,
+                      extensionPathProperty)
+      );
+    }
+    if (!extensionJar.isFile()) {
+      throw new InvalidExtensionException(
+        String.format("%s extension jar %s specified as %s must be a file.", extensionDescription, extensionJar,
+                      extensionPathProperty)
+      );
+    }
+  }
+
+  /**
+   * load and return the extension class
+   * @param extensionJar path to extension jar file
+   * @param extensionClassLoader extension class loader to use
+   * @param assignableClass check if the loaded class is assignableFrom this class
+   * @param tmpDir temporary dir
+   * @param interfaceNameInExceptionMessages interface name that will be used in exception messages
+   * @param interfaceClassName interface class name, extension implements this interface
+   * @return loaded extension class
+   * @throws IOException
+   * @throws InvalidExtensionException
+   */
+  @SuppressWarnings("unchecked")
+  public static Class loadExtensionClass(File extensionJar,
+                                         ExtensionClassLoader extensionClassLoader,
+                                         Class assignableClass,
+                                         File tmpDir,
+                                         String interfaceNameInExceptionMessages,
+                                         String interfaceClassName)
+    throws IOException, InvalidExtensionException {
+    String extensionClassName = getExtensionClassName(extensionJar, tmpDir,
+                                                      interfaceNameInExceptionMessages, interfaceClassName);
+    Class<?> extensionClass;
+    try {
+      extensionClass = extensionClassLoader.loadClass(extensionClassName);
+    } catch (ClassNotFoundException e) {
+      throw new InvalidExtensionException(
+        String.format("%s extension class %s not found. Please make sure that the right class is specified " +
+                        "in the extension jar's manifest located at %s.",
+                      interfaceNameInExceptionMessages, extensionClassName, extensionJar), e);
+    }
+    if (!assignableClass.isAssignableFrom(extensionClass)) {
+      throw new InvalidExtensionException(
+        String.format("Class %s defined as %s in the %s extension's manifest at %s must implement %s",
+                      extensionClass.getName(), Attributes.Name.MAIN_CLASS,
+                      interfaceNameInExceptionMessages, extensionJar,
+                      interfaceClassName));
+    }
+    return extensionClass;
+  }
+
+  /**
+   * populate and return properties for externsion, specified fromm configuration.
+   * @param cConf configuration
+   * @param extensionPrefix prefix used for the extension properties
+   * @return {@link Properties}
+   */
+  public static Properties createExtensionProperties(CConfiguration cConf, String extensionPrefix) {
+    Properties extensionProperties = new Properties();
+    for (Map.Entry<String, String> cConfEntry : cConf) {
+      if (cConfEntry.getKey().startsWith(extensionPrefix)) {
+        extensionProperties.put(
+          cConfEntry.getKey().substring(extensionPrefix.length()), cConfEntry.getValue()
+        );
+      }
+    }
+    return extensionProperties;
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/InvalidExtensionException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/InvalidExtensionException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.common.lang;
+
+/**
+ * Thrown when an extension jar is found to be invalid during inspection.
+ */
+public class InvalidExtensionException extends Exception {
+
+  public InvalidExtensionException(String message) {
+    super(message);
+  }
+
+  public InvalidExtensionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizerClassLoaderTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthorizerClassLoaderTest.java
@@ -18,10 +18,12 @@ package co.cask.cdap.security.authorization;
 
 import co.cask.cdap.api.app.Application;
 import co.cask.cdap.common.lang.ClassPathResources;
+import co.cask.cdap.common.lang.ExtensionClassLoader;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.security.spi.authorization.Authorizer;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import com.google.common.collect.ImmutableList;
+import com.google.common.io.Files;
 import com.google.gson.Gson;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.HTable;
@@ -31,37 +33,40 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 
+import java.io.File;
 import java.util.List;
 import javax.annotation.Nullable;
 
 /**
- * Tests for {@link AuthorizerClassLoader}.
+ * Tests for AuthorizerClassLoader.
  */
 public class AuthorizerClassLoaderTest {
-  private final ClassLoader parent = AuthorizerClassLoader.createParent();
+  File tmpDir = Files.createTempDir();
+  private final ClassLoader authorizerClassLoader =
+    new ExtensionClassLoader(tmpDir, AuthorizerInstantiator.class.getClassLoader(), Authorizer.class);
 
   @Test
   public void testAuthorizerClassLoaderParentAvailableClasses() throws ClassNotFoundException {
     // classes from java.* should be available
-    parent.loadClass(List.class.getName());
+    authorizerClassLoader.loadClass(List.class.getName());
     // classes from javax.* should be available
-    parent.loadClass(Nullable.class.getName());
+    authorizerClassLoader.loadClass(Nullable.class.getName());
     // classes from gson should be available
-    parent.loadClass(Gson.class.getName());
+    authorizerClassLoader.loadClass(Gson.class.getName());
     // classes from cdap-api should be available
-    parent.loadClass(Application.class.getName());
+    authorizerClassLoader.loadClass(Application.class.getName());
     // classes from twill-api should be available as dependencies of cdap-api
-    parent.loadClass(LocationFactory.class.getName());
+    authorizerClassLoader.loadClass(LocationFactory.class.getName());
     // classes from slf4j-api should be available as dependencies of cdap-api
-    parent.loadClass(Logger.class.getName());
+    authorizerClassLoader.loadClass(Logger.class.getName());
     // classes from cdap-proto should be available
-    parent.loadClass(Principal.class.getName());
+    authorizerClassLoader.loadClass(Principal.class.getName());
     // classes from cdap-security-spi should be available
-    parent.loadClass(Authorizer.class.getName());
-    parent.loadClass(UnauthorizedException.class.getName());
+    authorizerClassLoader.loadClass(Authorizer.class.getName());
+    authorizerClassLoader.loadClass(UnauthorizedException.class.getName());
     // classes from hadoop should be available
-    parent.loadClass(Configuration.class.getName());
-    parent.loadClass(UserGroupInformation.class.getName());
+    authorizerClassLoader.loadClass(Configuration.class.getName());
+    authorizerClassLoader.loadClass(UserGroupInformation.class.getName());
   }
 
   @Test
@@ -75,7 +80,7 @@ public class AuthorizerClassLoaderTest {
     // classes from cdap-common should not be available
     assertClassUnavailable(ClassPathResources.class);
     // classes from cdap-security should not be available
-    assertClassUnavailable(AuthorizerClassLoader.class);
+    assertClassUnavailable(AuthorizerInstantiator.class);
     // classes from cdap-data-fabric should not be available
     assertClassUnavailable("co.cask.cdap.data2.util.TableId");
     // classes from cdap-app-fabric should not be available
@@ -88,9 +93,9 @@ public class AuthorizerClassLoaderTest {
 
   private void assertClassUnavailable(String aClassName) {
     try {
-      parent.loadClass(aClassName);
-      Assert.fail(String.format("Class %s should not be available from the parent class loader of the " +
-                                  "AuthorizerClassLoader, but it is.", aClassName));
+      authorizerClassLoader.loadClass(aClassName);
+      Assert.fail(String.format("Class %s should not be available from the authorizer class loader, " +
+                                  "but it is.", aClassName));
     } catch (ClassNotFoundException e) {
       // expected
     }

--- a/cdap-watchdog-api/pom.xml
+++ b/cdap-watchdog-api/pom.xml
@@ -53,6 +53,10 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/LogProcessor.java
+++ b/cdap-watchdog-api/src/main/java/co/cask/cdap/api/log/LogProcessor.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.api.log;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+import java.util.Iterator;
+import java.util.Properties;
+
+/**
+ * LogProcessor to receive log messages from CDAP log.saver
+ */
+public interface LogProcessor {
+
+  /**
+   * Called during initialize, passed properties for log processor
+   * @param properties
+   */
+  void initialize(Properties properties);
+
+  /**
+   * Process method will be called with iterator of log messages, log messages received will be in sorted order,
+   * sorted by timestamp. This method should not throw any exception, if any unchecked exceptions are thrown,
+   * log.saver will log an error and the processor will not receive messages.
+   * Will start receiving messages on log.saver startup
+   *
+   * @param events list of {@link ILoggingEvent}
+   */
+  void process(Iterator<ILoggingEvent> events);
+
+  /**
+   * stop logprocessor
+   */
+  void stop();
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/CustomLogProcessors.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/CustomLogProcessors.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.save;
+
+import co.cask.cdap.api.log.LogProcessor;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.lang.ClassLoaders;
+import co.cask.cdap.common.lang.ExtensionClassHelper;
+import co.cask.cdap.common.lang.ExtensionClassLoader;
+import co.cask.cdap.common.lang.InstantiatorFactory;
+import co.cask.cdap.common.lang.InvalidExtensionException;
+import co.cask.cdap.common.lang.jar.BundleJarUtil;
+import co.cask.cdap.common.utils.DirUtils;
+import com.google.common.base.Splitter;
+import com.google.common.base.Throwables;
+import com.google.common.reflect.TypeToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+import java.util.zip.ZipException;
+
+/**
+ * class used to instantiate and get custom log processors
+ */
+public class CustomLogProcessors {
+  private static final Logger LOG = LoggerFactory.getLogger(CustomLogProcessors.class);
+  private static final String JAR_PATH_SEPARATOR = ",";
+
+  private final CConfiguration cConf;
+  private final InstantiatorFactory instantiatorFactory;
+  private final String jarPath;
+
+  public CustomLogProcessors(CConfiguration cConf) {
+    this.cConf = cConf;
+    this.instantiatorFactory = new InstantiatorFactory(false);
+    this.jarPath = cConf.get(Constants.LogSaver.LOG_PROCESSOR_EXTENSION_JAR_PATH, "");
+  }
+
+  /**
+   * Get the list of custom log processors
+   * @return
+   * @throws Exception
+   */
+  public List<LogProcessor> getLogProcessors() throws Exception {
+    List<LogProcessor> logProcessors = new ArrayList<>();
+    if (!jarPath.isEmpty()) {
+      Iterator<String> jarPaths = Splitter.on(JAR_PATH_SEPARATOR).split(jarPath).iterator();
+      while (jarPaths.hasNext()) {
+        logProcessors.add(getLogProcessor(jarPaths.next()));
+      }
+    }
+    return logProcessors;
+  }
+
+  private LogProcessor getLogProcessor(String logProcessorPluginJarPath) throws Exception {
+    try {
+      LOG.info("Loading Log Processor Jar file at {}", logProcessorPluginJarPath);
+      File logProcessorExtenstionJar = new File(logProcessorPluginJarPath);
+      ExtensionClassHelper.ensureValidExtensionJar(logProcessorExtenstionJar, "LogProcessor",
+                                                   Constants.LogSaver.LOG_PROCESSOR_EXTENSION_JAR_PATH);
+      File absoluteTmpFile = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
+                                      cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
+      File tmpDir = DirUtils.createTempDir(absoluteTmpFile);
+      ExtensionClassLoader logProcessorClassLoader = createLogProcessorClassLoader(logProcessorExtenstionJar,
+                                                                                      tmpDir);
+      return createAndInitializeLogProcessor(logProcessorExtenstionJar, logProcessorClassLoader, tmpDir);
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  /**
+   * Get properties - properties that start with Constants.LogSaver.EXTENSION_CONFIG_PREFIX are obtained to populate
+   * properties
+   * @return
+   */
+  public Properties getLogProcessorExtensionProperties() {
+    return ExtensionClassHelper.createExtensionProperties(cConf, Constants.LogSaver.EXTENSION_CONFIG_PREFIX);
+  }
+
+  private ExtensionClassLoader createLogProcessorClassLoader(File logProcessorJar, File tmpDir)
+    throws IOException, InvalidExtensionException {
+    LOG.info("Creating log processor extension using jar {}.", logProcessorJar);
+    try {
+      BundleJarUtil.unJar(Locations.toLocation(logProcessorJar), tmpDir);
+      return new ExtensionClassLoader(tmpDir, CustomLogProcessors.class.getClassLoader(), LogProcessor.class);
+    } catch (ZipException e) {
+      throw new InvalidExtensionException(
+        String.format("Log Processor extension jar %s specified as %s must be a jar file.", logProcessorJar,
+                      Constants.LogSaver.LOG_PROCESSOR_EXTENSION_JAR_PATH), e
+      );
+    }
+  }
+
+  private LogProcessor createAndInitializeLogProcessor(File logProcessorJar,
+                                                       ExtensionClassLoader logProcessorClassLoader,
+                                                       File tmpDir) throws IOException, InvalidExtensionException {
+
+    Class<? extends LogProcessor> logProcessorClass =
+      ExtensionClassHelper.loadExtensionClass(logProcessorJar, logProcessorClassLoader,
+                                              LogProcessor.class, tmpDir, "LogProcessor",
+                                              LogProcessor.class.getName());
+    // Set the context class loader to the LogProcessorClassLoader before creating a new instance of the extension,
+    // so all classes required in this process are created from the LogProcessorClassLoader.
+    ClassLoader oldClassLoader = ClassLoaders.setContextClassLoader(logProcessorClassLoader);
+    LOG.debug("Setting context classloader to {}. Old classloader was {}.", logProcessorClassLoader, oldClassLoader);
+    try {
+      LogProcessor logProcessor;
+      try {
+        logProcessor = instantiatorFactory.get(TypeToken.of(logProcessorClass)).create();
+      } catch (Exception e) {
+        throw new InvalidExtensionException(
+          String.format("Error while instantiating for log processor extension %s." +
+                          "Please make sure that the extension " +
+                          "is a public class with a default constructor.", logProcessorClass.getName()), e);
+      }
+
+      return logProcessor;
+    } finally {
+      // After the process of creation of a new instance has completed (success or failure), reset the context
+      // classloader back to the original class loader.
+      ClassLoaders.setContextClassLoader(oldClassLoader);
+      LOG.debug("Resetting context classloader to {} from {}.", oldClassLoader, logProcessorClassLoader);
+    }
+  }
+
+}

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/processor/CountingLogProcessor.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/processor/CountingLogProcessor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.processor;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import co.cask.cdap.api.log.LogProcessor;
+import com.google.common.base.Throwables;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.Iterator;
+import java.util.Properties;
+
+/**
+ * log processor that counts the events received - used by test case in
+ * {@link co.cask.cdap.logging.save.LogSaverPluginTest}
+ */
+public class CountingLogProcessor implements LogProcessor {
+  private int counter;
+  private File outputFile;
+
+  @Override
+  public void initialize(Properties properties) {
+    counter = 0;
+    outputFile = new File(properties.getProperty("output.file"));
+  }
+
+  @Override
+  public void process(Iterator<ILoggingEvent> events) {
+    while (events.hasNext()) {
+      counter++;
+      events.next();
+    }
+  }
+
+  @Override
+  public void stop() {
+    try (FileOutputStream fos = new FileOutputStream(outputFile)) {
+      fos.write(counter);
+      fos.flush();
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+}


### PR DESCRIPTION
Code Changes 
1) Added LogProcessor Interface in cdap-watch-dog API, that external applications can implement for processing logs from log.saver
2) The jar's for log.processor extensions and their properties would be specified through cdap-site.xml similar to how its performed in Authorizer.
3) Refactored AuthorizerInstantiator and AuthorizerClassLoader into ExtensionInstantiatorHelper and ExtensionClassLoader classes in cdap-common for reusability.
4) Test cases to check custom log.processor logic in LogSaverPlugin Test.

Pending
Testing on distributed.