### PR TITLE
CDAP-8089 Instead of using variable from HiveConf class, use string for configuration.

### DIFF
--- a/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/service/hive/BaseHiveExploreService.java
@@ -1304,8 +1304,8 @@ public abstract class BaseHiveExploreService extends AbstractIdleService impleme
       // Hence it will not be automatically added by Hive, instead we have to add it ourselves.
       sessionConf.put(MRJobConfig.MAPREDUCE_JOB_CREDENTIALS_BINARY, credentialsFilePath);
 
-      sessionConf.put(HiveConf.ConfVars.SUBMITLOCALTASKVIACHILD.toString(), Boolean.FALSE.toString());
-      sessionConf.put(HiveConf.ConfVars.SUBMITVIACHILD.toString(), Boolean.FALSE.toString());
+      sessionConf.put("hive.exec.submit.local.task.via.child", Boolean.FALSE.toString());
+      sessionConf.put("hive.exec.submitviachild", Boolean.FALSE.toString());
       if (ExploreServiceUtils.isTezEngine(hiveConf, additionalSessionConf)) {
         // Add token file location property for tez if engine is tez
         sessionConf.put("tez.credentials.path", credentialsFilePath);


### PR DESCRIPTION
Verified on secure CDH 5.1 cluster that `ExploreTest`s are passing.
JIRA: https://issues.cask.co/browse/CDAP-8089