### PR TITLE
[CDAP-7624] Fix issue where readless incrememts from different MR tasks cancel out each other

### DIFF
--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableTest.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableTest.java
@@ -67,7 +67,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -110,10 +112,10 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
 
   @Override
   protected BufferingTable getTable(DatasetContext datasetContext, String name,
-                                    DatasetProperties props) throws Exception {
+                                    DatasetProperties props, Map<String, String> args) throws Exception {
     // ttl=-1 means "keep data forever"
     DatasetSpecification spec = TABLE_DEFINITION.configure(name, props);
-    return new HBaseTable(datasetContext, spec, cConf, TEST_HBASE.getConfiguration(), hBaseTableUtil);
+    return new HBaseTable(datasetContext, spec, args, cConf, TEST_HBASE.getConfiguration(), hBaseTableUtil);
   }
 
   @Override
@@ -146,7 +148,8 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
     DatasetSpecification ttlTableSpec = DatasetSpecification.builder(ttlTable, HBaseTable.class.getName())
       .properties(props.getProperties())
       .build();
-    HBaseTable table = new HBaseTable(CONTEXT1, ttlTableSpec, cConf, TEST_HBASE.getConfiguration(), hBaseTableUtil);
+    HBaseTable table = new HBaseTable(CONTEXT1, ttlTableSpec, Collections.<String, String>emptyMap(),
+                                      cConf, TEST_HBASE.getConfiguration(), hBaseTableUtil);
 
     DetachedTxSystemClient txSystemClient = new DetachedTxSystemClient();
     Transaction tx = txSystemClient.startShort();
@@ -178,7 +181,8 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
     DatasetSpecification noTtlTableSpec = DatasetSpecification.builder(noTtlTable, HBaseTable.class.getName())
       .properties(props2.getProperties())
       .build();
-    HBaseTable table2 = new HBaseTable(CONTEXT1, noTtlTableSpec, cConf, TEST_HBASE.getConfiguration(), hBaseTableUtil);
+    HBaseTable table2 = new HBaseTable(CONTEXT1, noTtlTableSpec, Collections.<String, String>emptyMap(),
+                                       cConf, TEST_HBASE.getConfiguration(), hBaseTableUtil);
 
     tx = txSystemClient.startShort();
     table2.startTx(tx);
@@ -333,5 +337,4 @@ public class HBaseTableTest extends BufferingTableTest<BufferingTable> {
   private static byte[] b(String s) {
     return Bytes.toBytes(s);
   }
-
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableDefinition.java
@@ -47,7 +47,7 @@ public class HBaseTableDefinition extends AbstractTableDefinition<Table, HBaseTa
   @Override
   public Table getDataset(DatasetContext datasetContext, DatasetSpecification spec,
                           Map<String, String> arguments, ClassLoader classLoader) throws IOException {
-    return new HBaseTable(datasetContext, spec, cConf, hConf, hBaseTableUtil);
+    return new HBaseTable(datasetContext, spec, arguments, cConf, hConf, hBaseTableUtil);
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/inmemory/InMemoryTableTest.java
@@ -24,6 +24,8 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.dataset2.lib.table.BufferingTableTest;
 import co.cask.cdap.data2.dataset2.lib.table.TableProperties;
 
+import java.util.Map;
+
 /**
  *
  */
@@ -33,7 +35,7 @@ public class InMemoryTableTest extends BufferingTableTest<InMemoryTable> {
 
   @Override
   protected InMemoryTable getTable(DatasetContext datasetContext, String name,
-                                   DatasetProperties props) throws Exception {
+                                   DatasetProperties props, Map<String, String> runtimeArguments) throws Exception {
     ConflictDetection conflictLevel =
       TableProperties.getConflictDetectionLevel(props.getProperties(), ConflictDetection.ROW);
     return new InMemoryTable(datasetContext, name, conflictLevel, cConf);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableTest.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * test for LevelDB tables.
@@ -75,7 +76,7 @@ public class LevelDBTableTest extends BufferingTableTest<LevelDBTable> {
 
   @Override
   protected LevelDBTable getTable(DatasetContext datasetContext, String name,
-                                  DatasetProperties props) throws Exception {
+                                  DatasetProperties props, Map<String, String> runtimeArguments) throws Exception {
     DatasetSpecification spec = DatasetSpecification.builder(name, "table").properties(props.getProperties()).build();
     return new LevelDBTable(datasetContext, name, service, cConf, spec);
   }

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementHandler.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/increment/hbase98/IncrementHandler.java
@@ -27,10 +27,13 @@ import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Increment;
 import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
@@ -44,6 +47,7 @@ import org.apache.hadoop.hbase.regionserver.Store;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.regionserver.wal.WALEdit;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.tephra.TxConstants;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -72,7 +76,6 @@ public class IncrementHandler extends BaseRegionObserver {
   private HRegion region;
   private IncrementHandlerState state;
 
-
   @Override
   public void start(CoprocessorEnvironment e) throws IOException {
     if (e instanceof RegionCoprocessorEnvironment) {
@@ -90,7 +93,7 @@ public class IncrementHandler extends BaseRegionObserver {
   }
 
   @VisibleForTesting
-  public void setTimestampOracle(TimestampOracle timeOracle) {
+  void setTimestampOracle(TimestampOracle timeOracle) {
     state.setTimestampOracle(timeOracle);
   }
 
@@ -118,6 +121,58 @@ public class IncrementHandler extends BaseRegionObserver {
         scanner.close();
       }
     }
+  }
+
+  @Override
+  public Result preIncrementAfterRowLock(ObserverContext<RegionCoprocessorEnvironment> e, Increment increment)
+    throws IOException {
+
+    // this should only trigger for a transactional readless increment
+    boolean isIncrement = increment.getAttribute(HBaseTable.DELTA_WRITE) != null;
+    boolean transactional = state.containsTransactionalFamily(increment.getFamilyCellMap().keySet());
+    if (!isIncrement || !transactional) {
+      return null;
+    }
+    byte[] txBytes = increment.getAttribute(TxConstants.TX_OPERATION_ATTRIBUTE_KEY);
+    if (txBytes == null) {
+      throw new IllegalArgumentException("Attribute " + TxConstants.TX_OPERATION_ATTRIBUTE_KEY
+                                           + " must be set for transactional readless increments");
+    }
+    byte[] wpBytes = increment.getAttribute(HBaseTable.WRITE_POINTER);
+    if (wpBytes == null) {
+      throw new IllegalArgumentException("Attribute " + HBaseTable.WRITE_POINTER
+                                           + " must be set for transactional readless increments");
+    }
+    long writeVersion = Bytes.toLong(wpBytes);
+    Get get = new Get(increment.getRow());
+    get.setAttribute(TxConstants.TX_OPERATION_ATTRIBUTE_KEY, txBytes);
+    for (Map.Entry<byte[], NavigableMap<byte[], Long>> entry : increment.getFamilyMapOfLongs().entrySet()) {
+      byte[] family = entry.getKey();
+      for (byte[] column : entry.getValue().keySet()) {
+        get.addColumn(family, column);
+      }
+    }
+    Result result = region.get(get);
+
+    Put put = new Put(increment.getRow());
+    for (Map.Entry<byte[], NavigableMap<byte[], Long>> entry : increment.getFamilyMapOfLongs().entrySet()) {
+      byte[] family = entry.getKey();
+      for (Map.Entry<byte[], Long> colEntry: entry.getValue().entrySet()) {
+        byte[] column = colEntry.getKey();
+        long value = colEntry.getValue();
+        byte[] existingValue = result.getValue(family, column);
+        if (existingValue != null) {
+          long delta = Bytes.toLong(existingValue);
+          value += delta;
+        }
+        put.add(new KeyValue(increment.getRow(), family, column, writeVersion, Bytes.toBytes(value)));
+      }
+    }
+    if (!put.isEmpty()) {
+      region.put(put);
+    }
+    e.bypass();
+    return new Result();
   }
 
   @Override
@@ -204,7 +259,7 @@ public class IncrementHandler extends BaseRegionObserver {
         ScanType.COMPACT_RETAIN_DELETES, state.getCompactionBound(family), state.getOldestVisibleTimestamp(family));
   }
 
-  public static boolean isIncrement(Cell cell) {
+  static boolean isIncrement(Cell cell) {
     return !CellUtil.isDelete(cell) && cell.getValueLength() == IncrementHandlerState.DELTA_FULL_LENGTH &&
       Bytes.equals(cell.getValueArray(), cell.getValueOffset(), IncrementHandlerState.DELTA_MAGIC_PREFIX.length,
                    IncrementHandlerState.DELTA_MAGIC_PREFIX, 0, IncrementHandlerState.DELTA_MAGIC_PREFIX.length);

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementHandler.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/increment/hbase10cdh/IncrementHandler.java
@@ -27,10 +27,13 @@ import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Increment;
 import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
@@ -44,6 +47,7 @@ import org.apache.hadoop.hbase.regionserver.Store;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.regionserver.wal.WALEdit;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.tephra.TxConstants;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -72,7 +76,6 @@ public class IncrementHandler extends BaseRegionObserver {
   private HRegion region;
   private IncrementHandlerState state;
 
-
   @Override
   public void start(CoprocessorEnvironment e) throws IOException {
     if (e instanceof RegionCoprocessorEnvironment) {
@@ -90,7 +93,7 @@ public class IncrementHandler extends BaseRegionObserver {
   }
 
   @VisibleForTesting
-  public void setTimestampOracle(TimestampOracle timeOracle) {
+  void setTimestampOracle(TimestampOracle timeOracle) {
     state.setTimestampOracle(timeOracle);
   }
 
@@ -118,6 +121,58 @@ public class IncrementHandler extends BaseRegionObserver {
         scanner.close();
       }
     }
+  }
+
+  @Override
+  public Result preIncrementAfterRowLock(ObserverContext<RegionCoprocessorEnvironment> e, Increment increment)
+    throws IOException {
+
+    // this should only trigger for a transactional readless increment
+    boolean isIncrement = increment.getAttribute(HBaseTable.DELTA_WRITE) != null;
+    boolean transactional = state.containsTransactionalFamily(increment.getFamilyCellMap().keySet());
+    if (!isIncrement || !transactional) {
+      return null;
+    }
+    byte[] txBytes = increment.getAttribute(TxConstants.TX_OPERATION_ATTRIBUTE_KEY);
+    if (txBytes == null) {
+      throw new IllegalArgumentException("Attribute " + TxConstants.TX_OPERATION_ATTRIBUTE_KEY
+                                           + " must be set for transactional readless increments");
+    }
+    byte[] wpBytes = increment.getAttribute(HBaseTable.WRITE_POINTER);
+    if (wpBytes == null) {
+      throw new IllegalArgumentException("Attribute " + HBaseTable.WRITE_POINTER
+                                           + " must be set for transactional readless increments");
+    }
+    long writeVersion = Bytes.toLong(wpBytes);
+    Get get = new Get(increment.getRow());
+    get.setAttribute(TxConstants.TX_OPERATION_ATTRIBUTE_KEY, txBytes);
+    for (Map.Entry<byte[], NavigableMap<byte[], Long>> entry : increment.getFamilyMapOfLongs().entrySet()) {
+      byte[] family = entry.getKey();
+      for (byte[] column : entry.getValue().keySet()) {
+        get.addColumn(family, column);
+      }
+    }
+    Result result = region.get(get);
+
+    Put put = new Put(increment.getRow());
+    for (Map.Entry<byte[], NavigableMap<byte[], Long>> entry : increment.getFamilyMapOfLongs().entrySet()) {
+      byte[] family = entry.getKey();
+      for (Map.Entry<byte[], Long> colEntry: entry.getValue().entrySet()) {
+        byte[] column = colEntry.getKey();
+        long value = colEntry.getValue();
+        byte[] existingValue = result.getValue(family, column);
+        if (existingValue != null) {
+          long delta = Bytes.toLong(existingValue);
+          value += delta;
+        }
+        put.add(new KeyValue(increment.getRow(), family, column, writeVersion, Bytes.toBytes(value)));
+      }
+    }
+    if (!put.isEmpty()) {
+      region.put(put);
+    }
+    e.bypass();
+    return new Result();
   }
 
   @Override
@@ -204,7 +259,7 @@ public class IncrementHandler extends BaseRegionObserver {
         ScanType.COMPACT_RETAIN_DELETES, state.getCompactionBound(family), state.getOldestVisibleTimestamp(family));
   }
 
-  public static boolean isIncrement(Cell cell) {
+  static boolean isIncrement(Cell cell) {
     return !CellUtil.isDelete(cell) && cell.getValueLength() == IncrementHandlerState.DELTA_FULL_LENGTH &&
       Bytes.equals(cell.getValueArray(), cell.getValueOffset(), IncrementHandlerState.DELTA_MAGIC_PREFIX.length,
                    IncrementHandlerState.DELTA_MAGIC_PREFIX, 0, IncrementHandlerState.DELTA_MAGIC_PREFIX.length);

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/increment/hbase10cdh550/IncrementHandler.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/increment/hbase10cdh550/IncrementHandler.java
@@ -27,10 +27,13 @@ import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Increment;
 import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
@@ -44,6 +47,7 @@ import org.apache.hadoop.hbase.regionserver.Store;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.regionserver.wal.WALEdit;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.tephra.TxConstants;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -72,7 +76,6 @@ public class IncrementHandler extends BaseRegionObserver {
   private HRegion region;
   private IncrementHandlerState state;
 
-
   @Override
   public void start(CoprocessorEnvironment e) throws IOException {
     if (e instanceof RegionCoprocessorEnvironment) {
@@ -90,7 +93,7 @@ public class IncrementHandler extends BaseRegionObserver {
   }
 
   @VisibleForTesting
-  public void setTimestampOracle(TimestampOracle timeOracle) {
+  void setTimestampOracle(TimestampOracle timeOracle) {
     state.setTimestampOracle(timeOracle);
   }
 
@@ -118,6 +121,58 @@ public class IncrementHandler extends BaseRegionObserver {
         scanner.close();
       }
     }
+  }
+
+  @Override
+  public Result preIncrementAfterRowLock(ObserverContext<RegionCoprocessorEnvironment> e, Increment increment)
+    throws IOException {
+
+    // this should only trigger for a transactional readless increment
+    boolean isIncrement = increment.getAttribute(HBaseTable.DELTA_WRITE) != null;
+    boolean transactional = state.containsTransactionalFamily(increment.getFamilyCellMap().keySet());
+    if (!isIncrement || !transactional) {
+      return null;
+    }
+    byte[] txBytes = increment.getAttribute(TxConstants.TX_OPERATION_ATTRIBUTE_KEY);
+    if (txBytes == null) {
+      throw new IllegalArgumentException("Attribute " + TxConstants.TX_OPERATION_ATTRIBUTE_KEY
+                                           + " must be set for transactional readless increments");
+    }
+    byte[] wpBytes = increment.getAttribute(HBaseTable.WRITE_POINTER);
+    if (wpBytes == null) {
+      throw new IllegalArgumentException("Attribute " + HBaseTable.WRITE_POINTER
+                                           + " must be set for transactional readless increments");
+    }
+    long writeVersion = Bytes.toLong(wpBytes);
+    Get get = new Get(increment.getRow());
+    get.setAttribute(TxConstants.TX_OPERATION_ATTRIBUTE_KEY, txBytes);
+    for (Map.Entry<byte[], NavigableMap<byte[], Long>> entry : increment.getFamilyMapOfLongs().entrySet()) {
+      byte[] family = entry.getKey();
+      for (byte[] column : entry.getValue().keySet()) {
+        get.addColumn(family, column);
+      }
+    }
+    Result result = region.get(get);
+
+    Put put = new Put(increment.getRow());
+    for (Map.Entry<byte[], NavigableMap<byte[], Long>> entry : increment.getFamilyMapOfLongs().entrySet()) {
+      byte[] family = entry.getKey();
+      for (Map.Entry<byte[], Long> colEntry: entry.getValue().entrySet()) {
+        byte[] column = colEntry.getKey();
+        long value = colEntry.getValue();
+        byte[] existingValue = result.getValue(family, column);
+        if (existingValue != null) {
+          long delta = Bytes.toLong(existingValue);
+          value += delta;
+        }
+        put.add(new KeyValue(increment.getRow(), family, column, writeVersion, Bytes.toBytes(value)));
+      }
+    }
+    if (!put.isEmpty()) {
+      region.put(put);
+    }
+    e.bypass();
+    return new Result();
   }
 
   @Override
@@ -204,7 +259,7 @@ public class IncrementHandler extends BaseRegionObserver {
         ScanType.COMPACT_RETAIN_DELETES, state.getCompactionBound(family), state.getOldestVisibleTimestamp(family));
   }
 
-  public static boolean isIncrement(Cell cell) {
+  static boolean isIncrement(Cell cell) {
     return !CellUtil.isDelete(cell) && cell.getValueLength() == IncrementHandlerState.DELTA_FULL_LENGTH &&
       Bytes.equals(cell.getValueArray(), cell.getValueOffset(), IncrementHandlerState.DELTA_MAGIC_PREFIX.length,
                    IncrementHandlerState.DELTA_MAGIC_PREFIX, 0, IncrementHandlerState.DELTA_MAGIC_PREFIX.length);

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/increment/hbase10/IncrementHandler.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/increment/hbase10/IncrementHandler.java
@@ -27,10 +27,13 @@ import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Increment;
 import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
@@ -44,6 +47,7 @@ import org.apache.hadoop.hbase.regionserver.Store;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.regionserver.wal.WALEdit;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.tephra.TxConstants;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -72,7 +76,6 @@ public class IncrementHandler extends BaseRegionObserver {
   private HRegion region;
   private IncrementHandlerState state;
 
-
   @Override
   public void start(CoprocessorEnvironment e) throws IOException {
     if (e instanceof RegionCoprocessorEnvironment) {
@@ -90,7 +93,7 @@ public class IncrementHandler extends BaseRegionObserver {
   }
 
   @VisibleForTesting
-  public void setTimestampOracle(TimestampOracle timeOracle) {
+  void setTimestampOracle(TimestampOracle timeOracle) {
     state.setTimestampOracle(timeOracle);
   }
 
@@ -118,6 +121,58 @@ public class IncrementHandler extends BaseRegionObserver {
         scanner.close();
       }
     }
+  }
+
+  @Override
+  public Result preIncrementAfterRowLock(ObserverContext<RegionCoprocessorEnvironment> e, Increment increment)
+    throws IOException {
+
+    // this should only trigger for a transactional readless increment
+    boolean isIncrement = increment.getAttribute(HBaseTable.DELTA_WRITE) != null;
+    boolean transactional = state.containsTransactionalFamily(increment.getFamilyCellMap().keySet());
+    if (!isIncrement || !transactional) {
+      return null;
+    }
+    byte[] txBytes = increment.getAttribute(TxConstants.TX_OPERATION_ATTRIBUTE_KEY);
+    if (txBytes == null) {
+      throw new IllegalArgumentException("Attribute " + TxConstants.TX_OPERATION_ATTRIBUTE_KEY
+                                           + " must be set for transactional readless increments");
+    }
+    byte[] wpBytes = increment.getAttribute(HBaseTable.WRITE_POINTER);
+    if (wpBytes == null) {
+      throw new IllegalArgumentException("Attribute " + HBaseTable.WRITE_POINTER
+                                           + " must be set for transactional readless increments");
+    }
+    long writeVersion = Bytes.toLong(wpBytes);
+    Get get = new Get(increment.getRow());
+    get.setAttribute(TxConstants.TX_OPERATION_ATTRIBUTE_KEY, txBytes);
+    for (Map.Entry<byte[], NavigableMap<byte[], Long>> entry : increment.getFamilyMapOfLongs().entrySet()) {
+      byte[] family = entry.getKey();
+      for (byte[] column : entry.getValue().keySet()) {
+        get.addColumn(family, column);
+      }
+    }
+    Result result = region.get(get);
+
+    Put put = new Put(increment.getRow());
+    for (Map.Entry<byte[], NavigableMap<byte[], Long>> entry : increment.getFamilyMapOfLongs().entrySet()) {
+      byte[] family = entry.getKey();
+      for (Map.Entry<byte[], Long> colEntry: entry.getValue().entrySet()) {
+        byte[] column = colEntry.getKey();
+        long value = colEntry.getValue();
+        byte[] existingValue = result.getValue(family, column);
+        if (existingValue != null) {
+          long delta = Bytes.toLong(existingValue);
+          value += delta;
+        }
+        put.add(new KeyValue(increment.getRow(), family, column, writeVersion, Bytes.toBytes(value)));
+      }
+    }
+    if (!put.isEmpty()) {
+      region.put(put);
+    }
+    e.bypass();
+    return new Result();
   }
 
   @Override
@@ -204,7 +259,7 @@ public class IncrementHandler extends BaseRegionObserver {
         ScanType.COMPACT_RETAIN_DELETES, state.getCompactionBound(family), state.getOldestVisibleTimestamp(family));
   }
 
-  public static boolean isIncrement(Cell cell) {
+  static boolean isIncrement(Cell cell) {
     return !CellUtil.isDelete(cell) && cell.getValueLength() == IncrementHandlerState.DELTA_FULL_LENGTH &&
       Bytes.equals(cell.getValueArray(), cell.getValueOffset(), IncrementHandlerState.DELTA_MAGIC_PREFIX.length,
                    IncrementHandlerState.DELTA_MAGIC_PREFIX, 0, IncrementHandlerState.DELTA_MAGIC_PREFIX.length);

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10IncrementBuilder.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10IncrementBuilder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+/**
+ * HBase 1.0 specific implementation for {@link PutBuilder}.
+ */
+class HBase10IncrementBuilder extends DefaultIncrementBuilder {
+
+  HBase10IncrementBuilder(byte[] row) {
+    super(row);
+  }
+
+  @Override
+  public IncrementBuilder setAttribute(String name, byte[] value) {
+    increment.setAttribute(name, value);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableUtil.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableUtil.java
@@ -277,6 +277,11 @@ public class HBase10TableUtil extends HBaseTableUtil {
   }
 
   @Override
+  public IncrementBuilder buildIncrement(byte[] row) {
+    return new HBase10IncrementBuilder(row);
+  }
+
+  @Override
   public PutBuilder buildPut(byte[] row) {
     return new HBase10PutBuilder(row);
   }

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/increment/hbase11/IncrementHandler.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/increment/hbase11/IncrementHandler.java
@@ -27,10 +27,13 @@ import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Increment;
 import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
@@ -44,6 +47,7 @@ import org.apache.hadoop.hbase.regionserver.Store;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.regionserver.wal.WALEdit;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.tephra.TxConstants;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -72,7 +76,6 @@ public class IncrementHandler extends BaseRegionObserver {
   private Region region;
   private IncrementHandlerState state;
 
-
   @Override
   public void start(CoprocessorEnvironment e) throws IOException {
     if (e instanceof RegionCoprocessorEnvironment) {
@@ -90,7 +93,7 @@ public class IncrementHandler extends BaseRegionObserver {
   }
 
   @VisibleForTesting
-  public void setTimestampOracle(TimestampOracle timeOracle) {
+  void setTimestampOracle(TimestampOracle timeOracle) {
     state.setTimestampOracle(timeOracle);
   }
 
@@ -118,6 +121,58 @@ public class IncrementHandler extends BaseRegionObserver {
         scanner.close();
       }
     }
+  }
+
+  @Override
+  public Result preIncrementAfterRowLock(ObserverContext<RegionCoprocessorEnvironment> e, Increment increment)
+    throws IOException {
+
+    // this should only trigger for a transactional readless increment
+    boolean isIncrement = increment.getAttribute(HBaseTable.DELTA_WRITE) != null;
+    boolean transactional = state.containsTransactionalFamily(increment.getFamilyCellMap().keySet());
+    if (!isIncrement || !transactional) {
+      return null;
+    }
+    byte[] txBytes = increment.getAttribute(TxConstants.TX_OPERATION_ATTRIBUTE_KEY);
+    if (txBytes == null) {
+      throw new IllegalArgumentException("Attribute " + TxConstants.TX_OPERATION_ATTRIBUTE_KEY
+                                           + " must be set for transactional readless increments");
+    }
+    byte[] wpBytes = increment.getAttribute(HBaseTable.WRITE_POINTER);
+    if (wpBytes == null) {
+      throw new IllegalArgumentException("Attribute " + HBaseTable.WRITE_POINTER
+                                           + " must be set for transactional readless increments");
+    }
+    long writeVersion = Bytes.toLong(wpBytes);
+    Get get = new Get(increment.getRow());
+    get.setAttribute(TxConstants.TX_OPERATION_ATTRIBUTE_KEY, txBytes);
+    for (Map.Entry<byte[], NavigableMap<byte[], Long>> entry : increment.getFamilyMapOfLongs().entrySet()) {
+      byte[] family = entry.getKey();
+      for (byte[] column : entry.getValue().keySet()) {
+        get.addColumn(family, column);
+      }
+    }
+    Result result = region.get(get);
+
+    Put put = new Put(increment.getRow());
+    for (Map.Entry<byte[], NavigableMap<byte[], Long>> entry : increment.getFamilyMapOfLongs().entrySet()) {
+      byte[] family = entry.getKey();
+      for (Map.Entry<byte[], Long> colEntry: entry.getValue().entrySet()) {
+        byte[] column = colEntry.getKey();
+        long value = colEntry.getValue();
+        byte[] existingValue = result.getValue(family, column);
+        if (existingValue != null) {
+          long delta = Bytes.toLong(existingValue);
+          value += delta;
+        }
+        put.add(new KeyValue(increment.getRow(), family, column, writeVersion, Bytes.toBytes(value)));
+      }
+    }
+    if (!put.isEmpty()) {
+      region.put(put);
+    }
+    e.bypass();
+    return new Result();
   }
 
   @Override
@@ -204,7 +259,7 @@ public class IncrementHandler extends BaseRegionObserver {
         ScanType.COMPACT_RETAIN_DELETES, state.getCompactionBound(family), state.getOldestVisibleTimestamp(family));
   }
 
-  public static boolean isIncrement(Cell cell) {
+  static boolean isIncrement(Cell cell) {
     return !CellUtil.isDelete(cell) && cell.getValueLength() == IncrementHandlerState.DELTA_FULL_LENGTH &&
       Bytes.equals(cell.getValueArray(), cell.getValueOffset(), IncrementHandlerState.DELTA_MAGIC_PREFIX.length,
                    IncrementHandlerState.DELTA_MAGIC_PREFIX, 0, IncrementHandlerState.DELTA_MAGIC_PREFIX.length);

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/HBase11IncrementBuilder.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/HBase11IncrementBuilder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+/**
+ * HBase 1.0 specific implementation for {@link PutBuilder}.
+ */
+class HBase11IncrementBuilder extends DefaultIncrementBuilder {
+
+  HBase11IncrementBuilder(byte[] row) {
+    super(row);
+  }
+
+  @Override
+  public IncrementBuilder setAttribute(String name, byte[] value) {
+    increment.setAttribute(name, value);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/HBase11TableUtil.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/HBase11TableUtil.java
@@ -277,6 +277,11 @@ public class HBase11TableUtil extends HBaseTableUtil {
   }
 
   @Override
+  public IncrementBuilder buildIncrement(byte[] row) {
+    return new HBase11IncrementBuilder(row);
+  }
+
+  @Override
   public PutBuilder buildPut(byte[] row) {
     return new HBase11PutBuilder(row);
   }

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/increment/hbase12cdh570/IncrementHandler.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/increment/hbase12cdh570/IncrementHandler.java
@@ -27,10 +27,13 @@ import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Increment;
 import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
@@ -44,6 +47,7 @@ import org.apache.hadoop.hbase.regionserver.Store;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.regionserver.wal.WALEdit;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.tephra.TxConstants;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -72,7 +76,6 @@ public class IncrementHandler extends BaseRegionObserver {
   private Region region;
   private IncrementHandlerState state;
 
-
   @Override
   public void start(CoprocessorEnvironment e) throws IOException {
     if (e instanceof RegionCoprocessorEnvironment) {
@@ -90,7 +93,7 @@ public class IncrementHandler extends BaseRegionObserver {
   }
 
   @VisibleForTesting
-  public void setTimestampOracle(TimestampOracle timeOracle) {
+  void setTimestampOracle(TimestampOracle timeOracle) {
     state.setTimestampOracle(timeOracle);
   }
 
@@ -118,6 +121,58 @@ public class IncrementHandler extends BaseRegionObserver {
         scanner.close();
       }
     }
+  }
+
+  @Override
+  public Result preIncrementAfterRowLock(ObserverContext<RegionCoprocessorEnvironment> e, Increment increment)
+    throws IOException {
+
+    // this should only trigger for a transactional readless increment
+    boolean isIncrement = increment.getAttribute(HBaseTable.DELTA_WRITE) != null;
+    boolean transactional = state.containsTransactionalFamily(increment.getFamilyCellMap().keySet());
+    if (!isIncrement || !transactional) {
+      return null;
+    }
+    byte[] txBytes = increment.getAttribute(TxConstants.TX_OPERATION_ATTRIBUTE_KEY);
+    if (txBytes == null) {
+      throw new IllegalArgumentException("Attribute " + TxConstants.TX_OPERATION_ATTRIBUTE_KEY
+                                           + " must be set for transactional readless increments");
+    }
+    byte[] wpBytes = increment.getAttribute(HBaseTable.WRITE_POINTER);
+    if (wpBytes == null) {
+      throw new IllegalArgumentException("Attribute " + HBaseTable.WRITE_POINTER
+                                           + " must be set for transactional readless increments");
+    }
+    long writeVersion = Bytes.toLong(wpBytes);
+    Get get = new Get(increment.getRow());
+    get.setAttribute(TxConstants.TX_OPERATION_ATTRIBUTE_KEY, txBytes);
+    for (Map.Entry<byte[], NavigableMap<byte[], Long>> entry : increment.getFamilyMapOfLongs().entrySet()) {
+      byte[] family = entry.getKey();
+      for (byte[] column : entry.getValue().keySet()) {
+        get.addColumn(family, column);
+      }
+    }
+    Result result = region.get(get);
+
+    Put put = new Put(increment.getRow());
+    for (Map.Entry<byte[], NavigableMap<byte[], Long>> entry : increment.getFamilyMapOfLongs().entrySet()) {
+      byte[] family = entry.getKey();
+      for (Map.Entry<byte[], Long> colEntry: entry.getValue().entrySet()) {
+        byte[] column = colEntry.getKey();
+        long value = colEntry.getValue();
+        byte[] existingValue = result.getValue(family, column);
+        if (existingValue != null) {
+          long delta = Bytes.toLong(existingValue);
+          value += delta;
+        }
+        put.add(new KeyValue(increment.getRow(), family, column, writeVersion, Bytes.toBytes(value)));
+      }
+    }
+    if (!put.isEmpty()) {
+      region.put(put);
+    }
+    e.bypass();
+    return new Result();
   }
 
   @Override
@@ -204,7 +259,7 @@ public class IncrementHandler extends BaseRegionObserver {
         ScanType.COMPACT_RETAIN_DELETES, state.getCompactionBound(family), state.getOldestVisibleTimestamp(family));
   }
 
-  public static boolean isIncrement(Cell cell) {
+  static boolean isIncrement(Cell cell) {
     return !CellUtil.isDelete(cell) && cell.getValueLength() == IncrementHandlerState.DELTA_FULL_LENGTH &&
       Bytes.equals(cell.getValueArray(), cell.getValueOffset(), IncrementHandlerState.DELTA_MAGIC_PREFIX.length,
                    IncrementHandlerState.DELTA_MAGIC_PREFIX, 0, IncrementHandlerState.DELTA_MAGIC_PREFIX.length);

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570IncrementBuilder.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570IncrementBuilder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+/**
+ * HBase 1.0 specific implementation for {@link PutBuilder}.
+ */
+class HBase12CDH570IncrementBuilder extends DefaultIncrementBuilder {
+
+  HBase12CDH570IncrementBuilder(byte[] row) {
+    super(row);
+  }
+
+  @Override
+  public IncrementBuilder setAttribute(String name, byte[] value) {
+    increment.setAttribute(name, value);
+    return this;
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570TableUtil.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570TableUtil.java
@@ -277,6 +277,11 @@ public class HBase12CDH570TableUtil extends HBaseTableUtil {
   }
 
   @Override
+  public IncrementBuilder buildIncrement(byte[] row) {
+    return new HBase12CDH570IncrementBuilder(row);
+  }
+
+  @Override
   public PutBuilder buildPut(byte[] row) {
     return new HBase12CDH570PutBuilder(row);
   }

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/DefaultIncrementBuilder.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/DefaultIncrementBuilder.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.api.common.Bytes;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.client.Increment;
+
+import java.io.IOException;
+
+/**
+ * Default implementation of {@link IncrementBuilder}. Specific HBase compat module can extends and override methods.
+ */
+class DefaultIncrementBuilder implements IncrementBuilder {
+
+  protected final Increment increment;
+
+  DefaultIncrementBuilder(byte[] row) {
+    this.increment = new Increment(row);
+  }
+
+  @Override
+  public IncrementBuilder add(byte[] family, byte[] qualifier, long value) {
+    increment.addColumn(family, qualifier, value);
+    return this;
+  }
+
+  @Override
+  public IncrementBuilder add(byte[] family, byte[] qualifier, long ts, long value) throws IOException {
+    increment.add(new KeyValue(increment.getRow(), family, qualifier, ts, Bytes.toBytes(value)));
+    return this;
+  }
+
+  @Override
+  public IncrementBuilder setAttribute(String name, byte[] value) {
+    increment.setAttribute(name, value);
+    return this;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return increment.isEmpty();
+  }
+
+  @Override
+  public Increment build() {
+    return increment;
+  }
+
+  @Override
+  public String toString() {
+    return increment.toString();
+  }
+}

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
@@ -704,6 +704,13 @@ public abstract class HBaseTableUtil {
   }
 
   /**
+   * Creates a {@link IncrementBuilder} for the given row.
+   */
+  public IncrementBuilder buildIncrement(byte[] row) {
+    return new DefaultIncrementBuilder(row);
+  }
+
+  /**
    * Creates a {@link PutBuilder} by copying from another {@link Put} instance.
    */
   public PutBuilder buildPut(Put put) {

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/IncrementBuilder.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/IncrementBuilder.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import org.apache.hadoop.hbase.client.Increment;
+
+import java.io.IOException;
+
+/**
+ * Builder for creating {@link Increment}. This builder should be used for cross HBase versions compatibility.
+ * All methods on this class are just delegating to calls to {@link Increment} object.
+ */
+public interface IncrementBuilder {
+
+  IncrementBuilder add(byte[] family, byte[] qualifier, long value);
+
+  IncrementBuilder add(byte[] family, byte[] qualifier, long ts, long value) throws IOException;
+
+  IncrementBuilder setAttribute(String name, byte[] value);
+
+  boolean isEmpty();
+
+  Increment build();
+}


### PR DESCRIPTION
Issue is that all tasks write a delta with the same version. They don't check whether there is already a delta with the same write version. The fix is this:
- introduce a new runtime argument (to be used in MR) "safe.readless.increments"
- if this argument is true, then HBaseTable, upon persist(), issues an increment() to HBase instead of a put()
- the Increment() is handled region-server-side in a new coprocessor hook. It performs a get of the counters to be incremented, adds the increments, and then puts them back. All this happens under row lock. 
- this needs to be copied to all hbase-compat modules (lots of duplication!) 

Open questions: 
- How can we test this for all HBase versions? It turns out that we do not have any tests for readless increments with transactions in the compat modules. That means right now, they are only tested for HBase-0.98 (which is used by HBaseTableTest)
- HBase 0.96 does not have a coprocessor hook for increments while holding the lock. It is not clear how race conditions can be avoided there. Is it worth doing a different design for 0.96?
- Should we rely on the user to set this runtime argument when a table is used for readless increments in MR? Or should the MR dataset context always add this argument to all datasets?

When reviewing, please only review one compat module. The changes for other compat modules are identical (except for 0.96, it uses the preIncrement() instead of preIncrementAfterRowLock(). 
