### PR TITLE
CDAP-7948 Set 'org.apache.hadoop.ipc.Client' log level to ERROR

### DIFF
--- a/cdap-distributions/src/etc/cdap/conf.dist/logback.xml
+++ b/cdap-distributions/src/etc/cdap/conf.dist/logback.xml
@@ -28,6 +28,8 @@
     <logger name="org.apache.spark" level="WARN"/>
     <logger name="org.spark-project" level="WARN"/>
     <logger name="org.apache.hadoop" level="WARN"/>
+    <!--See CDAP-7948-->
+    <logger name="org.apache.hadoop.ipc.Client" level="ERROR"/>
     <logger name="org.apache.hive" level="WARN"/>
     <logger name="org.quartz.core" level="WARN"/>
     <logger name="org.eclipse.jetty" level="WARN"/>


### PR DESCRIPTION
CDAP-7948 Set 'org.apache.hadoop.ipc.Client' log level to ERROR, since there can be lots of WARNs on YARN HA clusters.

Long term fix is: CDAP-7948