### PR TITLE
CDAP-7844 Use the old stream view Id class for the class used for serialization/deserialization.

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/view/MDSViewStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/view/MDSViewStore.java
@@ -31,6 +31,7 @@ import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
 import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
 import co.cask.cdap.data2.transaction.Transactions;
 import co.cask.cdap.data2.transaction.TxCallable;
+import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.ViewDetail;
 import co.cask.cdap.proto.ViewSpecification;
 import co.cask.cdap.proto.id.DatasetId;
@@ -177,16 +178,18 @@ public final class MDSViewStore implements ViewStore {
   }
 
   private static final class StreamViewEntry {
-    private final StreamViewId id;
+    // This must use the deprecated stream view Id class, since this class is used for serialization and deserialization
+    // in the persistence layer. See CDAP-7844 for more details.
+    private final Id.Stream.View id;
     private final ViewSpecification spec;
 
     private StreamViewEntry(StreamViewId id, ViewSpecification spec) {
-      this.id = id;
+      this.id = id.toId();
       this.spec = spec;
     }
 
     public StreamViewId getId() {
-      return id;
+      return id.toEntityId();
     }
 
     public ViewSpecification getSpec() {


### PR DESCRIPTION
CDAP-7844 Use the old stream view Id class for the class used for serialization/deserialization.

Since we want to keep the format of the data the same, using the old Id class is the simplest way to do it.
Using Json parsing and custom serialization/deserialization is an approach that is messy and bug-prone.
In the future, we can move (and keep) the old Id class internally (if only in this place), instead of removing it.

The alternative would be to construct json (for persistence) in such a way that it matches the format of the old Id class.

See the JIRA for more details:
https://issues.cask.co/browse/CDAP-7844

http://builds.cask.co/browse/CDAP-RUT371