### PR TITLE
Add RetryPolicy to the CDAP API

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/ProgramConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/ProgramConfigurer.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.api;
 
+import co.cask.cdap.api.retry.RetryPolicy;
+
 import java.util.Map;
 
 /**
@@ -44,4 +46,13 @@ public interface ProgramConfigurer {
    * @param properties the properties to set
    */
   void setProperties(Map<String, String> properties);
+
+  /**
+   * Sets the {@link RetryPolicy} to use when a retry-able remote failure is encountered.
+   * If none is set, the configured CDAP default values will be used. Different program types have different
+   * default retry policies. This policy can be overridden by preferences and runtime arguments.
+   *
+   * @param retryPolicy the retry policy to set
+   */
+  void setRemoteRetryPolicy(RetryPolicy retryPolicy);
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/customaction/CustomActionConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/customaction/CustomActionConfigurer.java
@@ -16,34 +16,13 @@
 
 package co.cask.cdap.api.customaction;
 
+import co.cask.cdap.api.ProgramConfigurer;
 import co.cask.cdap.api.plugin.PluginConfigurer;
 import co.cask.cdap.api.workflow.Workflow;
-
-import java.util.Map;
 
 /**
  * Configurer for configuring the {@link CustomAction} in the {@link Workflow}.
  */
-public interface CustomActionConfigurer extends PluginConfigurer {
+public interface CustomActionConfigurer extends PluginConfigurer, ProgramConfigurer {
 
-  /**
-   * Sets the name of the {@link CustomAction}.
-   *
-   * @param name name of the CustomAction
-   */
-  void setName(String name);
-
-  /**
-   * Sets the description of the {@link CustomAction}.
-   *
-   * @param description description of the CustomAction
-   */
-  void setDescription(String description);
-
-  /**
-   * Sets a map of properties that will be available through {@link CustomActionSpecification} at runtime.
-   *
-   * @param properties properties
-   */
-  void setProperties(Map<String, String> properties);
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/customaction/CustomActionSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/customaction/CustomActionSpecification.java
@@ -17,9 +17,11 @@ package co.cask.cdap.api.customaction;
 
 import co.cask.cdap.api.common.PropertyProvider;
 import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.retry.RetryPolicy;
 import co.cask.cdap.api.workflow.Workflow;
 
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Specification for the custom java code that will be executed as a part of {@link Workflow}.
@@ -44,4 +46,10 @@ public interface CustomActionSpecification extends PropertyProvider {
    * @return an immutable set of {@link Dataset} name that are used by the {@link CustomAction}
    */
   Set<String> getDatasets();
+
+  /**
+   * @return RetryPolicy for remote calls or {@code null} if the CDAP default should be used.
+   */
+  @Nullable
+  RetryPolicy getRemoteRetryPolicy();
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/mapreduce/MapReduceSpecification.java
@@ -19,6 +19,7 @@ package co.cask.cdap.api.mapreduce;
 import co.cask.cdap.api.ProgramSpecification;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.common.PropertyProvider;
+import co.cask.cdap.api.retry.RetryPolicy;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,11 +43,13 @@ public class MapReduceSpecification implements ProgramSpecification, PropertyPro
   private final Resources driverResources;
   private final Resources mapperResources;
   private final Resources reducerResources;
+  private final RetryPolicy remoteRetryPolicy;
 
   public MapReduceSpecification(String className, String name, String description, String inputDataSet,
                                 String outputDataSet, Set<String> dataSets, Map<String, String> properties,
                                 @Nullable Resources driverResources,
-                                @Nullable Resources mapperResources, @Nullable Resources reducerResources) {
+                                @Nullable Resources mapperResources, @Nullable Resources reducerResources,
+                                @Nullable RetryPolicy remoteRetryPolicy) {
     this.className = className;
     this.name = name;
     this.description = description;
@@ -58,6 +61,7 @@ public class MapReduceSpecification implements ProgramSpecification, PropertyPro
     this.mapperResources = mapperResources;
     this.reducerResources = reducerResources;
     this.dataSets = getAllDatasets(dataSets, inputDataSet, outputDataSet);
+    this.remoteRetryPolicy = remoteRetryPolicy;
   }
 
   @Override
@@ -133,6 +137,14 @@ public class MapReduceSpecification implements ProgramSpecification, PropertyPro
   @Nullable
   public Resources getReducerResources() {
     return reducerResources;
+  }
+
+  /**
+   * @return RetryPolicy for remote calls or {@code null} if the CDAP default should be used.
+   */
+  @Nullable
+  public RetryPolicy getRemoteRetryPolicy() {
+    return remoteRetryPolicy;
   }
 
   private Set<String> getAllDatasets(Set<String> dataSets, String inputDataSet, String outputDataSet) {

--- a/cdap-api/src/main/java/co/cask/cdap/api/retry/RetryPolicy.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/retry/RetryPolicy.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.retry;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Defines retry behavior when CDAP encounters an error during a retry-able operation.
+ * Users should use the {@link #builder()} to create a RetryPolicy.
+ */
+public class RetryPolicy {
+  public static final RetryPolicy NONE = new RetryPolicy(Type.NONE, null, null, null);
+  private final Type type;
+  private final Long baseDelay;
+  private final Long maxDelay;
+  private final Long timeout;
+
+  /**
+   * Types of retry policies.
+   */
+  public enum Type {
+    NONE,
+    FIXED_DELAY,
+    EXPONENTIAL_BACKOFF
+  }
+
+  private RetryPolicy(@Nullable Type type, @Nullable Long timeout,
+                      @Nullable Long baseDelay, @Nullable Long maxDelay) {
+    this.type = type;
+    this.timeout = timeout;
+    this.baseDelay = baseDelay;
+    this.maxDelay = maxDelay;
+  }
+
+  /**
+   * @return the type of retry policy or null if the configured CDAP default should be used at runtime.
+   */
+  @Nullable
+  public Type getType() {
+    return type;
+  }
+
+  /**
+   * @return the initial delay between retries in milliseconds
+   * or null if the configured CDAP default should be used at runtime.
+   */
+  @Nullable
+  public Long getBaseDelay() {
+    return baseDelay;
+  }
+
+  /**
+   * @return the maximum delay between retries in milliseconds
+   * or null if the configured CDAP default should be used at runtime.
+   */
+  @Nullable
+  public Long getMaxDelay() {
+    return maxDelay;
+  }
+
+  /**
+   * @return the maximum total time in milliseconds to retry before failing
+   * or null if the configured CDAP default should be used at runtime.
+   */
+  @Nullable
+  public Long getTimeout() {
+    return timeout;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    RetryPolicy that = (RetryPolicy) o;
+
+    return type == that.type &&
+      Objects.equals(baseDelay, that.baseDelay) &&
+      Objects.equals(maxDelay, that.maxDelay) &&
+      Objects.equals(timeout, that.timeout);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, baseDelay, maxDelay, timeout);
+  }
+
+  @Override
+  public String toString() {
+    return "RetryPolicy{" +
+      "type=" + type +
+      ", initialDelay=" + baseDelay +
+      ", maxDelay=" + maxDelay +
+      ", timeout=" + timeout +
+      '}';
+  }
+
+  /**
+   * @return a builder to create a retry policy using the configured CDAP default backoff type.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Builds a RetryPolicy.
+   */
+  public static class Builder {
+    protected Type type;
+    protected Long baseDelay;
+    protected Long maxDelay;
+    protected Long timeout;
+
+    /**
+     * Set the type of retry policy. If none is given, the configured CDAP default will be used at runtime.
+     *
+     * @param type the type of retry policy
+     * @return this builder
+     */
+    public Builder setType(Type type) {
+      return this;
+    }
+
+    /**
+     * Set the initial delay between retries. If none is given, the configured CDAP default will be used at runtime.
+     *
+     * @param duration initial delay between retries
+     * @param timeUnit time unit of the duration. Must be in milliseconds or greater
+     * @return this builder
+     */
+    public Builder setBaseDelay(long duration, TimeUnit timeUnit) {
+      validateDuration("baseDelay", duration, timeUnit);
+      baseDelay = TimeUnit.MILLISECONDS.convert(duration, timeUnit);
+      return this;
+    }
+
+    /**
+     * Set the maximum delay between retries.
+     * If none is given, the configured CDAP default will be used at runtime. Has no effect if the backoff
+     * is {@link Type#FIXED_DELAY}.
+     *
+     * @param duration maximum delay between retries
+     * @param timeUnit time unit of the duration. Must be in milliseconds or greater
+     * @return this builder
+     */
+    public Builder setMaxDelay(long duration, TimeUnit timeUnit) {
+      validateDuration("maxDelay", duration, timeUnit);
+      maxDelay = TimeUnit.MILLISECONDS.convert(duration, timeUnit);
+      return this;
+    }
+
+    /**
+     * Set the amount of time to retry before failing.
+     * If none is given, the configured CDAP default will be used at runtime.
+     *
+     * @param duration amount of time to retry before failing
+     * @param timeUnit time unit of the duration. Must be in milliseconds or greater
+     * @return this builder
+     */
+    public Builder setTimeout(long duration, TimeUnit timeUnit) {
+      validateDuration("timeout", duration, timeUnit);
+      timeout = TimeUnit.MILLISECONDS.convert(duration, timeUnit);
+      return this;
+    }
+
+    protected void validateDuration(String property, long duration, TimeUnit timeUnit) {
+      if (duration <= 0) {
+        throw new IllegalArgumentException(
+          String.format("Invalid %s of %d. %s must be a positive number.", property, duration, property));
+      }
+      if (timeUnit == TimeUnit.MICROSECONDS || timeUnit == TimeUnit.NANOSECONDS) {
+        throw new IllegalArgumentException(
+          String.format("Invalid time unit for %s of %s. Time units must be milliseconds or greater",
+                        property, timeUnit));
+      }
+    }
+
+    public RetryPolicy build() {
+      // perform some sanity checks
+
+      // the max delay should not be less than the initial delay
+      if (maxDelay != null && baseDelay != null && maxDelay < baseDelay) {
+        throw new IllegalArgumentException(String.format(
+          "Invalid max (%d) and base (%d) delays. Max delay must be greater than or equal to initial delay.",
+          maxDelay, baseDelay));
+      }
+
+      if (timeout != null && baseDelay != null && timeout < baseDelay) {
+        throw new IllegalArgumentException(String.format(
+          "Invalid initial delay (%d) and timeout (%d). The timeout must be greater than or equal to initial delay.",
+          baseDelay, timeout));
+      }
+
+      return new RetryPolicy(type, timeout, baseDelay, maxDelay);
+    }
+  }
+
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceConfigurer.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceConfigurer.java
@@ -18,6 +18,7 @@ package co.cask.cdap.api.service.http;
 
 import co.cask.cdap.api.DatasetConfigurer;
 import co.cask.cdap.api.plugin.PluginConfigurer;
+import co.cask.cdap.api.retry.RetryPolicy;
 
 import java.util.Map;
 
@@ -33,4 +34,14 @@ public interface HttpServiceConfigurer extends DatasetConfigurer, PluginConfigur
    * @param properties the properties to set
    */
   void setProperties(Map<String, String> properties);
+
+  /**
+   * Sets the {@link RetryPolicy} to use when a retry-able remote failure is encountered.
+   * If none is set, the configured CDAP default values will be used.
+   * This policy can be overridden by preferences and runtime arguments.
+   * Individual service endpoints can override this retry policy through the RetryPolicy annotation.
+   *
+   * @param retryPolicy the retry policy to set
+   */
+  void setRemoteRetryPolicy(RetryPolicy retryPolicy);
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceHandlerSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/service/http/HttpServiceHandlerSpecification.java
@@ -19,6 +19,7 @@ package co.cask.cdap.api.service.http;
 import co.cask.cdap.api.ProgramSpecification;
 import co.cask.cdap.api.common.PropertyProvider;
 import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.retry.RetryPolicy;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -27,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Specification for a {@link HttpServiceHandler}.
@@ -39,19 +41,22 @@ public final class HttpServiceHandlerSpecification implements PropertyProvider, 
   private final Map<String, String> properties;
   private final Set<String> datasets;
   private final List<ServiceHttpEndpoint> endpoints;
+  private final RetryPolicy remoteRetryPolicy;
 
   /**
    * Create an instance of {@link HttpServiceHandlerSpecification}.
    */
   public HttpServiceHandlerSpecification(String className, String name,
                                          String description, Map<String, String> properties,
-                                         Set<String> datasets, List<ServiceHttpEndpoint> endpoints) {
+                                         Set<String> datasets, List<ServiceHttpEndpoint> endpoints,
+                                         RetryPolicy remoteRetryPolicy) {
     this.className = className;
     this.name = name;
     this.description = description;
     this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
     this.datasets = Collections.unmodifiableSet(new HashSet<>(datasets));
     this.endpoints = Collections.unmodifiableList(new ArrayList<>(endpoints));
+    this.remoteRetryPolicy = remoteRetryPolicy;
   }
 
   /**
@@ -107,5 +112,13 @@ public final class HttpServiceHandlerSpecification implements PropertyProvider, 
    */
   public List<ServiceHttpEndpoint> getEndpoints() {
     return endpoints;
+  }
+
+  /**
+   * @return RetryPolicy for remote calls or {@code null} if the CDAP default should be used.
+   */
+  @Nullable
+  public RetryPolicy getRemoteRetryPolicy() {
+    return remoteRetryPolicy;
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/spark/SparkSpecification.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.ProgramSpecification;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.common.PropertyProvider;
+import co.cask.cdap.api.retry.RetryPolicy;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -43,12 +44,14 @@ public final class SparkSpecification implements ProgramSpecification, PropertyP
   private final Resources clientResources;
   private final Resources driverResources;
   private final Resources executorResources;
+  private final RetryPolicy remoteRetryPolicy;
 
   public SparkSpecification(String className, String name, String description,
                             String mainClassName, Set<String> datasets, Map<String, String> properties,
                             @Nullable Resources clientResources,
                             @Nullable Resources driverResources,
-                            @Nullable Resources executorResources) {
+                            @Nullable Resources executorResources,
+                            @Nullable RetryPolicy remoteRetryPolicy) {
     this.className = className;
     this.name = name;
     this.description = description;
@@ -58,6 +61,7 @@ public final class SparkSpecification implements ProgramSpecification, PropertyP
     this.clientResources = clientResources;
     this.driverResources = driverResources;
     this.executorResources = executorResources;
+    this.remoteRetryPolicy = remoteRetryPolicy;
   }
 
   @Override
@@ -121,5 +125,13 @@ public final class SparkSpecification implements ProgramSpecification, PropertyP
   @Nullable
   public Resources getExecutorResources() {
     return executorResources;
+  }
+
+  /**
+   * @return RetryPolicy for remote calls or {@code null} if the CDAP default should be used.
+   */
+  @Nullable
+  public RetryPolicy getRemoteRetryPolicy() {
+    return remoteRetryPolicy;
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/worker/WorkerSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/worker/WorkerSpecification.java
@@ -20,12 +20,14 @@ import co.cask.cdap.api.ProgramSpecification;
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.common.PropertyProvider;
 import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.retry.RetryPolicy;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Specification for {@link Worker}s.
@@ -38,9 +40,11 @@ public final class WorkerSpecification implements ProgramSpecification, Property
   private final Set<String> datasets;
   private final Resources resources;
   private final int instances;
+  private final RetryPolicy remoteRetryPolicy;
 
   public WorkerSpecification(String className, String name, String description, Map<String, String> properties,
-                             Set<String> datasets, Resources resources, int instances) {
+                             Set<String> datasets, Resources resources, int instances,
+                             @Nullable RetryPolicy remoteRetryPolicy) {
     this.className = className;
     this.name = name;
     this.description = description;
@@ -48,6 +52,7 @@ public final class WorkerSpecification implements ProgramSpecification, Property
     this.datasets = Collections.unmodifiableSet(new HashSet<>(datasets));
     this.resources = resources;
     this.instances = instances;
+    this.remoteRetryPolicy = remoteRetryPolicy;
   }
 
   @Override
@@ -94,5 +99,13 @@ public final class WorkerSpecification implements ProgramSpecification, Property
    */
   public int getInstances() {
     return instances;
+  }
+
+  /**
+   * @return RetryPolicy for remote calls or {@code null} if the CDAP default should be used.
+   */
+  @Nullable
+  public RetryPolicy getRemoteRetryPolicy() {
+    return remoteRetryPolicy;
   }
 }

--- a/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/workflow/WorkflowSpecification.java
@@ -17,6 +17,7 @@ package co.cask.cdap.api.workflow;
 
 import co.cask.cdap.api.ProgramSpecification;
 import co.cask.cdap.api.common.PropertyProvider;
+import co.cask.cdap.api.retry.RetryPolicy;
 import co.cask.cdap.internal.dataset.DatasetCreationSpec;
 
 import java.util.ArrayList;
@@ -26,6 +27,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import javax.annotation.Nullable;
 
 /**
  * Specification for a {@link Workflow}
@@ -38,10 +40,12 @@ public final class WorkflowSpecification implements ProgramSpecification, Proper
   private final List<WorkflowNode> nodes;
   private final Map<String, WorkflowNode> nodeIdMap;
   private final Map<String, DatasetCreationSpec> localDatasetSpecs;
+  private final RetryPolicy remoteRetryPolicy;
 
   public WorkflowSpecification(String className, String name, String description,
                                Map<String, String> properties, List<WorkflowNode> nodes,
-                               Map<String, DatasetCreationSpec> localDatasetSpecs) {
+                               Map<String, DatasetCreationSpec> localDatasetSpecs,
+                               @Nullable RetryPolicy remoteRetryPolicy) {
     this.className = className;
     this.name = name;
     this.description = description;
@@ -50,6 +54,7 @@ public final class WorkflowSpecification implements ProgramSpecification, Proper
     this.nodes = Collections.unmodifiableList(new ArrayList<>(nodes));
     this.nodeIdMap = Collections.unmodifiableMap(generateNodeIdMap(nodes));
     this.localDatasetSpecs = Collections.unmodifiableMap(new HashMap<>(localDatasetSpecs));
+    this.remoteRetryPolicy = remoteRetryPolicy;
   }
 
   /**
@@ -128,6 +133,14 @@ public final class WorkflowSpecification implements ProgramSpecification, Proper
    */
   public Map<String, DatasetCreationSpec> getLocalDatasetSpecs() {
     return localDatasetSpecs;
+  }
+
+  /**
+   * @return RetryPolicy for remote calls or {@code null} if the CDAP default should be used.
+   */
+  @Nullable
+  public RetryPolicy getRemoteRetryPolicy() {
+    return remoteRetryPolicy;
   }
 
   @Override

--- a/cdap-api/src/main/java/co/cask/cdap/internal/customaction/DefaultCustomActionSpecification.java
+++ b/cdap-api/src/main/java/co/cask/cdap/internal/customaction/DefaultCustomActionSpecification.java
@@ -17,12 +17,14 @@ package co.cask.cdap.internal.customaction;
 
 import co.cask.cdap.api.customaction.CustomActionConfigurer;
 import co.cask.cdap.api.customaction.CustomActionSpecification;
+import co.cask.cdap.api.retry.RetryPolicy;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * The default implementation for a {@link CustomActionSpecification}.
@@ -34,17 +36,20 @@ public class DefaultCustomActionSpecification implements CustomActionSpecificati
   private final String description;
   private final Map<String, String> properties;
   private final Set<String> datasets;
+  private final RetryPolicy remoteRetryPolicy;
 
   /**
    * Constructor used by {@link CustomActionConfigurer}.
    */
   public DefaultCustomActionSpecification(String className, String name, String description,
-                                          Map<String, String> properties, Set<String> datasets) {
+                                          Map<String, String> properties, Set<String> datasets,
+                                          RetryPolicy remoteRetryPolicy) {
     this.className = className;
     this.name = name;
     this.description = description;
     this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
     this.datasets = Collections.unmodifiableSet(new HashSet<>(datasets));
+    this.remoteRetryPolicy = remoteRetryPolicy;
   }
 
   @Override
@@ -65,6 +70,12 @@ public class DefaultCustomActionSpecification implements CustomActionSpecificati
   @Override
   public Set<String> getDatasets() {
     return datasets;
+  }
+
+  @Nullable
+  @Override
+  public RetryPolicy getRemoteRetryPolicy() {
+    return remoteRetryPolicy;
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ServiceSpecificationCodec.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/ServiceSpecificationCodec.java
@@ -120,7 +120,8 @@ public class ServiceSpecificationCodec extends AbstractSpecificationCodec<Servic
                                                        spec.get("name").getAsString(),
                                                        spec.get("description").getAsString(),
                                                        properties, ImmutableSet.<String>of(),
-                                                       ImmutableList.<ServiceHttpEndpoint>of()));
+                                                       ImmutableList.<ServiceHttpEndpoint>of(),
+                                                       null));
     }
 
     ResourceSpecification resourceSpec = handlerSpec.getResourceSpecification();

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/customaction/DefaultCustomActionConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/customaction/DefaultCustomActionConfigurer.java
@@ -18,6 +18,7 @@ package co.cask.cdap.internal.app.customaction;
 import co.cask.cdap.api.customaction.CustomAction;
 import co.cask.cdap.api.customaction.CustomActionConfigurer;
 import co.cask.cdap.api.customaction.CustomActionSpecification;
+import co.cask.cdap.api.retry.RetryPolicy;
 import co.cask.cdap.internal.app.DefaultPluginConfigurer;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
@@ -44,6 +45,7 @@ public final class DefaultCustomActionConfigurer extends DefaultPluginConfigurer
   private String name;
   private String description;
   private Map<String, String> properties;
+  private RetryPolicy remoteRetryPolicy;
 
   private DefaultCustomActionConfigurer(CustomAction customAction, Id.Namespace deployNamespace, Id.Artifact artifactId,
                                        ArtifactRepository artifactRepository, PluginInstantiator pluginInstantiator) {
@@ -72,12 +74,17 @@ public final class DefaultCustomActionConfigurer extends DefaultPluginConfigurer
     this.properties = new HashMap<>(properties);
   }
 
+  @Override
+  public void setRemoteRetryPolicy(RetryPolicy retryPolicy) {
+    remoteRetryPolicy = retryPolicy;
+  }
+
   private DefaultCustomActionSpecification createSpecification() {
     Set<String> datasets = new HashSet<>();
     Reflections.visit(customAction, customAction.getClass(), new PropertyFieldExtractor(properties),
                       new DataSetFieldExtractor(datasets));
     return new DefaultCustomActionSpecification(customAction.getClass().getName(), name,
-                                                description, properties, datasets);
+                                                description, properties, datasets, remoteRetryPolicy);
   }
 
   public static CustomActionSpecification configureAction(CustomAction action, Id.Namespace deployNamespace,

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/mapreduce/DefaultMapReduceConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/mapreduce/DefaultMapReduceConfigurer.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.mapreduce.MapReduce;
 import co.cask.cdap.api.mapreduce.MapReduceConfigurer;
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
+import co.cask.cdap.api.retry.RetryPolicy;
 import co.cask.cdap.internal.app.DefaultPluginConfigurer;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import co.cask.cdap.internal.app.runtime.plugin.PluginInstantiator;
@@ -47,6 +48,7 @@ public final class DefaultMapReduceConfigurer extends DefaultPluginConfigurer im
   private Resources driverResources;
   private Resources mapperResources;
   private Resources reducerResources;
+  private RetryPolicy remoteRetryPolicy;
 
   public DefaultMapReduceConfigurer(MapReduce mapReduce, Id.Namespace deployNamespace, Id.Artifact artifactId,
                                     ArtifactRepository artifactRepository,
@@ -74,6 +76,11 @@ public final class DefaultMapReduceConfigurer extends DefaultPluginConfigurer im
   }
 
   @Override
+  public void setRemoteRetryPolicy(RetryPolicy retryPolicy) {
+    remoteRetryPolicy = retryPolicy;
+  }
+
+  @Override
   public void setDriverResources(Resources resources) {
     this.driverResources = resources;
   }
@@ -94,6 +101,7 @@ public final class DefaultMapReduceConfigurer extends DefaultPluginConfigurer im
                       new DataSetFieldExtractor(datasets));
     return new MapReduceSpecification(mapReduce.getClass().getName(), name, description,
                                       inputDataset, outputDataset, datasets,
-                                      properties, driverResources, mapperResources, reducerResources);
+                                      properties, driverResources, mapperResources, reducerResources,
+                                      remoteRetryPolicy);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
@@ -94,7 +94,8 @@ public class DistributedWorkerProgramRunner extends AbstractDistributedProgramRu
     WorkerSpecification newWorkerSpec = new WorkerSpecification(workerSpec.getClassName(), workerSpec.getName(),
                                                                 workerSpec.getDescription(), workerSpec.getProperties(),
                                                                 workerSpec.getDatasets(), newResources,
-                                                                Integer.valueOf(instances));
+                                                                Integer.valueOf(instances),
+                                                                workerSpec.getRemoteRetryPolicy());
 
     RunId runId = ProgramRunners.getRunId(options);
     LOG.info("Launching distributed worker {}", program.getId().run(runId));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/InMemoryWorkerRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/InMemoryWorkerRunner.java
@@ -71,7 +71,8 @@ public class InMemoryWorkerRunner extends AbstractInMemoryProgramRunner {
     WorkerSpecification newWorkerSpec = new WorkerSpecification(workerSpec.getClassName(), workerSpec.getName(),
                                                                 workerSpec.getDescription(), workerSpec.getProperties(),
                                                                 workerSpec.getDatasets(), newResources,
-                                                                Integer.valueOf(instances));
+                                                                Integer.valueOf(instances),
+                                                                workerSpec.getRemoteRetryPolicy());
 
     //RunId for worker
     RunId runId = ProgramRunners.getRunId(options);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
@@ -112,7 +112,8 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
     WorkerSpecification newWorkerSpec = new WorkerSpecification(workerSpec.getClassName(), workerSpec.getName(),
                                                                 workerSpec.getDescription(), workerSpec.getProperties(),
                                                                 workerSpec.getDatasets(), newResources,
-                                                                Integer.valueOf(instances));
+                                                                Integer.valueOf(instances),
+                                                                workerSpec.getRemoteRetryPolicy());
 
     // Setup dataset framework context, if required
     if (datasetFramework instanceof ProgramContextAware) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultHttpServiceHandlerConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/DefaultHttpServiceHandlerConfigurer.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.internal.app.services;
 
+import co.cask.cdap.api.retry.RetryPolicy;
 import co.cask.cdap.api.service.http.HttpServiceConfigurer;
 import co.cask.cdap.api.service.http.HttpServiceHandler;
 import co.cask.cdap.api.service.http.HttpServiceHandlerSpecification;
@@ -44,6 +45,7 @@ public class DefaultHttpServiceHandlerConfigurer extends DefaultPluginConfigurer
   private final String name;
   private Map<String, String> properties;
   private Set<String> datasets;
+  private RetryPolicy remoteRetryPolicy;
 
   /**
    * Instantiates the class with the given {@link HttpServiceHandler}.
@@ -73,6 +75,11 @@ public class DefaultHttpServiceHandlerConfigurer extends DefaultPluginConfigurer
     this.properties = new HashMap<>(properties);
   }
 
+  @Override
+  public void setRemoteRetryPolicy(RetryPolicy retryPolicy) {
+    remoteRetryPolicy = retryPolicy;
+  }
+
   /**
    * Creates a {@link HttpServiceHandlerSpecification} from the parameters stored in this class.
    *
@@ -86,6 +93,7 @@ public class DefaultHttpServiceHandlerConfigurer extends DefaultPluginConfigurer
                       new PropertyFieldExtractor(properties),
                       new ServiceEndpointExtractor(endpoints));
 
-    return new HttpServiceHandlerSpecification(handler.getClass().getName(), name, "", properties, datasets, endpoints);
+    return new HttpServiceHandlerSpecification(handler.getClass().getName(), name, "", properties, datasets, endpoints,
+                                               remoteRetryPolicy);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/spark/DefaultSparkConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/spark/DefaultSparkConfigurer.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app.spark;
 
 import co.cask.cdap.api.Resources;
+import co.cask.cdap.api.retry.RetryPolicy;
 import co.cask.cdap.api.spark.Spark;
 import co.cask.cdap.api.spark.SparkConfigurer;
 import co.cask.cdap.api.spark.SparkSpecification;
@@ -47,6 +48,7 @@ public final class DefaultSparkConfigurer extends DefaultPluginConfigurer implem
   private Resources clientResources;
   private Resources driverResources;
   private Resources executorResources;
+  private RetryPolicy remoteRetryPolicy;
 
   public DefaultSparkConfigurer(Spark spark, Id.Namespace deployNamespace, Id.Artifact artifactId,
                                 ArtifactRepository artifactRepository, PluginInstantiator pluginInstantiator) {
@@ -79,6 +81,11 @@ public final class DefaultSparkConfigurer extends DefaultPluginConfigurer implem
   }
 
   @Override
+  public void setRemoteRetryPolicy(RetryPolicy retryPolicy) {
+    remoteRetryPolicy = retryPolicy;
+  }
+
+  @Override
   public void setClientResources(Resources resources) {
     this.clientResources = resources;
   }
@@ -103,6 +110,6 @@ public final class DefaultSparkConfigurer extends DefaultPluginConfigurer implem
                       new DataSetFieldExtractor(datasets));
     return new SparkSpecification(spark.getClass().getName(), name, description,
                                   mainClassName, datasets, properties,
-                                  clientResources, driverResources, executorResources);
+                                  clientResources, driverResources, executorResources, remoteRetryPolicy);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -559,7 +559,8 @@ public class DefaultStore implements Store {
                                                                        workerSpec.getProperties(),
                                                                        workerSpec.getDatasets(),
                                                                        workerSpec.getResources(),
-                                                                       instances);
+                                                                       instances,
+                                                                       workerSpec.getRemoteRetryPolicy());
         ApplicationSpecification newAppSpec = replaceWorkerInAppSpec(appSpec, id, newSpecification);
         metaStore.updateAppSpec(id.getNamespace(), id.getApplication(), id.getVersion(), newAppSpec);
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/worker/DefaultWorkerConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/worker/DefaultWorkerConfigurer.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.internal.app.worker;
 
 import co.cask.cdap.api.Resources;
+import co.cask.cdap.api.retry.RetryPolicy;
 import co.cask.cdap.api.worker.Worker;
 import co.cask.cdap.api.worker.WorkerConfigurer;
 import co.cask.cdap.api.worker.WorkerSpecification;
@@ -45,6 +46,7 @@ public class DefaultWorkerConfigurer extends DefaultPluginConfigurer implements 
   private int instances;
   private Map<String, String> properties;
   private Set<String> datasets;
+  private RetryPolicy remoteRetryPolicy;
 
   public DefaultWorkerConfigurer(Worker worker, Id.Namespace deployNamespace, Id.Artifact artifactId,
                                  ArtifactRepository artifactRepository,
@@ -86,10 +88,15 @@ public class DefaultWorkerConfigurer extends DefaultPluginConfigurer implements 
     this.properties = new HashMap<>(properties);
   }
 
+  @Override
+  public void setRemoteRetryPolicy(RetryPolicy retryPolicy) {
+    remoteRetryPolicy = retryPolicy;
+  }
+
   public WorkerSpecification createSpecification() {
     // Grab all @Property fields
     Reflections.visit(worker, worker.getClass(), new PropertyFieldExtractor(properties));
     return new WorkerSpecification(worker.getClass().getName(), name, description,
-                                   properties, datasets, resource, instances);
+                                   properties, datasets, resource, instances, remoteRetryPolicy);
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConfigurer.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/workflow/DefaultWorkflowConfigurer.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.Predicate;
 import co.cask.cdap.api.customaction.CustomAction;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.retry.RetryPolicy;
 import co.cask.cdap.api.schedule.SchedulableProgramType;
 import co.cask.cdap.api.workflow.Workflow;
 import co.cask.cdap.api.workflow.WorkflowAction;
@@ -63,6 +64,7 @@ public class DefaultWorkflowConfigurer extends DefaultPluginConfigurer
   private String name;
   private String description;
   private Map<String, String> properties;
+  private RetryPolicy remoteRetryPolicy;
 
   public DefaultWorkflowConfigurer(Workflow workflow, DatasetConfigurer datasetConfigurer,
                                    Id.Namespace deployNamespace, Id.Artifact artifactId,
@@ -91,6 +93,11 @@ public class DefaultWorkflowConfigurer extends DefaultPluginConfigurer
   @Override
   public void setProperties(Map<String, String> properties) {
     this.properties = ImmutableMap.copyOf(properties);
+  }
+
+  @Override
+  public void setRemoteRetryPolicy(RetryPolicy retryPolicy) {
+    remoteRetryPolicy = retryPolicy;
   }
 
   @Override
@@ -158,7 +165,7 @@ public class DefaultWorkflowConfigurer extends DefaultPluginConfigurer
 
   public WorkflowSpecification createSpecification() {
     return new WorkflowSpecification(className, name, description, properties, createNodesWithId(nodes),
-                                     localDatasetSpecs);
+                                     localDatasetSpecs, remoteRetryPolicy);
   }
 
   private List<WorkflowNode> createNodesWithId(List<WorkflowNode> nodes) {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/CustomActionSpecificationCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/CustomActionSpecificationCodec.java
@@ -16,6 +16,7 @@
 package co.cask.cdap.proto.codec;
 
 import co.cask.cdap.api.customaction.CustomActionSpecification;
+import co.cask.cdap.api.retry.RetryPolicy;
 import co.cask.cdap.internal.customaction.DefaultCustomActionSpecification;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonElement;
@@ -42,7 +43,8 @@ public class CustomActionSpecificationCodec extends AbstractSpecificationCodec<C
     String description = jsonObj.get("description").getAsString();
     Set<String> datasets = deserializeSet(jsonObj.get("datasets"), context, String.class);
     Map<String, String> properties = deserializeMap(jsonObj.get("properties"), context, String.class);
-    return new DefaultCustomActionSpecification(className, name, description, properties, datasets);
+    RetryPolicy remoteRetryPolicy = context.deserialize(jsonObj.get("remoteRetryPolicy"), RetryPolicy.class);
+    return new DefaultCustomActionSpecification(className, name, description, properties, datasets, remoteRetryPolicy);
   }
 
   @Override
@@ -54,6 +56,7 @@ public class CustomActionSpecificationCodec extends AbstractSpecificationCodec<C
     jsonObj.add("description", new JsonPrimitive(src.getDescription()));
     jsonObj.add("datasets", serializeSet(src.getDatasets(), context, String.class));
     jsonObj.add("properties", serializeMap(src.getProperties(), context, String.class));
+    jsonObj.add("remoteRetryPolicy", context.serialize(src.getRemoteRetryPolicy()));
 
     return jsonObj;
   }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/MapReduceSpecificationCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/MapReduceSpecificationCodec.java
@@ -18,6 +18,7 @@ package co.cask.cdap.proto.codec;
 
 import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.mapreduce.MapReduceSpecification;
+import co.cask.cdap.api.retry.RetryPolicy;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -58,6 +59,7 @@ public final class MapReduceSpecificationCodec extends AbstractSpecificationCode
     }
     jsonObj.add("datasets", serializeSet(src.getDataSets(), context, String.class));
     jsonObj.add("properties", serializeMap(src.getProperties(), context, String.class));
+    jsonObj.add("remoteRetryPolicy", context.serialize(src.getRemoteRetryPolicy()));
 
     return jsonObj;
   }
@@ -80,8 +82,10 @@ public final class MapReduceSpecificationCodec extends AbstractSpecificationCode
 
     Set<String> dataSets = deserializeSet(jsonObj.get("datasets"), context, String.class);
     Map<String, String> properties = deserializeMap(jsonObj.get("properties"), context, String.class);
+    RetryPolicy remoteRetryPolicy = context.deserialize(jsonObj.get("remoteRetryPolicy"), RetryPolicy.class);
     return new MapReduceSpecification(className, name, description, inputDataSet, outputDataSet,
-                                      dataSets, properties, driverResources, mapperResources, reducerResources);
+                                      dataSets, properties, driverResources, mapperResources, reducerResources,
+                                      remoteRetryPolicy);
   }
 
   /**

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/SparkSpecificationCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/SparkSpecificationCodec.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.proto.codec;
 
 import co.cask.cdap.api.Resources;
+import co.cask.cdap.api.retry.RetryPolicy;
 import co.cask.cdap.api.spark.SparkSpecification;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonElement;
@@ -45,6 +46,7 @@ public final class SparkSpecificationCodec extends AbstractSpecificationCodec<Sp
     jsonObj.add("mainClassName", new JsonPrimitive(src.getMainClassName()));
     jsonObj.add("datasets", serializeSet(src.getDatasets(), context, String.class));
     jsonObj.add("properties", serializeMap(src.getProperties(), context, String.class));
+    jsonObj.add("remoteRetryPolicy", context.serialize(src.getRemoteRetryPolicy()));
 
     serializeResources(jsonObj, "client", context, src.getClientResources());
     serializeResources(jsonObj, "driver", context, src.getDriverResources());
@@ -64,13 +66,15 @@ public final class SparkSpecificationCodec extends AbstractSpecificationCodec<Sp
     String mainClassName = jsonObj.get("mainClassName").getAsString();
     Set<String> datasets = deserializeSet(jsonObj.get("datasets"), context, String.class);
     Map<String, String> properties = deserializeMap(jsonObj.get("properties"), context, String.class);
+    RetryPolicy remoteRetryPolicy = context.deserialize(jsonObj.get("remoteRetryPolicy"), RetryPolicy.class);
 
     Resources clientResources = deserializeResources(jsonObj, "client", context);
     Resources driverResources = deserializeResources(jsonObj, "driver", context);
     Resources executorResources = deserializeResources(jsonObj, "executor", context);
 
     return new SparkSpecification(className, name, description, mainClassName,
-                                  datasets, properties, clientResources, driverResources, executorResources);
+                                  datasets, properties, clientResources, driverResources, executorResources,
+                                  remoteRetryPolicy);
   }
 
   /**

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkerSpecificationCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkerSpecificationCodec.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.proto.codec;
 
 import co.cask.cdap.api.Resources;
+import co.cask.cdap.api.retry.RetryPolicy;
 import co.cask.cdap.api.worker.WorkerSpecification;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonElement;
@@ -43,6 +44,7 @@ public final class WorkerSpecificationCodec extends AbstractSpecificationCodec<W
     object.add("resources", context.serialize(spec.getResources(), Resources.class));
     object.add("datasets", serializeSet(spec.getDatasets(), context, String.class));
     object.addProperty("instances", spec.getInstances());
+    object.add("remoteRetryPolicy", context.serialize(spec.getRemoteRetryPolicy()));
     return object;
   }
 
@@ -58,7 +60,9 @@ public final class WorkerSpecificationCodec extends AbstractSpecificationCodec<W
     Resources resources = context.deserialize(jsonObj.get("resources"), Resources.class);
     Set<String> datasets = deserializeSet(jsonObj.get("datasets"), context, String.class);
     int instances = jsonObj.get("instances").getAsInt();
+    RetryPolicy remoteRetryPolicy = context.deserialize(jsonObj.get("remoteRetryPolicy"), RetryPolicy.class);
 
-    return new WorkerSpecification(className, name, description, properties, datasets, resources, instances);
+    return new WorkerSpecification(className, name, description, properties, datasets,
+                                   resources, instances, remoteRetryPolicy);
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkflowSpecificationCodec.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/codec/WorkflowSpecificationCodec.java
@@ -15,6 +15,7 @@
  */
 package co.cask.cdap.proto.codec;
 
+import co.cask.cdap.api.retry.RetryPolicy;
 import co.cask.cdap.api.workflow.WorkflowNode;
 import co.cask.cdap.api.workflow.WorkflowSpecification;
 import co.cask.cdap.internal.dataset.DatasetCreationSpec;
@@ -43,6 +44,7 @@ public final class WorkflowSpecificationCodec extends AbstractSpecificationCodec
     jsonObj.add("properties", serializeMap(src.getProperties(), context, String.class));
     jsonObj.add("nodes", serializeList(src.getNodes(), context, WorkflowNode.class));
     jsonObj.add("localDatasetSpecs", serializeMap(src.getLocalDatasetSpecs(), context, DatasetCreationSpec.class));
+    jsonObj.add("remoteRetryPolicy", context.serialize(src.getRemoteRetryPolicy()));
     return jsonObj;
   }
 
@@ -58,7 +60,9 @@ public final class WorkflowSpecificationCodec extends AbstractSpecificationCodec
     List<WorkflowNode> nodes = deserializeList(jsonObj.get("nodes"), context, WorkflowNode.class);
     Map<String, DatasetCreationSpec> localDatasetSpec = deserializeMap(jsonObj.get("localDatasetSpecs"), context,
                                                                        DatasetCreationSpec.class);
+    RetryPolicy remoteRetryPolicy = context.deserialize(jsonObj.get("remoteRetryPolicy"), RetryPolicy.class);
 
-    return new WorkflowSpecification(className, name, description, properties, nodes, localDatasetSpec);
+    return new WorkflowSpecification(className, name, description, properties,
+                                     nodes, localDatasetSpec, remoteRetryPolicy);
   }
 }


### PR DESCRIPTION
Also adding corresponding methods to set the RetryPolicy in
various program configurers, and methods to get the RetryPolicy
from various program specifications.

This change does not implement the RetryPolicy anywhere. It only
stores it in the application specification for later use.