### PR TITLE
(CDAP-7545) Added 4 more index columns in the metadata dataset to sup…

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/DatasetSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/DatasetSpecification.java
@@ -95,7 +95,7 @@ public final class DatasetSpecification {
     this.description = description;
     this.properties = Collections.unmodifiableSortedMap(new TreeMap<>(properties));
     this.originalProperties = originalProperties == null ? null :
-      Collections.unmodifiableMap(new TreeMap<String, String>(originalProperties));
+      Collections.unmodifiableMap(new TreeMap<>(originalProperties));
     this.datasetSpecs = Collections.unmodifiableSortedMap(new TreeMap<>(datasetSpecs));
   }
 
@@ -127,8 +127,9 @@ public final class DatasetSpecification {
   /**
    * Lookup a custom property of the dataset.
    * @param key the name of the property
-   * @return the value of the property or null if the property does not exist
+   * @return the value of the property or {@code null} if the property does not exist
    */
+  @Nullable
   public String getProperty(String key) {
     return properties.get(key);
   }
@@ -150,7 +151,7 @@ public final class DatasetSpecification {
    * @return the value of the property or defaultValue if the property does not exist
    */
   public long getLongProperty(String key, long defaultValue) {
-    return properties.containsKey(key) ? Long.parseLong(getProperty(key)) : defaultValue;
+    return properties.containsKey(key) ? Long.parseLong(properties.get(key)) : defaultValue;
   }
 
   /**
@@ -160,7 +161,7 @@ public final class DatasetSpecification {
    * @return the value of the property or defaultValue if the property does not exist
    */
   public int getIntProperty(String key, int defaultValue) {
-    return properties.containsKey(key) ? Integer.parseInt(getProperty(key)) : defaultValue;
+    return properties.containsKey(key) ? Integer.parseInt(properties.get(key)) : defaultValue;
   }
 
   /**

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataHttpHandlerTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataHttpHandlerTestRun.java
@@ -648,19 +648,17 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     Schema viewSchema = Schema.recordOf("record",
                                         Schema.Field.of("viewBody", Schema.nullableOf(Schema.of(Schema.Type.BYTES))));
     streamViewClient.createOrUpdate(view.toId(), new ViewSpecification(new FormatSpecification("format", viewSchema)));
-    Set<String> viewSystemTags = getTags(view, MetadataScope.SYSTEM);
-    Assert.assertEquals(ImmutableSet.of(AllProgramsApp.STREAM_NAME), viewSystemTags);
-    Map<String, String> viewSystemProperties = getProperties(view, MetadataScope.SYSTEM);
-    Assert.assertEquals(viewSchema.toString(),
-                        viewSystemProperties.get(AbstractSystemMetadataWriter.SCHEMA_KEY));
     ImmutableSet<String> viewUserTags = ImmutableSet.of("viewTag");
     addTags(view, viewUserTags);
     Assert.assertEquals(
-      ImmutableSet.of(new MetadataRecord(view, MetadataScope.USER, ImmutableMap.<String, String>of(),
-                                         viewUserTags),
-                      new MetadataRecord(view, MetadataScope.SYSTEM, viewSystemProperties,
-                                         viewSystemTags)),
-      getMetadata(view)
+      ImmutableSet.of(
+        new MetadataRecord(view, MetadataScope.USER, ImmutableMap.<String, String>of(), viewUserTags),
+        new MetadataRecord(view, MetadataScope.SYSTEM,
+                           ImmutableMap.of(AbstractSystemMetadataWriter.ENTITY_NAME_KEY, view.getEntityName(),
+                                           AbstractSystemMetadataWriter.SCHEMA_KEY, viewSchema.toString()),
+                           ImmutableSet.of(AllProgramsApp.STREAM_NAME))
+      ),
+      removeCreationTime(getMetadata(view))
     );
 
     // verify dataset system metadata

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/indexer/InvertedTimeIndexer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/indexer/InvertedTimeIndexer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.indexer;
+
+import co.cask.cdap.data2.metadata.dataset.MetadataEntry;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * {@link Indexer} that applies on a long value and returns its inverted long value, obtained by subtracting it from
+ * {@code Long.MAX_VALUE}. This can be used to return results in descending order of creation time.
+ */
+public class InvertedTimeIndexer implements Indexer {
+  @Override
+  public Set<String> getIndexes(MetadataEntry entry) {
+    String value = entry.getValue();
+    long creationTime;
+    try {
+      creationTime = Long.parseLong(value);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("Expected value in InvertedTimeIndexer to be a long but found " + value);
+    }
+    return Collections.singleton(String.valueOf(Long.MAX_VALUE - creationTime));
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/indexer/InvertedValueIndexer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/indexer/InvertedValueIndexer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.indexer;
+
+import co.cask.cdap.data2.metadata.dataset.MetadataEntry;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * An {@link Indexer} that returns lexicographically inverted indexes. The indexes returned have each character's
+ * ASCII value subtracted from the maximum ASCII value of a character (127).
+ */
+public class InvertedValueIndexer implements Indexer {
+  @Override
+  public Set<String> getIndexes(MetadataEntry entry) {
+    return Collections.singleton(lexInvert(entry.getValue()));
+  }
+
+  private String lexInvert(String input) {
+    StringBuilder reversed = new StringBuilder();
+    for (char c : input.toCharArray()) {
+      int ascii = (int) c;
+      // 127 is the max ASCII value
+      int inverted = 127 - ascii;
+      reversed.append((char) inverted);
+    }
+    return reversed.toString();
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/indexer/ValueOnlyIndexer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/indexer/ValueOnlyIndexer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.indexer;
+
+import co.cask.cdap.data2.metadata.dataset.MetadataEntry;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * {@link Indexer} that returns the {@link MetadataEntry} value as the only index.
+ */
+public class ValueOnlyIndexer implements Indexer {
+  @Override
+  public Set<String> getIndexes(MetadataEntry entry) {
+    return Collections.singleton(entry.getValue());
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
@@ -17,7 +17,6 @@
 package co.cask.cdap.data2.metadata.store;
 
 import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
-import co.cask.cdap.data2.metadata.indexer.Indexer;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
@@ -26,7 +25,6 @@ import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 /**
  * Defines operations on {@link MetadataDataset} for both system and user metadata.
@@ -50,16 +48,14 @@ public interface MetadataStore {
   void setProperties(MetadataScope scope, NamespacedEntityId namespacedEntityId, Map<String, String> properties);
 
   /**
-   * Adds/updates properties for the specified {@link NamespacedEntityId} in the specified {@link MetadataScope}.
+   * Sets the specified property for the specified {@link NamespacedEntityId} in the specified {@link MetadataScope}.
    *
-   * @param scope the {@link MetadataScope} to add/update the properties in
-   * @param namespacedEntityId the {@link NamespacedEntityId} to add the properties to
-   * @param properties the properties to add/update
-   * @param indexer {@link Indexer} to use for creating indexes
+   * @param scope the {@link MetadataScope} to set/update the property in
+   * @param namespacedEntityId the {@link NamespacedEntityId} to set the property for
+   * @param key the property key
+   * @param value the property value
    */
-  void setProperties(MetadataScope scope, NamespacedEntityId namespacedEntityId, Map<String, String> properties,
-                     @Nullable Indexer indexer);
-
+  void setProperty(MetadataScope scope, NamespacedEntityId namespacedEntityId, String key, String value);
 
   /**
    * Adds tags for the specified {@link NamespacedEntityId} in the specified {@link MetadataScope}.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
@@ -15,7 +15,6 @@
  */
 package co.cask.cdap.data2.metadata.store;
 
-import co.cask.cdap.data2.metadata.indexer.Indexer;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
@@ -39,8 +38,7 @@ public class NoOpMetadataStore implements MetadataStore {
   }
 
   @Override
-  public void setProperties(MetadataScope scope, NamespacedEntityId namespacedEntityId, Map<String, String> properties,
-                            Indexer indexer) {
+  public void setProperty(MetadataScope scope, NamespacedEntityId namespacedEntityId, String key, String value) {
     // NO-OP
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/AbstractSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/system/AbstractSystemMetadataWriter.java
@@ -18,7 +18,6 @@ package co.cask.cdap.data2.metadata.system;
 
 import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
-import co.cask.cdap.data2.metadata.indexer.SchemaIndexer;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataScope;
@@ -114,10 +113,11 @@ public abstract class AbstractSystemMetadataWriter implements SystemMetadataWrit
     if (tags.length > 0) {
       metadataStore.addTags(MetadataScope.SYSTEM, entityId, tags);
     }
+    // store additional properties that we want to index separately
     // if there is schema property then set that while providing schema indexer
-    if (!Strings.isNullOrEmpty(getSchemaToAdd())) {
-      metadataStore.setProperties(MetadataScope.SYSTEM, entityId,
-                                  ImmutableMap.of(SCHEMA_KEY, getSchemaToAdd()), new SchemaIndexer());
+    String schema = getSchemaToAdd();
+    if (!Strings.isNullOrEmpty(schema)) {
+      metadataStore.setProperty(MetadataScope.SYSTEM, entityId, SCHEMA_KEY, schema);
     }
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/indexer/InvertedValueIndexerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/indexer/InvertedValueIndexerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.indexer;
+
+import co.cask.cdap.data2.metadata.dataset.MetadataEntry;
+import co.cask.cdap.proto.id.NamespaceId;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Tests for {@link InvertedValueIndexer}.
+ */
+public class InvertedValueIndexerTest {
+  private final Indexer indexer = new InvertedValueIndexer();
+  private final NamespaceId ns = new NamespaceId("ns");
+
+  @Test
+  public void testSimple() {
+    List<String> inputs = ImmutableList.of(
+      "134342", "435ert5", "trdfrw", "_bfcfd", "r34_r3", "cgsdfgs)dfd", "gfsgfd2345245234", "dfsgs"
+    );
+    // expected is reverse sorted input
+    List<String> expected = new ArrayList<>(inputs);
+    Collections.sort(expected, Collections.<String>reverseOrder());
+    List<String> invertedIndexes = new ArrayList<>();
+    for (String input : inputs) {
+      invertedIndexes.add(Iterables.getOnlyElement(indexer.getIndexes(new MetadataEntry(ns, "dontcare", input))));
+    }
+    // inverted indexes sorted in ascending order
+    Collections.sort(invertedIndexes);
+    for (int i = 0; i < invertedIndexes.size(); i++) {
+      String invertedIndex = invertedIndexes.get(i);
+      String original = Iterables.getOnlyElement(indexer.getIndexes(new MetadataEntry(ns, "dontcare", invertedIndex)));
+      Assert.assertEquals(expected.get(i), original);
+    }
+  }
+}


### PR DESCRIPTION
…port efficient listing:

1. Entity Name;
2. Inverted Entity Name;
3. Creation Time;
4. Inverted Creation Time.

Additionally, fixed the following:
- (CDAP-5663) Made MetadataDataset aware of Indexers for each key. This makes rebuilding indexes seamless, and also ensures that clients of the dataset do not have to pass in the right index.
- (CDAP-5061) Fixed AbstractSystemMetadataWriter to not override all properties when a schema is specified, and instead just add the schema to the existing list of properties.


Jiras:
[CDAP-7545](https://issues.cask.co/browse/CDAP-7545)
[CDAP-5663](https://issues.cask.co/browse/CDAP-5663)
[CDAP-5061](https://issues.cask.co/browse/CDAP-5061)

Build: http://builds.cask.co/browse/CDAP-DUT5153


This is again being merged into an intermediate branch.

Pending for search:
1. Integration with the REST API
2. Lifecycle management of the 4 new index columns (deletion when all indexes are to be deleted etc)
2. Integration with tooling (upgrade, index rebuilding)