### PR TITLE
CDAP-7910 Hide entities in metadata search which starts with underscore

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
@@ -166,9 +166,9 @@ public class DefaultMetadataAdmin implements MetadataAdmin {
   public MetadataSearchResponse search(String namespaceId, String searchQuery,
                                        Set<MetadataSearchTargetType> types,
                                        SortInfo sortInfo, int offset, int limit,
-                                       int numCursors, String cursor) throws Exception {
+                                       int numCursors, String cursor, boolean showHidden) throws Exception {
     return filterAuthorizedSearchResult(
-      metadataStore.search(namespaceId, searchQuery, types, sortInfo, offset, limit, numCursors, cursor)
+      metadataStore.search(namespaceId, searchQuery, types, sortInfo, offset, limit, numCursors, cursor, showHidden)
     );
   }
 
@@ -192,7 +192,7 @@ public class DefaultMetadataAdmin implements MetadataAdmin {
           }
         })
       ),
-      results.getCursors());
+      results.getCursors(), results.isShowHidden());
   }
 
   // Helper methods to validate the metadata entries.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
@@ -23,12 +23,10 @@ import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResponse;
-import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
 import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 /**
  * Interface that the {@link MetadataHttpHandler} uses to interact with Metadata.
@@ -170,9 +168,11 @@ public interface MetadataAdmin {
    * @param cursor the cursor that acts as the starting index for the requested page. This is only applicable when
    *               #sortInfo is not {@link SortInfo#DEFAULT}. If offset is also specified, it is applied starting at
    *               the cursor. If {@code null}, the first row is used as the cursor
+   * @param showHidden boolean which specifies whether to display hidden entities (entity whose name start with "_")
+   *                    or not.
    * @return the {@link MetadataSearchResponse} containing search results for the specified search query and filters
    */
   MetadataSearchResponse search(String namespaceId, String searchQuery, Set<MetadataSearchTargetType> types,
                                 SortInfo sortInfo, int offset, int limit, int numCursors,
-                                String cursor) throws Exception;
+                                String cursor, boolean showHidden) throws Exception;
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
@@ -840,7 +840,8 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                              // 2147483647 is Integer.MAX_VALUE
                              @QueryParam("limit") @DefaultValue("2147483647") int limit,
                              @QueryParam("numCursors") @DefaultValue("0") int numCursors,
-                             @QueryParam("cursor") @DefaultValue("") String cursor) throws Exception {
+                             @QueryParam("cursor") @DefaultValue("") String cursor,
+                             @QueryParam("showHidden") @DefaultValue("false") boolean showHidden) throws Exception {
     Set<MetadataSearchTargetType> types = Collections.emptySet();
     if (targets != null) {
       types = ImmutableSet.copyOf(Iterables.transform(targets, STRING_TO_TARGET_TYPE));
@@ -853,7 +854,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
     }
     MetadataSearchResponse response =
       metadataAdmin.search(namespaceId, URLDecoder.decode(searchQuery, "UTF-8"), types,
-                           sortInfo, offset, limit, numCursors, cursor);
+                           sortInfo, offset, limit, numCursors, cursor, showHidden);
     responder.sendJson(HttpResponseStatus.OK, response, MetadataSearchResponse.class, GSON);
   }
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
@@ -80,11 +80,11 @@ public class MetadataAdminAuthorizationTest {
     EnumSet<MetadataSearchTargetType> types = EnumSet.allOf(MetadataSearchTargetType.class);
     Assert.assertFalse(
       metadataAdmin.search(NamespaceId.DEFAULT.getNamespace(), "*", types,
-                           SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 0, null).getResults().isEmpty());
+                           SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 0, null, false).getResults().isEmpty());
     SecurityRequestContext.setUserId("bob");
     Assert.assertTrue(
       metadataAdmin.search(NamespaceId.DEFAULT.getNamespace(), "*", types,
-                           SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 0, null).getResults().isEmpty());
+                           SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 0, null, false).getResults().isEmpty());
   }
 
   @AfterClass

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataHttpHandlerTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataHttpHandlerTestRun.java
@@ -32,6 +32,7 @@ import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
+import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.data2.metadata.system.AbstractSystemMetadataWriter;
 import co.cask.cdap.data2.metadata.system.DatasetSystemMetadataWriter;
 import co.cask.cdap.metadata.MetadataHttpHandler;
@@ -1256,14 +1257,19 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     // reproduce the scenario that caused the issue CDAP-7881
     NamespaceId namespace = new NamespaceId("pagination_with_target_type");
     namespaceClient.create(new NamespaceMeta.Builder().setName(namespace).build());
-
     StreamId stream1 = namespace.stream("text1");
     StreamId stream2 = namespace.stream("text2");
+    DatasetId trackerDataset = namespace.dataset("_auditLog");
+    DatasetId mydataset = namespace.dataset("mydataset");
 
-    // we need this dataset to be created before the streams, so that its metadata comes before the stream's metadata
-    // in the scan in MetadataDataset#search
+    // the creation order below will determine how we see the entities in search result sorted by entity creation time
+    // in ascending order
     datasetClient.create(
-      namespace.dataset("mydataset"),
+      trackerDataset,
+      new DatasetInstanceConfiguration(Table.class.getName(), Collections.<String, String>emptyMap())
+    );
+    datasetClient.create(
+      mydataset,
       new DatasetInstanceConfiguration(Table.class.getName(), Collections.<String, String>emptyMap())
     );
 
@@ -1271,19 +1277,31 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     streamClient.create(stream1);
     streamClient.create(stream2);
 
-    String sort = AbstractSystemMetadataWriter.ENTITY_NAME_KEY + " asc";
+    // do sorting with creation time here since the testSearchResultPagination does with entity name
+    // the sorted result order _auditLog mydataset text2 text1 (ascending: creation from earliest time)
+    String sort = AbstractSystemMetadataWriter.CREATION_TIME_KEY + " " + SortInfo.SortOrder.ASC;
 
     // offset 1, limit 2, 2 cursors, should return 2nd result, with 0 cursors since we don't have enough data
+    // set showHidden to true which will show the trackerDataset but will not be in search response since its not stream
     MetadataSearchResponse searchResponse = searchMetadata(namespace, "*",
                                                            ImmutableSet.of(MetadataSearchTargetType.STREAM),
-                                                           sort, 1, 2, 2, null);
+                                                           sort, 1, 2, 2, null, true);
     List<MetadataSearchResultRecord> expectedResults = ImmutableList.of(new MetadataSearchResultRecord(stream2));
     List<String> expectedCursors = ImmutableList.of();
     Assert.assertEquals(expectedResults, new ArrayList<>(searchResponse.getResults()));
     Assert.assertEquals(expectedCursors, searchResponse.getCursors());
 
+    // offset 1, limit 2, 2 cursors, should return just the dataset created above other than trackerDataset even
+    // though it was created before since showHidden is false and it should not affect pagination
+    searchResponse = searchMetadata(namespace, "*", ImmutableSet.of(MetadataSearchTargetType.DATASET),
+                                    sort, 0, 2, 2, null);
+    expectedResults = ImmutableList.of(new MetadataSearchResultRecord(mydataset));
+    expectedCursors = ImmutableList.of();
+    Assert.assertEquals(expectedResults, new ArrayList<>(searchResponse.getResults()));
+    Assert.assertEquals(expectedCursors, searchResponse.getCursors());
   }
 
+  @Test
   public void testSearchResultPagination() throws Exception {
     NamespaceId namespace = new NamespaceId("pagination");
     namespaceClient.create(new NamespaceMeta.Builder().setName(namespace).build());
@@ -1291,6 +1309,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     StreamId stream = namespace.stream("text");
     DatasetId dataset = namespace.dataset("mydataset");
     StreamViewId view = stream.view("view");
+    DatasetId trackerDataset = namespace.dataset("_auditLog");
 
     // create entities so system metadata is annotated
     streamClient.create(stream);
@@ -1299,13 +1318,29 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
       dataset,
       new DatasetInstanceConfiguration(Table.class.getName(), Collections.<String, String>emptyMap())
     );
+    datasetClient.create(
+      trackerDataset,
+      new DatasetInstanceConfiguration(Table.class.getName(), Collections.<String, String>emptyMap())
+    );
 
+    // search with showHidden to true
     EnumSet<MetadataSearchTargetType> targets = EnumSet.allOf(MetadataSearchTargetType.class);
     String sort = AbstractSystemMetadataWriter.ENTITY_NAME_KEY + " asc";
+    // search to get all the above entities offset 0, limit interger max  and cursors 0
+    MetadataSearchResponse searchResponse = searchMetadata(namespace, "*", targets, sort, 0, Integer.MAX_VALUE, 0,
+                                                           null, true);
+    List<MetadataSearchResultRecord> expectedResults = ImmutableList.of(new MetadataSearchResultRecord(trackerDataset),
+                                                                        new MetadataSearchResultRecord(dataset),
+                                                                        new MetadataSearchResultRecord(stream),
+                                                                        new MetadataSearchResultRecord(view));
+    List<String>  expectedCursors = ImmutableList.of();
+    Assert.assertEquals(expectedResults, new ArrayList<>(searchResponse.getResults()));
+    Assert.assertEquals(expectedCursors, searchResponse.getCursors());
+
     // no offset, limit 1, no cursors
-    MetadataSearchResponse searchResponse = searchMetadata(namespace, "*", targets, sort, 0, 1, 0, null);
-    List<MetadataSearchResultRecord> expectedResults = ImmutableList.of(new MetadataSearchResultRecord(dataset));
-    List<String> expectedCursors = ImmutableList.of();
+    searchResponse = searchMetadata(namespace, "*", targets, sort, 0, 1, 0, null);
+    expectedResults = ImmutableList.of(new MetadataSearchResultRecord(dataset));
+    expectedCursors = ImmutableList.of();
     Assert.assertEquals(expectedResults, new ArrayList<>(searchResponse.getResults()));
     Assert.assertEquals(expectedCursors, searchResponse.getCursors());
     // no offset, limit 1, 2 cursors, should return 1st result, with 2 cursors
@@ -1763,16 +1798,24 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
   protected MetadataSearchResponse searchMetadata(NamespaceId namespaceId, String query,
                                                   Set<MetadataSearchTargetType> targets,
                                                   @Nullable String sort, int offset, int limit,
-                                                  int numCursors, @Nullable String cursor) throws Exception {
+                                                  int numCursors, @Nullable String cursor, boolean showHidden)
+    throws Exception {
     MetadataSearchResponse searchResponse = super.searchMetadata(namespaceId, query, targets, sort, offset,
-                                                                 limit, numCursors, cursor);
+                                                                 limit, numCursors, cursor, showHidden);
     Set<MetadataSearchResultRecord> transformed = new LinkedHashSet<>();
     for (MetadataSearchResultRecord result : searchResponse.getResults()) {
       transformed.add(new MetadataSearchResultRecord(result.getEntityId()));
     }
     return new MetadataSearchResponse(searchResponse.getSort(), searchResponse.getOffset(), searchResponse.getLimit(),
                                       searchResponse.getNumCursors(), searchResponse.getTotal(), transformed,
-                                      searchResponse.getCursors());
+                                      searchResponse.getCursors(), searchResponse.isShowHidden());
+  }
+
+  private MetadataSearchResponse searchMetadata(NamespaceId namespaceId, String query,
+                                                Set<MetadataSearchTargetType> targets,
+                                                @Nullable String sort, int offset, int limit,
+                                                int numCursors, @Nullable String cursor) throws Exception {
+    return searchMetadata(namespaceId, query, targets, sort, offset, limit, numCursors, cursor, false);
   }
 
   private Set<MetadataRecord> removeCreationTime(Set<MetadataRecord> original) {

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataTestBase.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataTestBase.java
@@ -468,14 +468,15 @@ public abstract class MetadataTestBase extends ClientTestBase {
                                                            Set<MetadataSearchTargetType> targets,
                                                            @Nullable String sort) throws Exception {
     return metadataClient.searchMetadata(namespaceId.toId(), query, targets,
-                                         sort, 0, Integer.MAX_VALUE, 0, null).getResults();
+                                         sort, 0, Integer.MAX_VALUE, 0, null, false).getResults();
   }
 
   protected MetadataSearchResponse searchMetadata(NamespaceId namespaceId, String query,
                                                   Set<MetadataSearchTargetType> targets,
                                                   @Nullable String sort, int offset, int limit, int numCursors,
-                                                  @Nullable String cursor) throws Exception {
-    return metadataClient.searchMetadata(namespaceId.toId(), query, targets, sort, offset, limit, numCursors, cursor);
+                                                  @Nullable String cursor, boolean showHiddden) throws Exception {
+    return metadataClient.searchMetadata(namespaceId.toId(), query, targets, sort, offset, limit, numCursors,
+                                         cursor, showHiddden);
   }
 
   protected Set<String> getTags(ApplicationId app, MetadataScope scope) throws Exception {

--- a/cdap-common/src/main/java/co/cask/cdap/common/metadata/AbstractMetadataClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/metadata/AbstractMetadataClient.java
@@ -99,7 +99,7 @@ public abstract class AbstractMetadataClient {
   public MetadataSearchResponse searchMetadata(Id.Namespace namespace, String query,
                                                Set<MetadataSearchTargetType> targets)
     throws IOException, UnauthenticatedException, UnauthorizedException, BadRequestException {
-    return searchMetadata(namespace, query, targets, null, 0, Integer.MAX_VALUE, 0, null);
+    return searchMetadata(namespace, query, targets, null, 0, Integer.MAX_VALUE, 0, null, false);
   }
 
   /**
@@ -116,12 +116,14 @@ public abstract class AbstractMetadataClient {
    * @param cursor the cursor that acts as the starting index for the requested page. This is only applicable when
    *               #sortInfo is not default. If offset is also specified, it is applied starting at
    *               the cursor. If {@code null}, the first row is used as the cursor
+   * @param showHidden boolean which specifies whether to display hidden entities (entity whose name start with "_")
+   *                    or not.
    * @return A set of {@link MetadataSearchResultRecord} for the given query.
    */
   public MetadataSearchResponse searchMetadata(Id.Namespace namespace, String query,
                                                Set<MetadataSearchTargetType> targets, @Nullable String sort,
                                                int offset, int limit, int numCursors,
-                                               @Nullable String cursor)
+                                               @Nullable String cursor, boolean showHidden)
     throws IOException, UnauthenticatedException, UnauthorizedException, BadRequestException {
 
     String path = String.format("metadata/search?query=%s", query);
@@ -136,6 +138,9 @@ public abstract class AbstractMetadataClient {
     path += "&numCursors=" + numCursors;
     if (cursor != null) {
       path += "&cursor=" + cursor;
+    }
+    if (showHidden) {
+      path += "&showHidden=" + true;
     }
     URL searchURL = resolve(namespace, path);
     HttpResponse response = execute(HttpRequest.get(searchURL).build(), HttpResponseStatus.BAD_REQUEST.getCode());

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
@@ -375,7 +375,7 @@ public class DefaultMetadataStore implements MetadataStore {
   public MetadataSearchResponse search(String namespaceId, String searchQuery,
                                        Set<MetadataSearchTargetType> types,
                                        SortInfo sortInfo, int offset, int limit,
-                                       int numCursors, String cursor) throws BadRequestException {
+                                       int numCursors, String cursor, boolean showHidden) throws BadRequestException {
     Set<MetadataScope> searchScopes = EnumSet.allOf(MetadataScope.class);
     if ("*".equals(searchQuery)) {
       if (SortInfo.DEFAULT.equals(sortInfo)) {
@@ -390,18 +390,20 @@ public class DefaultMetadataStore implements MetadataStore {
         searchScopes = EnumSet.of(MetadataScope.SYSTEM);
       }
     }
-    return search(searchScopes, namespaceId, searchQuery, types, sortInfo, offset, limit, numCursors, cursor);
+    return search(searchScopes, namespaceId, searchQuery, types, sortInfo, offset, limit, numCursors, cursor,
+                  showHidden);
   }
 
   private MetadataSearchResponse search(Set<MetadataScope> scopes, String namespaceId,
                                         String searchQuery, Set<MetadataSearchTargetType> types,
                                         SortInfo sortInfo, int offset, int limit,
-                                        int numCursors, String cursor) throws BadRequestException {
+                                        int numCursors, String cursor, boolean showHidden) throws BadRequestException {
     List<MetadataEntry> results = new ArrayList<>();
     List<String> cursors = new ArrayList<>();
     for (MetadataScope scope : scopes) {
       SearchResults searchResults =
-        getSearchResults(scope, namespaceId, searchQuery, types, sortInfo, offset, limit, numCursors, cursor);
+        getSearchResults(scope, namespaceId, searchQuery, types, sortInfo, offset, limit, numCursors, cursor,
+                         showHidden);
       results.addAll(searchResults.getResults());
       cursors.addAll(searchResults.getCursors());
     }
@@ -442,7 +444,7 @@ public class DefaultMetadataStore implements MetadataStore {
 
     return new MetadataSearchResponse(
       sortInfo.getSortBy() + " " + sortInfo.getSortOrder(), offset, limit, numCursors, total,
-      addMetadataToEntities(sortedEntities, systemMetadata, userMetadata), cursors
+      addMetadataToEntities(sortedEntities, systemMetadata, userMetadata), cursors, showHidden
     );
   }
 
@@ -450,12 +452,12 @@ public class DefaultMetadataStore implements MetadataStore {
                                          final String searchQuery, final Set<MetadataSearchTargetType> types,
                                          final SortInfo sortInfo, final int offset,
                                          final int limit, final int numCursors,
-                                         final String cursor) throws BadRequestException {
+                                         final String cursor, final boolean showHidden) throws BadRequestException {
     return execute(
       new TransactionExecutor.Function<MetadataDataset, SearchResults>() {
         @Override
         public SearchResults apply(MetadataDataset input) throws Exception {
-          return input.search(namespaceId, searchQuery, types, sortInfo, offset, limit, numCursors, cursor);
+          return input.search(namespaceId, searchQuery, types, sortInfo, offset, limit, numCursors, cursor, showHidden);
         }
       }, scope);
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
@@ -23,7 +23,6 @@ import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResponse;
-import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
 import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 
 import java.util.Map;
@@ -176,12 +175,14 @@ public interface MetadataStore {
    * @param cursor the cursor that acts as the starting index for the requested page. This is only applicable when
    *               #sortInfo is not {@link SortInfo#DEFAULT}. If offset is also specified, it is applied starting at
    *               the cursor. If {@code null}, the first row is used as the cursor
+   * @param showHidden boolean which specifies whether to display hidden entities (entity whose name start with "_")
+   *                    or not.
    * @return the {@link MetadataSearchResponse} containing search results for the specified search query and filters
    */
   MetadataSearchResponse search(String namespaceId, String searchQuery,
                                 Set<MetadataSearchTargetType> types,
                                 SortInfo sortInfo, int offset, int limit,
-                                int numCursors, String cursor) throws BadRequestException;
+                                int numCursors, String cursor, boolean showHidden) throws BadRequestException;
 
   /**
    * Returns the snapshot of the metadata for entities on or before the given time in both {@link MetadataScope#USER}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
@@ -118,10 +118,11 @@ public class NoOpMetadataStore implements MetadataStore {
   @Override
   public MetadataSearchResponse search(String namespaceId, String searchQuery,
                                        Set<MetadataSearchTargetType> types,
-                                       SortInfo sort, int offset, int limit, int numCursors, String cursor) {
+                                       SortInfo sort, int offset, int limit, int numCursors, String cursor,
+                                       boolean showHidden) {
     return new MetadataSearchResponse(sort.toString(), offset, limit, numCursors, 0,
                                       Collections.<MetadataSearchResultRecord>emptySet(),
-                                      Collections.<String>emptyList());
+                                      Collections.<String>emptyList(), showHidden);
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
@@ -1070,7 +1070,8 @@ public class MetadataDatasetTest {
       @Override
       public void apply() throws Exception {
         // since no sort is to be performed by the dataset, we return all (ignore limit and offset)
-        SearchResults searchResults = dataset.search(namespaceId, "name*", targets, SortInfo.DEFAULT, 0, 3, 1, null);
+        SearchResults searchResults = dataset.search(namespaceId, "name*", targets, SortInfo.DEFAULT, 0, 3, 1, null,
+                                                     false);
         Assert.assertEquals(
           // since default indexer is used:
           // 1 index for flow: 'name11'
@@ -1082,39 +1083,40 @@ public class MetadataDatasetTest {
         // ascending sort by name. offset and limit should be respected.
         SortInfo nameAsc = new SortInfo(AbstractSystemMetadataWriter.ENTITY_NAME_KEY, SortInfo.SortOrder.ASC);
         // first 2 in ascending order
-        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 2, 0, null);
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 2, 0, null, false);
         Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry), searchResults.getResults());
         // return 2 with offset 1 in ascending order
-        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 1, 2, 0, null);
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 1, 2, 0, null, false);
         Assert.assertEquals(ImmutableList.of(dsEntry, appEntry), searchResults.getResults());
         // descending sort by name. offset and filter should be respected.
         SortInfo nameDesc = new SortInfo(AbstractSystemMetadataWriter.ENTITY_NAME_KEY, SortInfo.SortOrder.DESC);
         // first 2 in descending order
-        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 0, 2, 0, null);
+        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 0, 2, 0, null, false);
         Assert.assertEquals(ImmutableList.of(appEntry, dsEntry), searchResults.getResults());
         // last 1 in descending order
-        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 2, 1, 0, null);
+        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 2, 1, 0, null, false);
         Assert.assertEquals(ImmutableList.of(flowEntry), searchResults.getResults());
         // limit 0 should return empty
-        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 2, 0, 0, null);
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 2, 0, 0, null, false);
         Assert.assertTrue(searchResults.getResults().isEmpty());
-        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 1, 0, 0, null);
+        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 1, 0, 0, null, false);
         Assert.assertTrue(searchResults.getResults().isEmpty());
         // offset greater than total search results should return empty
-        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 4, 0, 0, null);
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 4, 0, 0, null, false);
         Assert.assertTrue(searchResults.getResults().isEmpty());
-        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 100, 0, 0, null);
+        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 100, 0, 0, null, false);
         Assert.assertTrue(searchResults.getResults().isEmpty());
 
         // test cursors
-        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 1, 3, null);
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 1, 3, null, false);
         // limit is 1, but we return 3 because 3 cursors are desired.
         Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry, appEntry), searchResults.getResults());
         // only 2 cursors are returned even though we requested 3 because we do not have enough data to return
         Assert.assertEquals(ImmutableList.of(dsName, appName), searchResults.getCursors());
 
         // use first cursor returned in the previous query. the rest of the parameters stay the same
-        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 1, 3, searchResults.getCursors().get(0));
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 1, 3, searchResults.getCursors().get(0),
+                                       false);
         // limit is 1, but we return 2 because 3 cursors are desired, however only 2 are available starting
         // at the cursor.
         Assert.assertEquals(ImmutableList.of(dsEntry, appEntry), searchResults.getResults());
@@ -1122,20 +1124,21 @@ public class MetadataDatasetTest {
         Assert.assertEquals(ImmutableList.of(appName), searchResults.getCursors());
 
         // use first cursor returned in the previous query. the rest of the parameters stay the same
-        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 1, 3, searchResults.getCursors().get(0));
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 1, 3, searchResults.getCursors().get(0),
+                                       false);
         // limit is 1, and even though 3 cursors are desired, we return only 1 result, because the after the cursor we
         // do not have enough data for 3 further cursors
         Assert.assertEquals(ImmutableList.of(appEntry), searchResults.getResults());
         // no cursors are returned even though we requested 3 because we do not have enough data
         Assert.assertEquals(ImmutableList.of(), searchResults.getCursors());
 
-        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 2, 3, null);
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 2, 3, null, false);
         // limit is 2, we return 3 because 3 cursors are desired
         Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry, appEntry), searchResults.getResults());
         // only 1 cursor is returned even though we requested 3 because we do not have enough data to return
         Assert.assertEquals(ImmutableList.of(appName), searchResults.getCursors());
 
-        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 3, 1, 2, null);
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 3, 1, 2, null, false);
         // limit is 1, we return 0 because offset is too high
         Assert.assertEquals(ImmutableList.of(), searchResults.getResults());
         // only 1 cursor is returned even though we requested 3 because we do not have enough data to return
@@ -1437,7 +1440,7 @@ public class MetadataDatasetTest {
   private List<MetadataEntry> searchByDefaultIndex(MetadataDataset dataset, String namespaceId, String searchQuery,
                                                    Set<MetadataSearchTargetType> types) {
     return dataset.search(namespaceId, searchQuery, types,
-                          SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 1, null).getResults();
+                          SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 1, null, false).getResults();
   }
 
   private static MetadataDataset getDataset(DatasetId instance) throws Exception {

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemover.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemover.java
@@ -56,7 +56,7 @@ final class DeletedDatasetMetadataRemover {
     for (NamespaceMeta namespaceMeta : nsStore.list()) {
       Set<MetadataSearchResultRecord> searchResults =
         metadataStore.search(namespaceMeta.getName(), "*", EnumSet.of(MetadataSearchTargetType.DATASET),
-                             SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 0, null).getResults();
+                             SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 0, null, false).getResults();
       for (MetadataSearchResultRecord searchResult : searchResults) {
         NamespacedEntityId entityId = searchResult.getEntityId();
         Preconditions.checkState(entityId instanceof DatasetId,

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataSearchResponse.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataSearchResponse.java
@@ -30,9 +30,10 @@ public class MetadataSearchResponse {
   private final int total;
   private final Set<MetadataSearchResultRecord> results;
   private final List<String> cursors;
+  private final boolean showHidden;
 
   public MetadataSearchResponse(String sort, int offset, int limit, int numCursors, int total,
-                                Set<MetadataSearchResultRecord> results, List<String> cursors) {
+                                Set<MetadataSearchResultRecord> results, List<String> cursors, boolean showHidden) {
     this.sort = sort;
     this.offset = offset;
     this.limit = limit;
@@ -40,6 +41,7 @@ public class MetadataSearchResponse {
     this.total = total;
     this.results = results;
     this.cursors = cursors;
+    this.showHidden = showHidden;
   }
 
   public String getSort() {
@@ -68,5 +70,9 @@ public class MetadataSearchResponse {
 
   public List<String> getCursors() {
     return cursors;
+  }
+
+  public boolean isShowHidden() {
+    return showHidden;
   }
 }


### PR DESCRIPTION
Issue: https://issues.cask.co/browse/CDAP-7910
Build: http://builds.cask.co/browse/CDAP-RUT405-1
ITM: http://builds.cask.co/browse/CDAP-ITM6-12

Note: This will need doc change in the Metadata Search API to tell user that they can see entities whose name starts with _ by specifying showHidden=true. Doc change will come in another PR.