### PR TITLE
(CDAP-7901) Always use ScanBuilder to setup HBase Scan properties

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -1076,6 +1076,7 @@ public final class Constants {
     public static final String LOCAL_DATA_DIR = "messaging.local.data.dir";
 
     public static final String HBASE_MAX_SCAN_THREADS = "messaging.hbase.max.scan.threads";
+    public static final String HBASE_SCAN_CACHE_ROWS = "messaging.hbase.scan.cache.rows";
     public static final String METADATA_TABLE_NAME = "messaging.metadata.table.name";
     public static final String MESSAGE_TABLE_NAME = "messaging.message.table.name";
     public static final String MESSAGE_TABLE_HBASE_SPLITS = "messaging.message.table.hbase.splits";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1186,6 +1186,15 @@
   </property>
 
   <property>
+    <name>messaging.hbase.scan.cache.rows</name>
+    <value>1000</value>
+    <description>
+      Number of rows for caching that will be passed to HBase scanners.
+      Higher caching values will enable faster scanning but will use more memory.
+    </description>
+  </property>
+
+  <property>
     <name>messaging.http.server.executor.threads</name>
     <value>0</value>
     <description>

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="4f81d8d5a9473f1da7372d40ca838229"
+DEFAULT_XML_MD5_HASH="2b450fdfa83ff136a8a96b64a09acbe1"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/hbase/HBaseMessageTable.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/hbase/HBaseMessageTable.java
@@ -45,21 +45,22 @@ import java.util.concurrent.ExecutorService;
 final class HBaseMessageTable extends AbstractMessageTable {
   private static final byte[] PAYLOAD_COL = Bytes.toBytes('p');
   private static final byte[] TX_COL = Bytes.toBytes('t');
-  private static final int SCAN_CACHE_ROWS = 1000;
 
   private final HBaseTableUtil tableUtil;
   private final byte[] columnFamily;
   private final HTable hTable;
   private final AbstractRowKeyDistributor rowKeyDistributor;
   private final ExecutorService scanExecutor;
+  private final int scanCacheRows;
 
   HBaseMessageTable(HBaseTableUtil tableUtil, HTable hTable, byte[] columnFamily,
-                    AbstractRowKeyDistributor rowKeyDistributor, ExecutorService scanExecutor) {
+                    AbstractRowKeyDistributor rowKeyDistributor, ExecutorService scanExecutor, int scanCacheRows) {
     this.tableUtil = tableUtil;
     this.hTable = hTable;
     this.columnFamily = Arrays.copyOf(columnFamily, columnFamily.length);
     this.rowKeyDistributor = rowKeyDistributor;
     this.scanExecutor = scanExecutor;
+    this.scanCacheRows = scanCacheRows;
   }
 
   @Override
@@ -67,7 +68,7 @@ final class HBaseMessageTable extends AbstractMessageTable {
     Scan scan = tableUtil.buildScan()
       .setStartRow(startRow)
       .setStopRow(stopRow)
-      .setCaching(SCAN_CACHE_ROWS)
+      .setCaching(scanCacheRows)
       .build();
 
     final ResultScanner scanner = DistributedScanner.create(hTable, scan, rowKeyDistributor, scanExecutor);
@@ -128,7 +129,7 @@ final class HBaseMessageTable extends AbstractMessageTable {
     Scan scan = tableUtil.buildScan()
       .setStartRow(startKey)
       .setStopRow(stopKey)
-      .setCaching(SCAN_CACHE_ROWS)
+      .setCaching(scanCacheRows)
       .build();
 
     List<Put> batchPuts = new ArrayList<>();

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/hbase/HBasePayloadTable.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/hbase/HBasePayloadTable.java
@@ -49,14 +49,17 @@ final class HBasePayloadTable extends AbstractPayloadTable {
   private final HTable hTable;
   private final AbstractRowKeyDistributor rowKeyDistributor;
   private final ExecutorService scanExecutor;
+  private final int scanCacheRows;
 
   HBasePayloadTable(HBaseTableUtil tableUtil, HTable hTable, byte[] columnFamily,
-                    AbstractRowKeyDistributor rowKeyDistributor, ExecutorService scanExecutor) {
+                    AbstractRowKeyDistributor rowKeyDistributor, ExecutorService scanExecutor,
+                    int scanCacheRows) {
     this.tableUtil = tableUtil;
     this.hTable = hTable;
     this.columnFamily = Arrays.copyOf(columnFamily, columnFamily.length);
     this.rowKeyDistributor = rowKeyDistributor;
     this.scanExecutor = scanExecutor;
+    this.scanCacheRows = scanCacheRows;
   }
 
   @Override
@@ -65,6 +68,7 @@ final class HBasePayloadTable extends AbstractPayloadTable {
     Scan scan = tableUtil.buildScan()
       .setStartRow(startRow)
       .setStopRow(stopRow)
+      .setCaching(scanCacheRows)
       .build();
     final ResultScanner scanner = DistributedScanner.create(hTable, scan, rowKeyDistributor, scanExecutor);
     final Iterator<Result> results = scanner.iterator();

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/hbase/HBaseTableFactory.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/hbase/HBaseTableFactory.java
@@ -95,7 +95,8 @@ public final class HBaseTableFactory implements TableFactory {
         .build();
       tableUtil.createTableIfNotExists(admin, tableId, htd);
     }
-    return new HBaseMetadataTable(tableUtil, tableUtil.createHTable(hConf, tableId), COLUMN_FAMILY);
+    return new HBaseMetadataTable(tableUtil, tableUtil.createHTable(hConf, tableId),
+                                  COLUMN_FAMILY, cConf.getInt(Constants.MessagingSystem.HBASE_SCAN_CACHE_ROWS));
   }
 
   @Override
@@ -105,7 +106,7 @@ public final class HBaseTableFactory implements TableFactory {
     return new HBaseMessageTable(
       tableUtil, hTable, COLUMN_FAMILY,
       new RowKeyDistributorByHashPrefix(new OneByteSimpleHash(getKeyDistributorBuckets(hTable, tableId))),
-      scanExecutor
+      scanExecutor, cConf.getInt(Constants.MessagingSystem.HBASE_SCAN_CACHE_ROWS)
     );
   }
 
@@ -116,7 +117,7 @@ public final class HBaseTableFactory implements TableFactory {
     return new HBasePayloadTable(
       tableUtil, hTable, COLUMN_FAMILY,
       new RowKeyDistributorByHashPrefix(new OneByteSimpleHash(getKeyDistributorBuckets(hTable, tableId))),
-      scanExecutor
+      scanExecutor, cConf.getInt(Constants.MessagingSystem.HBASE_SCAN_CACHE_ROWS)
     );
   }
 


### PR DESCRIPTION
- Also added a new configuration for setting the scan row cache size