### PR TITLE
Wait for node reports to be available before asserting yarn resources…

### DIFF
--- a/cdap-operational-stats-core/src/test/java/co/cask/cdap/operations/yarn/AbstractYarnOperationalStatsTest.java
+++ b/cdap-operational-stats-core/src/test/java/co/cask/cdap/operations/yarn/AbstractYarnOperationalStatsTest.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.operations.yarn;
 
+import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.operations.OperationalStats;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
@@ -28,6 +29,8 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Tests {@link OperationalStats} for Yarn.
@@ -56,7 +59,7 @@ public abstract class AbstractYarnOperationalStatsTest {
   }
 
   @Test
-  public void test() throws IOException {
+  public void test() throws Exception {
     YarnInfo info = new YarnInfo(conf);
     Assert.assertEquals("YARN", info.getServiceName());
     Assert.assertEquals("info", info.getStatType());
@@ -79,11 +82,17 @@ public abstract class AbstractYarnOperationalStatsTest {
     Assert.assertEquals(0, apps.getRunning());
     Assert.assertEquals(0, apps.getSubmitted());
     Assert.assertEquals(0, apps.getTotal());
-    YarnResources resources = new YarnResources(conf);
+    final YarnResources resources = new YarnResources(conf);
     Assert.assertEquals("YARN", resources.getServiceName());
     Assert.assertEquals("resources", resources.getStatType());
-    resources.collect();
-    Assert.assertTrue(resources.getTotalMemory() > 0);
+    // wait until node manager reports are available
+    Tasks.waitFor(true, new Callable<Boolean>() {
+      @Override
+      public Boolean call() throws Exception {
+        resources.collect();
+        return resources.getTotalMemory() > 0;
+      }
+    }, 10, TimeUnit.SECONDS);
     Assert.assertEquals(0, resources.getUsedMemory());
     Assert.assertEquals(resources.getTotalMemory(), resources.getFreeMemory());
     Assert.assertTrue(resources.getTotalVCores() > 0);


### PR DESCRIPTION
… in test

The test has been failing in branches, so attempting to fix by waiting for node reports to be available.