### PR TITLE
Setup SDK security for AMI for AWS Marketplace

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -190,6 +190,12 @@
     },
     {
       "type": "shell",
+      "execute_command": "sudo bash -c '{{ .Vars }} {{ .Path }}'",
+      "scripts": "scripts/sdk-ami-security.sh",
+      "only": ["cdap-sdk-ami"]
+    },
+    {
+      "type": "shell",
       "scripts": [
         "scripts/random-root-password.sh",
         "scripts/zero-disk.sh"

--- a/cdap-distributions/src/packer/scripts/cookbook-dir.sh
+++ b/cdap-distributions/src/packer/scripts/cookbook-dir.sh
@@ -26,6 +26,7 @@ cd /var/chef/cookbooks
 touch .gitignore
 
 if [[ $(which apt-get 2>/dev/null) ]]; then
+  apt-get update
   apt-get install -y --no-install-recommends git || exit 1
 else
   yum install -y git || exit 1

--- a/cdap-distributions/src/packer/scripts/sdk-ami-security.sh
+++ b/cdap-distributions/src/packer/scripts/sdk-ami-security.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# Copyright © 2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+#
+# Update SDK configuration to use CDAP Basic Authentication
+#
+
+# Strip closing </configuration> tag
+sed -e '/<\/configuration>/d' /opt/cdap/sdk/conf/cdap-site.xml > /opt/cdap/sdk/conf/cdap-site.xml.new
+
+# Append our security configuration
+echo "  <property>
+    <name>security.enabled</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>security.authentication.basic.realmfile</name>
+    <value>/opt/cdap/sdk/conf/realmfile</value>
+  </property>
+
+  <property>
+    <name>security.authentication.handlerClassName</name>
+    <value>co.cask.cdap.security.server.BasicAuthenticationHandler</value>
+  </property>
+
+</configuration>" >> /opt/cdap/sdk/conf/cdap-site.xml.new
+
+unalias mv # in case root has a "mv -i" alias
+mv -f /opt/cdap/sdk/conf/cdap-site.xml{.new,}
+
+# Create init script to populate realmfile
+echo '#!/usr/bin/env bash
+
+#
+# chkconfig: 2345 95 15
+# description: Creates /opt/cdap/sdk/conf/realmfile using AWS instance ID
+#
+### BEGIN INIT INFO
+# Provides:          cdap-realmfile
+# Short-Description: CDAP realmfile creator
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Required-Start:    $syslog $remote_fs
+# Required-Stop:     $syslog $remote_fs
+# Should-Start:
+# Should-Stop:
+### END INIT INFO
+
+if [[ ${1} == start ]]; then
+  if [[ -e /opt/cdap/sdk/conf/realmfile ]]; then
+    echo "CDAP SDK Realmfile already exists... skipping generation"
+  else
+    __instance_id=$(curl -q http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null)
+    echo "Creating CDAP SDK Realmfile with Instance ID as password"
+    echo "cdap: ${__instance_id}" > /opt/cdap/sdk/conf/realmfile
+    chown cdap:cdap /opt/cdap/sdk/conf/realmfile
+    chmod 0400 /opt/cdap/sdk/conf/realmfile
+  fi
+fi
+exit 0' > /etc/init.d/cdap-realmfile
+chmod 755 /etc/init.d/cdap-realmfile
+
+# Add to default run-levels
+if [[ $(which update-rc.d 2>/dev/null) ]]; then
+  update-rc.d cdap-realmfile defaults
+else
+  chkconfig --add cdap-realmfile
+fi
+
+# Make cdap own /opt/cdap
+chown -R cdap:cdap /opt/cdap
+
+exit 0


### PR DESCRIPTION
This adds an `sdk-ami-security.sh` script which is only executed when building `cdap-sdk-ami` Packer target.

- Updates `cdap-site.xml` from SDK to include Basic Realm file Auth for CDAP
  - `/opt/cdap/sdk/conf/realmfile`
- Creates `cdap-realmfile` init script
  - Read [instance ID from metadata](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
  - Write out `/opt/cdap/sdk/conf/realmfile`
    - User name: `cdap`
    - Password: `${instance-id}`
- Adds `cdap-realmfile` to default run-levels