### PR TITLE
CDAP-7292 fix spark kmeans example

### DIFF
--- a/cdap-examples/SparkKMeans/src/main/scala/co/cask/cdap/examples/sparkkmeans/SparkKMeansProgram.scala
+++ b/cdap-examples/SparkKMeans/src/main/scala/co/cask/cdap/examples/sparkkmeans/SparkKMeansProgram.scala
@@ -88,7 +88,7 @@ object SparkKMeansProgram {
   private final val LOG: Logger = LoggerFactory.getLogger(classOf[SparkKMeansProgram])
 
   private def pointVector(point: Point): Vector[Double] = {
-    DenseVector(Array(point.getX, point.getX, point.getZ).map(_.doubleValue()))
+    DenseVector(Array(point.getX, point.getY, point.getZ).map(_.doubleValue()))
   }
 
   private def closestPoint(p: Vector[Double], centers: Array[Vector[Double]]): Int = {


### PR DESCRIPTION
there was a careless error where the y coordinate was not being
used. Also changing the test to have it actually test the result.