### PR TITLE
Minor fix to documentation build

### DIFF
--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -122,6 +122,7 @@ function build_docs() {
   cd ${SCRIPT_PATH}
   check_includes
   ${SPHINX_BUILD} -w ${TARGET}/${SPHINX_MESSAGES} ${google_tag} ${SOURCE} ${TARGET}/${HTML}
+  build_extras
   consolidate_messages
 }
 
@@ -134,7 +135,6 @@ function build_docs_local() {
 
 function build_web() {
   build_docs ${GOOGLE_TAG_MANAGER_CODE}
-  build_extras
 }
 
 function build_extras() {

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -120,7 +120,9 @@ function _build_docs() {
   local title=${2}
   display_start_title "${title}"
 
-  clean_targets
+  if [[ ${type} == "docs_set" ]] || [[ ${type} == "docs_web_only" ]]; then
+    clean_targets
+  fi
   clear_messages_file
   if [[ ${type} == "docs_set" ]] || [[ ${type} == "docs_web_only" ]]; then
     build_docs_first_pass

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -120,11 +120,9 @@ function _build_docs() {
   local title=${2}
   display_start_title "${title}"
 
-  if [[ ${type} == "docs_set" ]] || [[ ${type} == "docs_web_only" ]]; then
-    clean_targets
-  fi
   clear_messages_file
   if [[ ${type} == "docs_set" ]] || [[ ${type} == "docs_web_only" ]]; then
+    clean_targets
     build_docs_first_pass
     clear_messages_file
     if [[ ${type} == "docs_set" ]]; then

--- a/cdap-docs/reference-manual/build.sh
+++ b/cdap-docs/reference-manual/build.sh
@@ -53,11 +53,6 @@ function build_extras() {
   if [[ -n ${USING_JAVADOCS} ]]; then
     echo "Copying Javadocs."
     rm -rf ${TARGET_PATH}/html/javadocs
-    warnings=$?
-    if [[ ${warnings} -ne 0 ]]; then
-      set_message "Unable to remove existing Javadocs"
-      return ${warnings}
-    fi
     cp -r ${API_JAVADOCS} ${TARGET_PATH}/html/.
     warnings=$?
     if [[ ${warnings} -ne 0 ]]; then

--- a/cdap-docs/reference-manual/build.sh
+++ b/cdap-docs/reference-manual/build.sh
@@ -52,15 +52,39 @@ function build_extras() {
 
   if [[ -n ${USING_JAVADOCS} ]]; then
     echo "Copying Javadocs."
-    rm -rf ${TARGET_PATH}/${HTML}/javadocs
-    cp -r ${API_JAVADOCS} ${TARGET_PATH}/${HTML}/.
-    mv -f ${TARGET_PATH}/${HTML}/${API_DOCS} ${TARGET_PATH}/${HTML}/javadocs
+    rm -rf ${TARGET_PATH}/html/javadocs
+    warnings=$?
+    if [[ ${warnings} -ne 0 ]]; then
+      set_message "Unable to remove existing Javadocs"
+      return ${warnings}
+    fi
+    cp -r ${API_JAVADOCS} ${TARGET_PATH}/html/.
+    warnings=$?
+    if [[ ${warnings} -ne 0 ]]; then
+      set_message "Unable to copy new Javadocs"
+      return ${warnings}
+    fi
+    mv -f ${TARGET_PATH}/html/${API_DOCS} ${TARGET_PATH}/html/javadocs
+    warnings=$?
+    if [[ ${warnings} -ne 0 ]]; then
+      set_message "Unable to move new Javadocs into place"
+      return ${warnings}
+    fi
+    echo "Copied Javadocs."
   else
     echo "Not using Javadocs."
   fi
 
-  echo "Copying license PDFs."
-  cp ${SCRIPT_PATH}/${LICENSES_PDF}/*.pdf ${TARGET_PATH}/${HTML}/licenses
+  cp ${SCRIPT_PATH}/licenses-pdf/*.pdf ${TARGET_PATH}/html/licenses
+  warnings=$?
+  if [[ ${warnings} -eq 0 ]]; then
+    echo "Copied license PDFs."
+  else
+    local m="Error ${warnings} copying license PDFs."
+    echo_red_bold "${m}"
+    set_message "${m}"
+    return ${warnings}
+  fi
 }
 
 run_command ${1}


### PR DESCRIPTION
Only clean targets if running either a "docs_set" or "docs_web_only"

Fixes a problem when running local builds that are run "dirty", reusing the existing target directories. This is a local optimization that saves time during documentation development.

Passes as a Quick Build: http://builds.cask.co/browse/CDAP-DQB174-4