### PR TITLE
CDAP-8069 Adjusts inclusion to have the correct line numbers

### DIFF
--- a/cdap-docs/developers-manual/build.sh
+++ b/cdap-docs/developers-manual/build.sh
@@ -72,6 +72,7 @@ function download_includes() {
   download_readme_file_and_test ${includes_dir} ${ingest_url} b798091f24f6ecfe05d614f1dd1f7a03 cdap-stream-clients/ruby
 
   echo_red_bold "Check included example files for changes"
+  
   test_an_include 8fdb325ac2ad92bca959bd2f12fc91d7 ../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
 
   test_an_include 4255a2e3d417e928ac5182ddd932139f ../../cdap-examples/HelloWorld/src/main/java/co/cask/cdap/examples/helloworld/HelloWorld.java

--- a/cdap-docs/developers-manual/source/building-blocks/datasets/overview.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/datasets/overview.rst
@@ -47,8 +47,8 @@ For example, to create a DataSet named *myCounters* of type
 `KeyValueTable <../../../reference-manual/javadocs/co/cask/cdap/api/dataset/lib/KeyValueTable.html>`__, write::
 
   public void configure() {
-      createDataset("myCounters", KeyValueTable.class);
-      ...
+    createDataset("myCounters", KeyValueTable.class);
+    ...
 
 Names (*myCounters*) that start with an underscore (``_``) will not be visible in the home
 page of the :ref:`CDAP UI <cdap-ui>`, though they will be visible elsewhere in the CDAP UI.
@@ -200,16 +200,18 @@ in an instance variable and makes it available through ``getContext()``:
 
 .. literalinclude:: /../../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
     :language: java
-    :lines: 63-68
+    :lines: 65-71
     :dedent: 2
+    :append: ...
+             }
 
 The handler defines several endpoints for dataset management, one of which can be used to create a new file set,
 either by cloning an existing file set's dataset properties, or by using the properties submitted in the request body:
 
 .. literalinclude:: /../../../cdap-examples/FileSetExample/src/main/java/co/cask/cdap/examples/fileset/FileSetService.java
     :language: java
-    :lines: 167-196
-    :dedent: 2
+    :lines: 161-201
+    :dedent: 4
 
 For more details, see the :ref:`examples-fileset`.
 
@@ -227,10 +229,10 @@ maximum age (in seconds) that data should be retained.
 When you create a dataset, you can configure its TTL as part of the creation::
 
   public void configure() {
-      createDataset("myCounters", Table.class, 
-                    DatasetProperties.builder().add(Table.PROPERTY_TTL, 
-                                                    "<age in seconds>").build());
-      ...
+    createDataset("myCounters", Table.class, 
+                  DatasetProperties.builder().add(Table.PROPERTY_TTL, 
+                                                  "<age in seconds>").build());
+    ...
   }
 
 The default TTL for all datasets is infinite, meaning that data will never expire. The TTL


### PR DESCRIPTION
Corrects the indentation of examples.
Adds a trailing ellipsis and closing brace bracket.
Adds a blank line to build.sh to improve readability.

Building as Quick Build: http://builds.cask.co/browse/CDAP-DQB222-1

Page of interest: _to be completed_