### PR TITLE
Create HVM:EBS AMI, not PV:EBS

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -44,15 +44,9 @@
     {
       "type": "amazon-ebs",
       "ami_name": "CDAP SDK {{user `sdk_version`}} ({{timestamp}})",
-      "instance_type": "m1.medium",
+      "instance_type": "m4.large",
       "region": "us-east-1",
-      "source_ami": "ami-a488dbb3",
-      "ami_groups": ["all"],
-      "ami_regions": [
-        "us-east-1",
-        "us-west-1",
-        "us-west-2"
-      ],
+      "source_ami": "ami-42d6fb55",
       "ssh_username": "ubuntu",
       "name": "cdap-sdk-ami"
     }


### PR DESCRIPTION
- Switch to HVM over PV to meet AWS Marketplace requirements
- Use HVM-compatible instance type/source AMI
- Do not publish publicly (Marketplace does this)
- Do not copy to other regions (Marketplace does this)