### PR TITLE
[CDAP-7823] Feature/ui admin operational stats

### DIFF
--- a/cdap-ui/app/cdap/components/AdminDetailPanel/index.js
+++ b/cdap-ui/app/cdap/components/AdminDetailPanel/index.js
@@ -50,7 +50,6 @@ class AdminDetailPanel extends Component {
         //Convert number into human readable text
         let pairs = [];
         Object.keys(this.props.serviceData[key]).map((item) => {
-
           let humanReadableNum;
 
           if(key === 'storage' || key === 'memory'){

--- a/cdap-ui/app/cdap/components/AdminMetadataPane/index.js
+++ b/cdap-ui/app/cdap/components/AdminMetadataPane/index.js
@@ -19,6 +19,7 @@ require('./AdminMetadataPane.less');
 import StatContainer from '../StatContainer/index.js';
 import shortid from 'shortid';
 import T from 'i18n-react';
+import {humanReadableDate} from 'services/helpers';
 
 function AdminMetadataPane({ statObject }){
 
@@ -30,13 +31,32 @@ function AdminMetadataPane({ statObject }){
   let statsList = [];
 
   statObject.stats.forEach((stat) => {
-    statsList.push (
-      <StatContainer
-        label={T.translate(`features.Management.DetailPanel.labels.${stat.statName}`)}
-        number={stat.statNum}
-        key={shortid.generate()}
-      />
-    );
+
+    //Ignore Stats Associated with WritePointer, ReadPointer, and VisibilityUpperBound
+    if(!(stat.statName === 'WritePointer' || stat.statName === 'ReadPointer' || stat.statName === 'VisibilityUpperBound')) {
+
+      //Convert snapshot time to human readable number
+      if(stat.statName === 'SnapshotTime'){
+        stat.statNum = humanReadableDate(Math.floor(stat.statNum.split(',').join('')), true);
+
+        statsList.push (
+          <StatContainer
+            label={T.translate(`features.Management.DetailPanel.labels.${stat.statName}`)}
+            number={stat.statNum}
+            date={true}
+            key={shortid.generate()}
+          />
+        );
+      } else {
+        statsList.push (
+          <StatContainer
+            label={T.translate(`features.Management.DetailPanel.labels.${stat.statName}`)}
+            number={stat.statNum}
+            key={shortid.generate()}
+          />
+        );
+      }
+    }
   });
 
   //Construct Columns of Statistics

--- a/cdap-ui/app/cdap/components/AdminOverviewPane/index.js
+++ b/cdap-ui/app/cdap/components/AdminOverviewPane/index.js
@@ -34,15 +34,17 @@ const propTypes = {
 
 function AdminOverviewPane({services}) {
   let cards = services.map((service) => {
-    return (
-      <OverviewPaneCard
-        key={shortid.generate()}
-        name={service.name}
-        version={service.version}
-        url={service.url}
-        logs={service.logs}
-      />
-    );
+    if(service.name !== 'CDAP'){
+      return (
+        <OverviewPaneCard
+          key={shortid.generate()}
+          name={service.name}
+          version={service.version}
+          url={service.url}
+          logs={service.logs}
+        />
+      );
+    }
   });
 
   return (

--- a/cdap-ui/app/cdap/components/InfoCard/InfoCard.less
+++ b/cdap-ui/app/cdap/components/InfoCard/InfoCard.less
@@ -55,6 +55,17 @@
     font-weight: 500;
   }
 
+  .primary-label {
+    font-size: 12px;
+    text-align: center;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 12px;
+    margin: auto;
+    color: #999999;
+  }
+
   .info-card-secondary-text {
     font-size: 14px;
     font-weight: 900;

--- a/cdap-ui/app/cdap/components/InfoCard/index.js
+++ b/cdap-ui/app/cdap/components/InfoCard/index.js
@@ -19,25 +19,38 @@ require('./InfoCard.less');
 var classNames = require('classnames');
 
 const propTypes = {
-  primaryText: PropTypes.string,
+  primaryText: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number
+  ]),
+  primaryLabel: PropTypes.string,
   secondaryText: PropTypes.string,
   superscriptText: PropTypes.string,
-  isLoading: PropTypes.bool
+  isLoading: PropTypes.bool,
+  primaryLabelOne: PropTypes.string,
+  primaryLabelTwo: PropTypes.string,
+  primaryLabelThree: PropTypes.string
 };
 
-function InfoCard({isLoading, primaryText, secondaryText, superscriptText}) {
-
+function InfoCard({isLoading, primaryText, primaryLabel, primaryLabelOne, primaryLabelTwo, primaryLabelThree, secondaryText}) {
   return (
     <div className="info-card">
-      <div
-        className={classNames("superscript-text", {'hidden' : isLoading})}
-      >
-        {superscriptText}
-      </div>
       <i className={classNames("fa", "fa-spinner", "fa-spin", "fa-2x", {"hidden" : !isLoading})} />
       <div className={classNames("info-card-text", {'hidden' : isLoading})}>
         <div className="info-card-main-text">
           {primaryText}
+        </div>
+        <div className="primary-label">
+            {primaryLabel}
+          <span>
+            {primaryLabelOne}
+          </span>
+          <span>
+            {primaryLabelTwo}
+          </span>
+          <span>
+            {primaryLabelThree}
+          </span>
         </div>
         <div className="info-card-secondary-text">
           {secondaryText}

--- a/cdap-ui/app/cdap/components/Management/Management.less
+++ b/cdap-ui/app/cdap/components/Management/Management.less
@@ -27,6 +27,18 @@
   background-color: #FFFFFF;
   padding: 20px;
 
+  .primary-label {
+    display: inline-flex;
+    justify-content: space-around;
+  }
+
+  .cdap-version-label {
+    text-align: right;
+    position: absolute;
+    right: 75px;
+    font-style: italic;
+  }
+
   .top-panel {
     margin-bottom: 20px;
   }

--- a/cdap-ui/app/cdap/components/Management/index.js
+++ b/cdap-ui/app/cdap/components/Management/index.js
@@ -30,17 +30,11 @@ import VersionActions from 'services/VersionStore/VersionActions';
 import MyCDAPVersionApi from 'api/version';
 import {MyServiceProviderApi} from 'api/serviceproviders';
 import Mousetrap from 'mousetrap';
+import moment from 'moment';
 
 import T from 'i18n-react';
 var shortid = require('shortid');
 var classNames = require('classnames');
-
-var dummyData = {
-  uptime: {
-    duration: '--',
-    unit: '-'
-  }
-};
 
 class Management extends Component {
 
@@ -53,6 +47,7 @@ class Management extends Component {
       version: '',
       loading: false,
       lastUpdated : 0,
+      uptime: 0,
       wizard : {
         actionIndex : null,
         actionType : null
@@ -69,21 +64,41 @@ class Management extends Component {
           for(let key in res){
             if(res.hasOwnProperty(key)){
               apps.push(key);
-              services.push({
-                name: T.translate(`features.Management.Component-Overview.headers.${key}`),
-                version: res[key].Version,
-                url: res[key].WebURL,
-                logs: res[key].LogsURL
-              });
+              if(key !== 'cdap'){
+                services.push({
+                  name: T.translate(`features.Management.Component-Overview.headers.${key}`),
+                  version: res[key].Version,
+                  url: res[key].WebURL,
+                  logs: res[key].LogsURL
+                });
+              } else {
+                //Uptime is attached to cdap response object
+                let uptime = res[key].Uptime;
+                let tempTime = moment.duration(uptime);
+                let days = tempTime.days() < 10 ? '0' + tempTime.days() : tempTime.days();
+                let hours = tempTime.hours() < 10 ? '0' + tempTime.hours() : tempTime.hours();
+                let minutes = tempTime.minutes() < 10 ? '0' + tempTime.minutes() : tempTime.minutes();
+                let time = `${days}:${hours}:${minutes}`;
+                this.setState({uptime: time});
+                services.push({
+                  name: T.translate(`features.Management.Component-Overview.headers.${key}`)
+                });
+              }
             }
           }
           this.getServices(apps);
-          let current = apps[0];
-          this.setState({
-            application : current,
-            applications : apps,
-            services : services
-          });
+          if(!this.state.application){
+            this.setState({
+              application : apps[0],
+              applications : apps,
+              services : services
+            });
+          } else {
+            this.setState({
+              applications : apps,
+              services : services
+            });
+          }
         }
       );
 
@@ -165,7 +180,6 @@ class Management extends Component {
   }
 
   setToContext(contextName) {
-
     if(this.state.application !== contextName){
 
       this.setState({
@@ -213,17 +227,17 @@ class Management extends Component {
           title={T.translate('features.Management.Title')}
         />
         <div className="top-panel">
+          <div className="cdap-version-label">
+            {T.translate('features.Management.Top.version-label')} - {this.state.version}
+          </div>
           <div className="admin-row top-row">
             <InfoCard
               isLoading={this.state.loading}
-              primaryText={this.state.version}
-              secondaryText={T.translate('features.Management.Top.version-label')}
-            />
-            <InfoCard
-              isLoading={this.state.loading}
-              primaryText={dummyData.uptime.duration}
+              primaryText={this.state.uptime}
+              primaryLabelOne={T.translate('features.Management.Top.primaryLabelOne')}
+              primaryLabelTwo={T.translate('features.Management.Top.primaryLabelTwo')}
+              primaryLabelThree={T.translate('features.Management.Top.primaryLabelThree')}
               secondaryText={T.translate('features.Management.Top.time-label')}
-              superscriptText={dummyData.uptime.unit}
             />
             <ServiceLabel/>
             <ServiceStatusPanel

--- a/cdap-ui/app/cdap/components/StatContainer/StatContainer.less
+++ b/cdap-ui/app/cdap/components/StatContainer/StatContainer.less
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 @import '../../styles/variables.less';
 
 .stat-container {
@@ -25,18 +26,18 @@
 
   .stat {
     min-width: 40px;
-    font-size: 25px;
+    font-size: 16px;
     color: @metadata-pane-primary-text-color;
     display: block;
   }
 
   .date-stat {
-    font-size: 12px;
+    font-size: 14px;
   }
 
   .stat-label {
     display: block;
     color: @metadata-pane-secondary-text-color;
-    font-size: 10px;
+    font-size: 13px;
   }
 }

--- a/cdap-ui/app/cdap/components/StatContainer/index.js
+++ b/cdap-ui/app/cdap/components/StatContainer/index.js
@@ -24,14 +24,16 @@ const propTypes = {
     PropTypes.string,
     PropTypes.number
   ]),
+  date: PropTypes.bool,
   label: PropTypes.string,
   isLoading: PropTypes.bool
 };
 
-function StatContainer({number, label}) {
+function StatContainer({number, label, date}) {
+  let statClasses = date ? 'stat date-stat' : 'stat';
   return (
     <div className={classNames("stat-container")}>
-      <div className="stat">
+      <div className={statClasses}>
         {number}
       </div>
       <div className="stat-label">

--- a/cdap-ui/app/cdap/main.js
+++ b/cdap-ui/app/cdap/main.js
@@ -57,6 +57,14 @@ class CDAP extends Component {
 
   componentWillMount(){
     cookie.save('DEFAULT_UI', 'NEW', {path: '/'});
+    if (window.CDAP_CONFIG.securityEnabled) {
+      NamespaceStore.dispatch({
+        type: NamespaceActions.updateUsername,
+        payload: {
+          username: cookie.load('CDAP_Auth_User')
+        }
+      });
+    }
     // Polls for namespace data
     MyNamespaceApi.pollList()
       .subscribe(
@@ -88,14 +96,6 @@ class CDAP extends Component {
   }
 
   render() {
-    if (window.CDAP_CONFIG.securityEnabled) {
-      NamespaceStore.dispatch({
-        type: NamespaceActions.updateUsername,
-        payload: {
-          username: cookie.load('CDAP_Auth_User')
-        }
-      });
-    }
 
     return (
       <Router basename="/cdap" history={history}>

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -130,6 +130,9 @@ features:
       updated-label:
         plural: seconds ago
         singular: second ago
+      primaryLabelOne: DAY
+      primaryLabelTwo: HR
+      primaryLabelThree: MIN
     Panels:
       nodes: Nodes
       virtual-cores: Virtual Cores
@@ -137,6 +140,7 @@ features:
       application: Application
     Services:
       appfabric: App Fabric
+      messaging_service: Messaging Service
       log_saver: Log Saver
       metrics_processor: Metrics Processor
       dataset_executor: Dataset Executor


### PR DESCRIPTION
<img width="1254" alt="screen shot 2016-12-17 at 4 54 56 pm" src="https://cloud.githubusercontent.com/assets/7697583/21290707/b313e49c-c479-11e6-9980-5e3c7bb23a49.png">

- Admin screen now reports operational stats under CDAP header
- Uptime is now formatted for readability

JIRA:
https://issues.cask.co/browse/CDAP-7823
https://issues.cask.co/browse/CDAP-7916

Bamboo Build:
http://builds.cask.co/browse/CDAP-DRC5143