### PR TITLE
CDAP-7486 CLI is not working in Windows when used with SDK

### DIFF
--- a/cdap-cli/pom.xml
+++ b/cdap-cli/pom.xml
@@ -148,7 +148,7 @@
             <artifactId>maven-resources-plugin</artifactId>
             <version>2.6</version>
             <executions>
-              <!-- Copy CLI scripts -->
+              <!-- Copy CDAP and CLI scripts -->
               <execution>
                 <id>copy-cli-scripts</id>
                 <phase>process-resources</phase>

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -334,6 +334,7 @@
                     <resource>
                       <directory>${project.basedir}/bin</directory>
                       <targetPath>bin</targetPath>
+                      <filtering>true</filtering>
                     </resource>
                     <resource>
                       <directory>${project.parent.basedir}/cdap-common/bin</directory>
@@ -509,8 +510,6 @@
                       <directory>${project.parent.basedir}/cdap-cli/bin</directory>
                       <targetPath>bin</targetPath>
                       <includes>
-                        <include>cdap</include>
-                        <include>functions.sh</include>
                         <include>cdap-cli.bat</include>
                         <include>cdap-cli.sh</include>
                       </includes>
@@ -592,15 +591,16 @@
                   <goal>run</goal>
                 </goals>
               </execution>
-              <!-- Rename CLI jar and make CLI scripts executable -->
+              <!-- Make CDAP and CLI scripts executable -->
               <execution>
                 <id>copy-cli-bash</id>
                 <phase>prepare-package</phase>
                 <configuration>
                   <target>
+                    <chmod file="${stage.opt.dir}/bin/cdap-cli.bat" perm="755"/>
+                    <chmod file="${stage.opt.dir}/bin/cdap.bat" perm="755"/>
                     <chmod file="${stage.opt.dir}/bin/cdap" perm="755"/>
                     <chmod file="${stage.opt.dir}/bin/functions.sh" perm="644"/>
-                    <chmod file="${stage.opt.dir}/bin/cdap-cli.bat" perm="755"/>
                   </target>
                 </configuration>
                 <goals>


### PR DESCRIPTION
Munge the Windows "cdap.bat" file to set the version correctly.

Then the CLI will work under Windows.

- Adjusted a comment to reflect what a section actually does
- Removed a duplicative copying
- Set the permissions

Manually tested on Windows 8.1. Both `cdap.bat` and `cdap-cli.bat` started as expected.

Fix for https://issues.cask.co/browse/CDAP-7846