### PR TITLE
CDAP-7634 Support multiple parts and Query and Path Param in AuthEnforce

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/security/AuthEnforce.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/security/AuthEnforce.java
@@ -24,19 +24,21 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 
 /**
  * Annotation for a method that needs Authorization enforcement.
  * <p>
  * {@link AuthEnforce#entities()}: Specifies the entity on which authorization will be enforced.
- * Method parameters and class variables which are needed as entities should be marked with {@link Name} annotation
- * with a unique name and those names should be provided here.
- * It can either be an EntityId or an array of Strings from which the EntityId on which enforcement is needed
- * (specified through {@link AuthEnforce#enforceOn()}) can be constructed.
- * This will first be looked up in method parameter and if not found it will be looked up in the class member variable.
- * If a class member variable is marked with the same name as a method parameter then the method parameter will take
- * precedence over the class member variable. If you you want the class member variable to be used then specify it
- * with this.AnnotationName
+ * Method parameters {@link Name}(preferred)/{@link QueryParam}/{@link PathParam} annotation with a unique name and
+ * those names should be provided here. if a class field needs to be specified then the field name itself should be
+ * specified here. It can either be an EntityId or an array of Strings from which the EntityId on which enforcement
+ * is needed (specified through {@link AuthEnforce#enforceOn()}) can be constructed. This will first be looked up
+ * in method parameter and if not found it will be looked up in the class member variable. If a class member
+ * variable is marked with the same name as a method parameter then the method parameter will take precedence over
+ * the class member variable. If you you want the class member variable to be used then specify it with
+ * this.AnnotationName
  * <p>
  * {@link AuthEnforce#enforceOn()}: CDAP entities (see {@link EntityId}) class on which enforcement will be done. If
  * you want to enforce on the parent of the entity specify that EntityId class here
@@ -48,9 +50,10 @@ import java.lang.annotation.Target;
 public @interface AuthEnforce {
 
   /**
-   * Specifies the entity on which authorization will be enforced. Method parameters and class variables which are
-   * needed as entities should be marked with {@link Name} annotation with a unique name and those names should be
-   * provided here. It can either be an EntityId or an array of Strings from which the EntityId on which enforcement
+   * Specifies the entity on which authorization will be enforced. Method parameters should be marked with
+   * {@link Name}(preferred)/{@link QueryParam}/{@link PathParam} annotation with a unique name and those names should be
+   * provided here. if a class field needs to be specified then the field name itself should be specified here. It can
+   * either be an EntityId or an array of Strings from which the EntityId on which enforcement
    * is needed (specified through {@link AuthEnforce#enforceOn()}) can be constructed. This will first be looked up
    * in method parameter and if not found it will be looked up in the class member variable. If a class member
    * variable is marked with the same name as a method parameter then the method parameter will take precedence over

--- a/cdap-common/src/main/java/co/cask/cdap/common/security/AuthEnforce.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/security/AuthEnforce.java
@@ -51,9 +51,9 @@ public @interface AuthEnforce {
 
   /**
    * Specifies the entity on which authorization will be enforced. Method parameters should be marked with
-   * {@link Name}(preferred)/{@link QueryParam}/{@link PathParam} annotation with a unique name and those names should be
-   * provided here. if a class field needs to be specified then the field name itself should be specified here. It can
-   * either be an EntityId or an array of Strings from which the EntityId on which enforcement
+   * {@link Name}(preferred)/{@link QueryParam}/{@link PathParam} annotation with a unique name and those names should
+   * be provided here. if a class field needs to be specified then the field name itself should be specified here.
+   * It can either be an EntityId or an array of Strings from which the EntityId on which enforcement
    * is needed (specified through {@link AuthEnforce#enforceOn()}) can be constructed. This will first be looked up
    * in method parameter and if not found it will be looked up in the class member variable. If a class member
    * variable is marked with the same name as a method parameter then the method parameter will take precedence over

--- a/cdap-common/src/main/java/co/cask/cdap/common/security/AuthEnforceRewriter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/security/AuthEnforceRewriter.java
@@ -18,11 +18,19 @@ package co.cask.cdap.common.security;
 
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.common.lang.ClassRewriter;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.id.InstanceId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
 import com.google.common.io.ByteStreams;
 import com.google.inject.Inject;
 import org.objectweb.asm.AnnotationVisitor;
@@ -50,6 +58,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 
 /**
  * <p>
@@ -63,13 +73,14 @@ import java.util.Set;
  * Pass 1: In first pass it visit all the classes skipping interfaces and looks for non-static methods which has
  * {@link AuthEnforce} annotation. If an {@link AuthEnforce} annotation is found then it store all the
  * {@link AuthEnforce} annotation details and also visits the parameter annotation and collects all the position of
- * parameters with {@link Name} annotation. Note: No byte code modification of the class is done in this pass.
+ * parameters with {@link Name}(preferered)/{@link QueryParam}/{@link PathParam} annotation. Note: No byte code
+ * modification of the class is done in this pass.
  * </p>
  * <p>
  * Pass 2: This pass only happen if a method with {@link AuthEnforce} annotation is found in the class during the
  * first pass. In this pass we rewrite the method which has {@link AuthEnforce} annotation. In the rewrite we
  * generate a call to
- * {@link AuthEnforceUtil#enforce(AuthorizationEnforcer, EntityId, AuthenticationContext, Set)} with
+ * {@link AuthEnforceUtil#enforce(AuthorizationEnforcer, Object[], Class, AuthenticationContext, Set)} with
  * all the annotation details collected in the first pass.
  * </p>
  * <p>
@@ -126,6 +137,9 @@ public class AuthEnforceRewriter implements ClassRewriter {
   private static final Type AUTHENTICATION_CONTEXT_TYPE = Type.getType(AuthenticationContext.class);
   private static final Type ACTION_TYPE = Type.getType(Action.class);
   private static final Type AUTH_ENFORCE_UTIL_TYPE = Type.getType(AuthEnforceUtil.class);
+  private static final Set<String> SUPPORTED_PARAMETER_ANNOTATIONS = Sets.newHashSet(Name.class.getName(),
+                                                                                     QueryParam.class.getName(),
+                                                                                     PathParam.class.getName());
 
   @Override
   public byte[] rewriteClass(String className, InputStream input) throws IOException {
@@ -150,7 +164,7 @@ public class AuthEnforceRewriter implements ClassRewriter {
     // in second pass we COMPUTE_FRAMES and visit classes with EXPAND_FRAMES
     ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
     cr.accept(new AuthEnforceAnnotationRewriter(className, cw, classVisitor.getFieldDetails(), methodAnnotations),
-              ClassReader.EXPAND_FRAMES);
+            ClassReader.EXPAND_FRAMES);
     return cw.toByteArray();
   }
 
@@ -197,13 +211,15 @@ public class AuthEnforceRewriter implements ClassRewriter {
         return null;
       }
 
+      final Type[] parameterTypes = Type.getArgumentTypes(methodDesc);
+
       // Visit the annotations of the method to determine if it has AuthEnforce annotation. If it does then collect
       // AuthEnforce annotation details and also sets a boolean flag hasEnforce which is used later in
       // visitParameterAnnotation to visit the annotations on parameters of this method only if it had AuthEnforce
       // annotation.
       return new MethodVisitor(Opcodes.ASM5) {
 
-        final Map<Integer, AnnotationNode> parameterAnnotationNode = new HashMap<>();
+        final Map<Integer, ParameterDetail> parameterDetails = new HashMap<>();
         AnnotationNode authEnforceAnnotationNode;
 
         @Override
@@ -220,16 +236,27 @@ public class AuthEnforceRewriter implements ClassRewriter {
         @Override
         public AnnotationVisitor visitParameterAnnotation(int parameter, String desc, boolean visible) {
           if (!(authEnforceAnnotationNode != null && visible &&
-            Name.class.getName().equals(Type.getType(desc).getClassName()))) {
+                  (SUPPORTED_PARAMETER_ANNOTATIONS.contains(Type.getType(desc).getClassName())))) {
             return null;
           }
           // Since AuthEnforce annotation was used on this method then look for parameters with named annotation and
           // store their position.
-          // TODO: Should also pick up names from QueryParam and PathParam annotations here as needed later and also
           // decide on a precedence order.
           AnnotationNode annotationNode = new AnnotationNode(desc);
-          // store the parameter position and its annotation detail
-          parameterAnnotationNode.put(parameter, annotationNode);
+          // store the parameter position and its type with annotation detail
+          ParameterDetail parameterDetail = new ParameterDetail(parameterTypes[parameter], annotationNode);
+          if (parameterDetails.containsKey(parameter)) {
+            // we already stored some annotation for this parameter update it if the current one is Name annotation
+            // as its preferred
+            if (Name.class.getName().equals(Type.getType(desc).getClassName())) {
+              LOG.info("Updating parameter details for parameter at position '%s' for method '%s' in class '%s' from " +
+                              "'%s' to '%s'. Since %s is preferred annotation.", parameter, methodName, className,
+                      parameterDetails.get(parameter), parameterDetail);
+              parameterDetails.put(parameter, parameterDetail);
+            }
+          } else {
+            parameterDetails.put(parameter, parameterDetail);
+          }
           return annotationNode;
         }
 
@@ -242,8 +269,8 @@ public class AuthEnforceRewriter implements ClassRewriter {
             return;
           }
           AuthEnforceAnnotationNodeProcessor nodeProcessor =
-            new AuthEnforceAnnotationNodeProcessor(authEnforceAnnotationNode);
-          Map<String, Integer> paramAnnotation = processParameterAnnotationNode(parameterAnnotationNode);
+                  new AuthEnforceAnnotationNodeProcessor(authEnforceAnnotationNode);
+          Map<String, Integer> paraPositions = processParameterAnnotationNode(parameterDetails);
 
           List<EntityPartDetail> entityPartDetails = new ArrayList<>();
           for (String name : nodeProcessor.getEntities()) {
@@ -259,25 +286,94 @@ public class AuthEnforceRewriter implements ClassRewriter {
               entityPart = new EntityPartDetail(fieldName, true);
             } else {
               // preference to method parameters
-              if (paramAnnotation.containsKey(name)) {
+              if (paraPositions.containsKey(name)) {
                 entityPart = new EntityPartDetail(name, false);
               } else if (fieldDetails.containsKey(name)) {
                 entityPart = new EntityPartDetail(name, true);
               } else {
                 // Didn't find a named method parameter or class field for the given entity name
                 throw new IllegalArgumentException(String.format("No named method parameter or a class field found " +
-                                                                   "with name %s in class %s for method %s whereas " +
-                                                                   "it was specified in %s annotation", name,
-                                                                 className, methodName,
-                                                                 AuthEnforce.class.getSimpleName()));
+                                "with name '%s' in class '%s' for method '%s' whereas " +
+                                "it was specified in '%s' annotation", name,
+                        className, methodName,
+                        AuthEnforce.class.getSimpleName()));
               }
             }
             entityPartDetails.add(entityPart);
           }
+          // verify that the entity parts specified in annotation is valid to do enforcement on the given enforceOn
+          verifyEntityParts(entityPartDetails, nodeProcessor.getEnforceOn(), parameterDetails, paraPositions);
           // Store all the information properly for the second pass
           methodAnnotations.put(new Method(methodName, methodDesc),
                                 new AnnotationDetail(entityPartDetails, nodeProcessor.getEnforceOn(),
-                                                     nodeProcessor.getActions(), paramAnnotation));
+                                                     nodeProcessor.getActions(), paraPositions));
+        }
+
+        /** Helper Methods **/
+
+        private void verifyEntityParts(List<EntityPartDetail> entityPartDetails, Type enforceOn,
+                                       Map<Integer, ParameterDetail> parameterAnnotationNode,
+                                       Map<String, Integer> paramAnnotation) {
+          Type entityPartType = getEntityPartType(parameterAnnotationNode, paramAnnotation, entityPartDetails.get(0));
+          // TODO: Later change this to even work with parent type as we will support enforceOn parent type
+          // if the first entity part is not string then it should be on same type specified in enforce on
+          if (!entityPartType.equals(Type.getType(String.class))) {
+            Preconditions.checkArgument(entityPartType.equals(enforceOn), "Found invalid entity type '%s' for " +
+                                                "enforceOn '%s' in annotation on '%s' method in '%s' class.",
+                    entityPartType.getClassName(), enforceOn.getClassName(), methodName, className);
+            Preconditions.checkArgument(getRequiredSize(enforceOn) != 0, "Invalid enforceOn %s provided.",
+                    enforceOn.getClassName());
+          } else {
+            // Since the entity part/parts provided is of String type so validate that we have sufficient part for
+            // EntityId creation
+            // verify that all parts are of type string
+            for (EntityPartDetail entityPartDetail : entityPartDetails) {
+              entityPartType = getEntityPartType(parameterAnnotationNode, paramAnnotation, entityPartDetail);
+              Preconditions.checkArgument(entityPartType.equals(Type.getType(String.class)),
+                      "Found part %s of type %s in a multiple part entity " +
+                              "specification of AuthEnforce. Only String is supported in multiple " +
+                              "parts.", entityPartDetail.getEntityName(), entityPartType);
+            }
+            int requiredSize = getRequiredSize(enforceOn);
+            Preconditions.checkArgument(requiredSize != 0, "Failed to determine required number of entity parts " +
+                    "needed for %s. Please make sure its a valid %s class for authorization " +
+                    "enforcement", enforceOn.getClassName(), EntityId.class.getSimpleName());
+            Preconditions.checkArgument(requiredSize == entityPartDetails.size(), "Found %s entity parts in " +
+                            "AuthEnforce annotation on method %s in class %s to do enforcement on %s " +
+                            "which requires %s entity parts or an %s", entityPartDetails.size(),
+                    methodName, className, enforceOn, requiredSize, enforceOn.getClassName());
+
+          }
+        }
+
+        private Type getEntityPartType(Map<Integer, ParameterDetail> parameterAnnotationNode,
+                                       Map<String, Integer> paramAnnotation, EntityPartDetail entityPartDetail) {
+          return entityPartDetail.isField() ? fieldDetails.get(entityPartDetail.getEntityName()) :
+                  parameterAnnotationNode.get(paramAnnotation.get(entityPartDetail.getEntityName())).getParameterType();
+        }
+
+        /**
+         * Return the required size of entity parts to create the {@link EntityId} on which authorization enforcement
+         * needs to be done as specified in {@link AuthEnforce#enforceOn()}
+         *
+         * @param enforceOn the {@link Type} of {@link EntityId} on which enforcement needs to be done
+         * @return the size of entity parts needed to create the above {@link EntityId} or 0 if found an invalid
+         * {@link EntityId} type.
+         */
+        private int getRequiredSize(Type enforceOn) {
+          if (enforceOn.equals(Type.getType(InstanceId.class)) || enforceOn.equals(Type.getType(NamespaceId.class))) {
+            return 1;
+          } else if (enforceOn.equals(Type.getType(StreamId.class)) ||
+                  enforceOn.equals(Type.getType(DatasetId.class)) ||
+                  enforceOn.equals(Type.getType(ApplicationId.class))) {
+            return 2;
+          } else if (enforceOn.equals(Type.getType(ArtifactId.class))) {
+            return 3;
+          } else if (enforceOn.equals(Type.getType(ProgramId.class))) {
+            return 4;
+          } else {
+            return 0;
+          }
         }
       };
     }
@@ -295,7 +391,7 @@ public class AuthEnforceRewriter implements ClassRewriter {
    * A {@link ClassVisitor} which is used in second pass of {@link AuthEnforceRewriter} to rewrite methods which has
    * {@link AuthEnforce} annotation on it with the annotation details collected from the first pass. This is only
    * called for classes which has at least one such method. This class does byte code rewrite to generate call to
-   * {@link AuthEnforceUtil#enforce(AuthorizationEnforcer, EntityId, AuthenticationContext, Set)}. To
+   * {@link AuthEnforceUtil#enforce(AuthorizationEnforcer, Object[], Class, AuthenticationContext, Set)}. To
    * see an example of generated byte code please see the documentation for {@link AuthEnforceRewriter}
    */
   private final class AuthEnforceAnnotationRewriter extends ClassVisitor {
@@ -333,13 +429,7 @@ public class AuthEnforceRewriter implements ClassRewriter {
         protected void onMethodEnter() {
           LOG.trace("AuthEnforce annotation found in class {} on method {}. Authorization enforcement command will " +
                       "be generated for Entities: {}, enforceOn: {}, actions: {}.", className, methodName,
-                    annotationDetail.getEntities(), annotationDetail.getEnforceOn(),
-                    annotationDetail.getActions());
-
-          // TODO: Remove this one we support AuthEnforce with multiple string parts
-          Preconditions.checkArgument(annotationDetail.getEntities().size() == 1,
-                                      "Currently Authorization annotation is only supported for EntityId from " +
-                                        "method parameter.");
+                    annotationDetail.getEntities(), annotationDetail.getEnforceOn(), annotationDetail.getActions());
 
           // do class rewrite to generate the call to
           // AuthEnforceUtil#enforce(AuthorizationEnforcer, EntityId, AuthenticationContext, Set)
@@ -350,17 +440,27 @@ public class AuthEnforceRewriter implements ClassRewriter {
 
           // push the parameters of method call on to the stack
 
-          // pushed the entity id
-          //TODO: This is because currently we don't support multi-part
-          EntityPartDetail entityPart = annotationDetail.getEntities().get(0);
-          if (entityPart.isField()) {
-            // load class field
-            loadThis();
-            getField(classType, entityPart.getEntityName(), fieldDetails.get(entityPart.getEntityName()));
-          } else {
-            // load method parameter
-            loadArg(0);
+          // push the entity array
+          push(annotationDetail.getEntities().size());
+          newArray(Type.getType(Object.class));
+          for (int i = 0; i < annotationDetail.getEntities().size(); i++) {
+            dup();
+            push(i);
+            EntityPartDetail entityPart = annotationDetail.getEntities().get(i);
+            if (entityPart.isField()) {
+              // load class field
+              loadThis();
+              getField(classType, entityPart.getEntityName(), fieldDetails.get(entityPart.getEntityName()));
+            } else {
+              // load method parameter
+              loadArg(annotationDetail.getParameterAnnotation().get(
+                      annotationDetail.getEntities().get(i).getEntityName()));
+            }
+            arrayStore(Type.getType(Object.class));
           }
+
+          // push the enforceOn type
+          push(annotationDetail.getEnforceOn());
 
           // push the authentication context
           // this.authenticationContext
@@ -386,7 +486,8 @@ public class AuthEnforceRewriter implements ClassRewriter {
           invokeStatic(AUTH_ENFORCE_UTIL_TYPE,
                        new Method("enforce", Type.getMethodDescriptor(Type.VOID_TYPE,
                                                                       AUTHORIZATION_ENFORCER_TYPE,
-                                                                      Type.getType(EntityId.class),
+                                                                      Type.getType(Object[].class),
+                                                                      Type.getType(Class.class),
                                                                       AUTHENTICATION_CONTEXT_TYPE,
                                                                       Type.getType(Set.class))));
         }
@@ -439,22 +540,40 @@ public class AuthEnforceRewriter implements ClassRewriter {
    * @return a new {@link Map} where the key is the parameter name given in the annotation and value is the
    * position of the parameter.
    */
-  private static Map<String, Integer> processParameterAnnotationNode(Map<Integer, AnnotationNode>
+  private static Map<String, Integer> processParameterAnnotationNode(Map<Integer, ParameterDetail>
                                                                        parameterAnnotationNode) {
     Map<String, Integer> parameterAnnotation = new HashMap<>();
-    for (Map.Entry<Integer, AnnotationNode> entry : parameterAnnotationNode.entrySet()) {
+    for (Map.Entry<Integer, ParameterDetail> entry : parameterAnnotationNode.entrySet()) {
       // the AnnotationNode of parameter will be an array of size 2 where 0 is "value" and 1 is the name provided in
       // the annotation.
-      String paraName = (String) entry.getValue().values.get(1);
-      // We expect all parameters to have unique names to ensure that here
-      Preconditions.checkArgument(!parameterAnnotation.containsKey(paraName),
-                                  String.format("A parameter with name %s was already found at position %s." +
-                                                  " Please use unique names.", paraName,
-                                                parameterAnnotation.get(paraName)));
-      // store the parameter position with the unique name given to it
-      parameterAnnotation.put(paraName, entry.getKey());
+      String paraName = (String) entry.getValue().getAnnotationNode().values.get(1);
+      int position = entry.getKey();
+      // if we have already seen a parameter named with this annotation then decide the preferred parameter if possible
+      if (parameterAnnotation.containsKey(paraName)) {
+        position = getPreferredParameter(parameterAnnotationNode.get(parameterAnnotation.get(paraName)),
+                parameterAnnotation.get(paraName), entry.getValue(), entry.getKey());
+
+      }
+      // store the parameter position with this name
+      parameterAnnotation.put(paraName, position);
     }
     return parameterAnnotation;
+  }
+
+  private static int getPreferredParameter(ParameterDetail previousDetails, int prevPosition,
+                                           ParameterDetail currentDetails, int currentPosition) {
+    if (Name.class.getName().equals(Type.getType(previousDetails.getAnnotationNode().desc).getClassName()) ||
+            Name.class.getName().equals(Type.getType(currentDetails.getAnnotationNode().desc).getClassName())) {
+      // if only one of them have Name annotation then give preference to that
+      if (!(Name.class.getName().equals(Type.getType(previousDetails.getAnnotationNode().desc).getClassName()) &&
+              Name.class.getName().equals(Type.getType(currentDetails.getAnnotationNode().desc).getClassName()))) {
+        return Name.class.getName().equals(Type.getType(previousDetails.getAnnotationNode().desc).getClassName()) ?
+                prevPosition : currentPosition;
+      }
+    }
+    throw new IllegalArgumentException(String.format("Found conflicting annotation %s and %s. If possible please " +
+                    "give preference to a parameter through %s annotation or use unique names.",
+            previousDetails.getAnnotationNode(), currentDetails.getAnnotationNode(), Name.class.getName()));
   }
 
   /**
@@ -542,6 +661,9 @@ public class AuthEnforceRewriter implements ClassRewriter {
     }
   }
 
+  /**
+   * Wrapper class to store the entity name and whether its a class field or not
+   */
   private static final class EntityPartDetail {
     private final String entityName;
     private final boolean isField;
@@ -557,6 +679,27 @@ public class AuthEnforceRewriter implements ClassRewriter {
 
     boolean isField() {
       return isField;
+    }
+  }
+
+  /**
+   * Wrapper class to store the parameter type and the annotation details for the parameter
+   */
+  private static final class ParameterDetail {
+    private final Type parameterType;
+    private final AnnotationNode annotationNode;
+
+    ParameterDetail(Type parameterType, AnnotationNode annotationNode) {
+      this.parameterType = parameterType;
+      this.annotationNode = annotationNode;
+    }
+
+    Type getParameterType() {
+      return parameterType;
+    }
+
+    AnnotationNode getAnnotationNode() {
+      return annotationNode;
     }
   }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/security/AuthEnforceUtil.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/security/AuthEnforceUtil.java
@@ -16,11 +16,20 @@
 
 package co.cask.cdap.common.security;
 
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.id.InstanceId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
+import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 
+import java.util.Arrays;
 import java.util.Set;
 
 /**
@@ -41,13 +50,58 @@ public final class AuthEnforceUtil {
    * Performs authorization enforcement
    *
    * @param authorizationEnforcer the {@link AuthorizationEnforcer} to use for performing the enforcement
-   * @param entities the {@link EntityId} on which authorization is to be enforced
+   * @param entities an {@link Object}[] of Strings from which an entity on which enforcement needs to be performed
+   *                 can be created of just {@link EntityId} on which on whose parent enforcement needs to be performed
    * @param authenticationContext the {@link AuthenticationContext}  of the user that performs the action
-   * @param actions the {@link Action}s being performed
-   * @throws Exception
+   * @param actions the {@link Action}s to check for during enforcement
+   * @throws Exception {@link UnauthorizedException} if the given authenticationContext is not authorized to perform
+   * the specified actions on the entity
    */
-  public static void enforce(AuthorizationEnforcer authorizationEnforcer, EntityId entities,
+  public static void enforce(AuthorizationEnforcer authorizationEnforcer, Object[] entities, Class enforceOn,
                              AuthenticationContext authenticationContext, Set<Action> actions) throws Exception {
-    authorizationEnforcer.enforce(entities, authenticationContext.getPrincipal(), actions);
+    authorizationEnforcer.enforce(getEntityId(entities, enforceOn), authenticationContext.getPrincipal(), actions);
+  }
+
+  private static EntityId getEntityId(Object[] entities, Class enforceOn) {
+    if (entities.length == 1 && entities[0] instanceof EntityId) {
+      // If EntityId was passed in then the size of the array should be one
+      return (EntityId) entities[0];
+    } else {
+      // If the size of the array is more than one we expect all the specified parameters to be String
+      String[] entityParts;
+      try {
+        entityParts = Arrays.copyOf(entities, entities.length, String[].class);
+      } catch (ArrayStoreException e) {
+        // Arrays.copyOf will throw ArrayStoreException if an element copied from original array is not a String
+        throw new IllegalArgumentException(String.format("%s annotation can be used for multiple part entities of " +
+                                                                 "String type only.", AuthEnforce.class.getName()), e);
+      }
+      return EntityIdFactory.getEntityId(entityParts, enforceOn);
+    }
+  }
+
+  private static class EntityIdFactory {
+    public static EntityId getEntityId(String[] entityParts, Class enforceOn) {
+      if (enforceOn.equals(InstanceId.class)) {
+        return new InstanceId(entityParts[0]);
+      } else if (enforceOn.equals(NamespaceId.class)) {
+        return new NamespaceId(entityParts[0]);
+      } else if (enforceOn.equals(ArtifactId.class)) {
+        return new ArtifactId(entityParts[0], entityParts[1], entityParts[2]);
+      } else if (enforceOn.equals(DatasetId.class)) {
+        return new DatasetId(entityParts[0], entityParts[1]);
+      } else if (enforceOn.equals(StreamId.class)) {
+        return new StreamId(entityParts[0], entityParts[1]);
+      } else if (enforceOn.equals(ApplicationId.class)) {
+        return new ApplicationId(entityParts[0], entityParts[1]);
+      } else if (enforceOn.equals(ProgramId.class)) {
+        return new ProgramId(entityParts[0], entityParts[1], entityParts[2], entityParts[3]);
+      } else {
+        // safeguard: this should not happen since we have already verified all that the entity id can be created from
+        // the given parts
+        throw new IllegalArgumentException(String.format("Failed to create an %s from the the given entity parts %s",
+                                                         enforceOn, Arrays.toString(entityParts)));
+      }
+    }
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
@@ -29,6 +29,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.security.AuditDetail;
 import co.cask.cdap.common.security.AuditPolicy;
+import co.cask.cdap.common.security.AuthEnforce;
 import co.cask.cdap.data.stream.StreamCoordinatorClient;
 import co.cask.cdap.data.stream.StreamFileWriterFactory;
 import co.cask.cdap.data.stream.service.upload.ContentWriterFactory;
@@ -45,8 +46,6 @@ import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.security.impersonation.Impersonator;
 import co.cask.cdap.security.impersonation.SecurityUtil;
-import co.cask.cdap.security.spi.authentication.AuthenticationContext;
-import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.BodyConsumer;
 import co.cask.http.HandlerContext;
@@ -120,8 +119,6 @@ public final class StreamHandler extends AbstractHttpHandler {
   private ExecutorService asyncExecutor;
   private final StreamWriterSizeCollector sizeCollector;
   private final Impersonator impersonator;
-  private final AuthorizationEnforcer authorizationEnforcer;
-  private final AuthenticationContext authenticationContext;
 
   @Inject
   StreamHandler(CConfiguration cConf,
@@ -129,8 +126,7 @@ public final class StreamHandler extends AbstractHttpHandler {
                 StreamFileWriterFactory writerFactory,
                 final MetricsCollectionService metricsCollectionService,
                 StreamWriterSizeCollector sizeCollector,
-                NamespaceQueryAdmin namespaceQueryAdmin, Impersonator impersonator,
-                AuthorizationEnforcer authorizationEnforcer, AuthenticationContext authenticationContext) {
+                NamespaceQueryAdmin namespaceQueryAdmin, Impersonator impersonator) {
     this.cConf = cConf;
     this.streamAdmin = streamAdmin;
     this.sizeCollector = sizeCollector;
@@ -150,8 +146,6 @@ public final class StreamHandler extends AbstractHttpHandler {
                                                    metricsCollectorFactory, impersonator);
     this.namespaceQueryAdmin = namespaceQueryAdmin;
     this.impersonator = impersonator;
-    this.authorizationEnforcer = authorizationEnforcer;
-    this.authenticationContext = authenticationContext;
   }
 
   @Override
@@ -250,24 +244,24 @@ public final class StreamHandler extends AbstractHttpHandler {
 
   @POST
   @Path("/{stream}")
+  @AuthEnforce(entities = {"namespace-id", "stream"}, enforceOn = StreamId.class, actions = Action.WRITE)
   public void enqueue(HttpRequest request, HttpResponder responder,
                       @PathParam("namespace-id") String namespaceId,
                       @PathParam("stream") String stream) throws Exception {
     StreamId streamId = validateAndGetStreamId(namespaceId, stream);
-    authorizationEnforcer.enforce(streamId, authenticationContext.getPrincipal(), Action.WRITE);
     streamWriter.enqueue(streamId, getHeaders(request, stream), request.getContent().toByteBuffer());
     responder.sendStatus(HttpResponseStatus.OK);
   }
 
   @POST
   @Path("/{stream}/async")
+  @AuthEnforce(entities = {"namespace-id", "stream"}, enforceOn = StreamId.class, actions = Action.WRITE)
   public void asyncEnqueue(HttpRequest request, HttpResponder responder,
                            @PathParam("namespace-id") String namespaceId,
                            @PathParam("stream") String stream) throws Exception {
     StreamId streamId = validateAndGetStreamId(namespaceId, stream);
     // No need to copy the content buffer as we always uses a ChannelBufferFactory that won't reuse buffer.
     // See StreamHttpService
-    authorizationEnforcer.enforce(streamId, authenticationContext.getPrincipal(), Action.WRITE);
     streamWriter.asyncEnqueue(streamId, getHeaders(request, stream),
                               request.getContent().toByteBuffer(), asyncExecutor);
     responder.sendStatus(HttpResponseStatus.ACCEPTED);
@@ -275,12 +269,12 @@ public final class StreamHandler extends AbstractHttpHandler {
 
   @POST
   @Path("/{stream}/batch")
+  @AuthEnforce(entities = {"namespace-id", "stream"}, enforceOn = StreamId.class, actions = Action.WRITE)
   public BodyConsumer batch(HttpRequest request, HttpResponder responder,
                             @PathParam("namespace-id") String namespaceId,
                             @PathParam("stream") String stream) throws Exception {
     StreamId streamId = validateAndGetStreamId(namespaceId, stream);
     checkStreamExists(streamId);
-    authorizationEnforcer.enforce(streamId, authenticationContext.getPrincipal(), Action.WRITE);
     try {
       return streamBodyConsumerFactory.create(request, createContentWriterFactory(streamId, request));
     } catch (UnsupportedOperationException e) {

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthEnforceRewriterTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthEnforceRewriterTest.java
@@ -23,6 +23,7 @@ import co.cask.cdap.internal.asm.ClassDefinition;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.InstanceId;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.security.auth.context.AuthenticationTestContext;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
@@ -69,19 +70,25 @@ public class AuthEnforceRewriterTest {
     testRewrite(getMethod(cls, "testMethodWithoutException", NamespaceId.class), rewrittenObject,
                 ExceptionAuthorizationEnforcer.ExpectedException.class, NamespaceId.DEFAULT);
 
-    // tests that class rewriting does not happen if an interface has a method with AuthEnforce
-    cls = classLoader.loadClass(DummyAuthEnforce.ClassImplementingInterfaceWithAuthAnnotation.class.getName());
-    rewrittenObject = loadRewritten(classLoader, DummyAuthEnforce.class.getName(), cls.getName());
-    invokeSetters(cls, rewrittenObject);
-    testRewrite(getMethod(cls, "interfaceMethodWithAuthEnforce", NamespaceId.class), rewrittenObject,
-                DummyAuthEnforce.EnforceNotCalledException.class, NamespaceId.DEFAULT);
+    testRewrite(getMethod(cls, "testNameAnnotationPref", NamespaceId.class, String.class), rewrittenObject,
+                NamespaceId.DEFAULT, ExceptionAuthorizationEnforcer.ExpectedException.class,
+                NamespaceId.DEFAULT, "stream");
+
+    testRewrite(getMethod(cls, "testMultipleParts", String.class, String.class), rewrittenObject,
+                new StreamId("ns", "stream"), ExceptionAuthorizationEnforcer.ExpectedException.class, "ns", "stream");
+
+    testRewrite(getMethod(cls, "testQueryPathParamAnnotations", String.class, String.class), rewrittenObject,
+                new StreamId("ns", "stream"), ExceptionAuthorizationEnforcer.ExpectedException.class, "ns", "stream");
+
+    testRewrite(getMethod(cls, "testMultipleAnnotationsPref", NamespaceId.class), rewrittenObject,
+                ExceptionAuthorizationEnforcer.ExpectedException.class, NamespaceId.DEFAULT);
 
     // test that class rewriting does not happen for classes which does not have AuthEnforce annotation on its method
     cls = classLoader.loadClass(DummyAuthEnforce.ClassWithoutAuthEnforce.class.getName());
     rewrittenObject = loadRewritten(classLoader, DummyAuthEnforce.class.getName(), cls.getName());
     invokeSetters(cls, rewrittenObject);
-    testRewrite(getMethod(cls, "methodWithoutAuthEnforce", NamespaceId.class), rewrittenObject, DummyAuthEnforce
-      .EnforceNotCalledException.class, NamespaceId.DEFAULT);
+    testRewrite(getMethod(cls, "methodWithoutAuthEnforce", NamespaceId.class), rewrittenObject,
+                DummyAuthEnforce.EnforceNotCalledException.class, NamespaceId.DEFAULT);
 
     // test that class rewriting works for a valid annotated method in another inner class and needs the
     // invokeSetters to called independently for this
@@ -114,6 +121,22 @@ public class AuthEnforceRewriterTest {
     testInvalidEntityHelper(DummyAuthEnforce.InvalidEntityName.class);
     // test that the class rewrite fails if two parameters are found with the same Name annotation
     testInvalidEntityHelper(DummyAuthEnforce.DuplicateEntityName.class);
+    // test that the class rewrite fails if less entity parts are provided than needed by enforceOn
+    testInvalidEntityHelper(DummyAuthEnforce.LessMultipleParts.class);
+    // test that the class rewrite fails if more entity parts are provided than needed by enforceOn
+    testInvalidEntityHelper(DummyAuthEnforce.MoreMultipleParts.class);
+    // test that the class rewrite fails if multiple entityId are provided and not strings
+    testInvalidEntityHelper(DummyAuthEnforce.MultipleEntityIds.class);
+    // test that the class rewrite fails if invalid enforceOn entity type is provided
+    testInvalidEntityHelper(DummyAuthEnforce.InvalidAuthEnforceEntityType.class);
+    // test that the class rewrite fails if invalid Annotation is used to annotate a parameter
+    testInvalidEntityHelper(DummyAuthEnforce.InvalidParameterAnnotationType.class);
+    // test that class rewrite fails if two parameter have same annotated name
+    testInvalidEntityHelper(DummyAuthEnforce.DuplicateAnnotationName.class);
+    // test that class rewrite fails if parameter have QueryParam and PathParam with same name
+    testInvalidEntityHelper(DummyAuthEnforce.SameQueryAndPathParam.class);
+    // test that the class rewrite fails if multiple part is specified of some other type than String
+    testInvalidEntityHelper(DummyAuthEnforce.EntitytWithString.class);
   }
 
   private void testInvalidEntityHelper(Class cls) throws Exception {
@@ -150,10 +173,11 @@ public class AuthEnforceRewriterTest {
 
         }
         ExceptionAuthorizationEnforcer.ExpectedException exception =
-          (ExceptionAuthorizationEnforcer.ExpectedException) e.getCause();
+                (ExceptionAuthorizationEnforcer.ExpectedException) e.getCause();
         if (!exception.getEntityId().equals(entityId)) {
-          Assert.fail(String.format("Expected %s with entity %s but found %s", ExceptionAuthorizationEnforcer
-            .ExpectedException.class.getSimpleName(), entityId, exception.getEntityId()));
+          Assert.fail(String.format("Expected %s with entity %s but found %s",
+                                    ExceptionAuthorizationEnforcer.ExpectedException.class.getSimpleName(),
+                                    entityId, exception.getEntityId()));
         }
       }
     }
@@ -165,12 +189,12 @@ public class AuthEnforceRewriterTest {
   }
 
   private void invokeSetters(Class<?> cls, Object rewrittenObject)
-    throws InvocationTargetException, IllegalAccessException {
+          throws InvocationTargetException, IllegalAccessException {
     Method[] declaredMethods = cls.getDeclaredMethods();
     for (Method declaredMethod : declaredMethods) {
       // if the method name starts with set_ then we know its an generated setter
       if (declaredMethod.getName().startsWith(AuthEnforceRewriter.GENERATED_SETTER_METHOD_PREFIX +
-                                                AuthEnforceRewriter.GENERATED_FIELD_PREFIX)) {
+                                                      AuthEnforceRewriter.GENERATED_FIELD_PREFIX)) {
         declaredMethod.setAccessible(true); // since its setter it might be private
         if (declaredMethod.getName().contains(AuthEnforceRewriter.AUTHENTICATION_CONTEXT_FIELD_NAME)) {
           declaredMethod.invoke(rewrittenObject, new AuthenticationTestContext());
@@ -178,7 +202,7 @@ public class AuthEnforceRewriterTest {
           declaredMethod.invoke(rewrittenObject, new ExceptionAuthorizationEnforcer());
         } else {
           throw new IllegalStateException(String.format("Found an expected setter method with name %s. While trying " +
-                                                          "invoke setter for %s and %s",
+                                                                "invoke setter for %s and %s",
                                                         declaredMethod.getName(),
                                                         AuthenticationContext.class.getSimpleName(),
                                                         AuthorizationEnforcer.class.getSimpleName()));
@@ -197,8 +221,8 @@ public class AuthEnforceRewriterTest {
   }
 
   private Object loadRewritten(ClassLoader classLoader, String outerClassName, String innerClassName)
-    throws ClassNotFoundException,
-    IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+          throws ClassNotFoundException, IllegalAccessException, InstantiationException, NoSuchMethodException,
+          InvocationTargetException {
     // the classes which we are loading from DummyAuthEnforce are inner classes so we need to instantiate the outer
     // class to load them.
     Class<?> outerClass = classLoader.loadClass(outerClassName);

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthEnforceRewriterTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/AuthEnforceRewriterTest.java
@@ -135,8 +135,10 @@ public class AuthEnforceRewriterTest {
     testInvalidEntityHelper(DummyAuthEnforce.DuplicateAnnotationName.class);
     // test that class rewrite fails if parameter have QueryParam and PathParam with same name
     testInvalidEntityHelper(DummyAuthEnforce.SameQueryAndPathParam.class);
-    // test that the class rewrite fails if multiple part is specified of some other type than String
-    testInvalidEntityHelper(DummyAuthEnforce.EntitytWithString.class);
+    // test that class rewrite fails if multiple part is specified of some other type than String
+    testInvalidEntityHelper(DummyAuthEnforce.EntityWithString.class);
+    // test that class rewrite fails if a blank string is provided in entity parts
+    testInvalidEntityHelper(DummyAuthEnforce.BlankEntityName.class);
   }
 
   private void testInvalidEntityHelper(Class cls) throws Exception {

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/DummyAuthEnforce.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/DummyAuthEnforce.java
@@ -21,7 +21,13 @@ import co.cask.cdap.common.security.AuthEnforce;
 import co.cask.cdap.common.security.AuthEnforceRewriter;
 import co.cask.cdap.proto.id.InstanceId;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ScheduleId;
+import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.security.Action;
+import com.google.inject.name.Named;
+
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 
 /**
  * A Dummy class which is just an wrapper and have different inner classes with {@link AuthEnforce} annotations.
@@ -61,9 +67,45 @@ public class DummyAuthEnforce {
       // exception during enforcement
     }
 
-    // to test that presence of a method with AuthEnforce in classs does not affect other methods which does have
+    // to test that presence of a method with AuthEnforce in class does not affect other methods which does have
     // AuthEnforce annotation
     public void testNoAuthEnforceAnnotation(@Name("namespaceId") NamespaceId namespaceId) throws Exception {
+      throw new EnforceNotCalledException();
+    }
+
+    // test AuthEnforce annotation which has multiple string parts in entities
+    @AuthEnforce(entities = {"namespace", "stream"}, enforceOn = StreamId.class, actions = Action.ADMIN)
+    public void testMultipleParts(@Name("namespace") String namespace, @Name("stream") String stream) throws Exception {
+      // the above annotation will call enforce after class rewrite which should throw an exception.
+      // If the line below is reached it means that enforce was not called as it supposed to be
+      throw new EnforceNotCalledException();
+    }
+
+    // test AuthEnforce where method parameters are marked with QueryParam and PathParam
+    @AuthEnforce(entities = {"namespace", "stream"}, enforceOn = StreamId.class, actions = Action.ADMIN)
+    public void testQueryPathParamAnnotations(@QueryParam("namespace") String namespace,
+                                              @PathParam("stream") String stream) throws Exception {
+      // the above annotation will call enforce after class rewrite which should throw an exception.
+      // If the line below is reached it means that enforce was not called as it supposed to be
+      throw new EnforceNotCalledException();
+    }
+
+    // test the preference of Name annotation when a method parameter is marked with Name and PathParam both
+    @AuthEnforce(entities = "namespace", enforceOn = NamespaceId.class, actions = Action.ADMIN)
+    public void testMultipleAnnotationsPref(@Name("namespace") @PathParam("namespaceId") NamespaceId namespaceId)
+            throws Exception {
+      // the above annotation will call enforce after class rewrite which should throw an exception.
+      // If the line below is reached it means that enforce was not called as it supposed to be
+      throw new EnforceNotCalledException();
+    }
+
+    // test the preference of Name annotation when two different parameters are marked with same name but one with Name
+    @AuthEnforce(entities = "namespaceId", enforceOn = NamespaceId.class, actions = Action.ADMIN)
+    public void testNameAnnotationPref(@Name("namespaceId") NamespaceId namespaceId,
+                                       @PathParam("namespaceId") String stream)
+            throws Exception {
+      // the above annotation will call enforce after class rewrite which should throw an exception.
+      // If the line below is reached it means that enforce was not called as it supposed to be
       throw new EnforceNotCalledException();
     }
   }
@@ -106,7 +148,7 @@ public class DummyAuthEnforce {
     }
 
     // tests that when a method parameter has Named annotation same as class field name and when specified in
-    // AuthEnforce entities method parameter gets prefernce
+    // AuthEnforce entities method parameter gets preference
     @AuthEnforce(entities = "someEntity", enforceOn = InstanceId.class, actions = Action.ADMIN)
     public void testParaPreference(@Name("someEntity") InstanceId instanceId) throws Exception {
       // the above annotation will call enforce after class rewrite which should throw an exception.
@@ -136,6 +178,99 @@ public class DummyAuthEnforce {
   }
 
   /**
+   * Class which has {@link AuthEnforce} annotation and parameter annotated with invalid annotation {@link Named}
+   */
+  public class InvalidParameterAnnotationType {
+
+    @AuthEnforce(entities = "wrongType", enforceOn = NamespaceId.class, actions = {Action.ADMIN, Action.READ})
+    public void testEntityNameAbsence(@Named("wrongType") NamespaceId namespaceId) throws Exception {
+      // no-op
+    }
+  }
+
+  /**
+   * Class which has {@link AuthEnforce} annotation and two parameters with same name
+   */
+  public class DuplicateAnnotationName {
+
+    @AuthEnforce(entities = "wrongType", enforceOn = StreamId.class, actions = {Action.ADMIN, Action.READ})
+    public void testDuplicationAnnotationWithSameName(@Name("name") String s1, @Name("name") String s2)
+            throws Exception {
+      // no-op
+    }
+  }
+
+  /**
+   * Class which has {@link AuthEnforce} annotation have multiple parts which is not only string type
+   */
+  public class EntitytWithString {
+
+    @AuthEnforce(entities = {"entity", "string"}, enforceOn = StreamId.class, actions = {Action.ADMIN, Action.READ})
+    public void testEntityAndString(@Name("entity") NamespaceId p1, @Name("string") String p2)
+            throws Exception {
+      // no-op
+    }
+  }
+
+  /**
+   * Class which has {@link AuthEnforce} annotation with same name in {@link QueryParam} and {@link PathParam}
+   */
+  public class SameQueryAndPathParam {
+
+    @AuthEnforce(entities = "wrongType", enforceOn = StreamId.class, actions = {Action.ADMIN, Action.READ})
+    public void testDuplicationAnnotationWithSameName(@QueryParam("name") String s1, @PathParam("name") String s2)
+            throws Exception {
+      // no-op
+    }
+  }
+
+  /**
+   * Class which has {@link AuthEnforce} annotation with invalid multiple parts
+   */
+  public class LessMultipleParts {
+
+    @AuthEnforce(entities = {"namespace"}, enforceOn = StreamId.class, actions = Action.ADMIN)
+    public void testLessMultipleParts(@Name("namespace") String namespace) throws Exception {
+      // no-op
+    }
+  }
+
+  /**
+   * Class which has {@link AuthEnforce} annotation with invalid multiple parts
+   */
+  public class MoreMultipleParts {
+
+    @AuthEnforce(entities = {"namespace", "artifact", "version"}, enforceOn = StreamId.class, actions = Action.READ)
+    public void testMoreMultipleParts(@Name("namespace") String namespace, @Name("artifact") String artifact,
+                                      @Name("version") String version) throws Exception {
+      // no-op
+    }
+  }
+
+  /**
+   * Class which has {@link AuthEnforce} annotation with invalid multiple parts
+   */
+  public class MultipleEntityIds {
+
+    @AuthEnforce(entities = {"namespace", "stream"}, enforceOn = StreamId.class, actions = Action.READ)
+    public void testMultipleEntityIds(@Name("namespace") NamespaceId namespace, @Name("artifact") StreamId stream)
+            throws Exception {
+      // no-op
+    }
+  }
+
+  /**
+   * Class which has {@link AuthEnforce} annotation with invalid enforce on
+   */
+  public class InvalidAuthEnforceEntityType {
+
+    @AuthEnforce(entities = {"schedule"}, enforceOn = ScheduleId.class, actions = Action.READ)
+    public void testInvalidEnforceOn(@Name("schedule") ScheduleId scheduleId) throws Exception {
+      // no-op
+    }
+  }
+
+  /**
    * Class which has {@link AuthEnforce} annotation without an invalid {@link Name} annotated parameter than the one
    * specified in {@link AuthEnforce#entities()}
    */
@@ -153,7 +288,7 @@ public class DummyAuthEnforce {
   public class DuplicateEntityName {
 
     @AuthEnforce(entities = "duplicateName", enforceOn = NamespaceId.class, actions = {Action.ADMIN, Action.READ})
-    public void testDuplicatEntityName(@Name("duplicateName") NamespaceId namespaceId,
+    public void testDuplicateEntityName(@Name("duplicateName") NamespaceId namespaceId,
                                        @Name("duplicateName") NamespaceId anotherNamespaceId) throws Exception {
       // no-op
     }

--- a/cdap-security/src/test/java/co/cask/cdap/security/authorization/DummyAuthEnforce.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/authorization/DummyAuthEnforce.java
@@ -178,6 +178,17 @@ public class DummyAuthEnforce {
   }
 
   /**
+   * Class which has {@link AuthEnforce} annotation without a blank {@link Name} annotated parameter
+   */
+  public class BlankEntityName {
+
+    @AuthEnforce(entities = "", enforceOn = NamespaceId.class, actions = {Action.ADMIN, Action.READ})
+    public void testBlankEntityName(@Name("") NamespaceId namespaceId) throws Exception {
+      // no-op
+    }
+  }
+
+  /**
    * Class which has {@link AuthEnforce} annotation and parameter annotated with invalid annotation {@link Named}
    */
   public class InvalidParameterAnnotationType {
@@ -203,7 +214,7 @@ public class DummyAuthEnforce {
   /**
    * Class which has {@link AuthEnforce} annotation have multiple parts which is not only string type
    */
-  public class EntitytWithString {
+  public class EntityWithString {
 
     @AuthEnforce(entities = {"entity", "string"}, enforceOn = StreamId.class, actions = {Action.ADMIN, Action.READ})
     public void testEntityAndString(@Name("entity") NamespaceId p1, @Name("string") String p2)


### PR DESCRIPTION
Opened PR https://github.com/caskdata/cdap/pull/7281 against develop.

Added support for: 
- Multiple parts in AuthEnforce annotation
- QueryParam and PathParam in AuthEnforce annotation. 

Pending:
- Support for enforcement on parent entity: Will come in another PR.

Build: http://builds.cask.co/browse/CDAP-DUT5587-1
ITM: http://builds.cask.co/browse/CDAP-ITM-117