### PR TITLE
[HYDRATOR-1236] - Import Schema not clickable

### DIFF
--- a/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -276,7 +276,7 @@ class HydratorPlusPlusNodeConfigCtrl {
   importSchema() {
     this.$timeout.cancel(this.importSchemaTimeout);
     this.importSchemaTimeout = this.$timeout(() => {
-      document.getElementById('schema-import-link').click();
+      angular.element(document.getElementById('schema-import-link')).triggerHandler('click');
     });
   }
   importFiles(files) {


### PR DESCRIPTION
- This issue seem to be `$timeout` loses the original event, which is required to programmatically trigger a click on a link in UI.
- The current fix uses `triggerHandler` api from jquery-lite (which anyways comes with angular (https://docs.angularjs.org/api/ng/function/angular.element))