### PR TITLE
CDAP-7702 : Adding generation id as part of rowkey of TMS Data tables

### DIFF
--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/MessagingUtils.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/MessagingUtils.java
@@ -30,18 +30,41 @@ public final class MessagingUtils {
   }
 
   /**
-   * Convert {@link TopicId} to byte array to be used a message tables row key prefix.
+   * Constants
+   */
+  public static final class Constants {
+    public static final String DEFAULT_GENERATION = Integer.toString(1);
+  }
+
+  /**
+   * Convert {@link TopicId} to byte array to be used for metadata table row key.
    *
    * @param topicId {@link TopicId}
    * @return byte array representation for the topic id
    */
-  public static byte[] toRowKeyPrefix(TopicId topicId) {
+  public static byte[] toMetadataRowKey(TopicId topicId) {
     String topic = topicId.getNamespace() + ":" + topicId.getTopic() + ":";
     return Bytes.toBytes(topic);
   }
 
   /**
-   * Convert byte array encoded with the {@link #toRowKeyPrefix(TopicId)} method back to the {@link TopicId}
+   * Convert {@link TopicId} and generation id to byte array to be used for data tables (message and payload) as
+   * row key prefix.
+   *
+   * @param topicId {@link TopicId}
+   * @param generation generation id of the topic
+   * @return byte array representation to be used as row key prefix for data tables
+   */
+  public static byte[] toDataKeyPrefix(TopicId topicId, int generation) {
+    byte[] metadataRowKey = toMetadataRowKey(topicId);
+    byte[] keyPrefix = new byte[metadataRowKey.length + Bytes.SIZEOF_INT];
+    Bytes.putBytes(keyPrefix, 0, metadataRowKey, 0, metadataRowKey.length);
+    Bytes.putInt(keyPrefix, metadataRowKey.length, generation);
+    return keyPrefix;
+  }
+
+  /**
+   * Convert byte array encoded with the {@link #toMetadataRowKey(TopicId)} method back to the {@link TopicId}
    *
    * @param topicBytes byte array which contains the representation of the topic id
    * @param offset offset to start decoding
@@ -57,7 +80,7 @@ public final class MessagingUtils {
   }
 
   /**
-   * Convert byte array encoded with the {@link #toRowKeyPrefix(TopicId)} method back to the {@link TopicId}.
+   * Convert byte array encoded with the {@link #toMetadataRowKey(TopicId)} method back to the {@link TopicId}.
    * Same as calling {@link #toTopicId(byte[], int, int)} with {@code offset = 0}
    * and {@code length = topicBytes.length}.
    *

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/service/ConcurrentMessageWriter.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/service/ConcurrentMessageWriter.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.metrics.MetricsCollector;
 import co.cask.cdap.api.metrics.NoopMetricsContext;
 import co.cask.cdap.messaging.RollbackDetail;
 import co.cask.cdap.messaging.StoreRequest;
+import co.cask.cdap.messaging.TopicMetadata;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 
@@ -94,17 +95,18 @@ final class ConcurrentMessageWriter implements Closeable {
    * is safe to be called concurrently from multiple threads.
    *
    * @param storeRequest contains information about payload to be store
+   * @param metadata {@link TopicMetadata} for the topic in the {@link StoreRequest}
    * @return if the store request is transactional, then returns a {@link RollbackDetail} containing
    *         information for rollback; otherwise {@code null} will be returned.
    * @throws IOException if failed to persist the data
    */
   @Nullable
-  RollbackDetail persist(StoreRequest storeRequest) throws IOException {
+  RollbackDetail persist(StoreRequest storeRequest, TopicMetadata metadata) throws IOException {
     if (closed.get()) {
       throw new IOException("Message writer is already closed");
     }
 
-    PendingStoreRequest pendingStoreRequest = new PendingStoreRequest(storeRequest);
+    PendingStoreRequest pendingStoreRequest = new PendingStoreRequest(storeRequest, metadata);
     pendingStoreQueue.enqueue(pendingStoreRequest);
 
     metricsCollector.increment("persist.requested", 1L);

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/service/CoreMessageFetcher.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/service/CoreMessageFetcher.java
@@ -141,15 +141,16 @@ final class CoreMessageFetcher extends MessageFetcher {
       // do the scanning based on time. The smallest start time should be the currentTime - TTL.
       if (startOffset == null || startOffset.getPublishTimestamp() < smallestPublishTime) {
         long fetchStartTime = Math.max(smallestPublishTime, startTime == null ? smallestPublishTime : startTime);
-        messageIterator = messageTable.fetch(topicId, fetchStartTime, messageLimit, getTransaction());
+        messageIterator = messageTable.fetch(topicMetadata, fetchStartTime, messageLimit, getTransaction());
       } else {
         // Start scanning based on the start message id
         if (startOffset.getPayloadWriteTimestamp() != 0L) {
           // This message ID refer to payload table. Scan the message table with the reference message ID inclusively.
-          messageIterator = messageTable.fetch(topicId, createMessageTableMessageId(startOffset),
+          messageIterator = messageTable.fetch(topicMetadata, createMessageTableMessageId(startOffset),
                                                true, messageLimit, getTransaction());
         } else {
-          messageIterator = messageTable.fetch(topicId, startOffset, isIncludeStart(), messageLimit, getTransaction());
+          messageIterator = messageTable.fetch(topicMetadata, startOffset, isIncludeStart(),
+                                               messageLimit, getTransaction());
         }
       }
       this.messageIterator = messageIterator;
@@ -180,7 +181,7 @@ final class CoreMessageFetcher extends MessageFetcher {
               if (payloadTable == null) {
                 payloadTable = payloadTableProvider.get();
               }
-              payloadIterator = payloadTable.fetch(topicId, messageEntry.getTransactionWritePointer(),
+              payloadIterator = payloadTable.fetch(topicMetadata, messageEntry.getTransactionWritePointer(),
                                                    new MessageId(createMessageId(messageEntry, null)),
                                                    inclusive, messageLimit);
             } catch (IOException e) {

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/service/CoreMessagingService.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/service/CoreMessagingService.java
@@ -25,6 +25,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.utils.TimeProvider;
 import co.cask.cdap.messaging.MessageFetcher;
 import co.cask.cdap.messaging.MessagingService;
+import co.cask.cdap.messaging.MessagingUtils;
 import co.cask.cdap.messaging.RollbackDetail;
 import co.cask.cdap.messaging.StoreRequest;
 import co.cask.cdap.messaging.TopicMetadata;
@@ -119,6 +120,8 @@ public class CoreMessagingService extends AbstractIdleService implements Messagi
     try (MetadataTable metadataTable = createMetadataTable()) {
       metadataTable.deleteTopic(topicId);
       topicCache.invalidate(topicId);
+      messageTableWriterCache.invalidate(topicId);
+      payloadTableWriterCache.invalidate(topicId);
     }
   }
 
@@ -160,7 +163,8 @@ public class CoreMessagingService extends AbstractIdleService implements Messagi
   @Override
   public RollbackDetail publish(StoreRequest request) throws TopicNotFoundException, IOException {
     try {
-      return messageTableWriterCache.get(request.getTopicId()).persist(request);
+      TopicMetadata metadata = topicCache.get(request.getTopicId());
+      return messageTableWriterCache.get(request.getTopicId()).persist(request, metadata);
     } catch (ExecutionException e) {
       Throwable cause = Objects.firstNonNull(e.getCause(), e);
       Throwables.propagateIfPossible(cause, TopicNotFoundException.class, IOException.class);
@@ -171,7 +175,8 @@ public class CoreMessagingService extends AbstractIdleService implements Messagi
   @Override
   public void storePayload(StoreRequest request) throws TopicNotFoundException, IOException {
     try {
-      payloadTableWriterCache.get(request.getTopicId()).persist(request);
+      TopicMetadata metadata = topicCache.get(request.getTopicId());
+      payloadTableWriterCache.get(request.getTopicId()).persist(request, metadata);
     } catch (ExecutionException e) {
       Throwable cause = Objects.firstNonNull(e.getCause(), e);
       Throwables.propagateIfPossible(cause, TopicNotFoundException.class, IOException.class);
@@ -185,20 +190,9 @@ public class CoreMessagingService extends AbstractIdleService implements Messagi
 
     Exception failure = null;
     try (MessageTable messageTable = createMessageTable(metadata)) {
-      // Safe to cast to short because message table only use the sequence id as unsigned bytes.
-      messageTable.delete(topicId, rollbackDetail.getStartTimestamp(), (short) rollbackDetail.getStartSequenceId(),
-                          rollbackDetail.getEndTimestamp(), (short) rollbackDetail.getEndSequenceId());
+      messageTable.rollback(metadata, rollbackDetail);
     } catch (Exception e) {
       failure = e;
-    }
-    try (PayloadTable payloadTable = createPayloadTable(metadata)) {
-      payloadTable.delete(topicId, rollbackDetail.getTransactionWritePointer());
-    } catch (Exception e) {
-      if (failure != null) {
-        failure.addSuppressed(e);
-      } else {
-        failure = e;
-      }
     }
 
     // Throw if there is any failure in rollback.
@@ -307,8 +301,9 @@ public class CoreMessagingService extends AbstractIdleService implements Messagi
   private Map<String, String> createDefaultProperties() {
     Map<String, String> properties = new HashMap<>();
 
-    // Default the TTL
+    // Default properties
     properties.put(TopicMetadata.TTL_KEY, cConf.get(Constants.MessagingSystem.TOPIC_DEFAULT_TTL_SECONDS));
+    properties.put(TopicMetadata.GENERATION_KEY, MessagingUtils.Constants.DEFAULT_GENERATION);
     return properties;
   }
 }

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/service/MessageTableStoreRequestWriter.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/service/MessageTableStoreRequestWriter.java
@@ -18,6 +18,7 @@ package co.cask.cdap.messaging.service;
 
 import co.cask.cdap.common.utils.TimeProvider;
 import co.cask.cdap.messaging.StoreRequest;
+import co.cask.cdap.messaging.TopicMetadata;
 import co.cask.cdap.messaging.store.MessageTable;
 import co.cask.cdap.proto.id.TopicId;
 
@@ -42,10 +43,11 @@ final class MessageTableStoreRequestWriter extends StoreRequestWriter<MessageTab
   }
 
   @Override
-  MessageTable.Entry getEntry(TopicId topicId, boolean transactional, long transactionWritePointer,
+  MessageTable.Entry getEntry(TopicMetadata metadata, boolean transactional, long transactionWritePointer,
                               long writeTimestamp, short sequenceId, @Nullable byte[] payload) {
     return entry
-      .setTopicId(topicId)
+      .setTopicId(metadata.getTopicId())
+      .setGeneration(metadata.getGeneration())
       .setTransactional(transactional)
       .setTransactionWritePointer(transactionWritePointer)
       .setPublishTimestamp(writeTimestamp)
@@ -69,6 +71,7 @@ final class MessageTableStoreRequestWriter extends StoreRequestWriter<MessageTab
   private static final class MutableMessageTableEntry implements MessageTable.Entry {
 
     private TopicId topicId;
+    private int generation;
     private boolean transactional;
     private long transactionWritePointer;
     private long publishTimestamp;
@@ -77,6 +80,11 @@ final class MessageTableStoreRequestWriter extends StoreRequestWriter<MessageTab
 
     MutableMessageTableEntry setTopicId(TopicId topicId) {
       this.topicId = topicId;
+      return this;
+    }
+
+    MutableMessageTableEntry setGeneration(int generation) {
+      this.generation = generation;
       return this;
     }
 
@@ -108,6 +116,11 @@ final class MessageTableStoreRequestWriter extends StoreRequestWriter<MessageTab
     @Override
     public TopicId getTopicId() {
       return topicId;
+    }
+
+    @Override
+    public int getGeneration() {
+      return generation;
     }
 
     @Override

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/service/PayloadTableStoreRequestWriter.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/service/PayloadTableStoreRequestWriter.java
@@ -18,6 +18,7 @@ package co.cask.cdap.messaging.service;
 
 import co.cask.cdap.common.utils.TimeProvider;
 import co.cask.cdap.messaging.StoreRequest;
+import co.cask.cdap.messaging.TopicMetadata;
 import co.cask.cdap.messaging.store.PayloadTable;
 import co.cask.cdap.proto.id.TopicId;
 
@@ -42,10 +43,11 @@ final class PayloadTableStoreRequestWriter extends StoreRequestWriter<PayloadTab
   }
 
   @Override
-  PayloadTable.Entry getEntry(TopicId topicId, boolean transactional, long transactionWritePointer,
+  PayloadTable.Entry getEntry(TopicMetadata metadata, boolean transactional, long transactionWritePointer,
                               long writeTimestamp, short sequenceId, @Nullable byte[] payload) {
     return entry
-      .setTopicId(topicId)
+      .setTopicId(metadata.getTopicId())
+      .setGeneration(metadata.getGeneration())
       .setTransactionWritePointer(transactionWritePointer)
       .setPayloadWriteTimestamp(writeTimestamp)
       .setPayloadSequenceId(sequenceId)
@@ -68,6 +70,7 @@ final class PayloadTableStoreRequestWriter extends StoreRequestWriter<PayloadTab
   private static final class MutablePayloadTableEntry implements PayloadTable.Entry {
 
     private TopicId topicId;
+    private int generation;
     private long transactionWritePointer;
     private long writeTimestamp;
     private short sequenceId;
@@ -75,6 +78,11 @@ final class PayloadTableStoreRequestWriter extends StoreRequestWriter<PayloadTab
 
     MutablePayloadTableEntry setTopicId(TopicId topicId) {
       this.topicId = topicId;
+      return this;
+    }
+
+    MutablePayloadTableEntry setGeneration(int generation) {
+      this.generation = generation;
       return this;
     }
 
@@ -101,6 +109,11 @@ final class PayloadTableStoreRequestWriter extends StoreRequestWriter<PayloadTab
     @Override
     public TopicId getTopicId() {
       return topicId;
+    }
+
+    @Override
+    public int getGeneration() {
+      return generation;
     }
 
     @Override

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/service/PendingStoreRequest.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/service/PendingStoreRequest.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.messaging.service;
 
 import co.cask.cdap.messaging.StoreRequest;
+import co.cask.cdap.messaging.TopicMetadata;
 
 import javax.annotation.Nullable;
 
@@ -26,6 +27,8 @@ import javax.annotation.Nullable;
 final class PendingStoreRequest extends StoreRequest {
 
   private final StoreRequest originalRequest;
+  private final TopicMetadata metadata;
+
   private boolean completed;
   private long startTimestamp;
   private long endTimestamp;
@@ -33,10 +36,15 @@ final class PendingStoreRequest extends StoreRequest {
   private int endSequenceId;
   private Throwable failureCause;
 
-  PendingStoreRequest(StoreRequest originalRequest) {
+  PendingStoreRequest(StoreRequest originalRequest, TopicMetadata topicMetadata) {
     super(originalRequest.getTopicId(), originalRequest.isTransactional(),
           originalRequest.getTransactionWritePointer());
     this.originalRequest = originalRequest;
+    this.metadata = topicMetadata;
+  }
+
+  TopicMetadata getTopicMetadata() {
+    return metadata;
   }
 
   boolean isCompleted() {

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/service/StoreRequestWriter.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/service/StoreRequestWriter.java
@@ -18,7 +18,7 @@ package co.cask.cdap.messaging.service;
 
 import co.cask.cdap.common.utils.TimeProvider;
 import co.cask.cdap.messaging.StoreRequest;
-import co.cask.cdap.proto.id.TopicId;
+import co.cask.cdap.messaging.TopicMetadata;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -98,7 +98,7 @@ abstract class StoreRequestWriter<T> implements Closeable {
   /**
    * Returns an entry to be written based on the provided information.
    *
-   * @param topicId the topic id
+   * @param metadata {@link TopicMetadata}
    * @param transactional whether a store request is transactional or not
    * @param transactionWritePointer the transaction write pointer if the request is transactional
    * @param writeTimestamp the timestamp to be used as the write timestamp
@@ -106,7 +106,7 @@ abstract class StoreRequestWriter<T> implements Closeable {
    * @param payload the message payload
    * @return an entry of type {@code <T>}.
    */
-  abstract T getEntry(TopicId topicId, boolean transactional, long transactionWritePointer,
+  abstract T getEntry(TopicMetadata metadata, boolean transactional, long transactionWritePointer,
                       long writeTimestamp, short sequenceId, @Nullable byte[] payload);
 
   /**
@@ -145,7 +145,7 @@ abstract class StoreRequestWriter<T> implements Closeable {
 
   /**
    * A resettable {@link Iterator} to transform payloads in a {@link PendingStoreRequest} to entries using
-   * the {@link #getEntry(TopicId, boolean, long, long, short, byte[])} method.
+   * the {@link #getEntry(TopicMetadata, boolean, long, long, short, byte[])} method.
    */
   private final class PayloadTransformIterator implements Iterator<T> {
 
@@ -172,9 +172,8 @@ abstract class StoreRequestWriter<T> implements Closeable {
       // or if the iterator is empty but we wanted to generate an entry with null payload
       if (storeRequest.hasNext() || (generateNullPayloadEntry && !computedFirst)) {
         byte[] payload = storeRequest.hasNext() ? storeRequest.next() : null;
-        nextEntry = getEntry(storeRequest.getTopicId(), storeRequest.isTransactional(),
-                             storeRequest.getTransactionWritePointer(),
-                             writeTimestamp, (short) seqId, payload);
+        nextEntry = getEntry(storeRequest.getTopicMetadata(), storeRequest.isTransactional(),
+                             storeRequest.getTransactionWritePointer(), writeTimestamp, (short) seqId, payload);
       }
       computedFirst = true;
       completed = nextEntry == null;

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/ImmutableMessageTableEntry.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/ImmutableMessageTableEntry.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
  */
 final class ImmutableMessageTableEntry implements MessageTable.Entry {
   private final TopicId topicId;
+  private final int generation;
   private final boolean transactional;
   private final long transactionWritePointer;
   private final byte[] payload;
@@ -38,13 +39,21 @@ final class ImmutableMessageTableEntry implements MessageTable.Entry {
     this.publishTimestamp = Bytes.toLong(row, row.length - Bytes.SIZEOF_SHORT - Bytes.SIZEOF_LONG);
     this.sequenceId = Bytes.toShort(row, row.length - Bytes.SIZEOF_SHORT);
     this.transactional = (txPtr != null);
-    this.transactionWritePointer = txPtr == null ? -1 : Bytes.toLong(txPtr);
-    this.topicId = MessagingUtils.toTopicId(row, 0, row.length - Bytes.SIZEOF_SHORT - Bytes.SIZEOF_LONG);
+    // since we mark tx as negative when tx is rolled back, we return the absolute value of tx
+    this.transactionWritePointer = txPtr == null ? -1 : Math.abs(Bytes.toLong(txPtr));
+    this.generation = Bytes.toInt(row, row.length - Bytes.SIZEOF_SHORT - Bytes.SIZEOF_LONG - Bytes.SIZEOF_INT);
+    this.topicId = MessagingUtils.toTopicId(row, 0, row.length - Bytes.SIZEOF_SHORT - Bytes.SIZEOF_LONG
+      - Bytes.SIZEOF_INT);
   }
 
   @Override
   public TopicId getTopicId() {
     return topicId;
+  }
+
+  @Override
+  public int getGeneration() {
+    return generation;
   }
 
   @Override

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/ImmutablePayloadTableEntry.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/ImmutablePayloadTableEntry.java
@@ -25,13 +25,16 @@ import co.cask.cdap.proto.id.TopicId;
  */
 final class ImmutablePayloadTableEntry implements PayloadTable.Entry {
   private final TopicId topicId;
+  private final int generation;
   private final long transactionWriterPointer;
   private final long publishTimestamp;
   private final short sequenceId;
   private final byte[] payload;
 
   ImmutablePayloadTableEntry(byte[] row, byte[] payload) {
-    this.topicId = MessagingUtils.toTopicId(row, 0, row.length - Bytes.SIZEOF_SHORT - (2 * Bytes.SIZEOF_LONG));
+    this.topicId = MessagingUtils.toTopicId(row, 0, row.length - Bytes.SIZEOF_SHORT - (2 * Bytes.SIZEOF_LONG)
+      - Bytes.SIZEOF_INT);
+    this.generation = Bytes.toInt(row, row.length - Bytes.SIZEOF_SHORT - (2 * Bytes.SIZEOF_LONG) - Bytes.SIZEOF_INT);
     this.transactionWriterPointer = Bytes.toLong(row, row.length - Bytes.SIZEOF_SHORT - (2 * Bytes.SIZEOF_LONG));
     this.publishTimestamp = Bytes.toLong(row, row.length - Bytes.SIZEOF_SHORT - Bytes.SIZEOF_LONG);
     this.sequenceId = Bytes.toShort(row, row.length - Bytes.SIZEOF_SHORT);
@@ -41,6 +44,11 @@ final class ImmutablePayloadTableEntry implements PayloadTable.Entry {
   @Override
   public TopicId getTopicId() {
     return topicId;
+  }
+
+  @Override
+  public int getGeneration() {
+    return generation;
   }
 
   @Override

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/PayloadTable.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/PayloadTable.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.messaging.store;
 
 import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.messaging.TopicMetadata;
 import co.cask.cdap.messaging.data.MessageId;
 import co.cask.cdap.proto.id.TopicId;
 
@@ -42,6 +43,11 @@ public interface PayloadTable extends Closeable {
     TopicId getTopicId();
 
     /**
+     * Returns the generation id of the topic.
+     */
+    int getGeneration();
+
+    /**
      * Returns the message payload.
      */
     byte[] getPayload();
@@ -65,14 +71,14 @@ public interface PayloadTable extends Closeable {
   /**
    * Fetches entries from the payload table under the given topic, starting from the given {@link MessageId}.
    *
-   * @param topicId topic to fetch from
+   * @param metadata {@link TopicMetadata} of the topic to fetch from
    * @param transactionWritePointer transaction write pointer
    * @param messageId message Id to start from
    * @param inclusive {@code true} to include the entry identified by the given {@link MessageId} as the first message
    * @param limit maximum number of entries to fetch
    * @return a {@link CloseableIterator} of entries
    */
-  CloseableIterator<Entry> fetch(TopicId topicId, long transactionWritePointer, MessageId messageId,
+  CloseableIterator<Entry> fetch(TopicMetadata metadata, long transactionWritePointer, MessageId messageId,
                                  boolean inclusive, int limit) throws IOException;
 
   /**
@@ -82,12 +88,4 @@ public interface PayloadTable extends Closeable {
    *                hence it is safe for the {@link Iterator} to reuse the same {@link Entry} instance
    */
   void store(Iterator<? extends Entry> entries) throws IOException;
-
-  /**
-   * Delete all the messages stored with the given transactionWritePointer under the given topic.
-   *
-   * @param topicId topic to delete from
-   * @param transactionWritePointer the transaction write pointer for scanning entries to delete.
-   */
-  void delete(TopicId topicId, long transactionWritePointer) throws IOException;
 }

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/hbase/HBaseMetadataTable.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/hbase/HBaseMetadataTable.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.messaging.TopicAlreadyExistsException;
 import co.cask.cdap.api.messaging.TopicNotFoundException;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.PutBuilder;
 import co.cask.cdap.messaging.MessagingUtils;
 import co.cask.cdap.messaging.TopicMetadata;
 import co.cask.cdap.messaging.store.MetadataTable;
@@ -27,7 +28,6 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.TopicId;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.client.Put;
@@ -52,6 +52,7 @@ final class HBaseMetadataTable implements MetadataTable {
 
   private static final byte[] COL = Bytes.toBytes("m");
   private static final Gson GSON = new Gson();
+
   // It has to be a sorted map since we depends on the serialized map for compareAndPut operation for topic update.
   private static final Type MAP_TYPE = new TypeToken<SortedMap<String, String>>() { }.getType();
 
@@ -67,7 +68,7 @@ final class HBaseMetadataTable implements MetadataTable {
 
   @Override
   public TopicMetadata getMetadata(TopicId topicId) throws IOException, TopicNotFoundException {
-    Get get = tableUtil.buildGet(MessagingUtils.toRowKeyPrefix(topicId))
+    Get get = tableUtil.buildGet(MessagingUtils.toMetadataRowKey(topicId))
       .addFamily(columnFamily)
       .build();
 
@@ -78,34 +79,65 @@ final class HBaseMetadataTable implements MetadataTable {
     }
 
     Map<String, String> properties = GSON.fromJson(Bytes.toString(value), MAP_TYPE);
-    return new TopicMetadata(topicId, properties);
+    TopicMetadata topicMetadata = new TopicMetadata(topicId, properties);
+    if (!topicMetadata.exists()) {
+      throw new TopicNotFoundException(topicId.getNamespace(), topicId.getTopic());
+    }
+    return topicMetadata;
   }
 
   @Override
   public void createTopic(TopicMetadata topicMetadata) throws TopicAlreadyExistsException, IOException {
     TopicId topicId = topicMetadata.getTopicId();
-    byte[] rowKey = MessagingUtils.toRowKeyPrefix(topicId);
-    Put put = tableUtil.buildPut(rowKey)
-      .add(columnFamily, COL, Bytes.toBytes(GSON.toJson(new TreeMap<>(topicMetadata.getProperties()), MAP_TYPE)))
+
+    byte[] rowKey = MessagingUtils.toMetadataRowKey(topicId);
+    PutBuilder putBuilder = tableUtil.buildPut(rowKey);
+
+    Get get = tableUtil.buildGet(rowKey)
+      .addFamily(columnFamily)
       .build();
 
-    if (!hTable.checkAndPut(rowKey, columnFamily, COL, null, put)) {
-      throw new TopicAlreadyExistsException(topicId.getNamespace(), topicId.getTopic());
+    boolean completed = false;
+    while (!completed) {
+      Result result = hTable.get(get);
+      byte[] value = result.getValue(columnFamily, COL);
+
+      if (value == null) {
+        TreeMap<String, String> properties = new TreeMap<>(topicMetadata.getProperties());
+        properties.put(TopicMetadata.GENERATION_KEY, MessagingUtils.Constants.DEFAULT_GENERATION);
+        putBuilder.add(columnFamily, COL, Bytes.toBytes(GSON.toJson(properties, MAP_TYPE)));
+        completed = hTable.checkAndPut(rowKey, columnFamily, COL, null, putBuilder.build());
+      } else {
+        Map<String, String> properties = GSON.fromJson(Bytes.toString(value), MAP_TYPE);
+        TopicMetadata metadata = new TopicMetadata(topicId, properties);
+        if (metadata.exists()) {
+          throw new TopicAlreadyExistsException(topicId.getNamespace(), topicId.getTopic());
+        }
+
+        int newGenerationId = (metadata.getGeneration() * -1) + 1;
+        TreeMap<String, String> newProperties = new TreeMap<>(properties);
+        newProperties.put(TopicMetadata.GENERATION_KEY, Integer.toString(newGenerationId));
+
+        putBuilder.add(columnFamily, COL, Bytes.toBytes(GSON.toJson(newProperties, MAP_TYPE)));
+        completed = hTable.checkAndPut(rowKey, columnFamily, COL, value, putBuilder.build());
+      }
     }
   }
 
   @Override
   public void updateTopic(TopicMetadata topicMetadata) throws TopicNotFoundException, IOException {
+    byte[] rowKey = MessagingUtils.toMetadataRowKey(topicMetadata.getTopicId());
     boolean completed = false;
 
     // Keep trying to update
-    byte[] rowKey = MessagingUtils.toRowKeyPrefix(topicMetadata.getTopicId());
-    Put put = tableUtil.buildPut(rowKey)
-      .add(columnFamily, COL, Bytes.toBytes(GSON.toJson(new TreeMap<>(topicMetadata.getProperties()), MAP_TYPE)))
-      .build();
-
     while (!completed) {
       TopicMetadata oldMetadata = getMetadata(topicMetadata.getTopicId());
+      TreeMap<String, String> newProperties = new TreeMap<>(topicMetadata.getProperties());
+      newProperties.put(TopicMetadata.GENERATION_KEY, Integer.toString(oldMetadata.getGeneration()));
+
+      Put put = tableUtil.buildPut(rowKey)
+        .add(columnFamily, COL, Bytes.toBytes(GSON.toJson(newProperties, MAP_TYPE)))
+        .build();
       byte[] oldValue = Bytes.toBytes(GSON.toJson(new TreeMap<>(oldMetadata.getProperties()), MAP_TYPE));
       completed = hTable.checkAndPut(rowKey, columnFamily, COL, oldValue, put);
     }
@@ -113,15 +145,19 @@ final class HBaseMetadataTable implements MetadataTable {
 
   @Override
   public void deleteTopic(TopicId topicId) throws TopicNotFoundException, IOException {
+    byte[] rowKey = MessagingUtils.toMetadataRowKey(topicId);
     boolean completed = false;
 
     // Keep trying to delete
-    byte[] rowKey = MessagingUtils.toRowKeyPrefix(topicId);
-    Delete delete = tableUtil.buildDelete(rowKey).build();
     while (!completed) {
-      TopicMetadata metadata = getMetadata(topicId);
-      byte[] oldValue = Bytes.toBytes(GSON.toJson(new TreeMap<>(metadata.getProperties()), MAP_TYPE));
-      completed = hTable.checkAndDelete(rowKey, columnFamily, COL, oldValue, delete);
+      TopicMetadata oldMetadata = getMetadata(topicId);
+      TreeMap<String, String> newProperties = new TreeMap<>(oldMetadata.getProperties());
+      newProperties.put(TopicMetadata.GENERATION_KEY, Integer.toString(oldMetadata.getGeneration() * -1));
+      Put put = tableUtil.buildPut(rowKey)
+        .add(columnFamily, COL, Bytes.toBytes(GSON.toJson(newProperties, MAP_TYPE)))
+        .build();
+      byte[] oldValue = Bytes.toBytes(GSON.toJson(new TreeMap<>(oldMetadata.getProperties()), MAP_TYPE));
+      completed = hTable.checkAndPut(rowKey, columnFamily, COL, oldValue, put);
     }
   }
 
@@ -150,7 +186,13 @@ final class HBaseMetadataTable implements MetadataTable {
     List<TopicId> topicIds = new ArrayList<>();
     try (ResultScanner resultScanner = hTable.getScanner(scan)) {
       for (Result result : resultScanner) {
-        topicIds.add(MessagingUtils.toTopicId(result.getRow()));
+        TopicId topicId = MessagingUtils.toTopicId(result.getRow());
+        byte[] value = result.getValue(columnFamily, COL);
+        Map<String, String> properties = GSON.fromJson(Bytes.toString(value), MAP_TYPE);
+        TopicMetadata metadata = new TopicMetadata(topicId, properties);
+        if (metadata.exists()) {
+          topicIds.add(topicId);
+        }
       }
     }
     return topicIds;

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/hbase/HBasePayloadTable.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/hbase/HBasePayloadTable.java
@@ -25,7 +25,6 @@ import co.cask.cdap.hbase.wd.DistributedScanner;
 import co.cask.cdap.messaging.store.AbstractPayloadTable;
 import co.cask.cdap.messaging.store.PayloadTable;
 import co.cask.cdap.messaging.store.RawPayloadTableEntry;
-import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
@@ -111,31 +110,6 @@ final class HBasePayloadTable extends AbstractPayloadTable {
 
     if (!batchPuts.isEmpty()) {
       hTable.put(batchPuts);
-      if (!hTable.isAutoFlush()) {
-        hTable.flushCommits();
-      }
-    }
-  }
-
-  @Override
-  protected void delete(byte[] startRow, byte[] stopRow) throws IOException {
-    Scan scan = tableUtil.buildScan()
-      .setStartRow(startRow)
-      .setStopRow(stopRow)
-      .build();
-
-    List<Delete> batchDeletes = new ArrayList<>();
-    try (ResultScanner scanner = DistributedScanner.create(hTable, scan, rowKeyDistributor, scanExecutor)) {
-      for (Result result : scanner) {
-        // No need to turn the key back to the original row key because we want to delete with the actual row key
-        Delete delete = tableUtil.buildDelete(result.getRow()).build();
-        batchDeletes.add(delete);
-        hTable.delete(delete);
-      }
-    }
-
-    if (!batchDeletes.isEmpty()) {
-      hTable.delete(batchDeletes);
       if (!hTable.isAutoFlush()) {
         hTable.flushCommits();
       }

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/leveldb/LevelDBMetadataTable.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/leveldb/LevelDBMetadataTable.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import javax.annotation.Nullable;
 
 /**
@@ -56,13 +57,17 @@ final class LevelDBMetadataTable implements MetadataTable {
   @Override
   public TopicMetadata getMetadata(TopicId topicId) throws IOException, TopicNotFoundException {
     try {
-      byte[] value = levelDB.get(MessagingUtils.toRowKeyPrefix(topicId));
+      byte[] value = levelDB.get(MessagingUtils.toMetadataRowKey(topicId));
       if (value == null) {
         throw new TopicNotFoundException(topicId.getNamespace(), topicId.getTopic());
       }
 
       Map<String, String> properties = GSON.fromJson(Bytes.toString(value), MAP_TYPE);
-      return new TopicMetadata(topicId, properties);
+      TopicMetadata topicMetadata = new TopicMetadata(topicId, properties);
+      if (!topicMetadata.exists()) {
+        throw new TopicNotFoundException(topicId.getNamespace(), topicId.getTopic());
+      }
+      return topicMetadata;
     } catch (DBException e) {
       // DBException is a RuntimeException. Turn it to IOException so that it forces caller to handle it.
       throw new IOException(e);
@@ -73,12 +78,23 @@ final class LevelDBMetadataTable implements MetadataTable {
   public void createTopic(TopicMetadata topicMetadata) throws TopicAlreadyExistsException, IOException {
     try {
       TopicId topicId = topicMetadata.getTopicId();
-      byte[] key = MessagingUtils.toRowKeyPrefix(topicId);
-      byte[] value = Bytes.toBytes(GSON.toJson(topicMetadata.getProperties()));
+      byte[] key = MessagingUtils.toMetadataRowKey(topicId);
+      TreeMap<String, String> properties = new TreeMap<>(topicMetadata.getProperties());
+      properties.put(TopicMetadata.GENERATION_KEY, MessagingUtils.Constants.DEFAULT_GENERATION);
+
       synchronized (this) {
-        if (levelDB.get(key) != null) {
-          throw new TopicAlreadyExistsException(topicId.getNamespace(), topicId.getTopic());
+        byte[] tableValue = levelDB.get(key);
+        if (tableValue != null) {
+          Map<String, String> oldProperties = GSON.fromJson(Bytes.toString(tableValue), MAP_TYPE);
+          TopicMetadata metadata = new TopicMetadata(topicId, oldProperties);
+          if (metadata.exists()) {
+            throw new TopicAlreadyExistsException(topicId.getNamespace(), topicId.getTopic());
+          }
+
+          int newGenerationId = (metadata.getGeneration() * -1) + 1;
+          properties.put(TopicMetadata.GENERATION_KEY, Integer.toString(newGenerationId));
         }
+        byte[] value = Bytes.toBytes(GSON.toJson(properties, MAP_TYPE));
         levelDB.put(key, value, WRITE_OPTIONS);
       }
     } catch (DBException e) {
@@ -90,13 +106,22 @@ final class LevelDBMetadataTable implements MetadataTable {
   public void updateTopic(TopicMetadata topicMetadata) throws TopicNotFoundException, IOException {
     try {
       TopicId topicId = topicMetadata.getTopicId();
-      byte[] key = MessagingUtils.toRowKeyPrefix(topicId);
-      byte[] value = Bytes.toBytes(GSON.toJson(topicMetadata.getProperties()));
+      byte[] key = MessagingUtils.toMetadataRowKey(topicId);
       synchronized (this) {
-        if (levelDB.get(key) == null) {
+        byte[] tableValue = levelDB.get(key);
+        if (tableValue == null) {
           throw new TopicNotFoundException(topicId.getNamespace(), topicId.getTopic());
         }
-        levelDB.put(key, value, WRITE_OPTIONS);
+
+        Map<String, String> oldProperties = GSON.fromJson(Bytes.toString(tableValue), MAP_TYPE);
+        TopicMetadata oldMetadata = new TopicMetadata(topicId, oldProperties);
+        if (!oldMetadata.exists()) {
+          throw new TopicNotFoundException(topicId.getNamespace(), topicId.getTopic());
+        }
+
+        TreeMap<String, String> newProperties = new TreeMap<>(topicMetadata.getProperties());
+        newProperties.put(TopicMetadata.GENERATION_KEY, Integer.toString(oldMetadata.getGeneration()));
+        levelDB.put(key, Bytes.toBytes(GSON.toJson(newProperties, MAP_TYPE)), WRITE_OPTIONS);
       }
     } catch (DBException e) {
       throw new IOException(e);
@@ -105,13 +130,24 @@ final class LevelDBMetadataTable implements MetadataTable {
 
   @Override
   public void deleteTopic(TopicId topicId) throws TopicNotFoundException, IOException {
-    byte[] rowKey = MessagingUtils.toRowKeyPrefix(topicId);
+    byte[] rowKey = MessagingUtils.toMetadataRowKey(topicId);
     try {
       synchronized (this) {
-        if (levelDB.get(rowKey) == null) {
+        byte[] tableValue = levelDB.get(rowKey);
+        if (tableValue == null) {
           throw new TopicNotFoundException(topicId.getNamespace(), topicId.getTopic());
         }
-        levelDB.delete(rowKey);
+
+        Map<String, String> oldProperties = GSON.fromJson(Bytes.toString(tableValue), MAP_TYPE);
+        TopicMetadata metadata = new TopicMetadata(topicId, oldProperties);
+        if (!metadata.exists()) {
+          throw new TopicNotFoundException(topicId.getNamespace(), topicId.getTopic());
+        }
+
+        // Mark the topic as deleted
+        TreeMap<String, String> newProperties = new TreeMap<>(metadata.getProperties());
+        newProperties.put(TopicMetadata.GENERATION_KEY, Integer.toString(-1 * metadata.getGeneration()));
+        levelDB.put(rowKey, Bytes.toBytes(GSON.toJson(newProperties, MAP_TYPE)), WRITE_OPTIONS);
       }
     } catch (DBException e) {
       throw new IOException(e);
@@ -140,7 +176,12 @@ final class LevelDBMetadataTable implements MetadataTable {
     try (CloseableIterator<Map.Entry<byte[], byte[]>> iterator = new DBScanIterator(levelDB, startKey, stopKey)) {
       while (iterator.hasNext()) {
         Map.Entry<byte[], byte[]> entry = iterator.next();
-        topicIds.add(MessagingUtils.toTopicId(entry.getKey()));
+        TopicId topicId = MessagingUtils.toTopicId(entry.getKey());
+        Map<String, String> properties = GSON.fromJson(Bytes.toString(entry.getValue()), MAP_TYPE);
+        TopicMetadata metadata = new TopicMetadata(topicId, properties);
+        if (metadata.exists()) {
+          topicIds.add(topicId);
+        }
       }
     }
     return topicIds;

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/leveldb/LevelDBPayloadTable.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/leveldb/LevelDBPayloadTable.java
@@ -27,10 +27,8 @@ import org.iq80.leveldb.WriteBatch;
 import org.iq80.leveldb.WriteOptions;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -87,25 +85,6 @@ public class LevelDBPayloadTable extends AbstractPayloadTable {
         writeBatch.put(Arrays.copyOf(key, key.length), Arrays.copyOf(value, value.length));
       }
       levelDB.write(writeBatch, WRITE_OPTIONS);
-    } catch (DBException ex) {
-      throw new IOException(ex);
-    }
-  }
-
-  @Override
-  protected void delete(byte[] startRow, byte[] stopRow) throws IOException {
-    List<byte[]> rowKeysToDelete = new ArrayList<>();
-    try (CloseableIterator<Map.Entry<byte[], byte[]>> rowIterator = new DBScanIterator(levelDB, startRow, stopRow)) {
-      while (rowIterator.hasNext()) {
-        Map.Entry<byte[], byte[]> candidateRow = rowIterator.next();
-        rowKeysToDelete.add(candidateRow.getKey());
-      }
-    }
-
-    try {
-      for (byte[] deleteRowKey : rowKeysToDelete) {
-        levelDB.delete(deleteRowKey);
-      }
     } catch (DBException ex) {
       throw new IOException(ex);
     }

--- a/cdap-tms/src/test/java/co/cask/cdap/messaging/MessagingUtilsTest.java
+++ b/cdap-tms/src/test/java/co/cask/cdap/messaging/MessagingUtilsTest.java
@@ -28,7 +28,7 @@ public class MessagingUtilsTest {
   @Test
   public void testTopicConversion() throws Exception {
     TopicId id = new TopicId("n1", "t1");
-    byte[] topicBytes = MessagingUtils.toRowKeyPrefix(id);
+    byte[] topicBytes = MessagingUtils.toMetadataRowKey(id);
     TopicId topicId = MessagingUtils.toTopicId(topicBytes);
     Assert.assertEquals(id, topicId);
   }

--- a/cdap-tms/src/test/java/co/cask/cdap/messaging/store/MessageTableTest.java
+++ b/cdap-tms/src/test/java/co/cask/cdap/messaging/store/MessageTableTest.java
@@ -18,9 +18,12 @@ package co.cask.cdap.messaging.store;
 
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.messaging.RollbackDetail;
+import co.cask.cdap.messaging.TopicMetadata;
 import co.cask.cdap.messaging.data.MessageId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.TopicId;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import org.apache.tephra.Transaction;
@@ -42,28 +45,34 @@ import javax.annotation.Nullable;
 public abstract class MessageTableTest {
   private static final TopicId T1 = NamespaceId.DEFAULT.topic("t1");
   private static final TopicId T2 = NamespaceId.DEFAULT.topic("t2");
+  private static final int GENERATION = 1;
+  private static final Map<String, String> DEFAULT_PROPERTY = ImmutableMap.of(TopicMetadata.GENERATION_KEY,
+                                                                              Integer.toString(GENERATION));
+  private static final TopicMetadata M1 = new TopicMetadata(T1, DEFAULT_PROPERTY);
+  private static final TopicMetadata M2 = new TopicMetadata(T2, DEFAULT_PROPERTY);
 
   protected abstract MessageTable getMessageTable() throws Exception;
 
   @Test
   public void testSingleMessage() throws Exception {
     TopicId topicId = NamespaceId.DEFAULT.topic("single");
+    TopicMetadata metadata = new TopicMetadata(topicId, DEFAULT_PROPERTY);
     String payload = "data";
     long txWritePtr = 123L;
     try (MessageTable table = getMessageTable()) {
       List<MessageTable.Entry> entryList = new ArrayList<>();
-      entryList.add(new TestMessageEntry(topicId, 0L, 0, txWritePtr, Bytes.toBytes(payload)));
+      entryList.add(new TestMessageEntry(topicId, GENERATION, 0L, 0, txWritePtr, Bytes.toBytes(payload)));
       table.store(entryList.iterator());
       byte[] messageId = new byte[MessageId.RAW_ID_SIZE];
       MessageId.putRawId(0L, (short) 0, 0L, (short) 0, messageId, 0);
 
-      try (CloseableIterator<MessageTable.Entry> iterator = table.fetch(topicId,
+      try (CloseableIterator<MessageTable.Entry> iterator = table.fetch(metadata,
                                                                         new MessageId(messageId), false, 50, null)) {
         // Fetch not including the first message, expect empty
         Assert.assertFalse(iterator.hasNext());
       }
 
-      try (CloseableIterator<MessageTable.Entry> iterator = table.fetch(topicId,
+      try (CloseableIterator<MessageTable.Entry> iterator = table.fetch(metadata,
                                                                         new MessageId(messageId), true, 50, null)) {
         // Fetch including the first message, should get the message
         Assert.assertTrue(iterator.hasNext());
@@ -72,18 +81,28 @@ public abstract class MessageTableTest {
         Assert.assertFalse(iterator.hasNext());
       }
 
-      try (CloseableIterator<MessageTable.Entry> iterator = table.fetch(topicId, 0, 50, null)) {
+      try (CloseableIterator<MessageTable.Entry> iterator = table.fetch(metadata, 0, 50, null)) {
         // Fetch by time, should get the entry
         MessageTable.Entry entry = iterator.next();
         Assert.assertArrayEquals(Bytes.toBytes(payload), entry.getPayload());
         Assert.assertFalse(iterator.hasNext());
       }
 
-      table.delete(topicId, 0L, (short) 0, 0L, (short) 0);
+      RollbackDetail rollbackDetail = new TestRollbackDetail(123L, 0, (short) 0, 0L, (short) 0);
+      table.rollback(metadata, rollbackDetail);
 
-      try (CloseableIterator<MessageTable.Entry> iterator = table.fetch(topicId,
+      try (CloseableIterator<MessageTable.Entry> iterator = table.fetch(metadata,
                                                                         new MessageId(messageId), true, 50, null)) {
-        // After message deleted, expected empty
+        // Fetching the message non-tx should provide a result even after deletion
+        MessageTable.Entry entry = iterator.next();
+        Assert.assertArrayEquals(Bytes.toBytes(payload), entry.getPayload());
+        Assert.assertFalse(iterator.hasNext());
+      }
+
+      Transaction tx = new Transaction(200, 200, new long[0], new long[0], -1);
+      try (CloseableIterator<MessageTable.Entry> iterator = table.fetch(metadata, new MessageId(messageId),
+                                                                        true, 50, tx)) {
+        // Fetching messages transactionally should not return any entry
         Assert.assertFalse(iterator.hasNext());
       }
     }
@@ -99,49 +118,53 @@ public abstract class MessageTableTest {
                                            startSequenceIds, endSequenceIds);
       table.store(entryList.iterator());
 
-      CloseableIterator<MessageTable.Entry> iterator = table.fetch(T1, 0, Integer.MAX_VALUE, null);
+      CloseableIterator<MessageTable.Entry> iterator = table.fetch(M1, 0, Integer.MAX_VALUE, null);
       checkPointerCount(iterator, 123, ImmutableSet.of(100L, 101L, 102L), 150);
 
       // Read with 85 items limit
-      iterator = table.fetch(T1, 0, 85, null);
+      iterator = table.fetch(M1, 0, 85, null);
       checkPointerCount(iterator, 123, ImmutableSet.of(100L, 101L, 102L), 85);
 
       // Read with all messages visible
       Transaction tx = new Transaction(200, 200, new long[0], new long[0], -1);
-      iterator = table.fetch(T1, 0, Integer.MAX_VALUE, tx);
+      iterator = table.fetch(M1, 0, Integer.MAX_VALUE, tx);
       checkPointerCount(iterator, 123, ImmutableSet.of(100L, 101L, 102L), 150);
 
       // Read with 101 as invalid transaction
       tx = new Transaction(200, 200, new long[] { 101 }, new long[0], -1);
-      iterator = table.fetch(T1, 0, Integer.MAX_VALUE, tx);
+      iterator = table.fetch(M1, 0, Integer.MAX_VALUE, tx);
       checkPointerCount(iterator, 123, ImmutableSet.of(100L, 102L), 100);
 
       // Mark 101 as in progress transaction, then we shouldn't read past committed transaction which is 100.
       tx = new Transaction(100, 100, new long[] {}, new long[] { 101 }, -1);
-      iterator = table.fetch(T1, 0, Integer.MAX_VALUE, tx);
+      iterator = table.fetch(M1, 0, Integer.MAX_VALUE, tx);
       checkPointerCount(iterator, 123, ImmutableSet.of(100L), 50);
 
       // Same read as above but with limit of 10 elements
-      iterator = table.fetch(T1, 0, 10, tx);
+      iterator = table.fetch(M1, 0, 10, tx);
       checkPointerCount(iterator, 123, ImmutableSet.of(100L), 10);
 
       // Reading non-tx from t2 should provide 150 items
-      iterator = table.fetch(T2, 0, Integer.MAX_VALUE, null);
+      iterator = table.fetch(M2, 0, Integer.MAX_VALUE, null);
       checkPointerCount(iterator, 321, ImmutableSet.of(100L, 101L, 102L), 150);
 
       // Delete txPtr entries for 101, and then try fetching again for that
-      table.delete(T1, publishTimestamp, startSequenceIds.get(101L), publishTimestamp, endSequenceIds.get(101L));
-      iterator = table.fetch(T1, 0, Integer.MAX_VALUE, null);
-      checkPointerCount(iterator, 123, ImmutableSet.of(100L, 102L), 100);
+      RollbackDetail rollbackDetail = new TestRollbackDetail(101L, publishTimestamp, startSequenceIds.get(101L),
+                                                             publishTimestamp, endSequenceIds.get(101L));
+      table.rollback(M1, rollbackDetail);
+      iterator = table.fetch(M1, 0, Integer.MAX_VALUE, null);
+      checkPointerCount(iterator, 123, ImmutableSet.of(100L, 101L, 102L), 150);
 
       // Delete txPtr entries for 100, and then try fetching transactionally all data
-      table.delete(T1, publishTimestamp, startSequenceIds.get(100L), publishTimestamp, endSequenceIds.get(100L));
+      rollbackDetail = new TestRollbackDetail(100L, publishTimestamp, startSequenceIds.get(100L),
+                                              publishTimestamp, endSequenceIds.get(100L));
+      table.rollback(M1, rollbackDetail);
       tx = new Transaction(200, 200, new long[0], new long[0], -1);
-      iterator = table.fetch(T1, 0, Integer.MAX_VALUE, tx);
+      iterator = table.fetch(M1, 0, Integer.MAX_VALUE, tx);
       checkPointerCount(iterator, 123, ImmutableSet.of(102L), 50);
 
       // Use the above tx and read from t2 and it should give all entries
-      iterator = table.fetch(T2, 0, Integer.MAX_VALUE, tx);
+      iterator = table.fetch(M2, 0, Integer.MAX_VALUE, tx);
       checkPointerCount(iterator, 321, ImmutableSet.of(100L, 101L, 102L), 150);
     }
   }
@@ -149,23 +172,24 @@ public abstract class MessageTableTest {
   @Test
   public void testEmptyPayload() throws Exception {
     TopicId topicId = NamespaceId.DEFAULT.topic("testEmptyPayload");
+    TopicMetadata metadata = new TopicMetadata(topicId, DEFAULT_PROPERTY);
 
     // This test the message table supports for empty payload. This is for the case where message table
     // stores only a reference to the payload table
     try (MessageTable table = getMessageTable()) {
       try {
-        table.store(Collections.singleton(new TestMessageEntry(topicId, 1L, 0, null, null)).iterator());
+        table.store(Collections.singleton(new TestMessageEntry(topicId, GENERATION, 1L, 0, null, null)).iterator());
         Assert.fail("Expected IllegalArgumentException");
       } catch (IllegalArgumentException e) {
         // Expected as non-transactional message cannot have null payload
       }
 
       // For transactional message, ok to have null payload
-      table.store(Collections.singleton(new TestMessageEntry(topicId, 1L, 0, 2L, null)).iterator());
+      table.store(Collections.singleton(new TestMessageEntry(topicId, GENERATION, 1L, 0, 2L, null)).iterator());
 
       // Fetch the entry to validate
       List<MessageTable.Entry> entries = new ArrayList<>();
-      try (CloseableIterator<MessageTable.Entry> iterator = table.fetch(topicId, 0L, Integer.MAX_VALUE, null)) {
+      try (CloseableIterator<MessageTable.Entry> iterator = table.fetch(metadata, 0L, Integer.MAX_VALUE, null)) {
         Iterators.addAll(entries, iterator);
       }
 
@@ -207,8 +231,8 @@ public abstract class MessageTableTest {
     for (Long writePtr : writePointers) {
       startSequences.put(writePtr, seqId);
       for (int i = 0; i < 50; i++) {
-        messageTable.add(new TestMessageEntry(T1, timestamp, seqId++, writePtr, Bytes.toBytes(data1)));
-        messageTable.add(new TestMessageEntry(T2, timestamp, seqId++, writePtr, Bytes.toBytes(data2)));
+        messageTable.add(new TestMessageEntry(T1, GENERATION, timestamp, seqId++, writePtr, Bytes.toBytes(data1)));
+        messageTable.add(new TestMessageEntry(T2, GENERATION, timestamp, seqId++, writePtr, Bytes.toBytes(data2)));
       }
       // Need to subtract the seqId with 1 since it is already incremented and we want the seqId being used
       // for the last written entry of this tx write ptr
@@ -218,17 +242,61 @@ public abstract class MessageTableTest {
     return timestamp;
   }
 
+  private static class TestRollbackDetail implements RollbackDetail {
+
+    private final long txWritePtr;
+    private final long startTimestamp;
+    private final int startSeqId;
+    private final long endTimestamp;
+    private final int endSeqId;
+
+    TestRollbackDetail(long txWritePtr, long startTimestamp, int startSeqId, long endTimestamp, int endSeqId) {
+      this.txWritePtr = txWritePtr;
+      this.startTimestamp = startTimestamp;
+      this.startSeqId = startSeqId;
+      this.endTimestamp = endTimestamp;
+      this.endSeqId = endSeqId;
+    }
+
+    @Override
+    public long getTransactionWritePointer() {
+      return txWritePtr;
+    }
+
+    @Override
+    public long getStartTimestamp() {
+      return startTimestamp;
+    }
+
+    @Override
+    public int getStartSequenceId() {
+      return startSeqId;
+    }
+
+    @Override
+    public long getEndTimestamp() {
+      return endTimestamp;
+    }
+
+    @Override
+    public int getEndSequenceId() {
+      return endSeqId;
+    }
+  }
+
   // Private class for publishing messages
   private static class TestMessageEntry implements MessageTable.Entry {
     private final TopicId topicId;
+    private final int generation;
     private final Long transactionWritePointer;
     private final byte[] payload;
     private final long publishTimestamp;
     private final short sequenceId;
 
-    TestMessageEntry(TopicId topicId, long publishTimestamp, int sequenceId,
+    TestMessageEntry(TopicId topicId, int generation, long publishTimestamp, int sequenceId,
                      @Nullable Long transactionWritePointer, @Nullable byte[] payload) {
       this.topicId = topicId;
+      this.generation = generation;
       this.transactionWritePointer = transactionWritePointer;
       this.publishTimestamp = publishTimestamp;
       this.sequenceId = (short) sequenceId;
@@ -238,6 +306,11 @@ public abstract class MessageTableTest {
     @Override
     public TopicId getTopicId() {
       return topicId;
+    }
+
+    @Override
+    public int getGeneration() {
+      return generation;
     }
 
     @Override

--- a/cdap-tms/src/test/java/co/cask/cdap/messaging/store/MetadataTableTest.java
+++ b/cdap-tms/src/test/java/co/cask/cdap/messaging/store/MetadataTableTest.java
@@ -43,13 +43,15 @@ public abstract class MetadataTableTest {
       }
 
       // Create topic default:t1
-      table.createTopic(new TopicMetadata(NamespaceId.DEFAULT.topic("t1"), "ttl", 10));
+      table.createTopic(new TopicMetadata(NamespaceId.DEFAULT.topic("t1"), "ttl", 10));;
       Assert.assertEquals(1, table.listTopics(NamespaceId.DEFAULT).size());
 
       // Create topic default:t2
       TopicMetadata topicMetadata = new TopicMetadata(NamespaceId.DEFAULT.topic("t2"), "ttl", 20);
       table.createTopic(topicMetadata);
-      Assert.assertEquals(topicMetadata, table.getMetadata(NamespaceId.DEFAULT.topic("t2")));
+      Assert.assertEquals(topicMetadata.getTopicId(), table.getMetadata(NamespaceId.DEFAULT.topic("t2")).getTopicId());
+      Assert.assertEquals(topicMetadata.getTTL(), table.getMetadata(NamespaceId.DEFAULT.topic("t2")).getTTL());
+      Assert.assertEquals(1, table.getMetadata(NamespaceId.DEFAULT.topic("t2")).getGeneration());
 
       // Create topic system:t3
       table.createTopic(new TopicMetadata(NamespaceId.SYSTEM.topic("t3"), "ttl", 30));
@@ -75,6 +77,29 @@ public abstract class MetadataTableTest {
       Assert.assertTrue(table.listTopics(NamespaceId.DEFAULT).isEmpty());
       Assert.assertTrue(table.listTopics(NamespaceId.SYSTEM).isEmpty());
       Assert.assertTrue(table.listTopics().isEmpty());
+    }
+  }
+
+  @Test
+  public void testGenerations() throws Exception {
+    try (MetadataTable table = createMetadataTable()) {
+      TopicId topicId = NamespaceId.DEFAULT.topic("gtopic");
+      for (int i = 1; i <= 50; i++) {
+        table.createTopic(new TopicMetadata(topicId, "ttl", 1));
+
+        TopicMetadata metadata = table.getMetadata(topicId);
+        Assert.assertEquals(i, metadata.getGeneration());
+        Assert.assertEquals(1, metadata.getTTL());
+
+        table.deleteTopic(topicId);
+
+        try {
+          table.getMetadata(topicId);
+          Assert.fail("Expected TopicNotFoundException");
+        } catch (TopicNotFoundException ex) {
+          // Expected
+        }
+      }
     }
   }
 

--- a/cdap-tms/src/test/java/co/cask/cdap/messaging/store/PayloadTableTest.java
+++ b/cdap-tms/src/test/java/co/cask/cdap/messaging/store/PayloadTableTest.java
@@ -18,16 +18,19 @@ package co.cask.cdap.messaging.store;
 
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.messaging.TopicMetadata;
 import co.cask.cdap.messaging.data.MessageId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.TopicId;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -36,44 +39,39 @@ import java.util.Set;
 public abstract class PayloadTableTest {
   private static final TopicId T1 = NamespaceId.DEFAULT.topic("t1");
   private static final TopicId T2 = NamespaceId.DEFAULT.topic("t2");
+  private static final int GENERATION = 1;
+  private static final Map<String, String> DEFAULT_PROPERTY = ImmutableMap.of(TopicMetadata.GENERATION_KEY,
+                                                                              Integer.toString(GENERATION));
+  private static final TopicMetadata M1 = new TopicMetadata(T1, DEFAULT_PROPERTY);
+  private static final TopicMetadata M2 = new TopicMetadata(T2, DEFAULT_PROPERTY);
 
   protected abstract PayloadTable getPayloadTable() throws Exception;
 
   @Test
   public void testSingleMessage() throws Exception {
     TopicId topicId = NamespaceId.DEFAULT.topic("single");
+    TopicMetadata metadata = new TopicMetadata(topicId, DEFAULT_PROPERTY);
     String payload = "data";
     long txWritePtr = 123L;
     try (PayloadTable table = getPayloadTable()) {
       List<PayloadTable.Entry> entryList = new ArrayList<>();
-      entryList.add(new TestPayloadEntry(topicId, txWritePtr, 0L, (short) 0, Bytes.toBytes(payload)));
+      entryList.add(new TestPayloadEntry(topicId, GENERATION, txWritePtr, 0L, (short) 0, Bytes.toBytes(payload)));
       table.store(entryList.iterator());
       byte[] messageId = new byte[MessageId.RAW_ID_SIZE];
       MessageId.putRawId(0L, (short) 0, 0L, (short) 0, messageId, 0);
-      try (CloseableIterator<PayloadTable.Entry> iterator = table.fetch(topicId, txWritePtr,
-                                                                        new MessageId(messageId),
+      try (CloseableIterator<PayloadTable.Entry> iterator = table.fetch(metadata, txWritePtr, new MessageId(messageId),
                                                                         false, Integer.MAX_VALUE)) {
         // Fetch not including the first message, expect empty
         Assert.assertFalse(iterator.hasNext());
       }
 
-      try (CloseableIterator<PayloadTable.Entry> iterator = table.fetch(topicId, txWritePtr,
-                                                                        new MessageId(messageId),
+      try (CloseableIterator<PayloadTable.Entry> iterator = table.fetch(metadata, txWritePtr, new MessageId(messageId),
                                                                         true, Integer.MAX_VALUE)) {
         // Fetch including the first message
         Assert.assertTrue(iterator.hasNext());
         PayloadTable.Entry entry = iterator.next();
         Assert.assertArrayEquals(Bytes.toBytes(payload), entry.getPayload());
         Assert.assertEquals(txWritePtr, entry.getTransactionWritePointer());
-        Assert.assertFalse(iterator.hasNext());
-      }
-
-      table.delete(topicId, txWritePtr);
-
-      try (CloseableIterator<PayloadTable.Entry> iterator = table.fetch(topicId, txWritePtr,
-                                                                        new MessageId(messageId),
-                                                                        true, Integer.MAX_VALUE)) {
-        // After delete the payload, expect empty fetch
         Assert.assertFalse(iterator.hasNext());
       }
     }
@@ -89,25 +87,20 @@ public abstract class PayloadTableTest {
       MessageId.putRawId(0L, (short) 0, 0L, (short) 0, messageId, 0);
 
       // Fetch data with 100 write pointer
-      CloseableIterator<PayloadTable.Entry> iterator = table.fetch(T1, 100, new MessageId(messageId), true,
+      CloseableIterator<PayloadTable.Entry> iterator = table.fetch(M1, 100, new MessageId(messageId), true,
                                                                    Integer.MAX_VALUE);
       checkData(iterator, 123, ImmutableSet.of(100L), 50);
 
       // Fetch only 10 items with 101 write pointer
-      iterator = table.fetch(T1, 101, new MessageId(messageId), true, 1);
+      iterator = table.fetch(M1, 101, new MessageId(messageId), true, 1);
       checkData(iterator, 123, ImmutableSet.of(101L), 1);
 
       // Fetch items with 102 write pointer
-      iterator = table.fetch(T1, 102, new MessageId(messageId), true, Integer.MAX_VALUE);
+      iterator = table.fetch(M1, 102, new MessageId(messageId), true, Integer.MAX_VALUE);
       checkData(iterator, 123, ImmutableSet.of(102L), 50);
 
-      // Delete items with 101 write pointer and then try and read from that
-      table.delete(T1, 101);
-      iterator = table.fetch(T1, 101, new MessageId(messageId), true, Integer.MAX_VALUE);
-      checkData(iterator, 123, null, 0);
-
       // Fetch from t2 with 101 write pointer
-      iterator = table.fetch(T2, 101, new MessageId(messageId), true, Integer.MAX_VALUE);
+      iterator = table.fetch(M2, 101, new MessageId(messageId), true, Integer.MAX_VALUE);
       checkData(iterator, 123, ImmutableSet.of(101L), 50);
     }
   }
@@ -132,8 +125,8 @@ public abstract class PayloadTableTest {
     short seqId = 0;
     for (Integer writePtr : writePointers) {
       for (int i = 0; i < 50; i++) {
-        payloadTable.add(new TestPayloadEntry(T1, writePtr, timestamp, seqId++, Bytes.toBytes(data)));
-        payloadTable.add(new TestPayloadEntry(T2, writePtr, timestamp, seqId++, Bytes.toBytes(data)));
+        payloadTable.add(new TestPayloadEntry(T1, GENERATION, writePtr, timestamp, seqId++, Bytes.toBytes(data)));
+        payloadTable.add(new TestPayloadEntry(T2, GENERATION, writePtr, timestamp, seqId++, Bytes.toBytes(data)));
       }
     }
   }
@@ -141,13 +134,16 @@ public abstract class PayloadTableTest {
   // Private class for publishing messages
   private static class TestPayloadEntry implements PayloadTable.Entry {
     private final TopicId topicId;
+    private final int generation;
     private final byte[] payload;
     private final long transactionWritePointer;
     private final long writeTimestamp;
     private final short seqId;
 
-    TestPayloadEntry(TopicId topicId, long transactionWritePointer, long writeTimestamp, short seqId, byte[] payload) {
+    TestPayloadEntry(TopicId topicId, int generation, long transactionWritePointer, long writeTimestamp,
+                     short seqId, byte[] payload) {
       this.topicId = topicId;
+      this.generation = generation;
       this.transactionWritePointer = transactionWritePointer;
       this.writeTimestamp = writeTimestamp;
       this.seqId = seqId;
@@ -157,6 +153,11 @@ public abstract class PayloadTableTest {
     @Override
     public TopicId getTopicId() {
       return topicId;
+    }
+
+    @Override
+    public int getGeneration() {
+      return generation;
     }
 
     @Override


### PR DESCRIPTION
TopicIds should have generations ( 1...MAXINT) so that when a topic is deleted and recreated, the messages present in the previous generation should not be considered during fetching. 

This is achieved by having a generation id as part of the rowKey in TMS Data tables. TopicMetada in MetadataTable keeps track of the last used generation id. This implies that rows are never deleted from MetadataTable. Ideally, we could delete rows once all the data from Data Tables corresponding to that topic has been removed, but that is not part of this PR.

When a topic is deleted, the generation id in MetadataTable for that TopicId, is made -ve of the current generation id. When the topic is recreated again, then the generation id is made +ve and it is bumped up by 1.

JIRA : https://issues.cask.co/browse/CDAP-7702
Build : http://builds.cask.co/browse/CDAP-RUT299-11