### PR TITLE
Specify Node.js 4.5.0 install for AMI/Docker/VM

### DIFF
--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -157,6 +157,15 @@
           "install_flavor": "openjdk",
           "jdk_version": 7
         },
+        "nodejs": {
+          "install_method": "binary",
+          "version": "4.5.0",
+          "binary": {
+            "checksum": {
+              "linux_x64": "5678ad94ee35e40fc3a2c545e136a0dc946ac4c039fca5898e1ea51ecf9e7c39"
+            }
+          }
+        },
         "openssh": {
           "server": {
             "permit_root_login": "without-password",

--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -162,7 +162,7 @@
           "version": "4.5.0",
           "binary": {
             "checksum": {
-              "linux_x64": "5678ad94ee35e40fc3a2c545e136a0dc946ac4c039fca5898e1ea51ecf9e7c39"
+              "linux_x64": "c6ee1f4303353e3605ff70de180431417eb594fe08daf612e692216236750c55"
             }
           }
         },

--- a/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
+++ b/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
@@ -5,6 +5,15 @@
       "url": "{{URI}}"
     }
   },
+  "nodejs": {
+    "install_method": "binary",
+    "version": "4.5.0",
+    "binary": {
+      "checksum": {
+        "linux_x64": "5678ad94ee35e40fc3a2c545e136a0dc946ac4c039fca5898e1ea51ecf9e7c39"
+      }
+    }
+  },
   "java": {
     "install_flavor": "openjdk",
     "jdk_version": 7

--- a/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
+++ b/cdap-distributions/src/packer/files/cdap-sdk-with-uri.json.template
@@ -10,7 +10,7 @@
     "version": "4.5.0",
     "binary": {
       "checksum": {
-        "linux_x64": "5678ad94ee35e40fc3a2c545e136a0dc946ac4c039fca5898e1ea51ecf9e7c39"
+        "linux_x64": "c6ee1f4303353e3605ff70de180431417eb594fe08daf612e692216236750c55"
       }
     }
   },

--- a/cdap-distributions/src/packer/files/cdap-sdk.json
+++ b/cdap-distributions/src/packer/files/cdap-sdk.json
@@ -2,6 +2,15 @@
   "cdap": {
     "version": "4.0.0-1"
   },
+  "nodejs": {
+    "install_method": "binary",
+    "version": "4.5.0",
+    "binary": {
+      "checksum": {
+        "linux_x64": "5678ad94ee35e40fc3a2c545e136a0dc946ac4c039fca5898e1ea51ecf9e7c39"
+      }
+    }
+  },
   "java": {
     "install_flavor": "openjdk",
     "jdk_version": 7

--- a/cdap-distributions/src/packer/files/cdap-sdk.json
+++ b/cdap-distributions/src/packer/files/cdap-sdk.json
@@ -7,7 +7,7 @@
     "version": "4.5.0",
     "binary": {
       "checksum": {
-        "linux_x64": "5678ad94ee35e40fc3a2c545e136a0dc946ac4c039fca5898e1ea51ecf9e7c39"
+        "linux_x64": "c6ee1f4303353e3605ff70de180431417eb594fe08daf612e692216236750c55"
       }
     }
   },

--- a/cdap-distributions/src/packer/scripts/cookbook-setup.sh
+++ b/cdap-distributions/src/packer/scripts/cookbook-setup.sh
@@ -21,7 +21,7 @@
 die() { echo $*; exit 1; }
 
 # Grab cookbooks using knife
-for cb in cdap hadoop idea maven nodejs openssh; do
+for cb in cdap idea maven openssh; do
   knife cookbook site install $cb || die "Cannot fetch cookbook $cb"
 done
 


### PR DESCRIPTION
Update to Node.js 4.5.0, the minimum version required for CDAP 4.0

Tested manually by building Docker container.

```bash
$ curl -s https://nodejs.org/download/release/v4.5.0/SHASUMS256.txt | grep node-v4.5.0-linux-x64.tar.xz
c6ee1f4303353e3605ff70de180431417eb594fe08daf612e692216236750c55  node-v4.5.0-linux-x64.tar.xz
```