### PR TITLE
Mark Workflow as FAILED if the action inside the workflow fails instead of marking it as COMPLETE.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -541,7 +541,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
 
   @Override
   protected void run() throws Exception {
-    LOG.info("Start workflow execution for {}", workflowSpec.getName());
+    LOG.info("Start workflow execution for {} with run id {}.", workflowSpec.getName(), workflowRunId.getRun());
     LOG.debug("Workflow specification is {}", workflowSpec);
     basicWorkflowContext.setState(new ProgramState(ProgramStatus.RUNNING, null));
     executeAll(workflowSpec.getNodes().iterator(), program.getApplicationSpecification(),

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/workflow/WorkflowProgramController.java
@@ -67,7 +67,7 @@ final class WorkflowProgramController extends AbstractProgramController {
   protected void doCommand(String name, Object value) throws Exception {
     LOG.info("Command ignored {}, {}", name, value);
   }
-  
+
   private void startListen(Service service) {
     // Forward state changes from the given service to this controller.
     service.addListener(new ServiceListenerAdapter() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ProgramLifecycleService.java
@@ -325,8 +325,10 @@ public class ProgramLifecycleService extends AbstractIdleService {
     final ProgramController controller = runtimeInfo.getController();
     final String runId = controller.getRunId().getId();
     final String twillRunId = runtimeInfo.getTwillRunId() == null ? null : runtimeInfo.getTwillRunId().getId();
-    if (programId.getType() != ProgramType.MAPREDUCE && programId.getType() != ProgramType.SPARK) {
-      // MapReduce/Spark state recording is done by the MapReduceProgramRunner/SparkProgramRunner
+    if (programId.getType() != ProgramType.MAPREDUCE && programId.getType() != ProgramType.SPARK
+      && programId.getType() != ProgramType.WORKFLOW) {
+      // MapReduce state recording is done by the MapReduceProgramRunner, Spark state recording
+      // is done by SparkProgramRunner, and Workflow state recording is done by WorkflowProgramRunner.
       // TODO [JIRA: CDAP-2013] Same needs to be done for other programs as well
       controller.addListener(new AbstractListener() {
         @Override

--- a/cdap-test/src/main/java/co/cask/cdap/test/ProgramManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/ProgramManager.java
@@ -22,6 +22,7 @@ import co.cask.cdap.proto.RunRecord;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -70,6 +71,33 @@ public interface ProgramManager<T extends ProgramManager> {
    * @throws InterruptedException if the method is interrupted while waiting for the status.
    */
   void waitForStatus(boolean status) throws InterruptedException;
+
+  /**
+   * Blocks until at least the one run record is available with the given {@link ProgramRunStatus}.
+   *
+   * @param status the status of the run record
+   * @param timeout amount of time units to wait
+   * @param timeoutUnit time unit type
+   * @throws InterruptedException if method is interrupted while waiting for runs
+   * @throws TimeoutException if timeout reached
+   * @throws ExecutionException if error getting runs
+   */
+  void waitForRun(ProgramRunStatus status, long timeout, TimeUnit timeoutUnit)
+    throws InterruptedException, ExecutionException, TimeoutException;
+
+  /**
+   * Blocks until at least {@code runCount} number of run records with the given {@link ProgramRunStatus}.
+   *
+   * @param status the status of the run record
+   * @param runCount the number of run records to wait for
+   * @param timeout amount of time units to wait
+   * @param timeoutUnit time unit type
+   * @throws InterruptedException if method is interrupted while waiting for runs
+   * @throws TimeoutException if timeout reached
+   * @throws ExecutionException if error getting runs
+   */
+  void waitForRuns(ProgramRunStatus status, int runCount, long timeout, TimeUnit timeoutUnit)
+    throws InterruptedException, ExecutionException, TimeoutException;
 
   /**
    * Wait for the status of the program, retrying a given number of times with a timeout between attempts.

--- a/cdap-unit-test/src/test/java/co/cask/cdap/admin/AdminAppTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/admin/AdminAppTestRun.java
@@ -25,6 +25,7 @@ import co.cask.cdap.api.dataset.table.Put;
 import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.internal.guava.reflect.TypeToken;
+import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.test.ApplicationManager;
 import co.cask.cdap.test.DataSetManager;
 import co.cask.cdap.test.FlowManager;
@@ -151,8 +152,8 @@ public class AdminAppTestRun extends TestFrameworkTestBase {
     // start the worker and wait for it to finish
     File newBasePath = new File(TMP_FOLDER.newFolder(), "extra");
     Assert.assertFalse(newBasePath.exists());
-    manager = manager.start(ImmutableMap.of("new.base.path", newBasePath.getPath()));
-    manager.waitForFinish(30, TimeUnit.SECONDS);
+    manager.start(ImmutableMap.of("new.base.path", newBasePath.getPath()));
+    manager.waitForRun(ProgramRunStatus.COMPLETED, 30, TimeUnit.SECONDS);
 
     // validate that worker created dataset a
     DataSetManager<Table> aManager = getDataset("a");
@@ -176,8 +177,8 @@ public class AdminAppTestRun extends TestFrameworkTestBase {
     Assert.assertNull(getDataset("d").get());
 
     // run the worker again to drop all datasets
-    manager = manager.start(ImmutableMap.of("dropAll", "true"));
-    manager.waitForFinish(30, TimeUnit.SECONDS);
+    manager.start(ImmutableMap.of("dropAll", "true"));
+    manager.waitForRuns(ProgramRunStatus.COMPLETED, 2, 30, TimeUnit.SECONDS);
 
     Assert.assertNull(getDataset("a").get());
     Assert.assertNull(getDataset("b").get());

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/app/TestFrameworkTestRun.java
@@ -356,7 +356,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(AppWithPlugin.WORKFLOW);
     workflowManager.start();
-    workflowManager.waitForFinish(10, TimeUnit.MINUTES);
+    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
     List<RunRecord> runRecords = workflowManager.getHistory();
     Assert.assertNotEquals(ProgramRunStatus.FAILED, runRecords.get(0).getStatus());
     DataSetManager<KeyValueTable> workflowTableManager = getDataset(AppWithPlugin.WORKFLOW_TABLE);
@@ -557,7 +557,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     workflowManager.start(ImmutableMap.of("workflow.success.file", workflowSuccess.getAbsolutePath(),
                                           "action.success.file", actionSuccess.getAbsolutePath(),
                                           "throw.exception", "true"));
-    workflowManager.waitForFinish(1, TimeUnit.MINUTES);
+    workflowManager.waitForRun(ProgramRunStatus.FAILED, 1, TimeUnit.MINUTES);
 
     // Since action and workflow failed the files should not exist
     Assert.assertFalse(workflowSuccess.exists());
@@ -565,7 +565,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
 
     workflowManager.start(ImmutableMap.of("workflow.success.file", workflowSuccess.getAbsolutePath(),
                                           "action.success.file", actionSuccess.getAbsolutePath()));
-    workflowManager.waitForFinish(1, TimeUnit.MINUTES);
+    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 1, TimeUnit.MINUTES);
     Assert.assertTrue(workflowSuccess.exists());
     Assert.assertTrue(actionSuccess.exists());
 
@@ -576,7 +576,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
                                           "test.killed", "true"));
     verifyFileExists(Lists.newArrayList(firstFile));
     workflowManager.stop();
-    workflowManager.waitForStatus(false);
+    workflowManager.waitForRun(ProgramRunStatus.KILLED, 1, TimeUnit.MINUTES);
     Assert.assertTrue(workflowKilled.exists());
   }
 
@@ -591,7 +591,7 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     serviceManager.waitForStatus(true);
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(DatasetWithCustomActionApp.CUSTOM_WORKFLOW).start();
-    workflowManager.waitForFinish(2, TimeUnit.MINUTES);
+    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 2, TimeUnit.MINUTES);
     appManager.stopAll();
 
     DataSetManager<KeyValueTable> outTableManager = getDataset(DatasetWithCustomActionApp.CUSTOM_TABLE);


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-6008
Build: http://builds.cask.co/browse/CDAP-DUT5245-15

Fix contains -
1. Moving recording of the RunRecord of the Workflow to the `WorkflowProgramRunner`
2. Added 2 methods in the `ProgramManager` interface - `waitForRun`, and `waitForRuns` which are used in the unit tests instead of `waitForFinish` to make sure that the Workflow program is reached to the specified state.
