### PR TITLE
Support old "svc-master run ${CLASSNAME}" syntax

### DIFF
--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -546,6 +546,7 @@ cdap_service() {
       echo ${CLASSPATH}
       __ret=0
       ;;
+    run) cdap_run_class ${__args} ; __ret=${?} ;;
     usage|-h|--help) echo "Usage: $0 ${__service} {start|stop|restart|status|condrestart|classpath}"; __ret=0 ;;
     *) die "Usage: $0 ${__service} {start|stop|restart|status|condrestart|classpath}" ;;
   esac


### PR DESCRIPTION
This adds a `run` action to `cdap_service` function, which just runs `cdap_run_class` with the arguments given. This will support the older upgrade syntax, which users are accustomed.