### PR TITLE
Restricting which CConf properties are accessible to Authentication Handlers

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/ServiceBindException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/ServiceBindException.java
@@ -13,19 +13,22 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.common;
+
+import java.io.IOException;
 
 /**
  * Thrown when a system service fails to bind to a socket address.
  */
-public class ServiceBindException extends Exception {
+public class ServiceBindException extends IOException {
 
   private final String service;
   private final String host;
   private final int port;
 
-  public ServiceBindException(String service, String host, int port) {
-    super(String.format("%s failed to bind to %s:%d", service, host, port));
+  public ServiceBindException(String service, String host, int port, Exception cause) {
+    super(String.format("%s failed to bind to %s:%d", service, host, port), cause);
     this.service = service;
     this.host = host;
     this.port = port;

--- a/cdap-docs/admin-manual/source/security/perimeter-security.rst
+++ b/cdap-docs/admin-manual/source/security/perimeter-security.rst
@@ -366,8 +366,9 @@ Custom Authentication
 
 To use a Custom Authentication mechanism, set the
 ``security.authentication.handlerClassName`` in ``cdap-site.xml`` with the custom
-handler's classname. Any properties set in ``cdap-site.xml`` are available through a
-``CConfiguration`` object and can be used to configure the handler. 
+handler's classname. Any properties set in either ``cdap-site.xml`` or ``cdap-security.xml``
+and that are prefixed with ``security.authentication.handler.`` are available through a
+``Map<String, String>`` object and can be used to configure the handler.
 
 To make your custom handler class available to the authentication service, copy your
 packaged jar file (and any additional dependency jars) to the ``security/lib/`` directory

--- a/cdap-docs/developers-manual/source/security/custom-authentication.rst
+++ b/cdap-docs/developers-manual/source/security/custom-authentication.rst
@@ -15,11 +15,6 @@ extending ``AbstractAuthenticationHandler`` and implementing its abstract method
 
   public class CustomAuthenticationHandler extends AbstractAuthenticationHandler {
 
-    @Inject
-    public CustomAuthenticationHandler(CConfiguration configuration) {
-      super(configuration);
-    }
-
     @Override
     protected LoginService getHandlerLoginService() {
       // ...

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/NettyRouter.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/NettyRouter.java
@@ -60,6 +60,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.BindException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -156,7 +157,7 @@ public class NettyRouter extends AbstractIdleService {
   }
 
   @Override
-  protected void startUp() throws Exception {
+  protected void startUp() throws ServiceBindException {
     ChannelUpstreamHandler connectionTracker = new SimpleChannelUpstreamHandler() {
       @Override
       public void channelOpen(ChannelHandlerContext ctx, ChannelStateEvent e)
@@ -288,11 +289,11 @@ public class NettyRouter extends AbstractIdleService {
 
         LOG.info("Started Netty Router for service {} on address {}.", service, boundAddress);
       } catch (ChannelException e) {
-        if (!(Throwables.getRootCause(e) instanceof BindException)) {
-          throw e;
+        if ((Throwables.getRootCause(e) instanceof BindException)) {
+          throw new ServiceBindException("Router", hostname.getCanonicalHostName(), port, e);
         }
 
-        throw new ServiceBindException("Router", hostname.getCanonicalHostName(), port);
+        throw e;
       }
     }
   }

--- a/cdap-kafka/src/main/java/co/cask/cdap/kafka/run/KafkaServerMain.java
+++ b/cdap-kafka/src/main/java/co/cask/cdap/kafka/run/KafkaServerMain.java
@@ -155,6 +155,7 @@ public class KafkaServerMain extends DaemonMain {
     Map<String, String> propConfigs = cConf.getValByRegex("^(kafka\\.server\\.)");
     for (Map.Entry<String, String> pair : propConfigs.entrySet()) {
       String key = pair.getKey();
+      // we get the value via the cConf, because cConf#getValByRegex does not do variable substitution
       String value = cConf.get(key);
       String trimmedKey = key.substring(13);
       prop.setProperty(trimmedKey, value);

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/AbstractAuthenticationHandler.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/AbstractAuthenticationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,9 +16,7 @@
 
 package co.cask.cdap.security.server;
 
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import com.google.inject.Inject;
 import org.eclipse.jetty.security.Authenticator;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
@@ -26,6 +24,7 @@ import org.eclipse.jetty.security.IdentityService;
 import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.util.security.Constraint;
 
+import java.util.Map;
 import javax.security.auth.login.Configuration;
 import javax.ws.rs.Path;
 
@@ -35,22 +34,19 @@ import javax.ws.rs.Path;
  */
 @Path("/*")
 public abstract class AbstractAuthenticationHandler extends ConstraintSecurityHandler {
-  protected final CConfiguration configuration;
-
-  @Inject
-  public AbstractAuthenticationHandler(CConfiguration configuration) {
-    this.configuration = configuration;
-  }
+  protected Map<String, String> handlerProps;
 
   /**
    * Initialize the handler context and other related services.
    */
-  public void init() throws Exception {
+  public void init(Map<String, String> handlerProps) throws Exception {
+    this.handlerProps = handlerProps;
+
     Constraint constraint = new Constraint();
     constraint.setRoles(new String[]{"*"});
     constraint.setAuthenticate(true);
 
-    if (configuration.getBoolean(Constants.Security.SSL.EXTERNAL_ENABLED)) {
+    if (Boolean.parseBoolean(handlerProps.get(Constants.Security.SSL.EXTERNAL_ENABLED))) {
       constraint.setDataConstraint(Constraint.DC_CONFIDENTIAL);
     }
 

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/BasicAuthenticationHandler.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/BasicAuthenticationHandler.java
@@ -16,9 +16,7 @@
 
 package co.cask.cdap.security.server;
 
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import com.google.inject.Inject;
 import org.eclipse.jetty.security.Authenticator;
 import org.eclipse.jetty.security.DefaultIdentityService;
 import org.eclipse.jetty.security.HashLoginService;
@@ -34,14 +32,9 @@ import javax.security.auth.login.Configuration;
 public class BasicAuthenticationHandler extends AbstractAuthenticationHandler {
   private IdentityService identityService;
 
-  @Inject
-  public BasicAuthenticationHandler(CConfiguration configuration) throws Exception {
-    super(configuration);
-  }
-
   @Override
   protected LoginService getHandlerLoginService() {
-    String realmFile = configuration.get(Constants.Security.BASIC_REALM_FILE);
+    String realmFile = handlerProps.get(Constants.Security.BASIC_REALM_FILE);
     HashLoginService loginService = new HashLoginService();
     loginService.setConfig(realmFile);
     loginService.setIdentityService(getHandlerIdentityService());

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/GrantAccessToken.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/GrantAccessToken.java
@@ -51,7 +51,6 @@ public class GrantAccessToken {
   private static final Logger LOG = LoggerFactory.getLogger(GrantAccessToken.class);
   private final TokenManager tokenManager;
   private final Codec<AccessToken> tokenCodec;
-  private final CConfiguration cConf;
   private final long tokenExpiration;
   private final long extendedTokenExpiration;
 
@@ -61,10 +60,9 @@ public class GrantAccessToken {
   @Inject
   public GrantAccessToken(TokenManager tokenManager,
                           Codec<AccessToken> tokenCodec,
-                          CConfiguration cConfiguration) {
+                          CConfiguration cConf) {
     this.tokenManager = tokenManager;
     this.tokenCodec = tokenCodec;
-    this.cConf = cConfiguration;
     this.tokenExpiration = cConf.getLong(Constants.Security.TOKEN_EXPIRATION);
     this.extendedTokenExpiration = cConf.getLong(Constants.Security.EXTENDED_TOKEN_EXPIRATION);
   }
@@ -99,7 +97,7 @@ public class GrantAccessToken {
   @Produces("application/json")
   public Response token(@Context HttpServletRequest request, @Context HttpServletResponse response)
       throws IOException, ServletException {
-    this.grantToken(request, response, tokenExpiration);
+    grantToken(request, response, tokenExpiration);
     return Response.status(200).build();
   }
 
@@ -111,7 +109,7 @@ public class GrantAccessToken {
   @Produces("application/json")
   public Response extendedToken(@Context HttpServletRequest request, @Context HttpServletResponse response)
     throws IOException, ServletException {
-    this.grantToken(request, response, extendedTokenExpiration);
+    grantToken(request, response, extendedTokenExpiration);
     return Response.status(200).build();
   }
 

--- a/cdap-security/src/main/java/co/cask/cdap/security/server/JAASAuthenticationHandler.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/server/JAASAuthenticationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.security.server;
 
-import co.cask.cdap.common.conf.CConfiguration;
 import org.eclipse.jetty.security.Authenticator;
 import org.eclipse.jetty.security.DefaultIdentityService;
 import org.eclipse.jetty.security.IdentityService;
@@ -27,10 +26,6 @@ import org.eclipse.jetty.security.authentication.BasicAuthenticator;
  * An abstract authentication handler that supports the JAAS interface for external authentication.
  */
 public abstract class JAASAuthenticationHandler extends AbstractAuthenticationHandler {
-
-  public JAASAuthenticationHandler(CConfiguration configuration) {
-    super(configuration);
-  }
 
   @Override
   public IdentityService getHandlerIdentityService() {

--- a/cdap-security/src/test/java/co/cask/cdap/security/server/CertificateAuthenticationHandler.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/server/CertificateAuthenticationHandler.java
@@ -16,8 +16,6 @@
 
 package co.cask.cdap.security.server;
 
-import co.cask.cdap.common.conf.CConfiguration;
-import com.google.inject.Inject;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jetty.security.Authenticator;
 import org.eclipse.jetty.security.DefaultIdentityService;
@@ -36,26 +34,18 @@ import javax.security.auth.login.Configuration;
  */
 public class CertificateAuthenticationHandler extends AbstractAuthenticationHandler {
 
-  public static final String AUTH_HANDLER_CONFIG_BASE = "security.authentication.handler.";
   public static final String AUTH_SSL_CONFIG_BASE = "security.auth.server.ssl.";
-
-  @Inject
-  public CertificateAuthenticationHandler(CConfiguration configuration) {
-    super(configuration);
-    new DefaultIdentityService();
-  }
 
   /**
    * Configure the Jetty {@link ClientCertAuthenticator} by setting the
    * Truststore.
    *
    * @param clientCertAuthenticator
-   * @param cConf
    */
-  private void setupClientCertAuthenticator(ClientCertAuthenticator clientCertAuthenticator, CConfiguration cConf) {
-    String trustStorePath = cConf.get(AUTH_SSL_CONFIG_BASE.concat("truststore.path"));
-    String trustStorePassword = cConf.get(AUTH_SSL_CONFIG_BASE.concat("truststore.password"));
-    String trustStoreType = cConf.get(AUTH_SSL_CONFIG_BASE.concat("truststore.type"));
+  private void setupClientCertAuthenticator(ClientCertAuthenticator clientCertAuthenticator) {
+    String trustStorePath = handlerProps.get(AUTH_SSL_CONFIG_BASE.concat("truststore.path"));
+    String trustStorePassword = handlerProps.get(AUTH_SSL_CONFIG_BASE.concat("truststore.password"));
+    String trustStoreType = handlerProps.get(AUTH_SSL_CONFIG_BASE.concat("truststore.type"));
 
     if (StringUtils.isNotEmpty(trustStorePath)) {
       clientCertAuthenticator.setTrustStore(trustStorePath);
@@ -73,15 +63,13 @@ public class CertificateAuthenticationHandler extends AbstractAuthenticationHand
 
   @Override
   protected LoginService getHandlerLoginService() {
-    String realmFile = configuration.get(AUTH_HANDLER_CONFIG_BASE.concat("realmfile"));
-    MTLSLoginService loginService = new MTLSLoginService(realmFile);
-    return loginService;
+    return new MTLSLoginService(handlerProps.get("realmfile"));
   }
 
   @Override
   protected Authenticator getHandlerAuthenticator() {
     ClientCertAuthenticator clientCertAuthenticator = new ClientCertAuthenticator();
-    setupClientCertAuthenticator(clientCertAuthenticator, configuration);
+    setupClientCertAuthenticator(clientCertAuthenticator);
     return clientCertAuthenticator;
   }
 

--- a/cdap-security/src/test/java/co/cask/cdap/security/server/ExternalAuthenticationServerTestBase.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/server/ExternalAuthenticationServerTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -54,6 +54,7 @@ import java.net.SocketAddress;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import javax.security.auth.login.Configuration;
 
 import static org.junit.Assert.assertEquals;
@@ -82,6 +83,7 @@ public abstract class ExternalAuthenticationServerTestBase {
 
   protected abstract HttpClient getHTTPClient() throws Exception;
 
+  @Nullable
   protected abstract Map<String, String> getAuthRequestHeader() throws Exception;
 
   protected abstract String getAuthenticatedUserName() throws Exception;
@@ -141,10 +143,6 @@ public abstract class ExternalAuthenticationServerTestBase {
 
   public ExternalAuthenticationServer getServer() {
     return server;
-  }
-
-  public Codec<AccessToken> getTokenCodec() {
-    return tokenCodec;
   }
 
   public DiscoveryServiceClient getDiscoveryServiceClient() {
@@ -312,9 +310,7 @@ public abstract class ExternalAuthenticationServerTestBase {
     }
 
     HttpResponse response = client.execute(request);
-
     assertEquals(404, response.getStatusLine().getStatusCode());
-
   }
 
   /**

--- a/cdap-security/src/test/java/co/cask/cdap/security/server/ExternalLDAPAuthenticationServerSSLTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/server/ExternalLDAPAuthenticationServerSSLTest.java
@@ -19,7 +19,6 @@ package co.cask.cdap.security.server;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.conf.SConfiguration;
-import com.google.common.collect.Maps;
 import com.unboundid.ldap.listener.InMemoryListenerConfig;
 import com.unboundid.util.ssl.KeyStoreKeyManager;
 import com.unboundid.util.ssl.SSLUtil;
@@ -39,6 +38,7 @@ import java.net.InetAddress;
 import java.net.URL;
 import java.security.SecureRandom;
 import java.security.cert.CertificateException;
+import java.util.HashMap;
 import java.util.Map;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
@@ -49,7 +49,7 @@ import javax.net.ssl.X509TrustManager;
  */
 public class ExternalLDAPAuthenticationServerSSLTest extends ExternalLDAPAuthenticationServerTestBase {
 
-  static ExternalLDAPAuthenticationServerSSLTest testServer;
+  private static ExternalLDAPAuthenticationServerSSLTest testServer;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -126,7 +126,7 @@ public class ExternalLDAPAuthenticationServerSSLTest extends ExternalLDAPAuthent
 
   @Override
   protected Map<String, String> getAuthRequestHeader() throws Exception {
-    Map headers = Maps.newHashMap();
+    Map<String, String> headers = new HashMap<>();
     headers.put("Authorization", "Basic YWRtaW46cmVhbHRpbWU=");
     return headers;
   }

--- a/cdap-security/src/test/java/co/cask/cdap/security/server/ExternalLDAPAuthenticationServerTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/server/ExternalLDAPAuthenticationServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,7 +19,6 @@ package co.cask.cdap.security.server;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.conf.SConfiguration;
-import com.google.common.collect.Maps;
 import com.unboundid.ldap.listener.InMemoryListenerConfig;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.DefaultHttpClient;
@@ -27,6 +26,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import java.net.InetAddress;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -34,7 +34,7 @@ import java.util.Map;
  */
 public class ExternalLDAPAuthenticationServerTest extends ExternalLDAPAuthenticationServerTestBase {
 
-  static ExternalLDAPAuthenticationServerTest testServer;
+  private static ExternalLDAPAuthenticationServerTest testServer;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -55,7 +55,7 @@ public class ExternalLDAPAuthenticationServerTest extends ExternalLDAPAuthentica
 
   @AfterClass
   public static void afterClass() throws Exception {
-      testServer.tearDown();
+    testServer.tearDown();
   }
 
   @Override
@@ -70,7 +70,7 @@ public class ExternalLDAPAuthenticationServerTest extends ExternalLDAPAuthentica
 
   @Override
   protected Map<String, String> getAuthRequestHeader() throws Exception {
-    Map headers = Maps.newHashMap();
+    Map<String, String> headers = new HashMap<>();
     headers.put("Authorization", "Basic YWRtaW46cmVhbHRpbWU=");
     return headers;
   }

--- a/cdap-security/src/test/java/co/cask/cdap/security/server/ExternalLDAPAuthenticationServerTestBase.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/server/ExternalLDAPAuthenticationServerTestBase.java
@@ -19,19 +19,13 @@ package co.cask.cdap.security.server;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.utils.Networks;
-
 import com.unboundid.ldap.listener.InMemoryDirectoryServer;
 import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
 import com.unboundid.ldap.listener.InMemoryListenerConfig;
 import com.unboundid.ldap.sdk.Entry;
-
 import org.junit.Assert;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.net.URL;
-
-import static org.mockito.Mockito.mock;
 
 
 /**
@@ -39,12 +33,8 @@ import static org.mockito.Mockito.mock;
  */
 public abstract class ExternalLDAPAuthenticationServerTestBase extends ExternalAuthenticationServerTestBase {
 
-  private static final Logger LOG = LoggerFactory.getLogger(ExternalLDAPAuthenticationServerTestBase.class);
   private static InMemoryDirectoryServer ldapServer;
   protected static int ldapPort = Networks.getRandomPort();
-
-  private static final Logger TEST_AUDIT_LOGGER = mock(Logger.class);
-
   protected static InMemoryListenerConfig ldapListenerConfig;
 
   /**
@@ -98,6 +88,5 @@ public abstract class ExternalLDAPAuthenticationServerTestBase extends ExternalA
   protected void stopExternalAuthenticationServer() throws Exception {
     ldapServer.shutDown(true);
   }
-
 
 }

--- a/cdap-security/src/test/java/co/cask/cdap/security/server/ExternalMTLSAuthenticationServerTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/server/ExternalMTLSAuthenticationServerTest.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.security.server;
 
 import co.cask.cdap.common.conf.CConfiguration;
@@ -52,8 +53,7 @@ public class ExternalMTLSAuthenticationServerTest extends ExternalMTLSAuthentica
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    URL serverTrustoreURL = ExternalMTLSAuthenticationServerTest.class.getClassLoader().getResource("server-trust" +
-                                                                                                      ".jks");
+    URL serverTrustoreURL = ExternalMTLSAuthenticationServerTest.class.getClassLoader().getResource("server-trust.jks");
     URL serverKeystoreURL = ExternalMTLSAuthenticationServerTest.class.getClassLoader().getResource("server-key.jks");
     URL realmURL = ExternalMTLSAuthenticationServerTest.class.getClassLoader().getResource("realm.properties");
 
@@ -123,13 +123,10 @@ public class ExternalMTLSAuthenticationServerTest extends ExternalMTLSAuthentica
     final KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
     KeyStore ks = KeyStore.getInstance("JKS");
     char[] ksPass = "secret".toCharArray();
-    FileInputStream fis = new FileInputStream(clientKeystoreURL.getPath());
-    ks.load(fis, ksPass);
-    kmf.init(ks, configuration.get("security.auth.server.ssl.keystore.password", "secret").toCharArray());
-
-    fis.close();
-    fis = null;
-
+    try (FileInputStream fis = new FileInputStream(clientKeystoreURL.getPath())) {
+      ks.load(fis, ksPass);
+      kmf.init(ks, configuration.get("security.auth.server.ssl.keystore.password", "secret").toCharArray());
+    }
     return kmf.getKeyManagers();
   }
 
@@ -147,13 +144,10 @@ public class ExternalMTLSAuthenticationServerTest extends ExternalMTLSAuthentica
     final KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
     KeyStore ks = KeyStore.getInstance("JKS");
     char[] ksPass = "secret".toCharArray();
-    FileInputStream fis = new FileInputStream(clientKeystoreURL.getPath());
-    ks.load(fis, ksPass);
-    kmf.init(ks, configuration.get("security.auth.server.ssl.keystore.password", "secret").toCharArray());
-
-    fis.close();
-    fis = null;
-
+    try (FileInputStream fis = new FileInputStream(clientKeystoreURL.getPath())) {
+      ks.load(fis, ksPass);
+      kmf.init(ks, configuration.get("security.auth.server.ssl.keystore.password", "secret").toCharArray());
+    }
     return kmf.getKeyManagers();
   }
 
@@ -166,7 +160,7 @@ public class ExternalMTLSAuthenticationServerTest extends ExternalMTLSAuthentica
   @Override
   protected TrustManager[] getTrustManagers() throws Exception {
     // Setting up the client's trust store, which trusts all certs
-    TrustManager[] tms = new TrustManager[]{new X509TrustManager() {
+    return new TrustManager[]{new X509TrustManager() {
       @Override
       public java.security.cert.X509Certificate[] getAcceptedIssuers() {
         return null;
@@ -181,11 +175,9 @@ public class ExternalMTLSAuthenticationServerTest extends ExternalMTLSAuthentica
       @Override
       public void checkServerTrusted(java.security.cert.X509Certificate[] x509Certificates, String s)
         throws CertificateException {
-        // no- op
+        // no-op
       }
     }};
-
-    return tms;
   }
 
   protected Map<String, String> getAuthRequestHeader() throws Exception {

--- a/cdap-security/src/test/java/co/cask/cdap/security/server/ExternalMTLSAuthenticationServerTestBase.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/server/ExternalMTLSAuthenticationServerTestBase.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.security.server;
 
 import co.cask.cdap.common.conf.CConfiguration;
@@ -31,8 +32,6 @@ import org.eclipse.jetty.plus.jaas.spi.PropertyFileLoginModule;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.net.URL;
 import java.security.SecureRandom;
@@ -47,7 +46,6 @@ import static org.junit.Assert.assertEquals;
  * Base test class for Mutual TLS Based ExternalAuthenticationServer.
  */
 public abstract class ExternalMTLSAuthenticationServerTestBase extends ExternalAuthenticationServerTestBase  {
-  private static final Logger LOG = LoggerFactory.getLogger(ExternalMTLSAuthenticationServerTestBase.class);
 
   protected abstract KeyManager[] getInvalidKeyManagers() throws Exception;
 
@@ -66,7 +64,7 @@ public abstract class ExternalMTLSAuthenticationServerTestBase extends ExternalA
     cConf.setInt(Constants.Security.AUTH_SERVER_BIND_PORT, Networks.getRandomPort());
     cConf.setInt(Constants.Security.AuthenticationServer.SSL_PORT, Networks.getRandomPort());
 
-    // Setting the Authentication Handler to the Certifcate Handler
+    // Setting the Authentication Handler to the Certificate Handler
     cConf.set(Constants.Security.AUTH_HANDLER_CLASS, CertificateAuthenticationHandler.class.getName());
     cConf.set(Constants.Security.LOGIN_MODULE_CLASS_NAME, PropertyFileLoginModule.class.getName());
     cConf.set(configBase.concat("debug"), "true");
@@ -99,7 +97,7 @@ public abstract class ExternalMTLSAuthenticationServerTestBase extends ExternalA
     return getHTTPClient(getKeyManagers(), getTrustManagers());
   }
 
-  protected HttpClient getHTTPClient(KeyManager[] kms, TrustManager[] tms) throws Exception {
+  private HttpClient getHTTPClient(KeyManager[] kms, TrustManager[] tms) throws Exception {
     SSLContext sslContext = SSLContext.getInstance("SSL");
     sslContext.init(kms, tms, new SecureRandom());
     // only for test purposes ignoring check of certificate hostname matching host on which server runs


### PR DESCRIPTION
Changes Authentication Handlers to be instantiated without injection, so that properties are passed in as a filtered Map<String, String>, instead of the entire cConf/sConf.

https://issues.cask.co/browse/CDAP-6398
http://builds.cask.co/browse/CDAP-DUT5135
http://builds.cask.co/browse/CDAP-RUT369-1