### PR TITLE
CDAP-7634 Use MainClassLoader as parent class loader in Explore

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/hive/ExploreUtils.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/hive/ExploreUtils.java
@@ -82,7 +82,8 @@ public final class ExploreUtils {
 
     LOG.debug("Explore ClassLoader urls {}", urls);
 
-    exploreClassLoader = new URLClassLoader(urls.toArray(new URL[urls.size()]), ClassLoader.getSystemClassLoader());
+    // The parent class loader is MainClassLoader since ExploreUtil will always be loaded from MainClassLoader
+    exploreClassLoader = new URLClassLoader(urls.toArray(new URL[urls.size()]), ExploreUtils.class.getClassLoader());
     return exploreClassLoader;
   }
 


### PR DESCRIPTION
- Earlier ExploreClassLoader's parent classloader was default application classloader.
- We changed the MasterServiceMain Classloader to MainClassLoader here: https://github.com/caskdata/cdap/pull/7114/files#diff-ef64c290689c73ddd269891673e5281fR188
- So use the MainClassLoader as parent classloader for Explore too else it will lead to class incompatibilities since classes will be loaded from different classloader hierarchy.