### PR TITLE
Fix error in CLI doc generation.

### DIFF
--- a/cdap-docs/tools/docs-cli-commands.py
+++ b/cdap-docs/tools/docs-cli-commands.py
@@ -14,10 +14,11 @@ import os
 import sys
 from optparse import OptionParser
 
-VERSION = "0.0.2"
+VERSION = "0.0.3"
 
 LITERAL = '``'
-SPACES = ' ' * 3
+SPACE = ' '
+SPACES = SPACE * 3
 QUOTE = '\''
 BACKSLASH = '\\'
 SECTION_LINE = SPACES + '**'
@@ -89,14 +90,20 @@ def create_parsed_line(line):
     opening_literal_quote = LITERAL + QUOTE
     closing_literal_quote = QUOTE + LITERAL
     new_line = ''
+    i = -1
     for c in line:
+        i +=1 
         if c == QUOTE:
             if not in_literal:
-                new_line += opening_literal_quote
+                if i and line[i-1] != SPACE: # Preceding character
+                    new_line += c
+                else:
+                    new_line += opening_literal_quote
+                    in_literal = not in_literal
             else:
                 new_line += closing_literal_quote
                 finished_literal = True
-            in_literal = not in_literal
+                in_literal = not in_literal
         else:
             if finished_literal:
                 if c.isalnum():


### PR DESCRIPTION
Quotes inside words weren't being handled correctly:

"user's" -> "users``'" instead of being ignored.

See "revoke actions" (second-to-last command) on this page:
https://builds.cask.co/artifact/CDAP-DQB183/shared/build-2/Docs-HTML/4.0.0-SNAPSHOT/en/reference-manual/cli-api.html

Passes a Quick Build: http://builds.cask.co/browse/CDAP-DQB185-1

Revised page: https://builds.cask.co/artifact/CDAP-DQB185/shared/build-1/Docs-HTML/4.0.0-SNAPSHOT/en/reference-manual/cli-api.html

Screenshot showing fixed page and page with error (right-column, "Revokes a user``'s"):
![screen shot 2016-12-07 at 3 28 52 pm](https://cloud.githubusercontent.com/assets/6394794/20991197/fe9b1aec-bc91-11e6-826c-02c6a5a68962.png)
