### PR TITLE
Add test cases for the mapping to compat modules in HBaseVersion.

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.data2.util.hbase;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.io.output.NullOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -209,40 +210,7 @@ public class HBaseVersion {
       Class versionInfoClass = Class.forName("org.apache.hadoop.hbase.util.VersionInfo");
       Method versionMethod = versionInfoClass.getMethod("getVersion");
       versionString = (String) versionMethod.invoke(null);
-      if (versionString.startsWith(HBASE_94_VERSION)) {
-        currentVersion = Version.HBASE_94;
-      } else if (versionString.startsWith(HBASE_96_VERSION)) {
-        currentVersion = Version.HBASE_96;
-      } else if (versionString.startsWith(HBASE_98_VERSION)) {
-        currentVersion = Version.HBASE_98;
-      } else if (versionString.startsWith(HBASE_10_VERSION)) {
-        VersionNumber ver = VersionNumber.create(versionString);
-        if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH55_CLASSIFIER)) {
-          currentVersion = Version.HBASE_10_CDH55;
-        } else if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH56_CLASSIFIER)) {
-          currentVersion = Version.HBASE_10_CDH56;
-        } else if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH_CLASSIFIER)) {
-          currentVersion = Version.HBASE_10_CDH;
-        } else {
-          currentVersion = Version.HBASE_10;
-        }
-      } else if (versionString.startsWith(HBASE_11_VERSION)) {
-        currentVersion = Version.HBASE_11;
-      } else if (versionString.startsWith(HBASE_12_VERSION)) {
-        VersionNumber ver = VersionNumber.create(versionString);
-        if (ver.getClassifier() != null &&
-          (ver.getClassifier().startsWith(CDH57_CLASSIFIER) ||
-            // CDH 5.7 compat module can be re-used with CDH 5.8 and CDH 5.9
-            ver.getClassifier().startsWith(CDH58_CLASSIFIER) ||
-            ver.getClassifier().startsWith(CDH59_CLASSIFIER))) {
-          currentVersion = Version.HBASE_12_CDH57;
-        } else {
-          // HBase-11 compat module can be re-used for HBASE-12 as there is no change needed in compat source.
-          currentVersion = Version.HBASE_11;
-        }
-      } else {
-        currentVersion = Version.UNKNOWN;
-      }
+      currentVersion = determineVersionFromVersionString(versionString);
     } catch (Throwable e) {
       // Get the Logger instance inside determineVersion() to prevent LoggerFactory.getLogger printing extra output to
       // stdout. No need for a static Logger instance because determineVersion() will only be called once.
@@ -254,6 +222,44 @@ public class HBaseVersion {
       if (versionString == null) {
         versionString = "unknown";
       }
+    }
+  }
+
+  @VisibleForTesting
+  static Version determineVersionFromVersionString(String versionString) throws ParseException {
+    if (versionString.startsWith(HBASE_94_VERSION)) {
+      return Version.HBASE_94;
+    } else if (versionString.startsWith(HBASE_96_VERSION)) {
+      return Version.HBASE_96;
+    } else if (versionString.startsWith(HBASE_98_VERSION)) {
+      return Version.HBASE_98;
+    } else if (versionString.startsWith(HBASE_10_VERSION)) {
+      VersionNumber ver = VersionNumber.create(versionString);
+      if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH55_CLASSIFIER)) {
+        return Version.HBASE_10_CDH55;
+      } else if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH56_CLASSIFIER)) {
+        return Version.HBASE_10_CDH56;
+      } else if (ver.getClassifier() != null && ver.getClassifier().startsWith(CDH_CLASSIFIER)) {
+        return Version.HBASE_10_CDH;
+      } else {
+        return Version.HBASE_10;
+      }
+    } else if (versionString.startsWith(HBASE_11_VERSION)) {
+      return Version.HBASE_11;
+    } else if (versionString.startsWith(HBASE_12_VERSION)) {
+      VersionNumber ver = VersionNumber.create(versionString);
+      if (ver.getClassifier() != null &&
+        (ver.getClassifier().startsWith(CDH57_CLASSIFIER) ||
+          // CDH 5.7 compat module can be re-used with CDH 5.8 and CDH 5.9
+          ver.getClassifier().startsWith(CDH58_CLASSIFIER) ||
+          ver.getClassifier().startsWith(CDH59_CLASSIFIER))) {
+        return Version.HBASE_12_CDH57;
+      } else {
+        // HBase-11 compat module can be re-used for HBASE-12 as there is no change needed in compat source.
+        return Version.HBASE_11;
+      }
+    } else {
+      return Version.UNKNOWN;
     }
   }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/HBaseVersionTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/HBaseVersionTest.java
@@ -58,4 +58,29 @@ public class HBaseVersionTest {
     Assert.assertNull(versionNumber.getClassifier());
     Assert.assertFalse(versionNumber.isSnapshot());
   }
+
+  @Test
+  public void testHBaseVersionToCompatMapping() throws ParseException {
+    // test the mapping from hbase version to the compat module we use for that version
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_96, "0.96.1.1");
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_98, "0.98.1");
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_98, "0.98.6");
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_10, "1.0.0");
+
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_10_CDH, "1.0.0-cdh5.4.4");
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_10_CDH55, "1.0.0-cdh5.5.2");
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_10_CDH56, "1.0.0-cdh5.6.1");
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_11, "1.1.1");
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_11, "1.2.0-IBM-7");
+
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.7.1");
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.7.1-SNAPSHOT");
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.8.2");
+    assertCompatModuleMapping(HBaseVersion.Version.HBASE_12_CDH57, "1.2.0-cdh5.9.0");
+  }
+
+  private void assertCompatModuleMapping(HBaseVersion.Version expectedCompatModule,
+                                         String hbaseVersion) throws ParseException {
+    Assert.assertEquals(expectedCompatModule, HBaseVersion.determineVersionFromVersionString(hbaseVersion));
+  }
 }


### PR DESCRIPTION
This would help avoid accidental changes to the mapping of existing hbase versions, such as while adding new mappings, or while merging conflicts (such as in https://github.com/caskdata/cdap/pull/7178).

http://builds.cask.co/browse/CDAP-RUT284-1