### PR TITLE
CDAP-7648 Avoid shipping Apache HTTP libs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -512,22 +512,6 @@
         <version>${leveldb.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>${http.component.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpcore</artifactId>
-        <version>${http.component.version}</version>
-      </dependency>
-      <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
         <version>${commons.codec.version}</version>
@@ -1317,6 +1301,24 @@
         <groupId>com.unboundid</groupId>
         <artifactId>unboundid-ldapsdk</artifactId>
         <version>${unboundid.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>${http.component.version}</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpcore</artifactId>
+        <version>${http.component.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Avoid shipping Apache HTTP jars, per the discussion here:
https://issues.cask.co/browse/CDAP-7648.

These are the jars which we no longer ship (due to this PR):
/opt/cdap/master/lib/org.apache.httpcomponents.httpclient-4.2.5.jar
/opt/cdap/master/lib/org.apache.httpcomponents.httpcore-4.2.5.jar

Running Integration tests here: http://builds.cask.co/browse/CDAP-ITM6-2
and with latest changes (e99a21d): http://builds.cask.co/browse/CDAP-ITM6-3