### PR TITLE
CDAP-7208 Improve CDAP master logging of events.

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/service/Service.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/Service.java
@@ -26,7 +26,7 @@ public interface Service {
 
   /**
    * Configure the Service by adding {@link HttpServiceHandler}s to handle requests.
-   * @param configurer to use to add handlers and workers to the Service.
+   * @param configurer to use to add handlers to the Service.
    */
   void configure(ServiceConfigurer configurer);
 }

--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/runtime/WorkflowTest.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/runtime/WorkflowTest.java
@@ -103,8 +103,8 @@ public class WorkflowTest {
       @Override
       public void init(ProgramController.State currentState, @Nullable Throwable cause) {
         LOG.info("Starting");
-        injector.getInstance(Store.class).setStart(controller.getProgramId(),
-                                                   controller.getRunId().getId(), System.currentTimeMillis());
+        injector.getInstance(Store.class).setStart(controller.getProgramRunId().getParent(),
+                                                   controller.getProgramRunId().getRun(), System.currentTimeMillis());
       }
 
       @Override
@@ -213,8 +213,8 @@ public class WorkflowTest {
       @Override
       public void init(ProgramController.State currentState, @Nullable Throwable cause) {
         LOG.info("Initializing");
-        injector.getInstance(Store.class).setStart(controller.getProgramId(),
-                                                   controller.getRunId().getId(), System.currentTimeMillis());
+        injector.getInstance(Store.class).setStart(controller.getProgramRunId().getParent(),
+                                                   controller.getProgramRunId().getRun(), System.currentTimeMillis());
       }
 
       @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramController.java
@@ -19,6 +19,7 @@ package co.cask.cdap.app.runtime;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramStatus;
 import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.ProgramRunId;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.twill.api.RunId;
 import org.apache.twill.common.Cancellable;
@@ -126,9 +127,9 @@ public interface ProgramController {
   }
 
   /**
-   * Returns the program Id which this controller is controlling.
+   * Returns the program run id which this controller is controlling.
    */
-  ProgramId getProgramId();
+  ProgramRunId getProgramRunId();
 
   /**
    * Returns the run Id which this controller is controlling.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractProgramController.java
@@ -18,6 +18,7 @@ package co.cask.cdap.internal.app.runtime;
 
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.ProgramRunId;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -52,6 +53,7 @@ public abstract class AbstractProgramController implements ProgramController {
 
   private final AtomicReference<State> state;
   private final ProgramId programId;
+  private final ProgramRunId programRunId;
   private final RunId runId;
   private final String componentName;
   private final Map<ListenerCaller, Cancellable> listeners;
@@ -68,6 +70,7 @@ public abstract class AbstractProgramController implements ProgramController {
   protected AbstractProgramController(ProgramId programId, RunId runId, @Nullable String componentName) {
     this.state = new AtomicReference<>(State.STARTING);
     this.programId = programId;
+    this.programRunId = programId.run(runId);
     this.runId = runId;
     this.componentName = componentName;
     this.listeners = new HashMap<>();
@@ -87,8 +90,8 @@ public abstract class AbstractProgramController implements ProgramController {
   }
 
   @Override
-  public ProgramId getProgramId() {
-    return programId;
+  public ProgramRunId getProgramRunId() {
+    return programRunId;
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -138,7 +138,6 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
     MapReduceSpecification spec = appSpec.getMapReduce().get(program.getName());
     Preconditions.checkNotNull(spec, "Missing MapReduceSpecification for %s", program.getName());
 
-    // Optionally get runId. If the map-reduce started by other program (e.g. Workflow), it inherit the runId.
     Arguments arguments = options.getArguments();
     RunId runId = ProgramRunners.getRunId(options);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractTwillProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractTwillProgramController.java
@@ -18,6 +18,7 @@ package co.cask.cdap.internal.app.runtime.distributed;
 import co.cask.cdap.app.runtime.ProgramController;
 import co.cask.cdap.internal.app.runtime.AbstractProgramController;
 import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.ProgramRunId;
 import com.google.common.util.concurrent.Futures;
 import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.apache.twill.api.RunId;
@@ -34,13 +35,11 @@ public abstract class AbstractTwillProgramController extends AbstractProgramCont
 
   private static final Logger LOG = LoggerFactory.getLogger(AbstractTwillProgramController.class);
 
-  protected final ProgramId programId;
   private final TwillController twillController;
   private volatile boolean stopRequested;
 
   protected AbstractTwillProgramController(ProgramId programId, TwillController twillController, RunId runId) {
     super(programId, runId);
-    this.programId = programId;
     this.twillController = twillController;
   }
 
@@ -62,7 +61,7 @@ public abstract class AbstractTwillProgramController extends AbstractProgramCont
     twillController.onRunning(new Runnable() {
       @Override
       public void run() {
-        LOG.info("Twill program running: {} {}", programId, twillController.getRunId());
+        LOG.info("Twill program running: {}, twill runId: {}", getProgramRunId(), twillController.getRunId());
         started();
       }
     }, Threads.SAME_THREAD_EXECUTOR);
@@ -70,7 +69,7 @@ public abstract class AbstractTwillProgramController extends AbstractProgramCont
     twillController.onTerminated(new Runnable() {
       @Override
       public void run() {
-        LOG.info("Twill program terminated: {} {}", programId, twillController.getRunId());
+        LOG.info("Twill program terminated: {}, twill runId: {}", getProgramRunId(), twillController.getRunId());
         if (stopRequested) {
           // Service was killed
           stop();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedFlowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedFlowProgramRunner.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.internal.app.runtime.distributed;
 
 import co.cask.cdap.api.app.ApplicationSpecification;
@@ -133,7 +134,8 @@ public final class DistributedFlowProgramRunner extends AbstractDistributedProgr
                                                                            streamAdmin, queueAdmin, txExecutorFactory);
 
       // Launch flowlet program runners
-      LOG.info("Launching distributed flow: " + program.getName() + ":" + flowSpec.getName());
+      RunId runId = ProgramRunners.getRunId(options);
+      LOG.info("Launching distributed flow: {}", program.getId().run(runId));
 
       TwillController controller = launcher.launch(new FlowTwillApplication(program, options.getUserArguments(),
                                                                             flowSpec, localizeResources, eventHandler));
@@ -141,7 +143,7 @@ public final class DistributedFlowProgramRunner extends AbstractDistributedProgr
         new DistributedFlowletInstanceUpdater(program.getId(), controller, queueAdmin,
                                               streamAdmin, flowletQueues, txExecutorFactory, impersonator);
 
-      return createProgramController(controller, program.getId(), ProgramRunners.getRunId(options), instanceUpdater);
+      return createProgramController(controller, program.getId(), runId, instanceUpdater);
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedMapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedMapReduceProgramRunner.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.internal.app.runtime.distributed;
 
 import co.cask.cdap.api.app.ApplicationSpecification;
@@ -44,7 +45,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Runs Mapreduce programm in distributed environment
+ * Runs Mapreduce program in distributed environment
  */
 public final class DistributedMapReduceProgramRunner extends AbstractDistributedProgramRunner {
 
@@ -84,11 +85,12 @@ public final class DistributedMapReduceProgramRunner extends AbstractDistributed
 
     List<String> extraClassPaths = MapReduceContainerHelper.localizeFramework(hConf, localizeResources);
 
-    LOG.info("Launching MapReduce program: " + program.getName() + ":" + spec.getName());
+    RunId runId = ProgramRunners.getRunId(options);
+    LOG.info("Launching MapReduce program: {}", program.getId().run(runId));
     TwillController controller = launcher.launch(
       new MapReduceTwillApplication(program, options.getUserArguments(), spec, localizeResources, eventHandler),
       extraClassPaths, Collections.singletonList(YarnClientProtocolProvider.class));
 
-    return createProgramController(controller, program.getId(), ProgramRunners.getRunId(options));
+    return createProgramController(controller, program.getId(), runId);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedServiceProgramRunner.java
@@ -83,12 +83,13 @@ public class DistributedServiceProgramRunner extends AbstractDistributedProgramR
     Preconditions.checkNotNull(serviceSpec, "Missing ServiceSpecification for %s", program.getName());
 
     // Launch service runnables program runners
-    LOG.info("Launching distributed service: {}:{}", program.getName(), serviceSpec.getName());
+    RunId runId = ProgramRunners.getRunId(options);
+    LOG.info("Launching distributed service: {}", program.getId().run(runId));
 
     TwillController controller = launcher.launch(new ServiceTwillApplication(program, options.getUserArguments(),
                                                                              serviceSpec,
                                                                              localizeResources, eventHandler));
-    return createProgramController(controller, program.getId(), ProgramRunners.getRunId(options));
+    return createProgramController(controller, program.getId(), runId);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWebappProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWebappProgramRunner.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.internal.app.runtime.distributed;
 
 import co.cask.cdap.api.app.ApplicationSpecification;
@@ -74,9 +75,10 @@ public final class DistributedWebappProgramRunner extends AbstractDistributedPro
     Preconditions.checkNotNull(processorType, "Missing processor type.");
     Preconditions.checkArgument(processorType == ProgramType.WEBAPP, "Only WEBAPP process type is supported.");
 
-    LOG.info("Launching distributed webapp: " + program.getName());
+    RunId runId = ProgramRunners.getRunId(options);
+    LOG.info("Launching distributed webapp: {}", program.getId().run(runId));
     TwillController controller = launcher.launch(new WebappTwillApplication(program, options.getUserArguments(),
                                                                             localizeResources, eventHandler));
-    return createProgramController(controller, program.getId(), ProgramRunners.getRunId(options));
+    return createProgramController(controller, program.getId(), runId);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
@@ -96,12 +96,13 @@ public class DistributedWorkerProgramRunner extends AbstractDistributedProgramRu
                                                                 workerSpec.getDatasets(), newResources,
                                                                 Integer.valueOf(instances));
 
-    LOG.info("Launching distributed worker {}", program.getName());
+    RunId runId = ProgramRunners.getRunId(options);
+    LOG.info("Launching distributed worker {}", program.getId().run(runId));
 
     TwillController controller = launcher.launch(new WorkerTwillApplication(program, options.getUserArguments(),
                                                                             newWorkerSpec,
                                                                             localizeResources, eventHandler));
-    return createProgramController(controller, program.getId(), ProgramRunners.getRunId(options));
+    return createProgramController(controller, program.getId(), runId);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.internal.app.runtime.distributed;
 
 import co.cask.cdap.api.Resources;
@@ -159,13 +160,14 @@ public final class DistributedWorkflowProgramRunner extends AbstractDistributedP
     // Add classpaths for MR framework
     extraClassPaths.addAll(MapReduceContainerHelper.localizeFramework(hConf, localizeResources));
 
-    LOG.info("Launching distributed workflow: " + program.getName() + ":" + workflowSpec.getName());
+    RunId runId = ProgramRunners.getRunId(options);
+    LOG.info("Launching distributed workflow: {}", program.getId().run(runId));
     TwillController controller = launcher.launch(
       new WorkflowTwillApplication(program, options.getUserArguments(),
                                    workflowSpec, localizeResources, eventHandler, driverMeta.resources),
       extraClassPaths, extraDependencies
     );
-    return createProgramController(controller, program.getId(), ProgramRunners.getRunId(options));
+    return createProgramController(controller, program.getId(), runId);
   }
 
   private static YarnConfiguration createConfiguration(YarnConfiguration hConf) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/FlowTwillProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/FlowTwillProgramController.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.internal.app.runtime.distributed;
 
 import co.cask.cdap.api.flow.FlowSpecification;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/ServiceTwillProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/ServiceTwillProgramController.java
@@ -56,9 +56,9 @@ final class ServiceTwillProgramController extends AbstractTwillProgramController
 
   private synchronized void changeInstances(String runnableId,
                                             int newInstanceCount, int oldInstanceCount) throws Exception {
-    LOG.info("Changing instances of {} from {} to {}", getProgramId(), oldInstanceCount, newInstanceCount);
+    LOG.info("Changing instances of {} from {} to {}", getProgramRunId(), oldInstanceCount, newInstanceCount);
     getTwillController().changeInstances(runnableId, newInstanceCount).get();
-    LOG.info("Completed changing instances of {} from {} to {}", getProgramId(), oldInstanceCount, newInstanceCount);
+    LOG.info("Completed changing instances of {} from {} to {}", getProgramRunId(), oldInstanceCount, newInstanceCount);
 
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WorkerTwillProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WorkerTwillProgramController.java
@@ -56,8 +56,8 @@ public class WorkerTwillProgramController extends AbstractTwillProgramController
 
   private synchronized void changeInstances(String runnableId,
                                             int newInstanceCount, int oldInstanceCount) throws Exception {
-    LOG.info("Changing instances of {} from {} to {}", getProgramId(), oldInstanceCount, newInstanceCount);
+    LOG.info("Changing instances of {} from {} to {}", getProgramRunId(), oldInstanceCount, newInstanceCount);
     getTwillController().changeInstances(runnableId, newInstanceCount).get();
-    LOG.info("Completed changing instances of {} from {} to {}", getProgramId(), oldInstanceCount, newInstanceCount);
+    LOG.info("Completed changing instances of {} from {} to {}", getProgramRunId(), oldInstanceCount, newInstanceCount);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/ServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/ServiceProgramRunner.java
@@ -48,7 +48,7 @@ import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.internal.ServiceListenerAdapter;
 
 /**
- * A {@link ProgramRunner} that runs a component inside a Service (either a HTTP Server or a Worker).
+ * A {@link ProgramRunner} that runs an HTTP Server inside a Service.
  */
 public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
 
@@ -111,7 +111,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
                                                           txClient, discoveryServiceClient,
                                                           pluginInstantiator, secureStore, secureStoreManager);
 
-      // Add a service listener to make sure the plugin instantiator is closed when the worker driver finished.
+      // Add a service listener to make sure the plugin instantiator is closed when the http server is finished.
       component.addListener(new ServiceListenerAdapter() {
         @Override
         public void terminated(Service.State from) {

--- a/cdap-app-fabric/src/main/java/org/apache/twill/yarn/YarnTwillController.java
+++ b/cdap-app-fabric/src/main/java/org/apache/twill/yarn/YarnTwillController.java
@@ -117,7 +117,7 @@ public final class YarnTwillController extends AbstractTwillController implement
 
       YarnApplicationReport report = processController.getReport();
       ApplicationId appId = report.getApplicationId();
-      LOG.debug("Application {} with id {} submitted", appName, appId);
+      LOG.info("Application {} with id {} submitted", appName, appId);
 
       YarnApplicationState state = report.getYarnApplicationState();
       StopWatch stopWatch = new StopWatch();

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
@@ -100,12 +100,13 @@ public final class DistributedSparkProgramRunner extends AbstractDistributedProg
     // Localize the spark-assembly jar and spark conf zip
     String sparkAssemblyJarName = SparkUtils.prepareSparkResources(tempDir, localizeResources);
 
-    LOG.info("Launching Spark program: {}", program.getId());
+    RunId runId = ProgramRunners.getRunId(options);
+    LOG.info("Launching Spark program: {}", program.getId().run(runId));
     TwillController controller = launcher.launch(
       new SparkTwillApplication(program, options.getUserArguments(),
                                 spec, localizeResources, eventHandler), sparkAssemblyJarName);
 
-    return createProgramController(controller, program.getId(), ProgramRunners.getRunId(options));
+    return createProgramController(controller, program.getId(), runId);
   }
 
   private static YarnConfiguration createConfiguration(YarnConfiguration hConf, CConfiguration cConf,


### PR DESCRIPTION
Includes the program run id, for more detailed traceability.
Some log messages didn't even include the application name, but instead logged the program name nice, such as this [example](https://slack-files.com/T02SZLS2R-F3CDFGS1F-e1cf0512f6).

Incremental progress of https://issues.cask.co/browse/CDAP-7208

http://builds.cask.co/browse/CDAP-RUT364-1