### PR TITLE
CDAP-7724 fix a race condition in stopping spark programs

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramControllerServiceAdapter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramControllerServiceAdapter.java
@@ -67,11 +67,12 @@ public class ProgramControllerServiceAdapter extends AbstractProgramController {
   @Override
   protected void doStop() throws Exception {
     if (service.state() != Service.State.TERMINATED && service.state() != Service.State.FAILED) {
-      LOG.debug("stopping service for program {}.", getProgramRunId());
+      LOG.debug("stopping controller service for program {}.", getProgramRunId());
       service.stopAndWait();
-      LOG.debug("stopped service for program {}, waiting for it to finish running listener hooks.", getProgramRunId());
+      LOG.debug("stopped controller service for program {}, waiting for it to finish running listener hooks.",
+                getProgramRunId());
       serviceStoppedLatch.await(30, TimeUnit.SECONDS);
-      LOG.debug("service for program {} finished running listener hooks.", getProgramRunId());
+      LOG.debug("controller service for program {} finished running listener hooks.", getProgramRunId());
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramControllerServiceAdapter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramControllerServiceAdapter.java
@@ -67,11 +67,11 @@ public class ProgramControllerServiceAdapter extends AbstractProgramController {
   @Override
   protected void doStop() throws Exception {
     if (service.state() != Service.State.TERMINATED && service.state() != Service.State.FAILED) {
-      LOG.debug("stopping service for program {}.", getProgramId());
+      LOG.debug("stopping service for program {}.", getProgramRunId());
       service.stopAndWait();
-      LOG.debug("stopped service for program {}, waiting for it to finish running listener hooks.", getProgramId());
-      serviceStoppedLatch.await(3, TimeUnit.MINUTES);
-      LOG.debug("service for program {} finished running listener hooks.", getProgramId());
+      LOG.debug("stopped service for program {}, waiting for it to finish running listener hooks.", getProgramRunId());
+      serviceStoppedLatch.await(30, TimeUnit.SECONDS);
+      LOG.debug("service for program {} finished running listener hooks.", getProgramRunId());
     }
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramControllerServiceAdapter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/ProgramControllerServiceAdapter.java
@@ -25,16 +25,22 @@ import org.apache.twill.internal.ServiceListenerAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
  * A {@link ProgramController} implementation that control a guava Service.
+ * The Service must execute Listeners in the order they were added to the Service, otherwise
+ * there may be race conditions if the thread that stops the controller is different than the thread
+ * that runs the service. Any Service that extends AbstractService meets this criteria.
  */
 public class ProgramControllerServiceAdapter extends AbstractProgramController {
 
   private static final Logger LOG = LoggerFactory.getLogger(ProgramControllerServiceAdapter.class);
 
   private final Service service;
+  private final CountDownLatch serviceStoppedLatch;
 
   public ProgramControllerServiceAdapter(Service service, ProgramId programId, RunId runId) {
     this(service, programId, runId, null);
@@ -44,6 +50,7 @@ public class ProgramControllerServiceAdapter extends AbstractProgramController {
                                          RunId runId, @Nullable String componentName) {
     super(programId, runId, componentName);
     this.service = service;
+    this.serviceStoppedLatch = new CountDownLatch(1);
     listenToRuntimeState(service);
   }
 
@@ -60,7 +67,11 @@ public class ProgramControllerServiceAdapter extends AbstractProgramController {
   @Override
   protected void doStop() throws Exception {
     if (service.state() != Service.State.TERMINATED && service.state() != Service.State.FAILED) {
+      LOG.debug("stopping service for program {}.", getProgramId());
       service.stopAndWait();
+      LOG.debug("stopped service for program {}, waiting for it to finish running listener hooks.", getProgramId());
+      serviceStoppedLatch.await(3, TimeUnit.MINUTES);
+      LOG.debug("service for program {} finished running listener hooks.", getProgramId());
     }
   }
 
@@ -79,11 +90,13 @@ public class ProgramControllerServiceAdapter extends AbstractProgramController {
       @Override
       public void failed(Service.State from, Throwable failure) {
         LOG.error("Program terminated with exception", failure);
+        serviceStoppedLatch.countDown();
         error(failure);
       }
 
       @Override
       public void terminated(Service.State from) {
+        serviceStoppedLatch.countDown();
         if (from != Service.State.STOPPING) {
           // Service completed by itself. Simply signal the state change of this controller.
           complete();

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsPipelineSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsPipelineSpec.java
@@ -30,14 +30,17 @@ import java.util.Set;
 public class DataStreamsPipelineSpec extends PipelineSpec {
   private final long batchIntervalMillis;
   private final String extraJavaOpts;
+  private final boolean stopGracefully;
 
   private DataStreamsPipelineSpec(Set<StageSpec> stages, Set<Connection> connections,
                                   Resources resources, Resources driverResources, Resources clientResources,
                                   boolean stageLoggingEnabled, long batchIntervalMillis,
-                                  String extraJavaOpts, int numOfRecordsPreview) {
-    super(stages, connections, resources, driverResources, clientResources, stageLoggingEnabled, numOfRecordsPreview);
+                                  String extraJavaOpts, int numOfRecordsPreview,
+                                  boolean stopGracefully) {
+      super(stages, connections, resources, driverResources, clientResources, stageLoggingEnabled, numOfRecordsPreview);
     this.batchIntervalMillis = batchIntervalMillis;
     this.extraJavaOpts = extraJavaOpts;
+    this.stopGracefully = stopGracefully;
   }
 
   public long getBatchIntervalMillis() {
@@ -46,6 +49,10 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
 
   public String getExtraJavaOpts() {
     return extraJavaOpts;
+  }
+
+  public boolean isStopGracefully() {
+    return stopGracefully;
   }
 
   @Override
@@ -63,7 +70,8 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
     DataStreamsPipelineSpec that = (DataStreamsPipelineSpec) o;
 
     return batchIntervalMillis == that.batchIntervalMillis &&
-      Objects.equals(extraJavaOpts, that.extraJavaOpts);
+      Objects.equals(extraJavaOpts, that.extraJavaOpts) &&
+      stopGracefully == that.stopGracefully;
   }
 
   @Override
@@ -76,6 +84,7 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
     return "DataStreamsPipelineSpec{" +
       "batchIntervalMillis=" + batchIntervalMillis +
       ", extraJavaOpts='" + extraJavaOpts + '\'' +
+      ", stopGracefully=" + stopGracefully +
       "} " + super.toString();
   }
 
@@ -89,9 +98,11 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
   public static class Builder extends PipelineSpec.Builder<Builder> {
     private final long batchIntervalMillis;
     private String extraJavaOpts;
+    private boolean stopGracefully;
 
     public Builder(long batchIntervalMillis) {
       this.batchIntervalMillis = batchIntervalMillis;
+      this.stopGracefully = false;
     }
 
     public Builder setExtraJavaOpts(String extraJavaOpts) {
@@ -99,9 +110,15 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
       return this;
     }
 
+    public Builder setStopGracefully(boolean stopGracefully) {
+      this.stopGracefully = stopGracefully;
+      return this;
+    }
+
     public DataStreamsPipelineSpec build() {
       return new DataStreamsPipelineSpec(stages, connections, resources, driverResources, clientResources,
-                                         stageLoggingEnabled, batchIntervalMillis, extraJavaOpts, numOfRecordsPreview);
+                                         stageLoggingEnabled, batchIntervalMillis, extraJavaOpts,
+                                         numOfRecordsPreview, stopGracefully);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsPipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/DataStreamsPipelineSpecGenerator.java
@@ -44,7 +44,8 @@ public class DataStreamsPipelineSpecGenerator
         String.format("Unable to parse batchInterval '%s'", config.getBatchInterval()));
     }
     DataStreamsPipelineSpec.Builder specBuilder = DataStreamsPipelineSpec.builder(batchIntervalMillis)
-      .setExtraJavaOpts(config.getExtraJavaOpts());
+      .setExtraJavaOpts(config.getExtraJavaOpts())
+      .setStopGracefully(config.getStopGracefully());
     configureStages(config, specBuilder);
     return specBuilder.build();
   }

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineDriver.java
@@ -108,7 +108,7 @@ public class SparkStreamingPipelineDriver implements JavaSparkMain {
       stopped = jssc.awaitTerminationOrTimeout(Long.MAX_VALUE);
     } finally {
       if (!stopped) {
-        jssc.stop(true, true);
+        jssc.stop(true, pipelineSpec.isStopGracefully());
       }
     }
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/v2/DataStreamsConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/co/cask/cdap/etl/proto/v2/DataStreamsConfig.java
@@ -31,6 +31,7 @@ public final class DataStreamsConfig extends ETLConfig {
   private final String extraJavaOpts;
   private final Boolean disableCheckpoints;
   private final String checkpointDir;
+  private final Boolean stopGracefully;
   // See comments in DataStreamsSparkLauncher for explanation on why we need this.
   private final boolean isUnitTest;
 
@@ -44,13 +45,15 @@ public final class DataStreamsConfig extends ETLConfig {
                             boolean isUnitTest,
                             boolean disableCheckpoints,
                             @Nullable String checkpointDir,
-                            int numOfRecordsPreview) {
+                            int numOfRecordsPreview,
+                            boolean stopGracefully) {
     super(stages, connections, resources, driverResources, clientResources, stageLoggingEnabled, numOfRecordsPreview);
     this.batchInterval = batchInterval;
     this.isUnitTest = isUnitTest;
     this.extraJavaOpts = "";
     this.disableCheckpoints = disableCheckpoints;
     this.checkpointDir = checkpointDir;
+    this.stopGracefully = stopGracefully;
   }
 
   public String getBatchInterval() {
@@ -69,6 +72,10 @@ public final class DataStreamsConfig extends ETLConfig {
     return extraJavaOpts == null || extraJavaOpts.isEmpty() ? "-XX:MaxPermSize=256m" : extraJavaOpts;
   }
 
+  public Boolean getStopGracefully() {
+    return stopGracefully == null ? false : stopGracefully;
+  }
+
   @Nullable
   public String getCheckpointDir() {
     return checkpointDir;
@@ -81,6 +88,7 @@ public final class DataStreamsConfig extends ETLConfig {
       ", extraJavaOpts='" + extraJavaOpts + '\'' +
       ", disableCheckpoints=" + disableCheckpoints +
       ", checkpointDir='" + checkpointDir + '\'' +
+      ", stopGracefully=" + stopGracefully +
       ", isUnitTest=" + isUnitTest +
       "} " + super.toString();
   }
@@ -102,7 +110,8 @@ public final class DataStreamsConfig extends ETLConfig {
     return Objects.equals(batchInterval, that.batchInterval) &&
       Objects.equals(extraJavaOpts, that.extraJavaOpts) &&
       Objects.equals(disableCheckpoints, that.disableCheckpoints) &&
-      Objects.equals(checkpointDir, that.checkpointDir);
+      Objects.equals(checkpointDir, that.checkpointDir) &&
+      Objects.equals(stopGracefully, that.stopGracefully);
   }
 
   @Override
@@ -120,22 +129,17 @@ public final class DataStreamsConfig extends ETLConfig {
   public static class Builder extends ETLConfig.Builder<Builder> {
     private final boolean isUnitTest;
     private String batchInterval;
-    private Resources driverResources;
     private String checkpointDir;
+    private boolean stopGraceFully;
 
     public Builder() {
       this.isUnitTest = true;
       this.batchInterval = "1m";
-      this.driverResources = new Resources();
+      this.stopGraceFully = false;
     }
 
     public Builder setBatchInterval(String batchInterval) {
       this.batchInterval = batchInterval;
-      return this;
-    }
-
-    public Builder setDriverResources(Resources driverResources) {
-      this.driverResources = driverResources;
       return this;
     }
 
@@ -144,10 +148,15 @@ public final class DataStreamsConfig extends ETLConfig {
       return this;
     }
 
+    public Builder setStopGracefully(boolean stopGraceFully) {
+      this.stopGraceFully = stopGraceFully;
+      return this;
+    }
+
     public DataStreamsConfig build() {
       return new DataStreamsConfig(stages, connections, resources, driverResources, clientResources,
                                    stageLoggingEnabled, batchInterval, isUnitTest, false, checkpointDir,
-                                   numOfRecordsPreview);
+                                   numOfRecordsPreview, stopGraceFully);
     }
   }
 }

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/SparkExecutionService.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/SparkExecutionService.java
@@ -69,7 +69,7 @@ public final class SparkExecutionService extends AbstractIdleService {
   private static final Logger LOG = LoggerFactory.getLogger(SparkExecutionService.class);
   private static final Gson GSON = new Gson();
   private static final Type TOKEN_TYPE = new TypeToken<Map<String, String>>() { }.getType();
-  private static final long SHUTDOWN_WAIT_SECONDS = 30L;
+  private static final long SHUTDOWN_WAIT_SECONDS = 20L;
 
   private final LocationFactory locationFactory;
   private final NettyHttpService httpServer;

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/SparkExecutionService.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/SparkExecutionService.java
@@ -69,6 +69,9 @@ public final class SparkExecutionService extends AbstractIdleService {
   private static final Logger LOG = LoggerFactory.getLogger(SparkExecutionService.class);
   private static final Gson GSON = new Gson();
   private static final Type TOKEN_TYPE = new TypeToken<Map<String, String>>() { }.getType();
+  // make sure this is less than twill's shutdown wait (30 seconds),
+  // otherwise it causes really confusing behavior as this service will begin shutting down
+  // and then twill may or may not kill it partway through.
   private static final long SHUTDOWN_WAIT_SECONDS = 20L;
 
   private final LocationFactory locationFactory;


### PR DESCRIPTION
Changed the program controller used for Spark and MapReduce to
wait for the underlying guava service to execute its listeners
before transitioning the controller to the killed state. Otherwise,
the service listeners may not complete before the twill runnable
finishes and shuts down. This manifests itself as a failure to
record the program state and perform other cleanup.