### PR TITLE
(CDAP-7823) Reported operational stats for CDAP

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/operations/AbstractOperationalStats.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/operations/AbstractOperationalStats.java
@@ -14,28 +14,28 @@
  * the License.
  */
 
-package co.cask.cdap.operations.hbase;
+package co.cask.cdap.operations;
 
-import co.cask.cdap.operations.AbstractOperationalStats;
-import com.google.common.annotations.VisibleForTesting;
-import org.apache.hadoop.conf.Configuration;
+import com.google.inject.Injector;
+
+import java.io.IOException;
 
 /**
- * Base class for HBase operational stats.
+ * A base class to provide default implementations for {@link OperationalStats} extensions
  */
-public abstract class AbstractHBaseStats extends AbstractOperationalStats {
-  @VisibleForTesting
-  static final String SERVICE_NAME = "HBase";
-
-  protected final Configuration conf;
-
-  @VisibleForTesting
-  AbstractHBaseStats(Configuration conf) {
-    this.conf = conf;
+public abstract class AbstractOperationalStats implements OperationalStats {
+  @Override
+  public void initialize(Injector injector) {
+    // no-op
   }
 
   @Override
-  public String getServiceName() {
-    return SERVICE_NAME;
+  public void collect() throws Exception {
+    // no-op
+  }
+
+  @Override
+  public void destroy() {
+    // no-op
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/operations/OperationalStats.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/operations/OperationalStats.java
@@ -16,7 +16,8 @@
 
 package co.cask.cdap.operations;
 
-import java.io.IOException;
+import com.google.inject.Injector;
+
 import javax.management.MBeanServer;
 import javax.management.MXBean;
 
@@ -29,6 +30,14 @@ import javax.management.MXBean;
  * property determined by {@link #getStatType()}.
  */
 public interface OperationalStats {
+
+  /**
+   * Initializes the operational stats extension. Called immediately after loading the operational stats extension.
+   *
+   * @param injector an {@link Injector} to inject the necessary CDAP classes
+   */
+  void initialize(Injector injector);
+
   /**
    * Returns the service name for which this operational stat is emitted. Service names are case-insensitive, and will
    * be converted to lower case.
@@ -43,5 +52,10 @@ public interface OperationalStats {
   /**
    * Collects the stats that are reported by this object.
    */
-  void collect() throws IOException;
+  void collect() throws Exception;
+
+  /**
+   * Performs any cleanup as necessary.
+   */
+  void destroy();
 }

--- a/cdap-operational-stats-core/pom.xml
+++ b/cdap-operational-stats-core/pom.xml
@@ -55,6 +55,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-app-fabric</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/AbstractCDAPStats.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/AbstractCDAPStats.java
@@ -14,33 +14,18 @@
  * the License.
  */
 
-package co.cask.cdap.operations.yarn;
+package co.cask.cdap.operations.cdap;
 
 import co.cask.cdap.operations.AbstractOperationalStats;
+import co.cask.cdap.operations.OperationalStats;
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.yarn.client.api.YarnClient;
-import org.apache.hadoop.yarn.conf.YarnConfiguration;
 
 /**
- * Base class for capturing stats from YARN.
+ * Base class for CDAP {@link OperationalStats}.
  */
-public abstract class AbstractYarnStats extends AbstractOperationalStats {
+public abstract class AbstractCDAPStats extends AbstractOperationalStats {
   @VisibleForTesting
-  static final String SERVICE_NAME = "Yarn";
-
-  protected final YarnConfiguration conf;
-
-  protected AbstractYarnStats(Configuration conf) {
-    this.conf = new YarnConfiguration(conf);
-  }
-
-  protected YarnClient createYARNClient() {
-    YarnClient yarnClient = YarnClient.createYarnClient();
-    yarnClient.init(conf);
-    yarnClient.start();
-    return yarnClient;
-  }
+  static final String SERVICE_NAME = "CDAP";
 
   @Override
   public String getServiceName() {

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/CDAPConnections.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/CDAPConnections.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.operations.cdap;
+
+import co.cask.cdap.api.dataset.lib.cube.AggregationFunction;
+import co.cask.cdap.api.metrics.MetricDataQuery;
+import co.cask.cdap.api.metrics.MetricStore;
+import co.cask.cdap.api.metrics.MetricTimeSeries;
+import co.cask.cdap.operations.OperationalStats;
+import com.google.inject.Injector;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * {@link OperationalStats} for reporting CDAP Router requests.
+ */
+public class CDAPConnections extends AbstractCDAPStats implements CDAPConnectionsMXBean {
+
+  private MetricStore metricStore;
+  private long totalRequests;
+  private long successful;
+  private long clientErrors;
+  private long serverErrors;
+  private long errorLogs;
+  private long warnLogs;
+
+  @Override
+  public void initialize(Injector injector) {
+    metricStore = injector.getInstance(MetricStore.class);
+  }
+
+  @Override
+  public String getStatType() {
+    return "connections";
+  }
+
+  @Override
+  public long getTotalRequests() {
+    return totalRequests;
+  }
+
+  @Override
+  public long getSuccessful() {
+    return successful;
+  }
+
+  @Override
+  public long getClientErrors() {
+    return clientErrors;
+  }
+
+  @Override
+  public long getServerErrors() {
+    return serverErrors;
+  }
+
+  @Override
+  public long getErrorLogs() {
+    return errorLogs;
+  }
+
+  @Override
+  public long getWarnLogs() {
+    return warnLogs;
+  }
+
+  @Override
+  public void collect() throws IOException {
+    totalRequests = getMetricValue("system.request.received");
+    successful = getMetricValue("system.response.successful");
+    clientErrors = getMetricValue("system.response.client-error");
+    serverErrors = getMetricValue("system.response.server-error");
+    errorLogs = getMetricValue("system.services.log.error");
+    warnLogs = getMetricValue("system.services.log.warn");
+  }
+
+  private long getMetricValue(String metricName) {
+    long currentTimeSecs = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    // we want metrics in the last hour
+    long startTime = currentTimeSecs - (60 * 60);
+    Collection<MetricTimeSeries> metricTimeSeries = metricStore.query(
+      new MetricDataQuery(startTime, currentTimeSecs, Integer.MAX_VALUE, metricName, AggregationFunction.SUM,
+                          Collections.<String, String>emptyMap(), Collections.<String>emptyList())
+    );
+    return metricTimeSeries.isEmpty() ? 0L : metricTimeSeries.iterator().next().getTimeValues().get(0).getValue();
+  }
+}

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/CDAPConnectionsMXBean.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/CDAPConnectionsMXBean.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.operations.cdap;
+
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+
+import javax.management.MXBean;
+
+/**
+ * {@link MXBean} for reporting CDAP Router request statistics.
+ */
+public interface CDAPConnectionsMXBean {
+
+  /**
+   * Returns the total number of requests in the last hour.
+   */
+  long getTotalRequests();
+
+  /**
+   * Returns the number of requests that were responded to with a {@link HttpResponseStatus#OK} in the last hour.
+   */
+  long getSuccessful();
+
+  /**
+   * Returns the number of requests that were responded to with a {@link HttpResponseStatus#BAD_REQUEST}
+   * in the last hour.
+   */
+  long getClientErrors();
+
+  /**
+   * Returns the number of requests that were responded to with a {@link HttpResponseStatus#INTERNAL_SERVER_ERROR}
+   * in the last hour.
+   */
+  long getServerErrors();
+
+  /**
+   * Returns the number of {@code ERROR} logs in the last hour.
+   */
+  long getErrorLogs();
+
+  /**
+   * Returns the number of {@code WARN} logs in the last hour.
+   */
+  long getWarnLogs();
+}

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/CDAPEntities.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/CDAPEntities.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.operations.cdap;
+
+import co.cask.cdap.api.data.stream.StreamSpecification;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.transaction.stream.StreamAdmin;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import co.cask.cdap.internal.app.services.ApplicationLifecycleService;
+import co.cask.cdap.internal.app.services.ProgramLifecycleService;
+import co.cask.cdap.operations.OperationalStats;
+import co.cask.cdap.proto.ApplicationRecord;
+import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.StreamId;
+import com.google.common.base.Predicates;
+import com.google.inject.Injector;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * {@link OperationalStats} for reporting CDAP entities.
+ */
+public class CDAPEntities extends AbstractCDAPStats implements CDAPEntitiesMXBean {
+  private NamespaceQueryAdmin nsQueryAdmin;
+  private ApplicationLifecycleService appLifecycleService;
+  private ProgramLifecycleService programLifecycleService;
+  private ArtifactRepository artifactRepository;
+  private DatasetFramework dsFramework;
+  private StreamAdmin streamAdmin;
+  private int namespaces;
+  private int artifacts;
+  private int apps;
+  private int programs;
+  private int datasets;
+  private int streams;
+  private int streamViews;
+
+  @Override
+  public void initialize(Injector injector) {
+    nsQueryAdmin = injector.getInstance(NamespaceQueryAdmin.class);
+    appLifecycleService = injector.getInstance(ApplicationLifecycleService.class);
+    programLifecycleService = injector.getInstance(ProgramLifecycleService.class);
+    artifactRepository = injector.getInstance(ArtifactRepository.class);
+    dsFramework = injector.getInstance(DatasetFramework.class);
+    streamAdmin = injector.getInstance(StreamAdmin.class);
+  }
+
+  @Override
+  public String getStatType() {
+    return "entities";
+  }
+
+  @Override
+  public int getNamespaces() {
+    return namespaces;
+  }
+
+  @Override
+  public int getArtifacts() {
+    return artifacts;
+  }
+
+  @Override
+  public int getApplications() {
+    return apps;
+  }
+
+  @Override
+  public int getPrograms() {
+    return programs;
+  }
+
+  @Override
+  public int getDatasets() {
+    return datasets;
+  }
+
+  @Override
+  public int getStreams() {
+    return streams;
+  }
+
+  @Override
+  public int getStreamViews() {
+    return streamViews;
+  }
+
+  @Override
+  public void collect() throws Exception {
+    reset();
+    List<NamespaceMeta> namespaceMetas;
+    namespaceMetas = nsQueryAdmin.list();
+    namespaces = namespaceMetas.size();
+    for (NamespaceMeta meta : namespaceMetas) {
+      List<ApplicationRecord> appRecords =
+        appLifecycleService.getApps(meta.getNamespaceId(), Predicates.<ApplicationRecord>alwaysTrue());
+      apps += appRecords.size();
+      Set<ProgramType> programTypes = EnumSet.of(ProgramType.FLOW, ProgramType.MAPREDUCE, ProgramType.SERVICE,
+                                                 ProgramType.SPARK, ProgramType.WORKER, ProgramType.WORKFLOW);
+      for (ProgramType programType : programTypes) {
+        programs += programLifecycleService.list(meta.getNamespaceId(), programType).size();
+      }
+      artifacts += artifactRepository.getArtifacts(meta.getNamespaceId(), true).size();
+      datasets += dsFramework.getInstances(meta.getNamespaceId()).size();
+      List<StreamSpecification> streamSpecs = streamAdmin.listStreams(meta.getNamespaceId());
+      streams += streamSpecs.size();
+      for (StreamSpecification streamSpec : streamSpecs) {
+        StreamId streamId = meta.getNamespaceId().stream(streamSpec.getName());
+        streamViews += streamAdmin.listViews(streamId).size();
+      }
+    }
+  }
+
+  private void reset() {
+    namespaces = 0;
+    artifacts = 0;
+    apps = 0;
+    programs = 0;
+    datasets = 0;
+    streams = 0;
+    streamViews = 0;
+  }
+}

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/CDAPEntitiesMXBean.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/CDAPEntitiesMXBean.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.operations.cdap;
+
+import javax.management.MXBean;
+
+/**
+ * {@link MXBean} for reporting CDAP entities
+ */
+public interface CDAPEntitiesMXBean {
+  /**
+   * Returns the number of namespaces in CDAP
+   */
+  int getNamespaces();
+
+  /**
+   * Returns the number of artifacts in CDAP
+   */
+  int getArtifacts();
+
+  /**
+   * Returns the number of applications in CDAP
+   */
+  int getApplications();
+
+  /**
+   * Returns the number of programs in CDAP
+   */
+  int getPrograms();
+
+  /**
+   * Returns the number of datasets in CDAP
+   */
+  int getDatasets();
+
+  /**
+   * Returns the number of streams in CDAP
+   */
+  int getStreams();
+
+  /**
+   * Returns the number of stream views in CDAP
+   */
+  int getStreamViews();
+}

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/CDAPInfo.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/CDAPInfo.java
@@ -14,28 +14,27 @@
  * the License.
  */
 
-package co.cask.cdap.operations.hbase;
+package co.cask.cdap.operations.cdap;
 
-import co.cask.cdap.operations.AbstractOperationalStats;
-import com.google.common.annotations.VisibleForTesting;
-import org.apache.hadoop.conf.Configuration;
+import co.cask.cdap.operations.OperationalStats;
 
 /**
- * Base class for HBase operational stats.
+ * {@link OperationalStats} representing CDAP information.
  */
-public abstract class AbstractHBaseStats extends AbstractOperationalStats {
-  @VisibleForTesting
-  static final String SERVICE_NAME = "HBase";
+public class CDAPInfo extends AbstractCDAPStats implements CDAPInfoMXBean {
+  private final long startTime;
 
-  protected final Configuration conf;
-
-  @VisibleForTesting
-  AbstractHBaseStats(Configuration conf) {
-    this.conf = conf;
+  public CDAPInfo() {
+    this.startTime = System.currentTimeMillis();
   }
 
   @Override
-  public String getServiceName() {
-    return SERVICE_NAME;
+  public long getUptime() {
+    return System.currentTimeMillis() - startTime;
+  }
+
+  @Override
+  public String getStatType() {
+    return "info";
   }
 }

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/CDAPInfoMXBean.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/CDAPInfoMXBean.java
@@ -14,28 +14,17 @@
  * the License.
  */
 
-package co.cask.cdap.operations.hbase;
+package co.cask.cdap.operations.cdap;
 
-import co.cask.cdap.operations.AbstractOperationalStats;
-import com.google.common.annotations.VisibleForTesting;
-import org.apache.hadoop.conf.Configuration;
+import javax.management.MXBean;
 
 /**
- * Base class for HBase operational stats.
+ * {@link MXBean} representing CDAP information.
  */
-public abstract class AbstractHBaseStats extends AbstractOperationalStats {
-  @VisibleForTesting
-  static final String SERVICE_NAME = "HBase";
+public interface CDAPInfoMXBean {
 
-  protected final Configuration conf;
-
-  @VisibleForTesting
-  AbstractHBaseStats(Configuration conf) {
-    this.conf = conf;
-  }
-
-  @Override
-  public String getServiceName() {
-    return SERVICE_NAME;
-  }
+  /**
+   * Returns the CDAP Master's uptime
+   */
+  long getUptime();
 }

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/CDAPTransactions.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/CDAPTransactions.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.operations.cdap;
+
+import co.cask.cdap.operations.OperationalStats;
+import com.google.inject.Injector;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.tephra.ChangeId;
+import org.apache.tephra.TransactionSystemClient;
+import org.apache.tephra.persist.TransactionSnapshot;
+import org.apache.tephra.snapshot.SnapshotCodecProvider;
+
+import java.io.InputStream;
+import java.util.Set;
+
+/**
+ * {@link OperationalStats} for reporting CDAP transaction statistics.
+ */
+public class CDAPTransactions extends AbstractCDAPStats implements CDAPTransactionsMXBean {
+
+  private TransactionSystemClient txClient;
+  private SnapshotCodecProvider codecProvider;
+  private int numInvalidTx;
+  private long snapshotTime;
+  private long readPointer;
+  private long writePointer;
+  private long visibilityUpperBound;
+  private int numInProgressTx;
+  private int numCommittingChangeSets;
+  private int numCommittedChangeSets;
+
+  @Override
+  public void initialize(Injector injector) {
+    txClient = injector.getInstance(TransactionSystemClient.class);
+    codecProvider = new SnapshotCodecProvider(injector.getInstance(Configuration.class));
+  }
+
+  @Override
+  public String getStatType() {
+    return "transactions";
+  }
+
+  @Override
+  public long getSnapshotTime() {
+    return snapshotTime;
+  }
+
+  @Override
+  public long getReadPointer() {
+    return readPointer;
+  }
+
+  @Override
+  public long getWritePointer() {
+    return writePointer;
+  }
+
+  @Override
+  public int getNumInProgressTransactions() {
+    return numInProgressTx;
+  }
+
+  @Override
+  public int getNumInvalidTransactions() {
+    return numInvalidTx;
+  }
+
+  @Override
+  public int getNumCommittingChangeSets() {
+    return numCommittingChangeSets;
+  }
+
+  @Override
+  public int getNumCommittedChangeSets() {
+    return numCommittedChangeSets;
+  }
+
+  @Override
+  public long getVisibilityUpperBound() {
+    return visibilityUpperBound;
+  }
+
+  @Override
+  public void collect() throws Exception {
+    numInvalidTx = txClient.getInvalidSize();
+    TransactionSnapshot txSnapshot;
+    try (InputStream inputStream = txClient.getSnapshotInputStream()) {
+      txSnapshot = codecProvider.decode(inputStream);
+    }
+    snapshotTime = txSnapshot.getTimestamp();
+    readPointer = txSnapshot.getReadPointer();
+    writePointer = txSnapshot.getWritePointer();
+    numInProgressTx = txSnapshot.getInProgress().size();
+    numCommittingChangeSets = 0;
+    for (Set<ChangeId> changeIds : txSnapshot.getCommittingChangeSets().values()) {
+      numCommittingChangeSets += changeIds.size();
+    }
+    numCommittedChangeSets = 0;
+    for (Set<ChangeId> changeIds : txSnapshot.getCommittedChangeSets().values()) {
+      numCommittedChangeSets += changeIds.size();
+    }
+    visibilityUpperBound = txSnapshot.getVisibilityUpperBound();
+  }
+}

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/CDAPTransactionsMXBean.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/cdap/CDAPTransactionsMXBean.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.operations.cdap;
+
+import javax.management.MXBean;
+
+/**
+ * {@link MXBean} for reporting CDAP transaction stats.
+ */
+public interface CDAPTransactionsMXBean {
+
+  /**
+   * Returns the time when the transaction snapshot was taken.
+   */
+  long getSnapshotTime();
+
+  /**
+   * Returns the read pointer at the time of the snapshot.
+   */
+  long getReadPointer();
+
+  /**
+   * Returns the next write pointer at the time of the snapshot.
+   */
+  long getWritePointer();
+
+  /**
+   * Returns the number of transactions that are currently in progress.
+   */
+  int getNumInProgressTransactions();
+
+  /**
+   * Returns the size of the invalid transaction list.
+   */
+  int getNumInvalidTransactions();
+
+  /**
+   * Returns the number of committing change sets (that have not yet been committed) across all write pointers.
+   */
+  int getNumCommittingChangeSets();
+
+  /**
+   * Returns the number of committed change sets across all write pointers.
+   */
+  int getNumCommittedChangeSets();
+
+  /**
+   * Returns a transaction id {@code X} such that any of the transactions newer than {@code X} might be invisible to
+   * some of the currently in-progress transactions or to those that will be started
+   * NOTE: the returned tx id can be invalid.
+   */
+  long getVisibilityUpperBound();
+}

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/hdfs/AbstractHDFSStats.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/hdfs/AbstractHDFSStats.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.operations.hdfs;
 
+import co.cask.cdap.operations.AbstractOperationalStats;
 import co.cask.cdap.operations.OperationalStats;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
@@ -23,7 +24,7 @@ import org.apache.hadoop.conf.Configuration;
 /**
  * Base class for {@link OperationalStats} for HDFS
  */
-public abstract class AbstractHDFSStats implements OperationalStats {
+public abstract class AbstractHDFSStats extends AbstractOperationalStats {
   @VisibleForTesting
   static final String SERVICE_NAME = "HDFS";
 

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/yarn/YarnApps.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/yarn/YarnApps.java
@@ -21,9 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.client.api.YarnClient;
-import org.apache.hadoop.yarn.exceptions.YarnException;
 
-import java.io.IOException;
 import java.util.List;
 
 /**
@@ -96,14 +94,12 @@ public class YarnApps extends AbstractYarnStats implements OperationalStats, Yar
   }
 
   @Override
-  public synchronized void collect() throws IOException {
+  public synchronized void collect() throws Exception {
     reset();
     YarnClient yarnClient = createYARNClient();
     List<ApplicationReport> applications;
     try {
       applications = yarnClient.getApplications();
-    } catch (YarnException e) {
-      throw new IOException(e);
     } finally {
       yarnClient.stop();
     }

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/yarn/YarnNodes.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/yarn/YarnNodes.java
@@ -21,9 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.NodeReport;
 import org.apache.hadoop.yarn.client.api.YarnClient;
-import org.apache.hadoop.yarn.exceptions.YarnException;
 
-import java.io.IOException;
 import java.util.List;
 
 /**
@@ -94,14 +92,12 @@ public class YarnNodes extends AbstractYarnStats implements YarnNodesMXBean {
   }
 
   @Override
-  public synchronized void collect() throws IOException {
+  public synchronized void collect() throws Exception {
     reset();
     List<NodeReport> nodeReports;
     YarnClient yarnClient = createYARNClient();
     try {
       nodeReports = yarnClient.getNodeReports();
-    } catch (YarnException e) {
-      throw new IOException(e);
     } finally {
       yarnClient.stop();
     }

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/yarn/YarnQueues.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/yarn/YarnQueues.java
@@ -21,9 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.QueueInfo;
 import org.apache.hadoop.yarn.client.api.YarnClient;
-import org.apache.hadoop.yarn.exceptions.YarnException;
 
-import java.io.IOException;
 import java.util.List;
 
 /**
@@ -65,14 +63,12 @@ public class YarnQueues extends AbstractYarnStats implements YarnQueuesMXBean {
   }
 
   @Override
-  public synchronized void collect() throws IOException {
+  public synchronized void collect() throws Exception {
     reset();
     List<QueueInfo> queues;
     YarnClient yarnClient = createYARNClient();
     try {
       queues = yarnClient.getAllQueues();
-    } catch (YarnException e) {
-      throw new IOException(e);
     } finally {
       yarnClient.stop();
     }

--- a/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/yarn/YarnResources.java
+++ b/cdap-operational-stats-core/src/main/java/co/cask/cdap/operations/yarn/YarnResources.java
@@ -23,11 +23,9 @@ import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.NodeReport;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.client.api.YarnClient;
-import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.List;
 
 /**
@@ -87,14 +85,12 @@ public class YarnResources extends AbstractYarnStats implements YarnResourcesMXB
   }
 
   @Override
-  public synchronized void collect() throws IOException {
+  public synchronized void collect() throws Exception {
     reset();
     List<NodeReport> nodeReports;
     YarnClient yarnClient = createYARNClient();
     try {
       nodeReports = yarnClient.getNodeReports();
-    } catch (YarnException e) {
-      throw new IOException(e);
     } finally {
       yarnClient.stop();
     }

--- a/cdap-operational-stats-core/src/main/resources/META-INF/services/co.cask.cdap.operations.OperationalStats
+++ b/cdap-operational-stats-core/src/main/resources/META-INF/services/co.cask.cdap.operations.OperationalStats
@@ -14,15 +14,19 @@
 # the License.
 #
 
+co.cask.cdap.operations.cdap.CDAPConnections
+co.cask.cdap.operations.cdap.CDAPEntities
+co.cask.cdap.operations.cdap.CDAPInfo
+co.cask.cdap.operations.cdap.CDAPTransactions
+co.cask.cdap.operations.hbase.HBaseEntities
+co.cask.cdap.operations.hbase.HBaseInfo
+co.cask.cdap.operations.hbase.HBaseLoad
+co.cask.cdap.operations.hbase.HBaseNodes
 co.cask.cdap.operations.hdfs.HDFSInfo
 co.cask.cdap.operations.hdfs.HDFSNodes
 co.cask.cdap.operations.hdfs.HDFSStorage
-co.cask.cdap.operations.yarn.YarnInfo
 co.cask.cdap.operations.yarn.YarnApps
+co.cask.cdap.operations.yarn.YarnInfo
 co.cask.cdap.operations.yarn.YarnNodes
 co.cask.cdap.operations.yarn.YarnQueues
 co.cask.cdap.operations.yarn.YarnResources
-co.cask.cdap.operations.hbase.HBaseInfo
-co.cask.cdap.operations.hbase.HBaseNodes
-co.cask.cdap.operations.hbase.HBaseLoad
-co.cask.cdap.operations.hbase.HBaseEntities

--- a/cdap-operational-stats-core/src/test/java/co/cask/cdap/operations/cdap/CDAPOperationalStatsTest.java
+++ b/cdap-operational-stats-core/src/test/java/co/cask/cdap/operations/cdap/CDAPOperationalStatsTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.operations.cdap;
+
+import co.cask.cdap.AllProgramsApp;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.internal.AppFabricTestHelper;
+import co.cask.cdap.operations.OperationalStats;
+import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.id.NamespaceId;
+import com.google.inject.Injector;
+import org.apache.tephra.Transaction;
+import org.apache.tephra.TransactionSystemClient;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collections;
+
+/**
+ * Tests for {@link OperationalStats} for CDAP
+ */
+public class CDAPOperationalStatsTest {
+  private static final NamespaceId NAMESPACE = new NamespaceId("operations");
+  private static final long TEST_START_TIME = System.currentTimeMillis();
+
+  private static Injector injector;
+  private static NamespaceAdmin namespaceAdmin;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    injector = AppFabricTestHelper.getInjector();
+    namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
+    namespaceAdmin.create(new NamespaceMeta.Builder().setName(NAMESPACE).build());
+    CConfiguration cConf = injector.getInstance(CConfiguration.class);
+    AppFabricTestHelper.deployApplication(NAMESPACE.toId(), AllProgramsApp.class, null, cConf);
+    TransactionSystemClient txClient = injector.getInstance(TransactionSystemClient.class);
+    Transaction tx1 = txClient.startShort();
+    txClient.canCommit(tx1, Collections.singleton(Bytes.toBytes("foo")));
+    Transaction tx2 = txClient.startShort();
+    txClient.commit(tx2);
+    Transaction tx3 = txClient.startShort();
+    txClient.invalidate(tx3.getTransactionId());
+  }
+
+  @AfterClass
+  public static void teardown() throws Exception {
+    namespaceAdmin.delete(NAMESPACE);
+  }
+
+  @Test
+  public void test() throws Exception {
+    CDAPInfo info = new CDAPInfo();
+    Assert.assertEquals(AbstractCDAPStats.SERVICE_NAME, info.getServiceName());
+    Assert.assertEquals("info", info.getStatType());
+    Assert.assertTrue(info.getUptime() <= System.currentTimeMillis());
+    CDAPEntities entities = new CDAPEntities();
+    entities.initialize(injector);
+    Assert.assertEquals(AbstractCDAPStats.SERVICE_NAME, entities.getServiceName());
+    Assert.assertEquals("entities", entities.getStatType());
+    entities.collect();
+    Assert.assertEquals(1, entities.getNamespaces());
+    Assert.assertEquals(1, entities.getArtifacts());
+    Assert.assertEquals(1, entities.getApplications());
+    Assert.assertEquals(7, entities.getPrograms());
+    Assert.assertEquals(4, entities.getDatasets());
+    Assert.assertEquals(1, entities.getStreams());
+    Assert.assertEquals(0, entities.getStreamViews());
+    CDAPTransactions transactions = new CDAPTransactions();
+    transactions.initialize(injector);
+    Assert.assertEquals(AbstractCDAPStats.SERVICE_NAME, transactions.getServiceName());
+    Assert.assertEquals("transactions", transactions.getStatType());
+    transactions.collect();
+    Assert.assertEquals(1, transactions.getNumInProgressTransactions());
+    Assert.assertEquals(1, transactions.getNumInvalidTransactions());
+    Assert.assertEquals(1, transactions.getNumCommittingChangeSets());
+    Assert.assertEquals(0, transactions.getNumCommittedChangeSets());
+    Assert.assertTrue(transactions.getVisibilityUpperBound() > TEST_START_TIME);
+    Assert.assertTrue(transactions.getSnapshotTime() > TEST_START_TIME);
+    Assert.assertTrue(transactions.getReadPointer() > TEST_START_TIME);
+    Assert.assertTrue(transactions.getWritePointer() > TEST_START_TIME);
+    CDAPConnections requests = new CDAPConnections();
+    requests.initialize(injector);
+    Assert.assertEquals(AbstractCDAPStats.SERVICE_NAME, requests.getServiceName());
+    Assert.assertEquals("connections", requests.getStatType());
+    requests.collect();
+  }
+}

--- a/cdap-operational-stats-core/src/test/java/co/cask/cdap/operations/yarn/AbstractYarnOperationalStatsTest.java
+++ b/cdap-operational-stats-core/src/test/java/co/cask/cdap/operations/yarn/AbstractYarnOperationalStatsTest.java
@@ -63,7 +63,7 @@ public abstract class AbstractYarnOperationalStatsTest {
   @Test
   public void test() throws Exception {
     YarnInfo info = new YarnInfo(conf);
-    Assert.assertEquals("YARN", info.getServiceName());
+    Assert.assertEquals(AbstractYarnStats.SERVICE_NAME, info.getServiceName());
     Assert.assertEquals("info", info.getStatType());
     Assert.assertNotNull(info.getVersion());
     Assert.assertNull(info.getWebURL());
@@ -73,7 +73,7 @@ public abstract class AbstractYarnOperationalStatsTest {
     Assert.assertNotNull(info.getLogsURL());
     Assert.assertEquals(info.getWebURL() + "/logs", info.getLogsURL());
     YarnApps apps = new YarnApps(conf);
-    Assert.assertEquals("YARN", apps.getServiceName());
+    Assert.assertEquals(AbstractYarnStats.SERVICE_NAME, apps.getServiceName());
     Assert.assertEquals("apps", apps.getStatType());
     apps.collect();
     Assert.assertEquals(0, apps.getAccepted());
@@ -85,7 +85,7 @@ public abstract class AbstractYarnOperationalStatsTest {
     Assert.assertEquals(0, apps.getSubmitted());
     Assert.assertEquals(0, apps.getTotal());
     final YarnResources resources = new YarnResources(conf);
-    Assert.assertEquals("YARN", resources.getServiceName());
+    Assert.assertEquals(AbstractYarnStats.SERVICE_NAME, resources.getServiceName());
     Assert.assertEquals("resources", resources.getStatType());
     // wait until node manager reports are available
     Tasks.waitFor(true, new Callable<Boolean>() {
@@ -101,7 +101,7 @@ public abstract class AbstractYarnOperationalStatsTest {
     Assert.assertEquals(0, resources.getUsedVCores());
     Assert.assertEquals(resources.getTotalVCores(), resources.getFreeVCores());
     YarnQueues queues = new YarnQueues(conf);
-    Assert.assertEquals("YARN", queues.getServiceName());
+    Assert.assertEquals(AbstractYarnStats.SERVICE_NAME, queues.getServiceName());
     Assert.assertEquals("queues", queues.getStatType());
     Assert.assertEquals(0, queues.getStopped());
     Assert.assertEquals(0, queues.getStopped());
@@ -111,7 +111,7 @@ public abstract class AbstractYarnOperationalStatsTest {
     Assert.assertEquals(0, queues.getStopped());
     Assert.assertEquals(queues.getRunning(), queues.getTotal());
     YarnNodes nodes = new YarnNodes(conf);
-    Assert.assertEquals("YARN", nodes.getServiceName());
+    Assert.assertEquals(AbstractYarnStats.SERVICE_NAME, nodes.getServiceName());
     Assert.assertEquals("nodes", nodes.getStatType());
     Assert.assertEquals(0, nodes.getTotalNodes());
     Assert.assertEquals(0, nodes.getHealthyNodes());

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -152,20 +152,26 @@ features:
         view-invalid: View Invalid Transactions
     DetailPanel:
       headers:
-        nodes: Nodes
-        entities: Entities
         apps: Apps
         blocks: Blocks
-        storage: Storage
+        connections: Connections
+        entities: Entities
+        load: Load
+        nodes: Nodes
         queues: Queues
         resources: Resources
-        load: Load
+        storage: Storage
+        transactions: Transactions
       labels:
         Accepted: Accepted
+        Applications: Applications
+        Artifacts: Artifacts
         AverageRegionsPerServer: Average Regions Per Server
-        RemainingBytes: Available
+        ClientErrors: Client Errors
         CorruptBlocks: Corrupt Blocks
+        Datasets: Datasets
         DeadRegionServers: Dead Region Servers
+        ErrorLogs: Errors in Logs
         Failed: Failed
         Finished: Finished
         FreeMemory: Free Memory
@@ -180,13 +186,25 @@ features:
         MissingBlocks: Missing Blocks
         Namenodes: Namenodes
         Namespaces: Namespaces
+        NumCommittingChangeSets: Committing Changes
+        NumCommittedChangeSets: Committed Changes
+        NumInProgressTransactions: In-Progress Transactions
+        NumInvalidTransactions: Invalid Transactions
+        NumRequests: No. of Requests
+        Programs: Programs
+        ReadPointer: Read Pointer
         RegionServers: Region Servers
         RegionsInTransition: Regions in Transition
-        NumRequests: No. of Requests
+        RemainingBytes: Available
         Running: Running
+        ServerErrors: Server Errors
         Snapshots: Snapshots
+        SnapshotTime: Last Snapshot Time
         Stopped: Stopped
+        Streams: Streams
+        StreamViews: Stream Views
         Submitted: Submitted
+        Successful: Successful
         Tables: Tables
         Total: Total
         TotalBytes: Total
@@ -194,25 +212,29 @@ features:
         TotalContainers: Total Containers
         TotalMemory: Total Memory
         TotalRegions: Total Regions
+        TotalRequests: Total Requests
         TotalVCores: Total Virtual Cores
-        totalRegionServers: Total Region Servers
         UnderReplicatedBlocks: Under Replicated Blocks
         UsedBytes: Used
         UsedMemory: Used Memory
         UsedVCores: Used Virtual Cores
         UnusableNodes: Unusable Nodes
         UnusableContainers: Unusable Containers
+        VisibilityUpperBound: Visibility Upper Bound
+        WarnLogs: Warnings in Logs
+        WritePointer: Write Pointer
 
     Component-Overview:
       label: Component Overview
       headers:
+        cdap: CDAP
         cdh: CDH
-        yarn: YARN
         hbase: HBASE
         hdfs: HDFS
-        zookeeper: Zookeeper
         kafka: Kafka
         spark: Spark
+        yarn: YARN
+        zookeeper: Zookeeper
 
   Market:
     search-placeholder: Search

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsHandler.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/query/MetricsHandler.java
@@ -79,8 +79,7 @@ public class MetricsHandler extends AbstractHttpHandler {
   private static final String PARAM_MAX_INTERPOLATE_GAP = "maxInterpolateGap";
   private static final String PARAM_AGGREGATE = "aggregate";
   private static final String PARAM_AUTO_RESOLUTION = "auto";
-
-  public static final String ANY_TAG_VALUE = "*";
+  private static final String ANY_TAG_VALUE = "*";
 
   private final MetricStore metricStore;
 


### PR DESCRIPTION
- Includes an Operational Stats Framework change to add initialize and destroy methods to operational extensions.
- The CDAP master injector is available to operational stats extensions via the initialize method

Jira: [CDAP-7823](https://issues.cask.co/browse/CDAP-7823)
Build: http://builds.cask.co/browse/CDAP-RUT333

There is one more stat that we could possibly report for CDAP, but opening PR to get review started and also because this needs a small UI change.

