### PR TITLE
Exclude copying Node.js into the SDK package

### DIFF
--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -373,6 +373,7 @@
                      <targetPath>ui</targetPath>
                      <excludes>
                       <exclude>**LICENSE**</exclude>
+                      <exclude>bin/node</exclude>
                      </excludes>
                    </resource>
                     <!-- Copy examples code -->


### PR DESCRIPTION
This will prevent the SDK from packaging a binary version of Node.js which may not match the target machine.