### PR TITLE
CDAP-5107 Add scope param

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
@@ -309,11 +309,11 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
                           @PathParam("namespace-id") String namespaceId,
                           @PathParam("artifact-name") String artifactName,
                           @PathParam("artifact-version") String artifactVersion,
-                          @PathParam("property") String key)
+                          @PathParam("property") String key,
+                          @QueryParam("scope") @DefaultValue("user") String scope)
     throws Exception {
 
-    NamespaceId namespace = NamespaceId.SYSTEM.getNamespace().equalsIgnoreCase(namespaceId) ?
-      NamespaceId.SYSTEM : validateAndGetNamespace(namespaceId);
+    NamespaceId namespace = validateAndGetScopedNamespace(Ids.namespace(namespaceId), scope);
     Id.Artifact artifactId = validateAndGetArtifactId(namespace, artifactName, artifactVersion);
 
     try {

--- a/cdap-docs/reference-manual/source/http-restful-api/artifact.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/artifact.rst
@@ -310,7 +310,7 @@ Retrieve an Artifact Property
 =============================
 To retrieve a specific property for a specific version of an artifact, submit an HTTP GET request::
 
-  GET /v3/namespaces/<namespace-id>/artifacts/<artifact-name>/versions/<artifact-version>/properties/<property>
+  GET /v3/namespaces/<namespace-id>/artifacts/<artifact-name>/versions/<artifact-version>/properties/<property>[?scope=<scope>]
 
 .. list-table::
    :widths: 20 80
@@ -326,11 +326,13 @@ To retrieve a specific property for a specific version of an artifact, submit an
      - Version of the artifact
    * - ``property``
      - Property to retrieve
+   * - ``scope``
+     - Optional scope filter. If not specified, defaults to 'user'.
 
 .. container:: highlight
 
   .. parsed-literal::
-    |$| GET /v3/namespaces/default/artifact/WordCount/versions/|release|/properties/author
+    |$| GET /v3/namespaces/default/artifact/WordCount/versions/|release|/properties/author?scope=user
     samuel
 
 .. _http-restful-api-artifact-delete-properties:


### PR DESCRIPTION
When retrieving an artifact property in the REST API, the scope should
be specified as a querystring, like the other "get" methods available.

Update the docs to reflect this change.

JIRA: https://issues.cask.co/browse/CDAP-5107
Bamboo: http://builds.cask.co/browse/CDAP-DUT5265