### PR TITLE
Do not trace input record for source and output record for sink

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/TransformExecutorFactory.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/TransformExecutorFactory.java
@@ -116,7 +116,7 @@ public abstract class TransformExecutorFactory<T> {
                                                                              StageMetrics stageMetrics,
                                                                              DataTracer dataTracer) {
     return new TrackedTransform<>(transform, stageMetrics, TrackedTransform.RECORDS_IN, null, dataTracer,
-                                  TrackedTransform.RECORDS_IN);
+                                  TrackedTransform.RECORDS_IN, null);
   }
 
   protected static <IN, OUT> TrackedTransform<IN, OUT> getTrackedAggregateStep(Transformation<IN, OUT> transform,
@@ -124,12 +124,13 @@ public abstract class TransformExecutorFactory<T> {
                                                                                DataTracer dataTracer) {
     // 'aggregator.groups' is the number of groups output by the aggregator
     return new TrackedTransform<>(transform, stageMetrics, "aggregator.groups", TrackedTransform.RECORDS_OUT,
-                                  dataTracer, null);
+                                  dataTracer, null, TrackedTransform.RECORDS_OUT);
   }
 
   protected static <IN, OUT> TrackedTransform<IN, OUT> getTrackedMergeStep(Transformation<IN, OUT> transform,
                                                                            StageMetrics stageMetrics,
                                                                            DataTracer dataTracer) {
-    return new TrackedTransform<>(transform, stageMetrics, null, TrackedTransform.RECORDS_OUT, dataTracer, null);
+    return new TrackedTransform<>(transform, stageMetrics, null, TrackedTransform.RECORDS_OUT, dataTracer, null,
+                                  TrackedTransform.RECORDS_OUT);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceTransformExecutorFactory.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceTransformExecutorFactory.java
@@ -30,6 +30,8 @@ import co.cask.cdap.etl.api.batch.BatchAggregator;
 import co.cask.cdap.etl.api.batch.BatchJoiner;
 import co.cask.cdap.etl.api.batch.BatchJoinerRuntimeContext;
 import co.cask.cdap.etl.api.batch.BatchRuntimeContext;
+import co.cask.cdap.etl.api.batch.BatchSink;
+import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.batch.KVTransformations;
 import co.cask.cdap.etl.batch.PipelinePluginInstantiator;
 import co.cask.cdap.etl.batch.TransformExecutorFactory;
@@ -150,7 +152,9 @@ public class MapReduceTransformExecutorFactory<T> extends TransformExecutorFacto
     }
     return new TrackedTransform(KVTransformations.getKVTransformation(stageName, pluginType, isMapPhase,
                                                                       getInitializedTransformation(stageName)),
-                                       stageMetrics, taskContext.getDataTracer(stageName));
+                                stageMetrics, taskContext.getDataTracer(stageName),
+                                BatchSource.PLUGIN_TYPE.equals(pluginType) ? null : TrackedTransform.RECORDS_IN,
+                                BatchSink.PLUGIN_TYPE.equals(pluginType) ? null : TrackedTransform.RECORDS_OUT);
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TrackedEmitter.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TrackedEmitter.java
@@ -21,6 +21,8 @@ import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.InvalidEntry;
 import co.cask.cdap.etl.api.StageMetrics;
 
+import javax.annotation.Nullable;
+
 /**
  * Wrapper around another emitter that tracks how many records were emitted.
  *
@@ -31,20 +33,23 @@ public class TrackedEmitter<T> implements Emitter<T> {
   private final Emitter<T> delegate;
   private final StageMetrics stageMetrics;
   private final String emitMetricName;
+  private final String previewOutName;
   private final DataTracer dataTracer;
 
-  public TrackedEmitter(Emitter<T> delegate, StageMetrics stageMetrics, String emitMetricName, DataTracer dataTracer) {
+  public TrackedEmitter(Emitter<T> delegate, StageMetrics stageMetrics, String emitMetricName, DataTracer dataTracer,
+                        @Nullable String previewOutName) {
     this.delegate = delegate;
     this.stageMetrics = stageMetrics;
     this.emitMetricName = emitMetricName;
     this.dataTracer = dataTracer;
+    this.previewOutName = previewOutName;
   }
 
   @Override
   public void emit(T value) {
     delegate.emit(value);
     stageMetrics.count(emitMetricName, 1);
-    if (dataTracer.isEnabled()) {
+    if (dataTracer.isEnabled() && previewOutName != null) {
       dataTracer.info(emitMetricName, value);
     }
   }
@@ -53,7 +58,7 @@ public class TrackedEmitter<T> implements Emitter<T> {
   public void emitError(InvalidEntry<T> value) {
     delegate.emitError(value);
     stageMetrics.count(RECORDS_ERROR, 1);
-    if (dataTracer.isEnabled()) {
+    if (dataTracer.isEnabled() && previewOutName != null) {
       dataTracer.info(RECORDS_ERROR, value);
     }
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TrackedTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TrackedTransform.java
@@ -39,21 +39,28 @@ public class TrackedTransform<IN, OUT> implements Transformation<IN, OUT>, Destr
   private final String metricInName;
   private final String metricOutName;
   private final String previewInName;
+  private final String previewOutName;
   private final DataTracer dataTracer;
 
   public TrackedTransform(Transformation<IN, OUT> transform, StageMetrics metrics, DataTracer dataTracer) {
-    this(transform, metrics, RECORDS_IN, RECORDS_OUT, dataTracer, RECORDS_IN);
+    this(transform, metrics, RECORDS_IN, RECORDS_OUT, dataTracer, RECORDS_IN, RECORDS_OUT);
+  }
+
+  public TrackedTransform(Transformation<IN, OUT> transform, StageMetrics metrics, DataTracer dataTracer,
+                          @Nullable String previewInName, @Nullable String previewOutName) {
+    this(transform, metrics, RECORDS_IN, RECORDS_OUT, dataTracer, previewInName, previewOutName);
   }
 
   public TrackedTransform(Transformation<IN, OUT> transform, StageMetrics metrics,
                           @Nullable String metricInName, @Nullable String metricOutName, DataTracer dataTracer,
-                          String previewInName) {
+                          @Nullable String previewInName, @Nullable String previewOutName) {
     this.transform = transform;
     this.metrics = metrics;
     this.metricInName = metricInName;
     this.metricOutName = metricOutName;
     this.dataTracer = dataTracer;
     this.previewInName = previewInName;
+    this.previewOutName = previewOutName;
   }
 
   @Override
@@ -65,7 +72,7 @@ public class TrackedTransform<IN, OUT> implements Transformation<IN, OUT>, Destr
       dataTracer.info(previewInName, input);
     }
     transform.transform(input, metricOutName == null ? emitter :
-      new TrackedEmitter<>(emitter, metrics, metricOutName, dataTracer));
+      new TrackedEmitter<>(emitter, metrics, metricOutName, dataTracer, previewOutName));
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/etl/realtime/ETLWorker.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/etl/realtime/ETLWorker.java
@@ -264,7 +264,7 @@ public class ETLWorker extends AbstractWorker {
                                                                new DefaultStageMetrics(metrics, sinkName),
                                                                TrackedTransform.RECORDS_IN,
                                                                null, context.getDataTracer(sinkName),
-                                                               TrackedTransform.RECORDS_IN);
+                                                               TrackedTransform.RECORDS_IN, null);
       transformationMap.put(sinkInfo.getName(), new TransformDetail(trackedTransform, new HashSet<String>()));
       sinks.put(sinkInfo.getName(), sink);
     }
@@ -331,7 +331,8 @@ public class ETLWorker extends AbstractWorker {
     TrackedEmitter<Object> trackedSourceEmitter =
       new TrackedEmitter<>(sourceEmitter,
                            new DefaultStageMetrics(metrics, sourceStageName),
-                           TrackedTransform.RECORDS_OUT, context.getDataTracer(sourceStageName));
+                           TrackedTransform.RECORDS_OUT, context.getDataTracer(sourceStageName),
+                           TrackedTransform.RECORDS_OUT);
     while (!stopped) {
       // Invoke poll method of the source to fetch data
       try {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/AggregatorAggregateFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/AggregatorAggregateFunction.java
@@ -51,7 +51,7 @@ public class AggregatorAggregateFunction<GROUP_KEY, GROUP_VAL, OUT>
                                                   pluginFunctionContext.createStageMetrics(),
                                                   "aggregator.groups",
                                                   TrackedTransform.RECORDS_OUT, pluginFunctionContext.getDataTracer(),
-                                                  null);
+                                                  null, TrackedTransform.RECORDS_OUT);
       emitter = new DefaultEmitter<>();
     }
     emitter.reset();

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/AggregatorGroupByFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/AggregatorGroupByFunction.java
@@ -50,7 +50,7 @@ public class AggregatorGroupByFunction<GROUP_KEY, GROUP_VAL>
                                                pluginFunctionContext.createStageMetrics(),
                                                TrackedTransform.RECORDS_IN,
                                                null, pluginFunctionContext.getDataTracer(),
-                                               TrackedTransform.RECORDS_IN);
+                                               TrackedTransform.RECORDS_IN, null);
       emitter = new DefaultEmitter<>();
     }
     emitter.reset();

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/BatchSinkFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/BatchSinkFunction.java
@@ -43,7 +43,7 @@ public class BatchSinkFunction implements PairFlatMapFunction<Object, Object, Ob
       BatchSink<Object, Object, Object> batchSink = pluginFunctionContext.createPlugin();
       batchSink.initialize(pluginFunctionContext.createBatchRuntimeContext());
       transform = new TrackedTransform<>(batchSink, pluginFunctionContext.createStageMetrics(),
-                                         pluginFunctionContext.getDataTracer());
+                                         pluginFunctionContext.getDataTracer(), TrackedTransform.RECORDS_IN, null);
       emitter = new TransformingEmitter<>(new Function<KeyValue<Object, Object>, Tuple2<Object, Object>>() {
         @Override
         public Tuple2<Object, Object> apply(KeyValue<Object, Object> input) {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/BatchSourceFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/BatchSourceFunction.java
@@ -42,7 +42,7 @@ public class BatchSourceFunction implements FlatMapFunction<Tuple2<Object, Objec
       BatchSource<Object, Object, Object> batchSource = pluginFunctionContext.createPlugin();
       batchSource.initialize(pluginFunctionContext.createBatchRuntimeContext());
       transform = new TrackedTransform<>(batchSource, pluginFunctionContext.createStageMetrics(),
-                                         pluginFunctionContext.getDataTracer());
+                                         pluginFunctionContext.getDataTracer(), null, TrackedTransform.RECORDS_OUT);
       emitter = new DefaultEmitter<>();
     }
     emitter.reset();

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/JoinMergeFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/JoinMergeFunction.java
@@ -55,7 +55,8 @@ public class JoinMergeFunction<JOIN_KEY, INPUT_RECORD, OUT>
       joinFunction = new TrackedTransform<>(new JoinOnTransform<>(joiner),
                                             pluginFunctionContext.createStageMetrics(),
                                             "joiner.keys",
-                                            TrackedTransform.RECORDS_OUT, pluginFunctionContext.getDataTracer(), null);
+                                            TrackedTransform.RECORDS_OUT, pluginFunctionContext.getDataTracer(), null,
+                                            TrackedTransform.RECORDS_OUT);
       emitter = new DefaultEmitter<>();
     }
     emitter.reset();

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/JoinOnFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/JoinOnFunction.java
@@ -52,10 +52,10 @@ public class JoinOnFunction<JOIN_KEY, INPUT_RECORD>
       BatchJoinerRuntimeContext context = pluginFunctionContext.createJoinerRuntimeContext();
       joiner.initialize(context);
       joinFunction = new TrackedTransform<>(new JoinOnTransform<>(joiner, inputStageName),
-                                               pluginFunctionContext.createStageMetrics(),
-                                               TrackedTransform.RECORDS_IN,
-                                               null, pluginFunctionContext.getDataTracer(),
-                                               TrackedTransform.RECORDS_IN);
+                                            pluginFunctionContext.createStageMetrics(),
+                                            TrackedTransform.RECORDS_IN,
+                                            null, pluginFunctionContext.getDataTracer(),
+                                            TrackedTransform.RECORDS_IN, null);
       emitter = new DefaultEmitter<>();
     }
     emitter.reset();


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/HYDRATOR-1123
Build: http://builds.cask.co/browse/CDAP-DUT5116-2
Since we are not sure about the data type of source and sink, we will not trace them using PreviewStore