### PR TITLE
CDAP-7208 Change twill logging to INFO by default (from WARN)

### DIFF
--- a/cdap-distributions/src/etc/cdap/conf.dist/logback.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/logback.xml
@@ -33,7 +33,7 @@
     <logger name="org.eclipse.jetty" level="WARN"/>
     <logger name="io.netty.util.internal" level="WARN"/>
 
-    <logger name="org.apache.twill" level="WARN"/>
+    <logger name="org.apache.twill" level="INFO"/>
     <logger name="co.cask.cdap" level="INFO"/>
 
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
For better traceability. Twill doesn't log excessively at the INFO level anyways.