### PR TITLE
Remove Chef on both APT and YUM distributions

### DIFF
--- a/cdap-distributions/src/packer/scripts/remove-chef.sh
+++ b/cdap-distributions/src/packer/scripts/remove-chef.sh
@@ -19,7 +19,11 @@
 #
 
 # Remove packages
-apt-get purge -y chef
+if [[ $(which apt-get 2>/dev/null) ]]; then
+  apt-get purge -y chef || exit 1
+else
+  yum erase -y chef || exit 1
+fi
 
 # Remove directory
 rm -rf /var/chef


### PR DESCRIPTION
Otherwise, we leave around Chef and it's dependencies.