### PR TITLE
HYDRATOR-915 dont check input schemas for actions

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/DefaultStageConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/DefaultStageConfigurer.java
@@ -21,11 +21,9 @@ package co.cask.cdap.etl.common;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.etl.api.MultiInputStageConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
-import co.cask.cdap.etl.api.batch.BatchJoiner;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import javax.annotation.Nullable;
 
 
@@ -53,7 +51,7 @@ public class DefaultStageConfigurer implements StageConfigurer, MultiInputStageC
   @Override
   @Nullable
   public Schema getInputSchema() {
-    return inputSchemas.entrySet().iterator().next().getValue();
+    return inputSchemas.isEmpty() ? null : inputSchemas.entrySet().iterator().next().getValue();
   }
 
   @Nullable
@@ -67,28 +65,8 @@ public class DefaultStageConfigurer implements StageConfigurer, MultiInputStageC
     this.outputSchema = outputSchema;
   }
 
-  public void addInputSchema(String stageType, String inputStageName, @Nullable Schema inputSchema) {
-    // Do not allow null input schema for Joiner
-    if (stageType.equalsIgnoreCase(BatchJoiner.PLUGIN_TYPE) && inputSchema == null) {
-        throw new IllegalArgumentException(String.format("Joiner cannot have any null input schemas, but stage %s " +
-                                                           "outputs a null schema.", inputStageName));
-    }
-
-    // Do not allow more than one input schema for stages other than Joiner
-    if (!stageType.equalsIgnoreCase(BatchJoiner.PLUGIN_TYPE) && !hasSameSchema(inputSchema)) {
-      throw new IllegalArgumentException("Two different input schema were set for the stage " + this.stageName);
-    }
-
+  public void addInputSchema(String inputStageName, @Nullable Schema inputSchema) {
     inputSchemas.put(inputStageName, inputSchema);
-  }
-
-  private boolean hasSameSchema(Schema inputSchema) {
-    if (!inputSchemas.isEmpty()) {
-      if (!Objects.equals(inputSchemas.values().iterator().next(), inputSchema)) {
-        return false;
-      }
-    }
-    return true;
   }
 }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/spec/PipelineSpecGeneratorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/co/cask/cdap/etl/spec/PipelineSpecGeneratorTest.java
@@ -25,6 +25,7 @@ import co.cask.cdap.api.dataset.lib.FileSet;
 import co.cask.cdap.etl.api.PipelineConfigurable;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.Transform;
+import co.cask.cdap.etl.api.action.Action;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.cdap.etl.api.batch.BatchSource;
 import co.cask.cdap.etl.batch.BatchPipelineSpec;
@@ -70,6 +71,7 @@ public class PipelineSpecGeneratorTest {
     pluginConfigurer.addMockPlugin(Transform.PLUGIN_TYPE, "mockA", new MockPlugin(SCHEMA_A), artifactIds);
     pluginConfigurer.addMockPlugin(Transform.PLUGIN_TYPE, "mockB", new MockPlugin(SCHEMA_B), artifactIds);
     pluginConfigurer.addMockPlugin(BatchSink.PLUGIN_TYPE, "mocksink", new MockPlugin(), artifactIds);
+    pluginConfigurer.addMockPlugin(Action.PLUGIN_TYPE, "mockaction", new MockPlugin(), artifactIds);
 
     specGenerator = new BatchPipelineSpecGenerator(pluginConfigurer,
                                                    ImmutableSet.of(BatchSource.PLUGIN_TYPE),
@@ -210,7 +212,7 @@ public class PipelineSpecGeneratorTest {
           .build())
       .addStage(
         StageSpec.builder("sink2", new PluginSpec(BatchSink.PLUGIN_TYPE, "mocksink", emptyMap, ARTIFACT_ID))
-          .addInputSchemas(ImmutableMap.<String, Schema>of("t1", SCHEMA_A, "t2", SCHEMA_A, "source", SCHEMA_A))
+          .addInputSchemas(ImmutableMap.of("t1", SCHEMA_A, "t2", SCHEMA_A, "source", SCHEMA_A))
           .addInputs("t1", "t2", "source")
           .build())
       .addStage(
@@ -222,14 +224,14 @@ public class PipelineSpecGeneratorTest {
           .build())
       .addStage(
         StageSpec.builder("t2", new PluginSpec(Transform.PLUGIN_TYPE, "mockA", emptyMap, ARTIFACT_ID))
-          .addInputSchemas(ImmutableMap.<String, Schema>of("source", SCHEMA_A, "t1", SCHEMA_A))
+          .addInputSchemas(ImmutableMap.of("source", SCHEMA_A, "t1", SCHEMA_A))
           .setOutputSchema(SCHEMA_A)
           .addInputs("source", "t1")
           .addOutputs("t3", "sink2")
           .build())
       .addStage(
         StageSpec.builder("t3", new PluginSpec(Transform.PLUGIN_TYPE, "mockB", emptyMap, ARTIFACT_ID))
-          .addInputSchemas(ImmutableMap.<String, Schema>of("t1", SCHEMA_A, "t2", SCHEMA_A))
+          .addInputSchemas(ImmutableMap.of("t1", SCHEMA_A, "t2", SCHEMA_A))
           .setOutputSchema(SCHEMA_B)
           .addInputs("t1", "t2")
           .addOutputs("sink1")
@@ -238,6 +240,79 @@ public class PipelineSpecGeneratorTest {
       .setResources(etlConfig.getResources())
       .setStageLoggingEnabled(etlConfig.isStageLoggingEnabled())
       .build();
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testDifferentInputSchemasForAction() {
+    /*
+     *           ---- transformA ---- sinkA ----
+     *           |                             |
+     * source ---                              |--- action
+     *           |                             |
+     *           ---- transformB ---- sinkB ----
+     *
+     * sink gets schema A and schema B as input, should fail
+     */
+    ETLPlugin mockAction = new ETLPlugin("mockaction", Action.PLUGIN_TYPE, ImmutableMap.<String, String>of(), null);
+    ETLBatchConfig config = ETLBatchConfig.builder("* * * * *")
+      .addStage(new ETLStage("source", MOCK_SOURCE))
+      .addStage(new ETLStage("tA", MOCK_TRANSFORM_A))
+      .addStage(new ETLStage("tB", MOCK_TRANSFORM_B))
+      .addStage(new ETLStage("sinkA", MOCK_SINK))
+      .addStage(new ETLStage("sinkB", MOCK_SINK))
+      .addStage(new ETLStage("action", mockAction))
+      .addConnection("source", "tA")
+      .addConnection("source", "tB")
+      .addConnection("tA", "sinkA")
+      .addConnection("tB", "sinkB")
+      .addConnection("sinkA", "action")
+      .addConnection("sinkB", "action")
+      .build();
+    PipelineSpec actual = specGenerator.generateSpec(config);
+
+    Map<String, String> emptyMap = ImmutableMap.of();
+    PipelineSpec expected = BatchPipelineSpec.builder()
+      .addStage(
+        StageSpec.builder("source", new PluginSpec(BatchSource.PLUGIN_TYPE, "mocksource", emptyMap, ARTIFACT_ID))
+          .setOutputSchema(SCHEMA_A)
+          .addOutputs("tA", "tB")
+          .build())
+      .addStage(
+        StageSpec.builder("sinkA", new PluginSpec(BatchSink.PLUGIN_TYPE, "mocksink", emptyMap, ARTIFACT_ID))
+          .addInputSchema("tA", SCHEMA_A)
+          .addInputs("tA")
+          .addOutputs("action")
+          .build())
+      .addStage(
+        StageSpec.builder("sinkB", new PluginSpec(BatchSink.PLUGIN_TYPE, "mocksink", emptyMap, ARTIFACT_ID))
+          .addInputSchema("tB", SCHEMA_B)
+          .addInputs("tB")
+          .addOutputs("action")
+          .build())
+      .addStage(
+        StageSpec.builder("tA", new PluginSpec(Transform.PLUGIN_TYPE, "mockA", emptyMap, ARTIFACT_ID))
+          .addInputSchema("source", SCHEMA_A)
+          .setOutputSchema(SCHEMA_A)
+          .addInputs("source")
+          .addOutputs("sinkA")
+          .build())
+      .addStage(
+        StageSpec.builder("tB", new PluginSpec(Transform.PLUGIN_TYPE, "mockB", emptyMap, ARTIFACT_ID))
+          .addInputSchema("source", SCHEMA_A)
+          .setOutputSchema(SCHEMA_B)
+          .addInputs("source")
+          .addOutputs("sinkB")
+          .build())
+      .addStage(
+        StageSpec.builder("action", new PluginSpec(Action.PLUGIN_TYPE, "mockaction", emptyMap, ARTIFACT_ID))
+          .addInputs("sinkA", "sinkB")
+          .build())
+      .addConnections(config.getConnections())
+      .setResources(config.getResources())
+      .setStageLoggingEnabled(config.isStageLoggingEnabled())
+      .build();
+
     Assert.assertEquals(expected, actual);
   }
 


### PR DESCRIPTION
Fixed a bug where the input schemas of stages preceding an action
were getting propagated, causing deployment errors if a pipeline
contained multiple sinks that connected to the same action.