### PR TITLE
Don't reset the 'count' each search index.

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
@@ -607,6 +607,7 @@ public class MetadataDataset extends AbstractDataset {
     // in addition, we want to pre-fetch 'numCursors' chunks of size 'limit'
     int fetchSize = offset + ((numCursors + 1) * limit);
     List<String> cursors = new ArrayList<>(numCursors);
+    int count = 0;
     for (String searchTerm : getSearchTerms(namespaceId, "*")) {
       byte[] startKey = Bytes.toBytes(searchTerm.substring(0, searchTerm.lastIndexOf("*")));
       byte[] stopKey = Bytes.stopKeyForPrefix(startKey);
@@ -622,7 +623,6 @@ public class MetadataDataset extends AbstractDataset {
       int mod = limit == 1 ? 0 : 1;
       try (Scanner scanner = indexedTable.scanByIndex(Bytes.toBytes(indexColumn), startKey, stopKey)) {
         Row next;
-        int count = 0;
         while ((next = scanner.next()) != null && count < fetchSize) {
           // skip until we reach offset
           if (count < offset) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
@@ -417,7 +417,7 @@ public class DefaultMetadataStore implements MetadataStore {
     // TODO: Figure out how all of this can be done server (HBase) side
     int startIndex = 0;
     int maxEndIndex;
-    int total = results.size();
+    int total = sortedEntities.size();
     if (SortInfo.DEFAULT.equals(sortInfo)) {
       // offset needs to be applied
       if (offset > sortedEntities.size()) {


### PR DESCRIPTION
Fix the 'totals' when searching metadata by weighted sort.
Don't reset the 'count' each search index. Otherwise, the offset can be skipped multiple times.

http://builds.cask.co/browse/CDAP-RUT419-1