### PR TITLE
CDAP-7116 Increase scheduler misfire threshold to 60 seconds, from 5 seconds

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -84,6 +84,7 @@ import co.cask.cdap.internal.app.runtime.schedule.LocalSchedulerService;
 import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerService;
 import co.cask.cdap.internal.app.runtime.schedule.store.DatasetBasedTimeScheduleStore;
+import co.cask.cdap.internal.app.runtime.schedule.store.TriggerMisfireLogger;
 import co.cask.cdap.internal.app.services.AppFabricServer;
 import co.cask.cdap.internal.app.services.ProgramLifecycleService;
 import co.cask.cdap.internal.app.services.StandaloneAppFabricServer;
@@ -448,6 +449,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       jrsf.initialize(scheduler);
       qs.initialize();
 
+      scheduler.getListenerManager().addTriggerListener(new TriggerMisfireLogger());
       return scheduler;
     }
   }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/DefaultSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/DefaultSchedulerService.java
@@ -94,11 +94,12 @@ public class DefaultSchedulerService {
       try {
         taskRunner.run(programId, builder.build(), userOverrides).get();
       } catch (TaskExecutionException e) {
+        LOG.warn("Error while running program {}. {}", programId, e);
         throw new JobExecutionException(e.getMessage(), e.getCause(), e.isRefireImmediately());
       } catch (Throwable t) {
-        // Do not  remove this log line. The exception at higher level gets caught by the quartz scheduler and is not
+        // Do not remove this log line. The exception at higher level gets caught by the quartz scheduler and is not
         // logged in cdap master logs making it hard to debug issues.
-        LOG.info("Error while running program {}. {}", programId, t);
+        LOG.warn("Error while running program {}. {}", programId, t);
         throw new JobExecutionException(t.getMessage(), t.getCause(), false);
       }
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/TriggerMisfireLogger.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/schedule/store/TriggerMisfireLogger.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.schedule.store;
+
+import org.quartz.Trigger;
+import org.quartz.listeners.TriggerListenerSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Logs schedule trigger misfires.
+ */
+public class TriggerMisfireLogger extends TriggerListenerSupport {
+  private static final Logger LOG = LoggerFactory.getLogger(TriggerMisfireLogger.class);
+
+  @Override
+  public String getName() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
+  protected Logger getLog() {
+    return LOG;
+  }
+
+  @Override
+  public void triggerMisfired(Trigger trigger) {
+    getLog().warn("Trigger {}.{} misfired job {}.{}  at: {}. Should have fired at: {}.",
+                  trigger.getKey().getGroup(), trigger.getKey().getName(),
+                  trigger.getJobKey().getGroup(), trigger.getJobKey().getName(), new java.util.Date(),
+                  trigger.getNextFireTime());
+  }
+}

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStoreTest.java
@@ -133,7 +133,7 @@ public class DatasetBasedTimeScheduleStoreTest {
     JobStore js;
     if (enablePersistence) {
       CConfiguration conf = injector.getInstance(CConfiguration.class);
-      js = new DatasetBasedTimeScheduleStore(factory, new ScheduleStoreTableUtil(dsFramework, conf));
+      js = new DatasetBasedTimeScheduleStore(factory, new ScheduleStoreTableUtil(dsFramework, conf), conf);
     } else {
       js = new RAMJobStore();
     }

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -220,6 +220,7 @@ public final class Constants {
    */
   public class Scheduler {
     public static final String CFG_SCHEDULER_MAX_THREAD_POOL_SIZE = "scheduler.max.thread.pool.size";
+    public static final String CFG_SCHEDULER_MISFIRE_THRESHOLD_MS = "scheduler.misfire.threshold.ms";
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -357,6 +357,15 @@
   </property>
 
   <property>
+    <name>scheduler.misfire.threshold.ms</name>
+    <value>60000</value>
+    <description>
+      The number of milliseconds by which a schedule execution can miss its
+      next-fire-time and still run
+    </description>
+  </property>
+
+  <property>
     <name>workflow.token.max.size.mb</name>
     <value>30</value>
     <description>

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="5f37143e83fd49d7f9786856538d3cea"
+DEFAULT_XML_MD5_HASH="fba3f38265dd6323aaf90634b6b9c2ea"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
[CDAP-7116](https://issues.cask.co/browse/CDAP-7116) Increase scheduler misfire threshold to 60 seconds, from a default of 5 seconds.

It's possible that the scheduled threads aren't launched within 5 seconds if hundreds of programs are being launched (due to a scarcity in CPU resources). RamStoreJob.java defaults to a misfire threshold of 5000ms.

Filed https://issues.cask.co/browse/CDAP-7830 for future improvements to handling misfires (rather than ignoring them as we are currently).

http://builds.cask.co/browse/CDAP-RUT352-5