### PR TITLE
Remember the System.out so that it can be reset correctly.

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/HBaseVersion.java
@@ -100,11 +100,12 @@ public class HBaseVersion {
    */
   public static void main(String[] args) {
     // Suppress any output to stdout
+    PrintStream stdout = System.out;
     System.setOut(new PrintStream(new NullOutputStream()));
     Version version = HBaseVersion.get();
 
     // Restore stdout
-    System.setOut(System.out);
+    System.setOut(stdout);
     System.out.println(version.getMajorVersion());
 
     if (args.length == 1 && "-v".equals(args[0])) {


### PR DESCRIPTION
Regression was introduced in #7172 as we were not resetting the `System.out` correctly. This causes failure in starting of the cdap. 