### PR TITLE
(CDAP-7412) Exposes TMS API to program context

### DIFF
--- a/cdap-api-spark/src/main/java/co/cask/cdap/api/spark/JavaSparkExecutionContext.java
+++ b/cdap-api-spark/src/main/java/co/cask/cdap/api/spark/JavaSparkExecutionContext.java
@@ -27,6 +27,7 @@ import co.cask.cdap.api.data.batch.Split;
 import co.cask.cdap.api.data.format.FormatSpecification;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.flow.flowlet.StreamEvent;
+import co.cask.cdap.api.messaging.MessagingContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
@@ -97,6 +98,14 @@ public abstract class JavaSparkExecutionContext implements RuntimeContext, Trans
    * @return A {@link Serializable} {@link SecureStore}.
    */
   public abstract SecureStore getSecureStore();
+
+  /**
+   * Returns a {@link MessagingContext} which can be used to interact with the transactional
+   * messaging system. Currently the returned instance can only be used in the Spark driver process.
+   *
+   * @return A {@link MessagingContext}
+   */
+  public abstract MessagingContext getMessagingContext();
 
   /**
    * Returns a {@link Serializable} {@link TaskLocalizationContext} which can be used to retrieve files localized to

--- a/cdap-api-spark/src/main/scala/co/cask/cdap/api/spark/SparkExecutionContext.scala
+++ b/cdap-api-spark/src/main/scala/co/cask/cdap/api/spark/SparkExecutionContext.scala
@@ -26,6 +26,7 @@ import co.cask.cdap.api.security.store.SecureStore
 import co.cask.cdap.api.stream.GenericStreamEventData
 import co.cask.cdap.api.workflow.{WorkflowInfo, WorkflowToken}
 import co.cask.cdap.api._
+import co.cask.cdap.api.messaging.MessagingContext
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.tephra.TransactionFailureException
@@ -83,6 +84,14 @@ trait SparkExecutionContext extends RuntimeContext with Transactional {
     * @return A [[scala.Serializable]] [[co.cask.cdap.api.plugin.PluginContext]]
     */
   def getSecureStore: SecureStore
+
+  /**
+    * Returns a [[co.cask.cdap.api.messaging.MessagingContext]] which can be used to interact with the transactional
+    * messaging system. Currently the returned instance can only be used in the Spark driver process.
+    *
+    * @return A [[co.cask.cdap.api.messaging.MessagingContext]]
+    */
+  def getMessagingContext: MessagingContext
 
   /**
     * Returns the [[co.cask.cdap.api.workflow.WorkflowToken]] if the Spark program

--- a/cdap-api/src/main/java/co/cask/cdap/api/Admin.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/Admin.java
@@ -21,13 +21,14 @@ import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.InstanceConflictException;
 import co.cask.cdap.api.dataset.InstanceNotFoundException;
+import co.cask.cdap.api.messaging.MessagingAdmin;
 import co.cask.cdap.api.security.store.SecureStoreManager;
 
 /**
  * This interface provides methods for operational calls from within a CDAP application.
  */
 @Beta
-public interface Admin extends SecureStoreManager {
+public interface Admin extends SecureStoreManager, MessagingAdmin {
   /**
    * Check whether a dataset exists in the current namespace.
    * @param name the name of the dataset

--- a/cdap-api/src/main/java/co/cask/cdap/api/customaction/CustomActionContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/customaction/CustomActionContext.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.RuntimeContext;
 import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.messaging.MessagingContext;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.workflow.WorkflowInfoProvider;
@@ -29,7 +30,7 @@ import co.cask.cdap.api.workflow.WorkflowInfoProvider;
  * Represents runtime context of the {@link CustomAction} in the Workflow.
  */
 public interface CustomActionContext extends RuntimeContext, DatasetContext, Transactional, WorkflowInfoProvider,
-  PluginContext, SecureStore, ServiceDiscoverer {
+  PluginContext, SecureStore, ServiceDiscoverer, MessagingContext {
 
   /**
    * Return the specification of the custom action.

--- a/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/FlowletContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/flow/flowlet/FlowletContext.java
@@ -20,12 +20,14 @@ import co.cask.cdap.api.RuntimeContext;
 import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.messaging.MessagingContext;
 import co.cask.cdap.api.security.store.SecureStore;
 
 /**
  * This interface represents the Flowlet context.
  */
-public interface FlowletContext extends RuntimeContext, DatasetContext, ServiceDiscoverer, SecureStore, Transactional {
+public interface FlowletContext extends RuntimeContext, DatasetContext, ServiceDiscoverer,
+  SecureStore, Transactional, MessagingContext {
   /**
    * @return Number of instances of this flowlet.
    */

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceContext.java
@@ -25,6 +25,7 @@ import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.batch.Input;
 import co.cask.cdap.api.data.batch.Output;
+import co.cask.cdap.api.messaging.MessagingContext;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.workflow.WorkflowInfoProvider;
@@ -33,7 +34,7 @@ import co.cask.cdap.api.workflow.WorkflowInfoProvider;
  * MapReduce job execution context.
  */
 public interface MapReduceContext extends RuntimeContext, DatasetContext, ServiceDiscoverer, Transactional,
-                                          PluginContext, ClientLocalizationContext, WorkflowInfoProvider, SecureStore {
+  PluginContext, ClientLocalizationContext, WorkflowInfoProvider, SecureStore, MessagingContext {
 
   /**
    * @return The specification used to configure this {@link MapReduce} job instance.

--- a/cdap-api/src/main/java/co/cask/cdap/api/messaging/MessagingContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/messaging/MessagingContext.java
@@ -67,7 +67,7 @@ public interface MessagingContext {
    * When those {@code fetch} methods are called without a transactional context, message will be fetched
    * without transaction.
    * </p>
-   * @return a new instance of {@link MessageFetcher}.
+   * @return a new instance of {@link MessageFetcher}. The returned instance cannot be shared across multiple threads.
    */
   MessageFetcher getMessageFetcher();
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceContext.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.RuntimeContext;
 import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.messaging.MessagingContext;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
 
@@ -27,7 +28,7 @@ import co.cask.cdap.api.security.store.SecureStore;
  * The context for a {@link HttpServiceHandler}. Currently contains methods to receive the
  * {@link HttpServiceHandlerSpecification} and the runtime arguments passed by the user.
  */
-public interface HttpServiceContext extends RuntimeContext, DatasetContext, ServiceDiscoverer,
+public interface HttpServiceContext extends RuntimeContext, DatasetContext, ServiceDiscoverer, MessagingContext,
   PluginContext, SecureStore, Transactional {
 
   /**

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkClientContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkClientContext.java
@@ -25,6 +25,7 @@ import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.messaging.MessagingContext;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
@@ -36,7 +37,7 @@ import co.cask.cdap.api.workflow.WorkflowInfoProvider;
  */
 @Beta
 public interface SparkClientContext extends RuntimeContext, DatasetContext, ClientLocalizationContext,
-  Transactional, ServiceDiscoverer, PluginContext, WorkflowInfoProvider, SecureStore {
+  Transactional, ServiceDiscoverer, PluginContext, WorkflowInfoProvider, SecureStore, MessagingContext {
 
   /**
    * @return The specification used to configure this {@link Spark} job instance.

--- a/cdap-api/src/main/java/co/cask/cdap/api/worker/WorkerContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/worker/WorkerContext.java
@@ -21,13 +21,14 @@ import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.stream.StreamWriter;
+import co.cask.cdap.api.messaging.MessagingContext;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
 
 /**
  * Context for {@link Worker}.
  */
-public interface WorkerContext extends RuntimeContext, ServiceDiscoverer, StreamWriter,
+public interface WorkerContext extends RuntimeContext, ServiceDiscoverer, StreamWriter, MessagingContext,
   DatasetContext, PluginContext, Transactional, SecureStore {
 
   /**

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowContext.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowContext.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.ServiceDiscoverer;
 import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.messaging.MessagingContext;
 import co.cask.cdap.api.plugin.PluginContext;
 import co.cask.cdap.api.security.store.SecureStore;
 
@@ -31,7 +32,7 @@ import java.util.Map;
  * Represents the runtime context of a {@link Workflow}. This context is also
  * available to {@link WorkflowAction}.
  */
-public interface WorkflowContext extends RuntimeContext, Transactional,
+public interface WorkflowContext extends RuntimeContext, Transactional, MessagingContext,
   ServiceDiscoverer, DatasetContext, PluginContext, SecureStore {
 
   WorkflowSpecification getWorkflowSpecification();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramRunnableModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramRunnableModule.java
@@ -44,6 +44,7 @@ import co.cask.cdap.internal.app.store.remote.RemoteLineageWriter;
 import co.cask.cdap.internal.app.store.remote.RemoteRuntimeStore;
 import co.cask.cdap.internal.app.store.remote.RemoteRuntimeUsageRegistry;
 import co.cask.cdap.logging.guice.LoggingModules;
+import co.cask.cdap.messaging.guice.MessagingClientModule;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
@@ -87,6 +88,7 @@ public class DistributedProgramRunnableModule {
       new ZKClientModule(),
       new KafkaClientModule(),
       new MetricsClientRuntimeModule().getDistributedModules(),
+      new MessagingClientModule(),
       new LocationRuntimeModule().getDistributedModules(),
       new LoggingModules().getDistributedModules(),
       new DiscoveryRuntimeModule().getDistributedModules(),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/preview/DefaultPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/preview/DefaultPreviewManager.java
@@ -43,6 +43,7 @@ import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactStore;
 import co.cask.cdap.logging.guice.LoggingModules;
+import co.cask.cdap.messaging.guice.MessagingClientModule;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.artifact.AppRequest;
@@ -224,6 +225,7 @@ public class DefaultPreviewManager implements PreviewManager {
       new MetricsClientRuntimeModule().getStandaloneModules(),
       new LoggingModules().getStandaloneModules(),
       new NamespaceStoreModule().getStandaloneModules(),
+      new MessagingClientModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DefaultAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DefaultAdmin.java
@@ -21,6 +21,9 @@ import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.InstanceNotFoundException;
+import co.cask.cdap.api.messaging.MessagingAdmin;
+import co.cask.cdap.api.messaging.TopicAlreadyExistsException;
+import co.cask.cdap.api.messaging.TopicNotFoundException;
 import co.cask.cdap.api.security.store.SecureStoreManager;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.proto.id.DatasetId;
@@ -28,6 +31,7 @@ import co.cask.cdap.proto.id.NamespaceId;
 
 import java.io.IOException;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Implementation of Admin that delegates dataset operations to a dataset framework.
@@ -37,11 +41,24 @@ public class DefaultAdmin implements Admin {
   private final DatasetFramework dsFramework;
   private final NamespaceId namespace;
   private final SecureStoreManager secureStoreManager;
+  private final MessagingAdmin messagingAdmin;
 
+  /**
+   * Creates an instance without messaging admin support.
+   */
   public DefaultAdmin(DatasetFramework dsFramework, NamespaceId namespace, SecureStoreManager secureStoreManager) {
+    this(dsFramework, namespace, secureStoreManager, null);
+  }
+
+  /**
+   * Creates an instance with all Admin functions supported.
+   */
+  public DefaultAdmin(DatasetFramework dsFramework, NamespaceId namespace,
+                      SecureStoreManager secureStoreManager, @Nullable MessagingAdmin messagingAdmin) {
     this.dsFramework = dsFramework;
     this.namespace = namespace;
     this.secureStoreManager = secureStoreManager;
+    this.messagingAdmin = messagingAdmin;
   }
 
   private DatasetId createInstanceId(String name) {
@@ -124,5 +141,46 @@ public class DefaultAdmin implements Admin {
   @Override
   public void deleteSecureData(String namespace, String name) throws Exception {
     secureStoreManager.deleteSecureData(namespace, name);
+  }
+
+  @Override
+  public void createTopic(String topic) throws TopicAlreadyExistsException, IOException {
+    if (messagingAdmin == null) {
+      throw new UnsupportedOperationException("Messaging not supported");
+    }
+    messagingAdmin.createTopic(topic);
+  }
+
+  @Override
+  public void createTopic(String topic,
+                          Map<String, String> properties) throws TopicAlreadyExistsException, IOException {
+    if (messagingAdmin == null) {
+      throw new UnsupportedOperationException("Messaging not supported");
+    }
+    messagingAdmin.createTopic(topic, properties);
+  }
+
+  @Override
+  public Map<String, String> getTopicProperties(String topic) throws TopicNotFoundException, IOException {
+    if (messagingAdmin == null) {
+      throw new UnsupportedOperationException("Messaging not supported");
+    }
+    return messagingAdmin.getTopicProperties(topic);
+  }
+
+  @Override
+  public void updateTopic(String topic, Map<String, String> properties) throws TopicNotFoundException, IOException {
+    if (messagingAdmin == null) {
+      throw new UnsupportedOperationException("Messaging not supported");
+    }
+    messagingAdmin.updateTopic(topic, properties);
+  }
+
+  @Override
+  public void deleteTopic(String topic) throws TopicNotFoundException, IOException {
+    if (messagingAdmin == null) {
+      throw new UnsupportedOperationException("Messaging not supported");
+    }
+    messagingAdmin.deleteTopic(topic);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -49,6 +49,7 @@ import co.cask.cdap.internal.app.runtime.workflow.BasicWorkflowToken;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
 import co.cask.cdap.logging.context.MapReduceLoggingContext;
 import co.cask.cdap.logging.context.WorkflowProgramLoggingContext;
+import co.cask.cdap.messaging.MessagingService;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
@@ -101,10 +102,11 @@ final class BasicMapReduceContext extends AbstractContext implements MapReduceCo
                         @Nullable File pluginArchive,
                         @Nullable PluginInstantiator pluginInstantiator,
                         SecureStore secureStore,
-                        SecureStoreManager secureStoreManager) {
+                        SecureStoreManager secureStoreManager,
+                        MessagingService messagingService) {
     super(program, programOptions, cConf, spec.getDataSets(), dsFramework, txClient, discoveryServiceClient, false,
           metricsCollectionService, createMetricsTags(workflowProgramInfo), secureStore, secureStoreManager,
-          pluginInstantiator);
+          messagingService, pluginInstantiator);
 
     this.workflowProgramInfo = workflowProgramInfo;
     this.loggingContext = createLoggingContext(program.getId(), getRunId(), workflowProgramInfo);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
@@ -27,6 +27,8 @@ import co.cask.cdap.api.data.batch.SplitReader;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
 import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
+import co.cask.cdap.api.messaging.MessageFetcher;
+import co.cask.cdap.api.messaging.MessagePublisher;
 import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreManager;
@@ -46,6 +48,7 @@ import co.cask.cdap.internal.app.runtime.batch.dataset.ForwardingSplitReader;
 import co.cask.cdap.internal.app.runtime.batch.dataset.output.MultipleOutputs;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
+import co.cask.cdap.messaging.MessagingService;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
@@ -115,10 +118,11 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
                             SecureStore secureStore,
                             SecureStoreManager secureStoreManager,
                             AuthorizationEnforcer authorizationEnforcer,
-                            AuthenticationContext authenticationContext) {
+                            AuthenticationContext authenticationContext,
+                            MessagingService messagingService) {
     super(program, programOptions, cConf,  ImmutableSet.<String>of(), dsFramework, txClient, discoveryServiceClient,
           true, metricsCollectionService, createMetricsTags(taskId, type, workflowProgramInfo), secureStore,
-          secureStoreManager, pluginInstantiator);
+          secureStoreManager, messagingService, pluginInstantiator);
     this.workflowProgramInfo = workflowProgramInfo;
     this.transaction = transaction;
     this.spec = spec;
@@ -233,6 +237,24 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
   @Override
   public InputContext getInputContext() {
     return inputContext;
+  }
+
+  @Override
+  public MessagePublisher getMessagePublisher() {
+    // TODO: CDAP-7807
+    throw new UnsupportedOperationException("Messaging is not supported in MapReduce task-level context");
+  }
+
+  @Override
+  public MessagePublisher getDirectMessagePublisher() {
+    // TODO: CDAP-7807
+    throw new UnsupportedOperationException("Messaging is not supported in MapReduce task-level context");
+  }
+
+  @Override
+  public MessageFetcher getMessageFetcher() {
+    // TODO: CDAP-7807
+    throw new UnsupportedOperationException("Messaging is not supported in MapReduce task-level context");
   }
 
   private static Map<String, String> createMetricsTags(@Nullable String taskId,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
@@ -31,6 +31,8 @@ import co.cask.cdap.api.macro.MacroEvaluator;
 import co.cask.cdap.api.mapreduce.MapReduceContext;
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
 import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
+import co.cask.cdap.api.messaging.MessageFetcher;
+import co.cask.cdap.api.messaging.MessagePublisher;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.api.preview.DataTracer;
 import co.cask.cdap.api.security.store.SecureStoreData;
@@ -297,5 +299,23 @@ public class MapReduceLifecycleContext<KEY, VALUE> implements MapReduceTaskConte
     return "MapReduceLifecycleContext{" +
       "delegate=" + delegate +
       '}';
+  }
+
+  @Override
+  public MessagePublisher getMessagePublisher() {
+    // TODO: CDAP-7807
+    throw new UnsupportedOperationException("Messaging is not supported in MapReduce task-level context");
+  }
+
+  @Override
+  public MessagePublisher getDirectMessagePublisher() {
+    // TODO: CDAP-7807
+    throw new UnsupportedOperationException("Messaging is not supported in MapReduce task-level context");
+  }
+
+  @Override
+  public MessageFetcher getMessageFetcher() {
+    // TODO: CDAP-7807
+    throw new UnsupportedOperationException("Messaging is not supported in MapReduce task-level context");
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -46,6 +46,7 @@ import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.internal.app.runtime.workflow.NameMappedDatasetFramework;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
 import co.cask.cdap.internal.lang.Reflections;
+import co.cask.cdap.messaging.MessagingService;
 import co.cask.cdap.proto.BasicThrowable;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
@@ -96,6 +97,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final SecureStoreManager secureStoreManager;
   private final AuthorizationEnforcer authorizationEnforcer;
   private final AuthenticationContext authenticationContext;
+  private final MessagingService messagingService;
 
   @Inject
   public MapReduceProgramRunner(Injector injector, CConfiguration cConf, Configuration hConf,
@@ -107,7 +109,8 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
                                 DiscoveryServiceClient discoveryServiceClient, RuntimeStore runtimeStore,
                                 SecureStore secureStore, SecureStoreManager secureStoreManager,
                                 AuthorizationEnforcer authorizationEnforcer,
-                                AuthenticationContext authenticationContext) {
+                                AuthenticationContext authenticationContext,
+                                MessagingService messagingService) {
     super(cConf);
     this.injector = injector;
     this.cConf = cConf;
@@ -123,6 +126,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.secureStoreManager = secureStoreManager;
     this.authorizationEnforcer = authorizationEnforcer;
     this.authenticationContext = authenticationContext;
+    this.messagingService = messagingService;
   }
 
   @Override
@@ -169,10 +173,10 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
       }
 
       final BasicMapReduceContext context =
-        new BasicMapReduceContext(program, options, cConf, spec,
-                                  workflowInfo, discoveryServiceClient,
+        new BasicMapReduceContext(program, options, cConf, spec, workflowInfo, discoveryServiceClient,
                                   metricsCollectionService, txSystemClient, programDatasetFramework, streamAdmin,
-                                  getPluginArchive(options), pluginInstantiator, secureStore, secureStoreManager);
+                                  getPluginArchive(options), pluginInstantiator, secureStore, secureStoreManager,
+                                  messagingService);
 
       Reflections.visit(mapReduce, mapReduce.getClass(),
                         new PropertyFieldSetter(context.getSpecification().getProperties()),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
@@ -30,6 +30,7 @@ import co.cask.cdap.data2.metadata.writer.ProgramContextAware;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.workflow.NameMappedDatasetFramework;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
+import co.cask.cdap.messaging.MessagingService;
 import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
@@ -160,6 +161,7 @@ public class MapReduceTaskContextProvider extends AbstractIdleService {
     final DatasetFramework datasetFramework = injector.getInstance(DatasetFramework.class);
     final SecureStore secureStore = injector.getInstance(SecureStore.class);
     final SecureStoreManager secureStoreManager = injector.getInstance(SecureStoreManager.class);
+    final MessagingService messagingService = injector.getInstance(MessagingService.class);
     // Multiple instances of BasicMapReduceTaskContext can shares the same program.
     final AtomicReference<Program> programRef = new AtomicReference<>();
 
@@ -213,7 +215,7 @@ public class MapReduceTaskContextProvider extends AbstractIdleService {
           spec, workflowInfo, discoveryServiceClient, metricsCollectionService, txClient,
           contextConfig.getTx(), programDatasetFramework, classLoader.getPluginInstantiator(),
           contextConfig.getLocalizedResources(), secureStore, secureStoreManager,
-          authorizationEnforcer, authenticationContext
+          authorizationEnforcer, authenticationContext, messagingService
         );
       }
     };

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/customaction/BasicCustomActionContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/customaction/BasicCustomActionContext.java
@@ -30,6 +30,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
+import co.cask.cdap.messaging.MessagingService;
 import org.apache.tephra.TransactionSystemClient;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
@@ -52,12 +53,13 @@ public class BasicCustomActionContext extends AbstractContext implements CustomA
                                   DatasetFramework datasetFramework, TransactionSystemClient txClient,
                                   DiscoveryServiceClient discoveryServiceClient,
                                   @Nullable PluginInstantiator pluginInstantiator,
-                                  SecureStore secureStore, SecureStoreManager secureStoreManager) {
+                                  SecureStore secureStore, SecureStoreManager secureStoreManager,
+                                  MessagingService messagingService) {
 
     super(workflow, programOptions, cConf, customActionSpecification.getDatasets(),
           datasetFramework, txClient, discoveryServiceClient, false,
           metricsCollectionService, workflowProgramInfo.updateMetricsTags(new HashMap<String, String>()), secureStore,
-          secureStoreManager, pluginInstantiator);
+          secureStoreManager, messagingService, pluginInstantiator);
 
     this.customActionSpecification = customActionSpecification;
     this.workflowProgramInfo = workflowProgramInfo;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/BasicFlowletContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/BasicFlowletContext.java
@@ -31,6 +31,7 @@ import co.cask.cdap.common.utils.ImmutablePair;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.logging.context.FlowletLoggingContext;
+import co.cask.cdap.messaging.MessagingService;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -65,11 +66,12 @@ final class BasicFlowletContext extends AbstractContext implements FlowletContex
                       DatasetFramework dsFramework,
                       SecureStore secureStore,
                       SecureStoreManager secureStoreManager,
+                      MessagingService messagingService,
                       CConfiguration cConf) {
     super(program, programOptions, cConf, datasets, dsFramework, txClient, discoveryServiceClient, false,
           metricsService, ImmutableMap.of(Constants.Metrics.Tag.FLOWLET, flowletId,
                                           Constants.Metrics.Tag.INSTANCE_ID, String.valueOf(instanceId)),
-          secureStore, secureStoreManager);
+          secureStore, secureStoreManager, messagingService);
 
     this.flowId = program.getName();
     this.flowletId = flowletId;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/flow/FlowletProgramRunner.java
@@ -79,6 +79,7 @@ import co.cask.cdap.internal.io.ReflectionDatumReader;
 import co.cask.cdap.internal.io.SchemaGenerator;
 import co.cask.cdap.internal.lang.Reflections;
 import co.cask.cdap.internal.specification.FlowletMethod;
+import co.cask.cdap.messaging.MessagingService;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.FlowletId;
@@ -143,6 +144,7 @@ public final class FlowletProgramRunner implements ProgramRunner {
   private final RuntimeUsageRegistry runtimeUsageRegistry;
   private final SecureStore secureStore;
   private final SecureStoreManager secureStoreManager;
+  private final MessagingService messageService;
 
   @Inject
   public FlowletProgramRunner(CConfiguration cConfiguration,
@@ -157,7 +159,8 @@ public final class FlowletProgramRunner implements ProgramRunner {
                               DatasetFramework dsFramework,
                               RuntimeUsageRegistry runtimeUsageRegistry,
                               SecureStore secureStore,
-                              SecureStoreManager secureStoreManager) {
+                              SecureStoreManager secureStoreManager,
+                              MessagingService messagingService) {
     this.cConf = cConfiguration;
     this.schemaGenerator = schemaGenerator;
     this.datumWriterFactory = datumWriterFactory;
@@ -171,6 +174,7 @@ public final class FlowletProgramRunner implements ProgramRunner {
     this.runtimeUsageRegistry = runtimeUsageRegistry;
     this.secureStore = secureStore;
     this.secureStoreManager = secureStoreManager;
+    this.messageService = messagingService;
   }
 
   @SuppressWarnings("unchecked")
@@ -221,7 +225,7 @@ public final class FlowletProgramRunner implements ProgramRunner {
       flowletContext = new BasicFlowletContext(program, options, flowletName, instanceId, instanceCount,
                                                flowletDef.getDatasets(), flowletDef.getFlowletSpec(),
                                                metricsCollectionService, discoveryServiceClient, txClient,
-                                               dsFramework, secureStore, secureStoreManager, cConf);
+                                               dsFramework, secureStore, secureStoreManager, messageService, cConf);
 
       // Creates tx related objects
       DataFabricFacade dataFabricFacade =

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/messaging/AbstractMessagePublisher.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/messaging/AbstractMessagePublisher.java
@@ -19,6 +19,8 @@ package co.cask.cdap.internal.app.runtime.messaging;
 import co.cask.cdap.api.messaging.MessagePublisher;
 import co.cask.cdap.api.messaging.TopicNotFoundException;
 import co.cask.cdap.common.io.ByteBuffers;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.TopicId;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterators;
 
@@ -61,4 +63,20 @@ abstract class AbstractMessagePublisher implements MessagePublisher {
       }
     }));
   }
+
+  @Override
+  public final void publish(String namespace, String topic,
+                            Iterator<byte[]> payloads) throws TopicNotFoundException, IOException {
+    NamespaceId namespaceId = new NamespaceId(namespace);
+    if (NamespaceId.SYSTEM.equals(namespaceId)) {
+      throw new IllegalArgumentException("Publish to '" + namespace + "' namespace is not allowed");
+    }
+    publish(namespaceId.topic(topic), payloads);
+  }
+
+  /**
+   * Publishes payloads to the given topic.
+   */
+  protected abstract void publish(TopicId topicId,
+                                  Iterator<byte[]> payloads) throws IOException, TopicNotFoundException;
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/messaging/BasicMessageFetcher.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/messaging/BasicMessageFetcher.java
@@ -66,8 +66,11 @@ final class BasicMessageFetcher implements MessageFetcher, TransactionAware {
                                           @Nullable String afterMessageId) throws IOException, TopicNotFoundException {
     co.cask.cdap.messaging.MessageFetcher fetcher = messagingService
       .prepareFetch(new NamespaceId(namespace).topic(topic))
-      .setLimit(limit)
-      .setStartMessage(Bytes.fromHexString(afterMessageId), false);
+      .setLimit(limit);
+
+    if (afterMessageId != null) {
+      fetcher.setStartMessage(Bytes.fromHexString(afterMessageId), false);
+    }
 
     if (transaction != null) {
       fetcher.setTransaction(transaction);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/messaging/BasicMessagingAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/messaging/BasicMessagingAdmin.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.messaging;
+
+import co.cask.cdap.api.messaging.MessagingAdmin;
+import co.cask.cdap.api.messaging.TopicAlreadyExistsException;
+import co.cask.cdap.api.messaging.TopicNotFoundException;
+import co.cask.cdap.messaging.MessagingService;
+import co.cask.cdap.messaging.TopicMetadata;
+import co.cask.cdap.proto.id.NamespaceId;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * A basic implementation of {@link MessagingAdmin} by delegating to {@link MessagingService}.
+ */
+public class BasicMessagingAdmin implements MessagingAdmin {
+
+  private final MessagingService messagingService;
+  private final NamespaceId namespace;
+
+  public BasicMessagingAdmin(MessagingService messagingService, NamespaceId namespace) {
+    this.messagingService = messagingService;
+    this.namespace = namespace;
+  }
+
+  @Override
+  public void createTopic(String topic) throws TopicAlreadyExistsException, IOException {
+    createTopic(topic, Collections.<String, String>emptyMap());
+  }
+
+  @Override
+  public void createTopic(String topic,
+                          Map<String, String> properties) throws TopicAlreadyExistsException, IOException {
+    messagingService.createTopic(new TopicMetadata(namespace.topic(topic), properties));
+  }
+
+  @Override
+  public Map<String, String> getTopicProperties(String topic) throws TopicNotFoundException, IOException {
+    return messagingService.getTopic(namespace.topic(topic)).getProperties();
+  }
+
+  @Override
+  public void updateTopic(String topic, Map<String, String> properties) throws TopicNotFoundException, IOException {
+    messagingService.updateTopic(new TopicMetadata(namespace.topic(topic), properties));
+  }
+
+  @Override
+  public void deleteTopic(String topic) throws TopicNotFoundException, IOException {
+    messagingService.deleteTopic(namespace.topic(topic));
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/messaging/DirectMessagePublisher.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/messaging/DirectMessagePublisher.java
@@ -20,7 +20,7 @@ import co.cask.cdap.api.messaging.MessagePublisher;
 import co.cask.cdap.api.messaging.TopicNotFoundException;
 import co.cask.cdap.messaging.MessagingService;
 import co.cask.cdap.messaging.client.StoreRequestBuilder;
-import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.TopicId;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -37,11 +37,7 @@ final class DirectMessagePublisher extends AbstractMessagePublisher {
   }
 
   @Override
-  public void publish(String namespace, String topic,
-                      Iterator<byte[]> payloads) throws IOException, TopicNotFoundException {
-    messagingService.publish(StoreRequestBuilder.of(new NamespaceId(namespace).topic(topic))
-      .addPayloads(payloads)
-      .build()
-    );
+  public void publish(TopicId topicId, Iterator<byte[]> payloads) throws IOException, TopicNotFoundException {
+    messagingService.publish(StoreRequestBuilder.of(topicId).addPayloads(payloads).build());
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/messaging/MessageIterator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/messaging/MessageIterator.java
@@ -63,6 +63,11 @@ final class MessageIterator extends AbstractCloseableIterator<Message> {
       public byte[] getPayload() {
         return rawMessage.getPayload();
       }
+
+      @Override
+      public String toString() {
+        return "Message{" + "id=" + getId() + ",payload=" + getPayloadAsString() + "}";
+      }
     };
   }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/messaging/MultiThreadMessagingContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/messaging/MultiThreadMessagingContext.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.runtime.messaging;
+
+import co.cask.cdap.api.messaging.MessageFetcher;
+import co.cask.cdap.api.messaging.MessagePublisher;
+import co.cask.cdap.api.messaging.MessagingContext;
+import co.cask.cdap.data2.dataset2.DynamicDatasetCache;
+import co.cask.cdap.data2.transaction.MultiThreadTransactionAware;
+import co.cask.cdap.messaging.MessagingService;
+import org.apache.tephra.TransactionAware;
+
+/**
+ * The basic implementation of {@link MessagingContext} for supporting message publishing/fetching in both
+ * non-transactional context and short transaction context (hence not for MR and Spark).
+ *
+ * Each program context should have an instance of this class, which is added as an extra {@link TransactionAware}
+ * through the {@link DynamicDatasetCache#addExtraTransactionAware(TransactionAware)} method so that it can tap into
+ * all transaction lifecycle events across all threads.
+ */
+public class MultiThreadMessagingContext extends MultiThreadTransactionAware<BasicMessagingContext>
+                                         implements MessagingContext {
+
+  private final MessagingService messagingService;
+
+  public MultiThreadMessagingContext(final MessagingService messagingService) {
+    this.messagingService = messagingService;
+  }
+
+  @Override
+  public MessagePublisher getMessagePublisher() {
+    return getCurrentThreadTransactionAware().getPublisher();
+  }
+
+  @Override
+  public MessagePublisher getDirectMessagePublisher() {
+    return new DirectMessagePublisher(messagingService);
+  }
+
+  @Override
+  public MessageFetcher getMessageFetcher() {
+    return getCurrentThreadTransactionAware().getFetcher();
+  }
+
+  @Override
+  protected BasicMessagingContext createTransactionAwareForCurrentThread() {
+    return new BasicMessagingContext(messagingService);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/ServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/ServiceProgramRunner.java
@@ -34,6 +34,7 @@ import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.internal.app.services.ServiceHttpServer;
+import co.cask.cdap.messaging.MessagingService;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.ProgramId;
 import com.google.common.base.Preconditions;
@@ -59,12 +60,14 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final ServiceAnnouncer serviceAnnouncer;
   private final SecureStore secureStore;
   private final SecureStoreManager secureStoreManager;
+  private final MessagingService messagingService;
 
   @Inject
   public ServiceProgramRunner(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
                               DatasetFramework datasetFramework, DiscoveryServiceClient discoveryServiceClient,
                               TransactionSystemClient txClient, ServiceAnnouncer serviceAnnouncer,
-                              SecureStore secureStore, SecureStoreManager secureStoreManager) {
+                              SecureStore secureStore, SecureStoreManager secureStoreManager,
+                              MessagingService messagingService) {
     super(cConf);
     this.metricsCollectionService = metricsCollectionService;
     this.datasetFramework = datasetFramework;
@@ -73,6 +76,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.serviceAnnouncer = serviceAnnouncer;
     this.secureStore = secureStore;
     this.secureStoreManager = secureStoreManager;
+    this.messagingService = messagingService;
   }
 
   @Override
@@ -109,7 +113,8 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
                                                           instanceId, instanceCount, serviceAnnouncer,
                                                           metricsCollectionService, datasetFramework,
                                                           txClient, discoveryServiceClient,
-                                                          pluginInstantiator, secureStore, secureStoreManager);
+                                                          pluginInstantiator, secureStore, secureStoreManager,
+                                                          messagingService);
 
       // Add a service listener to make sure the plugin instantiator is closed when the http server is finished.
       component.addListener(new ServiceListenerAdapter() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
@@ -27,6 +27,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
+import co.cask.cdap.messaging.MessagingService;
 import org.apache.tephra.TransactionContext;
 import org.apache.tephra.TransactionFailureException;
 import org.apache.tephra.TransactionSystemClient;
@@ -69,11 +70,12 @@ public class BasicHttpServiceContext extends AbstractContext implements Transact
                                  MetricsCollectionService metricsCollectionService,
                                  DatasetFramework dsFramework, DiscoveryServiceClient discoveryServiceClient,
                                  TransactionSystemClient txClient, @Nullable PluginInstantiator pluginInstantiator,
-                                 SecureStore secureStore, SecureStoreManager secureStoreManager) {
+                                 SecureStore secureStore, SecureStoreManager secureStoreManager,
+                                 MessagingService messagingService) {
     super(program, programOptions, cConf, spec == null ? Collections.<String>emptySet() : spec.getDatasets(),
           dsFramework, txClient, discoveryServiceClient, false,
           metricsCollectionService, createMetricsTags(spec, instanceId),
-          secureStore, secureStoreManager, pluginInstantiator);
+          secureStore, secureStoreManager, messagingService, pluginInstantiator);
     this.spec = spec;
     this.instanceId = instanceId;
     this.instanceCount = instanceCount;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
@@ -34,6 +34,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.logging.context.WorkerLoggingContext;
+import co.cask.cdap.messaging.MessagingService;
 import co.cask.cdap.proto.Id;
 import com.google.common.collect.ImmutableMap;
 import org.apache.tephra.TransactionSystemClient;
@@ -66,11 +67,12 @@ final class BasicWorkerContext extends AbstractContext implements WorkerContext 
                      StreamWriterFactory streamWriterFactory,
                      @Nullable PluginInstantiator pluginInstantiator,
                      SecureStore secureStore,
-                     SecureStoreManager secureStoreManager) {
+                     SecureStoreManager secureStoreManager,
+                     MessagingService messagingService) {
     super(program, programOptions, cConf, spec.getDatasets(),
           datasetFramework, transactionSystemClient, discoveryServiceClient, true,
           metricsCollectionService, ImmutableMap.of(Constants.Metrics.Tag.INSTANCE_ID, String.valueOf(instanceId)),
-          secureStore, secureStoreManager, pluginInstantiator);
+          secureStore, secureStoreManager, messagingService, pluginInstantiator);
 
     this.specification = spec;
     this.instanceId = instanceId;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
@@ -36,6 +36,7 @@ import co.cask.cdap.internal.app.runtime.ProgramControllerServiceAdapter;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
+import co.cask.cdap.messaging.MessagingService;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.ProgramId;
 import com.google.common.base.Preconditions;
@@ -63,12 +64,14 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final StreamWriterFactory streamWriterFactory;
   private final SecureStore secureStore;
   private final SecureStoreManager secureStoreManager;
+  private final MessagingService messagingService;
 
   @Inject
   public WorkerProgramRunner(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
                              DatasetFramework datasetFramework, DiscoveryServiceClient discoveryServiceClient,
                              TransactionSystemClient txClient, StreamWriterFactory streamWriterFactory,
-                             SecureStore secureStore, SecureStoreManager secureStoreManager) {
+                             SecureStore secureStore, SecureStoreManager secureStoreManager,
+                             MessagingService messagingService) {
     super(cConf);
     this.cConf = cConf;
     this.metricsCollectionService = metricsCollectionService;
@@ -78,6 +81,7 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.streamWriterFactory = streamWriterFactory;
     this.secureStore = secureStore;
     this.secureStoreManager = secureStoreManager;
+    this.messagingService = messagingService;
   }
 
   @Override
@@ -122,7 +126,8 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
                                                           cConf, instanceId, instanceCount,
                                                           metricsCollectionService, datasetFramework, txClient,
                                                           discoveryServiceClient, streamWriterFactory,
-                                                          pluginInstantiator, secureStore, secureStoreManager);
+                                                          pluginInstantiator, secureStore, secureStoreManager,
+                                                          messagingService);
 
       WorkerDriver worker = new WorkerDriver(program, newWorkerSpec, context);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/BasicWorkflowContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/BasicWorkflowContext.java
@@ -33,6 +33,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.internal.app.runtime.AbstractContext;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
+import co.cask.cdap.messaging.MessagingService;
 import com.google.common.collect.ImmutableMap;
 import org.apache.tephra.TransactionSystemClient;
 import org.apache.twill.discovery.DiscoveryServiceClient;
@@ -59,12 +60,13 @@ final class BasicWorkflowContext extends AbstractContext implements WorkflowCont
                        DatasetFramework datasetFramework, TransactionSystemClient txClient,
                        DiscoveryServiceClient discoveryServiceClient, Map<String, WorkflowNodeState> nodeStates,
                        @Nullable PluginInstantiator pluginInstantiator,
-                       SecureStore secureStore, SecureStoreManager secureStoreManager) {
+                       SecureStore secureStore, SecureStoreManager secureStoreManager,
+                       MessagingService messagingService) {
     super(program, programOptions, cConf, (spec == null) ? new HashSet<String>() : spec.getDatasets(),
           datasetFramework, txClient, discoveryServiceClient, false,
           metricsCollectionService, Collections.singletonMap(Constants.Metrics.Tag.WORKFLOW_RUN_ID,
                                                              ProgramRunners.getRunId(programOptions).getId()),
-          secureStore, secureStoreManager, pluginInstantiator);
+          secureStore, secureStoreManager, messagingService, pluginInstantiator);
     this.workflowSpec = workflowSpec;
     this.specification = spec;
     this.token = token;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramRunner.java
@@ -35,6 +35,7 @@ import co.cask.cdap.data2.metadata.writer.ProgramContextAware;
 import co.cask.cdap.internal.app.runtime.AbstractProgramRunnerWithPlugin;
 import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
+import co.cask.cdap.messaging.MessagingService;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.ProgramId;
 import com.google.common.base.Preconditions;
@@ -62,6 +63,7 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final RuntimeStore runtimeStore;
   private final SecureStore secureStore;
   private final SecureStoreManager secureStoreManager;
+  private final MessagingService messagingService;
   private final CConfiguration cConf;
 
   @Inject
@@ -70,7 +72,7 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
                                MetricsCollectionService metricsCollectionService, DatasetFramework datasetFramework,
                                DiscoveryServiceClient discoveryServiceClient, TransactionSystemClient txClient,
                                RuntimeStore runtimeStore, CConfiguration cConf, SecureStore secureStore,
-                               SecureStoreManager secureStoreManager) {
+                               SecureStoreManager secureStoreManager, MessagingService messagingService) {
     super(cConf);
     this.programRunnerFactory = programRunnerFactory;
     this.serviceAnnouncer = serviceAnnouncer;
@@ -82,6 +84,7 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.runtimeStore = runtimeStore;
     this.secureStore = secureStore;
     this.secureStoreManager = secureStoreManager;
+    this.messagingService = messagingService;
     this.cConf = cConf;
   }
 
@@ -111,7 +114,7 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
     WorkflowDriver driver = new WorkflowDriver(program, options, hostname, workflowSpec, programRunnerFactory,
                                                metricsCollectionService, datasetFramework, discoveryServiceClient,
                                                txClient, runtimeStore, cConf, pluginInstantiator,
-                                               secureStore, secureStoreManager);
+                                               secureStore, secureStoreManager, messagingService);
     // Controller needs to be created before starting the driver so that the state change of the driver
     // service can be fully captured by the controller.
     ProgramController controller = new WorkflowProgramController(program, driver, serviceAnnouncer, runId);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/preview/DefaultPreviewManagerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/preview/DefaultPreviewManagerTest.java
@@ -40,6 +40,7 @@ import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsServiceModule;
 import co.cask.cdap.logging.guice.LogReaderRuntimeModules;
 import co.cask.cdap.logging.guice.LoggingModules;
+import co.cask.cdap.messaging.guice.MessagingServerRuntimeModule;
 import co.cask.cdap.metadata.MetadataServiceModule;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.metrics.guice.MetricsHandlerModule;
@@ -95,6 +96,7 @@ public class DefaultPreviewManagerTest {
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getStandaloneModules(),
       new SecureStoreModules().getInMemoryModules(),
+      new MessagingServerRuntimeModule().getInMemoryModules(),
       new PreviewHttpModule()
     );
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
@@ -25,9 +25,9 @@ import co.cask.cdap.api.app.ApplicationSpecification;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.DatasetInstantiationException;
 import co.cask.cdap.api.dataset.Dataset;
-import co.cask.cdap.api.dataset.DatasetProperties;
-import co.cask.cdap.api.dataset.InstanceNotFoundException;
 import co.cask.cdap.api.macro.MacroEvaluator;
+import co.cask.cdap.api.messaging.MessageFetcher;
+import co.cask.cdap.api.messaging.MessagePublisher;
 import co.cask.cdap.api.metrics.MetricsContext;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.api.preview.DataTracer;
@@ -42,6 +42,7 @@ import co.cask.cdap.api.service.http.HttpServiceRequest;
 import co.cask.cdap.api.service.http.HttpServiceResponder;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
+import co.cask.cdap.common.test.NoopAdmin;
 import co.cask.cdap.internal.app.preview.NoopDataTracerFactory;
 import co.cask.http.HttpHandler;
 import co.cask.http.NettyHttpService;
@@ -82,7 +83,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -752,55 +752,7 @@ public class HttpHandlerGeneratorTest {
 
     @Override
     public Admin getAdmin() {
-      return new Admin() {
-        @Override
-        public boolean datasetExists(String name) {
-          return false;
-        }
-
-        @Nullable
-        @Override
-        public String getDatasetType(String name) throws InstanceNotFoundException {
-          throw new InstanceNotFoundException(name);
-        }
-
-        @Nullable
-        @Override
-        public DatasetProperties getDatasetProperties(String name) throws InstanceNotFoundException {
-          throw new InstanceNotFoundException(name);
-        }
-
-        @Override
-        public void createDataset(String name, String type, DatasetProperties properties) {
-          // nop-op
-        }
-
-        @Override
-        public void updateDataset(String name, DatasetProperties properties) {
-          // no-op
-        }
-
-        @Override
-        public void dropDataset(String name) {
-          // no-op
-        }
-
-        @Override
-        public void truncateDataset(String name) {
-          // nop-op
-        }
-
-        @Override
-        public void putSecureData(String namespace, String name, String data, String description,
-                                  Map<String, String> properties) throws Exception {
-          //no-op
-        }
-
-        @Override
-        public void deleteSecureData(String namespace, String name) throws Exception {
-          //no-op
-        }
-      };
+      return new NoopAdmin();
     }
 
     @Override
@@ -866,6 +818,21 @@ public class HttpHandlerGeneratorTest {
       } finally {
         System.clearProperty(IN_TX);
       }
+    }
+
+    @Override
+    public MessagePublisher getMessagePublisher() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public MessagePublisher getDirectMessagePublisher() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public MessageFetcher getMessageFetcher() {
+      throw new UnsupportedOperationException();
     }
   }
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/guice/AppFabricTestModule.java
@@ -43,6 +43,7 @@ import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
 import co.cask.cdap.internal.app.runtime.schedule.SchedulerException;
 import co.cask.cdap.logging.guice.LogReaderRuntimeModules;
 import co.cask.cdap.logging.guice.LoggingModules;
+import co.cask.cdap.messaging.guice.MessagingServerRuntimeModule;
 import co.cask.cdap.metadata.MetadataServiceModule;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.metrics.guice.MetricsHandlerModule;
@@ -130,6 +131,7 @@ public final class AppFabricTestModule extends AbstractModule {
     // we want to use RemotePrivilegesFetcher in this module, since app fabric service is started
     install(new AuthorizationEnforcementModule().getStandaloneModules());
     install(new SecureStoreModules().getInMemoryModules());
+    install(new MessagingServerRuntimeModule().getInMemoryModules());
   }
 
   private Scheduler createNoopScheduler() {

--- a/cdap-common/src/test/java/co/cask/cdap/common/test/NoopAdmin.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/test/NoopAdmin.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.test;
+
+import co.cask.cdap.api.Admin;
+import co.cask.cdap.api.dataset.DatasetManagementException;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.InstanceNotFoundException;
+import co.cask.cdap.api.messaging.TopicAlreadyExistsException;
+import co.cask.cdap.api.messaging.TopicNotFoundException;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * A {@link Admin} that performs no-operation on all methods.
+ */
+public class NoopAdmin implements Admin {
+
+  @Override
+  public boolean datasetExists(String name) throws DatasetManagementException {
+    return false;
+  }
+
+  @Override
+  public String getDatasetType(String name) throws DatasetManagementException {
+    throw new InstanceNotFoundException(name);
+  }
+
+  @Override
+  public DatasetProperties getDatasetProperties(String name) throws DatasetManagementException {
+    throw new InstanceNotFoundException(name);
+  }
+
+  @Override
+  public void createDataset(String name, String type,
+                            DatasetProperties properties) throws DatasetManagementException {
+    //no-op
+  }
+
+  @Override
+  public void updateDataset(String name, DatasetProperties properties) throws DatasetManagementException {
+    //no-op
+  }
+
+  @Override
+  public void dropDataset(String name) throws DatasetManagementException {
+    //no-op
+  }
+
+  @Override
+  public void truncateDataset(String name) throws DatasetManagementException {
+    //no-op
+  }
+
+  @Override
+  public void putSecureData(String namespace, String name, String data, String description,
+                            Map<String, String> properties) throws Exception {
+    // no-op
+  }
+
+  @Override
+  public void deleteSecureData(String namespace, String name) throws Exception {
+    // no-op
+  }
+
+  @Override
+  public void createTopic(String topic) throws TopicAlreadyExistsException, IOException {
+    // no-op
+  }
+
+  @Override
+  public void createTopic(String topic,
+                          Map<String, String> properties) throws TopicAlreadyExistsException, IOException {
+    // no-op
+  }
+
+  @Override
+  public Map<String, String> getTopicProperties(String topic) throws TopicNotFoundException, IOException {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public void updateTopic(String topic, Map<String, String> properties) throws TopicNotFoundException, IOException {
+    // no-op
+  }
+
+  @Override
+  public void deleteTopic(String topic) throws TopicNotFoundException, IOException {
+    // no-op
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DynamicDatasetCache.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/DynamicDatasetCache.java
@@ -263,6 +263,12 @@ public abstract class DynamicDatasetCache implements DatasetContext, Supplier<Tr
   public abstract Iterable<TransactionAware> getTransactionAwares();
 
   /**
+   * @return the current list of extra {@link TransactionAware}s that were added through the
+   * {@link #addExtraTransactionAware(TransactionAware)} method.
+   */
+  public abstract Iterable<TransactionAware> getExtraTransactionAwares();
+
+  /**
    * Add an extra transaction aware to the static datasets. This is a transaction aware that
    * is not instantiated through this factory, but needs to participate in every transaction.
    * Note that if a transaction is in progress, then this transaction aware will join that transaction.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/AbstractTransactionContext.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/AbstractTransactionContext.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction;
+
+import co.cask.cdap.api.common.Bytes;
+import com.google.common.base.Preconditions;
+import org.apache.tephra.Transaction;
+import org.apache.tephra.TransactionAware;
+import org.apache.tephra.TransactionConflictException;
+import org.apache.tephra.TransactionContext;
+import org.apache.tephra.TransactionFailureException;
+import org.apache.tephra.TransactionSystemClient;
+
+import java.util.Set;
+import java.util.TreeSet;
+import javax.annotation.Nullable;
+
+/**
+ * An abstract implementation of {@link TransactionContext} for governing general transaction lifecycle.
+ * This class provides flexibility on the set of
+ * {@link TransactionAware} to be participated in transactions.
+ *
+ * This abstract class extends from {@link TransactionContext} just for inheriting the type and public methods
+ * signatures. It is not using any functionality from the parent class.
+ */
+public abstract class AbstractTransactionContext extends TransactionContext {
+
+  private final TransactionSystemClient txClient;
+  private Transaction currentTx;
+
+  protected AbstractTransactionContext(TransactionSystemClient txClient) {
+    // Passing null to parent to make sure nothing in parent class would work
+    super(null);
+    this.txClient = txClient;
+  }
+
+  /**
+   * Provides the list of {@link TransactionAware} that are participating in transaction.
+   */
+  protected abstract Iterable<TransactionAware> getTransactionAwares();
+
+  /**
+   * Adds the given {@link TransactionAware} to participating in transaction.
+   *
+   * @param txAware the {@link TransactionAware} to add
+   * @return {@code true} if the given {@link TransactionAware} needs to participate in current transaction,
+   *                      {@code false} otherwise
+   */
+  protected abstract boolean doAddTransactionAware(TransactionAware txAware);
+
+  /**
+   * Removes the given {@link TransactionAware} from participating in transaction.
+   *
+   * @param txAware the {@link TransactionAware} to remove
+   * @return {@true} if removed, {@code false} otherwise
+   */
+  protected abstract boolean doRemoveTransactionAware(TransactionAware txAware);
+
+  /**
+   * Performs cleanup task after a transaction is completed (either committed or aborted).
+   */
+  protected void cleanup() {
+    // No-op
+  }
+
+  @Override
+  public final boolean addTransactionAware(TransactionAware txAware) {
+    boolean added = doAddTransactionAware(txAware);
+
+    // If there is an active transaction, call startTx on the given txAware as well
+    if (added && currentTx != null) {
+      txAware.startTx(currentTx);
+    }
+    return added;
+  }
+
+  @Override
+  public final boolean removeTransactionAware(TransactionAware txAware) {
+    Preconditions.checkState(currentTx == null, "Cannot remove TransactionAware while there is an active transaction.");
+    return doRemoveTransactionAware(txAware);
+  }
+
+  @Override
+  public void start() throws TransactionFailureException {
+    Preconditions.checkState(currentTx == null, "Already have an active transaction.");
+    currentTx = txClient.startShort();
+    startAllTxAwares();
+  }
+
+  @Override
+  public void start(int timeout) throws TransactionFailureException {
+    Preconditions.checkState(currentTx == null, "Already have an active transaction.");
+    currentTx = txClient.startShort(timeout);
+    startAllTxAwares();
+  }
+
+  @Override
+  public void finish() throws TransactionFailureException {
+    Preconditions.checkState(currentTx != null, "Cannot finish tx that has not been started");
+    // each of these steps will abort and rollback the tx in case if errors, and throw an exception
+    checkForConflicts();
+    persist();
+    commit();
+
+    try {
+      postCommit();
+    } finally {
+      currentTx = null;
+      cleanup();
+    }
+  }
+
+  @Override
+  public void abort() throws TransactionFailureException {
+    abort(null);
+  }
+
+  @Override
+  public void abort(@Nullable TransactionFailureException cause) throws TransactionFailureException {
+    if (currentTx == null) {
+      // might be called by some generic exception handler even though already aborted/finished - we allow that
+      return;
+    }
+    try {
+      boolean success = true;
+      for (TransactionAware txAware : getTransactionAwares()) {
+        try {
+          success = txAware.rollbackTx() && success;
+        } catch (Throwable e) {
+          if (cause == null) {
+            cause = new TransactionFailureException(
+              String.format("Unable to roll back changes in transaction-aware '%s' for transaction %d. ",
+                            txAware.getTransactionAwareName(), currentTx.getTransactionId()), e);
+          } else {
+            cause.addSuppressed(e);
+          }
+          success = false;
+        }
+      }
+      if (success) {
+        txClient.abort(currentTx);
+      } else {
+        txClient.invalidate(currentTx.getTransactionId());
+      }
+      if (cause != null) {
+        throw cause;
+      }
+    } finally {
+      currentTx = null;
+      cleanup();
+    }
+  }
+
+  @Override
+  public void checkpoint() throws TransactionFailureException {
+    Preconditions.checkState(currentTx != null, "Cannot checkpoint tx that has not been started");
+    persist();
+    try {
+      currentTx = txClient.checkpoint(currentTx);
+      // update the current transaction with all TransactionAwares
+      for (TransactionAware txAware : getTransactionAwares()) {
+        txAware.updateTx(currentTx);
+      }
+    } catch (TransactionFailureException e) {
+      abort(e);
+    } catch (Throwable e) {
+      abort(new TransactionFailureException(
+        String.format("Exception from checkpoint for transaction %d.", currentTx.getTransactionId()), e));
+    }
+  }
+
+  @Nullable
+  @Override
+  public Transaction getCurrentTransaction() {
+    return currentTx;
+  }
+
+  /**
+   * Calls {@link TransactionAware#startTx(Transaction)} on all {@link TransactionAware}.
+   */
+  private void startAllTxAwares() throws TransactionFailureException {
+    for (TransactionAware txAware : getTransactionAwares()) {
+      try {
+        txAware.startTx(currentTx);
+      } catch (Throwable e) {
+        try {
+          txClient.abort(currentTx);
+          throw new TransactionFailureException(
+            String.format("Unable to start transaction-aware '%s' for transaction %d. ",
+                          txAware.getTransactionAwareName(), currentTx.getTransactionId()), e);
+        } finally {
+          currentTx = null;
+        }
+      }
+    }
+  }
+
+  /**
+   * Collects the set of changes across all {@link TransactionAware}s by calling {@link TransactionAware#getTxChanges()}
+   * and checks if conflicts will arise when the transaction is going to be committed.
+   */
+  private void checkForConflicts() throws TransactionFailureException {
+    // Collects set of changes for conflict detection
+    Set<byte[]> changes = new TreeSet<>(Bytes.BYTES_COMPARATOR);
+    for (TransactionAware txAware : getTransactionAwares()) {
+      try {
+        changes.addAll(txAware.getTxChanges());
+      } catch (Throwable e) {
+        abort(new TransactionFailureException(
+          String.format("Unable to retrieve changes from transaction-aware '%s' for transaction %d. ",
+                        txAware.getTransactionAwareName(), currentTx.getTransactionId()), e));
+      }
+    }
+
+    // If there is no changes, no need to call canCommit
+    if (changes.isEmpty()) {
+      return;
+    }
+
+    try {
+      if (!txClient.canCommit(currentTx, changes)) {
+        throw new TransactionConflictException(
+          String.format("Conflict detected for transaction %d.", currentTx.getTransactionId()));
+      }
+    } catch (TransactionFailureException e) {
+      abort(e);
+    } catch (Throwable e) {
+      abort(new TransactionFailureException(
+        String.format("Exception from canCommit for transaction %d.", currentTx.getTransactionId()), e));
+    }
+  }
+
+  /**
+   * Calls {@link TransactionAware#commitTx()} on all {@link TransactionAware} to persist pending changes.
+   */
+  private void persist() throws TransactionFailureException {
+    for (TransactionAware txAware : getTransactionAwares()) {
+      boolean success = false;
+      Throwable cause = null;
+      try {
+        success = txAware.commitTx();
+      } catch (Throwable e) {
+        cause = e;
+      }
+      if (!success) {
+        abort(new TransactionFailureException(
+          String.format("Unable to persist changes of transaction-aware '%s' for transaction %d. ",
+                        txAware.getTransactionAwareName(), currentTx.getTransactionId()), cause));
+      }
+    }
+  }
+
+  /**
+   * Commits the current transaction.
+   */
+  private void commit() throws TransactionFailureException {
+    try {
+      if (!txClient.commit(currentTx)) {
+        // The only case that the commit call returning false is because of conflict.
+        // For all other kinds of error, exception will be raised.
+        throw new TransactionConflictException(
+          String.format("Conflict detected for transaction %d.", currentTx.getTransactionId()));
+      }
+    } catch (TransactionFailureException e) {
+      abort(e);
+    } catch (Throwable e) {
+      abort(new TransactionFailureException(
+        String.format("Exception from commit for transaction %d.", currentTx.getTransactionId()), e));
+    }
+  }
+
+  /**
+   * Calls the {@link TransactionAware#postTxCommit()} on all {@link TransactionAware}.
+   */
+  private void postCommit() throws TransactionFailureException {
+    TransactionFailureException cause = null;
+    for (TransactionAware txAware : getTransactionAwares()) {
+      try {
+        txAware.postTxCommit();
+      } catch (Throwable e) {
+        if (cause == null) {
+          cause = new TransactionFailureException(
+            String.format("Unable to perform post-commit in transaction-aware '%s' for transaction %d. ",
+                          txAware.getTransactionAwareName(), currentTx.getTransactionId()), e);
+        } else {
+          cause.addSuppressed(e);
+        }
+      }
+    }
+    if (cause != null) {
+      throw cause;
+    }
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/MultiThreadTransactionAware.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/MultiThreadTransactionAware.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
+import org.apache.tephra.Transaction;
+import org.apache.tephra.TransactionAware;
+
+import java.util.Collection;
+
+/**
+ * An abstract base class for implementing {@link TransactionAware} that is thread aware.
+ *
+ * @param <T> type of {@link TransactionAware} used in each thread.
+ */
+public abstract class MultiThreadTransactionAware<T extends TransactionAware> implements TransactionAware {
+
+  private final LoadingCache<Thread, T> perThreadTransactionAwares =
+    CacheBuilder.newBuilder().weakKeys()
+      .removalListener(new RemovalListener<Thread, T>() {
+        @Override
+        public void onRemoval(RemovalNotification<Thread, T> notification) {
+          T value = notification.getValue();
+          if (value != null) {
+            MultiThreadTransactionAware.this.onRemoval(value);
+          }
+        }
+      })
+      .build(new CacheLoader<Thread, T>() {
+        @Override
+        public T load(Thread thread) throws Exception {
+          return createTransactionAwareForCurrentThread();
+        }
+      });
+
+  protected abstract T createTransactionAwareForCurrentThread();
+
+  protected void onRemoval(T txAware) {
+    // no-op
+  }
+
+  protected final T getCurrentThreadTransactionAware() {
+    return perThreadTransactionAwares.getUnchecked(Thread.currentThread());
+  }
+
+  @Override
+  public final void startTx(Transaction transaction) {
+    getCurrentThreadTransactionAware().startTx(transaction);
+  }
+
+  @Override
+  public final void updateTx(Transaction transaction) {
+    getCurrentThreadTransactionAware().updateTx(transaction);
+  }
+
+  @Override
+  public final Collection<byte[]> getTxChanges() {
+    return getCurrentThreadTransactionAware().getTxChanges();
+  }
+
+  @Override
+  public final boolean commitTx() throws Exception {
+    return getCurrentThreadTransactionAware().commitTx();
+  }
+
+  @Override
+  public final void postTxCommit() {
+    getCurrentThreadTransactionAware().postTxCommit();
+  }
+
+  @Override
+  public final boolean rollbackTx() throws Exception {
+    return getCurrentThreadTransactionAware().rollbackTx();
+  }
+
+  @Override
+  public final String getTransactionAwareName() {
+    return getCurrentThreadTransactionAware().getTransactionAwareName();
+  }
+}

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/TransactionContextTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/transaction/TransactionContextTest.java
@@ -1,0 +1,694 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.inject.Inject;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.tephra.Transaction;
+import org.apache.tephra.TransactionAware;
+import org.apache.tephra.TransactionConflictException;
+import org.apache.tephra.TransactionContext;
+import org.apache.tephra.TransactionFailureException;
+import org.apache.tephra.TransactionManager;
+import org.apache.tephra.TransactionNotInProgressException;
+import org.apache.tephra.TransactionSystemClient;
+import org.apache.tephra.inmemory.InMemoryTxSystemClient;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Unit test for {@link AbstractTransactionContext}.
+ * All tests are copied from tephra TransactionContextTest.
+ */
+public class TransactionContextTest {
+
+  private static final byte[] A = { 'a' };
+  private static final byte[] B = { 'b' };
+
+  private static TransactionManager txManager;
+  private static DummyTxClient txClient;
+
+  private final DummyTxAware ds1 = new DummyTxAware();
+  private final DummyTxAware ds2 = new DummyTxAware();
+
+  @BeforeClass
+  public static void setup() {
+    txManager = new TransactionManager(new Configuration());
+    txManager.startAndWait();
+    txClient = new DummyTxClient(txManager);
+  }
+
+  @AfterClass
+  public static void finish() {
+    txManager.stopAndWait();
+  }
+
+  private TransactionContext newTransactionContext(TransactionAware... txAwares) {
+    return new SimpleTransactionContext(txClient, txAwares);
+  }
+
+  @Before
+  public void resetTxAwares() {
+    ds1.reset();
+    ds2.reset();
+  }
+
+  @Test
+  public void testSuccessful() throws TransactionFailureException, InterruptedException {
+    TransactionContext context = newTransactionContext(ds1, ds2);
+    // start transaction
+    context.start();
+    // add a change to ds1 and ds2
+    ds1.addChange(A);
+    ds2.addChange(B);
+    // commit transaction
+    context.finish();
+    // verify both are committed and post-committed
+    Assert.assertTrue(ds1.started);
+    Assert.assertTrue(ds2.started);
+    Assert.assertTrue(ds1.checked);
+    Assert.assertTrue(ds2.checked);
+    Assert.assertTrue(ds1.committed);
+    Assert.assertTrue(ds2.committed);
+    Assert.assertTrue(ds1.postCommitted);
+    Assert.assertTrue(ds2.postCommitted);
+    Assert.assertFalse(ds1.rolledBack);
+    Assert.assertFalse(ds2.rolledBack);
+    Assert.assertEquals(txClient.state, DummyTxClient.CommitState.Committed);
+  }
+
+  @Test
+  public void testPostCommitFailure() throws TransactionFailureException, InterruptedException {
+    ds1.failPostCommitTxOnce = InduceFailure.ThrowException;
+    TransactionContext context = newTransactionContext(ds1, ds2);
+    // start transaction
+    context.start();
+    // add a change to ds1 and ds2
+    ds1.addChange(A);
+    ds2.addChange(B);
+    // commit transaction should fail but without rollback as the failure happens post-commit
+    try {
+      context.finish();
+      Assert.fail("post commit failed - exception should be thrown");
+    } catch (TransactionFailureException e) {
+      Assert.assertEquals("post failure", e.getCause().getMessage());
+    }
+    // verify both are committed and post-committed
+    Assert.assertTrue(ds1.started);
+    Assert.assertTrue(ds2.started);
+    Assert.assertTrue(ds1.checked);
+    Assert.assertTrue(ds2.checked);
+    Assert.assertTrue(ds1.committed);
+    Assert.assertTrue(ds2.committed);
+    Assert.assertTrue(ds1.postCommitted);
+    Assert.assertTrue(ds2.postCommitted);
+    Assert.assertFalse(ds1.rolledBack);
+    Assert.assertFalse(ds2.rolledBack);
+    Assert.assertEquals(txClient.state, DummyTxClient.CommitState.Committed);
+  }
+
+  @Test
+  public void testPersistFailure() throws TransactionFailureException, InterruptedException {
+    ds1.failCommitTxOnce = InduceFailure.ThrowException;
+    TransactionContext context = newTransactionContext(ds1, ds2);
+    // start transaction
+    context.start();
+    // add a change to ds1 and ds2
+    ds1.addChange(A);
+    ds2.addChange(B);
+    // commit transaction should fail and cause rollback
+    try {
+      context.finish();
+      Assert.fail("Persist should have failed - exception should be thrown");
+    } catch (TransactionFailureException e) {
+      Assert.assertEquals("persist failure", e.getCause().getMessage());
+    }
+    // verify both are rolled back and tx is aborted
+    Assert.assertTrue(ds1.started);
+    Assert.assertTrue(ds2.started);
+    Assert.assertTrue(ds1.checked);
+    Assert.assertTrue(ds2.checked);
+    Assert.assertTrue(ds1.committed);
+    Assert.assertFalse(ds2.committed);
+    Assert.assertFalse(ds1.postCommitted);
+    Assert.assertFalse(ds2.postCommitted);
+    Assert.assertTrue(ds1.rolledBack);
+    Assert.assertTrue(ds2.rolledBack);
+    Assert.assertEquals(txClient.state, DummyTxClient.CommitState.Aborted);
+  }
+
+  @Test
+  public void testPersistFalse() throws TransactionFailureException, InterruptedException {
+    ds1.failCommitTxOnce = InduceFailure.ReturnFalse;
+    TransactionContext context = newTransactionContext(ds1, ds2);
+    // start transaction
+    context.start();
+    // add a change to ds1 and ds2
+    ds1.addChange(A);
+    ds2.addChange(B);
+    // commit transaction should fail and cause rollback
+    try {
+      context.finish();
+      Assert.fail("Persist should have failed - exception should be thrown");
+    } catch (TransactionFailureException e) {
+      Assert.assertNull(e.getCause()); // in this case, the ds simply returned false
+    }
+    // verify both are rolled back and tx is aborted
+    Assert.assertTrue(ds1.started);
+    Assert.assertTrue(ds2.started);
+    Assert.assertTrue(ds1.checked);
+    Assert.assertTrue(ds2.checked);
+    Assert.assertTrue(ds1.committed);
+    Assert.assertFalse(ds2.committed);
+    Assert.assertFalse(ds1.postCommitted);
+    Assert.assertFalse(ds2.postCommitted);
+    Assert.assertTrue(ds1.rolledBack);
+    Assert.assertTrue(ds2.rolledBack);
+    Assert.assertEquals(txClient.state, DummyTxClient.CommitState.Aborted);
+  }
+
+  @Test
+  public void testPersistAndRollbackFailure() throws TransactionFailureException, InterruptedException {
+    ds1.failCommitTxOnce = InduceFailure.ThrowException;
+    ds1.failRollbackTxOnce = InduceFailure.ThrowException;
+    TransactionContext context = newTransactionContext(ds1, ds2);
+    // start transaction
+    context.start();
+    // add a change to ds1 and ds2
+    ds1.addChange(A);
+    ds2.addChange(B);
+    // commit transaction should fail and cause rollback
+    try {
+      context.finish();
+      Assert.fail("Persist should have failed - exception should be thrown");
+    } catch (TransactionFailureException e) {
+      Assert.assertEquals("persist failure", e.getCause().getMessage());
+    }
+    // verify both are rolled back and tx is invalidated
+    Assert.assertTrue(ds1.started);
+    Assert.assertTrue(ds2.started);
+    Assert.assertTrue(ds1.checked);
+    Assert.assertTrue(ds2.checked);
+    Assert.assertTrue(ds1.committed);
+    Assert.assertFalse(ds2.committed);
+    Assert.assertFalse(ds1.postCommitted);
+    Assert.assertFalse(ds2.postCommitted);
+    Assert.assertTrue(ds1.rolledBack);
+    Assert.assertTrue(ds2.rolledBack);
+    Assert.assertEquals(txClient.state, DummyTxClient.CommitState.Invalidated);
+  }
+
+  @Test
+  public void testPersistAndRollbackFalse() throws TransactionFailureException, InterruptedException {
+    ds1.failCommitTxOnce = InduceFailure.ReturnFalse;
+    ds1.failRollbackTxOnce = InduceFailure.ReturnFalse;
+    TransactionContext context = newTransactionContext(ds1, ds2);
+    // start transaction
+    context.start();
+    // add a change to ds1 and ds2
+    ds1.addChange(A);
+    ds2.addChange(B);
+    // commit transaction should fail and cause rollback
+    try {
+      context.finish();
+      Assert.fail("Persist should have failed - exception should be thrown");
+    } catch (TransactionFailureException e) {
+      Assert.assertNull(e.getCause()); // in this case, the ds simply returned false
+    }
+    // verify both are rolled back and tx is invalidated
+    Assert.assertTrue(ds1.started);
+    Assert.assertTrue(ds2.started);
+    Assert.assertTrue(ds1.checked);
+    Assert.assertTrue(ds2.checked);
+    Assert.assertTrue(ds1.committed);
+    Assert.assertFalse(ds2.committed);
+    Assert.assertFalse(ds1.postCommitted);
+    Assert.assertFalse(ds2.postCommitted);
+    Assert.assertTrue(ds1.rolledBack);
+    Assert.assertTrue(ds2.rolledBack);
+    Assert.assertEquals(txClient.state, DummyTxClient.CommitState.Invalidated);
+  }
+
+  @Test
+  public void testCommitFalse() throws TransactionFailureException, InterruptedException {
+    txClient.failCommits = 1;
+    TransactionContext context = newTransactionContext(ds1, ds2);
+    // start transaction
+    context.start();
+    // add a change to ds1 and ds2
+    ds1.addChange(A);
+    ds2.addChange(B);
+    // commit transaction should fail and cause rollback
+    try {
+      context.finish();
+      Assert.fail("commit failed - exception should be thrown");
+    } catch (TransactionConflictException e) {
+      Assert.assertNull(e.getCause());
+    }
+    // verify both are rolled back and tx is aborted
+    Assert.assertTrue(ds1.started);
+    Assert.assertTrue(ds2.started);
+    Assert.assertTrue(ds1.checked);
+    Assert.assertTrue(ds2.checked);
+    Assert.assertTrue(ds1.committed);
+    Assert.assertTrue(ds2.committed);
+    Assert.assertFalse(ds1.postCommitted);
+    Assert.assertFalse(ds2.postCommitted);
+    Assert.assertTrue(ds1.rolledBack);
+    Assert.assertTrue(ds2.rolledBack);
+    Assert.assertEquals(txClient.state, DummyTxClient.CommitState.Aborted);
+  }
+
+  @Test
+  public void testCanCommitFalse() throws TransactionFailureException, InterruptedException {
+    txClient.failCanCommitOnce = true;
+    TransactionContext context = newTransactionContext(ds1, ds2);
+    // start transaction
+    context.start();
+    // add a change to ds1 and ds2
+    ds1.addChange(A);
+    ds2.addChange(B);
+    // commit transaction should fail and cause rollback
+    try {
+      context.finish();
+      Assert.fail("commit failed - exception should be thrown");
+    } catch (TransactionConflictException e) {
+      Assert.assertNull(e.getCause());
+    }
+    // verify both are rolled back and tx is aborted
+    Assert.assertTrue(ds1.started);
+    Assert.assertTrue(ds2.started);
+    Assert.assertTrue(ds1.checked);
+    Assert.assertTrue(ds2.checked);
+    Assert.assertFalse(ds1.committed);
+    Assert.assertFalse(ds2.committed);
+    Assert.assertFalse(ds1.postCommitted);
+    Assert.assertFalse(ds2.postCommitted);
+    Assert.assertTrue(ds1.rolledBack);
+    Assert.assertTrue(ds2.rolledBack);
+    Assert.assertEquals(txClient.state, DummyTxClient.CommitState.Aborted);
+  }
+
+  @Test
+  public void testChangesAndRollbackFailure() throws TransactionFailureException, InterruptedException {
+    ds1.failChangesTxOnce = InduceFailure.ThrowException;
+    ds1.failRollbackTxOnce = InduceFailure.ThrowException;
+    TransactionContext context = newTransactionContext(ds1, ds2);
+    // start transaction
+    context.start();
+    // add a change to ds1 and ds2
+    ds1.addChange(A);
+    ds2.addChange(B);
+    // commit transaction should fail and cause rollback
+    try {
+      context.finish();
+      Assert.fail("get changes failed - exception should be thrown");
+    } catch (TransactionFailureException e) {
+      Assert.assertEquals("changes failure", e.getCause().getMessage());
+    }
+    // verify both are rolled back and tx is invalidated
+    Assert.assertTrue(ds1.started);
+    Assert.assertTrue(ds2.started);
+    Assert.assertTrue(ds1.checked);
+    Assert.assertFalse(ds2.checked);
+    Assert.assertFalse(ds1.committed);
+    Assert.assertFalse(ds2.committed);
+    Assert.assertFalse(ds1.postCommitted);
+    Assert.assertFalse(ds2.postCommitted);
+    Assert.assertTrue(ds1.rolledBack);
+    Assert.assertTrue(ds2.rolledBack);
+    Assert.assertEquals(txClient.state, DummyTxClient.CommitState.Invalidated);
+  }
+
+  @Test
+  public void testStartAndRollbackFailure() throws TransactionFailureException, InterruptedException {
+    ds1.failStartTxOnce = InduceFailure.ThrowException;
+    TransactionContext context = newTransactionContext(ds1, ds2);
+    // start transaction
+    try {
+      context.start();
+      Assert.fail("start failed - exception should be thrown");
+    } catch (TransactionFailureException e) {
+      Assert.assertEquals("start failure", e.getCause().getMessage());
+    }
+    // verify both are not rolled back and tx is aborted
+    Assert.assertTrue(ds1.started);
+    Assert.assertFalse(ds2.started);
+    Assert.assertFalse(ds1.checked);
+    Assert.assertFalse(ds2.checked);
+    Assert.assertFalse(ds1.committed);
+    Assert.assertFalse(ds2.committed);
+    Assert.assertFalse(ds1.postCommitted);
+    Assert.assertFalse(ds2.postCommitted);
+    Assert.assertFalse(ds1.rolledBack);
+    Assert.assertFalse(ds2.rolledBack);
+    Assert.assertEquals(txClient.state, DummyTxClient.CommitState.Aborted);
+  }
+
+  @Test
+  public void testAddThenSuccess() throws TransactionFailureException, InterruptedException {
+    TransactionContext context = newTransactionContext(ds1);
+    // start transaction
+    context.start();
+    // add a change to ds1
+    ds1.addChange(A);
+    // add ds2 to the tx
+    context.addTransactionAware(ds2);
+    // add a change to ds2
+    ds2.addChange(B);
+    // commit transaction
+    context.finish();
+    // verify both are committed and post-committed
+    Assert.assertTrue(ds1.started);
+    Assert.assertTrue(ds2.started);
+    Assert.assertTrue(ds1.checked);
+    Assert.assertTrue(ds2.checked);
+    Assert.assertTrue(ds1.committed);
+    Assert.assertTrue(ds2.committed);
+    Assert.assertTrue(ds1.postCommitted);
+    Assert.assertTrue(ds2.postCommitted);
+    Assert.assertFalse(ds1.rolledBack);
+    Assert.assertFalse(ds2.rolledBack);
+    Assert.assertEquals(txClient.state, DummyTxClient.CommitState.Committed);
+  }
+
+  @Test
+  public void testAddThenFailure() throws TransactionFailureException, InterruptedException {
+    ds2.failCommitTxOnce = InduceFailure.ThrowException;
+
+    TransactionContext context = newTransactionContext(ds1);
+    // start transaction
+    context.start();
+    // add a change to ds1
+    ds1.addChange(A);
+    // add ds2 to the tx
+    context.addTransactionAware(ds2);
+    // add a change to ds2
+    ds2.addChange(B);
+    // commit transaction should fail and cause rollback
+    try {
+      context.finish();
+      Assert.fail("Persist should have failed - exception should be thrown");
+    } catch (TransactionFailureException e) {
+      Assert.assertEquals("persist failure", e.getCause().getMessage());
+    }
+    // verify both are rolled back and tx is aborted
+    Assert.assertTrue(ds1.started);
+    Assert.assertTrue(ds2.started);
+    Assert.assertTrue(ds1.checked);
+    Assert.assertTrue(ds2.checked);
+    Assert.assertTrue(ds1.committed);
+    Assert.assertTrue(ds2.committed);
+    Assert.assertFalse(ds1.postCommitted);
+    Assert.assertFalse(ds2.postCommitted);
+    Assert.assertTrue(ds1.rolledBack);
+    Assert.assertTrue(ds2.rolledBack);
+    Assert.assertEquals(txClient.state, DummyTxClient.CommitState.Aborted);
+  }
+
+  @Test
+  public void testAddThenRemoveSuccess() throws TransactionFailureException {
+    TransactionContext context = newTransactionContext();
+
+    context.start();
+    Assert.assertTrue(context.addTransactionAware(ds1));
+    ds1.addChange(A);
+
+    try {
+      context.removeTransactionAware(ds1);
+      Assert.fail("Removal of TransactionAware should fails when there is active transaction.");
+    } catch (IllegalStateException e) {
+      // Expected
+    }
+
+    context.finish();
+
+    Assert.assertTrue(context.removeTransactionAware(ds1));
+    // Removing a TransactionAware not added before should returns false
+    Assert.assertFalse(context.removeTransactionAware(ds2));
+
+    // Verify ds1 is committed and post-committed
+    Assert.assertTrue(ds1.started);
+    Assert.assertTrue(ds1.checked);
+    Assert.assertTrue(ds1.committed);
+    Assert.assertTrue(ds1.postCommitted);
+    Assert.assertFalse(ds1.rolledBack);
+
+    // Verify nothing happen to ds2
+    Assert.assertFalse(ds2.started);
+    Assert.assertFalse(ds2.checked);
+    Assert.assertFalse(ds2.committed);
+    Assert.assertFalse(ds2.postCommitted);
+    Assert.assertFalse(ds2.rolledBack);
+
+    Assert.assertEquals(txClient.state, DummyTxClient.CommitState.Committed);
+  }
+
+  @Test
+  public void testAndThenRemoveOnFailure() throws TransactionFailureException {
+    ds1.failCommitTxOnce = InduceFailure.ThrowException;
+    TransactionContext context = newTransactionContext();
+
+    context.start();
+    Assert.assertTrue(context.addTransactionAware(ds1));
+    ds1.addChange(A);
+
+    try {
+      context.finish();
+      Assert.fail("Persist should have failed - exception should be thrown");
+    } catch (TransactionFailureException e) {
+      Assert.assertEquals("persist failure", e.getCause().getMessage());
+    }
+
+    Assert.assertTrue(context.removeTransactionAware(ds1));
+
+    // Verify ds1 is rolled back
+    Assert.assertTrue(ds1.started);
+    Assert.assertTrue(ds1.checked);
+    Assert.assertTrue(ds1.committed);
+    Assert.assertFalse(ds1.postCommitted);
+    Assert.assertTrue(ds1.rolledBack);
+
+    Assert.assertEquals(txClient.state, DummyTxClient.CommitState.Aborted);
+  }
+
+  enum InduceFailure { NoFailure, ReturnFalse, ThrowException }
+
+  static class DummyTxAware implements TransactionAware {
+
+    Transaction tx;
+    boolean started = false;
+    boolean committed = false;
+    boolean checked = false;
+    boolean rolledBack = false;
+    boolean postCommitted = false;
+    List<byte[]> changes = Lists.newArrayList();
+
+    InduceFailure failStartTxOnce = InduceFailure.NoFailure;
+    InduceFailure failChangesTxOnce = InduceFailure.NoFailure;
+    InduceFailure failCommitTxOnce = InduceFailure.NoFailure;
+    InduceFailure failPostCommitTxOnce = InduceFailure.NoFailure;
+    InduceFailure failRollbackTxOnce = InduceFailure.NoFailure;
+
+    void addChange(byte[] key) {
+      changes.add(key);
+    }
+
+    void reset() {
+      tx = null;
+      started = false;
+      checked = false;
+      committed = false;
+      rolledBack = false;
+      postCommitted = false;
+      changes.clear();
+    }
+
+    @Override
+    public void startTx(Transaction tx) {
+      reset();
+      started = true;
+      this.tx = tx;
+      if (failStartTxOnce == InduceFailure.ThrowException) {
+        failStartTxOnce = InduceFailure.NoFailure;
+        throw new RuntimeException("start failure");
+      }
+    }
+
+    @Override
+    public void updateTx(Transaction tx) {
+      this.tx = tx;
+    }
+
+    @Override
+    public Collection<byte[]> getTxChanges() {
+      checked = true;
+      if (failChangesTxOnce == InduceFailure.ThrowException) {
+        failChangesTxOnce = InduceFailure.NoFailure;
+        throw new RuntimeException("changes failure");
+      }
+      return ImmutableList.copyOf(changes);
+    }
+
+    @Override
+    public boolean commitTx() throws Exception {
+      committed = true;
+      if (failCommitTxOnce == InduceFailure.ThrowException) {
+        failCommitTxOnce = InduceFailure.NoFailure;
+        throw new RuntimeException("persist failure");
+      }
+      if (failCommitTxOnce == InduceFailure.ReturnFalse) {
+        failCommitTxOnce = InduceFailure.NoFailure;
+        return false;
+      }
+      return true;
+    }
+
+    @Override
+    public void postTxCommit() {
+      postCommitted = true;
+      if (failPostCommitTxOnce == InduceFailure.ThrowException) {
+        failPostCommitTxOnce = InduceFailure.NoFailure;
+        throw new RuntimeException("post failure");
+      }
+    }
+
+    @Override
+    public boolean rollbackTx() throws Exception {
+      rolledBack = true;
+      if (failRollbackTxOnce == InduceFailure.ThrowException) {
+        failRollbackTxOnce = InduceFailure.NoFailure;
+        throw new RuntimeException("rollback failure");
+      }
+      if (failRollbackTxOnce == InduceFailure.ReturnFalse) {
+        failRollbackTxOnce = InduceFailure.NoFailure;
+        return false;
+      }
+      return true;
+    }
+
+    @Override
+    public String getTransactionAwareName() {
+      return "dummy";
+    }
+  }
+
+  private static final class DummyTxClient extends InMemoryTxSystemClient {
+
+    private boolean failCanCommitOnce;
+    private int failCommits;
+    private CommitState state = CommitState.Started;
+
+    private enum CommitState {
+      Started, Committed, Aborted, Invalidated
+    }
+
+    @Inject
+    DummyTxClient(TransactionManager txManager) {
+      super(txManager);
+    }
+
+    @Override
+    public boolean canCommit(Transaction tx, Collection<byte[]> changeIds) throws TransactionNotInProgressException {
+      if (failCanCommitOnce) {
+        failCanCommitOnce = false;
+        return false;
+      } else {
+        return super.canCommit(tx, changeIds);
+      }
+    }
+
+    @Override
+    public boolean commit(Transaction tx) throws TransactionNotInProgressException {
+      if (failCommits-- > 0) {
+        return false;
+      } else {
+        state = CommitState.Committed;
+        return super.commit(tx);
+      }
+    }
+
+    @Override
+    public Transaction startLong() {
+      state = CommitState.Started;
+      return super.startLong();
+    }
+
+    @Override
+    public Transaction startShort() {
+      state = CommitState.Started;
+      return super.startShort();
+    }
+
+    @Override
+    public Transaction startShort(int timeout) {
+      state = CommitState.Started;
+      return super.startShort(timeout);
+    }
+
+    @Override
+    public void abort(Transaction tx) {
+      state = CommitState.Aborted;
+      super.abort(tx);
+    }
+
+    @Override
+    public boolean invalidate(long tx) {
+      state = CommitState.Invalidated;
+      return super.invalidate(tx);
+    }
+  }
+
+  /**
+   * A transaction context that maintains {@link TransactionAware} in a simple list.
+   */
+  private static final class SimpleTransactionContext extends AbstractTransactionContext {
+
+    private final Set<TransactionAware> txAwares;
+
+    SimpleTransactionContext(TransactionSystemClient txClient, TransactionAware...txAwares) {
+      super(txClient);
+      this.txAwares = new LinkedHashSet<>(Arrays.asList(txAwares));
+    }
+
+    @Override
+    protected Iterable<TransactionAware> getTransactionAwares() {
+      return txAwares;
+    }
+
+    @Override
+    protected boolean doAddTransactionAware(TransactionAware txAware) {
+      return txAwares.add(txAware);
+    }
+
+    @Override
+    protected boolean doRemoveTransactionAware(TransactionAware txAware) {
+      return txAwares.remove(txAware);
+    }
+  }
+}

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -64,6 +64,7 @@ import co.cask.cdap.internal.app.services.AppFabricServer;
 import co.cask.cdap.logging.appender.LogAppenderInitializer;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.master.startup.ServiceResourceKeys;
+import co.cask.cdap.messaging.guice.MessagingClientModule;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.metrics.guice.MetricsStoreModule;
 import co.cask.cdap.notifications.feeds.guice.NotificationFeedServiceRuntimeModule;
@@ -511,6 +512,7 @@ public class MasterServiceMain extends DaemonMain {
       new DataSetsModules().getDistributedModules(),
       new MetricsClientRuntimeModule().getDistributedModules(),
       new MetricsStoreModule(),
+      new MessagingClientModule(),
       new ExploreClientModule(),
       new NotificationFeedServiceRuntimeModule().getDistributedModules(),
       new NotificationServiceRuntimeModule().getDistributedModules(),

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseQueueDebugger.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/HBaseQueueDebugger.java
@@ -71,6 +71,7 @@ import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.internal.app.queue.SimpleQueueSpecificationGenerator;
 import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
 import co.cask.cdap.internal.app.store.DefaultStore;
+import co.cask.cdap.messaging.guice.MessagingClientModule;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.metrics.guice.MetricsStoreModule;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
@@ -512,6 +513,7 @@ public class HBaseQueueDebugger extends AbstractIdleService {
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getMasterModule(),
       new SecureStoreModules().getDistributedModules(),
+      new MessagingClientModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeDatasetServiceManager.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeDatasetServiceManager.java
@@ -45,6 +45,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsService;
 import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsServiceModule;
+import co.cask.cdap.messaging.guice.MessagingClientModule;
 import co.cask.cdap.metrics.store.DefaultMetricDatasetFactory;
 import co.cask.cdap.metrics.store.DefaultMetricStore;
 import co.cask.cdap.metrics.store.MetricDatasetFactory;
@@ -145,6 +146,7 @@ class UpgradeDatasetServiceManager extends AbstractIdleService {
       new LocationRuntimeModule().getDistributedModules(),
       new IOModule(),
       new KafkaClientModule(),
+      new MessagingClientModule(),
       new DiscoveryRuntimeModule().getDistributedModules(),
       new DataSetServiceModules().getDistributedModules(),
       new DataFabricModules().getDistributedModules(),

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -67,6 +67,7 @@ import co.cask.cdap.internal.app.runtime.schedule.store.DatasetBasedTimeSchedule
 import co.cask.cdap.internal.app.runtime.schedule.store.ScheduleStoreTableUtil;
 import co.cask.cdap.internal.app.store.DefaultStore;
 import co.cask.cdap.logging.save.LogSaverTableUtil;
+import co.cask.cdap.messaging.guice.MessagingClientModule;
 import co.cask.cdap.metrics.store.DefaultMetricDatasetFactory;
 import co.cask.cdap.metrics.store.DefaultMetricStore;
 import co.cask.cdap.metrics.store.MetricDatasetFactory;
@@ -209,6 +210,7 @@ public class UpgradeTool {
       new LocationRuntimeModule().getDistributedModules(),
       new ZKClientModule(),
       new DiscoveryRuntimeModule().getDistributedModules(),
+      new MessagingClientModule(),
       Modules.override(new DataSetsModules().getDistributedModules()).with(
         new AbstractModule() {
           @Override

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/flow/FlowQueuePendingCorrector.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/flow/FlowQueuePendingCorrector.java
@@ -62,6 +62,8 @@ import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.internal.app.queue.SimpleQueueSpecificationGenerator;
 import co.cask.cdap.internal.app.runtime.flow.FlowUtils;
 import co.cask.cdap.internal.app.store.DefaultStore;
+import co.cask.cdap.messaging.guice.MessagingClientModule;
+import co.cask.cdap.messaging.guice.MessagingServerRuntimeModule;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.metrics.guice.MetricsStoreModule;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
@@ -355,6 +357,7 @@ public class FlowQueuePendingCorrector extends AbstractIdleService {
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getMasterModule(),
       new SecureStoreModules().getDistributedModules(),
+      new MessagingClientModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/AuthorizationContext.java
+++ b/cdap-security-spi/src/main/java/co/cask/cdap/security/spi/authorization/AuthorizationContext.java
@@ -19,10 +19,14 @@ package co.cask.cdap.security.spi.authorization;
 import co.cask.cdap.api.Admin;
 import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.messaging.TopicAlreadyExistsException;
+import co.cask.cdap.api.messaging.TopicNotFoundException;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 
+import java.io.IOException;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -45,4 +49,34 @@ public interface AuthorizationContext extends DatasetContext, Admin, Transaction
    * @return the {@link Properties} for the authorization extension
    */
   Properties getExtensionProperties();
+
+  /**
+   * Currently messaging is not supported. Calling this method always result in {@link UnsupportedOperationException}.
+   */
+  @Override
+  void createTopic(String topic) throws TopicAlreadyExistsException, IOException;
+
+  /**
+   * Currently messaging is not supported. Calling this method always result in {@link UnsupportedOperationException}.
+   */
+  @Override
+  void createTopic(String topic, Map<String, String> properties) throws TopicAlreadyExistsException, IOException;
+
+  /**
+   * Currently messaging is not supported. Calling this method always result in {@link UnsupportedOperationException}.
+   */
+  @Override
+  Map<String, String> getTopicProperties(String topic) throws TopicNotFoundException, IOException;
+
+  /**
+   * Currently messaging is not supported. Calling this method always result in {@link UnsupportedOperationException}.
+   */
+  @Override
+  void updateTopic(String topic, Map<String, String> properties) throws TopicNotFoundException, IOException;
+
+  /**
+   * Currently messaging is not supported. Calling this method always result in {@link UnsupportedOperationException}.
+   */
+  @Override
+  void deleteTopic(String topic) throws TopicNotFoundException, IOException;
 }

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationContext.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/DefaultAuthorizationContext.java
@@ -24,6 +24,8 @@ import co.cask.cdap.api.data.DatasetInstantiationException;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.messaging.TopicAlreadyExistsException;
+import co.cask.cdap.api.messaging.TopicNotFoundException;
 import co.cask.cdap.api.security.store.SecureStore;
 import co.cask.cdap.api.security.store.SecureStoreData;
 import co.cask.cdap.proto.security.Principal;
@@ -34,6 +36,7 @@ import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import org.apache.tephra.TransactionFailureException;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
 
@@ -154,6 +157,33 @@ public class DefaultAuthorizationContext implements AuthorizationContext {
   @Override
   public void deleteSecureData(String namespace, String name) throws Exception {
     delegateAdmin.deleteSecureData(namespace, name);
+  }
+
+
+  @Override
+  public void createTopic(String topic) throws TopicAlreadyExistsException, IOException {
+    throw new UnsupportedOperationException("Messaging not supported");
+  }
+
+  @Override
+  public void createTopic(String topic,
+                          Map<String, String> properties) throws TopicAlreadyExistsException, IOException {
+    throw new UnsupportedOperationException("Messaging not supported");
+  }
+
+  @Override
+  public Map<String, String> getTopicProperties(String topic) throws TopicNotFoundException, IOException {
+    throw new UnsupportedOperationException("Messaging not supported");
+  }
+
+  @Override
+  public void updateTopic(String topic, Map<String, String> properties) throws TopicNotFoundException, IOException {
+    throw new UnsupportedOperationException("Messaging not supported");
+  }
+
+  @Override
+  public void deleteTopic(String topic) throws TopicNotFoundException, IOException {
+    throw new UnsupportedOperationException("Messaging not supported");
   }
 
   public Principal getPrincipal() {

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/NoOpAuthorizationContextFactory.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/NoOpAuthorizationContextFactory.java
@@ -16,15 +16,12 @@
 
 package co.cask.cdap.security.authorization;
 
-import co.cask.cdap.api.Admin;
 import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.DatasetInstantiationException;
 import co.cask.cdap.api.dataset.Dataset;
-import co.cask.cdap.api.dataset.DatasetManagementException;
-import co.cask.cdap.api.dataset.DatasetProperties;
-import co.cask.cdap.api.dataset.InstanceNotFoundException;
+import co.cask.cdap.common.test.NoopAdmin;
 import co.cask.cdap.security.auth.context.AuthenticationTestContext;
 import co.cask.cdap.security.spi.authorization.AuthorizationContext;
 import co.cask.cdap.security.store.DummySecureStore;
@@ -39,7 +36,7 @@ import java.util.Properties;
 public class NoOpAuthorizationContextFactory implements AuthorizationContextFactory {
   @Override
   public AuthorizationContext create(Properties extensionProperties) {
-    return new DefaultAuthorizationContext(extensionProperties, new NoOpDatasetContext(), new NoOpAdmin(),
+    return new DefaultAuthorizationContext(extensionProperties, new NoOpDatasetContext(), new NoopAdmin(),
                                            new NoOpTransactional(), new AuthenticationTestContext(),
                                            new DummySecureStore());
   }
@@ -86,55 +83,6 @@ public class NoOpAuthorizationContextFactory implements AuthorizationContextFact
 
     @Override
     public void discardDataset(Dataset dataset) {
-      // no-op
-    }
-  }
-
-  private static class NoOpAdmin implements Admin {
-    @Override
-    public boolean datasetExists(String name) throws DatasetManagementException {
-      return false;
-    }
-
-    @Override
-    public String getDatasetType(String name) throws DatasetManagementException {
-      throw new InstanceNotFoundException(name);
-    }
-
-    @Override
-    public DatasetProperties getDatasetProperties(String name) throws DatasetManagementException {
-      throw new InstanceNotFoundException(name);
-    }
-
-    @Override
-    public void createDataset(String name, String type,
-                              DatasetProperties properties) throws DatasetManagementException {
-      //no-op
-    }
-
-    @Override
-    public void updateDataset(String name, DatasetProperties properties) throws DatasetManagementException {
-      //no-op
-    }
-
-    @Override
-    public void dropDataset(String name) throws DatasetManagementException {
-      //no-op
-    }
-
-    @Override
-    public void truncateDataset(String name) throws DatasetManagementException {
-      //no-op
-    }
-
-    @Override
-    public void putSecureData(String namespace, String name, String data, String description,
-                              Map<String, String> properties) throws Exception {
-      // no-op
-    }
-
-    @Override
-    public void deleteSecureData(String namespace, String name) throws Exception {
       // no-op
     }
   }

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/BasicSparkClientContext.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/BasicSparkClientContext.java
@@ -25,6 +25,8 @@ import co.cask.cdap.api.common.RuntimeArguments;
 import co.cask.cdap.api.data.DatasetInstantiationException;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.macro.MacroEvaluator;
+import co.cask.cdap.api.messaging.MessageFetcher;
+import co.cask.cdap.api.messaging.MessagePublisher;
 import co.cask.cdap.api.metrics.Metrics;
 import co.cask.cdap.api.plugin.PluginProperties;
 import co.cask.cdap.api.preview.DataTracer;
@@ -291,5 +293,20 @@ final class BasicSparkClientContext implements SparkClientContext {
   @Override
   public void execute(int timeoutInSeconds, TxRunnable runnable) throws TransactionFailureException {
     sparkRuntimeContext.execute(timeoutInSeconds, runnable);
+  }
+
+  @Override
+  public MessagePublisher getMessagePublisher() {
+    return sparkRuntimeContext.getMessagePublisher();
+  }
+
+  @Override
+  public MessagePublisher getDirectMessagePublisher() {
+    return sparkRuntimeContext.getDirectMessagePublisher();
+  }
+
+  @Override
+  public MessageFetcher getMessageFetcher() {
+    return sparkRuntimeContext.getMessageFetcher();
   }
 }

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRunner.java
@@ -46,6 +46,7 @@ import co.cask.cdap.internal.app.runtime.ProgramRunners;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.internal.app.runtime.workflow.NameMappedDatasetFramework;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
+import co.cask.cdap.messaging.MessagingService;
 import co.cask.cdap.proto.BasicThrowable;
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramType;
@@ -99,6 +100,7 @@ final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
   private final SecureStoreManager secureStoreManager;
   private final AuthorizationEnforcer authorizationEnforcer;
   private final AuthenticationContext authenticationContext;
+  private final MessagingService messagingService;
 
   @Inject
   SparkProgramRunner(CConfiguration cConf, Configuration hConf, LocationFactory locationFactory,
@@ -106,7 +108,8 @@ final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
                      MetricsCollectionService metricsCollectionService,
                      DiscoveryServiceClient discoveryServiceClient, StreamAdmin streamAdmin,
                      RuntimeStore runtimeStore, SecureStore secureStore, SecureStoreManager secureStoreManager,
-                     AuthorizationEnforcer authorizationEnforcer, AuthenticationContext authenticationContext) {
+                     AuthorizationEnforcer authorizationEnforcer, AuthenticationContext authenticationContext,
+                     MessagingService messagingService) {
     super(cConf);
     this.cConf = cConf;
     this.hConf = hConf;
@@ -121,6 +124,7 @@ final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
     this.secureStoreManager = secureStoreManager;
     this.authorizationEnforcer = authorizationEnforcer;
     this.authenticationContext = authenticationContext;
+    this.messagingService = messagingService;
   }
 
   @Override
@@ -168,7 +172,8 @@ final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
                                                                    discoveryServiceClient,
                                                                    metricsCollectionService, streamAdmin, workflowInfo,
                                                                    pluginInstantiator, secureStore, secureStoreManager,
-                                                                   authorizationEnforcer, authenticationContext);
+                                                                   authorizationEnforcer, authenticationContext,
+                                                                   messagingService);
       closeables.addFirst(runtimeContext);
 
       Spark spark;

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContext.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContext.java
@@ -33,6 +33,7 @@ import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
 import co.cask.cdap.logging.context.SparkLoggingContext;
 import co.cask.cdap.logging.context.WorkflowProgramLoggingContext;
+import co.cask.cdap.messaging.MessagingService;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.Ids;
 import co.cask.cdap.proto.id.ProgramId;
@@ -76,10 +77,11 @@ public final class SparkRuntimeContext extends AbstractContext implements Metric
                       SecureStore secureStore,
                       SecureStoreManager secureStoreManager,
                       AuthorizationEnforcer authorizationEnforcer,
-                      AuthenticationContext authenticationContext) {
+                      AuthenticationContext authenticationContext,
+                      MessagingService messagingService) {
     super(program, programOptions, cConf, getSparkSpecification(program).getDatasets(), datasetFramework, txClient,
           discoveryServiceClient, true, metricsCollectionService, createMetricsTags(workflowProgramInfo),
-          secureStore, secureStoreManager, pluginInstantiator);
+          secureStore, secureStoreManager, messagingService, pluginInstantiator);
 
     this.hConf = hConf;
     this.hostname = hostname;

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
@@ -40,6 +40,7 @@ import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import co.cask.cdap.internal.app.runtime.workflow.NameMappedDatasetFramework;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
 import co.cask.cdap.logging.appender.LogAppenderInitializer;
+import co.cask.cdap.messaging.MessagingService;
 import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
@@ -198,7 +199,8 @@ public final class SparkRuntimeContextProvider {
         injector.getInstance(SecureStore.class),
         injector.getInstance(SecureStoreManager.class),
         injector.getInstance(AuthorizationEnforcer.class),
-        injector.getInstance(AuthenticationContext.class)
+        injector.getInstance(AuthenticationContext.class),
+        injector.getInstance(MessagingService.class)
       );
       LoggingContextAccessor.setLoggingContext(sparkRuntimeContext.getLoggingContext());
       return sparkRuntimeContext;

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactionService.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactionService.java
@@ -86,11 +86,11 @@ final class SparkTransactionService extends AbstractIdleService {
 
   private final NettyHttpService httpServer;
 
-  SparkTransactionService(TransactionSystemClient txClient, String hostname) {
+  SparkTransactionService(TransactionSystemClient txClient, String hostname, String programName) {
     this.txClient = txClient;
     this.stageToJob = new ConcurrentHashMap<>();
     this.jobTransactions = new ConcurrentHashMap<>();
-    this.httpServer = NettyHttpService.builder()
+    this.httpServer = NettyHttpService.builder(programName + "-spark-tx")
       .addHttpHandlers(Collections.singleton(new SparkTransactionHandler()))
       .setHost(hostname)
       .build();
@@ -343,6 +343,7 @@ final class SparkTransactionService extends AbstractIdleService {
             throw new TransactionFailureException("Failed to invalid transaction on job failure. JobId: "
                                                     + jobId + ", transaction: " + jobTx);
           }
+          transactionInfo.onTransactionCompleted(succeeded, null);
         }
       } catch (Throwable t) {
         TransactionFailureException failureCause = Transactions.asTransactionFailure(t);

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
@@ -23,6 +23,7 @@ import co.cask.cdap.api.app.ApplicationSpecification
 import co.cask.cdap.api.data.batch.Split
 import co.cask.cdap.api.data.format.FormatSpecification
 import co.cask.cdap.api.flow.flowlet.StreamEvent
+import co.cask.cdap.api.messaging.MessagingContext
 import co.cask.cdap.api.metrics.Metrics
 import co.cask.cdap.api.plugin.PluginContext
 import co.cask.cdap.api.preview.DataTracer
@@ -61,6 +62,8 @@ class DefaultJavaSparkExecutionContext(sec: SparkExecutionContext) extends JavaS
   override def getPluginContext: PluginContext = sec.getPluginContext
 
   override def getSecureStore: SecureStore = sec.getSecureStore
+
+  override def getMessagingContext: MessagingContext = sec.getMessagingContext
 
   override def getWorkflowToken: WorkflowToken = sec.getWorkflowToken.orNull
 

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultSparkExecutionContext.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultSparkExecutionContext.scala
@@ -27,6 +27,7 @@ import co.cask.cdap.api.data.batch.{BatchWritable, DatasetOutputCommitter, Outpu
 import co.cask.cdap.api.data.format.FormatSpecification
 import co.cask.cdap.api.dataset.Dataset
 import co.cask.cdap.api.flow.flowlet.StreamEvent
+import co.cask.cdap.api.messaging.MessagingContext
 import co.cask.cdap.api.metrics.Metrics
 import co.cask.cdap.api.plugin.PluginContext
 import co.cask.cdap.api.preview.DataTracer
@@ -77,7 +78,7 @@ class DefaultSparkExecutionContext(runtimeContext: SparkRuntimeContext,
                                                      runtimeContext.getDatasetCache)
   private val workflowInfo = Option(runtimeContext.getWorkflowInfo)
   private val sparkTxService = new SparkTransactionService(runtimeContext.getTransactionSystemClient,
-                                                           runtimeContext.getHostname)
+                                                           runtimeContext.getHostname, runtimeContext.getProgramName)
   private val applicationEndLatch = new CountDownLatch(1)
   private val authorizationEnforcer = runtimeContext.getAuthorizationEnforcer
   private val authenticationContext = runtimeContext.getAuthenticationContext
@@ -145,6 +146,9 @@ class DefaultSparkExecutionContext(runtimeContext: SparkRuntimeContext,
   override def getMetrics: Metrics = new SparkUserMetrics(runtimeContext)
 
   override def getSecureStore: SecureStore = new SparkSecureStore(runtimeContext)
+
+  // TODO: CDAP-7807. Returns one that is serializable
+  override def getMessagingContext: MessagingContext = runtimeContext
 
   override def getPluginContext: PluginContext = new SparkPluginContext(runtimeContext)
 

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/SerializableSparkExecutionContext.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/SerializableSparkExecutionContext.scala
@@ -100,6 +100,8 @@ class SerializableSparkExecutionContext(val delegate: SparkExecutionContext) ext
 
   override def getSecureStore = delegate.getSecureStore
 
+  override def getMessagingContext = delegate.getMessagingContext
+
   override def getPluginContext = delegate.getPluginContext
 
   override def getMetrics = delegate.getMetrics

--- a/cdap-spark-core/src/test/java/co/cask/cdap/app/runtime/spark/SparkTransactionServiceTest.java
+++ b/cdap-spark-core/src/test/java/co/cask/cdap/app/runtime/spark/SparkTransactionServiceTest.java
@@ -70,7 +70,8 @@ public class SparkTransactionServiceTest {
 
     txClient = new InMemoryTxSystemClient(txManager);
 
-    sparkTxService = new SparkTransactionService(txClient, InetAddress.getLoopbackAddress().getCanonicalHostName());
+    sparkTxService = new SparkTransactionService(txClient, InetAddress.getLoopbackAddress().getCanonicalHostName(),
+                                                 "test");
     sparkTxService.startAndWait();
 
     sparkTxClient = new SparkTransactionClient(sparkTxService.getBaseURI());
@@ -176,7 +177,7 @@ public class SparkTransactionServiceTest {
     txManager.startAndWait();
     try {
       SparkTransactionService sparkTxService = new SparkTransactionService(
-        new InMemoryTxSystemClient(txManager), InetAddress.getLoopbackAddress().getCanonicalHostName());
+        new InMemoryTxSystemClient(txManager), InetAddress.getLoopbackAddress().getCanonicalHostName(), "test");
       sparkTxService.startAndWait();
       try {
         // Start a job

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/base/TestFrameworkTestSuite.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/base/TestFrameworkTestSuite.java
@@ -34,6 +34,7 @@ import co.cask.cdap.test.TestConfiguration;
 import co.cask.cdap.test.XSlowTests;
 import co.cask.cdap.test.app.ServiceLifeCycleTestRun;
 import co.cask.cdap.test.app.TestFrameworkTestRun;
+import co.cask.cdap.test.messaging.MessagingAppTestRun;
 import org.junit.ClassRule;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -52,6 +53,7 @@ import org.junit.runners.Suite;
   FlowStreamIntegrationTestRun.class,
   MapReduceStreamInputTestRun.class,
   MapReduceServiceIntegrationTestRun.class,
+  MessagingAppTestRun.class,
   ServiceLifeCycleTestRun.class,
   SparkFileSetTestRun.class,
   SparkMetricsIntegrationTestRun.class,

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/messaging/MessagingApp.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/messaging/MessagingApp.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.messaging;
+
+import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.api.messaging.Message;
+import co.cask.cdap.api.messaging.MessageFetcher;
+import co.cask.cdap.api.messaging.MessagePublisher;
+import co.cask.cdap.api.messaging.MessagingContext;
+import co.cask.cdap.api.worker.AbstractWorker;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
+import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.apache.tephra.TransactionFailureException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+
+/**
+ * An app containing programs for testing TMS interactions
+ */
+public class MessagingApp extends AbstractApplication {
+
+  static final String TOPIC = "topic";
+  static final String CONTROL_TOPIC = "controlTopic";
+
+  @Override
+  public void configure() {
+    addWorker(new MessagingWorker());
+    addWorker(new TransactionalMessagingWorker());
+    addSpark(new MessagingSpark());
+  }
+
+  /**
+   * Fetch and block until it get a message.
+   */
+  private static Message fetchMessage(MessageFetcher fetcher, String namespace, String topic,
+                                      @Nullable String afterMessageId, long timeout, TimeUnit unit) throws Exception {
+    CloseableIterator<Message> iterator = fetcher.fetch(namespace, topic, 1, afterMessageId);
+    Stopwatch stopwatch = new Stopwatch().start();
+    try {
+      while (!iterator.hasNext() && stopwatch.elapsedTime(unit) < timeout) {
+        TimeUnit.MILLISECONDS.sleep(100);
+        iterator = fetcher.fetch(namespace, topic, 1, afterMessageId);
+      }
+
+      if (!iterator.hasNext()) {
+        throw new TimeoutException("Failed to get any messages from " + topic +
+                                     " in " + timeout + " " + unit.name().toLowerCase());
+      }
+      // The payload contains the message to publish in next step
+      return iterator.next();
+    } finally {
+      iterator.close();
+    }
+  }
+
+  /**
+   * A worker for testing both transactional and non-transactional aspect of {@link MessagingContext}.
+   */
+  public static final class MessagingWorker extends AbstractWorker {
+
+    @Override
+    public void run() {
+      try {
+        // Create a topic
+        getContext().getAdmin().createTopic(TOPIC);
+
+        // Fetch a message published from test driver
+        final MessageFetcher fetcher = getContext().getMessageFetcher();
+        Message message = fetchMessage(fetcher, getContext().getNamespace(), TOPIC, null, 3, TimeUnit.SECONDS);
+
+        // Publish the message
+        final MessagePublisher publisher = getContext().getMessagePublisher();
+        String payload = message.getPayloadAsString();
+        publisher.publish(getContext().getNamespace(), TOPIC, payload + payload);
+
+        final AtomicReference<String> lastMessageId = new AtomicReference<>(message.getId());
+
+        // Execute publish and fetch in a transaction
+        getContext().execute(new TxRunnable() {
+          @Override
+          public void run(DatasetContext context) throws Exception {
+            // Fetch a message again, the test driver should published one
+            Message message = fetchMessage(fetcher, getContext().getNamespace(), TOPIC,
+                                           lastMessageId.get(), 3, TimeUnit.SECONDS);
+            lastMessageId.set(message.getId());
+
+            // Publish the message transactionally.
+            String payload = message.getPayloadAsString();
+            publisher.publish(getContext().getNamespace(), TOPIC, payload + payload);
+
+            // Block until the test driver publish a message to control topic
+            fetchMessage(fetcher, getContext().getNamespace(), CONTROL_TOPIC, null, 10, TimeUnit.SECONDS);
+          }
+        });
+
+      } catch (Exception e) {
+        throw Throwables.propagate(e);
+      }
+    }
+  }
+
+  /**
+   * A worker for testing transactional aspect of {@link MessagingContext}.
+   */
+  public static final class TransactionalMessagingWorker extends AbstractWorker {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TransactionalMessagingWorker.class);
+
+    @Override
+    public void run() {
+      // This boolean tells if getting the MessagePublisher/MessageFetcher inside tx or outside
+      final boolean getInTx = Boolean.valueOf(getContext().getRuntimeArguments().get("get.in.tx"));
+      final String payload = "payload";
+      final AtomicBoolean succeeded = new AtomicBoolean();
+      final CountDownLatch publishedLatch = new CountDownLatch(1);
+      final CountDownLatch publishCommitLatch = new CountDownLatch(1);
+
+      // Create two threads, one publish, one consumer, both transactionally.
+      Thread publishThread = new Thread(getClass().getSimpleName() + "-publish") {
+        @Override
+        public void run() {
+          try {
+            final AtomicReference<MessagePublisher> publisherRef = new AtomicReference<>();
+            if (!getInTx) {
+              // Get a publisher before starting tx. When the tx starts, it should get propagated into the publisher.
+              LOG.info("Get publisher outside of TX");
+              publisherRef.set(getContext().getMessagePublisher());
+            }
+
+            // Publish a message transactionally. Block until signaled before committing.
+            getContext().execute(new TxRunnable() {
+              @Override
+              public void run(DatasetContext context) throws Exception {
+                MessagePublisher publisher = publisherRef.get();
+                if (publisher == null) {
+                  LOG.info("Get publisher inside of TX");
+                  publisher = getContext().getMessagePublisher();
+                }
+                publisher.publish(getContext().getNamespace(), TOPIC, payload);
+                LOG.info("Message published");
+                publishedLatch.countDown();
+                publishCommitLatch.await();
+              }
+            });
+          } catch (TransactionFailureException e) {
+            throw Throwables.propagate(e);
+          }
+        }
+      };
+      Thread fetchThread = new Thread(getClass().getSimpleName() + "-fetch") {
+        @Override
+        public void run() {
+          final AtomicReference<MessageFetcher> fetcherRef = new AtomicReference<>();
+          if (!getInTx) {
+            // Get a fetcher before starting tx. When the tx starts, it should get propagated into the fetcher
+            LOG.info("Get fetcher outside of TX");
+            fetcherRef.set(getContext().getMessageFetcher());
+          }
+
+          try {
+            // Wait until published before starting the fetcher transaction
+            publishedLatch.await();
+            getContext().execute(new TxRunnable() {
+              @Override
+              public void run(DatasetContext context) throws Exception {
+                MessageFetcher fetcher = fetcherRef.get();
+                if (fetcher == null) {
+                  LOG.info("Get fetcher inside of TX");
+                  fetcher = getContext().getMessageFetcher();
+                }
+                // Should get nothing because publish tx hasn't been committed
+                try {
+                  fetchMessage(fetcher, getContext().getNamespace(), TOPIC, null, 3, TimeUnit.SECONDS);
+                  throw new IllegalStateException("Expected timeout");
+                } catch (TimeoutException e) {
+                  LOG.info("Expected timeout exception raised");
+                }
+                // Signal publish tx to commit
+                publishCommitLatch.countDown();
+                // Now should be able to fetch a message
+                Message message = fetchMessage(fetcher, getContext().getNamespace(), TOPIC, null, 3, TimeUnit.SECONDS);
+                LOG.info("Message fetched {}", message);
+                succeeded.set(payload.equals(message.getPayloadAsString()));
+              }
+            });
+          } catch (Exception e) {
+            throw Throwables.propagate(e);
+          }
+        }
+      };
+
+      publishThread.start();
+      fetchThread.start();
+      Uninterruptibles.joinUninterruptibly(publishThread);
+      Uninterruptibles.joinUninterruptibly(fetchThread);
+      Preconditions.checkState(succeeded.get(), "Expected succeeded to be true.");
+    }
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/messaging/MessagingAppTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/messaging/MessagingAppTestRun.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.messaging;
+
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.api.messaging.Message;
+import co.cask.cdap.api.messaging.MessageFetcher;
+import co.cask.cdap.api.messaging.MessagePublisher;
+import co.cask.cdap.api.messaging.MessagingAdmin;
+import co.cask.cdap.api.messaging.MessagingContext;
+import co.cask.cdap.api.messaging.TopicNotFoundException;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.utils.Tasks;
+import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.SparkManager;
+import co.cask.cdap.test.TestConfiguration;
+import co.cask.cdap.test.WorkerManager;
+import co.cask.cdap.test.base.TestFrameworkTestBase;
+import com.google.common.collect.Iterators;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Tests for applications interactions with TMS.
+ */
+public class MessagingAppTestRun extends TestFrameworkTestBase {
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
+
+  private static final NamespaceId NAMESPACE = new NamespaceId("messageTest");
+  private static File artifactJar;
+
+  @BeforeClass
+  public static void init() throws Exception {
+    artifactJar = createArtifactJar(MessagingApp.class);
+  }
+
+  @Before
+  public void beforeTest() throws Exception {
+    getNamespaceAdmin().create(new NamespaceMeta.Builder().setName(NAMESPACE).build());
+    getMessagingAdmin(NAMESPACE).createTopic(MessagingApp.CONTROL_TOPIC);
+  }
+
+  @Test
+  public void testWithWorker() throws Exception {
+    ApplicationManager appManager = deployWithArtifact(NAMESPACE, MessagingApp.class, artifactJar);
+
+    final WorkerManager workerManager = appManager.getWorkerManager(
+      MessagingApp.MessagingWorker.class.getSimpleName()).start();
+
+    MessagingContext messagingContext = getMessagingContext();
+    final MessagingAdmin messagingAdmin = getMessagingAdmin(NAMESPACE);
+
+    // Wait for the worker to create the topic
+    Tasks.waitFor(true, new Callable<Boolean>() {
+      @Override
+      public Boolean call() throws Exception {
+        try {
+          messagingAdmin.getTopicProperties(MessagingApp.TOPIC);
+          return true;
+        } catch (TopicNotFoundException e) {
+          return false;
+        }
+      }
+    }, 5, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+
+    // Publish a message
+    String message = "message";
+
+    MessagePublisher messagePublisher = messagingContext.getMessagePublisher();
+    messagePublisher.publish(NAMESPACE.getNamespace(), MessagingApp.TOPIC, message);
+
+    // The worker will publish back a message with payload as concat(message, message)
+    final MessageFetcher messageFetcher = messagingContext.getMessageFetcher();
+    Tasks.waitFor(message + message, new Callable<String>() {
+      @Override
+      public String call() throws Exception {
+        try (CloseableIterator<Message> iterator =
+               messageFetcher.fetch(NAMESPACE.getNamespace(), MessagingApp.TOPIC, Integer.MAX_VALUE, 0L)) {
+          Message message = Iterators.getLast(iterator, null);
+          return message == null ? null : message.getPayloadAsString();
+        }
+      }
+    }, 5, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+
+    // Publish concat(message + message) to the app
+    messagePublisher.publish(NAMESPACE.getNamespace(), MessagingApp.TOPIC, message + message);
+
+    // The worker will publish back a message with payload as concat(message, message, message, message)
+    // in a transaction, which it will block on a message to the CONTROL_TOPIC, hence the following wait for should
+    // timeout.
+    try {
+      Tasks.waitFor(message + message + message + message, new Callable<String>() {
+        @Override
+        public String call() throws Exception {
+          try (CloseableIterator<Message> iterator =
+                 messageFetcher.fetch(NAMESPACE.getNamespace(), MessagingApp.TOPIC, Integer.MAX_VALUE, 0L)) {
+            Message message = Iterators.getLast(iterator, null);
+            return message == null ? null : message.getPayloadAsString();
+          }
+        }
+      }, 2, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+      Assert.fail("Expected timeout exception");
+    } catch (TimeoutException e) {
+      // expected
+    }
+
+    // Now publish a message to the control topic, to unblock the transaction block.
+    messagePublisher.publish(NAMESPACE.getNamespace(), MessagingApp.CONTROL_TOPIC, message);
+
+    // Should expect a new message as concat(message, message, message, message)
+    Tasks.waitFor(message + message + message + message, new Callable<String>() {
+      @Override
+      public String call() throws Exception {
+        try (CloseableIterator<Message> iterator =
+               messageFetcher.fetch(NAMESPACE.getNamespace(), MessagingApp.TOPIC, Integer.MAX_VALUE, 0L)) {
+          Message message = Iterators.getLast(iterator, null);
+          return message == null ? null : message.getPayloadAsString();
+        }
+      }
+    }, 5, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+
+
+    // Wait for the worker to finish and verify that it completes successfully.
+    workerManager.waitForFinish(5, TimeUnit.SECONDS);
+    Tasks.waitFor(1, new Callable<Integer>() {
+      @Override
+      public Integer call() throws Exception {
+        return workerManager.getHistory(ProgramRunStatus.COMPLETED).size();
+      }
+    }, 5, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  public void testTxPublishFetch() throws Exception {
+    ApplicationManager appManager = deployWithArtifact(NAMESPACE, MessagingApp.class, artifactJar);
+    MessagingAdmin messagingAdmin = getMessagingAdmin(NAMESPACE);
+
+    final WorkerManager workerManager = appManager.getWorkerManager(
+      MessagingApp.TransactionalMessagingWorker.class.getSimpleName());
+
+    // Run the TransactionalMessagingWorker twice, one with getting publisher/fetcher inside TX, one outside.
+    for (boolean getInTx : Arrays.asList(true, false)) {
+      messagingAdmin.createTopic(MessagingApp.TOPIC);
+
+      workerManager.start(Collections.singletonMap("get.in.tx", Boolean.toString(getInTx)));
+
+      // Wait for the worker to finish and verify that it completes successfully.
+      workerManager.waitForFinish(5, TimeUnit.SECONDS);
+      messagingAdmin.deleteTopic(MessagingApp.TOPIC);
+    }
+
+    // Verify both executed successfully.
+    Tasks.waitFor(2, new Callable<Integer>() {
+      @Override
+      public Integer call() throws Exception {
+        return workerManager.getHistory(ProgramRunStatus.COMPLETED).size();
+      }
+    }, 5, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  public void testSparkMessaging() throws Exception {
+    ApplicationManager appManager = deployWithArtifact(NAMESPACE, MessagingApp.class, artifactJar);
+
+    final SparkManager sparkManager = appManager.getSparkManager(MessagingSpark.class.getSimpleName()).start();
+
+    final MessageFetcher fetcher = getMessagingContext().getMessageFetcher();
+    final AtomicReference<String> messageId = new AtomicReference<>();
+
+    // Wait for the Spark to create the topic
+    final MessagingAdmin messagingAdmin = getMessagingAdmin(NAMESPACE.getNamespace());
+    Tasks.waitFor(true, new Callable<Boolean>() {
+      @Override
+      public Boolean call() throws Exception {
+        try {
+          messagingAdmin.getTopicProperties(MessagingApp.TOPIC);
+          return true;
+        } catch (TopicNotFoundException e) {
+          return false;
+        }
+      }
+    }, 60, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+
+    // Expect a "start" message, followed by "block". There shouldn't be anything in between.
+    // This is to verify failed transaction is not publishing anything.
+    for (String expected : Arrays.asList("start", "block")) {
+      Tasks.waitFor(expected, new Callable<String>() {
+        @Override
+        public String call() throws Exception {
+          try (CloseableIterator<Message> iterator =
+                 fetcher.fetch(NAMESPACE.getNamespace(), MessagingApp.TOPIC, 1, messageId.get())) {
+            if (!iterator.hasNext()) {
+              return null;
+            }
+            Message message = iterator.next();
+            messageId.set(message.getId());
+            return message.getPayloadAsString();
+          }
+        }
+      }, 60, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+    }
+
+    // Publish a control message to unblock the Spark execution
+    getMessagingContext().getMessagePublisher().publish(NAMESPACE.getNamespace(), MessagingApp.CONTROL_TOPIC, "go");
+
+    // Expects a result message as "result-15", where 15 is the sum of 1,2,3,4,5
+    Tasks.waitFor("result-15", new Callable<String>() {
+      @Override
+      public String call() throws Exception {
+        try (CloseableIterator<Message> iterator =
+               fetcher.fetch(NAMESPACE.getNamespace(), MessagingApp.TOPIC, 1, messageId.get())) {
+          if (!iterator.hasNext()) {
+            return null;
+          }
+          Message message = iterator.next();
+          messageId.set(message.getId());
+          return message.getPayloadAsString();
+        }
+      }
+    }, 60, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+
+    sparkManager.waitForFinish(60, TimeUnit.SECONDS);
+    Tasks.waitFor(1, new Callable<Integer>() {
+      @Override
+      public Integer call() throws Exception {
+        return sparkManager.getHistory(ProgramRunStatus.COMPLETED).size();
+      }
+    }, 5, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+  }
+}

--- a/cdap-unit-test/src/test/scala/co/cask/cdap/spark/app/TransactionSpark.scala
+++ b/cdap-unit-test/src/test/scala/co/cask/cdap/spark/app/TransactionSpark.scala
@@ -71,13 +71,13 @@ class TransactionSpark extends AbstractSpark with SparkMain  {
       .saveAsDataset(runtimeArgs("result.all.dataset"))
 
     // Use an explicit transaction to read from the all dataset and perform filtering and write it to dataset
-    Transaction {
+    Transaction(() => {
       sc.fromDataset[Array[Byte], Array[Byte]](runtimeArgs("result.all.dataset"))
         .map(t => (t._1, Bytes.toInt(t._2)))
         .filter(t => t._2 >= runtimeArgs("result.threshold").toInt)
         .map(t => (t._1, Bytes.toBytes(t._2)))
         .saveAsDataset(runtimeArgs("result.threshold.dataset"))
-    }
+    })
 
     // Sleep for 5 mins. This allows the unit-test to verify the dataset results
     // committed by the transaction above.

--- a/cdap-unit-test/src/test/scala/co/cask/cdap/test/messaging/MessagingSpark.scala
+++ b/cdap-unit-test/src/test/scala/co/cask/cdap/test/messaging/MessagingSpark.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.test.messaging
+
+import java.util.concurrent.{TimeUnit, TimeoutException}
+
+import co.cask.cdap.api.data.DatasetContext
+import co.cask.cdap.api.messaging.{Message, MessageFetcher}
+import co.cask.cdap.api.spark.{AbstractSpark, SparkExecutionContext, SparkMain}
+import com.google.common.base.Stopwatch
+import org.apache.spark.SparkContext
+import org.apache.tephra.TransactionFailureException
+import org.slf4j.LoggerFactory
+
+/**
+  *
+  */
+class MessagingSpark extends AbstractSpark with SparkMain {
+
+  import MessagingSpark._
+
+  override protected def configure(): Unit = setMainClass(getClass)
+
+  /**
+    * This method will be called when the Spark program starts.
+    *
+    * @param sec the implicit context for interacting with CDAP
+    */
+  override def run(implicit sec: SparkExecutionContext): Unit = {
+    val sc = new SparkContext
+    val messagingContext = sec.getMessagingContext
+
+    // Create a topic
+    sec.getAdmin().createTopic(MessagingApp.TOPIC)
+
+    // Publish a messaging without transaction
+    val publisher = messagingContext.getMessagePublisher()
+    publisher.publish(sec.getNamespace(), MessagingApp.TOPIC, "start")
+
+    // Start an explicit transaction, publish a message, but then throw an exception so that the tx won't be committed
+    try {
+      Transaction(() => {
+        LOG.info("In first Transaction block")
+        val result = sc.parallelize(Seq(1, 2, 3, 4, 5)).reduce(_ + _)
+        publisher.publish(sec.getNamespace, MessagingApp.TOPIC, "result-" + result)
+        throw new Exception("Intentional")
+      })
+
+      // Shouldn't reach here
+      throw new IllegalStateException("Expected TransactionFailureException");
+    } catch {
+      case t: TransactionFailureException => LOG.info("Exception expected: {}", t)
+    }
+
+    publisher.publish(sec.getNamespace(), MessagingApp.TOPIC, "block");
+
+    // Wait for a control message to proceed
+    fetchMessage(messagingContext.getMessageFetcher(), sec.getNamespace(), MessagingApp.CONTROL_TOPIC,
+                 Option.empty, 5, TimeUnit.SECONDS);
+
+    // Start another explicit transaction and publish a message
+    Transaction((dc: DatasetContext) => {
+      val result = sc.parallelize(Seq(1, 2, 3, 4, 5)).reduce(_ + _)
+      publisher.publish(sec.getNamespace, MessagingApp.TOPIC, "result-" + result)
+    })
+  }
+
+  private def fetchMessage(fetcher: MessageFetcher, namespace: String, topic: String,
+                           afterMessageId: Option[String], timeout: Long, unit: TimeUnit): Message = {
+    var iterator = fetcher.fetch(namespace, topic, 1, afterMessageId.orNull)
+    val stopwatch = new Stopwatch().start
+    try {
+      while (!iterator.hasNext && stopwatch.elapsedTime(unit) < timeout) {
+        TimeUnit.MILLISECONDS.sleep(100)
+        iterator = fetcher.fetch(namespace, topic, 1, afterMessageId.orNull)
+      }
+      if (!iterator.hasNext) {
+        throw new TimeoutException("Failed to get any messages from " + topic +
+          " in " + timeout + " " + unit.name.toLowerCase)
+      }
+      // The payload contains the message to publish in next step
+      return iterator.next
+    } finally {
+      iterator.close()
+    }
+  }
+}
+
+object MessagingSpark {
+  val LOG = LoggerFactory.getLogger(classOf[MessagingSpark])
+}


### PR DESCRIPTION
This PR changes are grouped into two commits.

1. Changes on `TransactionContext` and `DynamicDatasetCache`. It is mainly the preparation step for controlling the order of `TransactionAware` as per TMS required to achieve low latency for consumers. @anew Please help review the first commit.
    - Introduced a AbstractTransactionContext
      - Allows sub-classes to control the list of transaction awares to be used in transaction
    - Updated SingleThreadDatasetCache extra tx aware ordering
      - Uses LIFO ordering
    - Introduced a MultiThreadTransactionAware abstract class
      - Supports adding it as extra transaction aware through MultiThreadDatasetCache for
        the SingleThreadDatasetCache created per thread
2. Exposing TMS functionalities to program context. This commit has quite a lot of changes, however most of them are systematic changes for passing `MessagingService` to the `BasicXXXContext` constructor. The actual logic is in `AbstractContext`.
    - MessagingContext is available for all non-tx and short-tx contexts
      - Have CDAP-7807 to cover MR tasks and Spark executors
    - Makes all program context extends from MessagingContext
      - Except MapReduceTaskContext (CDAP-7807)
    - Make Admin extends from MessagingAdmin
      - Explicit disable messaging admin support for AuthorizationContext as it
        is using SYSTEM namespace for the admin and unclear what the impact is for changing it.
        Also there is no use-case needed for auth context to use messaging system yet
    - Added unit-tests
      - Mainly using Worker to test, as it is most flexible in combining tx and non-tx tests
      - All implementations are going through the same class, hence testing with Worker should
        covered all other program types usage (except long tx, which we don't support yet until CDAP-7807)