### PR TITLE
CDAP-8003, 8012 Getting Started Corrections

### DIFF
--- a/cdap-docs/developers-manual/source/conf.py
+++ b/cdap-docs/developers-manual/source/conf.py
@@ -21,16 +21,23 @@ def setup(app):
     app.add_config_value('snapshot_version', '', 'env')
 
 # Set the condition
+archetype_version = "-DarchetypeVersion=%s" % release
 if release.endswith('SNAPSHOT'):
     snapshot_version = True
-    archetype_repository_version = ('-DarchetypeRepository=https://oss.sonatype.org/content/repositories/snapshots/' 
-      + " -DarchetypeVersion=%s" % release)
+    archetype_repository = '-DarchetypeRepository=https://oss.sonatype.org/content/repositories/snapshots/'
+    archetype_repository_version = "%s %s" % (archetype_repository, archetype_version)
 else:
     snapshot_version = False
-    archetype_repository_version = "-DarchetypeVersion=%s" % release
-    
+    archetype_repository = '-DarchetypeRepository=https://oss.sonatype.org/service/local/staging/deploy/maven2'
+    archetype_repository_version = archetype_version
+
 rst_epilog += """
 
+.. |archetype-repository| replace:: %(archetype_repository)s
+.. |archetype-version| replace:: %(archetype_version)s
 .. |archetype-repository-version| replace:: %(archetype_repository_version)s
 
-""" % {'archetype_repository_version': archetype_repository_version}
+""" % {'archetype_repository': archetype_repository,
+       'archetype_version': archetype_version,
+       'archetype_repository_version': archetype_repository_version,
+       }

--- a/cdap-docs/developers-manual/source/conf.py
+++ b/cdap-docs/developers-manual/source/conf.py
@@ -21,18 +21,18 @@ def setup(app):
     app.add_config_value('snapshot_version', '', 'env')
 
 # Set the condition
+snapshot_version = release.endswith('SNAPSHOT')
 archetype_version = "-DarchetypeVersion=%s" % release
-if release.endswith('SNAPSHOT'):
-    snapshot_version = True
+
+if snapshot_version:
     archetype_repository = '-DarchetypeRepository=https://oss.sonatype.org/content/repositories/snapshots/'
     archetype_repository_version = "%s %s" % (archetype_repository, archetype_version)
 else:
-    snapshot_version = False
-    archetype_repository = '-DarchetypeRepository=https://oss.sonatype.org/service/local/staging/deploy/maven2'
+    # For releases, repo is not required, but included here to simplify the code as replacements can't be empty
+    archetype_repository = '-DarchetypeRepository=https://repo1.maven.org/maven2/'
     archetype_repository_version = archetype_version
 
 rst_epilog += """
-
 .. |archetype-repository| replace:: %(archetype_repository)s
 .. |archetype-version| replace:: %(archetype_version)s
 .. |archetype-repository-version| replace:: %(archetype_repository_version)s

--- a/cdap-docs/developers-manual/source/conf.py
+++ b/cdap-docs/developers-manual/source/conf.py
@@ -9,6 +9,28 @@ import sys
 
 # Setup the config
 sys.path.insert(0, os.path.abspath('../../_common'))
+from common_conf import setup as _setup
 from common_conf import *
 
 html_short_title_toc, html_short_title, html_context = set_conf_for_manual()
+
+def setup(app):
+    # Call imported setup
+    _setup(app)
+    # Add a custom config value that can be used for conditional content
+    app.add_config_value('snapshot_version', '', 'env')
+
+# Set the condition
+if release.endswith('SNAPSHOT'):
+    snapshot_version = True
+    archetype_repository_version = ('-DarchetypeRepository=https://oss.sonatype.org/content/repositories/snapshots/' 
+      + " -DarchetypeVersion=%s" % release)
+else:
+    snapshot_version = False
+    archetype_repository_version = "-DarchetypeVersion=%s" % release
+    
+rst_epilog += """
+
+.. |archetype-repository-version| replace:: %(archetype_repository_version)s
+
+""" % {'archetype_repository_version': archetype_repository_version}

--- a/cdap-docs/developers-manual/source/getting-started/dev-env.rst
+++ b/cdap-docs/developers-manual/source/getting-started/dev-env.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014-2016 Cask Data, Inc.
+    :copyright: Copyright © 2014-2017 Cask Data, Inc.
 
 .. _dev-env:
 
@@ -8,7 +8,7 @@
 Development Environment Setup
 =============================
 
-.. this file is included in others; titles need to be +
+.. this file is included in others; titles need to be "-" rather than "="
 
 .. highlight:: console
 
@@ -21,24 +21,42 @@ interface methods.
 
 The best way to start developing a CDAP application is by using the Maven archetype:
 
-.. tabbed-parsed-literal::
+.. ifconfig:: snapshot_version
+
+  .. tabbed-parsed-literal::
   
-  $ mvn archetype:generate \
-      -DarchetypeGroupId=co.cask.cdap \
-      -DarchetypeArtifactId=cdap-app-archetype \
-      -DarchetypeVersion=\ |release| \
-      -DgroupId=org.example.app
+    $ mvn archetype:generate \
+        -DarchetypeGroupId=co.cask.cdap \
+        -DarchetypeArtifactId=cdap-app-archetype \
+        -DarchetypeRepository=https://oss.sonatype.org/content/repositories/snapshots/ \
+        -DarchetypeVersion=\ |release| \
+        -DartifactId=myExampleApp \
+        -DgroupId=org.example.app
+
+.. ifconfig:: not snapshot_version
+
+  .. tabbed-parsed-literal::
+  
+    $ mvn archetype:generate \
+        -DarchetypeGroupId=co.cask.cdap \
+        -DarchetypeArtifactId=cdap-app-archetype \
+        -DarchetypeVersion=\ |release| \
+        -DartifactId=myExampleApp \
+        -DgroupId=org.example.app
 
 This creates a Maven project with all required dependencies, Maven plugins, and a simple
-application template for the development of your application. You can import this Maven project
-into your preferred IDE |---| such as `IntelliJ <https://www.jetbrains.com/idea/>`__ or 
-`Eclipse <https://www.eclipse.org/>`__ |---| and start developing your first CDAP application.
+application template for the development of your application (``myExampleApp``). You can
+import this Maven project into your preferred IDE |---| such as `IntelliJ
+<https://www.jetbrains.com/idea/>`__ or `Eclipse <https://www.eclipse.org/>`__ |---| and
+start developing your first CDAP application.
 
 For an application that contains a MapReduce program, set the ``archetypeArtifactId`` to
 ``cdap-mapreduce-archetype``; for Spark, use either ``cdap-spark-java-archetype`` or
 ``cdap-spark-scala-archetype``.
 
-**Note:** Replace the *groupId* parameter (``org.example.app``) with your own organization, but it must not be replaced with ``co.cask.cdap``.
+**Note:** Replace the *artifactId* (``myExampleApp``) and *groupId* parameters
+(``org.example.app``) with your own app name and organization, but the *groupId* must not
+be replaced with ``co.cask.cdap``.
 
 Complete examples for each archetype:
 
@@ -48,29 +66,36 @@ Complete examples for each archetype:
 
   .. CDAP Application
 
-  $ mvn archetype:generate -DarchetypeGroupId=co.cask.cdap -DarchetypeArtifactId=cdap-app-archetype -DarchetypeVersion=\ |release| -DgroupId=org.example.app
+  $ mvn archetype:generate -DarchetypeGroupId=co.cask.cdap -DarchetypeArtifactId=cdap-app-archetype |archetype-repository-version|
 
   .. MapReduce Program
 
-  $ mvn archetype:generate -DarchetypeGroupId=co.cask.cdap -DarchetypeArtifactId=cdap-mapreduce-archetype -DarchetypeVersion=\ |release| -DgroupId=org.example.app
+  $ mvn archetype:generate -DarchetypeGroupId=co.cask.cdap -DarchetypeArtifactId=cdap-mapreduce-archetype |archetype-repository-version|
   
   .. Spark Program (Java)
 
-  $ mvn archetype:generate -DarchetypeGroupId=co.cask.cdap -DarchetypeArtifactId=cdap-spark-java-archetype -DarchetypeVersion=\ |release| -DgroupId=org.example.app
+  $ mvn archetype:generate -DarchetypeGroupId=co.cask.cdap -DarchetypeArtifactId=cdap-spark-java-archetype |archetype-repository-version|
   
   .. Spark Program (Scala)
   
-  $ mvn archetype:generate -DarchetypeGroupId=co.cask.cdap -DarchetypeArtifactId=cdap-spark-scala-archetype -DarchetypeVersion=\ |release| -DgroupId=org.example.app
+  $ mvn archetype:generate -DarchetypeGroupId=co.cask.cdap -DarchetypeArtifactId=cdap-spark-scala-archetype |archetype-repository-version|
+
+When prompted, complete the values for *groupId* and *artifactId* parameters. Enter for the *groupId* parameter your
+own organization; it must not be replaced with ``co.cask.cdap``. (The *version* and *package* parameters can be either
+specified or you can use the Maven defaults.)
 
 Maven supplies a guide to the naming convention used above at https://maven.apache.org/guides/mini/guide-naming-conventions.html.
 
 Using IntelliJ
 --------------
-1. Open `IntelliJ <https://www.jetbrains.com/idea/>`__ and import the Maven project.
-#. Go to menu *File -> Import Project*...
-#. Select the ``pom.xml`` in the Maven project's directory.
-#. Select the *Import Maven projects automatically* and *Automatically download: Sources, Documentation*
-   boxes in the *Import Project from Maven* dialog.
+1. Open `IntelliJ <https://www.jetbrains.com/idea/>`__ and import the Maven project by:
+
+   - If at the starting IntelliJ dialog, click on *Import Project*; or
+   - If an existing project is open, go to the menu item *File -> Open...*
+   
+#. Navigate to and select the ``pom.xml`` in the Maven project's directory.
+#. In the *Import Project from Maven* dialog, select the *Import Maven projects automatically* and *Automatically
+   download: Sources, Documentation* boxes.
 #. Click *Next*, complete the remaining dialogs, and the new CDAP project will be created and opened.
 
 Using Eclipse

--- a/cdap-docs/developers-manual/source/getting-started/dev-env.rst
+++ b/cdap-docs/developers-manual/source/getting-started/dev-env.rst
@@ -28,8 +28,8 @@ The best way to start developing a CDAP application is by using the Maven archet
     $ mvn archetype:generate \
         -DarchetypeGroupId=co.cask.cdap \
         -DarchetypeArtifactId=cdap-app-archetype \
-        -DarchetypeRepository=https://oss.sonatype.org/content/repositories/snapshots/ \
-        -DarchetypeVersion=\ |release| \
+        |archetype-repository| \
+        |archetype-version| \
         -DartifactId=myExampleApp \
         -DgroupId=org.example.app
 
@@ -40,7 +40,7 @@ The best way to start developing a CDAP application is by using the Maven archet
     $ mvn archetype:generate \
         -DarchetypeGroupId=co.cask.cdap \
         -DarchetypeArtifactId=cdap-app-archetype \
-        -DarchetypeVersion=\ |release| \
+        |archetype-version| \
         -DartifactId=myExampleApp \
         -DgroupId=org.example.app
 

--- a/cdap-docs/developers-manual/source/getting-started/standalone/virtual-machine.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/virtual-machine.rst
@@ -1,11 +1,11 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: CDAP Virtual Machine
-    :copyright: Copyright © 2014-2016 Cask Data, Inc.
+    :copyright: Copyright © 2014-2017 Cask Data, Inc.
 
-============================================
+=====================
 Virtual Machine Image
-============================================
+=====================
 
 .. index:: VM, Virtual, Machine
 
@@ -56,7 +56,7 @@ remove software, the admin user and password are both ``cdap``.
    :start-line: 30
 
 Starting and Stopping Standalone CDAP
-============================================
+=====================================
 
 Use the ``cdap`` script (located in ``/opt/cdap/sdk/bin``) to start and stop the Standalone CDAP:
 

--- a/cdap-docs/developers-manual/source/getting-started/standalone/zip.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/zip.rst
@@ -1,18 +1,22 @@
 .. meta::
     :author: Cask Data, Inc.
     :description: CDAP SDK Zip
-    :copyright: Copyright © 2014 Cask Data, Inc.
+    :copyright: Copyright © 2014-2017 Cask Data, Inc.
 
 .. highlight:: console
   
-============================================
+===============
 Binary Zip File
-============================================
+===============
 
 .. _standalone-zip-file:
 
-The **zip file** is available on the Downloads section of the Cask Website at `<http://cask.co/downloads/#cdap>`__.
-Click the link marked "SDK" of the *Software Development Kit (SDK).* 
+The **zip file** is available on the Downloads section of the Cask Website at
+`<http://cask.co/downloads/#cdap>`__. Click the tab marked "SDK" for the *Software
+Development Kit (SDK).* There will be a button download the latest version.
+
+The SDK includes the software required for development and a Standalone version of CDAP,
+suitable for running on a laptop.
 
 Once downloaded, unzip it to a directory on your machine:
 

--- a/cdap-docs/developers-manual/source/getting-started/standalone/zip.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/zip.rst
@@ -13,7 +13,7 @@ Binary Zip File
 
 The **zip file** is available on the Downloads section of the Cask Website at
 `<http://cask.co/downloads/#cdap>`__. Click the tab marked "SDK" for the *Software
-Development Kit (SDK).* There will be a button download the latest version.
+Development Kit (SDK).* There will be a button to download the latest version.
 
 The SDK includes the software required for development and a Standalone version of CDAP,
 suitable for running on a laptop.


### PR DESCRIPTION
Add corrected instructions for IntelliJ.
Add conditional configuration for SNAPSHOT builds
Add conditional archetypes for SNAPSHOT versions
Clean up some language and formatting in related files.

Fix for https://issues.cask.co/browse/CDAP-8003
Fix for https://issues.cask.co/browse/CDAP-8012

Building as: http://builds.cask.co/browse/CDAP-DQB218-1 (passes!)

Page of interest: http://builds.cask.co/artifact/CDAP-DQB218/shared/build-1/Docs-HTML/4.0.0/en/developers-manual/getting-started/dev-env.html#dev-env

*Note:* Replacement for https://github.com/caskdata/cdap/pull/7528. See this page for what happens when the SNAPSHOT version:

Page of interest: http://builds.cask.co/artifact/CDAP-DQB217/shared/build-1/Docs-HTML/4.1.0-SNAPSHOT/en/developers-manual/getting-started/dev-env.html#dev-env