### PR TITLE
CDAP-7208 Change twill logging to INFO by default (from WARN)

### DIFF
--- a/cdap-distributions/src/etc/cdap/conf.dist/logback-container.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/logback-container.xml
@@ -36,7 +36,7 @@
   <logger name="org.eclipse.jetty" level="WARN"/>
   <logger name="io.netty.util.internal" level="WARN"/>
 
-  <logger name="org.apache.twill" level="WARN"/>
+  <logger name="org.apache.twill" level="INFO"/>
   <logger name="co.cask.cdap" level="INFO"/>
 
   <!-- Redirected stdout and stderr of Hive operations -->


### PR DESCRIPTION
Same change as https://github.com/caskdata/cdap/pull/7398, but for containers. This is useful for traceability in the case that workflows launch yarn applications.