### PR TITLE
CDAP-7707 Mark all CDAP /etc files as config files

### DIFF
--- a/cdap-distributions/pom.xml
+++ b/cdap-distributions/pom.xml
@@ -95,6 +95,7 @@
                     --before-install "${project.basedir}/src/rpm/scripts/common-preinst"
                     --before-remove "${project.basedir}/src/rpm/scripts/common-prerm"
                     --iteration "${release.iteration}"
+                    --config-files ${package.config.dir}
                     etc
                   </commandlineArgs>
                 </configuration>
@@ -171,6 +172,7 @@
                     --before-install "${project.basedir}/src/debian/scripts/common-preinst"
                     --before-remove "${project.basedir}/src/debian/scripts/common-prerm"
                     --iteration "${release.iteration}"
+                    --config-files ${package.config.dir}
                     etc
                   </commandlineArgs>
                 </configuration>

--- a/cdap-distributions/pom.xml
+++ b/cdap-distributions/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014 Cask Data, Inc.
+  Copyright © 2014-2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -95,7 +95,7 @@
                     --before-install "${project.basedir}/src/rpm/scripts/common-preinst"
                     --before-remove "${project.basedir}/src/rpm/scripts/common-prerm"
                     --iteration "${release.iteration}"
-                    --config-files ${package.config.dir}
+                    ${package.config.dirs}
                     etc
                   </commandlineArgs>
                 </configuration>
@@ -172,7 +172,7 @@
                     --before-install "${project.basedir}/src/debian/scripts/common-preinst"
                     --before-remove "${project.basedir}/src/debian/scripts/common-prerm"
                     --iteration "${release.iteration}"
-                    --config-files ${package.config.dir}
+                    ${package.config.dirs}
                     etc
                   </commandlineArgs>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1873,6 +1873,7 @@
         <package.deb.arch>all</package.deb.arch>
         <package.rpm.arch>all</package.rpm.arch>
         <package.dirs>opt etc</package.dirs>
+        <package.config.dir>etc</package.config.dir>
       </properties>
       <build>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1873,7 +1873,7 @@
         <package.deb.arch>all</package.deb.arch>
         <package.rpm.arch>all</package.rpm.arch>
         <package.dirs>opt etc</package.dirs>
-        <package.config.dir>etc</package.config.dir>
+        <package.config.dirs>--config-files etc/cdap --config-files etc/logrotate.d --config-files etc/security</package.config.dirs>
       </properties>
       <build>
         <pluginManagement>


### PR DESCRIPTION
This causes all files, such as the `logrotate` configuration, to be marked as a configuration file by the file manager. This prevents them from being overwritten if they've been modified after install.