### PR TITLE
add package dependencies for system utilities used by package install…

### DIFF
--- a/cdap-distributions/pom.xml
+++ b/cdap-distributions/pom.xml
@@ -95,6 +95,9 @@
                     --before-install "${project.basedir}/src/rpm/scripts/common-preinst"
                     --before-remove "${project.basedir}/src/rpm/scripts/common-prerm"
                     --iteration "${release.iteration}"
+                    --depends chkconfig
+                    --depends glibc-common
+                    --depends shadow-utils
                     ${package.config.dirs}
                     etc
                   </commandlineArgs>
@@ -172,6 +175,9 @@
                     --before-install "${project.basedir}/src/debian/scripts/common-preinst"
                     --before-remove "${project.basedir}/src/debian/scripts/common-prerm"
                     --iteration "${release.iteration}"
+                    --depends dpkg
+                    --depends libc-bin
+                    --depends passwd
                     ${package.config.dirs}
                     etc
                   </commandlineArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -2336,6 +2336,7 @@
                       --before-remove "${project.parent.basedir}/cdap-distributions/src/rpm/scripts/prerm"
                       --after-remove "${project.parent.basedir}/cdap-distributions/src/rpm/scripts/postrm"
                       --iteration "${release.iteration}"
+                      --depends coreutils
                       --depends libxml2
                       ${package.rpm.depends}
                       ${package.dirs}
@@ -2388,6 +2389,7 @@
                       --before-remove "${project.parent.basedir}/cdap-distributions/src/debian/scripts/prerm"
                       --after-remove "${project.parent.basedir}/cdap-distributions/src/debian/scripts/postrm"
                       --iteration "${release.iteration}"
+                      --depends coreutils
                       --depends libxml2-utils
                       ${package.deb.depends}
                       ${package.dirs}


### PR DESCRIPTION
… scripts

- [x] fixes [CDAP-5344](https://issues.cask.co/browse/CDAP-5344)
- [x] adds package dependencies for packages used by rpm/deb install scripts.  See [CDAP-5344](https://issues.cask.co/browse/CDAP-5344) for listing of what's used.