### PR TITLE
Add description for kafka.zookeeper.quorum

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -890,7 +890,7 @@
       the ZooKeeper quorum set by ${zookeeper.quorum} and ZooKeeper nameSpace
       set by ${kafka.zookeeper.namespace} when setting up connection to
       the Kafka service used by CDAP. If the same Kafka service ZooKeeper quorum
-      and namespace is shared by multiple CDAP instances, each CDAP instance
+      and namespace are shared by multiple CDAP instances, each CDAP instance
       has to distinguish its Kafka topics from thos of other CDAP instances
       with unique ${log.kafka.topic}, ${notification.kafka.topic},
       ${metadata.updates.kafka.topic}, ${audit.kafka.topic},

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -886,15 +886,15 @@
     <name>kafka.zookeeper.quorum</name>
     <value></value>
     <description>
-      CDAP Kafka service ZooKeeper quorum and namespace. This will override
-      the ZooKeeper quorum set by ${zookeeper.quorum} and ZooKeeper nameSpace
-      set by ${kafka.zookeeper.namespace} when setting up connection to
+      CDAP Kafka service ZooKeeper quorum and namespace. If set, this will override
+      the ZooKeeper quorum (set by ${zookeeper.quorum}) and the ZooKeeper namespace
+      (set by ${kafka.zookeeper.namespace}) when setting up a connection to
       the Kafka service used by CDAP. If the same Kafka service ZooKeeper quorum
       and namespace are shared by multiple CDAP instances, each CDAP instance
-      has to distinguish its Kafka topics from thos of other CDAP instances
-      with unique ${log.kafka.topic}, ${notification.kafka.topic},
-      ${metadata.updates.kafka.topic}, ${audit.kafka.topic},
-      and ${metrics.kafka.topic.prefix}.
+      needs to distinguish its Kafka topics from those of other CDAP instances
+      with unique values for ${audit.kafka.topic}, ${log.kafka.topic},
+      ${notification.kafka.topic}, ${metadata.updates.kafka.topic}, and
+      ${metrics.kafka.topic.prefix}.
     </description>
   </property>
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -882,6 +882,22 @@
     </description>
   </property>
 
+  <property>
+    <name>kafka.zookeeper.quorum</name>
+    <value></value>
+    <description>
+      CDAP Kafka service ZooKeeper quorum and namespace. This will override
+      the ZooKeeper quorum set by ${zookeeper.quorum} and ZooKeeper nameSpace
+      set by ${kafka.zookeeper.namespace} when setting up connection to
+      the Kafka service used by CDAP. If the same Kafka service ZooKeeper quorum
+      and namespace is shared by multiple CDAP instances, each CDAP instance
+      has to distinguish its Kafka topics from thos of other CDAP instances
+      with unique ${log.kafka.topic}, ${notification.kafka.topic},
+      ${metadata.updates.kafka.topic}, ${audit.kafka.topic},
+      and ${metrics.kafka.topic.prefix}.
+    </description>
+  </property>
+
 
   <!-- Logging Configuration -->
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="0f635f1d61a011113a67b22b8935fc8e"
+DEFAULT_XML_MD5_HASH="0ccccd2324f1ea4c9ce91d9c407212eb"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB175-2
Add description for `kafka.zookeeper.quorum`: http://builds.cask.co/artifact/CDAP-DQB175/shared/build-2/Docs-HTML/3.5.2-SNAPSHOT/en/admin-manual/appendices/cdap-site.html#kafka-server