### PR TITLE
CDP-7531 Example Changes

### DIFF
--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -223,16 +223,18 @@ if git_build_vars.has_key(GIT_BRANCH_CDAP_GUIDES):
 else:
     cdap_guides_github_pattern = ''
 
+_cdap_ui_base = 'http://localhost:11011/oldcdap/ns/default'
+
 extlinks = {
-    'cdap-ui': ('http://localhost:11011/ns/default/%s', None),
-    'cdap-ui-apps': ('http://localhost:11011/ns/default/apps/%s', None),
-    'cdap-ui-apps-programs': ('http://localhost:11011/ns/default/apps/%s/overview/programs', None),
-    'cdap-ui-datasets': ('http://localhost:11011/ns/default/datasets/%s', None),
-    'cdap-ui-datasets-explore': ('http://localhost:11011/ns/default/datasets/%s/overview/explore', None),
-    'cdap-ui-datasets-explore': ('http://localhost:11011/ns/default/datasets/%s/overview/explore', None),
-    'cask-hydrator': ('http://localhost:11011/ns/default/hydrator/%s', None),
-    'cask-hydrator-studio': ('http://localhost:11011/ns/default/hydrator/studio/%s', None),
-    'cask-hydrator-studio-artifact': ('http://localhost:11011/ns/default/hydrator/studio?artifactType=%s', None),
+    'cdap-ui': ("%s/%%s" % _cdap_ui_base, None),
+    'cdap-ui-apps': ("%s/apps/%%s" % _cdap_ui_base, None),
+    'cdap-ui-apps-programs': ("%s/apps/%%s/overview/programs" % _cdap_ui_base, None),
+    'cdap-ui-data': ("%s/data/%%s" % _cdap_ui_base, None),
+    'cdap-ui-datasets': ("%s/datasets/%%s" % _cdap_ui_base, None),
+    'cdap-ui-datasets-explore': ("%s/datasets/%%s/overview/explore" % _cdap_ui_base, None),
+    'cask-hydrator': ("%s/%%s" % _cdap_ui_base, None),
+    'cask-hydrator-studio': ("%s/hydrator/%%s" % _cdap_ui_base, None),
+    'cask-hydrator-studio-artifact': ("%s/hydrator/studio?artifactType=%%s" % _cdap_ui_base, None),
     'cdap-java-source-github': (cdap_java_source_github_pattern , None),
     'cdap-security-extn-source-github': (cdap_security_extn_github_pattern, None),
     'cask-issue': ('https://issues.cask.co/browse/%s', ''),

--- a/cdap-docs/admin-manual/source/operations/cdap-ui.rst
+++ b/cdap-docs/admin-manual/source/operations/cdap-ui.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2016 Cask Data, Inc.
 
 .. _cdap-console:
 .. _cdap-ui:
@@ -10,7 +10,7 @@ CDAP UI
 =======
 
 The **CDAP UI** is available for deploying, querying and managing the Cask Data
-Application Platform in all modes of CDAP except an 
+Application Platform in all modes of CDAP except as an 
 :ref:`in-memory CDAP <in-memory-data-application-platform>`.
 
 Here is a screen-capture of the CDAP UI running on a Distributed CDAP:

--- a/cdap-docs/developers-manual/source/getting-started/building-apps.rst
+++ b/cdap-docs/developers-manual/source/getting-started/building-apps.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014-2015 Cask Data, Inc.
+    :copyright: Copyright © 2014-2016 Cask Data, Inc.
 
 .. _cdap-building-running:
 
@@ -100,7 +100,7 @@ Starting CDAP
 Before running an example application, check that an instance of CDAP is running and available; if not,
 follow the instructions for :ref:`Starting and Stopping Standalone CDAP. <start-stop-cdap>`
 
-If you can reach the CDAP UI through a browser at `http://localhost:11011/ <http://localhost:11011/>`__, 
+If you can reach the CDAP UI through a browser at :cdap-ui:`http://localhost:11011/ <>`,
 CDAP is running.
 
 .. _cdap-building-running-deploying:

--- a/cdap-docs/developers-manual/source/getting-started/building-apps.rst
+++ b/cdap-docs/developers-manual/source/getting-started/building-apps.rst
@@ -12,16 +12,16 @@ Building and Running CDAP Applications
 .. |example-dir| replace:: <example-directory>
 
 .. |development| replace:: *Development Home*
-.. _development: http://localhost:11011/ns/default
+.. _development: http://localhost:11011/oldcdap/ns/default
 
 .. |all_apps| replace:: *All Applications*
-.. _all_apps: http://localhost:11011/ns/default/apps
+.. _all_apps: http://localhost:11011/oldcdap/ns/default/apps
 
 .. |management| replace:: *Management Applications*
-.. _management: http://localhost:11011/admin/namespace/detail/default/apps
+.. _management: http://localhost:11011/oldcdap/admin/namespace/detail/default/apps
 
 .. |datasets| replace:: *Management Datasets*
-.. _datasets: http://localhost:11011/admin/namespace/detail/default/data
+.. _datasets: http://localhost:11011/oldcdap/admin/namespace/detail/default/data
 
 
 .. highlight:: console
@@ -49,7 +49,7 @@ Accessing CLI, curl, and the SDK bin
   ``libexec\bin\curl.exe``; use it as a substitute for ``curl`` in examples.
 
 - If you add the SDK bin directory to your path, you can simplify the commands. From within
-  the CDAP-SDK-home directory, enter:
+  the ``<CDAP-SDK-HOME>`` directory, enter:
   
   .. tabbed-parsed-literal::
   
@@ -71,12 +71,25 @@ Accessing CLI, curl, and the SDK bin
 Building an Example Application Artifact
 ----------------------------------------
 
-From the example's project root, build an example with the
+From the example's project root (such as ``examples/<example-dir>``), build an example with the
 `Apache Maven <http://maven.apache.org>`__ command:
 
 .. tabbed-parsed-literal::
 
   $ mvn clean package
+
+To build without running tests, use:
+
+.. tabbed-parsed-literal::
+
+  $ mvn clean package -DskipTests
+
+To build all the examples, switch to the main examples directory and run the Maven command:
+
+.. tabbed-parsed-literal::
+
+  $ cd <CDAP-SDK-HOME>/examples
+  $ mvn clean package -DskipTests
 
 
 .. _cdap-building-running-starting:

--- a/cdap-docs/developers-manual/source/getting-started/quick-start.rst
+++ b/cdap-docs/developers-manual/source/getting-started/quick-start.rst
@@ -356,9 +356,9 @@ on when and how many events you have sent):
   
   {"startTime":0,"endTime":1431467057,"series":[{"metricName":"system.process.events.processed","grouping":{},"data":[{"time":0,"value":3007}]}]}
 
-A much easier way to observe the flow is in the `CDAP UI: <http://localhost:11011>`__
-it shows a `visualization of the flow, <http://localhost:11011/ns/default/apps/Wise/programs/flows/WiseFlow/runs>`__
-annotated with its real-time metrics:
+A much easier way to observe the flow is in the :cdap-ui:`CDAP UI <>`: it shows a
+:cdap-ui-apps:`visualization of the flow <Wise/programs/flows/WiseFlow/runs>`, annotated
+with its real-time metrics:
 
 .. image:: ../_images/quickstart/wise-flow1.png
    :width: 600px

--- a/cdap-docs/developers-manual/source/getting-started/standalone/docker.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/docker.rst
@@ -92,7 +92,7 @@ started correctly.
    directory is under ``/opt/cdap/sdk``.
 
 #. Once CDAP starts, it will instruct you to connect to the CDAP UI with a web browser
-   at ``http://localhost:11011``. 
+   at :cdap-ui:`http://localhost:11011/ <>`. 
   
 #. If you are **running Docker on either Mac OS X or Microsoft Windows**, replace ``localhost`` 
    with the Docker VM's IP address (such as ``192.168.99.100``) that you obtained earlier.

--- a/cdap-docs/developers-manual/source/getting-started/standalone/virtual-machine.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/virtual-machine.rst
@@ -34,7 +34,7 @@ It has pre-installed all the software that you need to run and develop CDAP appl
   virtual machine has started.
 - Links on the desktop are provided to the CDAP SDK, CDAP UI, and CDAP documentation.
 - The Chromium web browser is included. The default page for the CDAP UI, available through a desktop link, is
-  ``http://localhost:11011``.
+  :cdap-ui:`http://localhost:11011/ <>`.
 
 No password is required to enter the virtual machine; however, should you need to install or
 remove software, the admin user and password are both ``cdap``.
@@ -72,7 +72,7 @@ Note that starting CDAP is not necessary if you use the Virtual Machine, as it
 starts the Standalone CDAP automatically on startup.
 
 Once CDAP is started successfully, in a web browser you will be able to see the CDAP
-UI running at ``http://localhost:11011``, where you can deploy example applications and
+UI running at :cdap-ui:`http://localhost:11011/ <>`, where you can deploy example applications and
 interact with CDAP. 
 
 .. include:: /_includes/building-apps.txt

--- a/cdap-docs/developers-manual/source/getting-started/start-stop-cdap.rst
+++ b/cdap-docs/developers-manual/source/getting-started/start-stop-cdap.rst
@@ -1,5 +1,5 @@
 .. :author: Cask Data, Inc.
-   :copyright: Copyright © 2014-2015 Cask Data, Inc.
+   :copyright: Copyright © 2014-2016 Cask Data, Inc.
 
 ============================================
 Starting and Stopping Standalone CDAP
@@ -28,9 +28,9 @@ installed):
 Note that starting CDAP is not necessary if you use either the Virtual Machine or the
 Docker image, as they both start the Standalone CDAP automatically on startup.
 
-Once CDAP is started successfully, in a web browser you will be able to see the CDAP
-UI running at ``http://localhost:11011``, where you can deploy example applications and
-interact with CDAP. 
+Once CDAP is started successfully, in a web browser you will be able to see the CDAP UI
+running at :cdap-ui:`http://localhost:11011/ <>`, where you can deploy example
+applications and interact with CDAP. 
 
 Note that in the case of the Docker container running inside a Virtual Machine (as on
 either Mac OS X or Microsoft Windows), you will need to substitute the Docker VM's IP

--- a/cdap-docs/examples-manual/source/examples/spam-classifier.rst
+++ b/cdap-docs/examples-manual/source/examples/spam-classifier.rst
@@ -88,10 +88,9 @@ Running the Spark Program
 -------------------------
 There are three ways to start the Spark program:
 
-1. Go to the |example-italic| `application overview page, programs tab
-   <http://localhost:11011/ns/default/apps/SpamClassifier/overview/programs>`__,
-   click |example-spark-literal| to get to the Spark program detail page, and add these runtime
-   arguments/preferences::
+1. Go to the |example-italic| :cdap-ui-apps-programs:`application overview page, programs
+   tab <SpamClassifier>`, click |example-spark-literal| to get to the Spark program detail
+   page, and add these runtime arguments/preferences::
 
      kafka.brokers:broker1-host:port
      kafka.topics:topic1,topic2

--- a/cdap-docs/examples-manual/source/examples/spark-k-means.rst
+++ b/cdap-docs/examples-manual/source/examples/spark-k-means.rst
@@ -89,9 +89,9 @@ Running the Spark Program
 -------------------------
 There are three ways to start the Spark program:
 
-1. Go to the *SparkKMeans* `application overview page, programs tab 
-   <http://localhost:11011/ns/default/apps/SparkKMeans/overview/programs>`__,
-   click ``CentersService`` to get to the service detail page, then click the *Start* button; or
+1. Go to the |example-italic| :cdap-ui-apps-programs:`application overview page, programs
+   tab <SparkKMeans>`, click |example-service-italic| to get to the service detail
+   page, then click the *Start* button; or
    
 #. Use the Command Line Interface:
 

--- a/cdap-docs/examples-manual/source/examples/user-profiles.rst
+++ b/cdap-docs/examples-manual/source/examples/user-profiles.rst
@@ -196,9 +196,9 @@ For example, such a conflict would show as (reformatted to fit)::
   co.cask.tephra.TransactionContext.finish(TransactionContext.java:79) ~[co.cask.tephra.tephra-core-0.4.1.jar:na] at 
   . . .
 
-(The log file is located at ``<CDAP-SDK-HOME>/logs/cdap-debug.log``. You should also see 
-error in the CDAP UI, in the `UserProfileService error log 
-<http://localhost:11011/ns/default/apps/UserProfiles/programs/services/UserProfileService/logs?filter=error>`__.)
+(The log file is located at ``<CDAP-SDK-HOME>/logs/cdap-debug.log``. You should also see
+an error in the CDAP UI, in the :cdap-ui-apps:`UserProfileService error log
+<UserProfiles/programs/services/UserProfileService/logs?filter=error>`.)
 
 Note that in order to see this happen (and to change from row- to column- and vice-versa),
 you need to :ref:`delete the existing dataset <user-profiles-delete-dataset>` ``profiles``

--- a/cdap-docs/examples-manual/source/examples/web-analytics.rst
+++ b/cdap-docs/examples-manual/source/examples/web-analytics.rst
@@ -144,9 +144,9 @@ Query the Unique Visitor Page Views
 ---------------------------------------
 Once the log data has been processed by the ``WebAnalyticsFlow``, we can explore the
 dataset ``UniqueVisitCount`` with a SQL query. You can easily execute SQL queries against
-datasets using the CDAP UI by going to the *Data* page showing `All Datasets 
-<http://localhost:11011/ns/default/data>`__, entering *UniqueVisitCount* in the search box, 
-and clicking on the **UniqueVisitCount** dataset:
+datasets using the CDAP UI by going to the *Data* page showing :cdap-ui-data:`All
+Datasets <>`, entering *UniqueVisitCount* in the search box, and clicking on the
+**UniqueVisitCount** dataset:
 
 .. figure:: _images/web-analytics-0.png
    :figwidth: 100%

--- a/cdap-docs/examples-manual/source/examples/word-count.rst
+++ b/cdap-docs/examples-manual/source/examples/word-count.rst
@@ -105,9 +105,8 @@ Running the Example
 
 Injecting Sentences
 -------------------
-In the application's `detail page
-<http://localhost:11011/ns/default/apps/WordCount/overview/programs>`__, click on the
-*WordCounter* flow. This takes you to the flow details page. 
+In the application's :cdap-ui-apps:`detail page <WordCount/overview/programs>`, click on
+the *WordCounter* flow. This takes you to the flow details page. 
 
 Now double-click on the *wordStream* stream on the left side of the flow visualization,
 which brings up a pop-up window. Enter a sentence such as ``"Hello CDAP"`` (without the

--- a/cdap-docs/examples-manual/source/tutorials/wise.rst
+++ b/cdap-docs/examples-manual/source/tutorials/wise.rst
@@ -603,7 +603,7 @@ With WISE, you can explore the datasets using SQL queries. The SQL interface on 
 called *Explore*, can be accessed through the CDAP UI:
 
 1. After deploying WISE in your Standalone CDAP instance, go to the *WISE* 
-   `overview page <http://localhost:11011/ns/default/apps/Wise/overview/status>`__:
+   :cdap-ui-apps:`overview page <Wise/overview/status>`:
 
    .. figure:: ../_images/wise_overview.png
       :figwidth: 100%

--- a/cdap-docs/introduction/source/index.rst
+++ b/cdap-docs/introduction/source/index.rst
@@ -3,7 +3,6 @@
     :description: Introduction to the Cask Data Application Platform
     :copyright: Copyright © 2015-2016 Cask Data, Inc.
 
-
 :hide-relations: true
 
 .. _introduction-to-cdap:

--- a/cdap-docs/tracker-manual/source/index.rst
+++ b/cdap-docs/tracker-manual/source/index.rst
@@ -101,11 +101,11 @@ Cask Tracker consists of an application in CDAP with two programs and four datas
 The Tracker UI is shipped with CDAP, started automatically in standalone CDAP as part of the
 CDAP UI. It is available at:
 
-  http://localhost:11011/ns/default/tracker/home
+  :cdap-ui:`http://localhost:11011/tracker/ns/default/home <tracker/home>`
   
 or (Distributed CDAP):
 
-  http://host:dashboard-bind-port/ns/default/tracker/home
+  http://host:dashboard-bind-port/tracker/ns/default/home
   
 
 Tracker is built from a system artifact included with CDAP, |literal-cask-tracker-version-jar|.


### PR DESCRIPTION
Fixes examples that include URLs that point to the CDAP UI to use the centrally-controlled versions that are in the `common_conf.py`. These point to the "old CDAP UI", as it is feature-complete.

Running as Quick Build: http://builds.cask.co/browse/CDAP-DQB199-1 (passes)

Fix for https://issues.cask.co/browse/CDAP-7531