### PR TITLE
[CDAP-7706] - Complex Schema Editor in React

### DIFF
--- a/cdap-ui/.babelrc
+++ b/cdap-ui/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["es2015", "react"],
-  "plugins": ["transform-async-to-generator"]
+  "plugins": []
 }

--- a/cdap-ui/.eslintrc.json
+++ b/cdap-ui/.eslintrc.json
@@ -38,7 +38,8 @@
     "expect": true,
     "jest": true,
     "beforeEach": true,
-    "afterEach": true
+    "afterEach": true,
+    "avsc": true
   },
   "plugins": ["react", "babel"],
   "extends": ["eslint:recommended", "plugin:react/recommended"]

--- a/cdap-ui/app/cdap/cdap.html
+++ b/cdap-ui/app/cdap/cdap.html
@@ -28,6 +28,7 @@
 <body>
   <div id="app-container"></div>
   <script type="text/javascript" src="/config.js"></script>
+  <script type="text/javascript" src="/cdap_assets/avsc-bundle.js"></script>
   <script type="text/javascript" src="/ui-config.js"></script>
   <script type="text/javascript" src="/cdap_assets/common.js"></script>
   <script type="text/javascript" src="/cdap_assets/cdap.js"></script>

--- a/cdap-ui/app/cdap/components/SchemaEditor/AbstractSchemaRow/AbstractSchemaRow.less
+++ b/cdap-ui/app/cdap/components/SchemaEditor/AbstractSchemaRow/AbstractSchemaRow.less
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+.abstract-schema-row {
+  border-bottom: 1px solid #ccc;
+  padding-left: 5px;
+
+  &:last-child {
+    border: 0;
+  }
+}

--- a/cdap-ui/app/cdap/components/SchemaEditor/AbstractSchemaRow/index.js
+++ b/cdap-ui/app/cdap/components/SchemaEditor/AbstractSchemaRow/index.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, {PropTypes} from 'react';
+import ArraySchemaRow from 'components/SchemaEditor/ArraySchemaRow';
+import MapSchemaRow from 'components/SchemaEditor/MapSchemaRow';
+import UnionSchemaRow from 'components/SchemaEditor/UnionSchemaRow';
+import EnumSchemaRow from 'components/SchemaEditor/EnumSchemaRow';
+import RecordSchemaRow from 'components/SchemaEditor/RecordSchemaRow';
+// import {parseType} from 'components/SchemaEditor/SchemaHelpers';
+
+
+require('./AbstractSchemaRow.less');
+
+export default function AbstractSchemaRow({row, onChange}) {
+  const renderSchemaRow = (row) => {
+    switch(row.displayType) {
+      case 'array':
+        return (
+          <ArraySchemaRow
+            row={row.type}
+            onChange={onChange}
+          />
+        );
+      case 'map':
+        return (
+          <MapSchemaRow
+            row={row.type}
+            onChange={onChange}
+          />
+        );
+      case 'union':
+        return (
+          <UnionSchemaRow
+            row={row.type}
+            onChange={onChange}
+          />
+        );
+      case 'enum':
+        return (
+          <EnumSchemaRow
+            row={row.type}
+            onChange={onChange}
+          />
+        );
+      case 'record':
+        return (
+          <RecordSchemaRow
+            row={row.type}
+            onChange={onChange}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+  return (
+    <div className="abstract-schema-row">
+      {
+        renderSchemaRow(row)
+      }
+    </div>
+  );
+}
+AbstractSchemaRow.propTypes = {
+  row: PropTypes.any,
+  onChange: PropTypes.func.isRequired
+};

--- a/cdap-ui/app/cdap/components/SchemaEditor/ArraySchemaRow/ArraySchemaRow.less
+++ b/cdap-ui/app/cdap/components/SchemaEditor/ArraySchemaRow/ArraySchemaRow.less
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+.array-schema-row {
+  > .schema-row {
+
+    >.field-name {
+      position: relative;
+      &:after {
+        color: #3c4355;
+        content: "\f0d7";
+        font-family: 'FontAwesome';
+        position: absolute;
+        top: 7px;
+        right: 10px;
+        z-index: 5;
+      }
+    }
+    > .field-type {
+      visibility: hidden;
+    }
+  }
+  .abstract-schema-row {
+    padding-left: 5px;
+    padding-top: 0;
+  }
+}

--- a/cdap-ui/app/cdap/components/SchemaEditor/ArraySchemaRow/index.js
+++ b/cdap-ui/app/cdap/components/SchemaEditor/ArraySchemaRow/index.js
@@ -1,0 +1,195 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, {PropTypes, Component} from 'react';
+  import {parseType, SCHEMA_TYPES, checkComplexType, checkParsedTypeForError} from 'components/SchemaEditor/SchemaHelpers';
+import SelectWithOptions from 'components/SelectWithOptions';
+import AbstractSchemaRow from 'components/SchemaEditor/AbstractSchemaRow';
+import {Input} from 'reactstrap';
+import classnames from 'classnames';
+import cloneDeep from 'lodash/cloneDeep';
+
+require('./ArraySchemaRow.less');
+
+export default class ArraySchemaRow extends Component{
+  constructor(props) {
+    super(props);
+    if (typeof props.row === 'object') {
+      let item = parseType(props.row);
+      let itemsType = item.type.getItemsType();
+      let parsedItemsType = parseType(itemsType);
+      this.state = {
+        displayType: {
+          type: parsedItemsType.displayType,
+          nullable: parsedItemsType.nullable
+        },
+        showAbstractSchemaRow: true,
+        error: ''
+      };
+      this.parsedType = itemsType;
+    } else {
+      this.state = {
+        displayType: {
+          type: 'string',
+          nullable: false
+        },
+        showAbstractSchemaRow: true,
+        error: ''
+      };
+      this.parsedType = 'string';
+    }
+    this.onTypeChange = this.onTypeChange.bind(this);
+    setTimeout(this.updateParent.bind(this));
+  }
+  onTypeChange(e) {
+    let selectedType = e.target.value;
+    if (this.state.displayType.nullable) {
+      this.parsedType = [selectedType, 'null'];
+    } else {
+      this.parsedType = selectedType;
+    }
+    this.setState({
+      displayType: {
+        type: e.target.value,
+        nullable: this.state.displayType.nullable
+      },
+      error: ''
+    }, function() {
+      if (!checkComplexType(selectedType)) {
+        this.updateParent();
+      }
+    }.bind(this));
+  }
+  onNullableChange(e) {
+    let parsedType = cloneDeep(this.parsedType);
+    if (!e.target.checked) {
+      this.parsedType = parsedType[0];
+    } else {
+      this.parsedType = [parsedType, 'null'];
+    }
+    this.setState({
+      displayType: {
+        type: this.state.displayType.type,
+        nullable: e.target.checked
+      },
+      error: ''
+    }, this.updateParent.bind(this));
+  }
+  onChildrenChange(itemsState) {
+    let error = checkParsedTypeForError({
+      type: 'array',
+      items: this.state.displayType.nullable ? [itemsState, 'null'] : itemsState
+    });
+    if (error) {
+      this.setState({error});
+      return;
+    } else {
+      this.setState({error: ''});
+    }
+    this.parsedType = this.state.displayType.nullable ? [cloneDeep(itemsState): 'null'] : cloneDeep(itemsState);
+    this.updateParent();
+  }
+  updateParent() {
+    let error = checkParsedTypeForError({
+      type: 'array',
+      items: this.parsedType
+    });
+    if (error) {
+      this.setState({error});
+      return;
+    }
+    this.props.onChange({
+      type: 'array',
+      items: cloneDeep(this.parsedType)
+    });
+  }
+  toggleAbstractSchemaRow() {
+    this.setState({ showAbstractSchemaRow: !this.state.showAbstractSchemaRow });
+  }
+  render() {
+    const showArrows = () => {
+      if (this.state.showAbstractSchemaRow) {
+        return (
+          <span
+            className="fa fa-caret-down"
+            onClick={this.toggleAbstractSchemaRow.bind(this)}
+          >
+          </span>
+        );
+      }
+      return (
+        <span
+          className="fa fa-caret-right"
+          onClick={this.toggleAbstractSchemaRow.bind(this)}
+        >
+        </span>
+      );
+    };
+    return (
+      <div className="array-schema-row">
+        <div className="text-danger">
+          {this.state.error}
+        </div>
+        <div className={
+            classnames("schema-row", {
+              "nested": checkComplexType(this.state.displayType.type)
+            })
+          }>
+          <div className="field-name">
+            <SelectWithOptions
+              options={SCHEMA_TYPES.types}
+              value={this.state.displayType.type}
+              onChange={this.onTypeChange}
+            />
+          {
+            checkComplexType(this.state.displayType.type) ?
+              showArrows()
+            :
+              null
+          }
+          </div>
+          <div className="field-type"></div>
+          <div className="field-isnull">
+            <div className="btn btn-link">
+              <Input
+                type="checkbox"
+                checked={this.state.displayType.nullable}
+                onChange={this.onNullableChange.bind(this)}
+              />
+            </div>
+          </div>
+          {
+            checkComplexType(this.state.displayType.type) && this.state.showAbstractSchemaRow  ?
+              <AbstractSchemaRow
+                row={{
+                  type: Array.isArray(this.parsedType) ? this.parsedType[0] : this.parsedType,
+                  displayType: this.state.displayType.type
+                }}
+                onChange={this.onChildrenChange.bind(this)}
+              />
+            :
+              null
+          }
+        </div>
+      </div>
+    );
+  }
+}
+
+ArraySchemaRow.propTypes = {
+  row: PropTypes.any,
+  onChange: PropTypes.func.isRequired
+};

--- a/cdap-ui/app/cdap/components/SchemaEditor/EnumSchemaRow/EnumSchemaRow.less
+++ b/cdap-ui/app/cdap/components/SchemaEditor/EnumSchemaRow/EnumSchemaRow.less
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+.enum-schema-row {
+  .schema-row {
+    >.field-type {
+      visibility: hidden;
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/SchemaEditor/EnumSchemaRow/index.js
+++ b/cdap-ui/app/cdap/components/SchemaEditor/EnumSchemaRow/index.js
@@ -1,0 +1,183 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, {PropTypes, Component} from 'react';
+import {parseType, checkParsedTypeForError} from 'components/SchemaEditor/SchemaHelpers';
+import {Input} from 'reactstrap';
+import {insertAt, removeAt} from 'services/helpers';
+import uuid from 'node-uuid';
+import T from 'i18n-react';
+require('./EnumSchemaRow.less');
+
+export default class EnumSchemaRow extends Component {
+  constructor(props) {
+    super(props);
+    if (typeof props.row === 'object') {
+      let rowType = parseType(props.row);
+      let symbols = rowType.type.getSymbols().map(symbol => ({symbol, id: uuid.v4()}));
+      this.state = {
+        symbols,
+        error: '',
+        refRequired: true
+      };
+    } else {
+      this.state = {
+        symbols: [{symbol: '', id: uuid.v4()}],
+        error: ''
+      };
+    }
+  }
+  checkForErrors(symbols) {
+    let parsedType = {
+      type: 'enum',
+      symbols: symbols.map(sobj => sobj.symbol).filter(symbol => symbol.length)
+    };
+    return checkParsedTypeForError(parsedType);
+  }
+  onSymbolChange(index, e) {
+    let symbols = this.state.symbols;
+    symbols[index].symbol = e.target.value;
+    let error = this.checkForErrors(symbols);
+    if (error) {
+      this.setState({error});
+      return;
+    }
+    this.setState({
+      symbols,
+      error: ''
+    }, () => {
+      this.props.onChange({
+        type: 'enum',
+        symbols: this.state.symbols.map(sobj => sobj.symbol).filter(symbol => symbol.length)
+      });
+    });
+  }
+  onSymbolAdd(index) {
+    let symbols = this.state.symbols.map(sobj => {
+      delete sobj.refRequired;
+      return sobj;
+    });
+    symbols = insertAt(symbols, index, {
+      symbol: '',
+      id: uuid.v4(),
+      refRequired: true
+    });
+    this.setState({symbols}, () => {
+      if (this.inputToFocus) {
+        this.inputToFocus.focus();
+      }
+      let error = this.checkForErrors(symbols);
+      if (error) {
+        return;
+      }
+      this.props.onChange({
+        type: 'enum',
+        symbols: this.state.symbols.map(sobj => sobj.symbol).filter(symbol => symbol.length)
+      });
+    });
+  }
+  onSymbolRemove(index) {
+    let symbols = this.state.symbols;
+    symbols = removeAt(symbols, index);
+    this.setState({
+      symbols,
+      error: ''
+    }, () => {
+      let error = this.checkForErrors(this.state.symbols);
+      if (error) {
+        this.setState({error});
+        return;
+      }
+      this.props.onChange({
+        type: 'enum',
+        symbols: this.state.symbols.map(sobj => sobj.symbol).filter(symbol => symbol.length)
+      });
+    });
+  }
+  onKeyPress(index, e) {
+    if (e.nativeEvent.keyCode === 13) {
+      this.onSymbolChange(index, e);
+      this.onSymbolAdd(index);
+    }
+  }
+  render() {
+    return (
+      <div className="enum-schema-row">
+        <div className="text-danger">
+          {this.state.error}
+        </div>
+        {
+          this.state.symbols.map((sobj, index) => {
+            return (
+              <div
+                className="schema-row"
+                key={sobj.id}
+              >
+                {
+                  sobj.refRequired ?
+                    <Input
+                      className="field-name"
+                      placeholder={T.translate('features.SchemaEditor.Labels.symbolName')}
+                      defaultValue={sobj.symbol}
+                      onFocus={() => sobj.symbol}
+                      onBlur={this.onSymbolChange.bind(this, index)}
+                      getRef={(ref) => this.inputToFocus = ref}
+                      onKeyPress={this.onKeyPress.bind(this, index)}
+                    />
+                  :
+                    <Input
+                      className="field-name"
+                      placeholder={T.translate('features.SchemaEditor.Labels.symbolName')}
+                      defaultValue={sobj.symbol}
+                      onFocus={() => sobj.symbol}
+                      onBlur={this.onSymbolChange.bind(this, index)}
+                      onKeyPress={this.onKeyPress.bind(this, index)}
+                    />
+                }
+                <div className="field-type"></div>
+                <div className="field-isnull">
+                  <div className="btn btn-link"></div>
+                  <div className="btn btn-link">
+                    <button
+                      className="fa fa-plus"
+                      onClick={this.onSymbolAdd.bind(this, index)}
+                    ></button>
+                  </div>
+                  <div className="btn btn-link">
+                    {
+                      this.state.symbols.length !== 1 ?
+                        <button
+                          className="fa fa-trash text-danger"
+                          onClick={this.onSymbolRemove.bind(this, index)}
+                        ></button>
+                      :
+                        null
+                    }
+                  </div>
+                </div>
+              </div>
+            );
+          })
+        }
+      </div>
+    );
+  }
+}
+
+EnumSchemaRow.propTypes = {
+  row: PropTypes.any,
+  onChange: PropTypes.func.isRequired
+};

--- a/cdap-ui/app/cdap/components/SchemaEditor/MapSchemaRow/MapSchemaRow.less
+++ b/cdap-ui/app/cdap/components/SchemaEditor/MapSchemaRow/MapSchemaRow.less
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+.map-schema-row {
+  .schema-row {
+    > .key-row,
+    > .value-row {
+      > .field-name {
+        width: ~"calc(100% - 80px - 75px)";
+        width: ~"-webkit-calc(100% - 80px - 75px)";
+        width: ~"-moz-calc(100% - 80px - 75px)";
+        display: inline-block;
+        position: relative;
+
+        .fa-caret-down,
+        .fa-caret-right {
+          position: absolute;
+          bottom: -2px;
+          left: 10px;
+          cursor: pointer;
+        }
+        div {
+          &:first-child {
+            margin: 0 10px;
+            width: 30px;
+            display: inline-block;
+          }
+        }
+      }
+      > .field-type {
+        width: 80px;
+      }
+      > .field-isnull {
+        width: 75px;
+        .btn.btn-link {
+          display: inline-block;
+          padding: 0 5px;
+          width: 24px;
+        }
+      }
+      &.nested {
+        border: 0;
+        box-shadow: 0px 0px 3px 1px rgba(1, 0, 0, 0.2);
+        border-radius: 4px;
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+
+        >.abstract-schema-row {
+          box-shadow: 1px -2px 1px rgba(0,0,0,0.25);
+        }
+        >.field-name {
+          box-shadow: rgba(1, 0, 0, 0.25) 1px -1px 7px;
+          border-radius: 4px;
+          position: relative;
+          width: 155px;
+          &:before {
+            position: absolute;
+            content: ' ';
+            top: 29px;
+            bottom: 0;
+            width: 100%;
+            background: white;
+            box-shadow: none;
+            height: 10px;
+          }
+        }
+        >.field-type {
+          width: ~"calc(100% - 155px - 75px)";
+          width: ~"-moz-calc(100% - 155px - 75px)";
+          width: ~"-webkit-calc(100% - 155px - 75px)";
+        }
+      }
+    }
+    > .key-row,
+    > .value-row {
+      > .field-name {
+        .form-control {
+          width: 90px;
+          vertical-align: inherit;
+          display: inline-block;
+        }
+        &:after {
+          color: #3c4355;
+          content: "\f0d7";
+          font-family: 'FontAwesome';
+          position: absolute;
+          top: 7px;
+          left: 130px;
+          z-index: 5;
+        }
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/SchemaEditor/MapSchemaRow/index.js
+++ b/cdap-ui/app/cdap/components/SchemaEditor/MapSchemaRow/index.js
@@ -1,0 +1,280 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, {PropTypes, Component} from 'react';
+import SelectWithOptions from 'components/SelectWithOptions';
+import {parseType, SCHEMA_TYPES, checkComplexType, checkParsedTypeForError} from 'components/SchemaEditor/SchemaHelpers';
+import AbstractSchemaRow from 'components/SchemaEditor/AbstractSchemaRow';
+import {Input} from 'reactstrap';
+import classnames from 'classnames';
+import cloneDeep from 'lodash/cloneDeep';
+
+require('./MapSchemaRow.less');
+
+export default class MapSchemaRow extends Component {
+  constructor(props) {
+    super(props);
+    if (typeof props.row === 'object') {
+      let rowType = parseType(props.row);
+      let parsedKeysType = parseType(rowType.type.getKeysType());
+      let parsedValuesType = parseType(rowType.type.getValuesType());
+      this.state = {
+        name: rowType.name,
+        keysType: parsedKeysType.displayType,
+        keysTypeNullable: parsedKeysType.nullable,
+        valuesType: parsedValuesType.displayType,
+        valuesTypeNullable: parsedValuesType.nullable,
+        error: '',
+        showKeysAbstractSchemaRow: true,
+        showValuesAbstractSchemaRow: true
+      };
+      this.parsedKeysType = rowType.type.getKeysType();
+      this.parsedValuesType = rowType.type.getValuesType();
+    } else {
+      this.state = {
+        name: props.row.name,
+        keysType: 'string',
+        keysTypeNullable: false,
+        valuesType: 'string',
+        valuesTypeNullable: false,
+        error: '',
+        showKeysAbstractSchemaRow: true,
+        showValuesAbstractSchemaRow: true
+      };
+      this.parsedKeysType = 'string';
+      this.parsedValuesType = 'string';
+    }
+    setTimeout(this.updateParent.bind(this));
+    this.onKeysTypeChange = this.onKeysTypeChange.bind(this);
+    this.onValuesTypeChange = this.onValuesTypeChange.bind(this);
+  }
+  onKeysTypeChange(e) {
+    this.parsedKeysType = this.state.keysTypeNullable ? [e.target.value, 'null'] : e.target.value;
+    this.setState({
+      keysType: e.target.value
+    }, function() {
+      if (!checkComplexType(this.state.keysType)) {
+        this.updateParent();
+      }
+    }.bind(this));
+  }
+  onValuesTypeChange(e) {
+    this.parsedValuesType = this.state.valuesTypeNullable ? [e.target.value, 'null'] : e.target.value;
+    this.setState({
+      valuesType: e.target.value
+    }, function() {
+      if (!checkComplexType(this.state.valuesType)) {
+        this.updateParent();
+      }
+    }.bind(this));
+  }
+  updateParent() {
+    let error = checkParsedTypeForError(this.parsedValuesType) || checkParsedTypeForError(this.parsedKeysType);
+    if (error) {
+      this.setState({error});
+      return;
+    }
+    this.props.onChange({
+      type: 'map',
+      keys: this.parsedKeysType,
+      values: this.parsedValuesType
+    });
+  }
+  onKeysChildrenChange(keysState) {
+    keysState = cloneDeep(keysState);
+    let error = checkParsedTypeForError(keysState);
+    if (error) {
+      this.setState({error});
+      return;
+    }
+    this.parsedKeysType = this.state.keysTypeNullable ? [keysState, 'null']: keysState;
+    this.updateParent();
+  }
+  onValuesChildrenChange(valuesState) {
+    valuesState = cloneDeep(valuesState);
+    let error = checkParsedTypeForError(valuesState);
+    if (error) {
+      this.setState({error});
+      return;
+    }
+    this.parsedValuesType = this.state.valuesTypeNullable ? [valuesState, 'null']: valuesState;
+    this.updateParent();
+  }
+  onKeysTypeNullableChange(e) {
+    if (e.target.checked) {
+      this.parsedKeysType = [this.parsedKeysType, 'null'];
+    } else {
+      this.parsedKeysType = this.parsedKeysType[0];
+    }
+    this.setState({
+      keysTypeNullable: e.target.checked,
+      error: ''
+    }, this.updateParent.bind(this));
+  }
+  onValuesTypeNullableChange(e) {
+    if (e.target.checked) {
+      this.parsedValuesType = [this.parsedValuesType, 'null'];
+    } else {
+      this.parsedValuesType = this.parsedValuesType[0];
+    }
+    this.setState({
+      valuesTypeNullable: e.target.checked,
+      error: ''
+    }, this.updateParent.bind(this));
+  }
+  toggleKeysAbstractSchemaRow() {
+    this.setState({showKeysAbstractSchemaRow: !this.state.showKeysAbstractSchemaRow});
+  }
+  toggleValuesAbstractSchemaRow() {
+    this.setState({showValuesAbstractSchemaRow: !this.state.showValuesAbstractSchemaRow});
+  }
+  render() {
+    const showKeysArrow = () => {
+      if (this.state.showKeysAbstractSchemaRow) {
+        return (
+          <span
+            className="fa fa-caret-down"
+            onClick={this.toggleKeysAbstractSchemaRow.bind(this)}
+          >
+          </span>
+        );
+      }
+      return (
+        <span
+          className="fa fa-caret-right"
+          onClick={this.toggleKeysAbstractSchemaRow.bind(this)}
+        >
+        </span>
+      );
+    };
+    const showValuesArrow = () => {
+      if (this.state.showValuesAbstractSchemaRow) {
+        return (
+          <span
+            className="fa fa-caret-down"
+            onClick={this.toggleValuesAbstractSchemaRow.bind(this)}
+          >
+          </span>
+        );
+      }
+      return (
+        <span
+          className="fa fa-caret-right"
+          onClick={this.toggleValuesAbstractSchemaRow.bind(this)}
+        >
+        </span>
+      );
+    };
+    return (
+      <div className="map-schema-row">
+        <div className="text-danger">
+          {this.state.error}
+        </div>
+        <div className="schema-row">
+          <div className={
+            classnames("key-row clearfix", {
+              "nested": checkComplexType(this.state.keysType)
+            })
+          }>
+            <div className="field-name">
+              <div> Key: </div>
+              <SelectWithOptions
+                options={SCHEMA_TYPES.types}
+                value={this.state.keysType}
+                onChange={this.onKeysTypeChange}
+              />
+              {
+                checkComplexType(this.state.keysType) ?
+                  showKeysArrow()
+                :
+                null
+              }
+            </div>
+            <div className="field-type"></div>
+            <div className="field-isnull">
+              <div className="btn btn-link">
+                <Input
+                  type="checkbox"
+                  checked={this.state.keysTypeNullable}
+                  onChange={this.onKeysTypeNullableChange.bind(this)}
+                />
+              </div>
+            </div>
+            {
+              checkComplexType(this.state.keysType) && this.state.showKeysAbstractSchemaRow ?
+                <AbstractSchemaRow
+                  row={{
+                    type: this.parsedKeysType,
+                    displayType: this.state.keysType
+                  }}
+                  onChange={this.onKeysChildrenChange.bind(this)}
+                />
+              :
+                null
+            }
+          </div>
+          <div className={
+            classnames("value-row clearfix", {
+              "nested": checkComplexType(this.state.valuesType)
+            })
+          }>
+            <div className="field-name">
+              <div>Value: </div>
+              <SelectWithOptions
+                options={SCHEMA_TYPES.types}
+                value={this.state.valuesType}
+                onChange={this.onValuesTypeChange}
+              />
+              {
+                checkComplexType(this.state.valuesType)?
+                  showValuesArrow()
+                :
+                null
+              }
+            </div>
+            <div className="field-type"></div>
+            <div className="field-isnull">
+              <div className="btn btn-link">
+                <Input
+                  type="checkbox"
+                  checked={this.state.valuesTypeNullable}
+                  onChange={this.onValuesTypeNullableChange.bind(this)}
+                />
+              </div>
+            </div>
+              {
+                checkComplexType(this.state.valuesType) && this.state.showValuesAbstractSchemaRow ?
+                  <AbstractSchemaRow
+                    row={{
+                      type: Array.isArray(this.parsedValuesType) ? this.parsedValuesType[0] : this.parsedValuesType,
+                      displayType: this.state.valuesType
+                    }}
+                    onChange={this.onValuesChildrenChange.bind(this)}
+                  />
+                :
+                  null
+              }
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+MapSchemaRow.propTypes = {
+  row: PropTypes.any,
+  onChange: PropTypes.func.isRequired
+};

--- a/cdap-ui/app/cdap/components/SchemaEditor/RecordSchemaRow/RecordSchemaRow.less
+++ b/cdap-ui/app/cdap/components/SchemaEditor/RecordSchemaRow/RecordSchemaRow.less
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+.record-schema-row {
+  > .schema-row {
+    &:only-child {
+      border: 0;
+    }
+  }
+  .schema-row {
+    box-shadow: 3px -2px 5px rgba(0, 0, 0, 0.25), 0px 0px 0px white;
+  }
+  .schema-row ~ .schema-row {
+    box-shadow: none;
+  }
+}

--- a/cdap-ui/app/cdap/components/SchemaEditor/RecordSchemaRow/index.js
+++ b/cdap-ui/app/cdap/components/SchemaEditor/RecordSchemaRow/index.js
@@ -1,0 +1,352 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, {PropTypes, Component} from 'react';
+import {SCHEMA_TYPES, checkComplexType, getParsedSchema, checkParsedTypeForError} from 'components/SchemaEditor/SchemaHelpers';
+import AbstractSchemaRow from 'components/SchemaEditor/AbstractSchemaRow';
+require('./RecordSchemaRow.less');
+import uuid from 'node-uuid';
+import {Input} from 'reactstrap';
+import SelectWithOptions from 'components/SelectWithOptions';
+import {insertAt, removeAt} from 'services/helpers';
+import T from 'i18n-react';
+import classnames from 'classnames';
+import cloneDeep from 'lodash/cloneDeep';
+
+export default class RecordSchemaRow extends Component{
+  constructor(props) {
+    super(props);
+    if (typeof props.row === 'object') {
+      let displayFields = getParsedSchema(props.row).map(field => {
+        field.showAbstractSchemaRow = true;
+        return field;
+      });
+      let parsedFields = displayFields
+        .map(({name, type, nullable}) => {
+          return {
+            name,
+            type: nullable ? [type, 'null'] : type
+          };
+        });
+      this.state = {
+        type: 'record',
+        name: 'a' +  uuid.v4().split('-').join(''),
+        displayFields,
+        error: ''
+      };
+      this.parsedFields = parsedFields;
+    } else {
+      this.state = {
+        type: 'record',
+        name: 'a' +  uuid.v4().split('-').join(''),
+        displayFields: [
+          {
+            name: '',
+            type: 'string',
+            displayType: 'string',
+            nullable: false,
+            id: uuid.v4(),
+            showAbstractSchemaRow: true
+          }
+        ],
+        error: ''
+      };
+      this.parsedFields = [{
+        name: '',
+        type: 'string'
+      }];
+    }
+    setTimeout(this.updateParent.bind(this));
+  }
+  onRowAdd(index, e) {
+    let displayFieldsCopy = [...this.state.displayFields].map(field => {
+      delete field.refRequired;
+      return field;
+    });
+    let parsedFieldsCopy = cloneDeep(this.parsedFields);
+    if (e.target.value) {
+      displayFieldsCopy[index].name = e.target.value;
+      parsedFieldsCopy[index].name = e.target.value;
+    }
+    let displayFields = insertAt(displayFieldsCopy, index, {
+      name: '',
+      displayType: 'string',
+      id: uuid.v4(),
+      refRequired: true,
+      nullable: false,
+      showAbstractSchemaRow: true
+    });
+    let parsedFields = insertAt(parsedFieldsCopy, index, {
+      name: '',
+      type: 'string'
+    });
+    this.parsedFields = parsedFields;
+    this.setState({ displayFields }, () => {
+      this.inputToFocus.focus();
+    });
+  }
+  onRowRemove(index) {
+    let displayFields = removeAt([...this.state.displayFields], index);
+    let parsedFields = removeAt(cloneDeep(this.parsedFields), index);
+    if (!displayFields.length) {
+      displayFields = [
+        {
+          name: '',
+          type: 'string',
+          displayType: 'string',
+          nullable: false,
+          id: uuid.v4(),
+          showAbstractSchemaRow: true
+        }
+      ];
+      parsedFields = [
+        {
+          name: '',
+          type: 'string'
+        }
+      ];
+    }
+    this.parsedFields = parsedFields;
+    this.setState({
+      displayFields,
+      error: this.checkForErrors(parsedFields)
+    }, this.updateParent.bind(this));
+  }
+  onNameChange(index, e) {
+    if (!e.target.value) {
+      return;
+    }
+    let displayFields = this.state.displayFields;
+    let parsedFields = cloneDeep(this.parsedFields);
+    displayFields[index].name = e.target.value;
+    parsedFields[index].name = e.target.value;
+    this.parsedFields = parsedFields;
+    this.setState({
+      displayFields,
+      error: ''
+    }, this.updateParent.bind(this));
+  }
+  onTypeChange(index, e) {
+    let selectType = e.target.value;
+    let displayFields = this.state.displayFields;
+    let parsedFields = cloneDeep(this.parsedFields);
+    displayFields[index].displayType = selectType;
+    displayFields[index].type = selectType;
+    if (displayFields[index].nullable) {
+      parsedFields[index].type = [
+        selectType,
+        'null'
+      ];
+    } else {
+      parsedFields[index].type = selectType;
+    }
+    this.parsedFields = parsedFields;
+    this.setState({
+      displayFields,
+      error: ''
+    }, function () {
+      if (!checkComplexType(selectType)) {
+        this.updateParent();
+      }
+    }.bind(this));
+  }
+  onNullableChange(index, e) {
+    let displayFields = this.state.displayFields;
+    let parsedFields = cloneDeep(this.parsedFields);
+    displayFields[index].nullable = e.target.checked;
+    if (e.target.checked) {
+      parsedFields[index].type = [
+        parsedFields[index].type,
+        'null'
+      ];
+    } else {
+      if (Array.isArray(parsedFields[index].type)) {
+        parsedFields[index].type = parsedFields[index].type[0];
+      }
+    }
+    this.parsedFields = parsedFields;
+    this.setState({
+      displayFields,
+      error: ''
+    }, this.updateParent.bind(this));
+  }
+  checkForErrors(parsedTypes) {
+    let parsedType = {
+      name: this.state.name,
+      type: 'record',
+      fields: parsedTypes.filter(field => field.name && field.type)
+    };
+    return checkParsedTypeForError(parsedType);
+  }
+  onChildrenChange(index, fieldType) {
+    let parsedFields = this.parsedFields;
+    let displayFields = this.state.displayFields;
+
+    if (displayFields[index].nullable) {
+      parsedFields[index].type = [
+        fieldType,
+        "null"
+      ];
+    } else {
+      parsedFields[index].type = fieldType;
+    }
+
+    let error = this.checkForErrors(parsedFields);
+    if (error) {
+      this.setState({error});
+      return;
+    }
+    this.parsedFields = parsedFields;
+    this.updateParent();
+  }
+  updateParent() {
+    let error = this.checkForErrors(this.parsedFields);
+    if (error) {
+      this.setState({error});
+      return;
+    }
+    this.props.onChange({
+      name: this.state.name,
+      type: 'record',
+      fields: this.parsedFields
+        .filter(field => field.name && field.type)
+    });
+  }
+  toggleAbstractSchemaRow(index) {
+    let displayFields = this.state.displayFields;
+    displayFields[index].showAbstractSchemaRow = !displayFields[index].showAbstractSchemaRow;
+    this.setState({
+      displayFields
+    });
+  }
+  render() {
+    const showArrow = (row, index) => {
+      if(row.showAbstractSchemaRow) {
+        return (
+          <span
+            className="fa fa-caret-down"
+            onClick={this.toggleAbstractSchemaRow.bind(this, index)}
+          >
+          </span>
+        );
+      }
+      return (
+        <span
+          className="fa fa-caret-right"
+          onClick={this.toggleAbstractSchemaRow.bind(this, index)}
+        >
+        </span>
+      );
+    };
+    return (
+      <div className="record-schema-row">
+        <div className="text-danger">
+          {this.state.error}
+        </div>
+        {
+          this.state
+              .displayFields
+              .map((row, index) => {
+                return (
+                  <div
+                    className={
+                      classnames("schema-row", {
+                        "nested": checkComplexType(row.displayType)
+                      })
+                    }
+                    key={row.id}
+                  >
+                    <div className="field-name">
+                      {
+                        row.refRequired ?
+                          <Input
+                            placeholder={T.translate('features.SchemaEditor.Labels.fieldName')}
+                            defaultValue={row.name}
+                            onFocus={() => row.name}
+                            getRef={(ref) => this.inputToFocus = ref}
+                            onBlur={this.onNameChange.bind(this, index)}
+                            onKeyPress={(e) => e.nativeEvent.keyCode === 13 ? this.onRowAdd(index, e) : null}
+                          />
+                        :
+                          <Input
+                            placeholder={T.translate('features.SchemaEditor.Labels.fieldName')}
+                            defaultValue={row.name}
+                            onFocus={() => row.name}
+                            onBlur={this.onNameChange.bind(this, index)}
+                            onKeyPress={(e) => e.nativeEvent.keyCode === 13 ? this.onRowAdd(index, e) : null}
+                          />
+                      }
+                      {
+                        checkComplexType(row.displayType) ?
+                          showArrow(row, index)
+                        :
+                        null
+                      }
+                    </div>
+                    <div className="field-type">
+                      <SelectWithOptions
+                        options={SCHEMA_TYPES.types}
+                        value={row.displayType}
+                        onChange={this.onTypeChange.bind(this, index)}
+                      />
+                    </div>
+                    <div className="field-isnull">
+                      <div className="btn btn-link">
+                        <Input
+                          type="checkbox"
+                          checked={row.nullable}
+                          onChange={this.onNullableChange.bind(this, index)}
+                        />
+                      </div>
+                      <div className="btn btn-link">
+                        <button
+                          className="fa fa-plus fa-xs"
+                          onClick={this.onRowAdd.bind(this, index)}
+                        ></button>
+                      </div>
+                      <div className="btn btn-link">
+                        <button
+                          className="fa fa-trash fa-xs text-danger"
+                          onClick={this.onRowRemove.bind(this, index)}
+                          >
+                        </button>
+                      </div>
+                    </div>
+                    {
+                      checkComplexType(row.displayType) && row.showAbstractSchemaRow  ?
+                        <AbstractSchemaRow
+                          row={{
+                            type: Array.isArray(this.parsedFields[index].type) ? this.parsedFields[index].type[0] : this.parsedFields[index].type,
+                            displayType: row.displayType
+                          }}
+                          onChange={this.onChildrenChange.bind(this, index)}
+                        />
+                      :
+                        null
+                    }
+                  </div>
+                );
+              })
+        }
+      </div>
+    );
+  }
+}
+
+RecordSchemaRow.propTypes = {
+  row: PropTypes.any,
+  onChange: PropTypes.func.isRequired
+};

--- a/cdap-ui/app/cdap/components/SchemaEditor/SchemaEditor.less
+++ b/cdap-ui/app/cdap/components/SchemaEditor/SchemaEditor.less
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+@import '../../styles/mixins.less';
+.schema-editor {
+  max-width: 400px;
+  min-height: 1500px;
+  .schema-header{
+    padding: 5px 0;
+    .field-name {
+      width: ~"calc(100% - 80px - 75px)";
+      width: ~"-moz-calc(100% - 80px - 75px)";
+      width: ~"-webkit-calc(100% - 80px - 75px)";
+    }
+    .field-isnull {
+      width: 70px;
+      margin-left: 5px;
+    }
+    .field-type {
+      width: 75px;
+      margin-left: 5px;
+    }
+    .field-name,
+    .field-type,
+    .field-isnull {
+      font-weight: bolder;
+      display: inline-block;
+    }
+  }
+  .schema-body {
+    .schema-row {
+      &:first-child {
+        border-top: 1px solid #ccc;
+        border-top: 0;
+      }
+      border-top: 1px solid #ccc;
+      &:not(.nested) {
+        box-shadow: none;
+        &.borderless {
+          border-top: 0;
+        }
+      }
+      >.abstract-schema-row {
+        box-shadow: 1px -2px 1px rgba(0,0,0,0.25);
+      }
+      > .field-name {
+        width: ~"calc(100% - 80px - 75px)";
+        width: ~"-moz-calc(100% - 80px - 75px)";
+        width: ~"-webkit-calc(100% - 80px - 75px)";
+      }
+      > .field-type {
+        width: 80px;
+        padding: 0 5px;
+        vertical-align: top;
+        position: relative;
+
+        &:after {
+          color: #3c4355;
+          content: "\f0d7";
+          font-family: 'FontAwesome';
+          position: absolute;
+          top: 25%;
+          right: 10px;
+          z-index: 5;
+        }
+      }
+      > .field-isnull {
+        width: 75px;
+        .btn.btn-link {
+          display: inline-block;
+          padding: 0;
+          width: 24px;
+          [class*="fa-"] {
+            padding: 0;
+            margin: 0;
+            border: 0;
+            background: transparent;
+          }
+        }
+      }
+      .field-name,
+      .field-type,
+      .field-isnull {
+        display: inline-block;
+      }
+      .form-control {
+        padding: 0 5px;
+        height: 25px;
+        margin: 5px 0 6px 0;
+        appearance: none;
+        border: 0;
+        box-shadow: none;
+        .appearance();
+        .placeholder-color(@color: #666666, @font-weight: 500);
+        &:focus {
+          border-color: #dddddd;
+          outline: 1px solid #098cf9;
+          box-shadow: none;
+        }
+      }
+      &.nested {
+        &:first-child {
+          border: 0;
+        }
+        border: 0;
+        box-shadow: -1px 0px 5px 1px rgba(1, 0, 0, 0.2);
+        border-radius: 4px;
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+        border-top-right-radius: 0;
+
+        >.field-name {
+          box-shadow: rgba(1, 0, 0, 0.25) 1px -1px 7px;
+          border-radius: 4px;
+          position: relative;
+          .fa-caret-down,
+          .fa-caret-right {
+            position: absolute;
+            bottom: -2px;
+            left: 5px;
+            cursor: pointer;
+          }
+          &:before {
+            position: absolute;
+            content: ' ';
+            top: 29px;
+            bottom: 0;
+            width: 100%;
+            background: white;
+            box-shadow: none;
+            height: 10px;
+          }
+        }
+      }
+      .text-danger {
+        word-break: break-word;
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/SchemaEditor/SchemaHelpers.js
+++ b/cdap-ui/app/cdap/components/SchemaEditor/SchemaHelpers.js
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import uuid from 'node-uuid';
+
+const SCHEMA_TYPES = {
+  'types': [
+    'boolean',
+    'bytes',
+    'double',
+    'float',
+    'int',
+    'long',
+    'string',
+    'array',
+    'enum',
+    'map',
+    'union',
+    'record'
+  ],
+  'simpleTypes': [
+    'boolean',
+    'bytes',
+    'double',
+    'float',
+    'int',
+    'long',
+    'string',
+  ]
+};
+
+function parseType(type) {
+  let storedType = type;
+  let nullable = false;
+
+  if (!type.getTypeName) {
+    try {
+      type = avsc.parse(type, {wrapUnions: true});
+      storedType = type;
+    } catch(e) {
+      return;
+    }
+  }
+
+  if (type.getTypeName() === 'union:wrapped') {
+    type = type.getTypes();
+
+    if (type[1] && type[1].getTypeName() === 'null') {
+      storedType = type[0];
+      type = type[0].getTypeName();
+      nullable = true;
+    } else {
+      type = 'union';
+    }
+  } else {
+    type = type.getTypeName();
+  }
+
+  return {
+    displayType: type,
+    type: storedType,
+    nullable: nullable,
+    nested: checkComplexType(type)
+  };
+}
+function getParsedSchema(schema) {
+  let defaultSchema = {
+    name: '',
+    type: 'string',
+    displayType: 'string',
+    nullable: false,
+    id: 'a' + uuid.v4().split('-').join(''),
+    nested: false
+  };
+  const isEmptySchema = (schema) => {
+    if (!schema && !(schema.fields || (schema.getFields && schema.getFields().length))) {
+      return true;
+    }
+    return false;
+  };
+
+  if (isEmptySchema(schema) || (!schema || schema === 'record')) {
+    return defaultSchema;
+  }
+  let parsed;
+
+  try {
+    parsed = avsc.parse(schema, { wrapUnions: true });
+  } catch(e) {
+    return;
+  }
+
+  let parsedSchema = parsed.getFields().map((field) => {
+    let type = field.getType();
+
+    let partialObj = parseType(type);
+
+    return Object.assign({}, partialObj, {
+      id: 'a' + uuid.v4().split('-').join(''),
+      name: field.getName()
+    });
+
+  });
+
+  return parsedSchema;
+}
+
+function checkComplexType(displayType) {
+  let complexTypes = ['array', 'enum', 'map', 'record', 'union'];
+  return complexTypes.indexOf(displayType) !== -1 ? true : false;
+}
+
+function checkParsedTypeForError(parsedTypes) {
+  let error = '';
+  try {
+    avsc.parse(parsedTypes);
+  } catch(e) {
+    error = e.message;
+  }
+  return error;
+}
+
+export {
+  SCHEMA_TYPES,
+  parseType,
+  checkComplexType,
+  getParsedSchema,
+  checkParsedTypeForError
+};

--- a/cdap-ui/app/cdap/components/SchemaEditor/SchemaStore.js
+++ b/cdap-ui/app/cdap/components/SchemaEditor/SchemaStore.js
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import {combineReducers, createStore} from 'redux';
+const defaultAction = {
+  type: '',
+  payload: {}
+};
+
+const defaultState = {
+  name: 'etlSchemabody',
+  type: 'record',
+  fields: [
+    {
+      name: '',
+      type: {},
+      displayType: 'string'
+    }
+  ]
+};
+
+const schema = (state = defaultState, action = defaultAction) => {
+  switch(action.type) {
+    case 'FIELD_UPDATE': {
+      return Object.assign({}, state, {fields: action.payload.schema.fields});
+    }
+    default:
+      return state;
+  }
+};
+
+var initialFields = [
+    {
+        "name": "email",
+        "type": "string"
+    },
+    {
+        "name": "phone",
+        "type": "int"
+    },
+    {
+        "name": "age",
+        "type": "long"
+    },
+    {
+        "name": "addresses",
+        "type": {
+            "type": "array",
+            "items": "string"
+        }
+    },
+    {
+        "name": "userid",
+        "type": {
+            "type": "record",
+            "name": "a2b2e0a4c40984f5f852fc9ca3546c325",
+            "fields": [
+                {
+                    "name": "FK_USERID",
+                    "type": "string"
+                },
+                {
+                    "name": "FK_EMAIL",
+                    "type": "string"
+                }
+            ]
+        }
+    },
+    {
+        "name": "userpref",
+        "type": {
+            "type": "enum",
+            "symbols": [
+                "NOEMAIL",
+                "SOMEEMAIL",
+                "PROMOEMAIL"
+            ]
+        }
+    },
+    {
+        "name": "FK1",
+        "type": {
+            "type": "map",
+            "keys": {
+                "type": "map",
+                "keys": {
+                    "type": "array",
+                    "items": "string"
+                },
+                "values": {
+                    "type": "enum",
+                    "symbols": [
+                        "EANUM1"
+                    ]
+                }
+            },
+            "values": "string"
+        }
+    },
+    {
+        "name": "SOmeKey",
+        "type": {
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "map",
+                    "keys": "string",
+                    "values": {
+                        "type": "record",
+                        "name": "a4c29a28e180043f49d41d3eff679506b",
+                        "fields": [
+                            {
+                                "name": "username",
+                                "type": "string"
+                            },
+                            {
+                                "name": "password",
+                                "type": "string"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+];
+
+var initialState = {
+  "schema": {
+    "name": "etlSchemabody",
+    "type": "record",
+    "fields": initialFields
+  }
+};
+
+let createStoreInstance = () => {
+  return createStore(
+    combineReducers({
+      schema
+    }),
+    initialState,
+    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+  );
+};
+
+export {createStoreInstance};
+let SchemaStore =  createStoreInstance();
+export default SchemaStore;

--- a/cdap-ui/app/cdap/components/SchemaEditor/UnionSchemaRow/UnionSchemaRow.less
+++ b/cdap-ui/app/cdap/components/SchemaEditor/UnionSchemaRow/UnionSchemaRow.less
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+.union-schema-row {
+  > .schema-row {
+    border: 0;
+    &.nested {
+      >.field-name {
+        box-shadow: rgba(1, 0, 0, 0.25) 1px -1px 7px;
+        border-radius: 4px;
+        width: 155px;
+      }
+    }
+    > .field-type {
+      visibility: hidden;
+    }
+    > .field-name {
+      position: relative;
+      &:after {
+        color: #3c4355;
+        content: "\f0d7";
+        font-family: 'FontAwesome';
+        position: absolute;
+        top: 7px;
+        right: 10px;
+        z-index: 5;
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/SchemaEditor/UnionSchemaRow/index.js
+++ b/cdap-ui/app/cdap/components/SchemaEditor/UnionSchemaRow/index.js
@@ -1,0 +1,222 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, {PropTypes, Component} from 'react';
+import {parseType, SCHEMA_TYPES, checkComplexType, checkParsedTypeForError} from 'components/SchemaEditor/SchemaHelpers';
+import SelectWithOptions from 'components/SelectWithOptions';
+import AbstractSchemaRow from 'components/SchemaEditor/AbstractSchemaRow';
+import {Input} from 'reactstrap';
+import {insertAt, removeAt} from 'services/helpers';
+import uuid from 'node-uuid';
+import classnames from 'classnames';
+import cloneDeep from 'lodash/cloneDeep';
+
+require('./UnionSchemaRow.less');
+
+export default class UnionSchemaRow extends Component {
+  constructor(props) {
+    super(props);
+    if (typeof props.row === 'object') {
+      let rowType = parseType(props.row);
+      let parsedTypes = rowType.type.getTypes();
+      let displayTypes = parsedTypes.map(type => Object.assign({}, parseType(type), {id: 'a' + uuid.v4()}));
+      this.state = {
+        displayTypes,
+        error: ''
+      };
+      this.parsedTypes = parsedTypes;
+    } else {
+      this.state = {
+        displayTypes: [
+          {
+            displayType: 'string',
+            type: 'string',
+            id: uuid.v4(),
+            nullable: false
+          }
+        ],
+        error: ''
+      };
+      this.parsedTypes = [
+        'string'
+      ];
+    }
+    setTimeout(this.updateParent.bind(this));
+    this.onTypeChange = this.onTypeChange.bind(this);
+  }
+  updateParent() {
+    let error = checkParsedTypeForError(this.parsedTypes);
+    if (error) {
+      this.setState({error});
+      return;
+    }
+    this.props.onChange(this.parsedTypes);
+  }
+  onNullableChange(index, e) {
+    let displayTypes = this.state.displayTypes;
+    let parsedTypes = cloneDeep(this.parsedTypes);
+    displayTypes[index].nullable = e.target.checked;
+    if (e.target.checked) {
+      parsedTypes[index] = [
+        parsedTypes[index],
+        'null'
+      ];
+    } else {
+      parsedTypes[index] = parsedTypes[index][0];
+    }
+    this.parsedTypes = parsedTypes;
+    this.setState({
+      displayTypes,
+      error: ''
+    }, this.updateParent.bind(this));
+  }
+  onTypeChange(index, e) {
+    let selectedType = e.target.value;
+    let displayTypes = this.state.displayTypes;
+    displayTypes[index].displayType = selectedType;
+    displayTypes[index].type = selectedType;
+    let parsedTypes = cloneDeep(this.parsedTypes);
+    if (displayTypes[index].nullable) {
+      parsedTypes[index] = [
+        selectedType,
+        'null'
+      ];
+    } else {
+      parsedTypes[index] = selectedType;
+    }
+    this.parsedTypes = parsedTypes;
+    this.setState({
+      displayTypes,
+      error: ''
+    }, () => {
+      if (!checkComplexType(selectedType)) {
+        this.updateParent();
+      }
+    });
+  }
+  onTypeAdd(index) {
+    let displayTypes = insertAt([...this.state.displayTypes], index, {
+      type: 'string',
+      displayType: 'string',
+      id: uuid.v4(),
+      nullable: false
+    });
+    let parsedTypes = insertAt(cloneDeep(this.parsedTypes), index, 'string');
+    this.parsedTypes = parsedTypes;
+    this.setState({ displayTypes }, this.updateParent.bind(this));
+  }
+  onTypeRemove(index) {
+    let displayTypes = removeAt([...this.state.displayTypes], index);
+    let parsedTypes = removeAt(cloneDeep(this.parsedTypes), index);
+    this.parsedTypes = parsedTypes;
+    this.setState({ displayTypes }, this.updateParent.bind(this));
+  }
+  onChildrenChange(index, parsedType) {
+    let parsedTypes = cloneDeep(this.parsedTypes);
+    let displayTypes = this.state.displayTypes;
+    let error;
+    if (displayTypes[index].nullable) {
+      parsedTypes[index] = [
+        parsedType,
+        "null"
+      ];
+    } else {
+      parsedTypes[index] = parsedType;
+    }
+    error = checkParsedTypeForError(parsedTypes);
+    if (error) {
+      this.setState({error});
+      return;
+    }
+    this.parsedTypes = parsedTypes;
+    this.updateParent();
+  }
+  render() {
+    return (
+      <div className="union-schema-row">
+        <div className="text-danger">
+          {this.state.error}
+        </div>
+          {
+            this.state.displayTypes.map((displayType, index) => {
+              return (
+                <div
+                  className={
+                    classnames("schema-row", {
+                      "nested": checkComplexType(displayType.displayType)
+                    })
+                  }
+                  key={displayType.id}
+                >
+                  <div className="field-name">
+                    <SelectWithOptions
+                      options={SCHEMA_TYPES.types}
+                      value={displayType.displayType}
+                      onChange={this.onTypeChange.bind(this, index)}
+                    />
+                  </div>
+                  <div className="field-type"></div>
+                  <div className="field-isnull">
+                    <div className="btn btn-link">
+                      <Input
+                        type="checkbox"
+                        checked={displayType.nullable}
+                        onChange={this.onNullableChange.bind(this, index)}
+                      />
+                    </div>
+                    <div className="btn btn-link">
+                      <span
+                        className="fa fa-plus"
+                        onClick={this.onTypeAdd.bind(this, index)}
+                      ></span>
+                    </div>
+                    <div className="btn btn-link">
+                      {
+                        this.state.displayTypes.length !== 1 ?
+                          <span
+                            className="fa fa-trash fa-xs text-danger"
+                            onClick={this.onTypeRemove.bind(this, index)}
+                          >
+                          </span>
+                        :
+                          null
+                      }
+                    </div>
+                  </div>
+                  {
+                    checkComplexType(displayType.displayType) ?
+                      <AbstractSchemaRow
+                        row={{
+                          type: Array.isArray(displayType.type) ? displayType.type[0] : displayType.type,
+                          displayType: displayType.displayType
+                        }}
+                        onChange={this.onChildrenChange.bind(this, index)}
+                      />
+                    :
+                      null
+                  }
+                </div>
+              );
+            })
+          }
+      </div>
+    );
+  }
+}
+UnionSchemaRow.propTypes = {
+  row: PropTypes.any,
+  onChange: PropTypes.func.isRequired
+};

--- a/cdap-ui/app/cdap/components/SchemaEditor/index.js
+++ b/cdap-ui/app/cdap/components/SchemaEditor/index.js
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, {Component} from 'react';
+import {Provider} from 'react-redux';
+require('./SchemaEditor.less');
+import {getParsedSchema} from 'components/SchemaEditor/SchemaHelpers';
+import RecordSchemaRow from 'components/SchemaEditor/RecordSchemaRow';
+import SchemaStore from 'components/SchemaEditor/SchemaStore';
+
+export default class SchemaEditor extends Component {
+  constructor(props) {
+    super(props);
+    let state = SchemaStore.getState();
+    let rows;
+    try {
+      rows = avsc.parse(state.schema, { wrapUnions: true });
+    } catch(e) {
+      console.log('Error parsing schema: ', e);
+    }
+    this.state = {
+      parsedRows: rows,
+      rawSchema: state.schema
+    };
+    const updateRowsAndDisplayFields = () => {
+      let state = SchemaStore.getState();
+      let rows;
+      try {
+        rows = getParsedSchema(state.schema);
+      } catch(e) {
+        return;
+      }
+      this.setState({
+        parsedRows: rows,
+        rawSchema: state.schema
+      });
+    };
+    SchemaStore.subscribe(updateRowsAndDisplayFields.bind(this));
+  }
+  shouldComponentUpdate(nextProps, nextState) {
+    return nextState.rawSchema.fields.length !== this.state.rawSchema.fields.length;
+  }
+  onChange(schema) {
+    SchemaStore.dispatch({
+      type: 'FIELD_UPDATE',
+      payload: {
+        schema
+      }
+    });
+  }
+  render() {
+    return (
+      <Provider store={SchemaStore}>
+        <div className="schema-editor">
+          <div className="schema-header">
+            <div className="field-name">
+              Name
+            </div>
+            <div className="field-type">
+              Type
+            </div>
+            <div className="field-isnull">
+              Null
+            </div>
+          </div>
+          <div className="schema-body">
+            <RecordSchemaRow
+              row={this.state.parsedRows}
+              onChange={this.onChange.bind(this)}
+            />
+          </div>
+        </div>
+      </Provider>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/main.js
+++ b/cdap-ui/app/cdap/main.js
@@ -42,6 +42,7 @@ import NamespaceActions from 'services/NamespaceStore/NamespaceActions';
 import RouteToNamespace from 'components/RouteToNamespace';
 import Helmet from 'react-helmet';
 import Wrangler from 'components/Wrangler';
+import SchemaEditor from 'components/SchemaEditor';
 
 class CDAP extends Component {
   constructor(props) {
@@ -99,6 +100,7 @@ class CDAP extends Component {
             <Match pattern="/Experimental" component={Experimental} />
             <Match pattern="/socket-example" component={ConnectionExample} />
             <Match pattern="/wrangler" component={Wrangler} />
+            <Match pattern="/schemaeditor" component={SchemaEditor} />
             <Miss component={Missed} />
           </div>
           <Footer version={this.version} />

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -106,10 +106,28 @@ function getArtifactNameAndVersion (nameWithVersion) {
   return { version, name };
 }
 
+
+function insertAt(arr, index, element) {
+  return [
+    ...arr.slice(0, index + 1),
+    element,
+    ...arr.slice(index + 1, arr.length)
+  ];
+}
+
+function removeAt(arr, index) {
+  return [
+    ...arr.slice(0, index),
+    ...arr.slice(index + 1, arr.length)
+  ];
+}
+
 export {
   objectQuery,
   convertBytesToHumanReadable,
   humanReadableNumber,
   isDescendant,
-  getArtifactNameAndVersion
+  getArtifactNameAndVersion,
+  insertAt,
+  removeAt
 };

--- a/cdap-ui/app/cdap/styles/mixins.less
+++ b/cdap-ui/app/cdap/styles/mixins.less
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+.placeholder-color(@color: white, @font-weight: 500) {
+    color: @color;
+    font-weight: @font-weight;
+}
+.appearance(@value: none) {
+  appearance: @value;
+  -webkit-appearance: @value;
+  -moz-appearance: @value;
+  -o-appearance: @value;
+  ::-ms-expand {
+    display: none;  // Need this to hide default select in IE10
+  }
+}

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -300,6 +300,10 @@ features:
       headerSearchResults: "Search results for: {query}"
       numResults: "{total} results found"
 
+  SchemaEditor:
+    Labels:
+      fieldName: Field Name
+      symbolName: Symbol Name
   Wizard:
     ApplicationUpload:
       Step1:

--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -111,7 +111,7 @@
     "react-redux": "4.4.5",
     "react-router": "4.0.0-alpha.4",
     "react-youtube": "7.1.1",
-    "reactstrap": "3.2.0",
+    "reactstrap": "3.9.1",
     "redux": "https://registry.npmjs.org/redux/-/redux-3.5.2.tgz",
     "redux-thunk": "2.0.1",
     "request": "2.69.0",

--- a/cdap-ui/webpack.config.cdap.js
+++ b/cdap-ui/webpack.config.cdap.js
@@ -32,6 +32,10 @@ var plugins = [
       to: './cdap.html'
     },
     {
+      from: path.resolve(__dirname, 'app', 'lib', 'avsc-bundle.js'),
+      to: './'
+    },
+    {
       from: './styles/fonts',
       to: './fonts/'
     },


### PR DESCRIPTION
- Initial implementation of Complex Schema in react
- In terms of design (code) its mostly similar
  - Instead of everything being a `complex-schema` there is a hierarchy. 
  - Top level is the `SchemaEditor` and it is composed of `RecordSchema`.
  - `RecordSchema` has individual rows that can be simple rows or rows of complex type.
  - Complex Types include - `UnionSchemaRow, MapSchemaRow, EnumSchemaRow, ArraySchemaRow, RecordSchemaRow`.
  - These are abstracted away using `AbstractSchemaRow` which is being used by any complex row types to nest other complex types under them.
- Styling is there (almost). There are still subtle changes that are required. But we can iterate over that in the next PR.

#### TODO:
- Unit tests are still in progress. Will come as separate PR.
- `Avsc` library is right now included as a script tag and used from the global context. We need to make this modular. Need to generate a webpack build. Right now we have `browserify` build but not a webpack one.
- `SchemaStore` is something that should go away. Ideally we shouldn't be needing it. Looks pointless now (it didn't look that way when I started 😛 )

Bamboo build: http://builds.cask.co/browse/CDAP-DRC4873-13