### PR TITLE
[HYDRATOR-1192] fix multiple macros specified for one plugin in runtime args

### DIFF
--- a/cdap-ui/app/hydrator/controllers/detail/top-panel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/detail/top-panel-ctrl.js
@@ -91,7 +91,11 @@ class HydratorDetailTopPanelController {
       for(let i = 0; i < macrosSpec.length; i++){
         if(this.myHelpers.objectQuery(macrosSpec[i], 'spec', 'properties', 'macros', 'lookupProperties') &&
           this.myHelpers.objectQuery(macrosSpec[i], 'spec', 'properties', 'macros', 'lookupProperties').length > 0){
-            macrosObj[this.myHelpers.objectQuery(macrosSpec[i], 'spec', 'properties', 'macros', 'lookupProperties')] = '';
+            let macrosKeys = this.myHelpers.objectQuery(macrosSpec[i], 'spec', 'properties', 'macros', 'lookupProperties');
+
+            macrosKeys.forEach((key) => {
+              macrosObj[key] = '';
+            });
         }
       }
       return macrosObj;


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/HYDRATOR-1192

Root cause:
The previous code assumed there is only 1 macro per plugin. 