### PR TITLE
Set SimpleKafkaConsumer log level to WARN, from INFO.

### DIFF
--- a/cdap-distributions/src/etc/cdap/conf.dist/logback-container.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/logback-container.xml
@@ -37,6 +37,7 @@
   <logger name="io.netty.util.internal" level="WARN"/>
 
   <logger name="org.apache.twill" level="INFO"/>
+  <logger name="org.apache.twill.internal.kafka.client.SimpleKafkaConsumer" level="WARN"/>
   <logger name="co.cask.cdap" level="INFO"/>
 
   <!-- Redirected stdout and stderr of Hive operations -->

--- a/cdap-distributions/src/etc/cdap/conf.dist/logback.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/logback.xml
@@ -34,6 +34,7 @@
     <logger name="io.netty.util.internal" level="WARN"/>
 
     <logger name="org.apache.twill" level="INFO"/>
+    <logger name="org.apache.twill.internal.kafka.client.SimpleKafkaConsumer" level="WARN"/>
     <logger name="co.cask.cdap" level="INFO"/>
 
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
Otherwise, when a CDAP program completes (successfully), there is stack trace in master logs.
It can be misleading, as it seems like there's an issue/error.
If someone is running hundreds of program runs per day, they will see hundreds of these stack traces in their master logs.

```
2016-12-17 21:57:47,828 - INFO  [ STOPPING:c.c.c.i.a.r.d.AbstractTwillProgramController$2@79] - Twill program terminated: program_run:default.ReadlessApp.-SNAPSHOT.mapreduce.Li
neCounter.ac5abd95-c4a3-11e6-93f2-42010a8e000b, twill runId: 44622b0b-17a3-4f18-9200-1bf010289716
16/12/17 21:57:57 INFO consumer.SimpleConsumer: Reconnect due to socket error: java.io.EOFException: Received -1 when reading from channel, socket has likely been closed.
2016-12-17 21:34:57,627 - INFO  [Kafka-Consumer-log-0:o.a.t.i.k.c.SimpleKafkaConsumer$ConsumerThread@387] - Exception when fetching message on TopicPartition{topic=log, partition=0}.
java.nio.channels.ClosedChannelException: null
        at kafka.network.BlockingChannel.send(BlockingChannel.scala:100) ~[org.apache.kafka.kafka_2.10-0.8.2.2.jar:na]
        at kafka.consumer.SimpleConsumer.liftedTree1$1(SimpleConsumer.scala:78) ~[org.apache.kafka.kafka_2.10-0.8.2.2.jar:na]
        at kafka.consumer.SimpleConsumer.kafka$consumer$SimpleConsumer$$sendRequest(SimpleConsumer.scala:68) ~[org.apache.kafka.kafka_2.10-0.8.2.2.jar:na]
        at kafka.consumer.SimpleConsumer$$anonfun$fetch$1$$anonfun$apply$mcV$sp$1.apply$mcV$sp(SimpleConsumer.scala:112) ~[org.apache.kafka.kafka_2.10-0.8.2.2.jar:na]
        at kafka.consumer.SimpleConsumer$$anonfun$fetch$1$$anonfun$apply$mcV$sp$1.apply(SimpleConsumer.scala:112) ~[org.apache.kafka.kafka_2.10-0.8.2.2.jar:na]
        at kafka.consumer.SimpleConsumer$$anonfun$fetch$1$$anonfun$apply$mcV$sp$1.apply(SimpleConsumer.scala:112) ~[org.apache.kafka.kafka_2.10-0.8.2.2.jar:na]
        at kafka.metrics.KafkaTimer.time(KafkaTimer.scala:33) ~[org.apache.kafka.kafka_2.10-0.8.2.2.jar:na]
        at kafka.consumer.SimpleConsumer$$anonfun$fetch$1.apply$mcV$sp(SimpleConsumer.scala:111) ~[org.apache.kafka.kafka_2.10-0.8.2.2.jar:na]
        at kafka.consumer.SimpleConsumer$$anonfun$fetch$1.apply(SimpleConsumer.scala:111) ~[org.apache.kafka.kafka_2.10-0.8.2.2.jar:na]
        at kafka.consumer.SimpleConsumer$$anonfun$fetch$1.apply(SimpleConsumer.scala:111) ~[org.apache.kafka.kafka_2.10-0.8.2.2.jar:na]
        at kafka.metrics.KafkaTimer.time(KafkaTimer.scala:33) ~[org.apache.kafka.kafka_2.10-0.8.2.2.jar:na]
        at kafka.consumer.SimpleConsumer.fetch(SimpleConsumer.scala:110) ~[org.apache.kafka.kafka_2.10-0.8.2.2.jar:na]
        at kafka.javaapi.consumer.SimpleConsumer.fetch(SimpleConsumer.scala:47) ~[org.apache.kafka.kafka_2.10-0.8.2.2.jar:na]
        at org.apache.twill.internal.kafka.client.SimpleKafkaConsumer$ConsumerThread.fetchMessages(SimpleKafkaConsumer.java:427) ~[org.apache.twill.twill-core-0.9.0.jar:0.9.0]
        at org.apache.twill.internal.kafka.client.SimpleKafkaConsumer$ConsumerThread.run(SimpleKafkaConsumer.java:355) ~[org.apache.twill.twill-core-0.9.0.jar:0.9.0]
16/12/17 21:34:57 INFO consumer.SimpleConsumer: Reconnect due to socket error: java.nio.channels.ClosedChannelException
```