### PR TITLE
(CDAP-7546) Added support for a sort parameter in the search REST API

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
@@ -23,6 +23,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.entity.EntityExistenceVerifier;
 import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
+import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
@@ -161,16 +162,10 @@ public class DefaultMetadataAdmin implements MetadataAdmin {
   }
 
   @Override
-  public Set<MetadataSearchResultRecord> searchMetadata(String namespaceId, String searchQuery,
-                                                        Set<MetadataSearchTargetType> types) throws Exception {
-
-    return filterAuthorizedSearchResult(metadataStore.searchMetadataOnType(namespaceId, searchQuery, types));
-  }
-
-  @Override
-  public Set<MetadataSearchResultRecord> searchMetadata(MetadataScope scope, String namespaceId, String searchQuery,
-                                                        Set<MetadataSearchTargetType> types) throws Exception {
-    return filterAuthorizedSearchResult(metadataStore.searchMetadataOnType(scope, namespaceId, searchQuery, types));
+  public Set<MetadataSearchResultRecord> search(String namespaceId, String searchQuery,
+                                                Set<MetadataSearchTargetType> types,
+                                                SortInfo sortInfo) throws Exception {
+    return filterAuthorizedSearchResult(metadataStore.search(namespaceId, searchQuery, types, sortInfo));
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
@@ -18,6 +18,7 @@ package co.cask.cdap.metadata;
 
 import co.cask.cdap.common.InvalidMetadataException;
 import co.cask.cdap.common.NotFoundException;
+import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
@@ -26,6 +27,7 @@ import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Interface that the {@link MetadataHttpHandler} uses to interact with Metadata.
@@ -153,27 +155,15 @@ public interface MetadataAdmin {
 
   /**
    * Executes a search for CDAP entities in the specified namespace with the specified search query and
-   * an optional set of {@link MetadataSearchTargetType entity types} in both
-   * {@link MetadataScope#USER} and {@link MetadataScope#SYSTEM}.
-   *
-   * @param namespaceId The namespace to filter the search by
-   * @param searchQuery The search query
-   * @param types The types of CDAP entity to be searched. If empty all possible types will be searched
-   * @return a {@link Set} containing a {@link MetadataSearchResultRecord} for each matching entity
-   */
-  Set<MetadataSearchResultRecord> searchMetadata(String namespaceId, String searchQuery,
-                                                 Set<MetadataSearchTargetType> types) throws Exception;
-
-  /**
-   * Executes a search for CDAP entities in the specified namespace with the specified search query and
    * an optional set of {@link MetadataSearchTargetType entity types} in the specified {@link MetadataScope}.
    *
-   * @param scope the {@link MetadataScope} to restrict the search to
    * @param namespaceId The namespace id to filter the search by
    * @param searchQuery The search query
    * @param types The types of CDAP entity to be searched. If empty all possible types will be searched
+   * @param sortInfo represents sorting information. Use {@link SortInfo#DEFAULT} to return search results without
+   *                 sorting (which implies that the sort order is by relevance to the search query)
    * @return a {@link Set} containing a {@link MetadataSearchResultRecord} for each matching entity
    */
-  Set<MetadataSearchResultRecord> searchMetadata(MetadataScope scope, String namespaceId, String searchQuery,
-                                                 Set<MetadataSearchTargetType> types) throws Exception;
+  Set<MetadataSearchResultRecord> search(String namespaceId, String searchQuery, Set<MetadataSearchTargetType> types,
+                                         SortInfo sortInfo) throws Exception;
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
@@ -19,14 +19,12 @@ package co.cask.cdap.metadata;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.codec.NamespacedEntityIdCodec;
-import co.cask.cdap.proto.codec.NamespacedIdCodec;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.DatasetId;
-import co.cask.cdap.proto.id.FlowletId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.StreamId;
@@ -51,8 +49,6 @@ import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBufferInputStream;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -60,13 +56,10 @@ import java.io.Reader;
 import java.lang.reflect.Type;
 import java.net.URLDecoder;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.NavigableSet;
 import java.util.Set;
-import java.util.TreeSet;
 import javax.annotation.Nullable;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -82,62 +75,17 @@ import javax.ws.rs.QueryParam;
 @Path(Constants.Gateway.API_VERSION_3)
 public class MetadataHttpHandler extends AbstractHttpHandler {
   private static final Gson GSON = new GsonBuilder()
-    .registerTypeAdapter(Id.NamespacedId.class, new NamespacedIdCodec())
     .registerTypeAdapter(NamespacedEntityId.class, new NamespacedEntityIdCodec())
     .create();
   private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
   private static final Type LIST_STRING_TYPE = new TypeToken<List<String>>() { }.getType();
   private static final Type SET_METADATA_RECORD_TYPE = new TypeToken<Set<MetadataRecord>>() { }.getType();
-  private static final Logger LOG = LoggerFactory.getLogger(MetadataHttpHandler.class);
 
   private static final Function<String, MetadataSearchTargetType> STRING_TO_TARGET_TYPE =
     new Function<String, MetadataSearchTargetType>() {
       @Override
       public MetadataSearchTargetType apply(String input) {
         return MetadataSearchTargetType.valueOf(input.toUpperCase());
-      }
-    };
-  private static final Comparator<MetadataSearchResultRecord> NAME_ASCENDING_COMPARATOR =
-    new Comparator<MetadataSearchResultRecord>() {
-      @Override
-      public int compare(MetadataSearchResultRecord o1, MetadataSearchResultRecord o2) {
-        NamespacedEntityId entityId1 = o1.getEntityId();
-        NamespacedEntityId entityId2 = o2.getEntityId();
-        int compareResult = entityId1.getEntityName().compareTo(entityId2.getEntityName());
-        if (compareResult != 0) {
-          return compareResult;
-        }
-        // same name, but different entity types?
-        compareResult = entityId1.getEntityType().compareTo(entityId2.getEntityType());
-        if (compareResult != 0) {
-          return compareResult;
-        }
-        // same name and entity type, but different namespace?
-        compareResult = entityId1.getNamespace().compareTo(entityId2.getNamespace());
-        if (compareResult != 0) {
-          return compareResult;
-        }
-        // same name, entity type and namespace, so dig deeper
-        switch (entityId1.getEntityType()) {
-          case APPLICATION:
-            return ((ApplicationId) entityId1).getVersion().compareTo(((ApplicationId) entityId2).getVersion());
-          case FLOWLET:
-            return ((FlowletId) entityId1).getFlow().compareTo(((FlowletId) entityId2).getFlow());
-          case PROGRAM:
-            ProgramId program1 = (ProgramId) entityId1;
-            ProgramId program2  = (ProgramId) entityId2;
-            compareResult = program1.getApplication().compareTo(program2.getApplication());
-            if (compareResult != 0) {
-              return compareResult;
-            }
-            compareResult = program1.getType().compareTo(program2.getType());
-            return compareResult;
-          case ARTIFACT:
-            return ((ArtifactId) entityId1).getVersion().compareTo(((ArtifactId) entityId2).getVersion());
-          default:
-            LOG.error("Unexpected type {}", entityId1.getEntityType());
-            return compareResult;
-        }
       }
     };
 
@@ -888,7 +836,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   @Path("/namespaces/{namespace-id}/metadata/search")
   public void searchMetadata(HttpRequest request, HttpResponder responder,
                              @PathParam("namespace-id") String namespaceId,
-                             @QueryParam("query") String searchQuery,
+                             @QueryParam("query") @DefaultValue("") String searchQuery,
                              @QueryParam("target") List<String> targets,
                              @QueryParam("sort") @DefaultValue("") String sort,
                              @QueryParam("offset") @DefaultValue("0") int offset,
@@ -896,27 +844,6 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
     Set<MetadataSearchTargetType> types = Collections.emptySet();
     if (targets != null) {
       types = ImmutableSet.copyOf(Iterables.transform(targets, STRING_TO_TARGET_TYPE));
-    }
-
-
-    String sortBy = "name";
-    String sortOrder = "asc";
-    if (!sort.isEmpty()) {
-      // TODO: This should perhaps be thrown from the indexer
-      String[] sortSplit = sort.split("\\s+");
-      if (sortSplit.length != 2) {
-        throw new BadRequestException("'sort' parameter should be a space separated string containing the field " +
-                                        "('name') and the sort order ('asc' or 'desc'). Found " +
-                                        sort);
-      }
-      sortBy = sortSplit[0];
-      sortOrder = sortSplit[1];
-      if (!"name".equalsIgnoreCase(sortBy)) {
-        throw new BadRequestException("Sort field must be 'name'. Found " + sortBy);
-      }
-      if (!"asc".equalsIgnoreCase(sortOrder) && !"desc".equalsIgnoreCase(sortOrder)) {
-        throw new BadRequestException("Sort order must be one of 'asc' or 'desc'. Found " + sortOrder);
-      }
     }
 
     int size = Integer.MAX_VALUE;
@@ -927,15 +854,12 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
         throw new BadRequestException(String.format("Parameter 'size' should be numeric. Found %s.", sizeStr));
       }
     }
-    if (searchQuery == null) {
-      throw new BadRequestException("Parameter 'query' should be passed to the search API.");
-    }
     Set<MetadataSearchResultRecord> results =
-      metadataAdmin.searchMetadata(namespaceId, URLDecoder.decode(searchQuery, "UTF-8"), types);
+      metadataAdmin.search(namespaceId, URLDecoder.decode(searchQuery, "UTF-8"), types,
+                           SortInfo.of(URLDecoder.decode(sort, "UTF-8")));
 
-    NavigableSet<MetadataSearchResultRecord> sorted = applySorting(results, sortBy, sortOrder);
-    Set<MetadataSearchResultRecord> paginated = paginate(sorted, offset, size);
-    MetadataSearchResponse response = new MetadataSearchResponse(sort, offset, size, sorted.size(), paginated);
+    Set<MetadataSearchResultRecord> paginated = paginate(results, offset, size);
+    MetadataSearchResponse response = new MetadataSearchResponse(sort, offset, size, results.size(), paginated);
     responder.sendJson(HttpResponseStatus.OK, response, MetadataSearchResponse.class, GSON);
   }
 
@@ -969,27 +893,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
     }
   }
 
-  private NavigableSet<MetadataSearchResultRecord> applySorting(Set<MetadataSearchResultRecord> original, String sortBy,
-                                                                String sortOrder) throws BadRequestException {
-    Comparator<MetadataSearchResultRecord> comparator = getComparator(sortBy);
-    TreeSet<MetadataSearchResultRecord> result = new TreeSet<>(comparator);
-    result.addAll(original);
-    if ("desc".equalsIgnoreCase(sortOrder)) {
-      return result.descendingSet();
-    }
-    return result;
-  }
-
-  private Comparator<MetadataSearchResultRecord> getComparator(String sortBy) throws BadRequestException {
-    switch (sortBy) {
-      case "name":
-        return NAME_ASCENDING_COMPARATOR;
-      default:
-        throw new BadRequestException("Unexpected sortBy " + sortBy + ". Expected 'name'.");
-    }
-  }
-
-  private Set<MetadataSearchResultRecord> paginate(NavigableSet<MetadataSearchResultRecord> sorted,
+  private Set<MetadataSearchResultRecord> paginate(Set<MetadataSearchResultRecord> sorted,
                                                    int offset, int size) {
     if (sorted.isEmpty()) {
       return sorted;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
@@ -20,6 +20,7 @@ import co.cask.cdap.AllProgramsApp;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.test.AppJarHelper;
+import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.internal.AppFabricTestHelper;
 import co.cask.cdap.internal.app.services.AppFabricServer;
 import co.cask.cdap.proto.Id;
@@ -76,11 +77,11 @@ public class MetadataAdminAuthorizationTest {
     SecurityRequestContext.setUserId(ALICE.getName());
     authorizer.grant(NamespaceId.DEFAULT, ALICE, Collections.singleton(Action.WRITE));
     AppFabricTestHelper.deployApplication(Id.Namespace.DEFAULT, AllProgramsApp.class, "{}", cConf);
-    Assert.assertFalse(metadataAdmin.searchMetadata(NamespaceId.DEFAULT.getNamespace(), "*",
-                                                    EnumSet.allOf(MetadataSearchTargetType.class)).isEmpty());
+    Assert.assertFalse(metadataAdmin.search(NamespaceId.DEFAULT.getNamespace(), "*",
+                                            EnumSet.allOf(MetadataSearchTargetType.class), SortInfo.DEFAULT).isEmpty());
     SecurityRequestContext.setUserId("bob");
-    Assert.assertTrue(metadataAdmin.searchMetadata(NamespaceId.DEFAULT.getNamespace(), "*",
-                                                   EnumSet.allOf(MetadataSearchTargetType.class)).isEmpty());
+    Assert.assertTrue(metadataAdmin.search(NamespaceId.DEFAULT.getNamespace(), "*",
+                                           EnumSet.allOf(MetadataSearchTargetType.class), SortInfo.DEFAULT).isEmpty());
   }
 
   @AfterClass

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataHttpHandlerTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataHttpHandlerTestRun.java
@@ -35,6 +35,7 @@ import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
 import co.cask.cdap.data2.metadata.system.AbstractSystemMetadataWriter;
 import co.cask.cdap.data2.metadata.system.DatasetSystemMetadataWriter;
 import co.cask.cdap.metadata.MetadataHttpHandler;
+import co.cask.cdap.proto.DatasetInstanceConfiguration;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramType;
@@ -59,6 +60,7 @@ import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.common.http.HttpRequest;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -72,8 +74,12 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -1103,7 +1109,6 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     StreamViewId view = stream.view("view");
     streamViewClient.createOrUpdate(view.toId(), new ViewSpecification(new FormatSpecification("csv", null, null)));
 
-
     // Add metadata
     addTags(app, tags);
     addTags(flow, tags);
@@ -1140,6 +1145,84 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     Assert.assertEquals(ImmutableSet.of(), searchMetadata(namespace, "mydataset"));
     Assert.assertEquals(ImmutableSet.of(), searchMetadata(namespace, "word*"));
     Assert.assertEquals(ImmutableSet.of(), searchMetadata(namespace, "tag1"));
+  }
+
+  @Test
+  public void testSearchResultSorting() throws Exception {
+    NamespaceId namespace = new NamespaceId("ns3");
+    namespaceClient.create(new NamespaceMeta.Builder().setName(namespace).build());
+
+    StreamId stream = namespace.stream("text");
+    DatasetId dataset = namespace.dataset("mydataset");
+    StreamViewId view = stream.view("view");
+
+    // create entities so system metadata is annotated
+    // also ensure that they are created at least 1 ms apart
+    streamClient.create(stream.toId());
+    TimeUnit.MILLISECONDS.sleep(1);
+    streamViewClient.createOrUpdate(view.toId(), new ViewSpecification(new FormatSpecification("csv", null, null)));
+    TimeUnit.MILLISECONDS.sleep(1);
+    datasetClient.create(
+      dataset.toId(),
+      new DatasetInstanceConfiguration(Table.class.getName(), Collections.<String, String>emptyMap())
+    );
+
+    // search with bad sort param
+    EnumSet<MetadataSearchTargetType> targets = EnumSet.allOf(MetadataSearchTargetType.class);
+    try {
+      searchMetadata(namespace, "*", targets, AbstractSystemMetadataWriter.ENTITY_NAME_KEY);
+    } catch (BadRequestException e) {
+      // expected
+    }
+
+    // search with bad sort field
+    try {
+      searchMetadata(namespace, "*", targets, "name asc");
+    } catch (BadRequestException e) {
+      // expected
+    }
+
+    // search with bad sort order
+    try {
+      searchMetadata(namespace, "*", targets, AbstractSystemMetadataWriter.ENTITY_NAME_KEY + " unknown");
+    } catch (BadRequestException e) {
+      // expected
+    }
+    // test ascending order of entity name
+    Set<MetadataSearchResultRecord> searchResults =
+      searchMetadata(namespace, "*", targets, AbstractSystemMetadataWriter.ENTITY_NAME_KEY + " asc");
+    List<MetadataSearchResultRecord> expected = ImmutableList.of(
+      new MetadataSearchResultRecord(dataset),
+      new MetadataSearchResultRecord(stream),
+      new MetadataSearchResultRecord(view)
+    );
+    Assert.assertEquals(expected, new ArrayList<>(searchResults));
+    // test descending order of entity name
+    searchResults = searchMetadata(namespace, "*", targets, AbstractSystemMetadataWriter.ENTITY_NAME_KEY + " desc");
+    expected = ImmutableList.of(
+      new MetadataSearchResultRecord(view),
+      new MetadataSearchResultRecord(stream),
+      new MetadataSearchResultRecord(dataset)
+    );
+    Assert.assertEquals(expected, new ArrayList<>(searchResults));
+    // test ascending order of creation time
+    searchResults = searchMetadata(namespace, "*", targets, AbstractSystemMetadataWriter.CREATION_TIME_KEY + " asc");
+    expected = ImmutableList.of(
+      new MetadataSearchResultRecord(stream),
+      new MetadataSearchResultRecord(view),
+      new MetadataSearchResultRecord(dataset)
+    );
+    Assert.assertEquals(expected, new ArrayList<>(searchResults));
+    // test descending order of creation time
+    searchResults = searchMetadata(namespace, "*", targets, AbstractSystemMetadataWriter.CREATION_TIME_KEY + " desc");
+    expected = ImmutableList.of(
+      new MetadataSearchResultRecord(dataset),
+      new MetadataSearchResultRecord(view),
+      new MetadataSearchResultRecord(stream)
+    );
+    Assert.assertEquals(expected, new ArrayList<>(searchResults));
+    // cleanup
+    namespaceClient.delete(namespace);
   }
 
   private Set<NamespacedEntityId> getEntities(Set<MetadataSearchResultRecord> results) {
@@ -1539,10 +1622,21 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
   /**
    * strips metadata from search results
    */
+  @Override
   protected Set<MetadataSearchResultRecord> searchMetadata(NamespaceId namespaceId, String query,
                                                            Set<MetadataSearchTargetType> targets) throws Exception {
-    Set<MetadataSearchResultRecord> results = super.searchMetadata(namespaceId, query, targets);
-    Set<MetadataSearchResultRecord> transformed = new HashSet<>();
+    return searchMetadata(namespaceId, query, targets, null);
+  }
+
+  /**
+   * strips metadata from search results
+   */
+  @Override
+  protected Set<MetadataSearchResultRecord> searchMetadata(NamespaceId namespaceId, String query,
+                                                           Set<MetadataSearchTargetType> targets,
+                                                           @Nullable String sort) throws Exception {
+    Set<MetadataSearchResultRecord> results = super.searchMetadata(namespaceId, query, targets, sort);
+    Set<MetadataSearchResultRecord> transformed = new LinkedHashSet<>();
     for (MetadataSearchResultRecord result : results) {
       transformed.add(new MetadataSearchResultRecord(result.getEntityId()));
     }

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataTestBase.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataTestBase.java
@@ -458,7 +458,15 @@ public abstract class MetadataTestBase extends ClientTestBase {
 
   protected Set<MetadataSearchResultRecord> searchMetadata(NamespaceId namespaceId, String query,
                                                            Set<MetadataSearchTargetType> targets) throws Exception {
-    return metadataClient.searchMetadata(namespaceId.toId(), query, targets).getResults();
+    // Note: Can't delegate this to the next method. This is because MetadataHttpHandlerTestRun overrides these two
+    // methods, to strip out metadata from search results for easier assertions.
+    return metadataClient.searchMetadata(namespaceId.toId(), query, targets, null).getResults();
+  }
+
+  protected Set<MetadataSearchResultRecord> searchMetadata(NamespaceId namespaceId, String query,
+                                                           Set<MetadataSearchTargetType> targets,
+                                                           @Nullable String sort) throws Exception {
+    return metadataClient.searchMetadata(namespaceId.toId(), query, targets, sort).getResults();
   }
 
   protected Set<String> getTags(ApplicationId app, MetadataScope scope) throws Exception {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/SortInfo.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/SortInfo.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2015-2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.dataset;
+
+import co.cask.cdap.common.BadRequestException;
+import co.cask.cdap.data2.metadata.system.AbstractSystemMetadataWriter;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.Iterables;
+
+import java.util.Iterator;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+
+/**
+ * Represents sorting info for search results.
+ */
+public class SortInfo {
+
+  private static final Pattern SPACE_SPLIT_PATTERN = Pattern.compile("\\s+");
+
+  /**
+   * Default sort order, when no custom sorting is desired. Sorts search results as a function of relative weights for
+   * the specified search query.
+   */
+  public static final SortInfo DEFAULT = new SortInfo(null, SortOrder.WEIGHTED);
+
+  /**
+   * Represents sorting order.
+   */
+  public enum SortOrder {
+    ASC,
+    DESC,
+    WEIGHTED
+  }
+
+  private final String sortBy;
+  private final SortOrder sortOrder;
+
+  public SortInfo(@Nullable String sortBy, SortOrder sortOrder) {
+    this.sortBy = sortBy;
+    this.sortOrder = sortOrder;
+  }
+
+  /**
+   * Returns the sort by column, unless the column does not matter, when the sort order is {@link SortOrder#WEIGHTED}.
+   */
+  @Nullable
+  public String getSortBy() {
+    return sortBy;
+  }
+
+  public SortOrder getSortOrder() {
+    return sortOrder;
+  }
+
+  /**
+   * Parses a {@link SortInfo} object from the specified string. The supported format is
+   * <pre>[sortBy][whitespace][sortOrder]</pre>.
+   *
+   * @param sort the string to parse into a {@link SortInfo}. If {@code null}, {@link #DEFAULT} is returned
+   * @return the parsed {@link SortInfo}
+   * @throws BadRequestException if the string does not conform to the expected format
+   */
+  public static SortInfo of(@Nullable String sort) throws BadRequestException {
+    if (Strings.isNullOrEmpty(sort)) {
+      return SortInfo.DEFAULT;
+    }
+    Iterable<String> sortSplit = Splitter.on(SPACE_SPLIT_PATTERN).trimResults().omitEmptyStrings().split(sort);
+    if (Iterables.size(sortSplit) != 2) {
+      throw new BadRequestException("'sort' parameter should be a space separated string containing the field " +
+                                      "('name' or 'create_time') and the sort order ('asc' or 'desc'). Found " + sort);
+    }
+    Iterator<String> iterator = sortSplit.iterator();
+    String sortBy = iterator.next();
+    String sortOrder = iterator.next();
+    if (!AbstractSystemMetadataWriter.ENTITY_NAME_KEY.equalsIgnoreCase(sortBy) &&
+      !AbstractSystemMetadataWriter.CREATION_TIME_KEY.equalsIgnoreCase(sortBy)) {
+      throw new BadRequestException("Sort field must be 'name' or 'create_time'. Found " + sortBy);
+    }
+    if (!"asc".equalsIgnoreCase(sortOrder) && !"desc".equalsIgnoreCase(sortOrder)) {
+      throw new BadRequestException("Sort order must be one of 'asc' or 'desc'. Found " + sortOrder);
+    }
+
+    return new SortInfo(sortBy, SortInfo.SortOrder.valueOf(sortOrder.toUpperCase()));
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/indexer/DefaultValueIndexer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/indexer/DefaultValueIndexer.java
@@ -18,6 +18,7 @@ package co.cask.cdap.data2.metadata.indexer;
 
 import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
 import co.cask.cdap.data2.metadata.dataset.MetadataEntry;
+import co.cask.cdap.data2.metadata.dataset.SortInfo;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -48,6 +49,20 @@ public class DefaultValueIndexer implements Indexer {
     }
     // add all value indexes too
     indexes.addAll(valueIndexes);
-    return indexes;
+    // store the index with key of the metadata, so that we allow searches of the form [key]:[value]
+    return addKeyValueIndexes(entry.getKey(), indexes);
+  }
+
+  @Override
+  public SortInfo.SortOrder getSortOrder() {
+    return SortInfo.SortOrder.WEIGHTED;
+  }
+
+  private Set<String> addKeyValueIndexes(String key, Set<String> indexes) {
+    Set<String> indexesWithKeyValue = new HashSet<>(indexes);
+    for (String index : indexes) {
+      indexesWithKeyValue.add(key + MetadataDataset.KEYVALUE_SEPARATOR + index);
+    }
+    return indexesWithKeyValue;
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/indexer/Indexer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/indexer/Indexer.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data2.metadata.indexer;
 
 import co.cask.cdap.data2.metadata.dataset.MetadataEntry;
+import co.cask.cdap.data2.metadata.dataset.SortInfo;
 
 import java.util.Set;
 
@@ -32,4 +33,9 @@ public interface Indexer {
    * @return a {@link Set Set&lt;String&gt;} containing indexes for the given {@link MetadataEntry}
    */
   Set<String> getIndexes(MetadataEntry entry);
+
+  /**
+   * Returns the {@link SortInfo.SortOrder} supported by this indexer.
+   */
+  SortInfo.SortOrder getSortOrder();
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/indexer/InvertedTimeIndexer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/indexer/InvertedTimeIndexer.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data2.metadata.indexer;
 
 import co.cask.cdap.data2.metadata.dataset.MetadataEntry;
+import co.cask.cdap.data2.metadata.dataset.SortInfo;
 
 import java.util.Collections;
 import java.util.Set;
@@ -36,5 +37,10 @@ public class InvertedTimeIndexer implements Indexer {
       throw new IllegalArgumentException("Expected value in InvertedTimeIndexer to be a long but found " + value);
     }
     return Collections.singleton(String.valueOf(Long.MAX_VALUE - creationTime));
+  }
+
+  @Override
+  public SortInfo.SortOrder getSortOrder() {
+    return SortInfo.SortOrder.DESC;
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/indexer/InvertedValueIndexer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/indexer/InvertedValueIndexer.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data2.metadata.indexer;
 
 import co.cask.cdap.data2.metadata.dataset.MetadataEntry;
+import co.cask.cdap.data2.metadata.dataset.SortInfo;
 
 import java.util.Collections;
 import java.util.Set;
@@ -40,5 +41,10 @@ public class InvertedValueIndexer implements Indexer {
       reversed.append((char) inverted);
     }
     return reversed.toString();
+  }
+
+  @Override
+  public SortInfo.SortOrder getSortOrder() {
+    return SortInfo.SortOrder.DESC;
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/indexer/SchemaIndexer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/indexer/SchemaIndexer.java
@@ -20,6 +20,7 @@ package co.cask.cdap.data2.metadata.indexer;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
 import co.cask.cdap.data2.metadata.dataset.MetadataEntry;
+import co.cask.cdap.data2.metadata.dataset.SortInfo;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -35,7 +36,13 @@ public class SchemaIndexer implements Indexer {
 
   @Override
   public Set<String> getIndexes(MetadataEntry entry) {
-    return createIndexes(getSchema(entry.getValue()));
+    Set<String> indexes = createIndexes(getSchema(entry.getValue()));
+    return addKeyValueIndexes(entry.getKey(), indexes);
+  }
+
+  @Override
+  public SortInfo.SortOrder getSortOrder() {
+    return SortInfo.SortOrder.WEIGHTED;
   }
 
   private Schema getSchema(String schemaStr) {
@@ -113,5 +120,14 @@ public class SchemaIndexer implements Indexer {
       schema = schema.getNonNullable();
     }
     return schema.getType().toString();
+  }
+
+
+  private Set<String> addKeyValueIndexes(String key, Set<String> indexes) {
+    Set<String> indexesWithKeyValue = new HashSet<>(indexes);
+    for (String index : indexes) {
+      indexesWithKeyValue.add(key + MetadataDataset.KEYVALUE_SEPARATOR + index);
+    }
+    return indexesWithKeyValue;
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/indexer/ValueOnlyIndexer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/indexer/ValueOnlyIndexer.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data2.metadata.indexer;
 
 import co.cask.cdap.data2.metadata.dataset.MetadataEntry;
+import co.cask.cdap.data2.metadata.dataset.SortInfo;
 
 import java.util.Collections;
 import java.util.Set;
@@ -28,5 +29,10 @@ public class ValueOnlyIndexer implements Indexer {
   @Override
   public Set<String> getIndexes(MetadataEntry entry) {
     return Collections.singleton(entry.getValue());
+  }
+
+  @Override
+  public SortInfo.SortOrder getSortOrder() {
+    return SortInfo.SortOrder.ASC;
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
@@ -16,7 +16,9 @@
 
 package co.cask.cdap.data2.metadata.store;
 
+import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
+import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
@@ -25,6 +27,7 @@ import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Defines operations on {@link MetadataDataset} for both system and user metadata.
@@ -158,40 +161,18 @@ public interface MetadataStore {
   void removeTags(MetadataScope scope, NamespacedEntityId namespacedEntityId, String ... tagsToRemove);
 
   /**
-   * Search the Metadata Dataset in both {@link MetadataScope#USER} and {@link MetadataScope#SYSTEM}.
-   */
-  Set<MetadataSearchResultRecord> searchMetadata(String namespaceId, String searchQuery);
-
-  /**
-   * Search the Metadata Dataset in the specified {@link MetadataScope}.
-   *
-   * @param scope the {@link MetadataScope} to restrict the search to
-   * @param namespaceId the namespace to search in
-   * @param searchQuery the search query, which could be of two forms: [key]:[value] or just [value]
-   */
-  Set<MetadataSearchResultRecord> searchMetadata(MetadataScope scope, String namespaceId, String searchQuery);
-
-  /**
    * Search the Metadata Dataset for the specified target types in both {@link MetadataScope#USER} and
    * {@link MetadataScope#SYSTEM}.
    *
    * @param namespaceId the namespace to search in
    * @param searchQuery the search query, which could be of two forms: [key]:[value] or just [value]
    * @param types the {@link MetadataSearchTargetType} to restrict the search to, if empty all types are searched
+   * @param sortInfo represents sorting information. Use {@link SortInfo#DEFAULT} to return search results without
+   *                 sorting (which implies that the sort order is by relevance to the search query)
    */
-  Set<MetadataSearchResultRecord> searchMetadataOnType(String namespaceId, String searchQuery,
-                                                       Set<MetadataSearchTargetType> types);
-
-  /**
-   * Search the Metadata Dataset for the specified target types in the specified {@link MetadataScope}.
-   *
-   * @param scope the {@link MetadataScope} to restrict the search to
-   * @param namespaceId the namespace to search in
-   * @param searchQuery the search query, which could be of two forms: [key]:[value] or just [value]
-   * @param types the {@link MetadataSearchTargetType} to restrict the search to, if empty all types are searched
-   */
-  Set<MetadataSearchResultRecord> searchMetadataOnType(MetadataScope scope, String namespaceId, String searchQuery,
-                                                       Set<MetadataSearchTargetType> types);
+  Set<MetadataSearchResultRecord> search(String namespaceId, String searchQuery,
+                                         Set<MetadataSearchTargetType> types,
+                                         SortInfo sortInfo) throws BadRequestException;
 
   /**
    * Returns the snapshot of the metadata for entities on or before the given time in both {@link MetadataScope#USER}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
@@ -15,6 +15,7 @@
  */
 package co.cask.cdap.data2.metadata.store;
 
+import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
@@ -114,24 +115,8 @@ public class NoOpMetadataStore implements MetadataStore {
   }
 
   @Override
-  public Set<MetadataSearchResultRecord> searchMetadata(String namespaceId, String searchQuery) {
-    return Collections.emptySet();
-  }
-
-  @Override
-  public Set<MetadataSearchResultRecord> searchMetadata(MetadataScope scope, String namespaceId, String searchQuery) {
-    return Collections.emptySet();
-  }
-
-  @Override
-  public Set<MetadataSearchResultRecord> searchMetadataOnType(String namespaceId, String searchQuery,
-                                                              Set<MetadataSearchTargetType> types) {
-    return Collections.emptySet();
-  }
-
-  @Override
-  public Set<MetadataSearchResultRecord> searchMetadataOnType(MetadataScope scope, String namespaceId,
-                                                              String searchQuery, Set<MetadataSearchTargetType> types) {
+  public Set<MetadataSearchResultRecord> search(String namespaceId, String searchQuery,
+                                                Set<MetadataSearchTargetType> types, SortInfo sort) {
     return Collections.emptySet();
   }
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
@@ -998,23 +998,13 @@ public class MetadataDatasetTest {
     txnl.execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {
-        dataset.setProperty(flow1, "key", "value");
+        dataset.setProperty(flow1, "key", value);
         dataset.setProperty(flow1, AbstractSystemMetadataWriter.SCHEMA_KEY, schema);
         dataset.setProperty(dataset1, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, name);
         dataset.setProperty(dataset1, AbstractSystemMetadataWriter.CREATION_TIME_KEY, String.valueOf(creationTime));
       }
     });
     final String namespaceId = flow1.getNamespace();
-    txnl.execute(new TransactionExecutor.Subroutine() {
-      @Override
-      public void apply() throws Exception {
-        String searchQuery = namespaceId + MetadataDataset.KEYVALUE_SEPARATOR + value;
-        try (Scanner scan = dataset.searchByIndex(MetadataDataset.DEFAULT_INDEX_COLUMN, searchQuery)) {
-          Assert.assertNotNull(scan.next());
-          Assert.assertNull(scan.next());
-        }
-      }
-    });
     txnl.execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {
@@ -1351,6 +1341,11 @@ public class MetadataDatasetTest {
     @Override
     public Set<String> getIndexes(MetadataEntry entry) {
       return ImmutableSet.of(reverse(entry.getKey()), reverse(entry.getValue()));
+    }
+
+    @Override
+    public SortInfo.SortOrder getSortOrder() {
+      return SortInfo.SortOrder.WEIGHTED;
     }
 
     private String reverse(String toReverse) {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/indexer/SchemaIndexerTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/indexer/SchemaIndexerTest.java
@@ -31,13 +31,16 @@ import java.util.Set;
  */
 public class SchemaIndexerTest {
 
+  private static final String KEY = "schema";
+  private static final String KEY_PREFIX = KEY + ":";
+
   @Test
   public void testSimpleSchema() throws Exception {
     Schema simpleSchema = Schema.of(Schema.Type.INT);
     Set<String> expected = Collections.emptySet();
     SchemaIndexer indexer = new SchemaIndexer();
     DatasetId datasetInstance = new DatasetId("ns1", "ds1");
-    Set<String> actual = indexer.getIndexes(new MetadataEntry(datasetInstance, "schema", simpleSchema.toString()));
+    Set<String> actual = indexer.getIndexes(new MetadataEntry(datasetInstance, KEY, simpleSchema.toString()));
     Assert.assertEquals(expected, actual);
   }
 
@@ -54,8 +57,8 @@ public class SchemaIndexerTest {
     Set<String> expected = ImmutableSet.of("record1", "record1:RECORD", "x", "x:STRING", "y", "y:ARRAY", "z", "z:MAP");
     SchemaIndexer indexer = new SchemaIndexer();
     DatasetId datasetInstance = new DatasetId("ns1", "ds1");
-    Set<String> actual = indexer.getIndexes(new MetadataEntry(datasetInstance, "schema", simpleSchema.toString()));
-    Assert.assertEquals(expected, actual);
+    Set<String> actual = indexer.getIndexes(new MetadataEntry(datasetInstance, KEY, simpleSchema.toString()));
+    Assert.assertEquals(addKeyPrefix(expected), actual);
   }
 
   @Test
@@ -94,8 +97,16 @@ public class SchemaIndexerTest {
                                            "i", "i:INT", "j", "j:UNION", "record1", "record1:RECORD");
     SchemaIndexer indexer = new SchemaIndexer();
     DatasetId datasetInstance = new DatasetId("ns1", "ds1");
-    Set<String> actual = indexer.getIndexes(new MetadataEntry(datasetInstance, "schema",
-                                                              superComplexSchema.toString()));
-    Assert.assertEquals(expected, actual);
+    Set<String> actual = indexer.getIndexes(new MetadataEntry(datasetInstance, KEY, superComplexSchema.toString()));
+    Assert.assertEquals(addKeyPrefix(expected), actual);
+  }
+
+  private Set<String> addKeyPrefix(Set<String> expectedValues) {
+    ImmutableSet.Builder<String> expected = ImmutableSet.<String>builder()
+      .addAll(expectedValues);
+    for (String expectedValue : expectedValues) {
+      expected.add(KEY_PREFIX + expectedValue);
+    }
+    return expected.build();
   }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/MetadataStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/MetadataStoreTest.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.data2.metadata.store;
 
+import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
@@ -25,6 +26,7 @@ import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data2.audit.AuditModule;
 import co.cask.cdap.data2.audit.InMemoryAuditPublisher;
+import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.audit.AuditMessage;
 import co.cask.cdap.proto.audit.AuditType;
@@ -38,6 +40,7 @@ import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.metadata.Metadata;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
+import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationTestModule;
@@ -60,6 +63,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -235,7 +239,6 @@ public class MetadataStoreTest {
     boolean auditEnabled = cConf.getBoolean(Constants.Audit.ENABLED);
     cConf.setBoolean(Constants.Audit.ENABLED, false);
     generateMetadataUpdates();
-    String topic = cConf.get(Constants.Audit.KAFKA_TOPIC);
 
     try {
       List<AuditMessage> publishedAuditMessages = auditPublisher.popMessages();
@@ -280,7 +283,7 @@ public class MetadataStoreTest {
     store.setProperties(MetadataScope.USER, dataset1, datasetUserProps);
 
     // Test score and metadata match
-    List<MetadataSearchResultRecord> actual = Lists.newArrayList(store.searchMetadata("ns1", "value1 multiword:av2"));
+    List<MetadataSearchResultRecord> actual = Lists.newArrayList(search("ns1", "value1 multiword:av2"));
 
     Map<MetadataScope, Metadata> expectedFlowMetadata =
       ImmutableMap.of(MetadataScope.USER, new Metadata(flowUserProps, flowUserTags),
@@ -298,7 +301,7 @@ public class MetadataStoreTest {
       );
     Assert.assertEquals(expected, actual);
 
-    actual = Lists.newArrayList(store.searchMetadata("ns1", "value1 sValue*"));
+    actual = Lists.newArrayList(search("ns1", "value1 sValue*"));
     expected = Lists.newArrayList(
       new MetadataSearchResultRecord(stream1,
                                      expectedStreamMetadata),
@@ -309,13 +312,17 @@ public class MetadataStoreTest {
     );
     Assert.assertEquals(expected, actual);
 
-    actual = Lists.newArrayList(store.searchMetadata("ns1", "*"));
+    actual = Lists.newArrayList(search("ns1", "*"));
     Assert.assertTrue(actual.containsAll(expected));
   }
 
   @AfterClass
   public static void teardown() {
     txManager.stopAndWait();
+  }
+
+  private Set<MetadataSearchResultRecord> search(String namespace, String searchQuery) throws BadRequestException {
+    return store.search(namespace, searchQuery, EnumSet.allOf(MetadataSearchTargetType.class), SortInfo.DEFAULT);
   }
 
   private void generateMetadataUpdates() {

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemover.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemover.java
@@ -17,7 +17,9 @@
 package co.cask.cdap.data.tools;
 
 import co.cask.cdap.api.dataset.DatasetManagementException;
+import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.id.DatasetId;
@@ -49,12 +51,12 @@ final class DeletedDatasetMetadataRemover {
     this.dsFramework = dsFramework;
   }
 
-  void remove() throws DatasetManagementException {
+  void remove() throws DatasetManagementException, BadRequestException {
     List<DatasetId> removedDatasets = new ArrayList<>();
     for (NamespaceMeta namespaceMeta : nsStore.list()) {
       Set<MetadataSearchResultRecord> searchResults =
-        metadataStore.searchMetadataOnType(namespaceMeta.getName(), "*",
-                                           ImmutableSet.of(MetadataSearchTargetType.DATASET));
+        metadataStore.search(namespaceMeta.getName(), "*",
+                             ImmutableSet.of(MetadataSearchTargetType.DATASET), SortInfo.DEFAULT);
       for (MetadataSearchResultRecord searchResult : searchResults) {
         NamespacedEntityId entityId = searchResult.getEntityId();
         Preconditions.checkState(entityId instanceof DatasetId,

--- a/cdap-master/src/test/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemoverTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemoverTest.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.data.tools;
 
-import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import co.cask.cdap.data.runtime.DataSetsModules;
@@ -43,7 +42,6 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.Collections;
 
 /**
@@ -80,7 +78,7 @@ public class DeletedDatasetMetadataRemoverTest {
   }
 
   @Test
-  public void test() throws IOException, DatasetManagementException {
+  public void test() throws Exception {
     DatasetId ds1 = NamespaceId.DEFAULT.dataset("ds1");
     DatasetId ds2 = NamespaceId.DEFAULT.dataset("ds2");
     DatasetId ds3 = NamespaceId.DEFAULT.dataset("ds3");
@@ -97,7 +95,7 @@ public class DeletedDatasetMetadataRemoverTest {
     verifyMetadataRemoval(ds3);
   }
 
-  private void verifyMetadataRemoval(DatasetId dsId) throws IOException, DatasetManagementException {
+  private void verifyMetadataRemoval(DatasetId dsId) throws Exception {
     DS_FRAMEWORK_TEST_UTIL.deleteInstance(dsId);
     assertNonEmptyMetadata(dsId);
     metadataRemover.remove();


### PR DESCRIPTION
- Standardized and removed unnecessary methods in MetadataStore and MetadataAdmin.
- 'sort' is accepted as a single string parameter in the REST API. This is so integration with more complex search/indexing engines can be possible by passing JSON strings, etc.
- MetadataAdmin and MetadataHttpHandler deal with sort as a single string, MetadataStore and MetadataDataset understand them as separate parameters and take appropriate action.
- Supported name and create_time as sort fields, asc and desc as sort order
- Special handling for *:
  - The search query '*' is treated as only recommended for listing purpose.
  - When this is the search query, and a sort order is not given, a warning is logged. However this operation is allowed for administrative purposes like upgrade.
  - When the search query is a non '*' string, it is treated as a more classical search, and the order of results is by the weight of the search term in every search result.
- URL encoded sort param
- Added sort support to client
- MetadataDataset should use indexes from indexers as-is, without allowing adding any suffix/prefix of its own.


Jira: [CDAP-7546](https://issues.cask.co/browse/CDAP-7546)
Build: http://builds.cask.co/browse/CDAP-RUT306-2