### PR TITLE
Remove MapReduce from description

### DIFF
--- a/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryWorkflow.java
+++ b/cdap-examples/Purchase/src/main/java/co/cask/cdap/examples/purchase/PurchaseHistoryWorkflow.java
@@ -26,7 +26,7 @@ public class PurchaseHistoryWorkflow extends AbstractWorkflow {
   @Override
   public void configure() {
       setName("PurchaseHistoryWorkflow");
-      setDescription("Workflow that runs the PurchaseHistoryBuilder MapReduce");
+      setDescription("Workflow that runs the PurchaseHistoryBuilder");
       addMapReduce("PurchaseHistoryBuilder");
   }
 }


### PR DESCRIPTION
* Fix the following integration test because the word MapReduce indexes the term for search

```
java.lang.AssertionError: expected:<[MetadataSearchResultRecord{entityId=program:default.PurchaseHistory.-SNAPSHOT.mapreduce.PurchaseHistoryBuilder, metadata={}}]> but was:<[MetadataSearchResultRecord{entityId=program:default.PurchaseHistory.-SNAPSHOT.mapreduce.PurchaseHistoryBuilder, metadata={}}, MetadataSearchResultRecord{entityId=program:default.PurchaseHistory.-SNAPSHOT.workflow.PurchaseHistoryWorkflow, metadata={}}]>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:743)
	at org.junit.Assert.assertEquals(Assert.java:118)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at co.cask.cdap.apps.metadata.PurchaseMetadataTest.assertProgramSearch(PurchaseMetadataTest.java:462)
	at co.cask.cdap.apps.metadata.PurchaseMetadataTest.testSearchUsingSystemMetadata(PurchaseMetadataTest.java:328)
```