### PR TITLE
CDAP-7409 TMS TTL Cleanup in HBase and LevelDB tables

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -1084,6 +1084,11 @@ public final class Constants {
 
     // The name of the HBase table attribute to store the bucket size being used by the RowKeyDistributor
     public static final String KEY_DISTRIBUTOR_BUCKETS_ATTR = "cdap.messaging.key.distributor.buckets";
+    public static final String TABLE_PREFIX_BYTES = "cdap.messaging.table.prefix.bytes";
+    public static final String HBASE_METADATA_TABLE_NAME = "cdap.messaging.metadata.table.name";
+    public static final String HBASE_METADATA_TABLE_NAMESPACE = "cdap.messaging.metadata.hbase.namespace";
+
+    public static final String COPROCESSOR_DIR = "messaging.coprocessor.dir";
   }
 
   /**

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -1070,6 +1070,7 @@ public final class Constants {
    */
   public static final class MessagingSystem {
     public static final String LOCAL_DATA_DIR = "messaging.local.data.dir";
+    public static final String LOCAL_TTL_CLEANUP_FREQUENCY = "messaging.local.data.ttl.cleanup.frequency";
 
     public static final String HBASE_MAX_SCAN_THREADS = "messaging.hbase.max.scan.threads";
     public static final String METADATA_TABLE_NAME = "messaging.metadata.table.name";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1141,6 +1141,11 @@
     <description>Number of seconds after which the messaging table cache will expire</description>
   </property>
 
+  <property>
+    <name>messaging.coprocessor.dir</name>
+    <value>/tms</value>
+    <description>Directory to store Messaging Service Table coprocessors</description>
+  </property>
 
   <!-- Metadata Configuration -->
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1101,6 +1101,12 @@
   </property>
 
   <property>
+    <name>messaging.local.data.ttl.cleanup.frequency</name>
+    <value>3600</value>
+    <description>Scheduling frequency of TTL cleanup thread in seconds (only used in Standalone CDAP)</description>
+  </property>
+
+  <property>
     <name>messaging.hbase.max.scan.threads</name>
     <value>48</value>
   </property>

--- a/cdap-hbase-compat-0.98/pom.xml
+++ b/cdap-hbase-compat-0.98/pom.xml
@@ -57,6 +57,17 @@
     </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-tms</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-hbase-compat-base</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase98/MessageTableRegionObserver.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase98/MessageTableRegionObserver.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.messaging.coprocessor.hbase98;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.HTable98NameConverter;
+import co.cask.cdap.data2.util.hbase.HTableNameConverter;
+import co.cask.cdap.messaging.MessagingUtils;
+import co.cask.cdap.messaging.TopicMetadata;
+import co.cask.cdap.messaging.store.ImmutableMessageTableEntry;
+import co.cask.cdap.messaging.store.hbase.HBaseMetadataTable;
+import co.cask.cdap.messaging.store.hbase.HBaseTableFactory;
+import co.cask.cdap.proto.id.TopicId;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CoprocessorEnvironment;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.HTableInterface;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.filter.FilterBase;
+import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.KeyValueScanner;
+import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.regionserver.Store;
+import org.apache.hadoop.hbase.regionserver.StoreScanner;
+import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * RegionObserver for the Message Table of Transactional Messaging Service.
+ *
+ * This region observer does row eviction during flush time and compact time by using Time-To-Live (TTL) information
+ * in MetadataTable to determine if a message has expired its TTL.
+ *
+ * TODO: Add logic to remove data corresponding to invalidated transactions
+ */
+public class MessageTableRegionObserver extends BaseRegionObserver {
+
+  private static final Log LOG = LogFactory.getLog(MessageTableRegionObserver.class);
+  private static final Gson GSON = new Gson();
+  private static final Type MAP_TYPE = new TypeToken<SortedMap<String, String>>() { }.getType();
+
+  private static final byte[] COL_FAMILY = HBaseTableFactory.COLUMN_FAMILY;
+  private static final byte[] COL = HBaseMetadataTable.COL;
+
+  private int prefixLength;
+  private LoadingCache<TopicId, TopicMetadata> topicCache;
+  private HTableInterface metadataTable;
+
+  @Override
+  public void start(CoprocessorEnvironment env) throws IOException {
+    if (env instanceof RegionCoprocessorEnvironment) {
+      HTableDescriptor tableDesc = ((RegionCoprocessorEnvironment) env).getRegion().getTableDesc();
+      prefixLength = Integer.parseInt(tableDesc.getValue(Constants.MessagingSystem.TABLE_PREFIX_BYTES));
+      String metadataTableNamespace = tableDesc.getValue(Constants.MessagingSystem.HBASE_METADATA_TABLE_NAMESPACE);
+      String metadataTableName = tableDesc.getValue(Constants.MessagingSystem.HBASE_METADATA_TABLE_NAME);
+      String hbaseNamespacePrefix = tableDesc.getValue(Constants.Dataset.TABLE_PREFIX);
+      HTableNameConverter nameConverter = new HTable98NameConverter();
+      metadataTable = env.getTable(nameConverter.toTableName(hbaseNamespacePrefix,
+                                                             TableId.from(metadataTableNamespace, metadataTableName)));
+      topicCache = CacheBuilder.newBuilder()
+        .expireAfterWrite(2, TimeUnit.MINUTES)
+        .maximumSize(1000)
+        .build(new CacheLoader<TopicId, TopicMetadata>() {
+
+          @Override
+          public TopicMetadata load(TopicId topicId) throws Exception {
+            Get get = new Get(MessagingUtils.toRowKeyPrefix(topicId));
+            Result result = metadataTable.get(get);
+            byte[] properties = result.getValue(COL_FAMILY, COL);
+            Map<String, String> propertyMap = GSON.fromJson(Bytes.toString(properties), MAP_TYPE);
+            return new TopicMetadata(topicId, propertyMap);
+          }
+        });
+    }
+  }
+
+  @Override
+  public InternalScanner preFlushScannerOpen(ObserverContext<RegionCoprocessorEnvironment> c, Store store,
+                                             KeyValueScanner memstoreScanner, InternalScanner s) throws IOException {
+    LOG.info("preFlush, filter using TTLFilter");
+    Scan scan = new Scan();
+    scan.setFilter(new TTLFilter(c.getEnvironment(), System.currentTimeMillis()));
+    return new StoreScanner(store, store.getScanInfo(), scan, Collections.singletonList(memstoreScanner),
+                            ScanType.COMPACT_DROP_DELETES, store.getSmallestReadPoint(), HConstants.OLDEST_TIMESTAMP);
+  }
+
+  @Override
+  public InternalScanner preCompactScannerOpen(ObserverContext<RegionCoprocessorEnvironment> c, Store store,
+                                               List<? extends KeyValueScanner> scanners, ScanType scanType,
+                                               long earliestPutTs, InternalScanner s,
+                                               CompactionRequest request) throws IOException {
+    LOG.info("preCompact, filter using TTLFilter");
+    Scan scan = new Scan();
+    scan.setFilter(new TTLFilter(c.getEnvironment(), System.currentTimeMillis()));
+    return new StoreScanner(store, store.getScanInfo(), scan, scanners, scanType, store.getSmallestReadPoint(),
+                            earliestPutTs);
+  }
+
+  private final class TTLFilter extends FilterBase {
+    private final RegionCoprocessorEnvironment env;
+    private final long timestamp;
+
+    TTLFilter(RegionCoprocessorEnvironment env, long timestamp) {
+      this.env = env;
+      this.timestamp = timestamp;
+    }
+
+    @Override
+    public ReturnCode filterKeyValue(Cell cell) throws IOException {
+      byte[] rowKey = Arrays.copyOfRange(cell.getRow(), prefixLength, cell.getRowLength());
+      ImmutableMessageTableEntry entry = new ImmutableMessageTableEntry(rowKey, null, null);
+      try {
+        TopicMetadata metadata = topicCache.get(entry.getTopicId());
+        if ((timestamp - entry.getPublishTimestamp()) > TimeUnit.SECONDS.toMillis(metadata.getTTL())) {
+          return ReturnCode.SKIP;
+        }
+      } catch (ExecutionException ex) {
+        LOG.debug("Region " + env.getRegion().getRegionNameAsString() + ", exception while" +
+                    "trying to fetch properties of topicId" + entry.getTopicId(), ex);
+      }
+      return ReturnCode.INCLUDE;
+    }
+  }
+}

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase98/PayloadTableRegionObserver.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase98/PayloadTableRegionObserver.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction.messaging.coprocessor.hbase98;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.HTable98NameConverter;
+import co.cask.cdap.data2.util.hbase.HTableNameConverter;
+import co.cask.cdap.messaging.MessagingUtils;
+import co.cask.cdap.messaging.TopicMetadata;
+import co.cask.cdap.messaging.store.ImmutablePayloadTableEntry;
+import co.cask.cdap.messaging.store.hbase.HBaseMetadataTable;
+import co.cask.cdap.messaging.store.hbase.HBaseTableFactory;
+import co.cask.cdap.proto.id.TopicId;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CoprocessorEnvironment;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.HTableInterface;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.filter.FilterBase;
+import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.KeyValueScanner;
+import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.regionserver.Store;
+import org.apache.hadoop.hbase.regionserver.StoreScanner;
+import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * RegionObserver for the Payload Table of Transactional Messaging Service.
+ *
+ * This region observer does row eviction during flush time and compact time by using Time-To-Live (TTL) information
+ * in MetadataTable to determine if a message has expired its TTL.
+ *
+ * TODO: Add logic to remove data corresponding to invalidated transactions
+ */
+public class PayloadTableRegionObserver extends BaseRegionObserver {
+
+  private static final Log LOG = LogFactory.getLog(PayloadTableRegionObserver.class);
+  private static final Gson GSON = new Gson();
+  private static final Type MAP_TYPE = new TypeToken<SortedMap<String, String>>() { }.getType();
+
+  private static final byte[] COL_FAMILY = HBaseTableFactory.COLUMN_FAMILY;
+  private static final byte[] COL = HBaseMetadataTable.COL;
+
+  private int prefixLength;
+  private LoadingCache<TopicId, TopicMetadata> topicCache;
+  private HTableInterface metadataTable;
+
+  @Override
+  public void start(CoprocessorEnvironment env) throws IOException {
+    if (env instanceof RegionCoprocessorEnvironment) {
+      HTableDescriptor tableDesc = ((RegionCoprocessorEnvironment) env).getRegion().getTableDesc();
+      prefixLength = Integer.parseInt(tableDesc.getValue(Constants.MessagingSystem.TABLE_PREFIX_BYTES));
+      String metadataTableNamespace = tableDesc.getValue(Constants.MessagingSystem.HBASE_METADATA_TABLE_NAMESPACE);
+      String metadataTableName = tableDesc.getValue(Constants.MessagingSystem.HBASE_METADATA_TABLE_NAME);
+      String hbaseNamespacePrefix = tableDesc.getValue(Constants.Dataset.TABLE_PREFIX);
+      HTableNameConverter nameConverter = new HTable98NameConverter();
+      metadataTable = env.getTable(nameConverter.toTableName(hbaseNamespacePrefix,
+                                                             TableId.from(metadataTableNamespace, metadataTableName)));
+      topicCache = CacheBuilder.newBuilder()
+        .expireAfterWrite(2, TimeUnit.MINUTES)
+        .maximumSize(1000)
+        .build(new CacheLoader<TopicId, TopicMetadata>() {
+
+          @Override
+          public TopicMetadata load(TopicId topicId) throws Exception {
+            Get get = new Get(MessagingUtils.toRowKeyPrefix(topicId));
+            Result result = metadataTable.get(get);
+            byte[] properties = result.getValue(COL_FAMILY, COL);
+            Map<String, String> propertyMap = GSON.fromJson(Bytes.toString(properties), MAP_TYPE);
+            return new TopicMetadata(topicId, propertyMap);
+          }
+        });
+    }
+  }
+
+  @Override
+  public InternalScanner preFlushScannerOpen(ObserverContext<RegionCoprocessorEnvironment> c, Store store,
+                                             KeyValueScanner memstoreScanner, InternalScanner s) throws IOException {
+    LOG.info("preFlush, filter using TTLFilter");
+    Scan scan = new Scan();
+    scan.setFilter(new TTLFilter(c.getEnvironment(), System.currentTimeMillis()));
+    return new StoreScanner(store, store.getScanInfo(), scan, Collections.singletonList(memstoreScanner),
+                            ScanType.COMPACT_DROP_DELETES, store.getSmallestReadPoint(), HConstants.OLDEST_TIMESTAMP);
+  }
+
+  @Override
+  public InternalScanner preCompactScannerOpen(ObserverContext<RegionCoprocessorEnvironment> c, Store store,
+                                               List<? extends KeyValueScanner> scanners, ScanType scanType,
+                                               long earliestPutTs, InternalScanner s,
+                                               CompactionRequest request) throws IOException {
+    LOG.info("preCompact, filter using TTLFilter");
+    Scan scan = new Scan();
+    scan.setFilter(new TTLFilter(c.getEnvironment(), System.currentTimeMillis()));
+    return new StoreScanner(store, store.getScanInfo(), scan, scanners, scanType, store.getSmallestReadPoint(),
+                            earliestPutTs);
+  }
+
+  private final class TTLFilter extends FilterBase {
+    private final RegionCoprocessorEnvironment env;
+    private final long timestamp;
+
+    TTLFilter(RegionCoprocessorEnvironment env, long timestamp) {
+      this.env = env;
+      this.timestamp = timestamp;
+    }
+
+    @Override
+    public ReturnCode filterKeyValue(Cell cell) throws IOException {
+      byte[] rowKey = Arrays.copyOfRange(cell.getRow(), prefixLength, cell.getRowLength());
+      ImmutablePayloadTableEntry entry = new ImmutablePayloadTableEntry(rowKey, null);
+      try {
+        TopicMetadata metadata = topicCache.get(entry.getTopicId());
+        if ((timestamp - entry.getPayloadWriteTimestamp()) > TimeUnit.SECONDS.toMillis(metadata.getTTL())) {
+          return ReturnCode.SKIP;
+        }
+      } catch (ExecutionException ex) {
+        LOG.debug("Region " + env.getRegion().getRegionNameAsString() + ", exception while" +
+                    "trying to fetch properties of topicId" + entry.getTopicId(), ex);
+      }
+      return ReturnCode.INCLUDE;
+    }
+  }
+}

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableUtil.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableUtil.java
@@ -18,6 +18,8 @@ package co.cask.cdap.data2.util.hbase;
 
 import co.cask.cdap.data2.increment.hbase98.IncrementHandler;
 import co.cask.cdap.data2.transaction.coprocessor.hbase98.DefaultTransactionProcessor;
+import co.cask.cdap.data2.transaction.messaging.coprocessor.hbase98.MessageTableRegionObserver;
+import co.cask.cdap.data2.transaction.messaging.coprocessor.hbase98.PayloadTableRegionObserver;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase98.DequeueScanObserver;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase98.HBaseQueueRegionObserver;
 import co.cask.cdap.data2.util.TableId;
@@ -255,6 +257,16 @@ public class HBase98TableUtil extends HBaseTableUtil {
   @Override
   public Class<? extends Coprocessor> getIncrementHandlerClassForVersion() {
     return IncrementHandler.class;
+  }
+
+  @Override
+  public Class<? extends Coprocessor> getMessageTableRegionObserverClassForVersion() {
+    return MessageTableRegionObserver.class;
+  }
+
+  @Override
+  public Class<? extends Coprocessor> getPayloadTableRegionObserverClassForVersion() {
+    return PayloadTableRegionObserver.class;
   }
 
   @Override

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
@@ -750,6 +750,8 @@ public abstract class HBaseTableUtil {
   public abstract Class<? extends Coprocessor> getQueueRegionObserverClassForVersion();
   public abstract Class<? extends Coprocessor> getDequeueScanObserverClassForVersion();
   public abstract Class<? extends Coprocessor> getIncrementHandlerClassForVersion();
+  public abstract Class<? extends Coprocessor> getMessageTableRegionObserverClassForVersion();
+  public abstract Class<? extends Coprocessor> getPayloadTableRegionObserverClassForVersion();
 
   protected abstract HTableNameConverter getHTableNameConverter();
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -238,6 +238,7 @@ public class MasterServiceMain extends DaemonMain {
     createDirectory("twill");
     createDirectory(cConf.get(QueueConstants.ConfigKeys.QUEUE_TABLE_COPROCESSOR_DIR,
                               QueueConstants.DEFAULT_QUEUE_TABLE_COPROCESSOR_DIR));
+    createDirectory(cConf.get(Constants.MessagingSystem.COPROCESSOR_DIR));
     createSystemHBaseNamespace();
     updateConfigurationTable();
     Services.startAndWait(zkClient, cConf.getLong(Constants.Zookeeper.CLIENT_STARTUP_TIMEOUT_MILLIS),

--- a/cdap-tms-tests/pom.xml
+++ b/cdap-tms-tests/pom.xml
@@ -26,8 +26,8 @@
     <version>4.0.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>cdap-tms</artifactId>
-  <name>CDAP Transactional Messaging System</name>
+  <artifactId>cdap-tms-tests</artifactId>
+  <name>CDAP Transactional Messaging System Tests</name>
   <packaging>jar</packaging>
 
   <dependencies>
@@ -76,6 +76,20 @@
       <artifactId>hbase-server</artifactId>
       <scope>provided</scope>
     </dependency>
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-server</artifactId>
+      <version>${hbase98.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
 
     <dependency>
       <groupId>co.cask.cdap</groupId>
@@ -88,6 +102,32 @@
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-tms</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-tms</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-hbase-compat-0.98</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-hbase-compat-0.98</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>test-jar</type>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
@@ -114,23 +154,5 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.4</version>
-        <executions>
-          <execution>
-            <id>test-jar</id>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 
 </project>

--- a/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseMessageTTLCoprocessorTestRun.java
+++ b/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseMessageTTLCoprocessorTestRun.java
@@ -15,8 +15,6 @@
  */
 package co.cask.cdap.messaging.store.hbase;
 
-import co.cask.cdap.api.common.Bytes;
-import co.cask.cdap.api.dataset.lib.CloseableIterator;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
@@ -27,36 +25,27 @@ import co.cask.cdap.data2.transaction.messaging.coprocessor.hbase98.MessageTable
 import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
-import co.cask.cdap.messaging.TopicMetadata;
-import co.cask.cdap.messaging.data.MessageId;
 import co.cask.cdap.messaging.store.MessageTable;
 import co.cask.cdap.messaging.store.MetadataTable;
 import co.cask.cdap.messaging.store.PayloadTable;
+import co.cask.cdap.messaging.store.TTLCleanupTest;
 import co.cask.cdap.messaging.store.TableFactory;
 import co.cask.cdap.proto.id.NamespaceId;
-import co.cask.cdap.proto.id.TopicId;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.twill.filesystem.LocationFactory;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Test;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TemporaryFolder;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
 
 /**
  * Tests for {@link HBaseMessageTable} coprocessor {@link MessageTableRegionObserver}.
  */
-public class HBaseMessageTTLCoprocessorTestRun {
+public class HBaseMessageTTLCoprocessorTestRun extends TTLCleanupTest {
 
   @ClassRule
   public static final ExternalResource TEST_BASE = HBaseMessageTestSuite.TEST_BASE;
@@ -95,202 +84,34 @@ public class HBaseMessageTTLCoprocessorTestRun {
     tableUtil.deleteNamespaceIfExists(hBaseAdmin, tableUtil.getHBaseNamespace(NamespaceId.SYSTEM));
   }
 
-  @Test
-  public void testPayloadTableCompaction() throws Exception {
-    try (MetadataTable metadataTable = getMetadataTable();
-         PayloadTable payloadTable = getPayloadTable()) {
-      TableId tableId = tableUtil.createHTableId(NamespaceId.SYSTEM,
-                                                 cConf.get(Constants.MessagingSystem.PAYLOAD_TABLE_NAME));
-      TopicId topicId = NamespaceId.DEFAULT.topic("t1");
-      byte[] tableName = tableUtil.getHTableDescriptor(hBaseAdmin, tableId).getName();
-      TopicMetadata topic = new TopicMetadata(topicId, "ttl", "3");
-      metadataTable.createTopic(topic);
-      List<PayloadTable.Entry> entries = new ArrayList<>();
-      entries.add(new TestPayloadEntry(topicId, "payloaddata", 101, (short) 0));
-      payloadTable.store(entries.iterator());
-
-      byte[] messageId = new byte[MessageId.RAW_ID_SIZE];
-      MessageId.putRawId(0L, (short) 0, 0L, (short) 0, messageId, 0);
-      CloseableIterator<PayloadTable.Entry> iterator = payloadTable.fetch(topicId, 101L, new MessageId(messageId), true,
-                                                                          Integer.MAX_VALUE);
-      Assert.assertTrue(iterator.hasNext());
-      PayloadTable.Entry entry = iterator.next();
-      Assert.assertFalse(iterator.hasNext());
-      Assert.assertEquals("payloaddata", Bytes.toString(entry.getPayload()));
-      Assert.assertEquals(101L, entry.getTransactionWritePointer());
-      iterator.close();
-
-      HBASE_TEST_BASE.forceRegionFlush(tableName);
-      HBASE_TEST_BASE.forceRegionCompact(tableName, true);
-
-      //Entry should still be there since ttl has not expired
-      iterator = payloadTable.fetch(topicId, 101L, new MessageId(messageId), true, Integer.MAX_VALUE);
-      Assert.assertTrue(iterator.hasNext());
-      entry = iterator.next();
-      Assert.assertFalse(iterator.hasNext());
-      Assert.assertEquals("payloaddata", Bytes.toString(entry.getPayload()));
-      Assert.assertEquals(101L, entry.getTransactionWritePointer());
-      iterator.close();
-
-      TimeUnit.SECONDS.sleep(3);
-      HBASE_TEST_BASE.forceRegionFlush(tableName);
-      HBASE_TEST_BASE.forceRegionCompact(tableName, true);
-
-      iterator = payloadTable.fetch(topicId, 101L, new MessageId(messageId), true, Integer.MAX_VALUE);
-      Assert.assertFalse(iterator.hasNext());
-      iterator.close();
-
-      // Update the TTL so that read filter will still try to read the old flushed data
-      metadataTable.updateTopic(new TopicMetadata(topicId, "ttl", "60"));
-      iterator = payloadTable.fetch(topicId, 101L, new MessageId(messageId), true, Integer.MAX_VALUE);
-      Assert.assertFalse(iterator.hasNext());
-      iterator.close();
-      metadataTable.deleteTopic(topicId);
+  @Override
+  protected void forceFlushAndCompact(Table table) throws Exception {
+    TableId tableId;
+    if (table.equals(Table.MESSAGE)) {
+      tableId = tableUtil.createHTableId(NamespaceId.SYSTEM, cConf.get(Constants.MessagingSystem.MESSAGE_TABLE_NAME));
+    } else {
+      tableId = tableUtil.createHTableId(NamespaceId.SYSTEM, cConf.get(Constants.MessagingSystem.PAYLOAD_TABLE_NAME));
     }
+
+    byte[] tableName = tableUtil.getHTableDescriptor(hBaseAdmin, tableId).getName();
+    HBASE_TEST_BASE.forceRegionFlush(tableName);
+    HBASE_TEST_BASE.forceRegionCompact(tableName, true);
   }
 
-  @Test
-  public void testMessageTableCompaction() throws Exception {
-    try (MetadataTable metadataTable = getMetadataTable();
-         MessageTable messageTable = getMessageTable()) {
-      TableId tableId = tableUtil.createHTableId(NamespaceId.SYSTEM,
-                                                 cConf.get(Constants.MessagingSystem.MESSAGE_TABLE_NAME));
-      TopicId topicId = NamespaceId.DEFAULT.topic("t1");
-      byte[] tableName = tableUtil.getHTableDescriptor(hBaseAdmin, tableId).getName();
-      TopicMetadata topic = new TopicMetadata(topicId, "ttl", "3");
-      metadataTable.createTopic(topic);
-      List<MessageTable.Entry> entries = new ArrayList<>();
-      entries.add(new TestMessageEntry(topicId, "data", 100, (short) 0));
-      messageTable.store(entries.iterator());
-
-      // Fetch the entries and make sure we are able to read it
-      CloseableIterator<MessageTable.Entry> iterator = messageTable.fetch(topicId, 0, Integer.MAX_VALUE, null);
-      Assert.assertTrue(iterator.hasNext());
-      MessageTable.Entry entry = iterator.next();
-      Assert.assertFalse(iterator.hasNext());
-      Assert.assertEquals(100, entry.getTransactionWritePointer());
-      Assert.assertEquals("data", Bytes.toString(entry.getPayload()));
-      iterator.close();
-
-      HBASE_TEST_BASE.forceRegionFlush(tableName);
-      HBASE_TEST_BASE.forceRegionCompact(tableName, true);
-
-      // Entry should still be there since the ttl has not expired
-      iterator = messageTable.fetch(topicId, 0, Integer.MAX_VALUE, null);
-      entry = iterator.next();
-      Assert.assertFalse(iterator.hasNext());
-      Assert.assertEquals(100, entry.getTransactionWritePointer());
-      Assert.assertEquals("data", Bytes.toString(entry.getPayload()));
-      iterator.close();
-
-      TimeUnit.SECONDS.sleep(3);
-      HBASE_TEST_BASE.forceRegionFlush(tableName);
-      HBASE_TEST_BASE.forceRegionCompact(tableName, true);
-
-      iterator = messageTable.fetch(topicId, 0, Integer.MAX_VALUE, null);
-      Assert.assertFalse(iterator.hasNext());
-      iterator.close();
-
-      // Update the TTL so that read filter will still try to read the old flushed data
-      metadataTable.updateTopic(new TopicMetadata(topicId, "ttl", "60"));
-      iterator = messageTable.fetch(topicId, 0, Integer.MAX_VALUE, null);
-      Assert.assertFalse(iterator.hasNext());
-      iterator.close();
-      metadataTable.deleteTopic(topicId);
-    }
+  @Override
+  protected MetadataTable getMetadataTable() throws Exception {
+    return tableFactory.createMetadataTable(NamespaceId.SYSTEM,
+                                            cConf.get(Constants.MessagingSystem.METADATA_TABLE_NAME));
   }
 
-  private static class TestPayloadEntry implements PayloadTable.Entry {
-    private final TopicId topicId;
-    private final String payload;
-    private final long txWritePtr;
-    private final long writeTimestamp;
-    private final short seqId;
-
-    TestPayloadEntry(TopicId topicId, String payload, long txWritePtr, short seqId) {
-      this.topicId = topicId;
-      this.payload = payload;
-      this.txWritePtr = txWritePtr;
-      this.writeTimestamp = System.currentTimeMillis();
-      this.seqId = seqId;
-    }
-
-    @Override
-    public TopicId getTopicId() {
-      return topicId;
-    }
-
-    @Override
-    public byte[] getPayload() {
-      return Bytes.toBytes(payload);
-    }
-
-    @Override
-    public long getTransactionWritePointer() {
-      return txWritePtr;
-    }
-
-    @Override
-    public long getPayloadWriteTimestamp() {
-      return writeTimestamp;
-    }
-
-    @Override
-    public short getPayloadSequenceId() {
-      return seqId;
-    }
+  @Override
+  protected PayloadTable getPayloadTable() throws Exception {
+    return tableFactory.createPayloadTable(NamespaceId.SYSTEM, cConf.get(Constants.MessagingSystem.PAYLOAD_TABLE_NAME));
   }
 
-  private static class TestMessageEntry implements MessageTable.Entry {
-    private final TopicId topicId;
-    private final long timestamp;
-    private final String payload;
-    private final long txWritePtr;
-    private final short seqId;
-
-    TestMessageEntry(TopicId topicId, String payload, long txWritePtr, short seqId) {
-      this.topicId = topicId;
-      this.timestamp = System.currentTimeMillis();
-      this.payload = payload;
-      this.txWritePtr = txWritePtr;
-      this.seqId = seqId;
-    }
-
-    @Override
-    public TopicId getTopicId() {
-      return topicId;
-    }
-
-    @Override
-    public boolean isPayloadReference() {
-      return false;
-    }
-
-    @Override
-    public boolean isTransactional() {
-      return true;
-    }
-
-    @Override
-    public long getTransactionWritePointer() {
-      return txWritePtr;
-    }
-
-    @Nullable
-    @Override
-    public byte[] getPayload() {
-      return Bytes.toBytes(payload);
-    }
-
-    @Override
-    public long getPublishTimestamp() {
-      return timestamp;
-    }
-
-    @Override
-    public short getSequenceId() {
-      return seqId;
-    }
+  @Override
+  protected MessageTable getMessageTable() throws Exception {
+    return tableFactory.createMessageTable(NamespaceId.SYSTEM, cConf.get(Constants.MessagingSystem.MESSAGE_TABLE_NAME));
   }
 
   public static Injector getInjector() {
@@ -299,18 +120,4 @@ public class HBaseMessageTTLCoprocessorTestRun {
       new NamespaceClientUnitTestModule().getModule(),
       new LocationRuntimeModule().getDistributedModules());
   }
-
-  private MetadataTable getMetadataTable() throws Exception {
-    return tableFactory.createMetadataTable(NamespaceId.SYSTEM,
-                                            cConf.get(Constants.MessagingSystem.METADATA_TABLE_NAME));
-  }
-
-  private PayloadTable getPayloadTable() throws Exception {
-    return tableFactory.createPayloadTable(NamespaceId.SYSTEM, cConf.get(Constants.MessagingSystem.PAYLOAD_TABLE_NAME));
-  }
-
-  private MessageTable getMessageTable() throws Exception {
-    return tableFactory.createMessageTable(NamespaceId.SYSTEM, cConf.get(Constants.MessagingSystem.MESSAGE_TABLE_NAME));
-  }
-
 }

--- a/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseMessageTTLCoprocessorTestRun.java
+++ b/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseMessageTTLCoprocessorTestRun.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.messaging.store.hbase;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.guice.ConfigModule;
+import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.NamespaceClientUnitTestModule;
+import co.cask.cdap.data.hbase.HBaseTestBase;
+import co.cask.cdap.data2.transaction.messaging.coprocessor.hbase98.MessageTableRegionObserver;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.messaging.TopicMetadata;
+import co.cask.cdap.messaging.data.MessageId;
+import co.cask.cdap.messaging.store.MessageTable;
+import co.cask.cdap.messaging.store.MetadataTable;
+import co.cask.cdap.messaging.store.PayloadTable;
+import co.cask.cdap.messaging.store.TableFactory;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.TopicId;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.twill.filesystem.LocationFactory;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Tests for {@link HBaseMessageTable} coprocessor {@link MessageTableRegionObserver}.
+ */
+public class HBaseMessageTTLCoprocessorTestRun {
+
+  @ClassRule
+  public static final ExternalResource TEST_BASE = HBaseMessageTestSuite.TEST_BASE;
+
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+  private static final HBaseTestBase HBASE_TEST_BASE = HBaseMessageTestSuite.HBASE_TEST_BASE;
+  private static final CConfiguration cConf = CConfiguration.create();
+
+  private static Configuration hConf;
+  private static HBaseAdmin hBaseAdmin;
+  private static HBaseTableUtil tableUtil;
+  private static TableFactory tableFactory;
+
+  @BeforeClass
+  public static void setupBeforeClass() throws Exception {
+    hConf = HBASE_TEST_BASE.getConfiguration();
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
+    cConf.set(Constants.CFG_HDFS_NAMESPACE, cConf.get(Constants.CFG_LOCAL_DATA_DIR));
+    cConf.set(Constants.CFG_HDFS_USER, System.getProperty("user.name"));
+
+    hBaseAdmin = HBASE_TEST_BASE.getHBaseAdmin();
+    hBaseAdmin.getConfiguration().set(HBaseTableUtil.CFG_HBASE_TABLE_COMPRESSION,
+                                      HBaseTableUtil.CompressionType.NONE.name());
+    tableUtil = new HBaseTableUtilFactory(cConf).get();
+    tableUtil.createNamespaceIfNotExists(hBaseAdmin, tableUtil.getHBaseNamespace(NamespaceId.SYSTEM));
+
+    LocationFactory locationFactory = getInjector().getInstance(LocationFactory.class);
+    tableFactory = new HBaseTableFactory(cConf, hBaseAdmin.getConfiguration(), tableUtil, locationFactory);
+  }
+
+  @AfterClass
+  public static void teardownAfterClass() throws Exception {
+    tableUtil.deleteAllInNamespace(hBaseAdmin, tableUtil.getHBaseNamespace(NamespaceId.SYSTEM));
+    tableUtil.deleteNamespaceIfExists(hBaseAdmin, tableUtil.getHBaseNamespace(NamespaceId.SYSTEM));
+  }
+
+  @Test
+  public void testPayloadTableCompaction() throws Exception {
+    try (MetadataTable metadataTable = getMetadataTable();
+         PayloadTable payloadTable = getPayloadTable()) {
+      TableId tableId = tableUtil.createHTableId(NamespaceId.SYSTEM,
+                                                 cConf.get(Constants.MessagingSystem.PAYLOAD_TABLE_NAME));
+      TopicId topicId = NamespaceId.DEFAULT.topic("t1");
+      byte[] tableName = tableUtil.getHTableDescriptor(hBaseAdmin, tableId).getName();
+      TopicMetadata topic = new TopicMetadata(topicId, "ttl", "3");
+      metadataTable.createTopic(topic);
+      List<PayloadTable.Entry> entries = new ArrayList<>();
+      entries.add(new TestPayloadEntry(topicId, "payloaddata", 101, (short) 0));
+      payloadTable.store(entries.iterator());
+
+      byte[] messageId = new byte[MessageId.RAW_ID_SIZE];
+      MessageId.putRawId(0L, (short) 0, 0L, (short) 0, messageId, 0);
+      CloseableIterator<PayloadTable.Entry> iterator = payloadTable.fetch(topicId, 101L, new MessageId(messageId), true,
+                                                                          Integer.MAX_VALUE);
+      Assert.assertTrue(iterator.hasNext());
+      PayloadTable.Entry entry = iterator.next();
+      Assert.assertFalse(iterator.hasNext());
+      Assert.assertEquals("payloaddata", Bytes.toString(entry.getPayload()));
+      Assert.assertEquals(101L, entry.getTransactionWritePointer());
+      iterator.close();
+
+      HBASE_TEST_BASE.forceRegionFlush(tableName);
+      HBASE_TEST_BASE.forceRegionCompact(tableName, true);
+
+      //Entry should still be there since ttl has not expired
+      iterator = payloadTable.fetch(topicId, 101L, new MessageId(messageId), true, Integer.MAX_VALUE);
+      Assert.assertTrue(iterator.hasNext());
+      entry = iterator.next();
+      Assert.assertFalse(iterator.hasNext());
+      Assert.assertEquals("payloaddata", Bytes.toString(entry.getPayload()));
+      Assert.assertEquals(101L, entry.getTransactionWritePointer());
+      iterator.close();
+
+      TimeUnit.SECONDS.sleep(3);
+      HBASE_TEST_BASE.forceRegionFlush(tableName);
+      HBASE_TEST_BASE.forceRegionCompact(tableName, true);
+
+      iterator = payloadTable.fetch(topicId, 101L, new MessageId(messageId), true, Integer.MAX_VALUE);
+      Assert.assertFalse(iterator.hasNext());
+      iterator.close();
+
+      // Update the TTL so that read filter will still try to read the old flushed data
+      metadataTable.updateTopic(new TopicMetadata(topicId, "ttl", "60"));
+      iterator = payloadTable.fetch(topicId, 101L, new MessageId(messageId), true, Integer.MAX_VALUE);
+      Assert.assertFalse(iterator.hasNext());
+      iterator.close();
+      metadataTable.deleteTopic(topicId);
+    }
+  }
+
+  @Test
+  public void testMessageTableCompaction() throws Exception {
+    try (MetadataTable metadataTable = getMetadataTable();
+         MessageTable messageTable = getMessageTable()) {
+      TableId tableId = tableUtil.createHTableId(NamespaceId.SYSTEM,
+                                                 cConf.get(Constants.MessagingSystem.MESSAGE_TABLE_NAME));
+      TopicId topicId = NamespaceId.DEFAULT.topic("t1");
+      byte[] tableName = tableUtil.getHTableDescriptor(hBaseAdmin, tableId).getName();
+      TopicMetadata topic = new TopicMetadata(topicId, "ttl", "3");
+      metadataTable.createTopic(topic);
+      List<MessageTable.Entry> entries = new ArrayList<>();
+      entries.add(new TestMessageEntry(topicId, "data", 100, (short) 0));
+      messageTable.store(entries.iterator());
+
+      // Fetch the entries and make sure we are able to read it
+      CloseableIterator<MessageTable.Entry> iterator = messageTable.fetch(topicId, 0, Integer.MAX_VALUE, null);
+      Assert.assertTrue(iterator.hasNext());
+      MessageTable.Entry entry = iterator.next();
+      Assert.assertFalse(iterator.hasNext());
+      Assert.assertEquals(100, entry.getTransactionWritePointer());
+      Assert.assertEquals("data", Bytes.toString(entry.getPayload()));
+      iterator.close();
+
+      HBASE_TEST_BASE.forceRegionFlush(tableName);
+      HBASE_TEST_BASE.forceRegionCompact(tableName, true);
+
+      // Entry should still be there since the ttl has not expired
+      iterator = messageTable.fetch(topicId, 0, Integer.MAX_VALUE, null);
+      entry = iterator.next();
+      Assert.assertFalse(iterator.hasNext());
+      Assert.assertEquals(100, entry.getTransactionWritePointer());
+      Assert.assertEquals("data", Bytes.toString(entry.getPayload()));
+      iterator.close();
+
+      TimeUnit.SECONDS.sleep(3);
+      HBASE_TEST_BASE.forceRegionFlush(tableName);
+      HBASE_TEST_BASE.forceRegionCompact(tableName, true);
+
+      iterator = messageTable.fetch(topicId, 0, Integer.MAX_VALUE, null);
+      Assert.assertFalse(iterator.hasNext());
+      iterator.close();
+
+      // Update the TTL so that read filter will still try to read the old flushed data
+      metadataTable.updateTopic(new TopicMetadata(topicId, "ttl", "60"));
+      iterator = messageTable.fetch(topicId, 0, Integer.MAX_VALUE, null);
+      Assert.assertFalse(iterator.hasNext());
+      iterator.close();
+      metadataTable.deleteTopic(topicId);
+    }
+  }
+
+  private static class TestPayloadEntry implements PayloadTable.Entry {
+    private final TopicId topicId;
+    private final String payload;
+    private final long txWritePtr;
+    private final long writeTimestamp;
+    private final short seqId;
+
+    TestPayloadEntry(TopicId topicId, String payload, long txWritePtr, short seqId) {
+      this.topicId = topicId;
+      this.payload = payload;
+      this.txWritePtr = txWritePtr;
+      this.writeTimestamp = System.currentTimeMillis();
+      this.seqId = seqId;
+    }
+
+    @Override
+    public TopicId getTopicId() {
+      return topicId;
+    }
+
+    @Override
+    public byte[] getPayload() {
+      return Bytes.toBytes(payload);
+    }
+
+    @Override
+    public long getTransactionWritePointer() {
+      return txWritePtr;
+    }
+
+    @Override
+    public long getPayloadWriteTimestamp() {
+      return writeTimestamp;
+    }
+
+    @Override
+    public short getPayloadSequenceId() {
+      return seqId;
+    }
+  }
+
+  private static class TestMessageEntry implements MessageTable.Entry {
+    private final TopicId topicId;
+    private final long timestamp;
+    private final String payload;
+    private final long txWritePtr;
+    private final short seqId;
+
+    TestMessageEntry(TopicId topicId, String payload, long txWritePtr, short seqId) {
+      this.topicId = topicId;
+      this.timestamp = System.currentTimeMillis();
+      this.payload = payload;
+      this.txWritePtr = txWritePtr;
+      this.seqId = seqId;
+    }
+
+    @Override
+    public TopicId getTopicId() {
+      return topicId;
+    }
+
+    @Override
+    public boolean isPayloadReference() {
+      return false;
+    }
+
+    @Override
+    public boolean isTransactional() {
+      return true;
+    }
+
+    @Override
+    public long getTransactionWritePointer() {
+      return txWritePtr;
+    }
+
+    @Nullable
+    @Override
+    public byte[] getPayload() {
+      return Bytes.toBytes(payload);
+    }
+
+    @Override
+    public long getPublishTimestamp() {
+      return timestamp;
+    }
+
+    @Override
+    public short getSequenceId() {
+      return seqId;
+    }
+  }
+
+  public static Injector getInjector() {
+    return Guice.createInjector(
+      new ConfigModule(cConf, hConf),
+      new NamespaceClientUnitTestModule().getModule(),
+      new LocationRuntimeModule().getDistributedModules());
+  }
+
+  private MetadataTable getMetadataTable() throws Exception {
+    return tableFactory.createMetadataTable(NamespaceId.SYSTEM,
+                                            cConf.get(Constants.MessagingSystem.METADATA_TABLE_NAME));
+  }
+
+  private PayloadTable getPayloadTable() throws Exception {
+    return tableFactory.createPayloadTable(NamespaceId.SYSTEM, cConf.get(Constants.MessagingSystem.PAYLOAD_TABLE_NAME));
+  }
+
+  private MessageTable getMessageTable() throws Exception {
+    return tableFactory.createMessageTable(NamespaceId.SYSTEM, cConf.get(Constants.MessagingSystem.MESSAGE_TABLE_NAME));
+  }
+
+}

--- a/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseMessageTestSuite.java
+++ b/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseMessageTestSuite.java
@@ -29,9 +29,10 @@ import org.junit.runners.Suite;
  */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
+  HBaseMetadataTableTestRun.class,
   HBaseMessageTableTestRun.class,
-  HBaseMessageTableTestRun.class,
-  HBasePayloadTableTestRun.class
+  HBasePayloadTableTestRun.class,
+  HBaseMessageTTLCoprocessorTestRun.class
 })
 public class HBaseMessageTestSuite {
 

--- a/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBasePayloadTableTestRun.java
+++ b/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBasePayloadTableTestRun.java
@@ -17,43 +17,62 @@
 package co.cask.cdap.messaging.store.hbase;
 
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.guice.ConfigModule;
+import co.cask.cdap.common.guice.LocationRuntimeModule;
+import co.cask.cdap.common.guice.NamespaceClientUnitTestModule;
 import co.cask.cdap.data.hbase.HBaseTestBase;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
-import co.cask.cdap.messaging.store.MetadataTable;
-import co.cask.cdap.messaging.store.MetadataTableTest;
+import co.cask.cdap.messaging.store.PayloadTable;
+import co.cask.cdap.messaging.store.PayloadTableTest;
 import co.cask.cdap.messaging.store.TableFactory;
 import co.cask.cdap.proto.id.NamespaceId;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.twill.filesystem.LocationFactory;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.ExternalResource;
+import org.junit.rules.TemporaryFolder;
 
 /**
- * Tests for {@link HBaseMetadataTable}
+ * HBase implementation of {@link PayloadTableTest}.
  */
-public class HBaseMetadataTableTestRun extends MetadataTableTest {
+public class HBasePayloadTableTestRun extends PayloadTableTest {
 
   @ClassRule
   public static final ExternalResource TEST_BASE = HBaseMessageTestSuite.TEST_BASE;
 
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
   private static final HBaseTestBase HBASE_TEST_BASE = HBaseMessageTestSuite.HBASE_TEST_BASE;
   private static final CConfiguration cConf = CConfiguration.create();
 
+  private static Configuration hConf;
   private static HBaseAdmin hBaseAdmin;
   private static HBaseTableUtil tableUtil;
   private static TableFactory tableFactory;
 
   @BeforeClass
   public static void setupBeforeClass() throws Exception {
+    hConf = HBASE_TEST_BASE.getConfiguration();
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
+    cConf.set(Constants.CFG_HDFS_NAMESPACE, cConf.get(Constants.CFG_LOCAL_DATA_DIR));
+    cConf.set(Constants.CFG_HDFS_USER, System.getProperty("user.name"));
+
     hBaseAdmin = HBASE_TEST_BASE.getHBaseAdmin();
     hBaseAdmin.getConfiguration().set(HBaseTableUtil.CFG_HBASE_TABLE_COMPRESSION,
                                       HBaseTableUtil.CompressionType.NONE.name());
     tableUtil = new HBaseTableUtilFactory(cConf).get();
     tableUtil.createNamespaceIfNotExists(hBaseAdmin, tableUtil.getHBaseNamespace(NamespaceId.CDAP));
 
-    tableFactory = new HBaseTableFactory(cConf, hBaseAdmin.getConfiguration(), tableUtil);
+    LocationFactory locationFactory = getInjector().getInstance(LocationFactory.class);
+    tableFactory = new HBaseTableFactory(cConf, hBaseAdmin.getConfiguration(), tableUtil, locationFactory);
   }
 
   @AfterClass
@@ -63,7 +82,14 @@ public class HBaseMetadataTableTestRun extends MetadataTableTest {
   }
 
   @Override
-  protected MetadataTable createMetadataTable() throws Exception {
-    return tableFactory.createMetadataTable(NamespaceId.CDAP, "metadata");
+  protected PayloadTable getPayloadTable() throws Exception {
+    return tableFactory.createPayloadTable(NamespaceId.CDAP, "payload");
+  }
+
+  public static Injector getInjector() {
+    return Guice.createInjector(
+      new ConfigModule(cConf, hConf),
+      new NamespaceClientUnitTestModule().getModule(),
+      new LocationRuntimeModule().getDistributedModules());
   }
 }

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/ImmutableMessageTableEntry.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/ImmutableMessageTableEntry.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 /**
  * An immutable implementation of {@link MessageTable.Entry}.
  */
-final class ImmutableMessageTableEntry implements MessageTable.Entry {
+public final class ImmutableMessageTableEntry implements MessageTable.Entry {
   private final TopicId topicId;
   private final boolean transactional;
   private final long transactionWritePointer;
@@ -33,7 +33,7 @@ final class ImmutableMessageTableEntry implements MessageTable.Entry {
   private final long publishTimestamp;
   private final short sequenceId;
 
-  ImmutableMessageTableEntry(byte[] row, @Nullable byte[] payload, @Nullable byte[] txPtr) {
+  public ImmutableMessageTableEntry(byte[] row, @Nullable byte[] payload, @Nullable byte[] txPtr) {
     this.payload = payload;
     this.publishTimestamp = Bytes.toLong(row, row.length - Bytes.SIZEOF_SHORT - Bytes.SIZEOF_LONG);
     this.sequenceId = Bytes.toShort(row, row.length - Bytes.SIZEOF_SHORT);

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/ImmutablePayloadTableEntry.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/ImmutablePayloadTableEntry.java
@@ -23,14 +23,14 @@ import co.cask.cdap.proto.id.TopicId;
 /**
  * An immutable implementation of {@link PayloadTable.Entry}.
  */
-final class ImmutablePayloadTableEntry implements PayloadTable.Entry {
+public final class ImmutablePayloadTableEntry implements PayloadTable.Entry {
   private final TopicId topicId;
   private final long transactionWriterPointer;
   private final long publishTimestamp;
   private final short sequenceId;
   private final byte[] payload;
 
-  ImmutablePayloadTableEntry(byte[] row, byte[] payload) {
+  public ImmutablePayloadTableEntry(byte[] row, byte[] payload) {
     this.topicId = MessagingUtils.toTopicId(row, 0, row.length - Bytes.SIZEOF_SHORT - (2 * Bytes.SIZEOF_LONG));
     this.transactionWriterPointer = Bytes.toLong(row, row.length - Bytes.SIZEOF_SHORT - (2 * Bytes.SIZEOF_LONG));
     this.publishTimestamp = Bytes.toLong(row, row.length - Bytes.SIZEOF_SHORT - Bytes.SIZEOF_LONG);

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/hbase/HBaseMetadataTable.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/hbase/HBaseMetadataTable.java
@@ -50,7 +50,7 @@ import java.util.TreeMap;
  */
 public class HBaseMetadataTable implements MetadataTable {
 
-  private static final byte[] COL = Bytes.toBytes("m");
+  public static final byte[] COL = Bytes.toBytes("m");
   private static final Gson GSON = new Gson();
   // It has to be a sorted map since we depends on the serialized map for compareAndPut operation for topic update.
   private static final Type MAP_TYPE = new TypeToken<SortedMap<String, String>>() { }.getType();

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/leveldb/LevelDBMessageTable.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/leveldb/LevelDBMessageTable.java
@@ -78,7 +78,6 @@ public class LevelDBMessageTable extends AbstractMessageTable {
     };
   }
 
-
   @Override
   protected void persist(Iterator<RawMessageTableEntry> entries) throws IOException {
     try (WriteBatch writeBatch = levelDB.createWriteBatch()) {

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/leveldb/LevelDBPayloadTable.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/leveldb/LevelDBPayloadTable.java
@@ -16,22 +16,26 @@
 
 package co.cask.cdap.messaging.store.leveldb;
 
+import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.lib.AbstractCloseableIterator;
 import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.messaging.MessagingUtils;
+import co.cask.cdap.messaging.TopicMetadata;
 import co.cask.cdap.messaging.store.AbstractPayloadTable;
+import co.cask.cdap.messaging.store.ImmutablePayloadTableEntry;
 import co.cask.cdap.messaging.store.PayloadTable;
 import co.cask.cdap.messaging.store.RawPayloadTableEntry;
+import co.cask.cdap.proto.id.TopicId;
 import org.iq80.leveldb.DB;
 import org.iq80.leveldb.DBException;
 import org.iq80.leveldb.WriteBatch;
 import org.iq80.leveldb.WriteOptions;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * LevelDB implementation of {@link PayloadTable}.
@@ -94,18 +98,45 @@ public class LevelDBPayloadTable extends AbstractPayloadTable {
 
   @Override
   protected void delete(byte[] startRow, byte[] stopRow) throws IOException {
-    List<byte[]> rowKeysToDelete = new ArrayList<>();
+    WriteBatch writeBatch = levelDB.createWriteBatch();
     try (CloseableIterator<Map.Entry<byte[], byte[]>> rowIterator = new DBScanIterator(levelDB, startRow, stopRow)) {
       while (rowIterator.hasNext()) {
-        Map.Entry<byte[], byte[]> candidateRow = rowIterator.next();
-        rowKeysToDelete.add(candidateRow.getKey());
+        writeBatch.delete(rowIterator.next().getKey());
       }
     }
 
     try {
-      for (byte[] deleteRowKey : rowKeysToDelete) {
-        levelDB.delete(deleteRowKey);
+      levelDB.write(writeBatch, WRITE_OPTIONS);
+    } catch (DBException ex) {
+      throw new IOException(ex);
+    }
+  }
+
+  /**
+   * Delete messages of a {@link TopicId} that has exceeded the TTL
+   *
+   * @param topicMetadata {@link TopicMetadata}
+   * @param currentTime current timestamp
+   * @throws IOException error occurred while trying to delete a row in LevelDB
+   */
+  public void pruneMessages(TopicMetadata topicMetadata, long currentTime) throws IOException {
+    WriteBatch writeBatch = levelDB.createWriteBatch();
+    long ttlInMs = TimeUnit.SECONDS.toMillis(topicMetadata.getTTL());
+    byte[] startRow = MessagingUtils.toRowKeyPrefix(topicMetadata.getTopicId());
+    byte[] stopRow = Bytes.stopKeyForPrefix(startRow);
+
+    try (CloseableIterator<Map.Entry<byte[], byte[]>> rowIterator = new DBScanIterator(levelDB, startRow, stopRow)) {
+      while (rowIterator.hasNext()) {
+        Map.Entry<byte[], byte[]> entry = rowIterator.next();
+        PayloadTable.Entry payloadTableEntry = new ImmutablePayloadTableEntry(entry.getKey(), entry.getValue());
+        if ((currentTime - payloadTableEntry.getPayloadWriteTimestamp()) > ttlInMs) {
+          writeBatch.delete(entry.getKey());
+        }
       }
+    }
+
+    try {
+      levelDB.write(writeBatch, WRITE_OPTIONS);
     } catch (DBException ex) {
       throw new IOException(ex);
     }

--- a/cdap-tms/src/test/java/co/cask/cdap/messaging/store/TTLCleanupTest.java
+++ b/cdap-tms/src/test/java/co/cask/cdap/messaging/store/TTLCleanupTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.messaging.store;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.messaging.TopicMetadata;
+import co.cask.cdap.messaging.data.MessageId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.TopicId;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Tests to verify the coprocessor TTL cleanup logic.
+ */
+public abstract class TTLCleanupTest {
+
+  @Test
+  public void testPayloadTableCompaction() throws Exception {
+    try (MetadataTable metadataTable = getMetadataTable();
+         PayloadTable payloadTable = getPayloadTable();
+         MessageTable messageTable = getMessageTable()) {
+      Assert.assertNotNull(messageTable);
+      TopicId topicId = NamespaceId.DEFAULT.topic("t2");
+      TopicMetadata topic = new TopicMetadata(topicId, "ttl", "3");
+      metadataTable.createTopic(topic);
+      List<PayloadTable.Entry> entries = new ArrayList<>();
+      entries.add(new TestPayloadEntry(topicId, "payloaddata", 101, (short) 0));
+      payloadTable.store(entries.iterator());
+
+      byte[] messageId = new byte[MessageId.RAW_ID_SIZE];
+      MessageId.putRawId(0L, (short) 0, 0L, (short) 0, messageId, 0);
+      CloseableIterator<PayloadTable.Entry> iterator = payloadTable.fetch(topicId, 101L, new MessageId(messageId), true,
+                                                                          Integer.MAX_VALUE);
+      Assert.assertTrue(iterator.hasNext());
+      PayloadTable.Entry entry = iterator.next();
+      Assert.assertFalse(iterator.hasNext());
+      Assert.assertEquals("payloaddata", Bytes.toString(entry.getPayload()));
+      Assert.assertEquals(101L, entry.getTransactionWritePointer());
+      iterator.close();
+
+      forceFlushAndCompact(Table.PAYLOAD);
+
+      //Entry should still be there since ttl has not expired
+      iterator = payloadTable.fetch(topicId, 101L, new MessageId(messageId), true, Integer.MAX_VALUE);
+      Assert.assertTrue(iterator.hasNext());
+      entry = iterator.next();
+      Assert.assertFalse(iterator.hasNext());
+      Assert.assertEquals("payloaddata", Bytes.toString(entry.getPayload()));
+      Assert.assertEquals(101L, entry.getTransactionWritePointer());
+      iterator.close();
+
+      TimeUnit.SECONDS.sleep(3);
+      forceFlushAndCompact(Table.PAYLOAD);
+
+      iterator = payloadTable.fetch(topicId, 101L, new MessageId(messageId), true, Integer.MAX_VALUE);
+      Assert.assertFalse(iterator.hasNext());
+      iterator.close();
+      metadataTable.deleteTopic(topicId);
+    }
+  }
+
+  @Test
+  public void testMessageTableCompaction() throws Exception {
+    try (MetadataTable metadataTable = getMetadataTable();
+         MessageTable messageTable = getMessageTable();
+         PayloadTable payloadTable = getPayloadTable()) {
+      Assert.assertNotNull(payloadTable);
+      TopicId topicId = NamespaceId.DEFAULT.topic("t1");
+      TopicMetadata topic = new TopicMetadata(topicId, "ttl", "3");
+      metadataTable.createTopic(topic);
+      List<MessageTable.Entry> entries = new ArrayList<>();
+      entries.add(new TestMessageEntry(topicId, "data", 100, (short) 0));
+      messageTable.store(entries.iterator());
+
+      // Fetch the entries and make sure we are able to read it
+      CloseableIterator<MessageTable.Entry> iterator = messageTable.fetch(topicId, 0, Integer.MAX_VALUE, null);
+      Assert.assertTrue(iterator.hasNext());
+      MessageTable.Entry entry = iterator.next();
+      Assert.assertFalse(iterator.hasNext());
+      Assert.assertEquals(100, entry.getTransactionWritePointer());
+      Assert.assertEquals("data", Bytes.toString(entry.getPayload()));
+      iterator.close();
+
+      forceFlushAndCompact(Table.MESSAGE);
+
+      // Entry should still be there since the ttl has not expired
+      iterator = messageTable.fetch(topicId, 0, Integer.MAX_VALUE, null);
+      entry = iterator.next();
+      Assert.assertFalse(iterator.hasNext());
+      Assert.assertEquals(100, entry.getTransactionWritePointer());
+      Assert.assertEquals("data", Bytes.toString(entry.getPayload()));
+      iterator.close();
+
+      TimeUnit.SECONDS.sleep(3);
+      forceFlushAndCompact(Table.MESSAGE);
+
+      iterator = messageTable.fetch(topicId, 0, Integer.MAX_VALUE, null);
+      Assert.assertFalse(iterator.hasNext());
+      iterator.close();
+    }
+  }
+
+  protected static enum Table {
+    MESSAGE,
+    PAYLOAD
+  }
+
+  protected abstract void forceFlushAndCompact(Table table) throws Exception;
+
+  protected abstract MetadataTable getMetadataTable() throws Exception;
+
+  protected abstract PayloadTable getPayloadTable() throws Exception;
+
+  protected abstract MessageTable getMessageTable() throws Exception;
+
+  private static class TestPayloadEntry implements PayloadTable.Entry {
+    private final TopicId topicId;
+    private final String payload;
+    private final long txWritePtr;
+    private final long writeTimestamp;
+    private final short seqId;
+
+    TestPayloadEntry(TopicId topicId, String payload, long txWritePtr, short seqId) {
+      this.topicId = topicId;
+      this.payload = payload;
+      this.txWritePtr = txWritePtr;
+      this.writeTimestamp = System.currentTimeMillis();
+      this.seqId = seqId;
+    }
+
+    @Override
+    public TopicId getTopicId() {
+      return topicId;
+    }
+
+    @Override
+    public byte[] getPayload() {
+      return Bytes.toBytes(payload);
+    }
+
+    @Override
+    public long getTransactionWritePointer() {
+      return txWritePtr;
+    }
+
+    @Override
+    public long getPayloadWriteTimestamp() {
+      return writeTimestamp;
+    }
+
+    @Override
+    public short getPayloadSequenceId() {
+      return seqId;
+    }
+  }
+
+  private static class TestMessageEntry implements MessageTable.Entry {
+    private final TopicId topicId;
+    private final long timestamp;
+    private final String payload;
+    private final long txWritePtr;
+    private final short seqId;
+
+    TestMessageEntry(TopicId topicId, String payload, long txWritePtr, short seqId) {
+      this.topicId = topicId;
+      this.timestamp = System.currentTimeMillis();
+      this.payload = payload;
+      this.txWritePtr = txWritePtr;
+      this.seqId = seqId;
+    }
+
+    @Override
+    public TopicId getTopicId() {
+      return topicId;
+    }
+
+    @Override
+    public boolean isPayloadReference() {
+      return false;
+    }
+
+    @Override
+    public boolean isTransactional() {
+      return true;
+    }
+
+    @Override
+    public long getTransactionWritePointer() {
+      return txWritePtr;
+    }
+
+    @Nullable
+    @Override
+    public byte[] getPayload() {
+      return Bytes.toBytes(payload);
+    }
+
+    @Override
+    public long getPublishTimestamp() {
+      return timestamp;
+    }
+
+    @Override
+    public short getSequenceId() {
+      return seqId;
+    }
+  }
+}

--- a/cdap-tms/src/test/java/co/cask/cdap/messaging/store/leveldb/LevelDBTTLCleanupTest.java
+++ b/cdap-tms/src/test/java/co/cask/cdap/messaging/store/leveldb/LevelDBTTLCleanupTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.messaging.store.leveldb;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.messaging.store.MessageTable;
+import co.cask.cdap.messaging.store.MetadataTable;
+import co.cask.cdap.messaging.store.PayloadTable;
+import co.cask.cdap.messaging.store.TTLCleanupTest;
+import co.cask.cdap.messaging.store.TableFactory;
+import co.cask.cdap.proto.id.NamespaceId;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests for TTL Cleanup logic in LevelDB.
+ */
+public class LevelDBTTLCleanupTest extends TTLCleanupTest {
+
+  @ClassRule
+  public static TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  private static TableFactory tableFactory;
+
+  @BeforeClass
+  public static void init() throws IOException {
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.MessagingSystem.LOCAL_TTL_CLEANUP_FREQUENCY, Long.toString(1));
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, tmpFolder.newFolder().getAbsolutePath());
+    tableFactory = new LevelDBTableFactory(cConf);
+  }
+
+  @Override
+  protected void forceFlushAndCompact(Table table) throws Exception {
+    // since we have a periodic thread doing the clean up, we don't/can't do much here.
+    TimeUnit.SECONDS.sleep(1);
+  }
+
+  @Override
+  protected MetadataTable getMetadataTable() throws Exception {
+    return tableFactory.createMetadataTable(NamespaceId.CDAP, "metadata");
+  }
+
+  @Override
+  protected PayloadTable getPayloadTable() throws Exception {
+    return tableFactory.createPayloadTable(NamespaceId.CDAP, "payload");
+  }
+
+  @Override
+  protected MessageTable getMessageTable() throws Exception {
+    return tableFactory.createMessageTable(NamespaceId.CDAP, "message");
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -2468,6 +2468,7 @@
 
       <modules>
         <module>cdap-data-fabric-tests</module>
+        <module>cdap-tms-tests</module>
         <module>cdap-cli-tests</module>
         <module>cdap-client-tests</module>
         <module>cdap-app-fabric-tests</module>


### PR DESCRIPTION
Summary:

1) First Commit:
* Adds cdap-tms-tests module since hbase-compat modules now depends on cdap-tms and thus for tests, we need to have a separate module so that there is no circular dependency (similar to cdap-data-fabric/cdap-data-fabric-tests modules) 
* Adding two coprocessors for Transaction Messaging Service TTL cleanup in HBase tables.
One for MessageTable and another for PayloadTable.
* The logic in the coprocessor queries the metadata table for the TTL value and then checks if the TTL has elapsed, in which case, it skips the cell. Otherwise, it retains the cell.

2) Second Commit: LevelDB implementation (scheduled thread that invokes ttl pruning for each topic on both message table and payload table). Tests are currently timing sensitive and thus might be flaky. Any thoughts how to make it more stable are welcome.

TODO : Before merging, we need to port both the coprocessors to all the hbase-compat-modules. Will do that after addressing comments on this PR, so that the PR is easy to review and it is easy to port the coprocessors to other compat modules.

Open Question: What happens to all the messages when a topic is deleted? For ex, in the coprocessor, we try to fetch the TopicMetadata given a TopicId (which we construct from the scanned row). If we fail to fetch the TopicMetadata, what should we do? In the current PR, the cell is retained. But the question arises, as to what happens to all the messages stored in MessageTable and PayloadTable.