### PR TITLE
Move copying of zipped docs from the deploy to the build script.

### DIFF
--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -346,6 +346,13 @@ function build_docs_package() {
       echo "Could not create zipped doc set ${TARGET_PATH}/${PROJECT_VERSION}"
       return ${errors}   
   fi
+  echo "Copying zip ${zip_dir_name}"
+  cp ${zip_dir_name}.zip ${TARGET_PATH}/${PROJECT_VERSION}
+  errors=$?
+  if [[ ${errors} -ne 0 ]]; then
+      echo "Could not copy zipped doc set into ${TARGET_PATH}/${PROJECT_VERSION}"
+      return ${errors}   
+  fi
   display_end_title ${title}
 }
 

--- a/cdap-docs/deploy.sh
+++ b/cdap-docs/deploy.sh
@@ -193,7 +193,6 @@ function deploy () {
   if [ "${BRANCH}" == '' ]; then
     _remote_dir=${_remote_dir}/${_version}
   fi
-  copy_zip_file ${_zip_file} ${_local_dir} ${_version}
   make_remote_dir ${_user} ${_host} ${_remote_dir}
   sync_local_dir_to_remote_dir ${_user} ${_host} ${_remote_dir} ${_zip_file} ${_local_dir} ${_version}
   decho "branch=${_branch}"


### PR DESCRIPTION
Cherry pick of https://github.com/caskdata/cdap/pull/7576

Running as: http://builds.cask.co/browse/CDAP-DDB58-1 (passed)