### PR TITLE
[CDAP-8062] Fix Home to update UI on namespace change

### DIFF
--- a/cdap-ui/app/cdap/components/EntityListView/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/index.js
@@ -137,6 +137,7 @@ class EntityListView extends Component {
 
     let queryObject = this.getQueryObject(nextProps.location.query);
     if (
+      (nextProps.params.namespace !== this.props.params.namespace) ||
       queryObject.filter !== this.state.filter &&
       queryObject.sort.fullSort !== this.state.sortObj.fullSort &&
       queryObject.query !== this.state.query &&


### PR DESCRIPTION
- When we updated the UI state we were solely relied on query parameters and left out url parameters. This PR accounts for namespace (which is the only url param in home page). 