### PR TITLE
(CDAP-7827) Use TwillPreparer to set log levels when program starts up

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/SystemArguments.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/SystemArguments.java
@@ -41,6 +41,21 @@ public final class SystemArguments {
   private static final String LOG_LEVEL = "system.log.level";
   public static final String TRANSACTION_TIMEOUT = "system.data.tx.timeout";
 
+  public static Map<String, String> getLogLevels(Map<String, String> args) {
+    Map<String, String> logLevels = new HashMap<>();
+    for (Map.Entry<String, String> entry : args.entrySet()) {
+      String loggerName = entry.getKey();
+      if (loggerName.length() > LOG_LEVEL.length() && loggerName.startsWith(LOG_LEVEL)) {
+        logLevels.put(loggerName.substring(LOG_LEVEL.length() + 1), entry.getValue());
+      }
+    }
+    String logLevel = args.get(LOG_LEVEL);
+    if (logLevel != null) {
+      logLevels.put(Logger.ROOT_LOGGER_NAME, logLevel);
+    }
+    return logLevels;
+  }
+
   /**
    * Set the log level for the {@link LogAppenderInitializer}.
    *
@@ -57,18 +72,7 @@ public final class SystemArguments {
    * @param initializer the LogAppenderInitializer which will be used to set up the log level
    */
   public static void setLogLevel(Map<String, String> args, LogAppenderInitializer initializer) {
-    Map<String, String> logPairs = new HashMap<>();
-    for (Map.Entry<String, String> entry : args.entrySet()) {
-      String key = entry.getKey();
-      if (!key.equals(LOG_LEVEL) && key.startsWith(LOG_LEVEL)) {
-        logPairs.put(entry.getKey().substring(LOG_LEVEL.length() + 1), entry.getValue());
-      }
-    }
-    String logLevel = args.get(LOG_LEVEL);
-    if (logLevel != null) {
-      logPairs.put(Logger.ROOT_LOGGER_NAME, logLevel);
-    }
-    initializer.setLogLevels(logPairs);
+    initializer.setLogLevels(getLogLevels(args));
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractDistributedProgramRunner.java
@@ -275,6 +275,7 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner,
               if (logbackURI != null) {
                 twillPreparer.addJVMOptions("-Dlogback.configurationFile=" + LOGBACK_FILE_NAME);
               }
+              setLogLevels(twillPreparer, program, options);
 
               String logLevelConf = cConf.get(Constants.COLLECT_APP_CONTAINER_LOG_LEVEL).toUpperCase();
               if ("OFF".equals(logLevelConf)) {
@@ -444,6 +445,23 @@ public abstract class AbstractDistributedProgramRunner implements ProgramRunner,
       conf.writeXml(writer);
     }
     return file;
+  }
+
+  protected TwillPreparer setLogLevels(TwillPreparer twillPreparer, Program program, ProgramOptions options) {
+    Map<String, String> logLevels = SystemArguments.getLogLevels(options.getUserArguments().asMap());
+    if (logLevels.isEmpty()) {
+      return twillPreparer;
+    }
+    return twillPreparer.setLogLevels(transformLogLevels(logLevels));
+  }
+
+  protected Map<String, LogEntry.Level> transformLogLevels(Map<String, String> logLevels) {
+    return Maps.transformValues(logLevels, new Function<String, LogEntry.Level>() {
+      @Override
+      public LogEntry.Level apply(String input) {
+        return LogEntry.Level.valueOf(input.toUpperCase());
+      }
+    });
   }
 
   private File saveCConf(CConfiguration conf, File file, List<String> newExtraJars) throws IOException {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
@@ -36,7 +36,6 @@ import co.cask.cdap.internal.app.runtime.AbstractListener;
 import co.cask.cdap.internal.app.runtime.BasicArguments;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.SimpleProgramOptions;
-import co.cask.cdap.internal.app.runtime.SystemArguments;
 import co.cask.cdap.internal.app.runtime.codec.ArgumentsCodec;
 import co.cask.cdap.internal.app.runtime.codec.ProgramOptionsCodec;
 import co.cask.cdap.logging.appender.LogAppenderInitializer;
@@ -175,7 +174,6 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
       // Initialize log appender
       logAppenderInitializer = injector.getInstance(LogAppenderInitializer.class);
       logAppenderInitializer.initialize();
-      SystemArguments.setLogLevel(programOpts.getUserArguments(), logAppenderInitializer);
 
       // Create the ProgramRunner
       programRunner = createProgramRunner(injector);

--- a/cdap-app-fabric/src/main/java/org/apache/twill/internal/ServiceMain.java
+++ b/cdap-app-fabric/src/main/java/org/apache/twill/internal/ServiceMain.java
@@ -229,12 +229,12 @@ public abstract class ServiceMain {
   }
 
   /**
-   * Override to return the right log level for the service.
+   * Return the right log level for the service.
    *
    * @param logger the {@link Logger} instance of the service context.
    * @return String of log level based on {@code slf4j} log levels.
    */
-  protected String getLoggerLevel(Logger logger) {
+  private String getLoggerLevel(Logger logger) {
     if (logger instanceof ch.qos.logback.classic.Logger) {
       return ((ch.qos.logback.classic.Logger) logger).getLevel().toString();
     }

--- a/cdap-app-fabric/src/main/java/org/apache/twill/internal/container/TwillContainerMain.java
+++ b/cdap-app-fabric/src/main/java/org/apache/twill/internal/container/TwillContainerMain.java
@@ -72,12 +72,6 @@ public final class TwillContainerMain extends ServiceMain {
 
   private static final Logger LOG = LoggerFactory.getLogger(TwillContainerMain.class);
 
-  private final Map<String, String> logLevels;
-
-  private TwillContainerMain(Map<String, String> logLevels) {
-    this.logLevels = logLevels;
-  }
-
   /**
    * Main method for launching a {@link TwillContainerService} which runs
    * a {@link org.apache.twill.api.TwillRunnable}.
@@ -148,19 +142,13 @@ public final class TwillContainerMain extends ServiceMain {
                                                               createAppLocation(conf, twillRuntimeSpec.getFsUser(),
                                                                                 twillRuntimeSpec.getTwillAppDir()),
                                                               defaultLogLevels, logLevels);
-    new TwillContainerMain(logLevels).doMain(
+    new TwillContainerMain().doMain(
       service,
       zkClientService,
       new LogFlushService(),
       new TwillZKPathService(containerZKClient, runId),
       new CloseableServiceWrapper(discoveryService)
     );
-  }
-
-  @Override
-  protected String getLoggerLevel(Logger logger) {
-    String logLevel = logLevels.get(Logger.ROOT_LOGGER_NAME);
-    return logLevel == null ? super.getLoggerLevel(logger) : logLevel;
   }
 
   private static void loadSecureStore() throws IOException {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-7827
Build: http://builds.cask.co/browse/CDAP-RUT351-1

Need to update the CDAP side to set the log levels using TwillPreparer as Twill needs to know all the log levels to help reset the log levels.