### PR TITLE
Use explicit version of ark cookbook from upstream

### DIFF
--- a/cdap-distributions/src/packer/scripts/cookbook-setup.sh
+++ b/cdap-distributions/src/packer/scripts/cookbook-setup.sh
@@ -25,6 +25,9 @@ for cb in cdap hadoop idea maven nodejs openssh; do
   knife cookbook site install $cb || die "Cannot fetch cookbook $cb"
 done
 
+### TODO: remove this hack when chef-cookbooks/ark#181 is solved
+knife cookbook site install ark 2.1.0 || die "Cannot fetch ark cookbook 2.1.0"
+
 # Do not change HOME for cdap user
 sed -i '/ home /d' /var/chef/cookbooks/cdap/recipes/sdk.rb
 


### PR DESCRIPTION
Pin the cookbook version until chef-cookbooks/ark#181 is resolved and a new version of the `ark` cookbook is released.

This fixed the Docker and VM builds for CDAP.