### PR TITLE
Reset docs to using the develop versions of repos.

### DIFF
--- a/cdap-docs/vars
+++ b/cdap-docs/vars
@@ -33,30 +33,30 @@ GIT_NODE_JS_MIN_VERSION="v4.5.0"
 # GIT_NODE_JS_MAX_VERSION="" # not currently known
 
 # This needs to be explicitly set as Git has trouble identifying it
-GIT_BRANCH_PARENT="release/4.0"
+GIT_BRANCH_PARENT="develop"
 
 # Used by admin-manual
-GIT_BRANCH_CDAP_SECURITY_EXTN="release/0.3"
+GIT_BRANCH_CDAP_SECURITY_EXTN="develop"
 
 # Used by developers-manual
-GIT_BRANCH_CDAP_CLIENTS="release/1.3.0"
-GIT_BRANCH_CDAP_INGEST="release/1.4.0"
+GIT_BRANCH_CDAP_CLIENTS="develop"
+GIT_BRANCH_CDAP_INGEST="develop"
 
-GIT_BRANCH_CDAP_APPS="release/cdap-4.0-compatible"
+GIT_BRANCH_CDAP_APPS="develop"
 GIT_VERSION_CDAP_APPS="0.8.0"
 
 # Used by examples manual
-GIT_BRANCH_CDAP_GUIDES="release/cdap-4.0-compatible"
+GIT_BRANCH_CDAP_GUIDES="develop"
 
 # Used by integrations-manual
-GIT_BRANCH_CDAP_PACKS="release/cdap-4.0-compatible"
+GIT_BRANCH_CDAP_PACKS="develop"
 GIT_VERSION_NAVIGATOR="0.1.0"
 
 # Used for Hydrator documentation
-GIT_BRANCH_CASK_HYDRATOR="release/1.5"
+GIT_BRANCH_CASK_HYDRATOR="develop"
 
 # Used for Tracker documentation
-GIT_BRANCH_CASK_TRACKER="release/0.3"
+GIT_BRANCH_CASK_TRACKER="develop"
 
 # Google Analytics Code
 GOOGLE_TAG_MANAGER_CODE="GTM-KWLFGH"


### PR DESCRIPTION
Resets referenced remote repo branches to `develop`.

Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB220-1 (passes)