### PR TITLE
CDAP-7161 Read permission for getting runtime args

### DIFF
--- a/cdap-docs/admin-manual/source/security/authorization.rst
+++ b/cdap-docs/admin-manual/source/security/authorization.rst
@@ -193,6 +193,8 @@ Programs
      - *ADMIN*
    * - Set runtime arguments
      - *ADMIN*
+   * - Retrieve runtime arguments
+     - * READ*
    * - Retrieving status
      - At least one of *READ*, *WRITE*, *ADMIN*, or *EXECUTE*
    * - List

--- a/cdap-docs/admin-manual/source/security/authorization.rst
+++ b/cdap-docs/admin-manual/source/security/authorization.rst
@@ -194,7 +194,7 @@ Programs
    * - Set runtime arguments
      - *ADMIN*
    * - Retrieve runtime arguments
-     - * READ*
+     - *READ*
    * - Retrieving status
      - At least one of *READ*, *WRITE*, *ADMIN*, or *EXECUTE*
    * - List

--- a/cdap-docs/admin-manual/source/security/authorization.rst
+++ b/cdap-docs/admin-manual/source/security/authorization.rst
@@ -195,7 +195,7 @@ Programs
      - *ADMIN*
    * - Retrieve runtime arguments
      - *READ*
-   * - Retrieving status
+   * - Retrieve status
      - At least one of *READ*, *WRITE*, *ADMIN*, or *EXECUTE*
    * - List
      - Only returns those programs on which user has at least one of *READ*, *WRITE*, *ADMIN*, or *EXECUTE*


### PR DESCRIPTION
In PR https://github.com/caskdata/cdap/pull/7362 we added authorization for getting runtime arguments. 

Quick Doc Build: http://builds.cask.co/browse/CDAP-DQB205-1
