### PR TITLE
Handle NamespaceNotFoundException while cleaning up expired log files

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/security/DefaultImpersonator.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/security/DefaultImpersonator.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.common.security;
 
+import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.kerberos.SecurityUtil;
 import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
@@ -65,13 +66,15 @@ public class DefaultImpersonator implements Impersonator {
   }
 
   @Override
-  public UserGroupInformation getUGI(NamespaceId namespaceId) throws IOException {
+  public UserGroupInformation getUGI(NamespaceId namespaceId) throws IOException, NamespaceNotFoundException {
     // don't impersonate if kerberos isn't enabled OR if the operation is in the system namespace
     if (!kerberosEnabled || NamespaceId.SYSTEM.equals(namespaceId)) {
       return UserGroupInformation.getCurrentUser();
     }
     try {
       return getUGI(namespaceQueryAdmin.get(namespaceId));
+    } catch (NamespaceNotFoundException e) {
+      throw e;
     } catch (Exception e) {
       Throwables.propagateIfInstanceOf(e, IOException.class);
       throw Throwables.propagate(e);

--- a/cdap-common/src/main/java/co/cask/cdap/common/security/Impersonator.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/security/Impersonator.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.common.security;
 
+import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.id.NamespaceId;
 import com.google.inject.ImplementedBy;
@@ -40,6 +41,7 @@ public interface Impersonator {
    * @param <T> return type of the callable
    *
    * @return the return value of the callable
+   * @throws NamespaceNotFoundException if the namespace does not exist
    * @throws Exception if the callable throws any exception
    */
   <T> T doAs(NamespaceId namespaceId, Callable<T> callable) throws Exception;
@@ -62,6 +64,7 @@ public interface Impersonator {
    * @param namespaceId namespace to lookup the user
    * @return {@link UserGroupInformation}
    * @throws IOException if there was any error fetching the {@link UserGroupInformation}
+   * @throws NamespaceNotFoundException if namespaceId does not exist
    */
-  UserGroupInformation getUGI(NamespaceId namespaceId) throws IOException;
+  UserGroupInformation getUGI(NamespaceId namespaceId) throws IOException, NamespaceNotFoundException;
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
@@ -295,9 +295,9 @@ public class FileStreamAdmin implements StreamAdmin {
 
   @Override
   public StreamConfig getConfig(final StreamId streamId) throws IOException {
-    // No Authorization check performed in this method. If required, it should be added before this method is invoked
-    UserGroupInformation ugi = impersonator.getUGI(streamId.getParent());
     try {
+      // No Authorization check performed in this method. If required, it should be added before this method is invoked
+      UserGroupInformation ugi = impersonator.getUGI(streamId.getParent());
       return ImpersonationUtils.doAs(ugi, new Callable<StreamConfig>() {
         @Override
         public StreamConfig call() throws IOException {
@@ -406,7 +406,7 @@ public class FileStreamAdmin implements StreamAdmin {
     // User should have write access to the namespace
     NamespaceId streamNamespace = streamId.getParent();
     ensureAccess(streamNamespace, Action.WRITE);
-    // revoke privleges to make sure there is no orphaned privleges
+    // revoke privileges to make sure there is no orphaned privileges
     privilegesManager.revoke(streamId);
     try {
       // Grant All access to the stream created to the User

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/ExistingEntitySystemMetadataWriter.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/ExistingEntitySystemMetadataWriter.java
@@ -23,6 +23,7 @@ import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.app.store.Store;
+import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.security.ImpersonationUtils;
 import co.cask.cdap.common.security.Impersonator;
@@ -144,7 +145,7 @@ class ExistingEntitySystemMetadataWriter {
   }
 
   private void writeSystemMetadataForDatasets(NamespaceId namespace, DatasetFramework dsFramework)
-    throws DatasetManagementException, IOException {
+    throws DatasetManagementException, IOException, NamespaceNotFoundException {
     SystemDatasetInstantiatorFactory systemDatasetInstantiatorFactory =
       new SystemDatasetInstantiatorFactory(locationFactory, dsFramework, cConf);
     try (SystemDatasetInstantiator systemDatasetInstantiator = systemDatasetInstantiatorFactory.create()) {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/FileMetaDataManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/FileMetaDataManager.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scanner;
 import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.io.Processor;
 import co.cask.cdap.common.io.RootLocationFactory;
@@ -33,6 +34,7 @@ import co.cask.cdap.logging.context.LoggingContextHelper;
 import co.cask.cdap.logging.save.LogSaverTableUtil;
 import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import org.apache.tephra.TransactionAware;
@@ -247,14 +249,25 @@ public final class FileMetaDataManager {
           while ((row = scanner.next()) != null) {
             byte[] rowKey = row.getRow();
             final NamespaceId namespaceId = getNamespaceId(rowKey);
-            String namespacedLogDir = impersonator.doAs(namespaceId, new Callable<String>() {
-              @Override
-              public String call() throws Exception {
-                return LoggingContextHelper.getNamespacedBaseDirLocation(namespacedLocationFactory,
-                                                                         logBaseDir, namespaceId,
-                                                                         impersonator).toString();
+            String namespacedLogDir = null;
+            try {
+              namespacedLogDir = impersonator.doAs(namespaceId, new Callable<String>() {
+                @Override
+                public String call() throws Exception {
+                  return LoggingContextHelper.getNamespacedBaseDirLocation(namespacedLocationFactory,
+                                                                           logBaseDir, namespaceId,
+                                                                           impersonator).toString();
+                }
+              });
+            } catch (Exception e) {
+              if (e instanceof NamespaceNotFoundException) {
+                LOG.warn("Namespace {} does not exist. Only delete metadata for it", namespaceId.getEntityName(), e);
+              } else {
+                LOG.warn("Error while accessing namespace {} for log cleanup, skipping it",
+                         namespaceId.getEntityName(), e);
+                continue;
               }
-            });
+            }
 
             for (final Map.Entry<byte[], byte[]> entry : row.getColumns().entrySet()) {
               try {
@@ -264,12 +277,21 @@ public final class FileMetaDataManager {
                   LOG.debug("Got file {} with start time {}", file, Bytes.toLong(colName));
                 }
 
+                if (Strings.isNullOrEmpty(namespacedLogDir)) {
+                  LOG.warn("File {} is not present and will be deleted from metadata because namespace {} " +
+                             "does not exist", Bytes.toString(entry.getValue()), namespaceId.getEntityName());
+                  table.delete(rowKey, colName);
+                  deletedColumns++;
+                  continue;
+                }
+
                 Location fileLocation = impersonator.doAs(namespaceId, new Callable<Location>() {
                   @Override
                   public Location call() throws Exception {
                     return rootLocationFactory.create(new URI(Bytes.toString(entry.getValue())));
                   }
                 });
+
                 if (!fileLocation.exists()) {
                   LOG.warn("Log file {} does not exist, but metadata is present", file);
                   table.delete(rowKey, colName);
@@ -281,7 +303,12 @@ public final class FileMetaDataManager {
                   deletedColumns++;
                 }
               } catch (Exception e) {
-                LOG.error("Got exception deleting file {}", Bytes.toString(entry.getValue()), e);
+                if (e instanceof NamespaceNotFoundException) {
+                  LOG.warn("File {} is not present because namespace {} does not exist",
+                           Bytes.toString(entry.getValue()), namespaceId.getEntityName());
+                } else {
+                  LOG.error("Got exception deleting file {}", Bytes.toString(entry.getValue()), e);
+                }
               }
             }
           }


### PR DESCRIPTION
Issues: https://issues.cask.co/browse/CDAP-7998, https://issues.cask.co/browse/CDAP-7999

Build: http://builds.cask.co/browse/CDAP-RUT444-6

Tested on secure cluster by deleting impersonated namespace: 

> 2017-01-14 00:11:53,895 - WARN  [log-saver-log-processor-0:c.c.c.c.n.AbstractNamespaceQueryClient@65] - Namespace vinishans does not exist. Only delete metadata for it
co.cask.cdap.common.NamespaceNotFoundException: 'namespace:vinishans' was not found.
	at co.cask.cdap.common.namespace.AbstractNamespaceQueryClient.get(AbstractNamespaceQueryClient.java:65)
	at co.cask.cdap.common.security.DefaultImpersonator.getUGI(DefaultImpersonator.java:75)
	at co.cask.cdap.common.security.DefaultImpersonator.doAs(DefaultImpersonator.java:60)
	at co.cask.cdap.logging.write.FileMetaDataManager$4.apply(FileMetaDataManager.java:254)
	at co.cask.cdap.logging.write.FileMetaDataManager$4.apply(FileMetaDataManager.java:243)
	at org.apache.tephra.DefaultTransactionExecutor.executeOnce(DefaultTransactionExecutor.java:138)
	at org.apache.tephra.DefaultTransactionExecutor.executeWithRetry(DefaultTransactionExecutor.java:117)
	at org.apache.tephra.DefaultTransactionExecutor.execute(DefaultTransactionExecutor.java:74)
	at co.cask.cdap.logging.write.FileMetaDataManager.execute(FileMetaDataManager.java:343)
	at co.cask.cdap.logging.write.FileMetaDataManager.cleanMetaData(FileMetaDataManager.java:243)
	at co.cask.cdap.logging.write.LogCleanup.run(LogCleanup.java:88)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:304)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:178)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)
2017-01-14 00:11:53,897 - WARN  [log-saver-log-processor-0:?@?] - File hdfs://host:port/tmp/vinishans/logs/avro/HelloWorld/flow-WhoFlow/2017-01-13/1484345974067.avro is not present and will be deleted from metadata because namespace vinishans does not exist
