### PR TITLE
(CDAP-7808) (HYDRATOR-1169) Do not trace input records and add endpoint to query for multiple tracer names

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/TransformExecutorFactory.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/TransformExecutorFactory.java
@@ -184,8 +184,7 @@ public abstract class TransformExecutorFactory<T> {
   protected static <IN, OUT> TrackedTransform<IN, OUT> getTrackedEmitKeyStep(Transformation<IN, OUT> transform,
                                                                              StageMetrics stageMetrics,
                                                                              DataTracer dataTracer) {
-    return new TrackedTransform<>(transform, stageMetrics, TrackedTransform.RECORDS_IN, null, dataTracer,
-                                  TrackedTransform.RECORDS_IN);
+    return new TrackedTransform<>(transform, stageMetrics, TrackedTransform.RECORDS_IN, null, dataTracer);
   }
 
   protected static <IN, OUT> TrackedTransform<IN, OUT> getTrackedAggregateStep(Transformation<IN, OUT> transform,
@@ -193,12 +192,12 @@ public abstract class TransformExecutorFactory<T> {
                                                                                DataTracer dataTracer) {
     // 'aggregator.groups' is the number of groups output by the aggregator
     return new TrackedTransform<>(transform, stageMetrics, "aggregator.groups", TrackedTransform.RECORDS_OUT,
-                                  dataTracer, null);
+                                  dataTracer);
   }
 
   protected static <IN, OUT> TrackedTransform<IN, OUT> getTrackedMergeStep(Transformation<IN, OUT> transform,
                                                                            StageMetrics stageMetrics,
                                                                            DataTracer dataTracer) {
-    return new TrackedTransform<>(transform, stageMetrics, null, TrackedTransform.RECORDS_OUT, dataTracer, null);
+    return new TrackedTransform<>(transform, stageMetrics, null, TrackedTransform.RECORDS_OUT, dataTracer);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TrackedTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/TrackedTransform.java
@@ -38,31 +38,25 @@ public class TrackedTransform<IN, OUT> implements Transformation<IN, OUT>, Destr
   private final StageMetrics metrics;
   private final String metricInName;
   private final String metricOutName;
-  private final String previewInName;
   private final DataTracer dataTracer;
 
   public TrackedTransform(Transformation<IN, OUT> transform, StageMetrics metrics, DataTracer dataTracer) {
-    this(transform, metrics, RECORDS_IN, RECORDS_OUT, dataTracer, RECORDS_IN);
+    this(transform, metrics, RECORDS_IN, RECORDS_OUT, dataTracer);
   }
 
   public TrackedTransform(Transformation<IN, OUT> transform, StageMetrics metrics,
-                          @Nullable String metricInName, @Nullable String metricOutName, DataTracer dataTracer,
-                          String previewInName) {
+                          @Nullable String metricInName, @Nullable String metricOutName, DataTracer dataTracer) {
     this.transform = transform;
     this.metrics = metrics;
     this.metricInName = metricInName;
     this.metricOutName = metricOutName;
     this.dataTracer = dataTracer;
-    this.previewInName = previewInName;
   }
 
   @Override
   public void transform(IN input, Emitter<OUT> emitter) throws Exception {
     if (metricInName != null) {
       metrics.count(metricInName, 1);
-    }
-    if (dataTracer.isEnabled() && previewInName != null) {
-      dataTracer.info(previewInName, input);
     }
     transform.transform(input, metricOutName == null ? emitter :
       new TrackedEmitter<>(emitter, metrics, metricOutName, dataTracer));

--- a/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/etl/realtime/ETLWorker.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-realtime/src/main/java/co/cask/cdap/etl/realtime/ETLWorker.java
@@ -263,8 +263,7 @@ public class ETLWorker extends AbstractWorker {
       TrackedTransform trackedTransform = new TrackedTransform(identityTransformation,
                                                                new DefaultStageMetrics(metrics, sinkName),
                                                                TrackedTransform.RECORDS_IN,
-                                                               null, context.getDataTracer(sinkName),
-                                                               TrackedTransform.RECORDS_IN);
+                                                               null, context.getDataTracer(sinkName));
       transformationMap.put(sinkInfo.getName(), new TransformDetail(trackedTransform, new HashSet<String>()));
       sinks.put(sinkInfo.getName(), sink);
     }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/RDDCollection.java
@@ -111,8 +111,7 @@ public class RDDCollection<T> implements SparkCollection<T> {
       new BasicSparkExecutionPluginContext(sec, jsc, datasetContext, stageName);
     compute.initialize(sparkPluginContext);
 
-    JavaRDD<T> countedInput = rdd.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in",
-                                                              sec.getDataTracer(stageName))).cache();
+    JavaRDD<T> countedInput = rdd.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in", null)).cache();
 
     return wrap(compute.transform(sparkPluginContext, countedInput)
                   .map(new CountingFunction<U>(stageName, sec.getMetrics(), "records.out",
@@ -131,8 +130,7 @@ public class RDDCollection<T> implements SparkCollection<T> {
     SparkExecutionPluginContext sparkPluginContext =
       new BasicSparkExecutionPluginContext(sec, jsc, datasetContext, stageName);
 
-    JavaRDD<T> countedRDD = rdd.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in",
-                                                            sec.getDataTracer(stageName))).cache();
+    JavaRDD<T> countedRDD = rdd.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in", null)).cache();
     sink.run(sparkPluginContext, countedRDD);
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/AggregatorAggregateFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/AggregatorAggregateFunction.java
@@ -50,8 +50,7 @@ public class AggregatorAggregateFunction<GROUP_KEY, GROUP_VAL, OUT>
       aggregateTransform = new TrackedTransform<>(new AggregateTransform<>(aggregator),
                                                   pluginFunctionContext.createStageMetrics(),
                                                   "aggregator.groups",
-                                                  TrackedTransform.RECORDS_OUT, pluginFunctionContext.getDataTracer(),
-                                                  null);
+                                                  TrackedTransform.RECORDS_OUT, pluginFunctionContext.getDataTracer());
       emitter = new DefaultEmitter<>();
     }
     emitter.reset();

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/AggregatorGroupByFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/AggregatorGroupByFunction.java
@@ -49,8 +49,7 @@ public class AggregatorGroupByFunction<GROUP_KEY, GROUP_VAL>
       groupByFunction = new TrackedTransform<>(new GroupByTransform<>(aggregator),
                                                pluginFunctionContext.createStageMetrics(),
                                                TrackedTransform.RECORDS_IN,
-                                               null, pluginFunctionContext.getDataTracer(),
-                                               TrackedTransform.RECORDS_IN);
+                                               null, pluginFunctionContext.getDataTracer());
       emitter = new DefaultEmitter<>();
     }
     emitter.reset();

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/CountingFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/CountingFunction.java
@@ -22,6 +22,8 @@ import co.cask.cdap.etl.api.StageMetrics;
 import co.cask.cdap.etl.common.DefaultStageMetrics;
 import org.apache.spark.api.java.function.Function;
 
+import javax.annotation.Nullable;
+
 /**
  * Function that doesn't transform anything, but just emits counts for the number of records from that stage.
  *
@@ -34,7 +36,8 @@ public class CountingFunction<T> implements Function<T, T> {
   private final DataTracer dataTracer;
   private transient StageMetrics stageMetrics;
 
-  public CountingFunction(String stageName, Metrics metrics, String metricName, DataTracer dataTracer) {
+  // DataTracer is null for records.in
+  public CountingFunction(String stageName, Metrics metrics, String metricName, @Nullable DataTracer dataTracer) {
     this.stageName = stageName;
     this.metrics = metrics;
     this.metricName = metricName;
@@ -46,7 +49,8 @@ public class CountingFunction<T> implements Function<T, T> {
     if (stageMetrics == null) {
       stageMetrics = new DefaultStageMetrics(metrics, stageName);
     }
-    if (dataTracer.isEnabled()) {
+    // we only want to trace the data for records.out
+    if (dataTracer != null && dataTracer.isEnabled()) {
       dataTracer.info(metricName, in);
     }
     stageMetrics.count(metricName, 1);

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/JoinMergeFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/JoinMergeFunction.java
@@ -55,7 +55,7 @@ public class JoinMergeFunction<JOIN_KEY, INPUT_RECORD, OUT>
       joinFunction = new TrackedTransform<>(new JoinOnTransform<>(joiner),
                                             pluginFunctionContext.createStageMetrics(),
                                             "joiner.keys",
-                                            TrackedTransform.RECORDS_OUT, pluginFunctionContext.getDataTracer(), null);
+                                            TrackedTransform.RECORDS_OUT, pluginFunctionContext.getDataTracer());
       emitter = new DefaultEmitter<>();
     }
     emitter.reset();

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/JoinOnFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/JoinOnFunction.java
@@ -54,8 +54,7 @@ public class JoinOnFunction<JOIN_KEY, INPUT_RECORD>
       joinFunction = new TrackedTransform<>(new JoinOnTransform<>(joiner, inputStageName),
                                                pluginFunctionContext.createStageMetrics(),
                                                TrackedTransform.RECORDS_IN,
-                                               null, pluginFunctionContext.getDataTracer(),
-                                               TrackedTransform.RECORDS_IN);
+                                               null, pluginFunctionContext.getDataTracer());
       emitter = new DefaultEmitter<>();
     }
     emitter.reset();

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/DStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/DStreamCollection.java
@@ -128,8 +128,7 @@ public class DStreamCollection<T> implements SparkCollection<T> {
   @Override
   public SparkCollection<T> window(StageInfo stageInfo, Windower windower) {
     String stageName = stageInfo.getName();
-    return wrap(stream.transform(new CountingTranformFunction<T>(stageName, sec.getMetrics(), "records.in",
-                                                                 sec.getDataTracer(stageName)))
+    return wrap(stream.transform(new CountingTranformFunction<T>(stageName, sec.getMetrics(), "records.in", null))
                   .window(Durations.seconds(windower.getWidth()), Durations.seconds(windower.getSlideInterval()))
                   .transform(new CountingTranformFunction<T>(stageName, sec.getMetrics(), "records.out",
                                                              sec.getDataTracer(stageName))));

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/ComputeTransformFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/ComputeTransformFunction.java
@@ -50,7 +50,7 @@ public class ComputeTransformFunction<T, U> implements Function2<JavaRDD<T>, Tim
       new SparkStreamingExecutionContext(sec, JavaSparkContext.fromSparkContext(data.context()),
                                          stageName, batchTime.milliseconds());
 
-    data = data.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in", sec.getDataTracer(stageName)));
+    data = data.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in", null));
     return compute.transform(sparkPluginContext, data)
       .map(new CountingFunction<U>(stageName, sec.getMetrics(), "records.out", sec.getDataTracer(stageName)));
   }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/CountingTranformFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/CountingTranformFunction.java
@@ -22,6 +22,8 @@ import co.cask.cdap.etl.spark.function.CountingFunction;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.Function;
 
+import javax.annotation.Nullable;
+
 /**
  * Function used to emit a metric for every item in an RDD.
  *
@@ -33,7 +35,9 @@ public class CountingTranformFunction<T> implements Function<JavaRDD<T>, JavaRDD
   private final String metricName;
   private final DataTracer dataTracer;
 
-  public CountingTranformFunction(String stageName, Metrics metrics, String metricName, DataTracer dataTracer) {
+  // DataTracer is null for records.in
+  public CountingTranformFunction(String stageName, Metrics metrics, String metricName,
+                                  @Nullable DataTracer dataTracer) {
     this.metrics = metrics;
     this.stageName = stageName;
     this.metricName = metricName;

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/StreamingBatchSinkFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/StreamingBatchSinkFunction.java
@@ -76,7 +76,7 @@ public class StreamingBatchSinkFunction<T> implements Function2<JavaRDD<T>, Time
       });
       isPrepared = true;
 
-      data = data.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in", sec.getDataTracer(stageName)));
+      data = data.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in", null));
       sinkFactory.writeFromRDD(data.flatMapToPair(sinkFunction), sec, stageName, Object.class, Object.class);
       isDone = true;
       sec.execute(new TxRunnable() {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-7808
https://issues.cask.co/browse/HYDRATOR-1169
Build: http://builds.cask.co/browse/CDAP-RUT338-1

We are putting a lot of duplicate records into `PreviewStore`, since the input records of one transform is actually output records from previous stages. And we add a REST endpoint to query for multiple tracer names provided.