### PR TITLE
(CDAP-5068) Added offset (default 0) and limit (default Integer.MAX_V…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
@@ -22,6 +22,7 @@ import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
+import co.cask.cdap.proto.metadata.MetadataSearchResponse;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
 import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 
@@ -157,13 +158,21 @@ public interface MetadataAdmin {
    * Executes a search for CDAP entities in the specified namespace with the specified search query and
    * an optional set of {@link MetadataSearchTargetType entity types} in the specified {@link MetadataScope}.
    *
-   * @param namespaceId The namespace id to filter the search by
-   * @param searchQuery The search query
-   * @param types The types of CDAP entity to be searched. If empty all possible types will be searched
+   * @param namespaceId the namespace id to filter the search by
+   * @param searchQuery the search query
+   * @param types the types of CDAP entity to be searched. If empty all possible types will be searched
    * @param sortInfo represents sorting information. Use {@link SortInfo#DEFAULT} to return search results without
    *                 sorting (which implies that the sort order is by relevance to the search query)
-   * @return a {@link Set} containing a {@link MetadataSearchResultRecord} for each matching entity
+   * @param offset the index to start with in the search results. To return results from the beginning, pass {@code 0}
+   * @param limit the number of results to return, starting from #offset. To return all, pass {@link Integer#MAX_VALUE}
+   * @param numCursors the number of cursors to return in the response. A cursor identifies the first index of the
+   *                   next page for pagination purposes
+   * @param cursor the cursor that acts as the starting index for the requested page. This is only applicable when
+   *               #sortInfo is not {@link SortInfo#DEFAULT}. If offset is also specified, it is applied starting at
+   *               the cursor. If {@code null}, the first row is used as the cursor
+   * @return the {@link MetadataSearchResponse} containing search results for the specified search query and filters
    */
-  Set<MetadataSearchResultRecord> search(String namespaceId, String searchQuery, Set<MetadataSearchTargetType> types,
-                                         SortInfo sortInfo) throws Exception;
+  MetadataSearchResponse search(String namespaceId, String searchQuery, Set<MetadataSearchTargetType> types,
+                                SortInfo sortInfo, int offset, int limit, int numCursors,
+                                String cursor) throws Exception;
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
@@ -77,11 +77,14 @@ public class MetadataAdminAuthorizationTest {
     SecurityRequestContext.setUserId(ALICE.getName());
     authorizer.grant(NamespaceId.DEFAULT, ALICE, Collections.singleton(Action.WRITE));
     AppFabricTestHelper.deployApplication(Id.Namespace.DEFAULT, AllProgramsApp.class, "{}", cConf);
-    Assert.assertFalse(metadataAdmin.search(NamespaceId.DEFAULT.getNamespace(), "*",
-                                            EnumSet.allOf(MetadataSearchTargetType.class), SortInfo.DEFAULT).isEmpty());
+    EnumSet<MetadataSearchTargetType> types = EnumSet.allOf(MetadataSearchTargetType.class);
+    Assert.assertFalse(
+      metadataAdmin.search(NamespaceId.DEFAULT.getNamespace(), "*", types,
+                           SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 1, null).getResults().isEmpty());
     SecurityRequestContext.setUserId("bob");
-    Assert.assertTrue(metadataAdmin.search(NamespaceId.DEFAULT.getNamespace(), "*",
-                                           EnumSet.allOf(MetadataSearchTargetType.class), SortInfo.DEFAULT).isEmpty());
+    Assert.assertTrue(
+      metadataAdmin.search(NamespaceId.DEFAULT.getNamespace(), "*", types,
+                           SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 1, null).getResults().isEmpty());
   }
 
   @AfterClass

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataHttpHandlerTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataHttpHandlerTestRun.java
@@ -1155,12 +1155,12 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
 
     // create entities so system metadata is annotated
     // also ensure that they are created at least 1 ms apart
-    streamClient.create(stream.toId());
+    streamClient.create(stream);
     TimeUnit.MILLISECONDS.sleep(1);
-    streamViewClient.createOrUpdate(view.toId(), new ViewSpecification(new FormatSpecification("csv", null, null)));
+    streamViewClient.createOrUpdate(view, new ViewSpecification(new FormatSpecification("csv", null, null)));
     TimeUnit.MILLISECONDS.sleep(1);
     datasetClient.create(
-      dataset.toId(),
+      dataset,
       new DatasetInstanceConfiguration(Table.class.getName(), Collections.<String, String>emptyMap())
     );
 
@@ -1168,6 +1168,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     EnumSet<MetadataSearchTargetType> targets = EnumSet.allOf(MetadataSearchTargetType.class);
     try {
       searchMetadata(namespace, "*", targets, AbstractSystemMetadataWriter.ENTITY_NAME_KEY);
+      Assert.fail();
     } catch (BadRequestException e) {
       // expected
     }
@@ -1175,6 +1176,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     // search with bad sort field
     try {
       searchMetadata(namespace, "*", targets, "name asc");
+      Assert.fail();
     } catch (BadRequestException e) {
       // expected
     }
@@ -1182,9 +1184,19 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     // search with bad sort order
     try {
       searchMetadata(namespace, "*", targets, AbstractSystemMetadataWriter.ENTITY_NAME_KEY + " unknown");
+      Assert.fail();
     } catch (BadRequestException e) {
       // expected
     }
+
+    // search with cursor for relevance sort
+    try {
+      searchMetadata(NamespaceId.DEFAULT, "search*", EnumSet.allOf(MetadataSearchTargetType.class), null, 1, "cursor");
+      Assert.fail();
+    } catch (BadRequestException e) {
+      // expected
+    }
+
     // test ascending order of entity name
     Set<MetadataSearchResultRecord> searchResults =
       searchMetadata(namespace, "*", targets, AbstractSystemMetadataWriter.ENTITY_NAME_KEY + " asc");
@@ -1218,6 +1230,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
       new MetadataSearchResultRecord(stream)
     );
     Assert.assertEquals(expected, new ArrayList<>(searchResults));
+
     // cleanup
     namespaceClient.delete(namespace);
   }

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataTestBase.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataTestBase.java
@@ -460,13 +460,20 @@ public abstract class MetadataTestBase extends ClientTestBase {
                                                            Set<MetadataSearchTargetType> targets) throws Exception {
     // Note: Can't delegate this to the next method. This is because MetadataHttpHandlerTestRun overrides these two
     // methods, to strip out metadata from search results for easier assertions.
-    return metadataClient.searchMetadata(namespaceId.toId(), query, targets, null).getResults();
+    return metadataClient.searchMetadata(namespaceId.toId(), query, targets, null, null).getResults();
   }
 
   protected Set<MetadataSearchResultRecord> searchMetadata(NamespaceId namespaceId, String query,
                                                            Set<MetadataSearchTargetType> targets,
                                                            @Nullable String sort) throws Exception {
-    return metadataClient.searchMetadata(namespaceId.toId(), query, targets, sort).getResults();
+    return metadataClient.searchMetadata(namespaceId.toId(), query, targets, sort, null).getResults();
+  }
+
+  protected Set<MetadataSearchResultRecord> searchMetadata(NamespaceId namespaceId, String query,
+                                                           Set<MetadataSearchTargetType> targets,
+                                                           @Nullable String sort, int numCursors,
+                                                           @Nullable String cursor) throws Exception {
+    return metadataClient.searchMetadata(namespaceId.toId(), query, targets, sort, cursor).getResults();
   }
 
   protected Set<String> getTags(ApplicationId app, MetadataScope scope) throws Exception {

--- a/cdap-common/src/main/java/co/cask/cdap/common/metadata/AbstractMetadataClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/metadata/AbstractMetadataClient.java
@@ -99,7 +99,7 @@ public abstract class AbstractMetadataClient {
   public MetadataSearchResponse searchMetadata(Id.Namespace namespace, String query,
                                                Set<MetadataSearchTargetType> targets)
     throws IOException, UnauthenticatedException, UnauthorizedException, BadRequestException {
-    return searchMetadata(namespace, query, targets, null);
+    return searchMetadata(namespace, query, targets, null, null);
   }
 
   /**
@@ -108,11 +108,13 @@ public abstract class AbstractMetadataClient {
    * @param namespace the namespace to search in
    * @param query the query string with which to search
    * @param targets {@link MetadataSearchTargetType}s to search. If empty, all possible types will be searched
-   * @param sort specifies sort field and sort order
+   * @param sort specifies sort field and sort order. If {@code null}, the sort order is by relevance
+   *
    * @return A set of {@link MetadataSearchResultRecord} for the given query.
    */
   public MetadataSearchResponse searchMetadata(Id.Namespace namespace, String query,
-                                               Set<MetadataSearchTargetType> targets, String sort)
+                                               Set<MetadataSearchTargetType> targets, @Nullable String sort,
+                                               @Nullable String cursor)
     throws IOException, UnauthenticatedException, UnauthorizedException, BadRequestException {
 
     String path = String.format("metadata/search?query=%s", query);
@@ -121,6 +123,9 @@ public abstract class AbstractMetadataClient {
     }
     if (sort != null) {
       path += "&sort=" + URLEncoder.encode(sort, "UTF-8");
+    }
+    if (cursor != null) {
+      path += "&cursor=" + cursor;
     }
     URL searchURL = resolve(namespace, path);
     HttpResponse response = execute(HttpRequest.get(searchURL).build(), HttpResponseStatus.BAD_REQUEST.getCode());

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/FuzzyRowFilter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/FuzzyRowFilter.java
@@ -155,8 +155,8 @@ public final class FuzzyRowFilter implements Filter {
     NO_NEXT
   }
 
-  static SatisfiesCode satisfies(byte[] row,
-                                 byte[] fuzzyKeyBytes, byte[] fuzzyKeyMeta) {
+  private static SatisfiesCode satisfies(byte[] row,
+                                         byte[] fuzzyKeyBytes, byte[] fuzzyKeyMeta) {
     return satisfies(row, 0, row.length, fuzzyKeyBytes, fuzzyKeyMeta);
   }
 
@@ -204,7 +204,7 @@ public final class FuzzyRowFilter implements Filter {
     return (fuzzyKeyByte & 0xFF) == 255;
   }
 
-  static byte[] getNextForFuzzyRule(byte[] row, byte[] fuzzyKeyBytes, byte[] fuzzyKeyMeta) {
+  private static byte[] getNextForFuzzyRule(byte[] row, byte[] fuzzyKeyBytes, byte[] fuzzyKeyMeta) {
     return getNextForFuzzyRule(row, 0, row.length, fuzzyKeyBytes, fuzzyKeyMeta);
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/SearchResults.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/SearchResults.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.metadata.dataset;
+
+import java.util.List;
+
+/**
+ * Represents a list of {@link MetadataEntry} that match a search query in the {@link MetadataDataset}, along with a
+ * list of cursors to start subsequent searches from.
+ */
+public class SearchResults {
+  private final List<MetadataEntry> results;
+  private final List<String> cursors;
+
+
+  SearchResults(List<MetadataEntry> results, List<String> cursors) {
+    this.results = results;
+    this.cursors = cursors;
+  }
+
+  public List<MetadataEntry> getResults() {
+    return results;
+  }
+
+  public List<String> getCursors() {
+    return cursors;
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/SortInfo.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/SortInfo.java
@@ -23,6 +23,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
@@ -97,5 +98,25 @@ public class SortInfo {
     }
 
     return new SortInfo(sortBy, SortInfo.SortOrder.valueOf(sortOrder.toUpperCase()));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SortInfo that = (SortInfo) o;
+
+    return Objects.equals(sortBy, that.sortBy) &&
+      Objects.equals(sortOrder, that.sortOrder);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sortBy, sortOrder);
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
@@ -22,12 +22,12 @@ import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
+import co.cask.cdap.proto.metadata.MetadataSearchResponse;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
 import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 /**
  * Defines operations on {@link MetadataDataset} for both system and user metadata.
@@ -169,10 +169,19 @@ public interface MetadataStore {
    * @param types the {@link MetadataSearchTargetType} to restrict the search to, if empty all types are searched
    * @param sortInfo represents sorting information. Use {@link SortInfo#DEFAULT} to return search results without
    *                 sorting (which implies that the sort order is by relevance to the search query)
+   * @param offset the index to start with in the search results. To return results from the beginning, pass {@code 0}
+   * @param limit the number of results to return, starting from #offset. To return all, pass {@link Integer#MAX_VALUE}
+   * @param numCursors the number of cursors to return in the response. A cursor identifies the first index of the
+   *                   next page for pagination purposes
+   * @param cursor the cursor that acts as the starting index for the requested page. This is only applicable when
+   *               #sortInfo is not {@link SortInfo#DEFAULT}. If offset is also specified, it is applied starting at
+   *               the cursor. If {@code null}, the first row is used as the cursor
+   * @return the {@link MetadataSearchResponse} containing search results for the specified search query and filters
    */
-  Set<MetadataSearchResultRecord> search(String namespaceId, String searchQuery,
-                                         Set<MetadataSearchTargetType> types,
-                                         SortInfo sortInfo) throws BadRequestException;
+  MetadataSearchResponse search(String namespaceId, String searchQuery,
+                                Set<MetadataSearchTargetType> types,
+                                SortInfo sortInfo, int offset, int limit,
+                                int numCursors, String cursor) throws BadRequestException;
 
   /**
    * Returns the snapshot of the metadata for entities on or before the given time in both {@link MetadataScope#USER}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
@@ -19,6 +19,7 @@ import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
+import co.cask.cdap.proto.metadata.MetadataSearchResponse;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
 import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import com.google.common.collect.ImmutableSet;
@@ -115,9 +116,12 @@ public class NoOpMetadataStore implements MetadataStore {
   }
 
   @Override
-  public Set<MetadataSearchResultRecord> search(String namespaceId, String searchQuery,
-                                                Set<MetadataSearchTargetType> types, SortInfo sort) {
-    return Collections.emptySet();
+  public MetadataSearchResponse search(String namespaceId, String searchQuery,
+                                       Set<MetadataSearchTargetType> types,
+                                       SortInfo sort, int offset, int limit, int numCursors, String cursor) {
+    return new MetadataSearchResponse(sort.toString(), offset, limit, 0,
+                                      Collections.<MetadataSearchResultRecord>emptySet(),
+                                      Collections.<String>emptyList());
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
@@ -26,6 +26,7 @@ import co.cask.cdap.data2.metadata.indexer.InvertedValueIndexer;
 import co.cask.cdap.data2.metadata.system.AbstractSystemMetadataWriter;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
@@ -49,6 +50,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -76,8 +78,7 @@ public class MetadataDatasetTest {
   private final DatasetId dataset1 = new DatasetId("ns1", "ds1");
   private final StreamId stream1 = new StreamId("ns1", "s1");
   private final StreamViewId view1 = new StreamViewId(stream1.getNamespace(), stream1.getStream(), "v1");
-  private final co.cask.cdap.proto.id.ArtifactId artifact1 =
-    new co.cask.cdap.proto.id.ArtifactId("ns1", "a1", "1.0.0");
+  private final ArtifactId artifact1 = new ArtifactId("ns1", "a1", "1.0.0");
 
   @Before
   public void before() throws Exception {
@@ -363,46 +364,46 @@ public class MetadataDatasetTest {
       @Override
       public void apply() throws Exception {
         List<MetadataEntry> results =
-          dataset.search("ns1", "tags:*", ImmutableSet.of(MetadataSearchTargetType.ALL));
+          searchByDefaultIndex("ns1", "tags:*", ImmutableSet.of(MetadataSearchTargetType.ALL));
         // results for dataset1 - ns1:tags:tag12, ns1:tags:tag2, ns1:tags:tag3, ns1:tags:tag33, ns1:tags:tag12-tag33
         Assert.assertEquals(11, results.size());
 
         // Try to search for tag1*
-        results = dataset.search("ns1", "tags:tag1*", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "tags:tag1*", ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertEquals(4, results.size());
 
         // Try to search for tag1 with spaces in search query and mixed case of tags keyword
-        results = dataset.search("ns1", "  tAGS  :  tag1  ", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "  tAGS  :  tag1  ", ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertEquals(2, results.size());
 
         // Try to search for tag4
-        results = dataset.search("ns1", "tags:tag4", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "tags:tag4", ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertEquals(1, results.size());
 
         // Try to search for tag33
-        results = dataset.search("ns1", "tags:tag33", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "tags:tag33", ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertEquals(1, results.size());
 
         // Try to search for a tag which has - in it
-        results = dataset.search("ns1", "tag12-tag33", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "tag12-tag33", ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertEquals(1, results.size());
 
         // Try to search for tag33 with spaces in query
-        results = dataset.search("ns1", "  tag33  ", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "  tag33  ", ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertEquals(1, results.size());
 
         // Try to search for tag3
-        results = dataset.search("ns1", "tags:tag3*", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "tags:tag3*", ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertEquals(3, results.size());
 
         // try search in another namespace
-        results = dataset.search("ns2", "tags:tag1", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns2", "tags:tag1", ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertEquals(1, results.size());
 
-        results = dataset.search("ns2", "tag3", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns2", "tag3", ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertEquals(1, results.size());
 
-        results = dataset.search("ns2", "tag*", ImmutableSet.of(MetadataSearchTargetType.APP));
+        results = searchByDefaultIndex("ns2", "tag*", ImmutableSet.of(MetadataSearchTargetType.APP));
         // 9 due to matches of type ns2:tag1, ns2:tags:tag1, and splitting of tag3_more
         Assert.assertEquals(9, results.size());
 
@@ -423,7 +424,7 @@ public class MetadataDatasetTest {
       @Override
       public void apply() throws Exception {
         List<MetadataEntry> results =
-          dataset.search("ns1", "tags:tag3*", ImmutableSet.of(MetadataSearchTargetType.ALL));
+          searchByDefaultIndex("ns1", "tags:tag3*", ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertEquals(0, results.size());
         Assert.assertEquals(0, dataset.getTags(app1).size());
         Assert.assertEquals(0, dataset.getTags(flow1).size());
@@ -454,31 +455,31 @@ public class MetadataDatasetTest {
       @Override
       public void apply() throws Exception {
         List<MetadataEntry> results =
-          dataset.search("ns1", "value1", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+          searchByDefaultIndex("ns1", "value1", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
         Assert.assertEquals(ImmutableList.of(entry), results);
 
         // Search for it based on a word in value with spaces in search query
-        results = dataset.search("ns1", "  aV1   ", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+        results = searchByDefaultIndex("ns1", "  aV1   ", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
         Assert.assertEquals(ImmutableList.of(multiWordEntry), results);
 
         // Search for it based split patterns to make sure nothing is matched
-        results = dataset.search("ns1", "-", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "-", ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertTrue(results.isEmpty());
-        results = dataset.search("ns1", ",", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", ",", ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertTrue(results.isEmpty());
-        results = dataset.search("ns1", "_", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "_", ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertTrue(results.isEmpty());
-        results = dataset.search("ns1", ", ,", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", ", ,", ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertTrue(results.isEmpty());
-        results = dataset.search("ns1", ", - ,", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", ", - ,", ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertTrue(results.isEmpty());
 
         // Search for it based on a word in value
-        results = dataset.search("ns1", "av5", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+        results = searchByDefaultIndex("ns1", "av5", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
         Assert.assertEquals(ImmutableList.of(multiWordEntry), results);
 
         // Case insensitive
-        results = dataset.search("ns1", "ValUe1", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+        results = searchByDefaultIndex("ns1", "ValUe1", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
         Assert.assertEquals(ImmutableList.of(entry), results);
 
       }
@@ -494,7 +495,7 @@ public class MetadataDatasetTest {
       @Override
       public void apply() throws Exception {
         List<MetadataEntry> results =
-          dataset.search("ns1", "value1", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+          searchByDefaultIndex("ns1", "value1", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
         Assert.assertEquals(2, results.size());
         for (MetadataEntry result : results) {
           Assert.assertEquals("value1", result.getValue());
@@ -513,13 +514,13 @@ public class MetadataDatasetTest {
       @Override
       public void apply() throws Exception {
         List<MetadataEntry> results =
-          dataset.search("ns1", "value2*", ImmutableSet.of(MetadataSearchTargetType.ALL));
+          searchByDefaultIndex("ns1", "value2*", ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertEquals(2, results.size());
         for (MetadataEntry result : results) {
           Assert.assertTrue(result.getValue().startsWith("value2"));
         }
         // Search based on value prefix in the wrong namespace
-        results = dataset.search("ns12", "value2*", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns12", "value2*", ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertTrue(results.isEmpty());
       }
     });
@@ -553,21 +554,21 @@ public class MetadataDatasetTest {
       public void apply() throws Exception {
         // Search for it based on value
         List<MetadataEntry> results =
-          dataset.search("ns1", "key1" + MetadataDataset.KEYVALUE_SEPARATOR + "value1",
-                         ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+          searchByDefaultIndex("ns1", "key1" + MetadataDataset.KEYVALUE_SEPARATOR + "value1",
+                               ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
         Assert.assertEquals(ImmutableList.of(flowEntry1), results);
 
         // Search for it based on a word in value with spaces in search query
-        results = dataset.search("ns1", "  multiword" + MetadataDataset.KEYVALUE_SEPARATOR + "aV1   ",
-                                 ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+        results = searchByDefaultIndex("ns1", "  multiword" + MetadataDataset.KEYVALUE_SEPARATOR + "aV1   ",
+                                       ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
 
         MetadataEntry flowMultiWordEntry = new MetadataEntry(flow1, multiWordKey, multiWordValue);
         Assert.assertEquals(ImmutableList.of(flowMultiWordEntry), results);
 
         // Search for it based on a word in value
         results =
-          dataset.search("ns1", multiWordKey + MetadataDataset.KEYVALUE_SEPARATOR + "aV5",
-                         ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+          searchByDefaultIndex("ns1", multiWordKey + MetadataDataset.KEYVALUE_SEPARATOR + "aV5",
+                               ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
         Assert.assertEquals(ImmutableList.of(flowMultiWordEntry), results);
       }
     });
@@ -581,30 +582,30 @@ public class MetadataDatasetTest {
       @Override
       public void apply() throws Exception {
         List<MetadataEntry> results =
-          dataset.search("ns1", multiWordKey + MetadataDataset.KEYVALUE_SEPARATOR + "aV5",
-                         ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+          searchByDefaultIndex("ns1", multiWordKey + MetadataDataset.KEYVALUE_SEPARATOR + "aV5",
+                               ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
         // search results should be empty after removing this key as the indexes are deleted
         Assert.assertTrue(results.isEmpty());
 
         // Test wrong ns
         List<MetadataEntry> results2 =
-          dataset.search("ns12", "key1" + MetadataDataset.KEYVALUE_SEPARATOR + "value1",
-                         ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+          searchByDefaultIndex("ns12", "key1" + MetadataDataset.KEYVALUE_SEPARATOR + "value1",
+                               ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
         Assert.assertTrue(results2.isEmpty());
 
         // Test multi word query
-        results = dataset.search("ns1", "  value1  av2 ", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "  value1  av2 ", ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertEquals(Sets.newHashSet(flowEntry1, streamEntry1), Sets.newHashSet(results));
 
-        results = dataset.search("ns1", "  value1  sValue1 ", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "  value1  sValue1 ", ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertEquals(Sets.newHashSet(flowEntry1, streamEntry1, streamEntry2), Sets.newHashSet(results));
 
-        results = dataset.search("ns1", "  valu*  sVal* ", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "  valu*  sVal* ", ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertEquals(Sets.newHashSet(flowEntry1, flowEntry2, streamEntry1, streamEntry2),
                             Sets.newHashSet(results));
 
         // Using empty filter should also search for all target types
-        results = dataset.search("ns1", "  valu*  sVal* ", ImmutableSet.<MetadataSearchTargetType>of());
+        results = searchByDefaultIndex("ns1", "  valu*  sVal* ", ImmutableSet.<MetadataSearchTargetType>of());
         Assert.assertEquals(Sets.newHashSet(flowEntry1, flowEntry2, streamEntry1, streamEntry2),
                             Sets.newHashSet(results));
       }
@@ -615,10 +616,8 @@ public class MetadataDatasetTest {
   @Test
   public void testSearchIncludesSystemEntities() throws InterruptedException, TransactionFailureException {
     // Use the same artifact in two different namespaces - system and ns2
-    final co.cask.cdap.proto.id.ArtifactId sysArtifact = new co.cask.cdap.proto.id.ArtifactId(
-      NamespaceId.SYSTEM.getNamespace(), "artifact", "1.0");
-    final co.cask.cdap.proto.id.ArtifactId ns2Artifact = new co.cask.cdap.proto.id.ArtifactId(
-      "ns2", "artifact", "1.0");
+    final ArtifactId sysArtifact = NamespaceId.SYSTEM.artifact("artifact", "1.0");
+    final ArtifactId ns2Artifact = new ArtifactId("ns2", "artifact", "1.0");
     final String multiWordKey = "multiword";
     final String multiWordValue = "aV1 av2 ,  -  ,  av3 - av4_av5 av6";
 
@@ -639,31 +638,31 @@ public class MetadataDatasetTest {
     txnl.execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {
-        List<MetadataEntry> results = dataset.search("ns1", "aV5", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        List<MetadataEntry> results = searchByDefaultIndex("ns1", "aV5", ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertEquals(Sets.newHashSet(flowMultiWordEntry, systemArtifactEntry), Sets.newHashSet(results));
         // search only programs - should only return flow
-        results = dataset.search("ns1", multiWordKey + MetadataDataset.KEYVALUE_SEPARATOR + "aV5",
-                                 ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+        results = searchByDefaultIndex("ns1", multiWordKey + MetadataDataset.KEYVALUE_SEPARATOR + "aV5",
+                                       ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
         Assert.assertEquals(ImmutableList.of(flowMultiWordEntry), results);
         // search only artifacts - should only return system artifact
-        results = dataset.search("ns1", multiWordKey + MetadataDataset.KEYVALUE_SEPARATOR + multiWordValue,
-                                 ImmutableSet.of(MetadataSearchTargetType.ARTIFACT));
+        results = searchByDefaultIndex("ns1", multiWordKey + MetadataDataset.KEYVALUE_SEPARATOR + multiWordValue,
+                                       ImmutableSet.of(MetadataSearchTargetType.ARTIFACT));
         // this query returns the system artifact 4 times, since the dataset returns a list with duplicates for scoring
         // purposes. Convert to a Set for comparison.
         Assert.assertEquals(Sets.newHashSet(systemArtifactEntry), Sets.newHashSet(results));
         // search all entities in namespace 'ns2' - should return the system artifact and the same artifact in ns2
-        results = dataset.search("ns2", multiWordKey + MetadataDataset.KEYVALUE_SEPARATOR + "aV4",
-                                 ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns2", multiWordKey + MetadataDataset.KEYVALUE_SEPARATOR + "aV4",
+                                       ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertEquals(Sets.newHashSet(systemArtifactEntry, ns2ArtifactEntry), Sets.newHashSet(results));
         // search only programs in a namespace 'ns2'. Should return empty
-        results = dataset.search("ns2", "aV*", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+        results = searchByDefaultIndex("ns2", "aV*", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
         Assert.assertTrue(results.isEmpty());
         // search all entities in namespace 'ns3'. Should return only the system artifact
-        results = dataset.search("ns3", "av*", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns3", "av*", ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertEquals(Sets.newHashSet(systemArtifactEntry), Sets.newHashSet(results));
         // search the system namespace for all entities. Should return only the system artifact
-        results = dataset.search(NamespaceId.SYSTEM.getEntityName(), "av*",
-                                 ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex(NamespaceId.SYSTEM.getEntityName(), "av*",
+                                       ImmutableSet.of(MetadataSearchTargetType.ALL));
         Assert.assertEquals(Sets.newHashSet(systemArtifactEntry), Sets.newHashSet(results));
       }
     });
@@ -691,14 +690,14 @@ public class MetadataDatasetTest {
       @Override
       public void apply() throws Exception {
         Assert.assertEquals(ImmutableList.of(new MetadataEntry(flow1, "key1", "value1")),
-                            dataset.search(flow1.getNamespace(), "value1",
-                                           ImmutableSet.<MetadataSearchTargetType>of()));
+                            searchByDefaultIndex(flow1.getNamespace(), "value1",
+                                                 ImmutableSet.<MetadataSearchTargetType>of()));
         Assert.assertEquals(ImmutableList.of(new MetadataEntry(flow1, "key2", "value2")),
-                            dataset.search(flow1.getNamespace(), "value2",
-                                           ImmutableSet.<MetadataSearchTargetType>of()));
+                            searchByDefaultIndex(flow1.getNamespace(), "value2",
+                                                 ImmutableSet.<MetadataSearchTargetType>of()));
         Assert.assertEquals(ImmutableList.of(new MetadataEntry(flow1, MetadataDataset.TAGS_KEY, "tag1,tag2")),
-                            dataset.search(flow1.getNamespace(), "tag2",
-                                           ImmutableSet.<MetadataSearchTargetType>of()));
+                            searchByDefaultIndex(flow1.getNamespace(), "tag2",
+                                                 ImmutableSet.<MetadataSearchTargetType>of()));
       }
     });
 
@@ -717,21 +716,25 @@ public class MetadataDatasetTest {
       public void apply() throws Exception {
         // Searching for value1 should be empty
         Assert.assertEquals(ImmutableList.of(),
-                            dataset.search(flow1.getNamespace(), "value1",
-                                           ImmutableSet.<MetadataSearchTargetType>of()));
+                            searchByDefaultIndex(flow1.getNamespace(), "value1",
+                                                 ImmutableSet.<MetadataSearchTargetType>of()));
         // Instead key1 has value value3 now
         Assert.assertEquals(ImmutableList.of(new MetadataEntry(flow1, "key1", "value3")),
-                            dataset.search(flow1.getNamespace(), "value3",
-                                           ImmutableSet.<MetadataSearchTargetType>of()));
+                            searchByDefaultIndex(flow1.getNamespace(), "value3",
+                                                 ImmutableSet.<MetadataSearchTargetType>of()));
         // key2 was deleted
         Assert.assertEquals(ImmutableList.of(),
-                            dataset.search(flow1.getNamespace(), "value2",
-                                           ImmutableSet.<MetadataSearchTargetType>of()));
+                            searchByDefaultIndex(flow1.getNamespace(), "value2",
+                                                 ImmutableSet.<MetadataSearchTargetType>of()));
         // tag2 was deleted
-        Assert.assertEquals(ImmutableList.of(),
-                            dataset.search(flow1.getNamespace(), "tag2", ImmutableSet.<MetadataSearchTargetType>of()));
-        Assert.assertEquals(ImmutableList.of(new MetadataEntry(flow1, MetadataDataset.TAGS_KEY, "tag1")),
-                            dataset.search(flow1.getNamespace(), "tag1", ImmutableSet.<MetadataSearchTargetType>of()));
+        Assert.assertEquals(
+          ImmutableList.of(),
+          searchByDefaultIndex(flow1.getNamespace(), "tag2", ImmutableSet.<MetadataSearchTargetType>of()))
+        ;
+        Assert.assertEquals(
+          ImmutableList.of(new MetadataEntry(flow1, MetadataDataset.TAGS_KEY, "tag1")),
+          searchByDefaultIndex(flow1.getNamespace(), "tag1", ImmutableSet.<MetadataSearchTargetType>of())
+        );
       }
     });
   }
@@ -876,13 +879,13 @@ public class MetadataDatasetTest {
     txnl.execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {
-        List<MetadataEntry> searchResults = dataset.search(namespaceId, "flowValue", targetTypes);
+        List<MetadataEntry> searchResults = searchByDefaultIndex(dataset, namespaceId, "flowValue", targetTypes);
         Assert.assertTrue(searchResults.isEmpty());
-        searchResults = dataset.search(namespaceId, "flowKey:flow*", targetTypes);
+        searchResults = searchByDefaultIndex(dataset, namespaceId, "flowKey:flow*", targetTypes);
         Assert.assertTrue(searchResults.isEmpty());
-        searchResults = dataset.search(namespaceId, "datasetValue", targetTypes);
+        searchResults = searchByDefaultIndex(dataset, namespaceId, "datasetValue", targetTypes);
         Assert.assertTrue(searchResults.isEmpty());
-        searchResults = dataset.search(namespaceId, "datasetKey:dataset*", targetTypes);
+        searchResults = searchByDefaultIndex(dataset, namespaceId, "datasetKey:dataset*", targetTypes);
         Assert.assertTrue(searchResults.isEmpty());
       }
     });
@@ -898,20 +901,20 @@ public class MetadataDatasetTest {
     txnl.execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {
-        List<MetadataEntry> flowSearchResults = dataset.search(namespaceId, "flowValue", targetTypes);
-        List<MetadataEntry> dsSearchResults = dataset.search(namespaceId, "datasetValue", targetTypes);
+        List<MetadataEntry> flowSearchResults = searchByDefaultIndex(dataset, namespaceId, "flowValue", targetTypes);
+        List<MetadataEntry> dsSearchResults = searchByDefaultIndex(dataset, namespaceId, "datasetValue", targetTypes);
         if (!flowSearchResults.isEmpty()) {
           Assert.assertEquals(1, flowSearchResults.size());
-          flowSearchResults = dataset.search(namespaceId, "flowKey:flow*", targetTypes);
+          flowSearchResults = searchByDefaultIndex(dataset, namespaceId, "flowKey:flow*", targetTypes);
           Assert.assertEquals(1, flowSearchResults.size());
           Assert.assertTrue(dsSearchResults.isEmpty());
-          dsSearchResults = dataset.search(namespaceId, "datasetKey:dataset*", targetTypes);
+          dsSearchResults = searchByDefaultIndex(dataset, namespaceId, "datasetKey:dataset*", targetTypes);
           Assert.assertTrue(dsSearchResults.isEmpty());
         } else {
-          flowSearchResults = dataset.search(namespaceId, "flowKey:flow*", targetTypes);
+          flowSearchResults = searchByDefaultIndex(dataset, namespaceId, "flowKey:flow*", targetTypes);
           Assert.assertTrue(flowSearchResults.isEmpty());
           Assert.assertEquals(1, dsSearchResults.size());
-          dsSearchResults = dataset.search(namespaceId, "datasetKey:dataset*", targetTypes);
+          dsSearchResults = searchByDefaultIndex(dataset, namespaceId, "datasetKey:dataset*", targetTypes);
           Assert.assertEquals(1, dsSearchResults.size());
         }
       }
@@ -926,13 +929,13 @@ public class MetadataDatasetTest {
     txnl.execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {
-        List<MetadataEntry> searchResults = dataset.search(namespaceId, "flowValue", targetTypes);
+        List<MetadataEntry> searchResults = searchByDefaultIndex(dataset, namespaceId, "flowValue", targetTypes);
         Assert.assertEquals(1, searchResults.size());
-        searchResults = dataset.search(namespaceId, "flowKey:flow*", targetTypes);
+        searchResults = searchByDefaultIndex(dataset, namespaceId, "flowKey:flow*", targetTypes);
         Assert.assertEquals(1, searchResults.size());
-        searchResults = dataset.search(namespaceId, "datasetValue", targetTypes);
+        searchResults = searchByDefaultIndex(dataset, namespaceId, "datasetValue", targetTypes);
         Assert.assertEquals(1, searchResults.size());
-        searchResults = dataset.search(namespaceId, "datasetKey:dataset*", targetTypes);
+        searchResults = searchByDefaultIndex(dataset, namespaceId, "datasetKey:dataset*", targetTypes);
         Assert.assertEquals(1, searchResults.size());
       }
     });
@@ -957,13 +960,13 @@ public class MetadataDatasetTest {
     txnl.execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {
-        List<MetadataEntry> searchResults = dataset.search(namespaceId, "flowValue", targetTypes);
+        List<MetadataEntry> searchResults = searchByDefaultIndex(dataset, namespaceId, "flowValue", targetTypes);
         Assert.assertEquals(ImmutableList.of(expectedFlowEntry), searchResults);
-        searchResults = dataset.search(namespaceId, "flowKey:flow*", targetTypes);
+        searchResults = searchByDefaultIndex(dataset, namespaceId, "flowKey:flow*", targetTypes);
         Assert.assertEquals(ImmutableList.of(expectedFlowEntry), searchResults);
-        searchResults = dataset.search(namespaceId, "datasetValue", targetTypes);
+        searchResults = searchByDefaultIndex(dataset, namespaceId, "datasetValue", targetTypes);
         Assert.assertEquals(ImmutableList.of(expectedDatasetEntry), searchResults);
-        searchResults = dataset.search(namespaceId, "datasetKey:dataset*", targetTypes);
+        searchResults = searchByDefaultIndex(dataset, namespaceId, "datasetKey:dataset*", targetTypes);
         Assert.assertEquals(ImmutableList.of(expectedDatasetEntry), searchResults);
       }
     });
@@ -1038,6 +1041,105 @@ public class MetadataDatasetTest {
         assertNoIndexes(dataset, MetadataDataset.INVERTED_CREATION_TIME_INDEX_COLUMN, namespaceId, time);
         assertSingleIndex(dataset, MetadataDataset.INVERTED_CREATION_TIME_INDEX_COLUMN, namespaceId,
                           String.valueOf(Long.MAX_VALUE - creationTime));
+      }
+    });
+  }
+
+  @Test
+  public void testPagination() throws Exception {
+    final MetadataDataset dataset =
+      getDataset(DatasetFrameworkTestUtil.NAMESPACE_ID.dataset("testPagination"), MetadataScope.SYSTEM);
+    TransactionExecutor txnl = dsFrameworkUtil.newInMemoryTransactionExecutor((TransactionAware) dataset);
+    final String flowName = "name11";
+    final String dsName = "name21 name22";
+    final String appName = "name31 name32 name33";
+    txnl.execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        dataset.setProperty(flow1, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, flowName);
+        dataset.setProperty(dataset1, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, dsName);
+        dataset.setProperty(app1, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, appName);
+      }
+    });
+    final String namespaceId = flow1.getNamespace();
+    final EnumSet<MetadataSearchTargetType> targets = EnumSet.allOf(MetadataSearchTargetType.class);
+    final MetadataEntry flowEntry = new MetadataEntry(flow1, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, flowName);
+    final MetadataEntry dsEntry = new MetadataEntry(dataset1, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, dsName);
+    final MetadataEntry appEntry = new MetadataEntry(app1, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, appName);
+    txnl.execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        // since no sort is to be performed by the dataset, we return all (ignore limit and offset)
+        SearchResults searchResults = dataset.search(namespaceId, "name*", targets, SortInfo.DEFAULT, 0, 3, 1, null);
+        Assert.assertEquals(
+          // since default indexer is used:
+          // 1 index for flow: 'name11'
+          // 3 indexes for dataset: 'name21', 'name21 name22', 'name22'
+          // 4 indexes for app: 'name31', 'name31 name32 name33', 'name32', 'name33'
+          ImmutableList.of(flowEntry, dsEntry, dsEntry, dsEntry, appEntry, appEntry, appEntry, appEntry),
+          searchResults.getResults()
+        );
+        // ascending sort by name. offset and limit should be respected.
+        SortInfo nameAsc = new SortInfo(AbstractSystemMetadataWriter.ENTITY_NAME_KEY, SortInfo.SortOrder.ASC);
+        // first 2 in ascending order
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 2, 1, null);
+        Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry), searchResults.getResults());
+        // return 2 with offset 1 in ascending order
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 1, 2, 1, null);
+        Assert.assertEquals(ImmutableList.of(dsEntry, appEntry), searchResults.getResults());
+        // descending sort by name. offset and filter should be respected.
+        SortInfo nameDesc = new SortInfo(AbstractSystemMetadataWriter.ENTITY_NAME_KEY, SortInfo.SortOrder.DESC);
+        // first 2 in descending order
+        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 0, 2, 1, null);
+        Assert.assertEquals(ImmutableList.of(appEntry, dsEntry), searchResults.getResults());
+        // last 1 in descending order
+        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 2, 1, 1, null);
+        Assert.assertEquals(ImmutableList.of(flowEntry), searchResults.getResults());
+        // limit 0 should return empty
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 2, 0, 1, null);
+        Assert.assertTrue(searchResults.getResults().isEmpty());
+        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 1, 0, 1, null);
+        Assert.assertTrue(searchResults.getResults().isEmpty());
+        // offset greater than total search results should return empty
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 4, 0, 1, null);
+        Assert.assertTrue(searchResults.getResults().isEmpty());
+        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 100, 0, 1, null);
+        Assert.assertTrue(searchResults.getResults().isEmpty());
+
+        // test cursors
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 1, 3, null);
+        // limit is 1, but we return 3 because 3 cursors are desired.
+        Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry, appEntry), searchResults.getResults());
+        // only 2 cursors are returned even though we requested 3 because we do not have enough data to return
+        Assert.assertEquals(ImmutableList.of(dsName, appName), searchResults.getCursors());
+
+        // use first cursor returned in the previous query. the rest of the parameters stay the same
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 1, 3, searchResults.getCursors().get(0));
+        // limit is 1, but we return 2 because 3 cursors are desired, however only 2 are available starting
+        // at the cursor.
+        Assert.assertEquals(ImmutableList.of(dsEntry, appEntry), searchResults.getResults());
+        // only 1 cursor is returned even though we requested 3 because we do not have enough data to return
+        Assert.assertEquals(ImmutableList.of(appName), searchResults.getCursors());
+
+        // use first cursor returned in the previous query. the rest of the parameters stay the same
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 1, 3, searchResults.getCursors().get(0));
+        // limit is 1, and even though 3 cursors are desired, we return only 1 result, because the after the cursor we
+        // do not have enough data for 3 further cursors
+        Assert.assertEquals(ImmutableList.of(appEntry), searchResults.getResults());
+        // no cursors are returned even though we requested 3 because we do not have enough data
+        Assert.assertEquals(ImmutableList.of(), searchResults.getCursors());
+
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 2, 3, null);
+        // limit is 2, we return 3 because 3 cursors are desired
+        Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry, appEntry), searchResults.getResults());
+        // only 1 cursor is returned even though we requested 3 because we do not have enough data to return
+        Assert.assertEquals(ImmutableList.of(appName), searchResults.getCursors());
+
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 3, 1, 2, null);
+        // limit is 1, we return 0 because offset is too high
+        Assert.assertEquals(ImmutableList.of(), searchResults.getResults());
+        // only 1 cursor is returned even though we requested 3 because we do not have enough data to return
+        Assert.assertEquals(ImmutableList.of(), searchResults.getCursors());
       }
     });
   }
@@ -1321,6 +1423,21 @@ public class MetadataDatasetTest {
   private <T> T getFirst(Iterable<T> iterable) {
     Assert.assertEquals(1, Iterables.size(iterable));
     return iterable.iterator().next();
+  }
+
+  // should be called inside a transaction. This method does not start a transaction on its own, so that you can
+  // have multiple invocations in the same transaction.
+  private List<MetadataEntry> searchByDefaultIndex(String namespaceId, String searchQuery,
+                                                   Set<MetadataSearchTargetType> types) {
+    return searchByDefaultIndex(dataset, namespaceId, searchQuery, types);
+  }
+
+  // should be called inside a transaction. This method does not start a transaction on its own, so that you can
+  // have multiple invocations in the same transaction.
+  private List<MetadataEntry> searchByDefaultIndex(MetadataDataset dataset, String namespaceId, String searchQuery,
+                                                   Set<MetadataSearchTargetType> types) {
+    return dataset.search(namespaceId, searchQuery, types,
+                          SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 1, null).getResults();
   }
 
   private static MetadataDataset getDataset(DatasetId instance) throws Exception {

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemover.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemover.java
@@ -28,11 +28,11 @@ import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
 import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.cdap.store.NamespaceStore;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
@@ -55,8 +55,8 @@ final class DeletedDatasetMetadataRemover {
     List<DatasetId> removedDatasets = new ArrayList<>();
     for (NamespaceMeta namespaceMeta : nsStore.list()) {
       Set<MetadataSearchResultRecord> searchResults =
-        metadataStore.search(namespaceMeta.getName(), "*",
-                             ImmutableSet.of(MetadataSearchTargetType.DATASET), SortInfo.DEFAULT);
+        metadataStore.search(namespaceMeta.getName(), "*", EnumSet.of(MetadataSearchTargetType.DATASET),
+                             SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 1, null).getResults();
       for (MetadataSearchResultRecord searchResult : searchResults) {
         NamespacedEntityId entityId = searchResult.getEntityId();
         Preconditions.checkState(entityId instanceof DatasetId,

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataSearchResponse.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataSearchResponse.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.proto.metadata;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -24,16 +25,19 @@ import java.util.Set;
 public class MetadataSearchResponse {
   private final String sort;
   private final int offset;
-  private final int size;
+  private final int limit;
   private final int total;
   private final Set<MetadataSearchResultRecord> results;
+  private final List<String> cursors;
 
-  public MetadataSearchResponse(String sort, int offset, int size, int total, Set<MetadataSearchResultRecord> results) {
+  public MetadataSearchResponse(String sort, int offset, int limit, int total,
+                                Set<MetadataSearchResultRecord> results, List<String> cursors) {
     this.sort = sort;
     this.offset = offset;
-    this.size = size;
+    this.limit = limit;
     this.total = total;
     this.results = results;
+    this.cursors = cursors;
   }
 
   public String getSort() {
@@ -44,8 +48,8 @@ public class MetadataSearchResponse {
     return offset;
   }
 
-  public int getSize() {
-    return size;
+  public int getLimit() {
+    return limit;
   }
 
   public int getTotal() {
@@ -54,5 +58,9 @@ public class MetadataSearchResponse {
 
   public Set<MetadataSearchResultRecord> getResults() {
     return results;
+  }
+
+  public List<String> getCursors() {
+    return cursors;
   }
 }


### PR DESCRIPTION
…ALUE) parameters to paginate search results

Pagination is handled independently for two kinds of search queries:
- Search for listing (searchQuery = *):
  - In this case, pagination only reads the required amount of data from the appropriate column (determined by sort field and sort order) in the dataset
  - Once the data is received from the dataset, no additional sorting or scoring is applied on the results
- Search for relevance queries
  - In this case, pagination reads *all* the results that match the search query from the dataset
  - Scoring is then done on the client side, followed by pagination
- Add support for cursors in search. Users can specify the number of cursors to return as a parameter 'numCursors' in the REST API. When used for listing,
the API will then fetch offset + (numCursors * limit) results. However, it will only return 'limit' number of results.
- Additionally, the API will return an array of upto 'numCursors' strings, that can be used to fetch subsequent search pages.
- To specify that the search should begin at a cursor, pass it as the 'cursor' parameter. Given this parameter, the search will begin at the specified cursor,
and apply offset and limit starting from there.

(CDAP-7742) First read all indexes from MetadataDataset from both user and system scopes, then score them by relevance

Jiras:
[CDAP-5058](https://issues.cask.co/browse/CDAP-5068)
[CDAP-7742](https://issues.cask.co/browse/CDAP-7742)

Build: http://builds.cask.co/browse/CDAP-RUT307