### PR TITLE
[CDAP-7514] Provide classloader isolation for program context.execute()

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/AbstractContext.java
@@ -17,9 +17,11 @@
 package co.cask.cdap.internal.app.runtime;
 
 import co.cask.cdap.api.Admin;
+import co.cask.cdap.api.ProgramLifecycle;
 import co.cask.cdap.api.RuntimeContext;
 import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.annotation.TransactionControl;
 import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.common.RuntimeArguments;
 import co.cask.cdap.api.data.DatasetContext;
@@ -43,6 +45,8 @@ import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.app.services.AbstractServiceDiscoverer;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.lang.ClassLoaders;
+import co.cask.cdap.common.lang.CombineClassLoader;
 import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DynamicDatasetCache;
@@ -57,7 +61,9 @@ import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
+import org.apache.tephra.RetryStrategies;
 import org.apache.tephra.TransactionFailureException;
 import org.apache.tephra.TransactionSystemClient;
 import org.apache.twill.api.RunId;
@@ -381,17 +387,157 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
   }
 
   @Override
-  public void execute(TxRunnable runnable) throws TransactionFailureException {
-    transactional.execute(runnable);
+  public void execute(final TxRunnable runnable) throws TransactionFailureException {
+    execute(runnable, false);
+  }
+
+  /**
+   * Execute in a transaction with optional retry on conflict.
+   */
+  public void execute(final TxRunnable runnable, boolean retryOnConflict) throws TransactionFailureException {
+    ClassLoader oldClassLoader = ClassLoaders.setContextClassLoader(getClass().getClassLoader());
+    try {
+      Transactional txnl = retryOnConflict
+        ? Transactions.createTransactionalWithRetry(transactional, RetryStrategies.retryOnConflict(20, 100))
+        : transactional;
+      txnl.execute(new TxRunnable() {
+        @Override
+        public void run(DatasetContext context) throws Exception {
+          ClassLoader oldClassLoader = setContextCombinedClassLoader();
+          try {
+            runnable.run(context);
+          } finally {
+            ClassLoaders.setContextClassLoader(oldClassLoader);
+          }
+        }
+      });
+    } finally {
+      ClassLoaders.setContextClassLoader(oldClassLoader);
+    }
   }
 
   @Override
-  public void execute(int timeoutInSeconds, TxRunnable runnable) throws TransactionFailureException {
-    transactional.execute(timeoutInSeconds, runnable);
+  public void execute(int timeoutInSeconds, final TxRunnable runnable) throws TransactionFailureException {
+    ClassLoader oldClassLoader = ClassLoaders.setContextClassLoader(getClass().getClassLoader());
+    try {
+      transactional.execute(timeoutInSeconds, new TxRunnable() {
+        @Override
+        public void run(DatasetContext context) throws Exception {
+          ClassLoader oldClassLoader = setContextCombinedClassLoader();
+          try {
+            runnable.run(context);
+          } finally {
+            ClassLoaders.setContextClassLoader(oldClassLoader);
+          }
+        }
+      });
+    } finally {
+      ClassLoaders.setContextClassLoader(oldClassLoader);
+    }
   }
 
   @Override
   public DataTracer getDataTracer(String dataTracerName) {
     return dataTracerFactory.getDataTracer(program.getId().getParent(), dataTracerName);
+  }
+
+  /**
+   * Run some code with the context class loader combined from the program class loader and the system class loader.
+   */
+  public void executeChecked(final ThrowingRunnable runnable) throws Exception {
+    ClassLoader oldClassloader = setContextCombinedClassLoader();
+    try {
+      runnable.run();
+    } finally {
+      ClassLoaders.setContextClassLoader(oldClassloader);
+    }
+  }
+
+  /**
+   * Run some code with the context class loader combined from the program class loader and the system class loader.
+   */
+  public void executeUnchecked(final Runnable runnable) {
+    ClassLoader oldClassloader = setContextCombinedClassLoader();
+    try {
+      runnable.run();
+    } finally {
+      ClassLoaders.setContextClassLoader(oldClassloader);
+    }
+  }
+
+  /**
+   * Runnable that can throw an exception.
+   */
+  public interface ThrowingRunnable {
+    void run() throws Exception;
+  }
+
+  /**
+   * Initialize a program. The initialize() method is executed with the context class loader combined from the
+   * program class loader and the system class loader. If the transaction control is implicit, then this code
+   * is wrapped into a transaction, possibly with retry on conflict.
+   *
+   * @param program the program to be initialized
+   * @param programContext the program context
+   * @param txControl the transaction control
+   * @param retryOnConflict if true, transactional execution will be retried on conflict
+   * @param <T> the type of the program context
+   */
+  public <T extends AbstractContext> void initializeProgram(final ProgramLifecycle<? super T> program,
+                                                            final T programContext, TransactionControl txControl,
+                                                            boolean retryOnConflict)
+    throws Exception {
+    if (TransactionControl.IMPLICIT == txControl) {
+      programContext.execute(new TxRunnable() {
+        @Override
+        public void run(DatasetContext context) throws Exception {
+          program.initialize(programContext);
+        }
+      }, retryOnConflict);
+    } else {
+      programContext.executeChecked(new ThrowingRunnable() {
+        @Override
+        public void run() throws Exception {
+          program.initialize(programContext);
+        }
+      });
+    }
+  }
+
+  /**
+   * Destroy a program. The destroy() method is executed with the context class loader combined from the
+   * program class loader and the system class loader. If the transaction control is implicit, then this code
+   * is wrapped into a transaction, possibly with retry on conflict.
+   *
+   * @param program the program to be destroyed
+   * @param programContext the program context
+   * @param txControl the transaction control
+   * @param retryOnConflict if true, transactional execution will be retried on conflict
+   * @param <T> the type of the program context
+   */
+  public <T extends AbstractContext> void destroyProgram(final ProgramLifecycle<? super T> program,
+                                                         final T programContext, TransactionControl txControl,
+                                                         boolean retryOnConflict)
+    throws TransactionFailureException {
+    if (TransactionControl.IMPLICIT == txControl) {
+      programContext.execute(new TxRunnable() {
+        @Override
+        public void run(DatasetContext context) throws Exception {
+          program.destroy();
+        }
+      }, retryOnConflict);
+    } else {
+      programContext.executeUnchecked(new Runnable() {
+        @Override
+        public void run() {
+          program.destroy();
+        }
+      });
+    }
+  }
+
+  private ClassLoader setContextCombinedClassLoader() {
+    return ClassLoaders.setContextClassLoader(
+      new CombineClassLoader(null, ImmutableList.of(program.getClassLoader(), getClass().getClassLoader())));
   }
 }


### PR DESCRIPTION
… and lifecycle methods

Improves AbstractContext:
- add a method to set the combined program class loader
- add methods to execute a runnable with that class loader
- all transactions are executed with that class loader
- add methods to initialize/destroy a program, depending on transaction control with or without a tx.

Program runner use the new methods in AbstractContext to initialize/destroy programs and to run program code. 

I did not change the way that MapReduce tasks and Spark perform lifecycle. They are already using the correct class loaders, but their logic is more complex, and it did not make sense to refactor that into the common code in AbstractContext.