### PR TITLE
[CDAP-8064] Download button in Explore fast action doesn't download in Firefox, opens on same tab in Safari

### DIFF
--- a/cdap-ui/app/cdap/components/FastAction/ExploreAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/ExploreAction/index.js
@@ -49,7 +49,7 @@ export default class ExploreAction extends Component {
       let match = explorableTables.filter(db => db.table === `${type}_${entityId.toLowerCase()}`);
       if (match.length) {
         this.setState({
-          disabled: !this.state.disabled
+          disabled: false
         });
       }
     };

--- a/cdap-ui/server/express.js
+++ b/cdap-ui/server/express.js
@@ -153,10 +153,11 @@ function makeApp (authAddress, cdapConfig, uiSettings) {
 
   app.get('/downloadLogs', function(req, res) {
     var url = decodeURIComponent(req.query.backendUrl);
+    var method = (req.query.method || 'GET');
     log.info('Download Logs Start: ', url);
     var customHeaders;
     var requestObject = {
-      method: 'GET',
+      method: method,
       url: url,
       rejectUnauthorized: false,
       requestCert: true,


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-8064
Bamboo build: http://builds.cask.co/browse/CDAP-DRC5287

- Fixed downloads in Firefox and Safari by pointing to a backend api that handles downloads