### PR TITLE
Fix version error and highlight Cloudera install requirements.

### DIFF
--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -296,7 +296,10 @@ if version:
 """ % {'version': version}
 
 if short_version:
-    previous_short_version = float(short_version) -0.1
+    if git_build_vars.has_key('GIT_PREVIOUS_SHORT_VERSION'):
+        previous_short_version = git_build_vars['GIT_PREVIOUS_SHORT_VERSION']
+    else:
+        previous_short_version = float(short_version) -0.1
     rst_epilog += """
 .. |short-version| replace:: %(short_version)s
 .. |short-version-x| replace:: %(short_version)s.x

--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -107,6 +107,10 @@ changes.
 Downloading and Distributing Packages
 =====================================
 
+**Note:** Both the :ref:`Custom Service Descriptor (CSD) <cloudera-installation-download>`
+and the :ref:`CDAP Parcel <cloudera-installation-download-distribute-parcel>` must be
+downloaded and installed in order to successfully install CDAP.
+
 .. _cloudera-installation-download:
 
 Downloading and Installing CSD

--- a/cdap-docs/vars
+++ b/cdap-docs/vars
@@ -29,7 +29,7 @@ BUILD_RST_HASH="5db96f8c4866f62b2f28b4ca3c99448c"
 # All "GIT_" variables are loaded by the Sphinx build and need to be static as they are not sourced
 #
 
-GIT_PREVIOUS_SHORT_VERSION="3.6.0"
+GIT_PREVIOUS_SHORT_VERSION="3.6"
 
 GIT_NODE_JS_MIN_VERSION="v4.5.0"
 # GIT_NODE_JS_MAX_VERSION="" # not currently known

--- a/cdap-docs/vars
+++ b/cdap-docs/vars
@@ -29,6 +29,8 @@ BUILD_RST_HASH="5db96f8c4866f62b2f28b4ca3c99448c"
 # All "GIT_" variables are loaded by the Sphinx build and need to be static as they are not sourced
 #
 
+GIT_PREVIOUS_SHORT_VERSION="3.6.0"
+
 GIT_NODE_JS_MIN_VERSION="v4.5.0"
 # GIT_NODE_JS_MAX_VERSION="" # not currently known
 


### PR DESCRIPTION
Fixes an error where the previous short version is not _current version - 0.1._

Adds text to highlight a Cloudera install requirement.

Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB223-2 (passes)

Pages of interest:
- Upgrading Cloudera: http://builds.cask.co/artifact/CDAP-DQB223/shared/build-2/Docs-HTML/4.0.1-SNAPSHOT/en/admin-manual/upgrading/cloudera.html#upgrading-cdap
- Installing Cloudera: http://builds.cask.co/artifact/CDAP-DQB223/shared/build-2/Docs-HTML/4.0.1-SNAPSHOT/en/admin-manual/installation/cloudera.html#downloading-and-distributing-packages