### PR TITLE
CDAP-7757 Use OpenJDK for redistributable images, not Oracle JDK

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -122,11 +122,8 @@
           "distribution_version": "2.1.7.0"
         },
         "java": {
-          "install_flavor": "oracle",
-          "jdk_version": 7,
-          "oracle": {
-            "accept_oracle_download_terms": true
-          }
+          "install_flavor": "openjdk",
+          "jdk_version": 7
         }
       },
       "only": ["cdap-sdk-vm"]
@@ -155,6 +152,10 @@
             "comment": "COPY SDK ZIP TO files/cdap-sdk.zip BEFORE RUNNING ME",
             "url": "file:///tmp/cdap-sdk.zip"
           }
+        },
+        "java": {
+          "install_flavor": "openjdk",
+          "jdk_version": 7
         },
         "openssh": {
           "server": {

--- a/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
+++ b/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
@@ -4,5 +4,9 @@
     "sdk": {
       "url": "{{URI}}"
     }
+  },
+  "java": {
+    "install_flavor": "openjdk",
+    "jdk_version": 7
   }
 }

--- a/cdap-distributions/src/packer/files/cdap-sdk.json
+++ b/cdap-distributions/src/packer/files/cdap-sdk.json
@@ -1,5 +1,9 @@
 {
   "cdap": {
-    "version": "3.4.0-1"
+    "version": "3.5.2-1"
+  },
+  "java": {
+    "install_flavor": "openjdk",
+    "jdk_version": 7
   }
 }


### PR DESCRIPTION
This is a cherry-pick from #7262 with `cdap-sdk.json` conflicts resolved.