### PR TITLE
[HYDRATOR-1145] - Fixes styling for Modals & Wizards in Market/Resource center

### DIFF
--- a/cdap-ui/app/cdap/components/CardActionFeedback/CardActionFeedback.less
+++ b/cdap-ui/app/cdap/components/CardActionFeedback/CardActionFeedback.less
@@ -29,8 +29,7 @@
   .main-message {
     height: @feedback-height;
     line-height: @feedback-height - 1;
-    border: 1px solid black;
-    border-top: 0;
+    border: 0;
   }
   .feedback-icon {
     margin: auto 10px;

--- a/cdap-ui/app/cdap/components/CaskWizards/AddNamespace/AddNamespace.less
+++ b/cdap-ui/app/cdap/components/CaskWizards/AddNamespace/AddNamespace.less
@@ -12,23 +12,18 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
-*/
-.threshold-step {
-  &.form-group {
-    text-align: center;
-    padding-top: 30px;
-  }
-  input {
-    height: 120px;
-    font-size: 60px;
-    width: 250px;
-    margin: 0 auto;
-    text-align: center;
-  }
-  h3,
-  p {
-    margin: 0;
-    font-weight: 500;
-  }
-  h3 { margin-top: 10px; }
-}
+ */
+@import '../../WizardModal/WizardModal.less';
+
+ // Specific hack for hydrator.
+ body {
+   .modal {
+     .wizard-modal.create-stream-wizard {
+       &.add-namespace-wizard {
+         &.modal-dialog {
+           margin-top: @wizard-modal-margin-top;
+         }
+       }
+     }
+   }
+ }

--- a/cdap-ui/app/cdap/components/CaskWizards/ApplicationUpload/ApplicationUpload.less
+++ b/cdap-ui/app/cdap/components/CaskWizards/ApplicationUpload/ApplicationUpload.less
@@ -12,23 +12,18 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
-*/
-.threshold-step {
-  &.form-group {
-    text-align: center;
-    padding-top: 30px;
-  }
-  input {
-    height: 120px;
-    font-size: 60px;
-    width: 250px;
-    margin: 0 auto;
-    text-align: center;
-  }
-  h3,
-  p {
-    margin: 0;
-    font-weight: 500;
-  }
-  h3 { margin-top: 10px; }
-}
+ */
+@import '../../WizardModal/WizardModal.less';
+
+ // Specific hack for hydrator.
+ body {
+   .modal {
+     .wizard-modal.create-stream-wizard {
+       &.artifact-upload-wizard {
+         &.modal-dialog {
+           margin-top: @wizard-modal-margin-top;
+         }
+       }
+     }
+   }
+ }

--- a/cdap-ui/app/cdap/components/CaskWizards/ApplicationUpload/UploadStep/UploadStep.less
+++ b/cdap-ui/app/cdap/components/CaskWizards/ApplicationUpload/UploadStep/UploadStep.less
@@ -17,4 +17,5 @@
   height: 100%;
   width: 100%;
   margin-bottom: 10px;
+  display: flex;
 }

--- a/cdap-ui/app/cdap/components/CaskWizards/ApplicationUpload/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/ApplicationUpload/index.js
@@ -21,6 +21,7 @@ import ApplicationUploadWizardConfig from 'services/WizardConfigs/ApplicationUpl
 import ApplicationUploadStore from 'services/WizardStores/ApplicationUpload/ApplicationUploadStore';
 import ApplicationUploadActions from 'services/WizardStores/ApplicationUpload/ApplicationUploadActions';
 import {UploadApplication} from 'services/WizardStores/ApplicationUpload/ActionCreator';
+import T from 'i18n-react';
 
 export default class ApplicationUploadWizard extends Component {
   constructor(props) {
@@ -46,9 +47,12 @@ export default class ApplicationUploadWizard extends Component {
     return UploadApplication();
   }
   render() {
+    let input = this.props.input;
+    let headerLabel = input.headerLabel;
+    let wizardModalTitle = (headerLabel ? headerLabel : T.translate('features.Resource-Center.Application.modelheadertitle')) ;
     return (
       <WizardModal
-        title="Application Upload Wizard"
+        title={wizardModalTitle}
         isOpen={this.state.showWizard}
         toggle={this.toggleWizard.bind(this, false)}
         className="artifact-upload-wizard"
@@ -66,5 +70,6 @@ export default class ApplicationUploadWizard extends Component {
 
 ApplicationUploadWizard.propTypes = {
   isOpen: PropTypes.bool,
-  onClose: PropTypes.func
+  onClose: PropTypes.func,
+  input: PropTypes.any
 };

--- a/cdap-ui/app/cdap/components/CaskWizards/ArtifactUpload/ArtifactUpload.less
+++ b/cdap-ui/app/cdap/components/CaskWizards/ArtifactUpload/ArtifactUpload.less
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+@import '../../WizardModal/WizardModal.less';
 
 .artifact-upload-wizard {
   .modal-body {
@@ -36,6 +37,19 @@
     }
     select[multiple] {
       height: 55px;
+    }
+  }
+}
+
+// Specific hack for hydrator.
+body {
+  .modal {
+    .wizard-modal.create-stream-wizard {
+      &.artifact-upload-wizard {
+        &.modal-dialog {
+          margin-top: @wizard-modal-margin-top;
+        }
+      }
     }
   }
 }

--- a/cdap-ui/app/cdap/components/CaskWizards/ArtifactUpload/UploadStep/UploadStep.less
+++ b/cdap-ui/app/cdap/components/CaskWizards/ArtifactUpload/UploadStep/UploadStep.less
@@ -18,6 +18,8 @@
   .upload-instruction {
     margin-top: 0;
     width: 100%;
+    font-weight: normal;
+    font-size: 13px;
   }
   .wizard-steps-content {
     .wizard-step-content-container {

--- a/cdap-ui/app/cdap/components/CaskWizards/ArtifactUpload/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/ArtifactUpload/index.js
@@ -60,8 +60,9 @@ export default class ArtifactUploadWizard extends Component {
   render() {
     let input = this.props.input;
     let pkg = input.package || {};
+    let headerLabel = input.headerLabel;
 
-    let wizardModalTitle = (pkg.label ? pkg.label + " | " : '') + T.translate('features.Wizard.Informational.headerlabel') ;
+    let wizardModalTitle = (pkg.label ? pkg.label + " | " : '') + (headerLabel ? headerLabel : T.translate('features.Wizard.Informational.headerlabel')) ;
     return (
       <WizardModal
         title={wizardModalTitle}
@@ -85,7 +86,7 @@ ArtifactUploadWizard.defaultProps = {
     action: {
       arguments: {}
     },
-    package: {}
+    package: {},
   },
   isMarket: false
 };

--- a/cdap-ui/app/cdap/components/CaskWizards/HydratorPipeline/HydratorPipeline.less
+++ b/cdap-ui/app/cdap/components/CaskWizards/HydratorPipeline/HydratorPipeline.less
@@ -15,7 +15,7 @@
  */
 
 .wizard-modal.create-stream-wizard {
-  &.hydrator-pipeline-modal {
+  &.hydrator-pipeline-wizard-modal {
     &.modal-dialog {
       margin-top: 300px;
       height: auto;
@@ -55,6 +55,19 @@
               }
             }
           }
+        }
+      }
+    }
+  }
+}
+
+// Specific hack for hydrator.
+body {
+  .modal {
+    .wizard-modal.create-stream-wizard {
+      &.hydrator-pipeline-wizard-modal {
+        &.modal-dialog {
+          margin-top: 300px;
         }
       }
     }

--- a/cdap-ui/app/cdap/components/CaskWizards/HydratorPipeline/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/HydratorPipeline/index.js
@@ -58,8 +58,7 @@ export default class HydratorPipeline extends Component {
       <Modal
         isOpen={this.state.isOpen}
         toggle={this.closeHandler.bind(this)}
-        className="wizard-modal create-stream-wizard hydrator-pipeline-modal"
-        backdrop={false}
+        className="wizard-modal create-stream-wizard hydrator-pipeline-wizard-modal"
         size="lg"
       >
         <ModalHeader>

--- a/cdap-ui/app/cdap/components/CaskWizards/Informational/Informational.less
+++ b/cdap-ui/app/cdap/components/CaskWizards/Informational/Informational.less
@@ -12,23 +12,18 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
-*/
-.threshold-step {
-  &.form-group {
-    text-align: center;
-    padding-top: 30px;
-  }
-  input {
-    height: 120px;
-    font-size: 60px;
-    width: 250px;
-    margin: 0 auto;
-    text-align: center;
-  }
-  h3,
-  p {
-    margin: 0;
-    font-weight: 500;
-  }
-  h3 { margin-top: 10px; }
-}
+ */
+@import '../../WizardModal/WizardModal.less';
+
+ // Specific hack for hydrator.
+ body {
+   .modal {
+     .wizard-modal.create-stream-wizard {
+       &.upload-data-wizard {
+         &.modal-dialog {
+           margin-top: @wizard-modal-margin-top;
+         }
+       }
+     }
+   }
+ }

--- a/cdap-ui/app/cdap/components/CaskWizards/PluginArtifactUpload/PluginArtifactUpload.less
+++ b/cdap-ui/app/cdap/components/CaskWizards/PluginArtifactUpload/PluginArtifactUpload.less
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
+@import '../../WizardModal/WizardModal.less';
 .artifact-upload-wizard {
   .modal-body {
 
@@ -38,3 +38,17 @@
     }
   }
 }
+
+
+ // Specific hack for hydrator.
+ body {
+   .modal {
+     .wizard-modal.create-stream-wizard {
+       &.artifact-upload-wizard {
+         &.modal-dialog {
+           margin-top: @wizard-modal-margin-top;
+         }
+       }
+     }
+   }
+ }

--- a/cdap-ui/app/cdap/components/CaskWizards/PluginArtifactUpload/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/PluginArtifactUpload/index.js
@@ -57,8 +57,9 @@ export default class PluginArtifactUploadWizard extends Component {
   render() {
     let input = this.props.input;
     let pkg = input.package || {};
+    let headerLabel = input.headerLabel;
 
-    let wizardModalTitle = (pkg.label ? pkg.label + " | " : '') + T.translate('features.Wizard.Informational.headerlabel') ;
+    let wizardModalTitle = (pkg.label ? pkg.label + " | " : '') + (headerLabel ? headerLabel : T.translate('features.Wizard.Informational.headerlabel')) ;
     return (
       <WizardModal
         title={wizardModalTitle}

--- a/cdap-ui/app/cdap/components/CaskWizards/StreamCreate/StreamCreate.less
+++ b/cdap-ui/app/cdap/components/CaskWizards/StreamCreate/StreamCreate.less
@@ -12,23 +12,18 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
-*/
-.threshold-step {
-  &.form-group {
-    text-align: center;
-    padding-top: 30px;
-  }
-  input {
-    height: 120px;
-    font-size: 60px;
-    width: 250px;
-    margin: 0 auto;
-    text-align: center;
-  }
-  h3,
-  p {
-    margin: 0;
-    font-weight: 500;
-  }
-  h3 { margin-top: 10px; }
-}
+ */
+
+@import '../../WizardModal/WizardModal.less';
+ // Specific hack for hydrator.
+ body {
+   .modal {
+     .wizard-modal.create-stream-wizard {
+       &.create-stream-wizard {
+         &.modal-dialog {
+           margin-top: @wizard-modal-margin-top;
+         }
+       }
+     }
+   }
+ }

--- a/cdap-ui/app/cdap/components/CaskWizards/StreamCreate/ThresholdStep/ThresholdStep.less
+++ b/cdap-ui/app/cdap/components/CaskWizards/StreamCreate/ThresholdStep/ThresholdStep.less
@@ -16,10 +16,10 @@
 .threshold-step {
   &.form-group {
     text-align: center;
-    padding-top: 25px;
+    padding-top: 10px;
   }
   input {
-    height: 135px;
+    height: 120px;
     font-size: 60px;
     width: 250px;
     margin: 0 auto;

--- a/cdap-ui/app/cdap/components/CaskWizards/UploadData/UploadData.less
+++ b/cdap-ui/app/cdap/components/CaskWizards/UploadData/UploadData.less
@@ -12,23 +12,18 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
-*/
-.threshold-step {
-  &.form-group {
-    text-align: center;
-    padding-top: 30px;
+ */
+
+@import '../../WizardModal/WizardModal.less';
+// Specific hack for hydrator.
+body {
+  .modal {
+    .wizard-modal.create-stream-wizard {
+      &.create-stream-wizard {
+        &.modal-dialog {
+          margin-top: @wizard-modal-margin-top;
+        }
+      }
+    }
   }
-  input {
-    height: 120px;
-    font-size: 60px;
-    width: 250px;
-    margin: 0 auto;
-    text-align: center;
-  }
-  h3,
-  p {
-    margin: 0;
-    font-weight: 500;
-  }
-  h3 { margin-top: 10px; }
 }

--- a/cdap-ui/app/cdap/components/FileDnD/FileDnD.less
+++ b/cdap-ui/app/cdap/components/FileDnD/FileDnD.less
@@ -18,7 +18,7 @@
    cursor: pointer;
    height: 100%;
    width: 100%;
-   border: 1px dashed;
+   border: 1px dashed #ccc;
    display: flex;
    align-items: center;
    justify-content: center;
@@ -27,11 +27,17 @@
       opacity: 0.7;
    }
    .file-metadata-container {
+    display: flex;
+    flex-direction: column;
+      .fa-upload {
+        margin-bottom: 7px;
+        color: #5a84e4;
+      }
       span {
-         line-height: 14px;
-         color: #666;
-         margin: 0;
-         font-size: 14px;
+        line-height: 20px;
+        color: #666;
+        margin: 0;
+        font-size: 14px;
       }
    }
 

--- a/cdap-ui/app/cdap/components/FileDnD/index.js
+++ b/cdap-ui/app/cdap/components/FileDnD/index.js
@@ -25,16 +25,19 @@ export default function FileDnD({file, onDropHandler, error}) {
       className="file-drop-container"
       onDrop={onDropHandler}>
       <div className="file-metadata-container text-center">
+        <i className="fa fa-upload fa-3x"></i>
         {
           file.name && file.name.length ? (<span>{file.name}</span>)
             :
-            (<span>
-               Drag and Drop the file to be uploaded
-              <br />
-              or
-              <br />
-              Click to select file from your computer
-            </span>)
+            (
+              <span>
+                 Drag and Drop the file to be uploaded
+                <br />
+                or
+                <br />
+                Click to select file from your computer
+              </span>
+            )
         }
         {
           error ?

--- a/cdap-ui/app/cdap/components/MarketPlaceEntity/MarketPlaceEntity.less
+++ b/cdap-ui/app/cdap/components/MarketPlaceEntity/MarketPlaceEntity.less
@@ -54,12 +54,45 @@
     padding: 0;
   }
 
+  .experimental-banner {
+    top: -16px;
+    left: -25px;
+    width: 47px;
+    display: inline-block;
+    position: relative;
+    color: white;
+    background-color: #ff6600;
+    text-shadow: 0px 1px 2px #bbb;
+    -webkit-box-shadow: 0px 2px 4px #888;
+    -moz-box-shadow: 0px 2px 4px #888;
+    box-shadow: 0px 2px 4px #888;
+    font-size: 12px;
+    display: block;
+
+    &:before {
+      content: ' ';
+      position: absolute;
+      width: 0;
+      height: 0;
+      left: 0px;
+      top: 100%;
+      border-width: 5px 5px;
+      border-style: solid;
+      border-color: #c55306 #c55306 transparent transparent;
+    }
+  }
   .package-icon-container {
     img {
       width: 125px;
     }
   }
   &.expanded {
+
+    .experimental-banner {
+      left: -26px;
+      top: -18px;
+      text-align: center;
+    }
     cursor: default;
 
     .cask-card {

--- a/cdap-ui/app/cdap/components/MarketPlaceEntity/index.js
+++ b/cdap-ui/app/cdap/components/MarketPlaceEntity/index.js
@@ -165,6 +165,12 @@ export default class MarketPlaceEntity extends Component {
             onClick={this.openDetailedMode.bind(this)}
             size="LG"
           >
+            {
+              this.props.entity.beta ?
+                <div className="experimental-banner">BETA</div>
+              :
+                null
+            }
             <div className="package-icon-container">
               <img src={MyMarketApi.getIcon(this.props.entity)} />
             </div>
@@ -182,6 +188,12 @@ export default class MarketPlaceEntity extends Component {
             cardStyle={style}
             onClick={this.openDetailedMode.bind(this)}
           >
+            {
+              this.props.entity.beta ?
+                <div className="experimental-banner">BETA</div>
+              :
+                null
+            }
             <div className="clearfix">
               <div
                 className="package-icon-container">
@@ -271,6 +283,7 @@ MarketPlaceEntity.propTypes = {
     description: PropTypes.string,
     org: PropTypes.string,
     created: PropTypes.number,
-    cdapVersion: PropTypes.string
+    cdapVersion: PropTypes.string,
+    beta: PropTypes.bool
   })
 };

--- a/cdap-ui/app/cdap/components/PlusButtonModal/PlusButtonModal.less
+++ b/cdap-ui/app/cdap/components/PlusButtonModal/PlusButtonModal.less
@@ -70,11 +70,16 @@
             line-height: 30px;
           }
         }
-        .btn-resource-center {
-          background-color: #464a57;
-          color: #efefef;
+        .navigation-button {
           font-weight: 500;
           padding: 0 10px 0 5px;
+          background: white;
+          color: #ff6600;
+          box-shadow: 0px 1px 10px 0 rgba(0, 0, 0, 0.3);
+
+          &.resource-center {
+            color: #5a84e4;
+          }
           &:focus {
             outline: 0;
           }

--- a/cdap-ui/app/cdap/components/PlusButtonModal/index.js
+++ b/cdap-ui/app/cdap/components/PlusButtonModal/index.js
@@ -77,7 +77,9 @@ export default class PlusButtonModal extends Component {
           </span>
           <div className="pull-right">
             <button
-              className="btn btn-sm btn-resource-center"
+              className={classNames("btn btn-sm navigation-button", {
+                'resource-center': this.state.viewMode === 'resourcecenter'
+              })}
               onClick={this.toggleView.bind(this)}
             >
               <span

--- a/cdap-ui/app/cdap/components/ResourceCenter/index.js
+++ b/cdap-ui/app/cdap/components/ResourceCenter/index.js
@@ -102,6 +102,7 @@ export default class ResourceCenter extends Component {
         <AbstractWizard
           wizardType="create_app_rc"
           isOpen={true}
+          input={{headerLabel: T.translate('features.Resource-Center.Application.modalheadertitle')}}
           onClose={this.toggleWizard.bind(this, 'createApplicationWizard')}
         />
       );
@@ -111,7 +112,7 @@ export default class ResourceCenter extends Component {
         <AbstractWizard
           isOpen={true}
           wizardType="create_artifact_rc"
-          backdrop={false}
+          input={{headerLabel: T.translate('features.Resource-Center.Artifact.modalheadertitle')}}
           onClose={this.toggleWizard.bind(this, 'createArtifactWizard')}
         />
       );
@@ -121,7 +122,7 @@ export default class ResourceCenter extends Component {
         <AbstractWizard
           isOpen={true}
           wizardType="create_plugin_artifact_rc"
-          backdrop={false}
+          input={{headerLabel: T.translate('features.Resource-Center.Plugins.modalheadertitle')}}
           onClose={this.toggleWizard.bind(this, 'createPluginArtifactWizard')}
         />
       );

--- a/cdap-ui/app/cdap/components/Wizard/Wizard.less
+++ b/cdap-ui/app/cdap/components/Wizard/Wizard.less
@@ -18,7 +18,7 @@
   .wizard-body {
     display: flex;
     height: 90%;
-    border: 1px solid black;
+    border: 0;
 
     .wizard-steps-header {
       width: 150px;

--- a/cdap-ui/app/cdap/components/Wizard/WizardStepContent/WizardStepContent.less
+++ b/cdap-ui/app/cdap/components/Wizard/WizardStepContent/WizardStepContent.less
@@ -20,7 +20,7 @@
     padding: 10px;
   }
   .step-banner {
-    background: #464a57;
+    background: darkgray;
     color: #fff;
     padding: 5px 15px;
     height: 51px;
@@ -38,6 +38,7 @@
     .progress-counter {
       line-height: 40px;
       vertical-align: middle;
+      font-size: 14px;
     }
   }
   .step-content {

--- a/cdap-ui/app/cdap/components/Wizard/WizardStepHeader/WizardStepHeader.less
+++ b/cdap-ui/app/cdap/components/Wizard/WizardStepHeader/WizardStepHeader.less
@@ -16,9 +16,8 @@
 @import '../../../styles/variables.less';
 
 .cask-wizard-step-header {
-  height: 53px;
-  border: 0;
-  border-bottom: 2px solid #dbdbdb;
+  height: 51px;
+  border-bottom: 1px solid #bbbbbb;
   font-size: 12px;
   color: #666;
   display: flex;
@@ -28,7 +27,7 @@
   font-weight: 500;
 
   &.active {
-    background: #ff6600;
+    background: #5a84e4;
     color: #fff;
   }
   &.completed {

--- a/cdap-ui/app/cdap/components/Wizard/index.js
+++ b/cdap-ui/app/cdap/components/Wizard/index.js
@@ -210,9 +210,9 @@ export default class Wizard extends Component{
     let stepHeaders = this.props
       .wizardConfig
       .steps
-      .map( (step, index) => (
+      .map( (step) => (
         <WizardStepHeader
-          label={`${index + 1} ${step.shorttitle}`}
+          label={`${step.shorttitle}`}
           className={ isStepComplete(step.id) ? 'completed' : null}
           id={step.id}
           key={shortid.generate()}

--- a/cdap-ui/app/cdap/components/WizardModal/WizardModal.less
+++ b/cdap-ui/app/cdap/components/WizardModal/WizardModal.less
@@ -15,14 +15,14 @@
  */
 
 @import '../../styles/variables.less';
-@wizard-header-color: #262933;
-
+@wizard-header-color: #464a57;
+@wizard-modal-margin-top: 180px;
 .wizard-modal {
   overflow-x: hidden;
   &.modal-dialog {
     height: 65vh;
     width: 60vw;
-    margin-top: 180px;
+    margin-top: @wizard-modal-margin-top;
     max-width: 1050px;
 
     .modal-content {
@@ -45,6 +45,7 @@
         height: ~"-moz-calc(100% - 51px)";
         height: ~"-webkit-calc(100% - 51px)";
         max-height: 400px;
+        overflow: visible;
 
         > div {
           height: 100%;
@@ -54,17 +55,18 @@
         padding: 0;
         background: @wizard-header-color;
         color: white;
-        border-bottom: 0;
+        border: 0;
 
         h4 {
           font-weight: normal;
+          font-size: 14px;
+
           span {
             line-height: 30px;
             padding: 5px 10px;
           }
           .close-section {
             span { padding: 5px 20px; }
-            border-left: 1px solid;
             cursor: pointer;
           }
         }

--- a/cdap-ui/app/cdap/components/WizardModal/index.js
+++ b/cdap-ui/app/cdap/components/WizardModal/index.js
@@ -20,14 +20,13 @@ import classnames from 'classnames';
 
 require('./WizardModal.less');
 
-export default function WizardModal({children, title, isOpen, toggle, className, backdrop}) {
+export default function WizardModal({children, title, isOpen, toggle, className}) {
   return (
     <Modal
       isOpen={isOpen}
       toggle={toggle}
       className={classnames("wizard-modal", className)}
       size="lg"
-      backdrop={backdrop}
     >
       <ModalHeader>
         <span className="pull-left">
@@ -68,6 +67,5 @@ WizardModal.propTypes = {
   title: PropTypes.string,
   isOpen: PropTypes.bool,
   toggle: PropTypes.func,
-  className: PropTypes.string,
-  backdrop: PropTypes.bool
+  className: PropTypes.string
 };

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -261,6 +261,7 @@ features:
       description: Upload a custom Application artifact or create an instance of Application from existing Artifact.
       actionbtn0: Upload
       actionbtn-1: Create
+      modalheadertitle: Upload Application
     Stream-View:
       label: Stream View
       description: Stream View is non-materialized view over a Stream with schema on read capability. Create a view over existing Stream.
@@ -273,10 +274,12 @@ features:
       label: Artifact
       description: Artifact is a JAR file that contains either a native Application or collection of Plugins.
       actionbtn0: Upload
+      modalheadertitle: Upload Artifact
     Plugins:
       label: Plugins
       description: Plugin is a easy way to extend the functionality of a Application.
       actionbtn0: Upload
+      modalheadertitle: Upload Plugin Artifact
 
   SplashScreen:
     dontShow: Don't show this again

--- a/cdap-ui/app/directives/dag-plus/my-dag.less
+++ b/cdap-ui/app/directives/dag-plus/my-dag.less
@@ -24,7 +24,7 @@
 
 my-dag-plus {
   .zoom-control {
-    z-index: 1023;
+    z-index: 998;
     right: 15px;
   }
 

--- a/cdap-ui/app/hydrator/adapters.less
+++ b/cdap-ui/app/hydrator/adapters.less
@@ -156,12 +156,12 @@ body.theme-cdap {
   &.state-hydrator-create {
     .alerts {
       top: 50px;
-      z-index: 1030;
+      z-index: 999;
     }
   }
   &.state-hydrator-detail {
     .alerts {
-      z-index: 1028;
+      z-index: 999;
     }
 
     .zoom-control {

--- a/cdap-ui/app/hydrator/bottompanel.less
+++ b/cdap-ui/app/hydrator/bottompanel.less
@@ -104,7 +104,7 @@ body.theme-cdap.state-hydrator {
     min-height: ~"-moz-calc(40vh - 113px)";
     min-height: ~"-webkit-calc(40vh - 113px)";
     min-height: ~"calc(40vh - 113px)";
-    z-index: 1024;
+    z-index: 999;
     transition: height 0.2s ease;
 
     // Styling for minimized bottom panel
@@ -113,7 +113,7 @@ body.theme-cdap.state-hydrator {
       right: 0;
       bottom: 53px;
       min-height: 0;
-      z-index: 1025;
+      z-index: 999;
 
       .console-type {
         display: none;
@@ -134,7 +134,7 @@ body.theme-cdap.state-hydrator {
       bottom: 53px;
       overflow-y: scroll;
       overflow-x: hidden;
-      z-index: 1029;
+      z-index: 999;
       div.console-tabs {
         border-top: 0;
       }
@@ -549,6 +549,6 @@ body.theme-cdap.state-hydrator {
     // Creates a bottom border for the bottom panel, needed to accommodate the single scroll
     border-top: 1px solid @table-border-color;
     position: fixed;
-    z-index: 1025;
+    z-index: 999;
   }
 }

--- a/cdap-ui/app/hydrator/controllers/create/leftpanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/leftpanel-ctrl.js
@@ -269,7 +269,7 @@ class HydratorPlusPlusLeftPanelCtrl {
         size: 'lg',
         backdrop: 'static',
         keyboard: false,
-        windowTopClass: 'confirm-modal hydrator-modal',
+        windowTopClass: 'confirm-modal hydrator-modal center',
         controller: ['$scope', 'HydratorPlusPlusConfigStore', 'HydratorPlusPlusConfigActions', function($scope, HydratorPlusPlusConfigStore, HydratorPlusPlusConfigActions) {
           $scope.isSaving = false;
           $scope.discard = () => {

--- a/cdap-ui/app/hydrator/leftpanel.less
+++ b/cdap-ui/app/hydrator/leftpanel.less
@@ -25,7 +25,7 @@ body.theme-cdap.state-hydrator-create {
     top: 50px;
     bottom: 53px;
     left: 0;
-    z-index: 1024;
+    z-index: 999;
     width: 130px;
     background: #e1e1e1;
 

--- a/cdap-ui/app/hydrator/templates/detail/top-panel.html
+++ b/cdap-ui/app/hydrator/templates/detail/top-panel.html
@@ -277,6 +277,7 @@
       tooltip-append-to-body="true"
       tooltip-class="toppanel-tooltip"
       ng-click="caskConfirm()"
+      confirmable-modal-class="hydrator-modal center"
       cask-confirmable="TopPanelCtrl.do('Delete')"
       data-confirmable-content="Are you sure you want to delete the pipeline <strong>'{{TopPanelCtrl.app.name}}'</strong>?">
       <span class="icon-delete"></span>

--- a/cdap-ui/app/hydrator/templates/list.html
+++ b/cdap-ui/app/hydrator/templates/list.html
@@ -118,12 +118,14 @@
                 ng-if="pipeline.isDraft"
                 ng-click="caskConfirm()"
                 cask-confirmable="ListController.deleteDraft(pipeline.id)"
+                confirmable-modal-class="hydrator-modal center"
                 data-confirmable-content="Are you sure you want to delete the draft '<strong>{{ pipeline.name }}</strong>'?"
               ></span>
               <span class="fa fa-trash text-danger delete-draft"
                 ng-if="!pipeline.isDraft"
                 ng-click="caskConfirm()"
                 cask-confirmable="ListController.deleteApp(pipeline.name)"
+                confirmable-modal-class="hydrator-modal center"
                 data-confirmable-content="Are you sure you want to delete the pipeline '<strong>{{ pipeline.name }}</strong>'?"
               ></span>
             </td>

--- a/cdap-ui/app/hydrator/toppanel.less
+++ b/cdap-ui/app/hydrator/toppanel.less
@@ -27,7 +27,7 @@ body.theme-cdap {
       position: fixed;
       top: 50px;
       right: 0;
-      z-index: 1029;
+      z-index: 999;
       border-left: 0;
       border-top: 0;
 
@@ -130,7 +130,7 @@ body.theme-cdap {
     }
 
     .error-tooltip {
-      z-index: 1029;
+      z-index: 999;
       &.top {
         .tooltip-arrow { border-top: 5px solid @brand-danger; }
       }
@@ -157,7 +157,7 @@ body.theme-cdap {
       max-height: ~"-webkit-calc(100vh - 143px)";
       overflow: auto;
       right: 0;
-      z-index: 1039;
+      z-index: 999;
       box-shadow: 0 7px 7px fade(black, 10%), 0 19px 59px fade(black, 20%);
       h5 { margin: 10px 10px 0; }
       .arguments-container {
@@ -211,7 +211,7 @@ body.theme-cdap {
       top: 0;
       left: 0;
       opacity: 0;
-      z-index: 1030;
+      z-index: 999;
     }
   }
   &.state-hydrator-create {
@@ -254,7 +254,7 @@ body.theme-cdap {
         display: flex;
         background-color: transparent;
         min-width: 0;
-        z-index: 1021;
+        z-index: 999;
         box-shadow: none;
         transition: all 0.2s ease;
 
@@ -577,7 +577,7 @@ body.theme-cdap {
     div.side-panel.top {
       font-weight: 500;
       left: 0;
-      z-index: 1028;
+      z-index: 999;
       height: 60px;
       box-shadow: 0 7px 7px fade(black, 10%), 0 10px 59px fade(black, 25%);
       h1 {

--- a/cdap-ui/app/styles/common.less
+++ b/cdap-ui/app/styles/common.less
@@ -141,7 +141,7 @@ footer {
   font-size: 14px;
   position: absolute;
   bottom: 0;
-  z-index: 1400;
+  z-index: 999;
   width: 100%;
   > .container {
     padding-right: 15px;


### PR DESCRIPTION
- Fixes styling for wizard colors, height, error
- Fixes all wizards to handle hydrator modal style 
- Fixes hydrator styles to fix the new z-index exposed by reactstrap

This is branched off from this [PR#7245 ](https://github.com/caskdata/cdap/pull/7245). Once that is merged this should reduce in size

Bamboo build: http://builds.cask.co/browse/CDAP-DRC4999-1