### PR TITLE
Add guice binding for TMS to ContextManager, to fix explore failures.

### DIFF
--- a/cdap-explore/src/main/java/co/cask/cdap/hive/context/ContextManager.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/hive/context/ContextManager.java
@@ -45,6 +45,7 @@ import co.cask.cdap.data2.transaction.stream.StreamConfig;
 import co.cask.cdap.explore.guice.ExploreClientModule;
 import co.cask.cdap.hive.datasets.DatasetSerDe;
 import co.cask.cdap.hive.stream.StreamSerDe;
+import co.cask.cdap.messaging.guice.MessagingClientModule;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.StreamId;
@@ -148,6 +149,7 @@ public class ContextManager {
       new AuthorizationEnforcementModule().getDistributedModules(),
       new SecureStoreModules().getDistributedModules(),
       new AuthenticationContextModules().getMasterModule(),
+      new MessagingClientModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/LogSaverTwillRunnable.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/run/LogSaverTwillRunnable.java
@@ -36,6 +36,7 @@ import co.cask.cdap.logging.guice.LogSaverServiceModule;
 import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.logging.save.KafkaLogSaverService;
 import co.cask.cdap.logging.service.LogSaverStatusService;
+import co.cask.cdap.messaging.guice.MessagingClientModule;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
@@ -204,6 +205,7 @@ public final class LogSaverTwillRunnable extends AbstractTwillRunnable {
       new AuditModule().getDistributedModules(),
       new AuthorizationEnforcementModule().getDistributedModules(),
       new AuthenticationContextModules().getMasterModule(),
+      new MessagingClientModule(),
       new AbstractModule() {
         @Override
         protected void configure() {


### PR DESCRIPTION
Add guice binding for TMS to ContextManager, to fix explore failures.
Otherwise, explore queries fail, and you see this in the stdout of the explore container (see below).
ContextManagerTest.java doesn't catch this, because the failure is due to a just in time binding (see [LineageWriterDatasetFramework](https://github.com/caskdata/cdap/blob/da6bec5515eeab20595785484d377bed33dbfc38/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriterDatasetFramework.java#L100-L100)).

Tested the fix on a cluster where the failure was occurring.

```
11:18:14.258 [main] ERROR o.a.h.h.ql.exec.mr.MapredLocalTask - Hive Runtime Error: Map local work failed
org.apache.hadoop.hive.ql.metadata.HiveException: Failed with exception Guice provision errors:

1) No implementation for co.cask.cdap.messaging.MessagingService was bound.
  while locating co.cask.cdap.messaging.MessagingService
    for parameter 1 at co.cask.cdap.data2.audit.DefaultAuditPublisher.<init>(DefaultAuditPublisher.java:55)
  while locating co.cask.cdap.data2.audit.DefaultAuditPublisher
  while locating co.cask.cdap.data2.audit.AuditModule$AuditPublisherProvider
  at co.cask.cdap.data2.audit.AuditModule$3.configure(AuditModule.java:63)
  while locating co.cask.cdap.data2.audit.AuditPublisher
    for parameter 0 at co.cask.cdap.data2.metadata.writer.LineageWriterDatasetFramework.setAuditPublisher(LineageWriterDatasetFramework.java:101)
  while locating co.cask.cdap.data2.metadata.writer.LineageWriterDatasetFramework
  while locating co.cask.cdap.data2.dataset2.DatasetFramework

1 errorcom.google.inject.ProvisionException: Guice provision errors:

1) No implementation for co.cask.cdap.messaging.MessagingService was bound.
  while locating co.cask.cdap.messaging.MessagingService
    for parameter 1 at co.cask.cdap.data2.audit.DefaultAuditPublisher.<init>(DefaultAuditPublisher.java:55)
  while locating co.cask.cdap.data2.audit.DefaultAuditPublisher
  while locating co.cask.cdap.data2.audit.AuditModule$AuditPublisherProvider
  at co.cask.cdap.data2.audit.AuditModule$3.configure(AuditModule.java:63)
  while locating co.cask.cdap.data2.audit.AuditPublisher
    for parameter 0 at co.cask.cdap.data2.metadata.writer.LineageWriterDatasetFramework.setAuditPublisher(LineageWriterDatasetFramework.java:101)
  while locating co.cask.cdap.data2.metadata.writer.LineageWriterDatasetFramework
  while locating co.cask.cdap.data2.dataset2.DatasetFramework

1 error
        at com.google.inject.internal.InjectorImpl$4.get(InjectorImpl.java:987)
        at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1013)
        at co.cask.cdap.hive.context.ContextManager.createContext(ContextManager.java:176)
        at co.cask.cdap.hive.context.ContextManager.getContext(ContextManager.java:127)
        at co.cask.cdap.hive.datasets.DatasetSerDe.getDatasetSchema(DatasetSerDe.java:106)
        at co.cask.cdap.hive.datasets.DatasetSerDe.initialize(DatasetSerDe.java:95)
        at org.apache.hadoop.hive.serde2.SerDeUtils.initializeSerDe(SerDeUtils.java:521)
        at org.apache.hadoop.hive.ql.exec.FetchOperator.getRowInspectorFromTable(FetchOperator.java:242)
        at org.apache.hadoop.hive.ql.exec.FetchOperator.getOutputObjectInspector(FetchOperator.java:719)
        at org.apache.hadoop.hive.ql.exec.mr.MapredLocalTask.initializeOperators(MapredLocalTask.java:454)
        at org.apache.hadoop.hive.ql.exec.mr.MapredLocalTask.startForward(MapredLocalTask.java:361)
        at org.apache.hadoop.hive.ql.exec.mr.MapredLocalTask.executeInProcess(MapredLocalTask.java:341)
        at org.apache.hadoop.hive.ql.exec.mr.ExecDriver.main(ExecDriver.java:735)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at org.apache.hadoop.util.RunJar.run(RunJar.java:221)
        at org.apache.hadoop.util.RunJar.main(RunJar.java:136)

        at org.apache.hadoop.hive.ql.exec.FetchOperator.getOutputObjectInspector(FetchOperator.java:756) ~[hive-exec-0.14.0.2.2.9.0-3393.jar.980d573d-c044-4071-aa0a-483aba44f79c.jar:0.14.0.2.2.9.0-3393]
        at org.apache.hadoop.hive.ql.exec.mr.MapredLocalTask.initializeOperators(MapredLocalTask.java:454) ~[hive-exec-0.14.0.2.2.9.0-3393.jar.980d573d-c044-4071-aa0a-483aba44f79c.jar:0.14.0.2.2.9.0-3393]
        at org.apache.hadoop.hive.ql.exec.mr.MapredLocalTask.startForward(MapredLocalTask.java:361) ~[hive-exec-0.14.0.2.2.9.0-3393.jar.980d573d-c044-4071-aa0a-483aba44f79c.jar:0.14.0.2.2.9.0-3393]
        at org.apache.hadoop.hive.ql.exec.mr.MapredLocalTask.executeInProcess(MapredLocalTask.java:341) ~[hive-exec-0.14.0.2.2.9.0-3393.jar.980d573d-c044-4071-aa0a-483aba44f79c.jar:0.14.0.2.2.9.0-3393]
        at org.apache.hadoop.hive.ql.exec.mr.ExecDriver.main(ExecDriver.java:735) [hive-exec-0.14.0.2.2.9.0-3393.jar.980d573d-c044-4071-aa0a-483aba44f79c.jar:0.14.0.2.2.9.0-3393]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.7.0_75]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57) ~[na:1.7.0_75]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.7.0_75]
        at java.lang.reflect.Method.invoke(Method.java:606) ~[na:1.7.0_75]
        at org.apache.hadoop.util.RunJar.run(RunJar.java:221) [hadoop-common-2.6.0.2.2.9.0-3393.jar:na]
        at org.apache.hadoop.util.RunJar.main(RunJar.java:136) [hadoop-common-2.6.0.2.2.9.0-3393.jar:na]
```