### PR TITLE
Remove release notes for 3.6.1. They will be added back later.

### DIFF
--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -23,27 +23,6 @@ Cask Data Application Platform Release Notes
    :backlinks: none
    :depth: 2
 
-`Release 3.6.1 <http://docs.cask.co/cdap/3.6.1/index.html>`__
-=============================================================
-
-Improvements
-------------
-
-- :cask-issue:`CDAP-7404` - Added authorization for schedules in CDAP.
-
-- :cask-issue:`HYDRATOR-997` - The SSH hostname and the command to be executed are now
-  macro-enabled for the SSH action plugin.
-
-Bug Fixes
----------
-
-- :cask-issue:`CDAP-7318` - Fixed an issue that would cause MapReduce and Spark programs
-  to fail if too many macros were being used.
-
-- :cask-issue:`CDAP-7438`, :cask-issue:`CDAP-7439` - Removed the requirement of running
-  "kinit" prior to running either the Upgrade or Transaction Debugger tools of CDAP on a
-  secure Hadoop cluster.
-
 `Release 3.6.0 <http://docs.cask.co/cdap/3.6.0/index.html>`__
 =============================================================
 


### PR DESCRIPTION
Remove release notes for 3.6.1. They will be added closer to the actual release.