### PR TITLE
Return correctly on non-MapR in cdap_check_mapr

### DIFF
--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -255,6 +255,7 @@ cdap_check_mapr() {
   if [[ -f /opt/mapr/MapRBuildVersion ]]; then
     return 0
   fi
+  return 1
 }
 
 #


### PR DESCRIPTION
Otherwise, we will only return `1` if the `if` itself fails.