### PR TITLE
CDAP-7161 Add auth enforcement to get program runtime args

### DIFF
--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
@@ -529,6 +529,21 @@ public class AppFabricClient {
     verifyResponse(HttpResponseStatus.OK, mockResponder.getStatus(), "Saving runtime arguments failed");
   }
 
+  public Map<String, String> getRuntimeArgs(ProgramId programId) throws Exception {
+    DefaultHttpRequest request = new DefaultHttpRequest(
+      HttpVersion.HTTP_1_1, HttpMethod.GET,
+      String.format("%s/apps/%s/%s/%s/runtimeargs", getNamespacePath(programId.getNamespace()),
+                    programId.getApplication(), programId.getType().getCategoryName(), programId.getProgram())
+    );
+    request.setHeader(Constants.Gateway.API_KEY, "api-key-example");
+    MockResponder mockResponder = new MockResponder();
+    programLifecycleHttpHandler.getProgramRuntimeArgs(request, mockResponder, programId.getNamespace(),
+                                                       programId.getApplication(),
+                                                       programId.getType().getCategoryName(), programId.getProgram());
+    verifyResponse(HttpResponseStatus.OK, mockResponder.getStatus(), "Getting runtime arguments failed");
+    return mockResponder.decodeResponseContent(MAP_TYPE);
+  }
+
   public List<PluginInstanceDetail> getPlugins(ApplicationId application) throws Exception {
     DefaultHttpRequest request = new DefaultHttpRequest(
       HttpVersion.HTTP_1_1, HttpMethod.GET,

--- a/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteApplicationManager.java
+++ b/cdap-integration-test/src/main/java/co/cask/cdap/test/remote/RemoteApplicationManager.java
@@ -187,4 +187,9 @@ public class RemoteApplicationManager extends AbstractApplicationManager {
   public void setRuntimeArgs(ProgramId programId, Map<String, String> args) throws Exception {
     programClient.setRuntimeArgs(programId, args);
   }
+
+  @Override
+  public Map<String, String> getRuntimeArgs(ProgramId programId) throws Exception {
+    return programClient.getRuntimeArgs(programId);
+  }
 }

--- a/cdap-test/src/main/java/co/cask/cdap/test/AbstractProgramManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/AbstractProgramManager.java
@@ -126,4 +126,9 @@ public abstract class AbstractProgramManager<T extends ProgramManager> implement
   public void setRuntimeArgs(Map<String, String> args) throws Exception {
     applicationManager.setRuntimeArgs(programId, args);
   }
+
+  @Override
+  public Map<String, String> getRuntimeArgs() throws Exception {
+    return applicationManager.getRuntimeArgs(programId);
+  }
 }

--- a/cdap-test/src/main/java/co/cask/cdap/test/ApplicationManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/ApplicationManager.java
@@ -171,4 +171,12 @@ public interface ApplicationManager {
    * @param args the arguments to save
    */
   void setRuntimeArgs(ProgramId programId, Map<String, String> args) throws Exception;
+
+  /**
+   * Gets runtime arguments of the specified program.
+   *
+   * @param programId the {@link ProgramId program} to get runtime arguments for
+   * @return args the arguments
+   */
+  Map<String, String> getRuntimeArgs(ProgramId programId) throws Exception;
 }

--- a/cdap-test/src/main/java/co/cask/cdap/test/ProgramManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/ProgramManager.java
@@ -98,4 +98,11 @@ public interface ProgramManager<T extends ProgramManager> {
    * @param args the runtime arguments to save
    */
   void setRuntimeArgs(Map<String, String> args) throws Exception;
+
+  /**
+   * Get runtime arguments of this program
+   *
+   * @return args the runtime arguments of the programs
+   */
+  Map<String, String> getRuntimeArgs() throws Exception;
 }

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultApplicationManager.java
@@ -199,4 +199,9 @@ public class DefaultApplicationManager extends AbstractApplicationManager {
   public void setRuntimeArgs(ProgramId programId, Map<String, String> args) throws Exception {
     appFabricClient.setRuntimeArgs(programId, args);
   }
+
+  @Override
+  public Map<String, String> getRuntimeArgs(ProgramId programId) throws Exception {
+    return appFabricClient.getRuntimeArgs(programId);
+  }
 }

--- a/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
@@ -724,6 +724,8 @@ public class AuthorizationTest extends TestBase {
     // alice should also be able to save runtime arguments for all future runs of the program
     Map<String, String> args = ImmutableMap.of("key", "value");
     greetingService.setRuntimeArgs(args);
+    // Alice should be able to get runtime arguments as she has ADMIN on it
+    Assert.assertEquals(args, greetingService.getRuntimeArgs());
     dummyAppManager.stopProgram(serviceId.toId());
     Tasks.waitFor(false, new Callable<Boolean>() {
       @Override
@@ -770,6 +772,15 @@ public class AuthorizationTest extends TestBase {
     } catch (UnauthorizedException expected) {
       // expected
     }
+
+    try {
+      greetingService.getRuntimeArgs();
+      Assert.fail("Getting runtime arguments should have failed because bob does not have READ privileges on the " +
+                    "service");
+    } catch (UnauthorizedException expected) {
+      // expected
+    }
+
     SecurityRequestContext.setUserId(ALICE.getName());
     dummyAppManager.delete();
     assertNoAccess(appId);


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/CDAP-7161

- Checks for READ on program to get runtime args
- Moved the getRuntimeArgs logic to ProgramLifecycleService from Handler
- Unit test to check for above auth

Build: http://builds.cask.co/browse/CDAP-RUT358-2
ITM: http://builds.cask.co/browse/CDAP-ITM6-9