### PR TITLE
Remove all "till" references that should be "until".

### DIFF
--- a/cdap-api-spark/src/main/scala/co/cask/cdap/api/spark/SparkExecutionContext.scala
+++ b/cdap-api-spark/src/main/scala/co/cask/cdap/api/spark/SparkExecutionContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -210,7 +210,7 @@ trait SparkExecutionContext extends RuntimeContext with Transactional {
     * @param startTime the starting time of the stream to be read in milliseconds (inclusive);
     *                  default is 0, which means reading from beginning of the stream.
     * @param endTime the ending time of the streams to be read in milliseconds (exclusive);
-    *                default is [[scala.Long.MaxValue]], which means reading till the last event.
+    *                default is [[scala.Long.MaxValue]], which means reading until the last event.
     * @tparam T value type
     * @return a new [[org.apache.spark.rdd.RDD]] instance that reads from the given stream.
     * @throws co.cask.cdap.api.data.DatasetInstantiationException if the stream doesn't exist
@@ -234,7 +234,7 @@ trait SparkExecutionContext extends RuntimeContext with Transactional {
     * @param startTime the starting time of the stream to be read in milliseconds (inclusive);
     *                  default is 0, which means reading from beginning of the stream.
     * @param endTime the ending time of the streams to be read in milliseconds (exclusive);
-    *                default is [[scala.Long.MaxValue]], which means reading till the last event.
+    *                default is [[scala.Long.MaxValue]], which means reading until the last event.
     * @tparam T value type
     * @return a new [[org.apache.spark.rdd.RDD]] instance that reads from the given stream.
     * @throws co.cask.cdap.api.data.DatasetInstantiationException if the stream doesn't exist

--- a/cdap-api-spark/src/main/scala/co/cask/cdap/api/spark/SparkMain.scala
+++ b/cdap-api-spark/src/main/scala/co/cask/cdap/api/spark/SparkMain.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -319,7 +319,7 @@ trait SparkMain extends Serializable {
       * @param startTime the starting time of the stream to be read in milliseconds (inclusive);
       *                  default is 0, which means reading from beginning of the stream.
       * @param endTime the ending time of the streams to be read in milliseconds (exclusive);
-      *                default is [[scala.Long.MaxValue]], which means reading till the last event.
+      *                default is [[scala.Long.MaxValue]], which means reading until the last event.
       * @param sec the [[co.cask.cdap.api.spark.SparkExecutionContext]] of the current execution
       * @param decoder a function to convert a [[co.cask.cdap.api.flow.flowlet.StreamEvent]] to a value of type `T`
       * @tparam T value type
@@ -340,7 +340,7 @@ trait SparkMain extends Serializable {
       * @param startTime the starting time of the stream to be read in milliseconds (inclusive);
       *                  default is 0, which means reading from beginning of the stream.
       * @param endTime the ending time of the streams to be read in milliseconds (exclusive);
-      *                default is [[scala.Long.MaxValue]], which means reading till the last event.
+      *                default is [[scala.Long.MaxValue]], which means reading until the last event.
       * @param sec the [[co.cask.cdap.api.spark.SparkExecutionContext]] of the current execution
       * @param decoder a function to convert a [[co.cask.cdap.api.flow.flowlet.StreamEvent]] to a value of type `T`
       * @tparam T value type

--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -383,7 +383,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     // Resume on already running Workflow should give conflict
     resumeWorkflow(programId, runId, 409);
 
-    // Wait till fork execution in the Workflow starts
+    // Wait  fork execution in the Workflow starts
     while (!(forkedSimpleActionFile.exists() && anotherForkedSimpleActionFile.exists())) {
       TimeUnit.MILLISECONDS.sleep(50);
     }
@@ -553,7 +553,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     // Get the runId for the currently running Workflow
     String runId = getRunIdOfRunningProgram(programId);
 
-    // Wait till first action in the Workflow starts executing
+    // Wait until first action in the Workflow starts executing
     verifyFileExists(Lists.newArrayList(firstFile));
 
     verifyRunningProgramCount(programId, runId, 1);
@@ -582,7 +582,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     // Store the new RunId
     runId = newRunId;
 
-    // Wait till first action in the Workflow starts executing
+    // Wait until first action in the Workflow starts executing
     verifyFileExists(Lists.newArrayList(firstFile));
 
     verifyRunningProgramCount(programId, runId, 1);
@@ -590,7 +590,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     // Signal the first action to continue
     Assert.assertTrue(firstDoneFile.createNewFile());
 
-    // Wait till fork in the Workflow starts executing
+    // Wait until fork in the Workflow starts executing
     verifyFileExists(Lists.newArrayList(branch1File, branch2File));
 
     // Two actions should be running in Workflow as a part of the fork
@@ -599,7 +599,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     // Stop the program while in fork
     stopProgram(programId, 200);
 
-    // Wait till the program stop
+    // Wait until the program stop
     waitState(programId, ProgramStatus.STOPPED.name());
 
     // Current endpoint would return 404
@@ -618,13 +618,13 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     // Restart the run again
     startProgram(programId);
 
-    // Wait till the Workflow is running
+    // Wait until the Workflow is running
     waitState(programId, ProgramStatus.RUNNING.name());
 
     // Store the new RunRecord for the currently running run
     runId = getRunIdOfRunningProgram(programId);
 
-    // Wait till first action in the Workflow starts executing
+    // Wait until first action in the Workflow starts executing
     verifyFileExists(Lists.newArrayList(firstFile));
 
     verifyRunningProgramCount(programId, runId, 1);
@@ -632,7 +632,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     // Signal the first action to continue
     Assert.assertTrue(firstDoneFile.createNewFile());
 
-    // Wait till fork in the Workflow starts executing
+    // Wait until fork in the Workflow starts executing
     verifyFileExists(Lists.newArrayList(branch1File, branch2File));
 
     // Two actions should be running in Workflow as a part of the fork
@@ -1041,7 +1041,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     Assert.assertEquals(404, suspendSchedule(TEST_NAMESPACE1, appName, scheduleName1));
     Assert.assertEquals(404, resumeSchedule(TEST_NAMESPACE1, appName, scheduleName1));
 
-    TimeUnit.SECONDS.sleep(2); //wait till any running jobs just before suspend call completes.
+    TimeUnit.SECONDS.sleep(2); // Wait until any running jobs just before suspend call completes.
   }
 
   @Test
@@ -1070,7 +1070,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
                                   "simple.action.donefile", doneFile.getAbsolutePath());
     startProgram(programId, propertyMap);
 
-    // Wait till the execution of actions in both Workflow runs is started.
+    // Wait until the execution of actions in both Workflow runs is started.
     while (!(instance1File.exists() && instance2File.exists())) {
       TimeUnit.MILLISECONDS.sleep(50);
     }
@@ -1185,7 +1185,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
 
     // Since the number of good records are lesser than the number of bad records,
     // 'else' branch of the condition will get executed.
-    // Wait till the execution of the fork on the else branch starts
+    // Wait until the execution of the fork on the else branch starts
     while (!(elseForkOneActionFile.exists() &&
              elseForkAnotherActionFile.exists() &&
              elseForkThirdActionFile.exists())) {
@@ -1236,7 +1236,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
 
     // Since the number of good records are greater than the number of bad records,
     // 'if' branch of the condition will get executed.
-    // Wait till the execution of the fork on the if branch starts
+    // Wait until the execution of the fork on the 'if' branch starts
     while (!(ifForkOneActionFile.exists() && ifForkAnotherActionFile.exists())) {
       TimeUnit.MILLISECONDS.sleep(50);
     }

--- a/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric-tests/src/test/java/co/cask/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -383,7 +383,7 @@ public class WorkflowHttpHandlerTest  extends AppFabricTestBase {
     // Resume on already running Workflow should give conflict
     resumeWorkflow(programId, runId, 409);
 
-    // Wait  fork execution in the Workflow starts
+    // Wait until fork execution in the Workflow starts
     while (!(forkedSimpleActionFile.exists() && anotherForkedSimpleActionFile.exists())) {
       TimeUnit.MILLISECONDS.sleep(50);
     }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/SandboxConfigurator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/deploy/SandboxConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -130,7 +130,7 @@ public final class SandboxConfigurator implements Configurator {
       return Futures.immediateFailedFuture(e);
     }
 
-    // Start a thread that waits for command execution to complete or till it's cancelled.
+    // Start a thread that waits for command execution to complete or until it's cancelled.
     new Thread() {
       @Override
       public void run() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/AbstractHttpHandlerDelegator.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/service/http/AbstractHttpHandlerDelegator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -125,7 +125,7 @@ public abstract class AbstractHttpHandlerDelegator<T extends HttpServiceHandler>
         final ClassLoader programContextClassLoader = new CombineClassLoader(
           null, ImmutableList.of(contentProducer.getClass().getClassLoader(), getClass().getClassLoader()));
 
-        // Capture the context since we need to keep it till the end of the content producing.
+        // Capture the context since we need to keep it until the end of the content producing.
         // We don't need to worry about double capturing of the context when HttpContentConsumer is used.
         // This is because when HttpContentConsumer is used, the responder constructed here will get closed and this
         // BodyProducerFactory won't be used.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/WorkflowDataset.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/WorkflowDataset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -129,7 +129,7 @@ public class WorkflowDataset extends AbstractDataset {
    *
    * @param id The workflow id
    * @param startTime The start of the time range from where the user wants the statistics
-   * @param endTime The end of the time range till where the user wants the statistics
+   * @param endTime The end of the time range until where the user wants the statistics
    * @param percentiles The list of percentiles that the user wants information on
    * @return A statistics object that provides information about the workflow or null if there are no runs associated
    * with the workflow

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowFailureInForkApp.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/WorkflowFailureInForkApp.java
@@ -106,7 +106,7 @@ public class WorkflowFailureInForkApp extends AbstractApplication {
       //noinspection ResultOfMethodCallIgnored
       file.createNewFile();
 
-      // Wait till the SecondMapReduce program is ready to throw an exception
+      // Wait until the SecondMapReduce program is ready to throw an exception
       file = new File(args.get("wait.file"));
       while (!file.exists()) {
         TimeUnit.MILLISECONDS.sleep(50);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/ConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/ConfiguratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2016 Cask Data, Inc.
+ * Copyright © 2014-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -59,7 +59,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Tests the configurators.
  *
- * NOTE: Till we can build the JAR it's difficult to test other configurators
+ * NOTE: Until we can build the JAR it's difficult to test other configurators
  * {@link co.cask.cdap.internal.app.deploy.InMemoryConfigurator} &
  * {@link co.cask.cdap.internal.app.deploy.SandboxConfigurator}
  */

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/join/Join.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/join/Join.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -90,7 +90,7 @@ public class Join<JOIN_KEY, INPUT_RECORD, OUT> {
   private void getCartesianProduct(List<List<JoinElement<INPUT_RECORD>>> list, int index,
                                    List<JoinElement<INPUT_RECORD>> joinRow,
                                    Set<String> joinRowInputs, Set<String> requiredInputs) throws Exception {
-    // check till the end of the list and emit only if records from all the required inputs are present in joinElements
+    // Check until the end of the list and emit only if records from all the required inputs are present in joinElements
     if (index == list.size() && joinRowInputs.containsAll(requiredInputs)) {
       emitter.emit(joiner.merge(joinKey, joinRow));
       return;

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/join/Join.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/join/Join.java
@@ -90,7 +90,7 @@ public class Join<JOIN_KEY, INPUT_RECORD, OUT> {
   private void getCartesianProduct(List<List<JoinElement<INPUT_RECORD>>> list, int index,
                                    List<JoinElement<INPUT_RECORD>> joinRow,
                                    Set<String> joinRowInputs, Set<String> requiredInputs) throws Exception {
-    // Check until the end of the list and emit only if records from all the required inputs are present in joinElements
+    // Check up to the end of the list and emit only if records from all the required inputs are present in joinElements
     if (index == list.size() && joinRowInputs.containsAll(requiredInputs)) {
       emitter.emit(joiner.merge(joinKey, joinRow));
       return;

--- a/cdap-common/src/main/java/co/cask/cdap/common/ServiceUnavailableException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/ServiceUnavailableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -26,7 +26,7 @@ public class ServiceUnavailableException extends RuntimeException implements Htt
   private final String serviceName;
 
   public ServiceUnavailableException(String serviceName) {
-    super("Service '" + serviceName + "' is not available. Please wait till it is up and running.");
+    super("Service '" + serviceName + "' is not available. Please wait until it is up and running.");
     this.serviceName = serviceName;
   }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/app/RunIds.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/app/RunIds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -45,7 +45,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public final class RunIds {
   private static final Random RANDOM = new Random();
 
-  // Number of 100ns intervals since 15 October 1582 00:00:000000000 till UNIX epoch
+  // Number of 100ns intervals since 15 October 1582 00:00:000000000 until UNIX epoch
   private static final long NUM_100NS_INTERVALS_SINCE_UUID_EPOCH = 0x01b21dd213814000L;
   // Multiplier to convert millisecond into 100ns
   private static final long HUNDRED_NANO_MULTIPLIER = 10000;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/LiveFileReader.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/LiveFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -83,7 +83,7 @@ public abstract class LiveFileReader<T, P> implements FileReader<T, P> {
         // To handle these cases, an extra read is done when a new reader is available but current read
         // gives no event, so that
         // 1. If the writer properly closed the file, by the time we see a new file here, an extra read should be
-        //    able to see events till the end of file, as writer won't create new file before old one is closed.
+        //    able to see events until the end of file, as writer won't create new file before old one is closed.
         // 2. If the writer crashed, an extra read will still yield no event, but that's ok, as no more write will
         //    be happening to the old file.
         eventCount = currentReader.read(events, maxEvents, getReadTimeoutNano(startTime, timeoutNano),

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/LiveFileReader.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/file/LiveFileReader.java
@@ -78,13 +78,14 @@ public abstract class LiveFileReader<T, P> implements FileReader<T, P> {
       }
 
       if (eventCount == 0) {
-        // Not yet EOF. Since next reader is already available, it could either be the reader doesn't see
+        // Not yet EOF. Since the next reader is already available, it could either be the reader doesn't see
         // the last flush from the writer in the read() above or the writer actually crashed.
-        // To handle these cases, an extra read is done when a new reader is available but current read
-        // gives no event, so that
+        // To handle these cases, an extra read is done when a new reader is available but the current read
+        // gives no event, so that:
         // 1. If the writer properly closed the file, by the time we see a new file here, an extra read should be
-        //    able to see events until the end of file, as writer won't create new file before old one is closed.
-        // 2. If the writer crashed, an extra read will still yield no event, but that's ok, as no more write will
+        //    able to see events up to the end of file, as the writer won't create a new file before the old one is
+        //    closed.
+        // 2. If the writer crashed, an extra read will still yield no event, but that's ok, as no more writes will
         //    be happening to the old file.
         eventCount = currentReader.read(events, maxEvents, getReadTimeoutNano(startTime, timeoutNano),
                                         TimeUnit.NANOSECONDS, readFilter);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/AbstractStreamFileConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/AbstractStreamFileConsumer.java
@@ -523,7 +523,7 @@ public abstract class AbstractStreamFileConsumer implements StreamConsumer {
   /**
    * Returns the initial scanned states for the given entry key.
    *
-   * Conceptually scan will perform from the given entry key until the end of entry represented
+   * Conceptually scan will perform from the given entry key up to the end of entry represented
    * by that stream file (i.e. offset = Long.MAX_VALUE) as indicated by the row prefix (row prefix uniquely identify
    * the stream file).
    * However, due to memory limit, scanning is done progressively until it sees an entry with state value

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/AbstractStreamFileConsumer.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/AbstractStreamFileConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -523,7 +523,7 @@ public abstract class AbstractStreamFileConsumer implements StreamConsumer {
   /**
    * Returns the initial scanned states for the given entry key.
    *
-   * Conceptually scan will perform from the given entry key till the end of entry represented
+   * Conceptually scan will perform from the given entry key until the end of entry represented
    * by that stream file (i.e. offset = Long.MAX_VALUE) as indicated by the row prefix (row prefix uniquely identify
    * the stream file).
    * However, due to memory limit, scanning is done progressively until it sees an entry with state value
@@ -546,8 +546,8 @@ public abstract class AbstractStreamFileConsumer implements StreamConsumer {
       entryStates.put(row, rowStates);
     }
 
-    // Scan from the given row till to max file offset
-    // Last 8 bytes are the file offset, make it max value so that it scans till last offset.
+    // Scan from the given row until to max file offset
+    // Last 8 bytes are the file offset, make it max value so that it scans until last offset.
     byte[] stopRow = Arrays.copyOf(row, row.length);
     Bytes.putLong(stopRow, stopRow.length - Longs.BYTES, Long.MAX_VALUE);
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2016 Cask Data, Inc.
+ * Copyright © 2014-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -191,7 +191,7 @@ public class MasterServiceMain extends DaemonMain {
   public static void main(final String[] args) throws Exception {
     ClassLoader classLoader = MainClassLoader.createFromContext();
     if (classLoader == null) {
-      LOG.warn("Failed to create CDAP system ClassLoader. AuthEnforce annotation will not be rewritten");
+      LOG.warn("Failed to create CDAP system ClassLoader. AuthEnforce annotation will not be rewritten.");
       new MasterServiceMain().doMain(args);
     } else {
       Thread.currentThread().setContextClassLoader(classLoader);
@@ -270,7 +270,7 @@ public class MasterServiceMain extends DaemonMain {
    * we want other users to be able to write to the "path" directory,
    * currently only cdap.user has read-write permissions
    * while other users can only read the "{hdfs.namespace}/{path}" dir,
-   * we want to let others to be able to write to "path" directory, till we have a better solution.
+   * we want to let others to be able to write to "path" directory, until we have a better solution.
    */
   private void createDirectory(String path) {
     String hdfsNamespace = cConf.get(Constants.CFG_HDFS_NAMESPACE);

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/submit/DistributedSparkSubmitter.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/submit/DistributedSparkSubmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -92,7 +92,7 @@ public class DistributedSparkSubmitter extends AbstractSparkSubmitter {
   @Override
   protected void triggerShutdown() {
     // Just stop the execution service and block on that.
-    // It will wait till the "completed" call from the Spark driver.
+    // It will wait until the "completed" call from the Spark driver.
     sparkExecutionService.stopAndWait();
   }
 

--- a/cdap-ui/app/cdap/services/WizardStores/ArtifactUpload/ActionCreator.js
+++ b/cdap-ui/app/cdap/services/WizardStores/ArtifactUpload/ActionCreator.js
@@ -32,7 +32,7 @@ const uploadArtifact = () => {
     }
 
     // core-plugins-3.4.0-SNAPSHOT.jar
-    // extracts version from the jar file name. We then get the name of the artifact (that is from the beginning until version beginning)
+    // extracts version from the jar file name. We then get the name of the artifact (that is from the beginning up to version beginning)
     let regExpRule = new RegExp('(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:[.\\-](.*))?$');
     let version = regExpRule.exec(nameWithVersion)[0];
     let name = nameWithVersion.substr(0, nameWithVersion.indexOf(version) -1);

--- a/cdap-ui/app/cdap/services/WizardStores/ArtifactUpload/ActionCreator.js
+++ b/cdap-ui/app/cdap/services/WizardStores/ArtifactUpload/ActionCreator.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -32,7 +32,7 @@ const uploadArtifact = () => {
     }
 
     // core-plugins-3.4.0-SNAPSHOT.jar
-    // extracts version from the jar file name. We then get the name of the artifact (that is from the beginning till version beginning)
+    // extracts version from the jar file name. We then get the name of the artifact (that is from the beginning until version beginning)
     let regExpRule = new RegExp('(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:[.\\-](.*))?$');
     let version = regExpRule.exec(nameWithVersion)[0];
     let name = nameWithVersion.substr(0, nameWithVersion.indexOf(version) -1);

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -125,7 +125,7 @@ function isDescendant(parent, child) {
 
 function getArtifactNameAndVersion (nameWithVersion) {
   // core-plugins-3.4.0-SNAPSHOT.jar
-  // extracts version from the jar file name. We then get the name of the artifact (that is from the beginning till version beginning)
+  // extracts version from the jar file name. We then get the name of the artifact (that is from the beginning until version beginning)
   let regExpRule = new RegExp('(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:[.\\-](.*))?$');
   let version = regExpRule.exec(nameWithVersion)[0];
   let name = nameWithVersion.substr(0, nameWithVersion.indexOf(version) -1);

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -125,7 +125,7 @@ function isDescendant(parent, child) {
 
 function getArtifactNameAndVersion (nameWithVersion) {
   // core-plugins-3.4.0-SNAPSHOT.jar
-  // extracts version from the jar file name. We then get the name of the artifact (that is from the beginning until version beginning)
+  // extracts version from the jar file name. We then get the name of the artifact (that is from the beginning up to version beginning)
   let regExpRule = new RegExp('(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:[.\\-](.*))?$');
   let version = regExpRule.exec(nameWithVersion)[0];
   let name = nameWithVersion.substr(0, nameWithVersion.indexOf(version) -1);

--- a/cdap-ui/app/hydrator/controllers/create/popovers/load-artifact-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/popovers/load-artifact-ctrl.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -40,7 +40,7 @@ angular.module(`${PKG.name}.feature.hydrator`)
     };
     let getArtifactNameAndVersion = (nameWithVersion) => {
       // core-plugins-3.4.0-SNAPSHOT.jar
-      // extracts version from the jar file name. We then get the name of the artifact (that is from the beginning till version beginning)
+      // extracts version from the jar file name. We then get the name of the artifact (that is from the beginning until version beginning)
       let regExpRule = new RegExp('(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:[.\\-](.*))?$');
       let version = regExpRule.exec(nameWithVersion)[0];
       let name = nameWithVersion.substr(0, nameWithVersion.indexOf(version) -1);

--- a/cdap-ui/app/hydrator/controllers/create/popovers/load-artifact-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/popovers/load-artifact-ctrl.js
@@ -40,7 +40,7 @@ angular.module(`${PKG.name}.feature.hydrator`)
     };
     let getArtifactNameAndVersion = (nameWithVersion) => {
       // core-plugins-3.4.0-SNAPSHOT.jar
-      // extracts version from the jar file name. We then get the name of the artifact (that is from the beginning until version beginning)
+      // extracts version from the jar file name. We then get the name of the artifact (that is from the beginning up to version beginning)
       let regExpRule = new RegExp('(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:[.\\-](.*))?$');
       let version = regExpRule.exec(nameWithVersion)[0];
       let name = nameWithVersion.substr(0, nameWithVersion.indexOf(version) -1);

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithServices.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/AppWithServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -238,7 +238,7 @@ public class AppWithServices extends AbstractApplication {
     @Override
     public void run() {
       try {
-        // Run this loop till stop is called.
+        // Run this loop until stop is called.
         while (!workerStopped) {
           getContext().execute(new TxRunnable() {
             @Override

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2016 Cask Data, Inc.
+ * Copyright © 2014-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -708,7 +708,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     runtimeArgs.putAll(additionalParams);
     wfManager.start(runtimeArgs);
 
-    // Wait till custom action in the Workflow is triggered.
+    // Wait until custom action in the Workflow is triggered.
     while (!waitFile.exists()) {
       TimeUnit.MILLISECONDS.sleep(50);
     }
@@ -855,29 +855,29 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
       }
     }, 10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
 
-    //check scheduled state
+    // Check scheduled state
     Assert.assertEquals("SCHEDULED", wfmanager.getSchedule(scheduleName).status(200));
 
-    //check status of non-existent schedule
+    // Check status of non-existent schedule
     Assert.assertEquals("NOT_FOUND", wfmanager.getSchedule("doesnt exist").status(404));
 
-    //suspend the schedule
+    // Suspend the schedule
     wfmanager.getSchedule(scheduleName).suspend();
 
-    //Check that after suspend it goes to "SUSPENDED" state
+    // Check that after suspend it goes to "SUSPENDED" state
     waitForScheduleState(scheduleName, wfmanager, Scheduler.ScheduleState.SUSPENDED);
 
-    // test workflow token while suspended
+    // Test workflow token while suspended
     String pid = history.get(0).getPid();
     WorkflowTokenDetail workflowToken = wfmanager.getToken(pid, WorkflowToken.Scope.SYSTEM, null);
     Assert.assertEquals(0, workflowToken.getTokenData().size());
     workflowToken = wfmanager.getToken(pid, null, null);
     Assert.assertEquals(2, workflowToken.getTokenData().size());
 
-    // wait till workflow finishes execution
+    // Wait until workflow finishes execution
     waitForWorkflowStatus(wfmanager, ProgramRunStatus.COMPLETED);
 
-    // verify workflow token after workflow completion
+    // Verify workflow token after workflow completion
     WorkflowTokenNodeDetail workflowTokenAtNode =
       wfmanager.getTokenAtNode(pid, AppWithSchedule.DummyAction.class.getSimpleName(),
                                WorkflowToken.Scope.USER, "finished");
@@ -905,9 +905,9 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
       out.write(String.format("%s\n", event5));
     }
 
-    // batch upload file containing 10 events
+    // Batch upload file containing 10 events
     batchStream.send(testData, "text/csv");
-    // verify upload
+    // Verify upload
     List<StreamEvent> uploadedEvents = batchStream.getEvents(0, System.currentTimeMillis(), 100);
     Assert.assertEquals(5, uploadedEvents.size());
     Assert.assertEquals(event1, Bytes.toString(uploadedEvents.get(0).getBody()));

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/AvroFileReader.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/AvroFileReader.java
@@ -215,7 +215,7 @@ public class AvroFileReader {
         skipLen = DEFAULT_SKIP_LEN;
       }
 
-      // For open file, endPosition sync marker is unknown so start from file length and read until the actual eof
+      // For open file, endPosition sync marker is unknown so start from file length and read up to the actual EOF
       dataFileReader.sync(length);
       long finalSync = dataFileReader.previousSync();
       logSegment = readToEndSyncPosition(dataFileReader, logFilter, fromTimeMs, -1);
@@ -266,8 +266,8 @@ public class AvroFileReader {
     List<LogEvent> logSegment = new ArrayList<>();
     GenericRecord datum = null;
     long currentSyncPosition = dataFileReader.previousSync();
-    // Read until the end if endSyncPosition is not known (in case of open file)
-    // or read until endSyncPosition has reached
+    // Read up to the end if endSyncPosition is not known (in case of an open file)
+    // or read until endSyncPosition has been reached
     while (dataFileReader.hasNext() && (endSyncPosition == -1 || (currentSyncPosition < endSyncPosition))) {
       datum = dataFileReader.next(datum);
       ILoggingEvent loggingEvent = LoggingEvent.decode(datum);

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/AvroFileReader.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/read/AvroFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2016 Cask Data, Inc.
+ * Copyright © 2014-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -215,7 +215,7 @@ public class AvroFileReader {
         skipLen = DEFAULT_SKIP_LEN;
       }
 
-      // For open file, endPosition sync marker is unknown so start from file length and read till the actual eof
+      // For open file, endPosition sync marker is unknown so start from file length and read until the actual eof
       dataFileReader.sync(length);
       long finalSync = dataFileReader.previousSync();
       logSegment = readToEndSyncPosition(dataFileReader, logFilter, fromTimeMs, -1);
@@ -266,7 +266,7 @@ public class AvroFileReader {
     List<LogEvent> logSegment = new ArrayList<>();
     GenericRecord datum = null;
     long currentSyncPosition = dataFileReader.previousSync();
-    // Read till the end if endSyncPosition is not known (in case of open file)
+    // Read until the end if endSyncPosition is not known (in case of open file)
     // or read until endSyncPosition has reached
     while (dataFileReader.hasNext() && (endSyncPosition == -1 || (currentSyncPosition < endSyncPosition))) {
       datum = dataFileReader.next(datum);

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogWriterPlugin.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/save/KafkaLogWriterPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -233,7 +233,7 @@ public class KafkaLogWriterPlugin extends AbstractKafkaLogProcessor {
 
         // Cannot insert event into message table
         // since there are still maxNumberOfBucketsInTable buckets that need to be processed
-        // sleep for the time duration till event falls in the window
+        // sleep for the time duration until event falls in the window
         LOG.trace("key={}, oldestBucketKey={}, maxNumberOfBucketsInTable={}, buckets={}. Sleeping for {} ms.",
                   firstKey, oldestBucketKey, maxNumberOfBucketsInTable, numBuckets, SLEEP_TIME_MS);
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/FileMetaDataManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/FileMetaDataManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2016 Cask Data, Inc.
+ * Copyright © 2014-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -155,7 +155,7 @@ public final class FileMetaDataManager {
   }
 
   /**
-   * Scans meta data and gathers all the files older than tillTime
+   * Scans meta data and gathers all the files older than untilTime
    *
    * @param startTableKey row key for the scan and column from where scan will be started
    * @param limit batch size for number of columns to be read
@@ -232,12 +232,12 @@ public final class FileMetaDataManager {
   }
 
   /**
-   * Deletes meta data until a given time, while keeping the latest meta data even if less than tillTime.
-   * @param tillTime time till the meta data will be deleted.
+   * Deletes meta data until a given time, while keeping the latest meta data even if less than untilTime.
+   * @param untilTime time until the meta data will be deleted.
    * @param callback callback called before deleting a meta data column.
    * @return total number of columns deleted.
    */
-  public int cleanMetaData(final long tillTime, final DeleteCallback callback) throws Exception {
+  public int cleanMetaData(final long untilTime, final DeleteCallback callback) throws Exception {
     return execute(new TransactionExecutor.Function<Table, Integer>() {
       @Override
       public Integer apply(Table table) throws Exception {
@@ -274,8 +274,8 @@ public final class FileMetaDataManager {
                   LOG.warn("Log file {} does not exist, but metadata is present", file);
                   table.delete(rowKey, colName);
                   deletedColumns++;
-                } else if (fileLocation.lastModified() < tillTime) {
-                  // Delete if file last modified time is less than tillTime
+                } else if (fileLocation.lastModified() < untilTime) {
+                  // Delete if file last modified time is less than untilTime
                   callback.handle(namespaceId, fileLocation, namespacedLogDir);
                   table.delete(rowKey, colName);
                   deletedColumns++;

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/FileMetaDataManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/FileMetaDataManager.java
@@ -122,6 +122,7 @@ public final class FileMetaDataManager {
 
   /**
    * Returns a list of log files for a logging context.
+   *
    * @param loggingContext logging context.
    * @return Sorted map containing key as start time, and value as log file.
    */
@@ -155,7 +156,7 @@ public final class FileMetaDataManager {
   }
 
   /**
-   * Scans meta data and gathers all the files older than untilTime
+   * Scans meta data and gathers all the files up to a limited number of records.
    *
    * @param startTableKey row key for the scan and column from where scan will be started
    * @param limit batch size for number of columns to be read
@@ -232,7 +233,8 @@ public final class FileMetaDataManager {
   }
 
   /**
-   * Deletes meta data until a given time, while keeping the latest meta data even if less than untilTime.
+   * Deletes meta data until a given time, while keeping the latest meta data even if less than the given time.
+   *
    * @param untilTime time until the meta data will be deleted.
    * @param callback callback called before deleting a meta data column.
    * @return total number of columns deleted.

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/LogCleanup.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/LogCleanup.java
@@ -85,7 +85,7 @@ public final class LogCleanup implements Runnable {
       long untilTime = System.currentTimeMillis() - retentionDurationMs;
       final SetMultimap<String, Location> parentDirs = HashMultimap.create();
       final Map<String, NamespaceId> namespacedLogBaseDirMap = new HashMap<>();
-      fileMetaDataManager.cleanMetaData(tillTime,
+      fileMetaDataManager.cleanMetaData(untilTime,
                                         new FileMetaDataManager.DeleteCallback() {
                                           @Override
                                           public void handle(NamespaceId namespaceId, final Location location,
@@ -102,7 +102,7 @@ public final class LogCleanup implements Runnable {
 
       // clean log files which does not have corresponding meta data
       try {
-        cleanFilesWithoutMeta(tillTime, namespacedLogBaseDirMap, parentDirs,
+        cleanFilesWithoutMeta(untilTime, namespacedLogBaseDirMap, parentDirs,
                               MAX_DISK_FILES_SCANNED, MAX_META_FILES_SCANNED);
       } catch (Exception e) {
         LOG.error("Got exception while cleaning up disk files without meta data", e);

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/write/LogCleanupTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/write/LogCleanupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2016 Cask Data, Inc.
+ * Copyright © 2014-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -425,7 +425,7 @@ public class LogCleanupTest {
     final Map<String, NamespaceId> namespaceIdMap = new HashMap<>();
 
 
-    // Here, we have kept disk scan limit as 15. Since we do not collect files modified after till time, we only have
+    // Here, we have kept disk scan limit as 15. Since we do not collect files modified after "till time", we only have
     // 10 log files with meta and 10 log file without meta. So in worst case 10 + 4, 10 + 4, 10 + 2 we will need 3
     // iterations of cleanFilesWithoutMeta()
     for (int i = 0; i < 3; i++) {

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/write/LogCleanupTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/write/LogCleanupTest.java
@@ -425,7 +425,7 @@ public class LogCleanupTest {
     final Map<String, NamespaceId> namespaceIdMap = new HashMap<>();
 
 
-    // Here, we have kept disk scan limit as 15. Since we do not collect files modified after "till time", we only have
+    // Here, we have kept disk scan limit as 15. Since we do not collect files modified after "untilTime", we only have
     // 10 log files with meta and 10 log file without meta. So in worst case 10 + 4, 10 + 4, 10 + 2 we will need 3
     // iterations of cleanFilesWithoutMeta()
     for (int i = 0; i < 3; i++) {


### PR DESCRIPTION
This all started with a log message that was incorrectly worded, 'till I got rid of all of the "till" usage.

Yes, many are in comments. But if we leave them in, it makes it very hard to make sure they have been weeded out. 