### PR TITLE
Revert "CDAP-7176 Pass in the current user's short username to CLISer…

### DIFF
--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -1201,11 +1201,7 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
 
   // no new methods should use this directly. Instead, use openHiveSession
   protected SessionHandle doOpenHiveSession(Map<String, String> sessionConf) throws HiveSQLException {
-    try {
-      return cliService.openSession(UserGroupInformation.getCurrentUser().getShortUserName(), "", sessionConf);
-    } catch (IOException e) {
-      throw Throwables.propagate(e);
-    }
+    return cliService.openSession("", "", sessionConf);
   }
 
   private void closeHiveSession(SessionHandle sessionHandle) {


### PR DESCRIPTION
Revert "CDAP-7176 Pass in the current user's short username to CLIService#openSession, instead of empty string. This can be used by Hive to determine the YARN queue to be used."

This reverts commit 3725c9bf322dfee0cc9831b839813b98fe06dcbc.

This fix can't be simply backported to 3.5, because it triggers a codepath in hive code, which doesn't execute as expected, because we don't properly set up the explore classpath:

```
java.lang.RuntimeException: Could not load shims in class org.apache.hadoop.hive.schshim.FairSchedulerShim
        at org.apache.hadoop.hive.shims.ShimLoader.createShim(ShimLoader.java:150)
        at org.apache.hadoop.hive.shims.ShimLoader.getSchedulerShims(ShimLoader.java:134)
        at org.apache.hadoop.hive.shims.Hadoop23Shims.refreshDefaultQueue(Hadoop23Shims.java:304)
        at org.apache.hive.service.cli.session.HiveSessionImpl.<init>(HiveSessionImpl.java:111)
        at org.apache.hive.service.cli.session.SessionManager.openSession(SessionManager.java:193)
        at org.apache.hive.service.cli.CLIService.openSession(CLIService.java:173)
        at co.cask.cdap.explore.service.hive.BaseHiveExploreService.doOpenHiveSession(BaseHiveExploreService.java:1205)
        at co.cask.cdap.explore.service.hive.BaseHiveExploreService.openHiveSession(BaseHiveExploreService.java:1192)
        at co.cask.cdap.explore.service.hive.BaseHiveExploreService.createNamespace(BaseHiveExploreService.java:730)
        at co.cask.cdap.explore.executor.ExploreMetadataHttpHandler$5$1.call(ExploreMetadataHttpHandler.java:143)
        at co.cask.cdap.explore.executor.ExploreMetadataHttpHandler$5$1.call(ExploreMetadataHttpHandler.java:140)
        at co.cask.cdap.common.security.ImpersonationUtils$1.run(ImpersonationUtils.java:46)
        at java.security.AccessController.doPrivileged(Native Method)
        at javax.security.auth.Subject.doAs(Subject.java:415)
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1678)
        at co.cask.cdap.common.security.ImpersonationUtils.doAs(ImpersonationUtils.java:43)
        at co.cask.cdap.common.security.DefaultImpersonator.doAs(DefaultImpersonator.java:64)
        at co.cask.cdap.explore.executor.ExploreMetadataHttpHandler$5.execute(ExploreMetadataHttpHandler.java:140)
        at co.cask.cdap.explore.executor.ExploreMetadataHttpHandler$5.execute(ExploreMetadataHttpHandler.java:130)
        at co.cask.cdap.explore.executor.AbstractExploreMetadataHttpHandler$1.execute(AbstractExploreMetadataHttpHandler.java:53)
        at co.cask.cdap.explore.executor.AbstractExploreMetadataHttpHandler$1.execute(AbstractExploreMetadataHttpHandler.java:49)
        at co.cask.cdap.explore.executor.AbstractExploreMetadataHttpHandler.genericEndpointExecution(AbstractExploreMetadataHttpHandler.java:65)
        at co.cask.cdap.explore.executor.AbstractExploreMetadataHttpHandler.handleResponseEndpointExecution(AbstractExploreMetadataHttpHandler.java:49)
        at co.cask.cdap.explore.executor.ExploreMetadataHttpHandler.create(ExploreMetadataHttpHandler.java:130)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at co.cask.http.HttpMethodInfo.invoke(HttpMethodInfo.java:80)
        at co.cask.http.HttpDispatcher.messageReceived(HttpDispatcher.java:38)
        at org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:70)
        at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:564)
        at org.jboss.netty.channel.DefaultChannelPipeline$DefaultChannelHandlerContext.sendUpstream(DefaultChannelPipeline.java:791)
        at org.jboss.netty.channel.SimpleChannelUpstreamHandler.messageReceived(SimpleChannelUpstreamHandler.java:124)
        at co.cask.cdap.common.http.AuthenticationChannelHandler.messageReceived(AuthenticationChannelHandler.java:64)
        at org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:70)
        at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:564)
        at org.jboss.netty.channel.DefaultChannelPipeline$DefaultChannelHandlerContext.sendUpstream(DefaultChannelPipeline.java:791)
        at org.jboss.netty.handler.execution.ChannelUpstreamEventRunnable.doRun(ChannelUpstreamEventRunnable.java:43)
        at org.jboss.netty.handler.execution.ChannelEventRunnable.run(ChannelEventRunnable.java:67)
        at org.jboss.netty.handler.execution.OrderedMemoryAwareThreadPoolExecutor$ChildExecutor.run(OrderedMemoryAwareThreadPoolExecutor.java:314)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
        at java.lang.Thread.run(Thread.java:745)
java.lang.ClassNotFoundException: org.apache.hadoop.hive.schshim.FairSchedulerShim
        at java.net.URLClassLoader$1.run(URLClassLoader.java:366)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:355)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.net.URLClassLoader.findClass(URLClassLoader.java:354)
        at co.cask.cdap.common.lang.InterceptableClassLoader.findClass(InterceptableClassLoader.java:36)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:425)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:358)
        at java.lang.Class.forName0(Native Method)
        at java.lang.Class.forName(Class.java:191)
        at org.apache.hadoop.hive.shims.ShimLoader.createShim(ShimLoader.java:147)
        at org.apache.hadoop.hive.shims.ShimLoader.getSchedulerShims(ShimLoader.java:134)
        at org.apache.hadoop.hive.shims.Hadoop23Shims.refreshDefaultQueue(Hadoop23Shims.java:304)
        at org.apache.hive.service.cli.session.HiveSessionImpl.<init>(HiveSessionImpl.java:111)
        at org.apache.hive.service.cli.session.SessionManager.openSession(SessionManager.java:193)
        at org.apache.hive.service.cli.CLIService.openSession(CLIService.java:173)
        at co.cask.cdap.explore.service.hive.BaseHiveExploreService.doOpenHiveSession(BaseHiveExploreService.java:1205)
        at co.cask.cdap.explore.service.hive.BaseHiveExploreService.openHiveSession(BaseHiveExploreService.java:1192)
        at co.cask.cdap.explore.service.hive.BaseHiveExploreService.createNamespace(BaseHiveExploreService.java:730)
        at co.cask.cdap.explore.executor.ExploreMetadataHttpHandler$5$1.call(ExploreMetadataHttpHandler.java:143)
        at co.cask.cdap.explore.executor.ExploreMetadataHttpHandler$5$1.call(ExploreMetadataHttpHandler.java:140)
        at co.cask.cdap.common.security.ImpersonationUtils$1.run(ImpersonationUtils.java:46)
        at java.security.AccessController.doPrivileged(Native Method)
        at javax.security.auth.Subject.doAs(Subject.java:415)
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1678)
        at co.cask.cdap.common.security.ImpersonationUtils.doAs(ImpersonationUtils.java:43)
        at co.cask.cdap.common.security.DefaultImpersonator.doAs(DefaultImpersonator.java:64)
        at co.cask.cdap.explore.executor.ExploreMetadataHttpHandler$5.execute(ExploreMetadataHttpHandler.java:140)
        at co.cask.cdap.explore.executor.ExploreMetadataHttpHandler$5.execute(ExploreMetadataHttpHandler.java:130)
        at co.cask.cdap.explore.executor.AbstractExploreMetadataHttpHandler$1.execute(AbstractExploreMetadataHttpHandler.java:53)
        at co.cask.cdap.explore.executor.AbstractExploreMetadataHttpHandler$1.execute(AbstractExploreMetadataHttpHandler.java:49)
        at co.cask.cdap.explore.executor.AbstractExploreMetadataHttpHandler.genericEndpointExecution(AbstractExploreMetadataHttpHandler.java:65)
        at co.cask.cdap.explore.executor.AbstractExploreMetadataHttpHandler.handleResponseEndpointExecution(AbstractExploreMetadataHttpHandler.java:49)
        at co.cask.cdap.explore.executor.ExploreMetadataHttpHandler.create(ExploreMetadataHttpHandler.java:130)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at co.cask.http.HttpMethodInfo.invoke(HttpMethodInfo.java:80)
        at co.cask.http.HttpDispatcher.messageReceived(HttpDispatcher.java:38)
        at org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:70)
        at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:564)
        at org.jboss.netty.channel.DefaultChannelPipeline$DefaultChannelHandlerContext.sendUpstream(DefaultChannelPipeline.java:791)
        at org.jboss.netty.channel.SimpleChannelUpstreamHandler.messageReceived(SimpleChannelUpstreamHandler.java:124)
        at co.cask.cdap.common.http.AuthenticationChannelHandler.messageReceived(AuthenticationChannelHandler.java:64)
        at org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:70)
        at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:564)
        at org.jboss.netty.channel.DefaultChannelPipeline$DefaultChannelHandlerContext.sendUpstream(DefaultChannelPipeline.java:791)
        at org.jboss.netty.handler.execution.ChannelUpstreamEventRunnable.doRun(ChannelUpstreamEventRunnable.java:43)
        at org.jboss.netty.handler.execution.ChannelEventRunnable.run(ChannelEventRunnable.java:67)
        at org.jboss.netty.handler.execution.OrderedMemoryAwareThreadPoolExecutor$ChildExecutor.run(OrderedMemoryAwareThreadPoolExecutor.java:314)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
        at java.lang.Thread.run(Thread.java:745)
```