### PR TITLE
CDAP-7256 Avoid leaking Hive classes to programs.

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/ProgramResources.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/ProgramResources.java
@@ -44,7 +44,8 @@ public final class ProgramResources {
   private static final Logger LOG = LoggerFactory.getLogger(ProgramResources.class);
 
   private static final List<String> HADOOP_PACKAGES = ImmutableList.of("org.apache.hadoop.");
-  private static final List<String> HBASE_PACKAGES = ImmutableList.of("org.apache.hadoop.hbase.");
+  private static final List<String> EXCLUDE_PACKAGES = ImmutableList.of("org.apache.hadoop.hbase.",
+                                                                        "org.apache.hadoop.hive.");
 
   private static final Predicate<URI> JAR_ONLY_URI = new Predicate<URI>() {
     @Override
@@ -75,7 +76,7 @@ public final class ProgramResources {
   /**
    * Returns a Set of resources name that are visible through the cdap-api module as well as Hadoop classes.
    * This includes all classes+resources in cdap-api plus all classes+resources that cdap-api
-   * depends on (for example, sl4j, guava, gson, etc).
+   * depends on (for example, sl4j, gson, etc).
    */
   private static Set<String> createBaseResources() throws IOException {
     // Everything should be traceable in the same ClassLoader of this class, which is the CDAP system ClassLoader
@@ -92,7 +93,7 @@ public final class ProgramResources {
 
     // Gather Hadoop classes and resources
     getResources(ClassPath.from(classLoader, JAR_ONLY_URI),
-                 HADOOP_PACKAGES, HBASE_PACKAGES, ClassPathResources.RESOURCE_INFO_TO_RESOURCE_NAME, result);
+                 HADOOP_PACKAGES, EXCLUDE_PACKAGES, ClassPathResources.RESOURCE_INFO_TO_RESOURCE_NAME, result);
 
     return Collections.unmodifiableSet(result);
   }

--- a/cdap-common/src/main/java/co/cask/cdap/common/twill/HadoopClassExcluder.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/twill/HadoopClassExcluder.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.common.twill;
 
 import org.apache.twill.api.ClassAcceptor;


### PR DESCRIPTION
Avoid making hive classes visible to program classloader, from the platform.
This shouldn't affect distributed CDAP, since hive classes shouldn't even be in the system classpath for programs running in distributed CDAP.
For SDK/unit tests, we want to avoid program classloader from getting hive classes from the platform - for instance, those defined in hive-exec.

Users should package whatever hive classes they need in their application.

https://issues.cask.co/browse/CDAP-7256
http://builds.cask.co/browse/CDAP-RUT296-3