### PR TITLE
CDAP-7911 Disallow both 'query' and 'sort' parameters in metadata search.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
@@ -37,6 +37,7 @@ import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpResponder;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.gson.Gson;
@@ -851,10 +852,18 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
         throw new BadRequestException("Cursors are not supported when sort info is not specified.");
       }
     }
-    MetadataSearchResponse response =
-      metadataAdmin.search(namespaceId, URLDecoder.decode(searchQuery, "UTF-8"), types,
-                           sortInfo, offset, limit, numCursors, cursor);
-    responder.sendJson(HttpResponseStatus.OK, response, MetadataSearchResponse.class, GSON);
+    try {
+      MetadataSearchResponse response =
+        metadataAdmin.search(namespaceId, URLDecoder.decode(searchQuery, "UTF-8"), types,
+                             sortInfo, offset, limit, numCursors, cursor);
+      responder.sendJson(HttpResponseStatus.OK, response, MetadataSearchResponse.class, GSON);
+    } catch (Exception e) {
+      // if MetadataDataset throws an exception, it gets wrapped
+      if (Throwables.getRootCause(e) instanceof IllegalArgumentException) {
+        throw new BadRequestException(e);
+      }
+      throw e;
+    }
   }
 
   private Set<MetadataRecord> getMetadata(NamespacedEntityId namespacedEntityId,

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataHttpHandlerTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataHttpHandlerTestRun.java
@@ -1190,6 +1190,19 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
   }
 
   @Test
+  public void testInvalidParams() throws Exception {
+    NamespaceId namespace = new NamespaceId("testInvalidParams");
+    namespaceClient.create(new NamespaceMeta.Builder().setName(namespace).build());
+    try {
+      EnumSet<MetadataSearchTargetType> targets = EnumSet.allOf(MetadataSearchTargetType.class);
+      searchMetadata(namespace, "text", targets, AbstractSystemMetadataWriter.CREATION_TIME_KEY + " desc");
+      Assert.fail("Expected not to be able to specify 'query' and 'sort' parameters.");
+    } catch (BadRequestException expected) {
+       // expected
+    }
+  }
+
+  @Test
   public void testSearchResultSorting() throws Exception {
     NamespaceId namespace = new NamespaceId("sorting");
     namespaceClient.create(new NamespaceMeta.Builder().setName(namespace).build());

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
@@ -559,10 +559,13 @@ public class MetadataDataset extends AbstractDataset {
   public SearchResults search(String namespaceId, String searchQuery, Set<MetadataSearchTargetType> types,
                               SortInfo sortInfo, int offset, int limit, int numCursors,
                               @Nullable String cursor) {
-    if (SortInfo.DEFAULT.equals(sortInfo)) {
-      return searchByDefaultIndex(namespaceId, searchQuery, types);
+    if (!SortInfo.DEFAULT.equals(sortInfo)) {
+      if (!"*".equals(searchQuery)) {
+        throw new IllegalArgumentException("Cannot search with non-default sort with any query other than '*'");
+      }
+      return searchByCustomIndex(namespaceId, types, sortInfo, offset, limit, numCursors, cursor);
     }
-    return searchByCustomIndex(namespaceId, types, sortInfo, offset, limit, numCursors, cursor);
+    return searchByDefaultIndex(namespaceId, searchQuery, types);
   }
 
   private SearchResults searchByDefaultIndex(String namespaceId, String searchQuery,


### PR DESCRIPTION
CDAP-7911 Disallow specifying both 'query' and 'sort' parameters in metadata search.
https://issues.cask.co/browse/CDAP-7911