### PR TITLE
CDAP-7481 Adding available CDAP System Metrics in docs

### DIFF
--- a/cdap-docs/reference-manual/source/http-restful-api/metrics.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/metrics.rst
@@ -275,8 +275,8 @@ These metrics are available in a stream context:
    * - ``system.collect.bytes``
      - Number of bytes collected by the stream
 
-These metrics on request and response are available for system and user services:
 
+These metrics are available for services, for system services component context and user services context:
 .. list-table::
    :header-rows: 1
    :widths: 60 40
@@ -290,8 +290,8 @@ These metrics on request and response are available for system and user services
    * - ``system.response.{server-error, client-error}``
      - Number of ``server-error`` or ``client-error`` responses sent
 
-These metrics on logging are available on the application context:
 
+These metrics are available for every application context:
 .. list-table::
    :header-rows: 1
    :widths: 60 40
@@ -301,8 +301,8 @@ These metrics on logging are available on the application context:
    * - ``system.app.log.{error, info, warn}``
      - Number of ``error``, ``info``, or ``warn`` log messages logged by the application
 
-These metrics on logging are available for the system services, in the system component context:
 
+These metrics are available for the system services, in the system component context:
 .. list-table::
    :header-rows: 1
    :widths: 60 40
@@ -331,7 +331,7 @@ These metrics are available for the CDAP transaction service:
    * - ``system.{canCommit, commit, committed, inprogress, invalidate, abort}.latency``
      - Time taken (in milliseconds) to perform a specified transaction state update
    * - ``system.{invalid, committing, committed, inprogress}.size``
-     - Number of transaction data structures
+     - Number of transactions of various types that are active
 
 These metrics are available for the YARN cluster resources:
 

--- a/cdap-docs/reference-manual/source/http-restful-api/metrics.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/metrics.rst
@@ -275,6 +275,72 @@ These metrics are available in a stream context:
    * - ``system.collect.bytes``
      - Number of bytes collected by the stream
 
+These metrics on Request/Response are available for system and user services.
+.. list-table::
+   :header-rows: 1
+   :widths: 60 40
+
+   * - REST Metrics
+     - Description
+   * - ``system.request.received``
+     - Number of requests received for the service
+   * - ``system.response.successful``
+     - Number of successful responses sent
+   * - ``system.response.{server-error, client-error}``
+     - Number of {server-error, client-error} responses sent
+
+These metrics on logging are available on the app context
+.. list-table::
+   :header-rows: 1
+   :widths: 60 40
+
+   * - App Logging Metrics
+     - Description
+   * - ``system.app.log.{error, info, warn}``
+     - Number of {error, info, warn} log messages logged by the app
+
+
+These metrics on logging are available for the system services, in system component context
+.. list-table::
+   :header-rows: 1
+   :widths: 60 40
+
+   * - App Logging Metrics
+     - Description
+   * - ``system.services.log.{error, info, warn}``
+     - Number of {error, info, warn} log messages logged by the system service
+
+These metrics are available for the CDAP transaction service
+.. list-table::
+   :header-rows: 1
+   :widths: 60 40
+
+   * - Transaction Metrics
+     - Description
+   * - ``system.start.{short, long}``
+     - Number of short, long transactions started
+   * - ``system.start.{short, long}.latency``
+     - Time taken to start short, long transactions.
+   * - ``system.wal.append.count``
+     - Number of transaction edits added to Write Ahead log
+   * - ``system.{canCommit, commit, committed, inprogress, invalidate, abort}``
+     - Number of transactions in a transaction state.
+   * - ``system.{canCommit, commit, committed, inprogress, invalidate, abort}.latency``
+     - Time take to perform the transaction state update
+   * - ``system.{invalid, committing, committed, inprogress}.size``
+     - size of transaction data structures
+
+These metrics are available for the yarn cluster resources
+.. list-table::
+   :header-rows: 1
+   :widths: 60 40
+
+   * - Yarn cluster metrics
+     - Description
+   * - system.resources.{total, available, used}.memory
+     - Size of total, available and used cluster memory
+   * - system.resources.{total, available, used}.vcores
+     - Size of total, available and used cluster vcores
 
 Searches and Queries
 ====================

--- a/cdap-docs/reference-manual/source/http-restful-api/metrics.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/metrics.rst
@@ -275,72 +275,76 @@ These metrics are available in a stream context:
    * - ``system.collect.bytes``
      - Number of bytes collected by the stream
 
-These metrics on Request/Response are available for system and user services.
+These metrics on request and response are available for system and user services:
+
 .. list-table::
    :header-rows: 1
    :widths: 60 40
 
-   * - REST Metrics
+   * - Request and Response Metric
      - Description
    * - ``system.request.received``
      - Number of requests received for the service
    * - ``system.response.successful``
      - Number of successful responses sent
    * - ``system.response.{server-error, client-error}``
-     - Number of {server-error, client-error} responses sent
+     - Number of ``server-error`` or ``client-error`` responses sent
 
-These metrics on logging are available on the app context
+These metrics on logging are available on the application context:
+
 .. list-table::
    :header-rows: 1
    :widths: 60 40
 
-   * - App Logging Metrics
+   * - Application Logging Metric
      - Description
    * - ``system.app.log.{error, info, warn}``
-     - Number of {error, info, warn} log messages logged by the app
+     - Number of ``error``, ``info``, or ``warn`` log messages logged by the application
 
+These metrics on logging are available for the system services, in the system component context:
 
-These metrics on logging are available for the system services, in system component context
 .. list-table::
    :header-rows: 1
    :widths: 60 40
 
-   * - App Logging Metrics
+   * - System Services Logging Metric
      - Description
    * - ``system.services.log.{error, info, warn}``
-     - Number of {error, info, warn} log messages logged by the system service
+     - Number of ``error``, ``info``, or ``warn`` log messages logged by the system services
 
-These metrics are available for the CDAP transaction service
+These metrics are available for the CDAP transaction service:
+
 .. list-table::
    :header-rows: 1
    :widths: 60 40
 
-   * - Transaction Metrics
+   * - Transaction Metric
      - Description
    * - ``system.start.{short, long}``
-     - Number of short, long transactions started
+     - Number of ``short`` or ``long`` transactions started
    * - ``system.start.{short, long}.latency``
-     - Time taken to start short, long transactions.
+     - Time taken (in milliseconds) to start ``short`` or ``long`` transactions
    * - ``system.wal.append.count``
-     - Number of transaction edits added to Write Ahead log
+     - Number of transaction edits added to the write-ahead log
    * - ``system.{canCommit, commit, committed, inprogress, invalidate, abort}``
-     - Number of transactions in a transaction state.
+     - Number of transactions in a specified transaction state
    * - ``system.{canCommit, commit, committed, inprogress, invalidate, abort}.latency``
-     - Time take to perform the transaction state update
+     - Time taken (in milliseconds) to perform a specified transaction state update
    * - ``system.{invalid, committing, committed, inprogress}.size``
-     - size of transaction data structures
+     - Number of transaction data structures
 
-These metrics are available for the yarn cluster resources
+These metrics are available for the YARN cluster resources:
+
 .. list-table::
    :header-rows: 1
    :widths: 60 40
 
-   * - Yarn cluster metrics
+   * - YARN Cluster Metric
      - Description
-   * - system.resources.{total, available, used}.memory
-     - Size of total, available and used cluster memory
-   * - system.resources.{total, available, used}.vcores
-     - Size of total, available and used cluster vcores
+   * - ``system.resources.{total, available, used}.memory``
+     - Size (in megabytes) of total, available, or used cluster memory
+   * - ``system.resources.{total, available, used}.vcores``
+     - Number of total, available, or used cluster virtual cores
 
 Searches and Queries
 ====================

--- a/cdap-docs/reference-manual/source/http-restful-api/metrics.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/metrics.rst
@@ -276,7 +276,8 @@ These metrics are available in a stream context:
      - Number of bytes collected by the stream
 
 
-These metrics are available for services, for system services component context and user services context:
+These metrics are available for services, for the system services component context or the user services context:
+
 .. list-table::
    :header-rows: 1
    :widths: 60 40
@@ -292,6 +293,7 @@ These metrics are available for services, for system services component context 
 
 
 These metrics are available for every application context:
+
 .. list-table::
    :header-rows: 1
    :widths: 60 40
@@ -303,6 +305,7 @@ These metrics are available for every application context:
 
 
 These metrics are available for the system services, in the system component context:
+
 .. list-table::
    :header-rows: 1
    :widths: 60 40
@@ -331,7 +334,7 @@ These metrics are available for the CDAP transaction service:
    * - ``system.{canCommit, commit, committed, inprogress, invalidate, abort}.latency``
      - Time taken (in milliseconds) to perform a specified transaction state update
    * - ``system.{invalid, committing, committed, inprogress}.size``
-     - Number of transactions of various types that are active
+     - Number of transactions of a specified type that are active
 
 These metrics are available for the YARN cluster resources:
 


### PR DESCRIPTION
Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB173-3
Passes Run 3.

Page of interest: http://builds.cask.co/artifact/CDAP-DQB173/shared/build-3/Docs-HTML/4.0.0-SNAPSHOT/en/reference-manual/http-restful-api/metrics.html#available-system-metrics