### PR TITLE
Configure OpenSSH and lock root account

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -145,7 +145,7 @@
     {
       "type": "chef-solo",
       "remote_cookbook_paths": "/var/chef/cookbooks",
-      "run_list": "recipe[cdap::sdk]",
+      "run_list": "recipe[openssh],recipe[cdap::sdk]",
       "skip_install": true,
       "json": {
         "cdap": {
@@ -154,6 +154,13 @@
           "sdk": {
             "comment": "COPY SDK ZIP TO files/cdap-sdk.zip BEFORE RUNNING ME",
             "url": "file:///tmp/cdap-sdk.zip"
+          }
+        },
+        "openssh": {
+          "server": {
+            "permit_root_login": "without-password",
+            "password_authentication": "no",
+            "use_dns": "no"
           }
         }
       }
@@ -177,13 +184,15 @@
         "scripts/remove-chef.sh",
         "scripts/sdk-cleanup.sh",
         "scripts/network-cleanup.sh",
-        "scripts/apt-cleanup.sh",
-        "scripts/random-root-password.sh"
+        "scripts/apt-cleanup.sh"
       ]
     },
     {
       "type": "shell",
-      "scripts": "scripts/zero-disk.sh",
+      "scripts": [
+        "scripts/random-root-password.sh",
+        "scripts/zero-disk.sh"
+      ],
       "only": ["cdap-sdk-vm"]
     },
     {

--- a/cdap-distributions/src/packer/scripts/cookbook-setup.sh
+++ b/cdap-distributions/src/packer/scripts/cookbook-setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -21,7 +21,7 @@
 die() { echo $*; exit 1; }
 
 # Grab cookbooks using knife
-for cb in cdap hadoop idea maven nodejs; do
+for cb in cdap hadoop idea maven nodejs openssh; do
   knife cookbook site install $cb || die "Cannot fetch cookbook $cb"
 done
 

--- a/cdap-distributions/src/packer/scripts/ssh-cleanup.sh
+++ b/cdap-distributions/src/packer/scripts/ssh-cleanup.sh
@@ -18,4 +18,7 @@
 rm -f /etc/ssh/*_key /etc/ssh/*_key.pub
 rm -f /root/.ssh/authorized_keys* /home/*/.ssh/authorized_keys*
 
+# Lock root
+passwd -l root
+
 exit 0


### PR DESCRIPTION
This configures OpenSSH using the AWS Guidelines for Shared Linux AMIs.

- Permit root login with a key only
- Disable password logins
- Disable DNS lookups
- Only scramble root password on VM, which has an otherwise known password
- Disable root account from direct login