### PR TITLE
Various fixes for pagination + UI changes

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
@@ -183,7 +183,7 @@ public class DefaultMetadataAdmin implements MetadataAdmin {
     Principal principal = authenticationContext.getPrincipal();
     final Predicate<EntityId> filter = authorizationEnforcer.createFilter(principal);
     return new MetadataSearchResponse(
-      results.getSort(), results.getOffset(), results.getLimit(), results.getTotal(),
+      results.getSort(), results.getOffset(), results.getLimit(), results.getNumCursors(), results.getTotal(),
       ImmutableSet.copyOf(
         Iterables.filter(results.getResults(), new com.google.common.base.Predicate<MetadataSearchResultRecord>() {
           @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
@@ -166,7 +166,7 @@ public interface MetadataAdmin {
    * @param offset the index to start with in the search results. To return results from the beginning, pass {@code 0}
    * @param limit the number of results to return, starting from #offset. To return all, pass {@link Integer#MAX_VALUE}
    * @param numCursors the number of cursors to return in the response. A cursor identifies the first index of the
-   *                   next page for pagination purposes
+   *                   next page for pagination purposes. Defaults to {@code 0}
    * @param cursor the cursor that acts as the starting index for the requested page. This is only applicable when
    *               #sortInfo is not {@link SortInfo#DEFAULT}. If offset is also specified, it is applied starting at
    *               the cursor. If {@code null}, the first row is used as the cursor

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
@@ -839,15 +839,17 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                              @QueryParam("offset") @DefaultValue("0") int offset,
                              // 2147483647 is Integer.MAX_VALUE
                              @QueryParam("limit") @DefaultValue("2147483647") int limit,
-                             @QueryParam("numCursors") @DefaultValue("1") int numCursors,
+                             @QueryParam("numCursors") @DefaultValue("0") int numCursors,
                              @QueryParam("cursor") @DefaultValue("") String cursor) throws Exception {
     Set<MetadataSearchTargetType> types = Collections.emptySet();
     if (targets != null) {
       types = ImmutableSet.copyOf(Iterables.transform(targets, STRING_TO_TARGET_TYPE));
     }
     SortInfo sortInfo = SortInfo.of(URLDecoder.decode(sort, "UTF-8"));
-    if (SortInfo.DEFAULT.equals(sortInfo) && !(cursor.isEmpty())) {
-      throw new BadRequestException("Cursors are not supported when sort info is not specified.");
+    if (SortInfo.DEFAULT.equals(sortInfo)) {
+      if (!(cursor.isEmpty()) || 0 != numCursors) {
+        throw new BadRequestException("Cursors are not supported when sort info is not specified.");
+      }
     }
     MetadataSearchResponse response =
       metadataAdmin.search(namespaceId, URLDecoder.decode(searchQuery, "UTF-8"), types,

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
@@ -80,11 +80,11 @@ public class MetadataAdminAuthorizationTest {
     EnumSet<MetadataSearchTargetType> types = EnumSet.allOf(MetadataSearchTargetType.class);
     Assert.assertFalse(
       metadataAdmin.search(NamespaceId.DEFAULT.getNamespace(), "*", types,
-                           SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 1, null).getResults().isEmpty());
+                           SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 0, null).getResults().isEmpty());
     SecurityRequestContext.setUserId("bob");
     Assert.assertTrue(
       metadataAdmin.search(NamespaceId.DEFAULT.getNamespace(), "*", types,
-                           SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 1, null).getResults().isEmpty());
+                           SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 0, null).getResults().isEmpty());
   }
 
   @AfterClass

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataTestBase.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataTestBase.java
@@ -29,6 +29,7 @@ import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.id.StreamViewId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
+import co.cask.cdap.proto.metadata.MetadataSearchResponse;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
 import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.cdap.proto.metadata.lineage.CollapseType;
@@ -460,20 +461,21 @@ public abstract class MetadataTestBase extends ClientTestBase {
                                                            Set<MetadataSearchTargetType> targets) throws Exception {
     // Note: Can't delegate this to the next method. This is because MetadataHttpHandlerTestRun overrides these two
     // methods, to strip out metadata from search results for easier assertions.
-    return metadataClient.searchMetadata(namespaceId.toId(), query, targets, null, null).getResults();
+    return metadataClient.searchMetadata(namespaceId.toId(), query, targets).getResults();
   }
 
   protected Set<MetadataSearchResultRecord> searchMetadata(NamespaceId namespaceId, String query,
                                                            Set<MetadataSearchTargetType> targets,
                                                            @Nullable String sort) throws Exception {
-    return metadataClient.searchMetadata(namespaceId.toId(), query, targets, sort, null).getResults();
+    return metadataClient.searchMetadata(namespaceId.toId(), query, targets,
+                                         sort, 0, Integer.MAX_VALUE, 0, null).getResults();
   }
 
-  protected Set<MetadataSearchResultRecord> searchMetadata(NamespaceId namespaceId, String query,
-                                                           Set<MetadataSearchTargetType> targets,
-                                                           @Nullable String sort, int numCursors,
-                                                           @Nullable String cursor) throws Exception {
-    return metadataClient.searchMetadata(namespaceId.toId(), query, targets, sort, cursor).getResults();
+  protected MetadataSearchResponse searchMetadata(NamespaceId namespaceId, String query,
+                                                  Set<MetadataSearchTargetType> targets,
+                                                  @Nullable String sort, int offset, int limit, int numCursors,
+                                                  @Nullable String cursor) throws Exception {
+    return metadataClient.searchMetadata(namespaceId.toId(), query, targets, sort, offset, limit, numCursors, cursor);
   }
 
   protected Set<String> getTags(ApplicationId app, MetadataScope scope) throws Exception {

--- a/cdap-common/src/main/java/co/cask/cdap/common/metadata/AbstractMetadataClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/metadata/AbstractMetadataClient.java
@@ -99,7 +99,7 @@ public abstract class AbstractMetadataClient {
   public MetadataSearchResponse searchMetadata(Id.Namespace namespace, String query,
                                                Set<MetadataSearchTargetType> targets)
     throws IOException, UnauthenticatedException, UnauthorizedException, BadRequestException {
-    return searchMetadata(namespace, query, targets, null, null);
+    return searchMetadata(namespace, query, targets, null, 0, Integer.MAX_VALUE, 0, null);
   }
 
   /**
@@ -109,11 +109,18 @@ public abstract class AbstractMetadataClient {
    * @param query the query string with which to search
    * @param targets {@link MetadataSearchTargetType}s to search. If empty, all possible types will be searched
    * @param sort specifies sort field and sort order. If {@code null}, the sort order is by relevance
-   *
+   * @param offset the index to start with in the search results. To return results from the beginning, pass {@code 0}
+   * @param limit the number of results to return, starting from #offset. To return all, pass {@link Integer#MAX_VALUE}
+   * @param numCursors the number of cursors to return in the response. A cursor identifies the first index of the
+   *                   next page for pagination purposes
+   * @param cursor the cursor that acts as the starting index for the requested page. This is only applicable when
+   *               #sortInfo is not default. If offset is also specified, it is applied starting at
+   *               the cursor. If {@code null}, the first row is used as the cursor
    * @return A set of {@link MetadataSearchResultRecord} for the given query.
    */
   public MetadataSearchResponse searchMetadata(Id.Namespace namespace, String query,
                                                Set<MetadataSearchTargetType> targets, @Nullable String sort,
+                                               int offset, int limit, int numCursors,
                                                @Nullable String cursor)
     throws IOException, UnauthenticatedException, UnauthorizedException, BadRequestException {
 
@@ -124,6 +131,9 @@ public abstract class AbstractMetadataClient {
     if (sort != null) {
       path += "&sort=" + URLEncoder.encode(sort, "UTF-8");
     }
+    path += "&offset=" + offset;
+    path += "&limit=" + limit;
+    path += "&numCursors=" + numCursors;
     if (cursor != null) {
       path += "&cursor=" + cursor;
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
@@ -172,7 +172,7 @@ public interface MetadataStore {
    * @param offset the index to start with in the search results. To return results from the beginning, pass {@code 0}
    * @param limit the number of results to return, starting from #offset. To return all, pass {@link Integer#MAX_VALUE}
    * @param numCursors the number of cursors to return in the response. A cursor identifies the first index of the
-   *                   next page for pagination purposes
+   *                   next page for pagination purposes. Defaults to {@code 0}
    * @param cursor the cursor that acts as the starting index for the requested page. This is only applicable when
    *               #sortInfo is not {@link SortInfo#DEFAULT}. If offset is also specified, it is applied starting at
    *               the cursor. If {@code null}, the first row is used as the cursor

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
@@ -119,7 +119,7 @@ public class NoOpMetadataStore implements MetadataStore {
   public MetadataSearchResponse search(String namespaceId, String searchQuery,
                                        Set<MetadataSearchTargetType> types,
                                        SortInfo sort, int offset, int limit, int numCursors, String cursor) {
-    return new MetadataSearchResponse(sort.toString(), offset, limit, 0,
+    return new MetadataSearchResponse(sort.toString(), offset, limit, numCursors, 0,
                                       Collections.<MetadataSearchResultRecord>emptySet(),
                                       Collections.<String>emptyList());
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
@@ -1082,28 +1082,28 @@ public class MetadataDatasetTest {
         // ascending sort by name. offset and limit should be respected.
         SortInfo nameAsc = new SortInfo(AbstractSystemMetadataWriter.ENTITY_NAME_KEY, SortInfo.SortOrder.ASC);
         // first 2 in ascending order
-        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 2, 1, null);
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 2, 0, null);
         Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry), searchResults.getResults());
         // return 2 with offset 1 in ascending order
-        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 1, 2, 1, null);
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 1, 2, 0, null);
         Assert.assertEquals(ImmutableList.of(dsEntry, appEntry), searchResults.getResults());
         // descending sort by name. offset and filter should be respected.
         SortInfo nameDesc = new SortInfo(AbstractSystemMetadataWriter.ENTITY_NAME_KEY, SortInfo.SortOrder.DESC);
         // first 2 in descending order
-        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 0, 2, 1, null);
+        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 0, 2, 0, null);
         Assert.assertEquals(ImmutableList.of(appEntry, dsEntry), searchResults.getResults());
         // last 1 in descending order
-        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 2, 1, 1, null);
+        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 2, 1, 0, null);
         Assert.assertEquals(ImmutableList.of(flowEntry), searchResults.getResults());
         // limit 0 should return empty
-        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 2, 0, 1, null);
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 2, 0, 0, null);
         Assert.assertTrue(searchResults.getResults().isEmpty());
-        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 1, 0, 1, null);
+        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 1, 0, 0, null);
         Assert.assertTrue(searchResults.getResults().isEmpty());
         // offset greater than total search results should return empty
-        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 4, 0, 1, null);
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 4, 0, 0, null);
         Assert.assertTrue(searchResults.getResults().isEmpty());
-        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 100, 0, 1, null);
+        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 100, 0, 0, null);
         Assert.assertTrue(searchResults.getResults().isEmpty());
 
         // test cursors

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/MetadataStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/MetadataStoreTest.java
@@ -368,7 +368,7 @@ public class MetadataStoreTest {
   }
 
   private Set<MetadataSearchResultRecord> search(String ns, String searchQuery) throws BadRequestException {
-    return search(ns, searchQuery, 0, Integer.MAX_VALUE, 1);
+    return search(ns, searchQuery, 0, Integer.MAX_VALUE, 0);
   }
 
   private Set<MetadataSearchResultRecord> search(String ns, String searchQuery,

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemover.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemover.java
@@ -56,7 +56,7 @@ final class DeletedDatasetMetadataRemover {
     for (NamespaceMeta namespaceMeta : nsStore.list()) {
       Set<MetadataSearchResultRecord> searchResults =
         metadataStore.search(namespaceMeta.getName(), "*", EnumSet.of(MetadataSearchTargetType.DATASET),
-                             SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 1, null).getResults();
+                             SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 0, null).getResults();
       for (MetadataSearchResultRecord searchResult : searchResults) {
         NamespacedEntityId entityId = searchResult.getEntityId();
         Preconditions.checkState(entityId instanceof DatasetId,

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataSearchResponse.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataSearchResponse.java
@@ -26,15 +26,17 @@ public class MetadataSearchResponse {
   private final String sort;
   private final int offset;
   private final int limit;
+  private final int numCursors;
   private final int total;
   private final Set<MetadataSearchResultRecord> results;
   private final List<String> cursors;
 
-  public MetadataSearchResponse(String sort, int offset, int limit, int total,
+  public MetadataSearchResponse(String sort, int offset, int limit, int numCursors, int total,
                                 Set<MetadataSearchResultRecord> results, List<String> cursors) {
     this.sort = sort;
     this.offset = offset;
     this.limit = limit;
+    this.numCursors = numCursors;
     this.total = total;
     this.results = results;
     this.cursors = cursors;
@@ -50,6 +52,10 @@ public class MetadataSearchResponse {
 
   public int getLimit() {
     return limit;
+  }
+
+  public int getNumCursors() {
+    return numCursors;
   }
 
   public int getTotal() {

--- a/cdap-ui/README.rst
+++ b/cdap-ui/README.rst
@@ -28,7 +28,7 @@ Prerequisites
   CDAP UI extensively uses ``bower``, ``gulp``, and ``webpack`` during its build process.
   Even though it's not necessary, it will be useful if they are installed globally::
 
-    $ npm instal gulp bower webpack -g
+    $ npm install gulp bower webpack -g
 
 Install Dependencies
 --------------------
@@ -43,7 +43,7 @@ Building CDAP in React
 ::
 
   $ npm run cdap-dev-build ## build version
-  $ npm run cdap-dev-buil-w ## watch version
+  $ npm run cdap-dev-build-w ## watch version
 
 
 Building Hydrator and Tracker in Angular

--- a/cdap-ui/app/cdap/api/search.js
+++ b/cdap-ui/app/cdap/api/search.js
@@ -21,5 +21,5 @@ let dataSrc = DataSourceConfigurer.getInstance();
 let searchpath = '/namespaces/:namespace/metadata/search';
 
 export const MySearchApi = {
-  search: apiCreator(dataSrc, 'GET', 'REQUEST', searchpath),
+  search: apiCreator(dataSrc, 'GET', 'REQUEST', searchpath + '?numCursors=10&'),
 };

--- a/cdap-ui/app/cdap/components/Home/index.js
+++ b/cdap-ui/app/cdap/components/Home/index.js
@@ -69,16 +69,28 @@ class Home extends Component {
 
     this.sortOptions = [
       {
-        displayName: T.translate('features.Home.Header.sortOptions.nameAsc.displayName'),
-        sort: 'name',
+        displayName: T.translate('features.Home.Header.sortOptions.entityNameAsc.displayName'),
+        sort: 'entity-name',
         order: 'asc',
-        fullSort: 'name asc'
+        fullSort: 'entity-name asc'
       },
       {
-        displayName: T.translate('features.Home.Header.sortOptions.nameDesc.displayName'),
-        sort: 'name',
+        displayName: T.translate('features.Home.Header.sortOptions.entityNameDesc.displayName'),
+        sort: 'entity-name',
         order: 'desc',
-        fullSort: 'name desc'
+        fullSort: 'entity-name desc'
+      },
+      {
+        displayName: T.translate('features.Home.Header.sortOptions.creationTimeAsc.displayName'),
+        sort: 'creation-time',
+        order: 'asc',
+        fullSort: 'creation-time asc'
+      },
+      {
+        displayName: T.translate('features.Home.Header.sortOptions.creationTimeDesc.displayName'),
+        sort: 'creation-time',
+        order: 'desc',
+        fullSort: 'creation-time desc'
       }
     ];
 
@@ -256,7 +268,7 @@ class Home extends Component {
       namespace: namespace,
       query: `${query}*`,
       target: filter,
-      size: this.pageSize,
+      limit: this.pageSize,
       offset: offset,
       sort: sortObj.fullSort
     };

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -78,10 +78,14 @@ features:
       sort: Sort
       pagination: Page
       sortOptions:
-        nameAsc:
+        entityNameAsc:
           displayName: A - Z
-        nameDesc:
+        entityNameDesc:
           displayName: Z - A
+        creationTimeDesc:
+          displayName: Most Recently Created
+        creationTimeAsc:
+          displayName: Least Recently Created
   Dashboard:
     Title: Dashboard
 


### PR DESCRIPTION
	(CDAP-5068) Various pagination fixes  …
- MetadataDataset returns:
  - 'limit' + (numCursors * limit) number of results for queries that use custom index
  - all results for queries that use default index
- In addition, for custom index queries, it also provides a hint to calculate the total results based on the number of cursors
- MetadataStore then uses the above information to:
  - apply pagination for queries that use custom indexes
  - apply sorting + offset + pagination for queries that use default indexes
- In addition, MetadataStore also returns the right 'total' number of results
- Fixed the semantics of 'numCursors' so that if 'n' cursors are requested, 'n' are returned, unless there isn't enough data
  - Also added a validation that numCursors should not be specified for relevance search
- Refactored MetadataHttpHandlerTestRun and added missing tests for pagination
- UI updates for changes to sorting and pagination query parameters


Jira: [CDAP-5068](https://issues.cask.co/browse/CDAP-5068)
Build: http://builds.cask.co/browse/CDAP-RUT325