### PR TITLE
(CDAP-7908) MetadataDataset now needs a scope property too. Also move…

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeDatasetServiceManager.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeDatasetServiceManager.java
@@ -42,6 +42,7 @@ import co.cask.cdap.data2.datafabric.dataset.RemoteDatasetFramework;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutorService;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsService;
 import co.cask.cdap.gateway.handlers.meta.RemoteSystemOperationsServiceModule;
@@ -87,6 +88,7 @@ class UpgradeDatasetServiceManager extends AbstractIdleService {
   private final DatasetFramework datasetFramework;
   private final DatasetOpExecutorService datasetOpExecutorService;
   private final RemoteSystemOperationsService remoteSystemOperationsService;
+  private final MetadataStore metadataStore;
 
   @Inject
   UpgradeDatasetServiceManager(CConfiguration cConf, Configuration hConf,
@@ -97,10 +99,15 @@ class UpgradeDatasetServiceManager extends AbstractIdleService {
     this.datasetFramework = injector.getInstance(DatasetFramework.class);
     this.datasetOpExecutorService = injector.getInstance(DatasetOpExecutorService.class);
     this.remoteSystemOperationsService = injector.getInstance(RemoteSystemOperationsService.class);
+    this.metadataStore = injector.getInstance(MetadataStore.class);
   }
 
-  public DatasetFramework getDSFramework() {
+  DatasetFramework getDSFramework() {
     return datasetFramework;
+  }
+
+  MetadataStore getMetadataStore() {
+    return metadataStore;
   }
 
   @Override

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -75,6 +75,7 @@ import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
@@ -122,7 +123,6 @@ public class UpgradeTool {
   private final DatasetUpgrader dsUpgrade;
   private final QueueAdmin queueAdmin;
   private final DatasetSpecificationUpgrader dsSpecUpgrader;
-  private final MetadataStore metadataStore;
   private final ExistingEntitySystemMetadataWriter existingEntitySystemMetadataWriter;
   private final UpgradeDatasetServiceManager upgradeDatasetServiceManager;
   private final NamespaceStore nsStore;
@@ -175,7 +175,6 @@ public class UpgradeTool {
     this.txService = injector.getInstance(TransactionService.class);
     this.zkClientService = injector.getInstance(ZKClientService.class);
     this.dsFramework = injector.getInstance(DatasetFramework.class);
-    this.metadataStore = injector.getInstance(MetadataStore.class);
     this.streamStateStoreUpgrader = injector.getInstance(StreamStateStoreUpgrader.class);
     this.dsUpgrade = injector.getInstance(DatasetUpgrader.class);
     this.dsSpecUpgrader = injector.getInstance(DatasetSpecificationUpgrader.class);
@@ -441,6 +440,7 @@ public class UpgradeTool {
 
     // TODO: CDAP-7835: This should be moved out (probably to MetadataService) so it can be run after CDAP starts up.
     LOG.info("Writing system metadata to existing entities...");
+    MetadataStore metadataStore = upgradeDatasetServiceManager.getMetadataStore();
     try {
       existingEntitySystemMetadataWriter.write(upgradeDatasetServiceManager.getDSFramework());
       LOG.info("Removing metadata for deleted datasets...");
@@ -457,11 +457,11 @@ public class UpgradeTool {
   }
 
   private void upgradeMetadataDatasetSpecs() {
-    upgradeMetadataDatasetSpec(DefaultMetadataStore.BUSINESS_METADATA_INSTANCE_ID);
-    upgradeMetadataDatasetSpec(DefaultMetadataStore.SYSTEM_METADATA_INSTANCE_ID);
+    upgradeMetadataDatasetSpec(MetadataScope.USER, DefaultMetadataStore.BUSINESS_METADATA_INSTANCE_ID);
+    upgradeMetadataDatasetSpec(MetadataScope.SYSTEM, DefaultMetadataStore.SYSTEM_METADATA_INSTANCE_ID);
   }
 
-  private void upgradeMetadataDatasetSpec(DatasetId metadataDatasetId) {
+  private void upgradeMetadataDatasetSpec(MetadataScope scope, DatasetId metadataDatasetId) {
     DatasetSpecification oldMetadataDatasetSpec = datasetInstanceManager.get(metadataDatasetId);
     if (oldMetadataDatasetSpec == null) {
       LOG.info("Metadata Dataset {} not found. No upgrade necessary.", metadataDatasetId);
@@ -475,17 +475,22 @@ public class UpgradeTool {
     // TODO: CDAP-7835: This should be moved out (probably to MetadataService) so it can be run after CDAP starts up.
     Gson gson = new Gson();
     JsonObject jsonObject = gson.toJsonTree(oldMetadataDatasetSpec, DatasetSpecification.class).getAsJsonObject();
+    JsonObject metadataDatasetProperties = jsonObject.get("properties").getAsJsonObject();
+    metadataDatasetProperties.addProperty("scope", scope.name());
     // change the columnsToIndex since in 4.0 we added 4 more index columns
     JsonObject metadataIndexObject = jsonObject.get("datasetSpecs").getAsJsonObject()
       .get("metadata_index").getAsJsonObject();
     JsonObject properties = metadataIndexObject.get("properties").getAsJsonObject();
     properties.addProperty("columnsToIndex", MetadataDataset.COLUMNS_TO_INDEX);
+    properties.addProperty("scope", scope.name());
     JsonObject dProperties = metadataIndexObject.get("datasetSpecs").getAsJsonObject().get("d").getAsJsonObject()
       .get("properties").getAsJsonObject();
     JsonObject iProperties = metadataIndexObject.get("datasetSpecs").getAsJsonObject().get("i").getAsJsonObject()
       .get("properties").getAsJsonObject();
     dProperties.addProperty("columnsToIndex", MetadataDataset.COLUMNS_TO_INDEX);
+    dProperties.addProperty("scope", scope.name());
     iProperties.addProperty("columnsToIndex", MetadataDataset.COLUMNS_TO_INDEX);
+    iProperties.addProperty("scope", scope.name());
 
     DatasetSpecification newMetadataDatasetSpec = gson.fromJson(jsonObject, DatasetSpecification.class);
     datasetInstanceManager.delete(metadataDatasetId);


### PR DESCRIPTION
…d the MetadataStore instance creation in UpgradeTool to get it from the injector created in UpgradeDatasetServiceManager. This is done so the MetadataStore gets the right remote DatasetFramework instead of the in memory one.

Jira: [CDAP-7908](https://issues.cask.co/browse/CDAP-7908)
Build: http://builds.cask.co/browse/CDAP-RUT399