### PR TITLE
save and recapture stty around spark-shell call

### DIFF
--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -464,6 +464,7 @@ cdap_set_hive_classpath() {
 # Attempts to find SPARK_HOME
 #
 cdap_set_spark() {
+  local readonly __saved_stty=$(stty -g 2>/dev/null)
   # First, see if we're set to something sane
   if [[ -n ${SPARK_HOME} ]] && [[ -d ${SPARK_HOME} ]]; then
     export SPARK_HOME
@@ -481,6 +482,8 @@ cdap_set_spark() {
       ERR_FILE=$(mktemp)
       SPARK_VAR_OUT=$(echo 'for ((key, value) <- sys.env) println (key + "=" + value); exit' | spark-shell --master local 2>${ERR_FILE})
       __ret=$?
+      # spark-shell invocation above does not properly restore the stty.
+      stty ${__saved_stty}
       SPARK_ERR_MSG=$(< ${ERR_FILE})
       rm ${ERR_FILE}
       if [[ ${__ret} -ne 0 ]]; then


### PR DESCRIPTION
simple fix for [CDAP-7694](https://issues.cask.co/browse/CDAP-7694).  Captures and restores stty settings around the spark call that messes them up.