### PR TITLE
CDAP-7176 Pass in the current user's short username to CLIService#openSession

### DIFF
--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -1193,7 +1193,11 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
 
   // no new methods should use this directly. Instead, use openHiveSession
   protected SessionHandle doOpenHiveSession(Map<String, String> sessionConf) throws HiveSQLException {
-    return cliService.openSession("", "", sessionConf);
+    try {
+      return cliService.openSession(UserGroupInformation.getCurrentUser().getShortUserName(), "", sessionConf);
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
   }
 
   private void closeHiveSession(SessionHandle sessionHandle) {


### PR DESCRIPTION
Pass in the current user's short username to CLIService#openSession, instead of empty string. This can be used by Hive to determine the YARN queue to be used.

https://issues.cask.co/browse/CDAP-7176

Pending: Test on CDH 5.8 cluster, where the problem was observed.