### PR TITLE
CDAP-8032 configurable retry policy for service unavailable errors

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/DatasetProperties.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/DatasetProperties.java
@@ -70,7 +70,7 @@ public final class DatasetProperties {
   @Override
   public String toString() {
     return "DatasetProperties{" +
-      "description=" + description +
+      "description='" + description + '\'' +
       ", properties=" + properties +
       '}';
   }

--- a/cdap-api/src/main/java/co/cask/cdap/api/retry/RetriesExhaustedException.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/retry/RetriesExhaustedException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.retry;
+
+/**
+ * An exception that indicates an operation failed after it was retried.
+ */
+public class RetriesExhaustedException extends RuntimeException {
+
+  public RetriesExhaustedException(String message) {
+    super(message);
+  }
+
+  public RetriesExhaustedException(Throwable cause) {
+    super(cause);
+  }
+
+  public RetriesExhaustedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/cdap-api/src/main/java/co/cask/cdap/api/retry/RetryableException.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/retry/RetryableException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.api.retry;
+
+/**
+ * An exception that indicates an operation failed in a retryable way. For example, reading from an external system
+ * may fail if that system is temporarily unavailable.
+ */
+public class RetryableException extends RuntimeException {
+
+  public RetryableException() {
+  }
+
+  public RetryableException(String message) {
+    super(message);
+  }
+
+  public RetryableException(Throwable cause) {
+    super(cause);
+  }
+
+  public RetryableException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/StreamWriterFactory.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/StreamWriterFactory.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.app.stream;
 
 import co.cask.cdap.api.data.stream.StreamWriter;
+import co.cask.cdap.common.service.RetryStrategy;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.id.EntityId;
 import com.google.inject.assistedinject.Assisted;
@@ -28,8 +29,11 @@ public interface StreamWriterFactory {
   /**
    * @param owners the owners of the {@link StreamWriter}
    * @param run run information
+   * @param retryStrategy the retry strategy to use if writes fail in a retryable fashion
    * @return a {@link StreamWriter} for the specified namespaceId
    */
-  StreamWriter create(@Assisted("run") Id.Run run, @Assisted("owners") Iterable<? extends EntityId> owners);
+  StreamWriter create(@Assisted("run") Id.Run run,
+                      @Assisted("owners") Iterable<? extends EntityId> owners,
+                      @Assisted("retryStrategy") RetryStrategy retryStrategy);
 }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DefaultAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/DefaultAdmin.java
@@ -25,6 +25,9 @@ import co.cask.cdap.api.messaging.MessagingAdmin;
 import co.cask.cdap.api.messaging.TopicAlreadyExistsException;
 import co.cask.cdap.api.messaging.TopicNotFoundException;
 import co.cask.cdap.api.security.store.SecureStoreManager;
+import co.cask.cdap.common.service.Retries;
+import co.cask.cdap.common.service.RetryStrategies;
+import co.cask.cdap.common.service.RetryStrategy;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -42,23 +45,26 @@ public class DefaultAdmin implements Admin {
   private final NamespaceId namespace;
   private final SecureStoreManager secureStoreManager;
   private final MessagingAdmin messagingAdmin;
+  private final RetryStrategy retryStrategy;
 
   /**
    * Creates an instance without messaging admin support.
    */
   public DefaultAdmin(DatasetFramework dsFramework, NamespaceId namespace, SecureStoreManager secureStoreManager) {
-    this(dsFramework, namespace, secureStoreManager, null);
+    this(dsFramework, namespace, secureStoreManager, null, RetryStrategies.noRetry());
   }
 
   /**
    * Creates an instance with all Admin functions supported.
    */
   public DefaultAdmin(DatasetFramework dsFramework, NamespaceId namespace,
-                      SecureStoreManager secureStoreManager, @Nullable MessagingAdmin messagingAdmin) {
+                      SecureStoreManager secureStoreManager, @Nullable MessagingAdmin messagingAdmin,
+                      RetryStrategy retryStrategy) {
     this.dsFramework = dsFramework;
     this.namespace = namespace;
     this.secureStoreManager = secureStoreManager;
     this.messagingAdmin = messagingAdmin;
+    this.retryStrategy = retryStrategy;
   }
 
   private DatasetId createInstanceId(String name) {
@@ -66,70 +72,110 @@ public class DefaultAdmin implements Admin {
   }
 
   @Override
-  public boolean datasetExists(String name) throws DatasetManagementException {
-    return dsFramework.getDatasetSpec(createInstanceId(name)) != null;
+  public boolean datasetExists(final String name) throws DatasetManagementException {
+    return Retries.callWithRetries(new Retries.Callable<Boolean, DatasetManagementException>() {
+      @Override
+      public Boolean call() throws DatasetManagementException {
+        return dsFramework.getDatasetSpec(createInstanceId(name)) != null;
+      }
+    }, retryStrategy);
   }
 
   @Override
-  public String getDatasetType(String name) throws DatasetManagementException {
-    DatasetSpecification spec = dsFramework.getDatasetSpec(createInstanceId(name));
-    if (spec == null) {
-      throw new InstanceNotFoundException(name);
-    }
-    return spec.getType();
+  public String getDatasetType(final String name) throws DatasetManagementException {
+    return Retries.callWithRetries(new Retries.Callable<String, DatasetManagementException>() {
+      @Override
+      public String call() throws DatasetManagementException {
+        DatasetSpecification spec = dsFramework.getDatasetSpec(createInstanceId(name));
+        if (spec == null) {
+          throw new InstanceNotFoundException(name);
+        }
+        return spec.getType();
+      }
+    }, retryStrategy);
   }
 
   @Override
-  public DatasetProperties getDatasetProperties(String name) throws DatasetManagementException {
-    DatasetSpecification spec = dsFramework.getDatasetSpec(createInstanceId(name));
-    if (spec == null) {
-      throw new InstanceNotFoundException(name);
-    }
-    return DatasetProperties.of(spec.getOriginalProperties());
+  public DatasetProperties getDatasetProperties(final String name) throws DatasetManagementException {
+    return Retries.callWithRetries(new Retries.Callable<DatasetProperties, DatasetManagementException>() {
+      @Override
+      public DatasetProperties call() throws DatasetManagementException {
+        DatasetSpecification spec = dsFramework.getDatasetSpec(createInstanceId(name));
+        if (spec == null) {
+          throw new InstanceNotFoundException(name);
+        }
+        return DatasetProperties.of(spec.getOriginalProperties());
+      }
+    }, retryStrategy);
   }
 
   @Override
-  public void createDataset(String name, String type, DatasetProperties properties) throws DatasetManagementException {
-    try {
-      dsFramework.addInstance(type, createInstanceId(name), properties);
-    } catch (IOException ioe) {
-      // not the prettiest message, but this replicates exactly what RemoteDatasetFramework throws
-      throw new DatasetManagementException(String.format("Failed to add instance %s, details: %s",
-                                                         name, ioe.getMessage()), ioe);
-    }
+  public void createDataset(final String name, final String type,
+                            final DatasetProperties properties) throws DatasetManagementException {
+    Retries.callWithRetries(new Retries.Callable<Void, DatasetManagementException>() {
+      @Override
+      public Void call() throws DatasetManagementException {
+        try {
+          dsFramework.addInstance(type, createInstanceId(name), properties);
+        } catch (IOException ioe) {
+          // not the prettiest message, but this replicates exactly what RemoteDatasetFramework throws
+          throw new DatasetManagementException(String.format("Failed to add instance %s, details: %s",
+                                                             name, ioe.getMessage()), ioe);
+        }
+        return null;
+      }
+    }, retryStrategy);
   }
 
   @Override
-  public void updateDataset(String name, DatasetProperties properties) throws DatasetManagementException {
-    try {
-      dsFramework.updateInstance(createInstanceId(name), properties);
-    } catch (IOException ioe) {
-      // not the prettiest message, but this replicates exactly what RemoteDatasetFramework throws
-      throw new DatasetManagementException(String.format("Failed to update instance %s, details: %s",
-                                                         name, ioe.getMessage()), ioe);
-    }
+  public void updateDataset(final String name, final DatasetProperties properties) throws DatasetManagementException {
+    Retries.callWithRetries(new Retries.Callable<Void, DatasetManagementException>() {
+      @Override
+      public Void call() throws DatasetManagementException {
+        try {
+          dsFramework.updateInstance(createInstanceId(name), properties);
+        } catch (IOException ioe) {
+          // not the prettiest message, but this replicates exactly what RemoteDatasetFramework throws
+          throw new DatasetManagementException(String.format("Failed to update instance %s, details: %s",
+                                                             name, ioe.getMessage()), ioe);
+        }
+        return null;
+      }
+    }, retryStrategy);
   }
 
   @Override
-  public void dropDataset(String name) throws DatasetManagementException {
-    try {
-      dsFramework.deleteInstance(createInstanceId(name));
-    } catch (IOException ioe) {
-      // not the prettiest message, but this replicates exactly what RemoteDatasetFramework throws
-      throw new DatasetManagementException(String.format("Failed to delete instance %s, details: %s",
-                                                         name, ioe.getMessage()), ioe);
-    }
+  public void dropDataset(final String name) throws DatasetManagementException {
+    Retries.callWithRetries(new Retries.Callable<Void, DatasetManagementException>() {
+      @Override
+      public Void call() throws DatasetManagementException {
+        try {
+          dsFramework.deleteInstance(createInstanceId(name));
+        } catch (IOException ioe) {
+          // not the prettiest message, but this replicates exactly what RemoteDatasetFramework throws
+          throw new DatasetManagementException(String.format("Failed to delete instance %s, details: %s",
+                                                             name, ioe.getMessage()), ioe);
+        }
+        return null;
+      }
+    }, retryStrategy);
   }
 
   @Override
-  public void truncateDataset(String name) throws DatasetManagementException {
-    try {
-      dsFramework.truncateInstance(createInstanceId(name));
-    } catch (IOException ioe) {
-      // not the prettiest message, but this replicates exactly what RemoteDatasetFramework throws
-      throw new DatasetManagementException(String.format("Failed to truncate instance %s, details: %s",
-                                                         name, ioe.getMessage()), ioe);
-    }
+  public void truncateDataset(final String name) throws DatasetManagementException {
+    Retries.callWithRetries(new Retries.Callable<Void, DatasetManagementException>() {
+      @Override
+      public Void call() throws DatasetManagementException {
+        try {
+          dsFramework.truncateInstance(createInstanceId(name));
+        } catch (IOException ioe) {
+          // not the prettiest message, but this replicates exactly what RemoteDatasetFramework throws
+          throw new DatasetManagementException(String.format("Failed to truncate instance %s, details: %s",
+                                                             name, ioe.getMessage()), ioe);
+        }
+        return null;
+      }
+    }, retryStrategy);
   }
 
   @Override
@@ -144,43 +190,114 @@ public class DefaultAdmin implements Admin {
   }
 
   @Override
-  public void createTopic(String topic) throws TopicAlreadyExistsException, IOException {
+  public void createTopic(final String topic) throws TopicAlreadyExistsException, IOException {
     if (messagingAdmin == null) {
       throw new UnsupportedOperationException("Messaging not supported");
     }
-    messagingAdmin.createTopic(topic);
+
+    try {
+      Retries.callWithRetries(new Retries.Callable<Void, Exception>() {
+        @Override
+        public Void call() throws TopicAlreadyExistsException, IOException {
+          messagingAdmin.createTopic(topic);
+          return null;
+        }
+      }, retryStrategy);
+    } catch (TopicAlreadyExistsException | IOException | RuntimeException | Error e) {
+      throw e;
+    } catch (Exception e) {
+      // this should never happen
+      throw new RuntimeException(e);
+    }
   }
 
   @Override
-  public void createTopic(String topic,
-                          Map<String, String> properties) throws TopicAlreadyExistsException, IOException {
+  public void createTopic(final String topic,
+                          final Map<String, String> properties) throws TopicAlreadyExistsException, IOException {
     if (messagingAdmin == null) {
       throw new UnsupportedOperationException("Messaging not supported");
     }
-    messagingAdmin.createTopic(topic, properties);
+
+    try {
+      Retries.callWithRetries(new Retries.Callable<Void, Exception>() {
+        @Override
+        public Void call() throws TopicAlreadyExistsException, IOException {
+          messagingAdmin.createTopic(topic, properties);
+          return null;
+        }
+      }, retryStrategy);
+    } catch (TopicAlreadyExistsException | IOException | RuntimeException | Error e) {
+      throw e;
+    } catch (Exception e) {
+      // this should never happen
+      throw new RuntimeException(e);
+    }
   }
 
   @Override
-  public Map<String, String> getTopicProperties(String topic) throws TopicNotFoundException, IOException {
+  public Map<String, String> getTopicProperties(final String topic) throws TopicNotFoundException, IOException {
     if (messagingAdmin == null) {
       throw new UnsupportedOperationException("Messaging not supported");
     }
-    return messagingAdmin.getTopicProperties(topic);
+
+    try {
+      return Retries.callWithRetries(new Retries.Callable<Map<String, String>, Exception>() {
+        @Override
+        public Map<String, String> call() throws TopicNotFoundException, IOException {
+          return messagingAdmin.getTopicProperties(topic);
+        }
+      }, retryStrategy);
+    } catch (TopicNotFoundException | IOException | RuntimeException | Error e) {
+      throw e;
+    } catch (Exception e) {
+      // this should never happen
+      throw new RuntimeException(e);
+    }
   }
 
   @Override
-  public void updateTopic(String topic, Map<String, String> properties) throws TopicNotFoundException, IOException {
+  public void updateTopic(final String topic,
+                          final Map<String, String> properties) throws TopicNotFoundException, IOException {
     if (messagingAdmin == null) {
       throw new UnsupportedOperationException("Messaging not supported");
     }
-    messagingAdmin.updateTopic(topic, properties);
+
+    try {
+      Retries.callWithRetries(new Retries.Callable<Void, Exception>() {
+        @Override
+        public Void call() throws TopicNotFoundException, IOException {
+          messagingAdmin.updateTopic(topic, properties);
+          return null;
+        }
+      }, retryStrategy);
+    } catch (TopicNotFoundException | IOException | RuntimeException | Error e) {
+      throw e;
+    } catch (Exception e) {
+      // this should never happen
+      throw new RuntimeException(e);
+    }
   }
 
   @Override
-  public void deleteTopic(String topic) throws TopicNotFoundException, IOException {
+  public void deleteTopic(final String topic) throws TopicNotFoundException, IOException {
     if (messagingAdmin == null) {
       throw new UnsupportedOperationException("Messaging not supported");
     }
-    messagingAdmin.deleteTopic(topic);
+
+    try {
+      Retries.callWithRetries(new Retries.Callable<Void, Exception>() {
+        @Override
+        public Void call() throws TopicNotFoundException, IOException {
+          messagingAdmin.deleteTopic(topic);
+          return null;
+        }
+      }, retryStrategy);
+    } catch (TopicNotFoundException | IOException | RuntimeException | Error e) {
+      throw e;
+    } catch (Exception e) {
+      // this should never happen
+      throw new RuntimeException(e);
+    }
   }
+
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/SystemArguments.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/SystemArguments.java
@@ -20,13 +20,19 @@ import co.cask.cdap.api.Resources;
 import co.cask.cdap.api.common.RuntimeArguments;
 import co.cask.cdap.app.runtime.Arguments;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.service.RetryStrategies;
+import co.cask.cdap.common.service.RetryStrategy;
+import co.cask.cdap.common.service.RetryStrategyType;
 import co.cask.cdap.logging.appender.LogAppenderInitializer;
+import co.cask.cdap.proto.ProgramType;
 import org.apache.tephra.TxConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
@@ -39,6 +45,11 @@ public final class SystemArguments {
   private static final String MEMORY_KEY = "system.resources.memory";
   private static final String CORES_KEY = "system.resources.cores";
   private static final String LOG_LEVEL = "system.log.level";
+  private static final String RETRY_POLICY_TYPE = "system." + Constants.Retry.TYPE;
+  private static final String RETRY_POLICY_MAX_TIME_SECS = "system." + Constants.Retry.MAX_TIME_SECS;
+  private static final String RETRY_POLICY_MAX_RETRIES = "system." + Constants.Retry.MAX_RETRIES;
+  private static final String RETRY_POLICY_DELAY_BASE_MS = "system." + Constants.Retry.DELAY_BASE_MS;
+  private static final String RETRY_POLICY_DELAY_MAX_MS = "system." + Constants.Retry.DELAY_MAX_MS;
   public static final String TRANSACTION_TIMEOUT = "system.data.tx.timeout";
 
   public static Map<String, String> getLogLevels(Map<String, String> args) {
@@ -139,6 +150,82 @@ public final class SystemArguments {
   }
 
   /**
+   * Get the retry strategy for a program given its arguments and the CDAP defaults for the program type.
+   *
+   * @return the retry strategy to use for internal calls
+   * @throws IllegalArgumentException if there is an invalid value for an argument
+   */
+  public static RetryStrategy getRetryStrategy(Map<String, String> args, ProgramType programType,
+                                               CConfiguration cConf) {
+    String keyPrefix;
+    switch (programType) {
+      case MAPREDUCE:
+        keyPrefix = Constants.Retry.MAPREDUCE_PREFIX;
+        break;
+      case SPARK:
+        keyPrefix = Constants.Retry.SPARK_PREFIX;
+        break;
+      case WORKFLOW:
+        keyPrefix = Constants.Retry.WORKFLOW_PREFIX;
+        break;
+      case WORKER:
+        keyPrefix = Constants.Retry.WORKER_PREFIX;
+        break;
+      case SERVICE:
+        keyPrefix = Constants.Retry.SERVICE_PREFIX;
+        break;
+      case FLOW:
+        keyPrefix = Constants.Retry.FLOW_PREFIX;
+        break;
+      case CUSTOM_ACTION:
+        keyPrefix = Constants.Retry.CUSTOM_ACTION_PREFIX;
+        break;
+      default:
+        throw new IllegalArgumentException("Invalid program type " + programType);
+    }
+    String typeKey = keyPrefix + Constants.Retry.TYPE;
+    String maxRetriesKey = keyPrefix + Constants.Retry.MAX_RETRIES;
+    String maxTimeKey = keyPrefix + Constants.Retry.MAX_TIME_SECS;
+    String baseDelayKey = keyPrefix + Constants.Retry.DELAY_BASE_MS;
+    String maxDelayKey = keyPrefix + Constants.Retry.DELAY_MAX_MS;
+
+
+    String typeStr = args.get(RETRY_POLICY_TYPE);
+    if (typeStr == null) {
+      typeStr = cConf.get(typeKey);
+    }
+    RetryStrategyType type = RetryStrategyType.from(typeStr);
+
+    if (type == RetryStrategyType.NONE) {
+      return RetryStrategies.noRetry();
+    }
+
+    int maxRetries = getNonNegativeInt(args, RETRY_POLICY_MAX_RETRIES, RETRY_POLICY_MAX_RETRIES,
+                                       cConf.getInt(maxRetriesKey));
+    long maxTimeSecs = getNonNegativeLong(args, RETRY_POLICY_MAX_TIME_SECS, RETRY_POLICY_MAX_TIME_SECS,
+                                          cConf.getLong(maxTimeKey));
+    long baseDelay = getNonNegativeLong(args, RETRY_POLICY_DELAY_BASE_MS, RETRY_POLICY_DELAY_BASE_MS,
+                                        cConf.getLong(baseDelayKey));
+
+    RetryStrategy baseStrategy;
+    switch (type) {
+      case FIXED_DELAY:
+        baseStrategy = RetryStrategies.fixDelay(baseDelay, TimeUnit.MILLISECONDS);
+        break;
+      case EXPONENTIAL_BACKOFF:
+        long maxDelay = getNonNegativeLong(args, RETRY_POLICY_DELAY_MAX_MS, RETRY_POLICY_DELAY_MAX_MS,
+                                           cConf.getLong(maxDelayKey));
+        baseStrategy = RetryStrategies.exponentialDelay(baseDelay, maxDelay, TimeUnit.MILLISECONDS);
+        break;
+      default:
+        // not possible
+        throw new IllegalStateException("Unknown retry type " + type);
+    }
+
+    return RetryStrategies.limit(maxRetries, RetryStrategies.timeLimit(maxTimeSecs, TimeUnit.SECONDS, baseStrategy));
+  }
+
+  /**
    * Returns the {@link Resources} based on configurations in the given arguments.
    *
    * Same as calling {@link #getResources(Map, Resources)} with first argument from {@link Arguments#asMap()}.
@@ -168,23 +255,80 @@ public final class SystemArguments {
 
   /**
    * Gets a positive integer value from the given map using the given key.
-   * If there is no such key or if the value is negative, returns {@code null}.
+   * If there is no such key or if the value is not positive, returns {@code null}.
    */
   private static Integer getPositiveInt(Map<String, String> map, String key, String description) {
+    Integer val = getInt(map, key, description);
+    if (val != null && val <= 0) {
+      LOG.warn("Ignoring invalid {} '{}' from runtime arguments. It must be a positive integer.",
+               description, val);
+      return null;
+    }
+    return val;
+  }
+
+  /**
+   * Gets a non-negative (can be 0) integer value from the given map using the given key.
+   * If there is no such key or if the value is negative, returns the default.
+   */
+  private static int getNonNegativeInt(Map<String, String> map, String key, String description, int defaultVal) {
+    Integer val = getInt(map, key, description);
+    if (val == null) {
+      return defaultVal;
+    } else if (val < 0) {
+      LOG.warn("Ignoring invalid {} '{}' from runtime arguments. It must be a non-negative integer.",
+               description, val);
+      return defaultVal;
+    }
+    return val;
+  }
+
+  /**
+   * Gets a non-negative (can be 0) long value from the given map using the given key.
+   * If there is no such key or if the value is negative, returns the default.
+   */
+  private static long getNonNegativeLong(Map<String, String> map, String key, String description, long defaultVal) {
+    Long val = getLong(map, key, description);
+    if (val == null) {
+      return defaultVal;
+    } else if (val < 0) {
+      LOG.warn("Ignoring invalid {} '{}' from runtime arguments. It must be a non-negative long.",
+               description, val);
+      return defaultVal;
+    }
+    return val;
+  }
+
+  private static Integer getInt(Map<String, String> map, String key, String description) {
     String value = map.get(key);
     if (value == null) {
       return null;
     }
 
     try {
-      int intValue = Integer.parseInt(value);
-      if (intValue <= 0) {
-        throw new IllegalArgumentException("Negative " + description + " is not allowed.");
-      }
-      return intValue;
-    } catch (Exception e) {
+      return Integer.parseInt(value);
+    } catch (NumberFormatException e) {
       // Only the log the stack trace as debug, as usually it's not needed.
-      LOG.warn("Ignoring invalid {} '{}' from runtime arguments. It must be a positive integer.", description, value);
+      LOG.warn("Ignoring invalid {} '{}' from runtime arguments. It could not be parsed as an integer.",
+               description, value);
+      LOG.debug("Invalid {}", description, e);
+    }
+
+    return null;
+  }
+
+  private static Long getLong(Map<String, String> map, String key, String description) {
+    String value = map.get(key);
+    if (value == null) {
+      return null;
+    }
+
+    try {
+      return Long.parseLong(value);
+    } catch (NumberFormatException e) {
+      // Only the log the stack trace as debug, as usually it's not needed.
+      LOG.warn("Ignoring invalid {} '{}' from runtime arguments. It could not be parsed as a long.",
+               description, value);
       LOG.debug("Invalid {}", description, e);
     }
 

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/worker/BasicWorkerContext.java
@@ -78,7 +78,9 @@ final class BasicWorkerContext extends AbstractContext implements WorkerContext 
     this.instanceId = instanceId;
     this.instanceCount = instanceCount;
     this.loggingContext = createLoggingContext(program.getId().toId(), getRunId());
-    this.streamWriter = streamWriterFactory.create(new Id.Run(program.getId().toId(), getRunId().getId()), getOwners());
+    this.streamWriter = streamWriterFactory.create(new Id.Run(program.getId().toId(), getRunId().getId()),
+                                                   getOwners(),
+                                                   retryStrategy);
   }
 
   private LoggingContext createLoggingContext(Id.Program programId, RunId runId) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/batch/MapReduceProgramRunnerTest.java
@@ -328,10 +328,10 @@ public class MapReduceProgramRunnerTest extends MapReduceRunnerTestBase {
 
     // Get dataset from a non existing namespace
     try {
-      final ObjectStore<String> inputwrong = datasetCache.getDataset("nonExistingNameSpace", "keys");
+      datasetCache.getDataset("nonExistingNameSpace", "keys");
       Assert.fail("getDataset() should throw an exception when accessing dataset from a non-existing namespace.");
     } catch (DatasetInstantiationException e) {
-      Assert.assertTrue(e.getMessage().equals("Could not instantiate dataset 'nonExistingNameSpace:keys'"));
+      // expected
     }
 
     final String testString = "persisted data";
@@ -374,10 +374,10 @@ public class MapReduceProgramRunnerTest extends MapReduceRunnerTestBase {
     final java.io.File outputDir = new java.io.File(TEMP_FOLDER.newFolder(), "output");
 
     try {
-      final KeyValueTable jobConfigTable = datasetCache.getDataset("someOtherNameSpace", "jobConfig");
+      datasetCache.getDataset("someOtherNameSpace", "jobConfig");
       Assert.fail("getDataset() should throw an exception when accessing a non-existing dataset.");
     } catch (DatasetInstantiationException e) {
-      Assert.assertTrue(e.getMessage().equals("Could not instantiate dataset 'someOtherNameSpace:jobConfig'"));
+      // expected
     }
     // Should work if explicitly specify the default namespace
     final KeyValueTable jobConfigTable = datasetCache.getDataset(NamespaceId.DEFAULT.getNamespace(), "jobConfig");

--- a/cdap-common/src/main/java/co/cask/cdap/common/ServiceUnavailableException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/ServiceUnavailableException.java
@@ -17,16 +17,22 @@
 package co.cask.cdap.common;
 
 import co.cask.cdap.api.common.HttpErrorStatusProvider;
+import co.cask.cdap.api.retry.RetryableException;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
 /**
  * Exception thrown when the service is not running.
  */
-public class ServiceUnavailableException extends RuntimeException implements HttpErrorStatusProvider {
+public class ServiceUnavailableException extends RetryableException implements HttpErrorStatusProvider {
   private final String serviceName;
 
   public ServiceUnavailableException(String serviceName) {
     super("Service '" + serviceName + "' is not available. Please wait until it is up and running.");
+    this.serviceName = serviceName;
+  }
+
+  public ServiceUnavailableException(String serviceName, Throwable cause) {
+    super("Service '" + serviceName + "' is not available. Please wait until it is up and running.", cause);
     this.serviceName = serviceName;
   }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -1135,4 +1135,23 @@ public final class Constants {
   public static final class Replication {
     public static final String CDAP_SHUTDOWN_TIME_FILENAME = "cdap_shutdown_time";
   }
+
+  /**
+   * Constants for retry policies.
+   */
+  public static final class Retry {
+    private static final String PREFIX = "retry.policy.";
+    public static final String TYPE = PREFIX + "type";
+    public static final String MAX_TIME_SECS = PREFIX + "max.time.secs";
+    public static final String MAX_RETRIES = PREFIX + "max.retries";
+    public static final String DELAY_BASE_MS = PREFIX + "base.delay.ms";
+    public static final String DELAY_MAX_MS = PREFIX + "max.delay.ms";
+    public static final String MAPREDUCE_PREFIX = "mapreduce.";
+    public static final String SPARK_PREFIX = "spark.";
+    public static final String WORKFLOW_PREFIX = "workflow.";
+    public static final String CUSTOM_ACTION_PREFIX = "custom.action.";
+    public static final String WORKER_PREFIX = "worker.";
+    public static final String SERVICE_PREFIX = "service.";
+    public static final String FLOW_PREFIX = "flow.";
+  }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/internal/remote/RemoteOpsClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/internal/remote/RemoteOpsClient.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.common.internal.remote;
 
+import co.cask.cdap.common.ServiceUnavailableException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.EndpointStrategy;
@@ -49,7 +50,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
@@ -88,9 +88,9 @@ public class RemoteOpsClient {
   }
 
   private String resolve(String resource) {
-    Discoverable discoverable = endpointStrategySupplier.get().pick(3L, TimeUnit.SECONDS);
+    Discoverable discoverable = endpointStrategySupplier.get().pick();
     if (discoverable == null) {
-      throw new RuntimeException(String.format("Cannot discover service %s", discoverableServiceName));
+      throw new ServiceUnavailableException(discoverableServiceName);
     }
     InetSocketAddress address = discoverable.getSocketAddress();
     String scheme = Arrays.equals(Constants.Security.SSL_URI_SCHEME.getBytes(), discoverable.getPayload()) ?

--- a/cdap-common/src/main/java/co/cask/cdap/common/service/Retries.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/service/Retries.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.service;
+
+import co.cask.cdap.api.Predicate;
+import co.cask.cdap.api.retry.RetriesExhaustedException;
+import co.cask.cdap.api.retry.RetryableException;
+import com.google.common.base.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Utilities to perform logic with retries.
+ */
+public final class Retries {
+  private static final Logger LOG = LoggerFactory.getLogger(Retries.class);
+  private static final Predicate<Throwable> DEFAULT_PREDICATE = new Predicate<Throwable>() {
+    @Override
+    public boolean apply(Throwable throwable) {
+      return throwable instanceof RetryableException;
+    }
+  };
+
+  private Retries() {
+
+  }
+
+  /**
+   * A Callable whose throwable is generic. This is used so that
+   * {@link #callWithRetries(Callable, RetryStrategy, Predicate)} does not have to wrap any exceptions.
+   *
+   * @param <V> the type of return value
+   * @param <T> the type of throwable
+   */
+  public interface Callable<V, T extends Throwable> {
+    V call() throws T;
+  }
+
+  /**
+   * The same as calling {@link #supplyWithRetries(Supplier, RetryStrategy, Predicate)} where a retryable failure
+   * is defined as a {@link RetryableException}.
+   *
+   * @param supplier the callable to run
+   * @param retryStrategy the retry strategy to use if the supplier throws a {@link RetryableException}
+   * @param <V> the type of object returned by the supplier
+   * @return the return value of the supplier
+   * @throws RuntimeException if the supplier failed in a way that is not retryable, or the retries were exhausted.
+   *   If retries were exhausted, a {@link RetriesExhaustedException} will be added as a suppressed exception.
+   *   If the call was interrupted while waiting between retries, the {@link InterruptedException} will be added
+   *   as a suppressed exception
+   */
+  public static <V> V supplyWithRetries(Supplier<V> supplier, RetryStrategy retryStrategy) {
+    return supplyWithRetries(supplier, retryStrategy, DEFAULT_PREDICATE);
+  }
+
+  /**
+   * Executes {@link Supplier#get()}, retrying the call if it throws something retryable. This is similar to
+   * {@link #callWithRetries(Callable, RetryStrategy, Predicate)}, except it will simply re-throw any non-retryable
+   * exception instead of wrapping it in an ExecutionException. If you need to run logic that throws a
+   * checked exception, use {@link #callWithRetries(Callable, RetryStrategy, Predicate)} instead.
+   *
+   * @param supplier the callable to run
+   * @param retryStrategy the retry strategy to use if the supplier fails in a retryable way
+   * @param isRetryable predicate to determine whether the supplier failure is retryable or not
+   * @param <V> the type of object returned by the supplier
+   * @return the return value of the supplier
+   * @throws RuntimeException if the supplier failed in a way that is not retryable, or the retries were exhausted.
+   *   If retries were exhausted, a {@link RetriesExhaustedException} will be added as a suppressed exception.
+   *   If the call was interrupted while waiting between retries, the {@link InterruptedException} will be added
+   *   as a suppressed exception
+   */
+  public static <V> V supplyWithRetries(final Supplier<V> supplier, RetryStrategy retryStrategy,
+                                        Predicate<Throwable> isRetryable) {
+    return callWithRetries(new Callable<V, RuntimeException>() {
+      @Override
+      public V call() throws RuntimeException {
+        return supplier.get();
+      }
+    }, retryStrategy, isRetryable);
+  }
+
+  /**
+   * The same as calling {@link #callWithRetries(Callable, RetryStrategy, Predicate)} where a retryable failure
+   * is defined as a {@link RetryableException}.
+   *
+   * @param callable the callable to run
+   * @param retryStrategy the retry strategy to use if the callable throws a {@link RetryableException}
+   * @param <V> the type of return value
+   * @param <T> the type of throwable
+   * @return the return value of the callable
+   * @throws T if the callable failed in a way that is not retryable, or the retries were exhausted.
+   *   If retries were exhausted, a {@link RetriesExhaustedException} will be added as a suppressed exception.
+   *   If the call was interrupted while waiting between retries, the {@link InterruptedException} will be added
+   *   as a suppressed exception
+   */
+  public static <V, T extends Throwable> V callWithRetries(Callable<V, T> callable,
+                                                           RetryStrategy retryStrategy) throws T {
+    return callWithRetries(callable, retryStrategy, DEFAULT_PREDICATE);
+  }
+
+  /**
+   * Executes a {@link Callable}, retrying the call if it throws something retryable.
+   *
+   * @param callable the callable to run
+   * @param retryStrategy the retry strategy to use if the callable fails in a retryable way
+   * @param isRetryable predicate to determine whether the callable failure is retryable or not
+   * @param <V> the type of return value
+   * @param <T> the type of throwable
+   * @return the return value of the callable
+   * @throws T if the callable failed in a way that is not retryable, or the retries were exhausted.
+   *   If retries were exhausted, a {@link RetriesExhaustedException} will be added as a suppressed exception.
+   *   If the call was interrupted while waiting between retries, the {@link InterruptedException} will be added
+   *   as a suppressed exception
+   */
+  public static <V, T extends Throwable> V callWithRetries(Callable<V, T> callable,
+                                                           RetryStrategy retryStrategy,
+                                                           Predicate<Throwable> isRetryable) throws T {
+
+    int failures = 0;
+    long startTime = System.currentTimeMillis();
+    while (true) {
+      try {
+        V v = callable.call();
+        if (failures > 0) {
+          LOG.debug("Retry succeeded after {} retries.", failures);
+        }
+        return v;
+      } catch (Throwable t) {
+        if (!isRetryable.apply(t)) {
+          throw t;
+        }
+
+        long retryTime = retryStrategy.nextRetry(++failures, startTime);
+        if (retryTime < 0) {
+          String errMsg = String.format("Retries exhausted after %d failures and %d ms.",
+                                        failures, System.currentTimeMillis() - startTime);
+          LOG.debug(errMsg);
+          t.addSuppressed(new RetriesExhaustedException(errMsg));
+          throw t;
+        }
+
+        LOG.debug("Call failed, retrying again after {} ms.", retryTime, t);
+        try {
+          TimeUnit.MILLISECONDS.sleep(retryTime);
+        } catch (InterruptedException e) {
+          // if we were interrupted while waiting for the next retry, treat it like no retries were attempted
+          t.addSuppressed(e);
+          Thread.currentThread().interrupt();
+          throw t;
+        }
+      }
+    }
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/service/RetryStrategyType.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/service/RetryStrategyType.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.service;
+
+/**
+ * Types of retry strategies that users can configure for programs.
+ */
+public enum RetryStrategyType {
+  NONE("none"),
+  FIXED_DELAY("fixed.delay"),
+  EXPONENTIAL_BACKOFF("exponential.backoff");
+
+  private final String id;
+
+  RetryStrategyType(String id) {
+    this.id = id;
+  }
+
+  public static RetryStrategyType from(String str) {
+    switch (str.toLowerCase()) {
+      case "none":
+        return NONE;
+      case "fixed.delay":
+        return FIXED_DELAY;
+      case "exponential.backoff":
+        return EXPONENTIAL_BACKOFF;
+      default:
+        throw new IllegalArgumentException(String.format("Unknown RetryStrategyType %s. Must be one of %s.",
+                                                         str, "none, fixed.delay, or exponential.backoff"));
+    }
+  }
+
+  @Override
+  public String toString() {
+    return id;
+  }
+}

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1677,6 +1677,289 @@
   </property>
 
 
+  <!-- Retry Policies Configuration -->
+
+  <property>
+    <name>custom.action.retry.policy.base.delay.ms</name>
+    <value>1000</value>
+    <description>
+      The base delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>custom.action.retry.policy.max.delay.ms</name>
+    <value>30000</value>
+    <description>
+      The maximum delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>custom.action.retry.policy.max.retries</name>
+    <value>1000</value>
+    <description>
+      The maximum number of retries to attempt before aborting
+    </description>
+  </property>
+
+  <property>
+    <name>custom.action.retry.policy.max.time.secs</name>
+    <value>600</value>
+    <description>
+      The maximum elapsed time in seconds before retries are aborted
+    </description>
+  </property>
+
+  <property>
+    <name>custom.action.retry.policy.type</name>
+    <value>exponential.backoff</value>
+    <description>
+      The type of retry policy for custom actions
+    </description>
+  </property>
+
+  <property>
+    <name>flow.retry.policy.base.delay.ms</name>
+    <value>100</value>
+    <description>
+      The base delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>flow.retry.policy.max.delay.ms</name>
+    <value>1000</value>
+    <description>
+      The maximum delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>flow.retry.policy.max.retries</name>
+    <value>3</value>
+    <description>
+      The maximum number of retries to attempt before aborting
+    </description>
+  </property>
+
+  <property>
+    <name>flow.retry.policy.max.time.secs</name>
+    <value>10</value>
+    <description>
+      The maximum elapsed time in seconds before retries are aborted
+    </description>
+  </property>
+
+  <property>
+    <name>flow.retry.policy.type</name>
+    <value>none</value>
+    <description>
+      The type of retry policy for flows
+    </description>
+  </property>
+
+  <property>
+    <name>mapreduce.retry.policy.base.delay.ms</name>
+    <value>1000</value>
+    <description>
+      The base delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>mapreduce.retry.policy.max.delay.ms</name>
+    <value>30000</value>
+    <description>
+      The maximum delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>mapreduce.retry.policy.max.retries</name>
+    <value>1000</value>
+    <description>
+      The maximum number of retries to attempt before aborting
+    </description>
+  </property>
+
+  <property>
+    <name>mapreduce.retry.policy.max.time.secs</name>
+    <value>600</value>
+    <description>
+      The maximum elapsed time in seconds before retries are aborted
+    </description>
+  </property>
+
+  <property>
+    <name>mapreduce.retry.policy.type</name>
+    <value>exponential.backoff</value>
+    <description>
+      The type of retry policy for mapreduce
+    </description>
+  </property>
+
+  <property>
+    <name>service.retry.policy.base.delay.ms</name>
+    <value>100</value>
+    <description>
+      The base delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>service.retry.policy.max.delay.ms</name>
+    <value>1000</value>
+    <description>
+      The maximum delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>service.retry.policy.max.retries</name>
+    <value>3</value>
+    <description>
+      The maximum number of retries to attempt before aborting
+    </description>
+  </property>
+
+  <property>
+    <name>service.retry.policy.max.time.secs</name>
+    <value>10</value>
+    <description>
+      The maximum elapsed time in seconds before retries are aborted
+    </description>
+  </property>
+
+  <property>
+    <name>service.retry.policy.type</name>
+    <value>none</value>
+    <description>
+      The type of retry policy for services
+    </description>
+  </property>
+
+  <property>
+    <name>spark.retry.policy.base.delay.ms</name>
+    <value>1000</value>
+    <description>
+      The base delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>spark.retry.policy.max.delay.ms</name>
+    <value>30000</value>
+    <description>
+      The maximum delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>spark.retry.policy.max.retries</name>
+    <value>1000</value>
+    <description>
+      The maximum number of retries to attempt before aborting
+    </description>
+  </property>
+
+  <property>
+    <name>spark.retry.policy.max.time.secs</name>
+    <value>600</value>
+    <description>
+      The maximum elapsed time in seconds before retries are aborted
+    </description>
+  </property>
+
+  <property>
+    <name>spark.retry.policy.type</name>
+    <value>exponential.backoff</value>
+    <description>
+      The type of retry policy for spark
+    </description>
+  </property>
+
+  <property>
+    <name>worker.retry.policy.base.delay.ms</name>
+    <value>1000</value>
+    <description>
+      The base delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>worker.retry.policy.max.delay.ms</name>
+    <value>30000</value>
+    <description>
+      The maximum delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>worker.retry.policy.max.retries</name>
+    <value>1000</value>
+    <description>
+      The maximum number of retries to attempt before aborting
+    </description>
+  </property>
+
+  <property>
+    <name>worker.retry.policy.max.time.secs</name>
+    <value>600</value>
+    <description>
+      The maximum elapsed time in seconds before retries are aborted
+    </description>
+  </property>
+
+  <property>
+    <name>worker.retry.policy.type</name>
+    <value>exponential.backoff</value>
+    <description>
+      The type of retry policy for workers
+    </description>
+  </property>
+
+  <property>
+    <name>workflow.retry.policy.base.delay.ms</name>
+    <value>1000</value>
+    <description>
+      The base delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>workflow.retry.policy.max.delay.ms</name>
+    <value>30000</value>
+    <description>
+      The maximum delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>workflow.retry.policy.max.retries</name>
+    <value>1000</value>
+    <description>
+      The maximum number of retries to attempt before aborting
+    </description>
+  </property>
+
+  <property>
+    <name>workflow.retry.policy.max.time.secs</name>
+    <value>600</value>
+    <description>
+      The maximum elapsed time in seconds before retries are aborted
+    </description>
+  </property>
+
+  <property>
+    <name>workflow.retry.policy.type</name>
+    <value>exponential.backoff</value>
+    <description>
+      The type of retry policy for workflows
+    </description>
+  </property>
+
+
   <!-- Router Configuration -->
 
   <property>

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/dataset/SystemDatasetInstantiator.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/dataset/SystemDatasetInstantiator.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.api.dataset.DatasetManagementException;
+import co.cask.cdap.common.ServiceUnavailableException;
 import co.cask.cdap.data2.datafabric.dataset.type.ConstantClassLoaderProvider;
 import co.cask.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
 import co.cask.cdap.data2.datafabric.dataset.type.DirectoryClassLoaderProvider;
@@ -29,6 +30,7 @@ import co.cask.cdap.data2.metadata.lineage.AccessType;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.EntityId;
 import com.google.common.base.Objects;
+import com.google.common.base.Throwables;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -103,6 +105,7 @@ public class SystemDatasetInstantiator implements Closeable {
       }
       return dataset;
     } catch (Exception e) {
+      Throwables.propagateIfInstanceOf(e, ServiceUnavailableException.class);
       throw new DatasetInstantiationException("Failed to access dataset: " + datasetId, e);
     }
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -70,7 +70,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
@@ -390,7 +389,7 @@ class DatasetServiceClient {
   }
 
   private String resolve(String resource) throws DatasetManagementException {
-    Discoverable discoverable = endpointStrategySupplier.get().pick(3, TimeUnit.SECONDS);
+    Discoverable discoverable = endpointStrategySupplier.get().pick();
     if (discoverable == null) {
       throw new ServiceUnavailableException("DatasetService");
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriterDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/writer/LineageWriterDatasetFramework.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.annotation.WriteOnly;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.dataset.DatasetManagementException;
 import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.common.ServiceUnavailableException;
 import co.cask.cdap.data.runtime.DataSetsModules;
 import co.cask.cdap.data2.audit.AuditPublisher;
 import co.cask.cdap.data2.audit.AuditPublishers;
@@ -177,7 +178,7 @@ public class LineageWriterDatasetFramework extends ForwardingDatasetFramework im
                                                                   classLoaderProvider, owners, accessType);
           }
         });
-    } catch (IOException | DatasetManagementException e) {
+    } catch (IOException | DatasetManagementException | ServiceUnavailableException e) {
       throw e;
     } catch (Exception e) {
       throw new DatasetManagementException("Failed to create dataset instance: " + datasetInstanceId, e);

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="018de95a34db2c71a014577d2afc9ec8"
+DEFAULT_XML_MD5_HASH="63e604f66cfc70c795da8a48a8b1869f"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/MessagingService.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/MessagingService.java
@@ -18,6 +18,7 @@ package co.cask.cdap.messaging;
 
 import co.cask.cdap.api.messaging.TopicAlreadyExistsException;
 import co.cask.cdap.api.messaging.TopicNotFoundException;
+import co.cask.cdap.common.ServiceUnavailableException;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.TopicId;
 
@@ -38,6 +39,7 @@ public interface MessagingService {
    * @param topicMetadata topic to be created
    * @throws TopicAlreadyExistsException if the topic to be created already exist
    * @throws IOException if failed to create the topic
+   * @throws ServiceUnavailableException if the messaging service is not available
    */
   void createTopic(TopicMetadata topicMetadata) throws TopicAlreadyExistsException, IOException;
 
@@ -47,6 +49,7 @@ public interface MessagingService {
    * @param topicMetadata the topic metadata to be updated
    * @throws TopicNotFoundException if the topic doesn't exist
    * @throws IOException if failed to update the topic metadata
+   * @throws ServiceUnavailableException if the messaging service is not available
    */
   void updateTopic(TopicMetadata topicMetadata) throws TopicNotFoundException, IOException;
 
@@ -56,6 +59,7 @@ public interface MessagingService {
    * @param topicId the topic to be deleted
    * @throws TopicNotFoundException if the topic doesn't exist
    * @throws IOException if failed to delete the topic
+   * @throws ServiceUnavailableException if the messaging service is not available
    */
   void deleteTopic(TopicId topicId) throws TopicNotFoundException, IOException;
 
@@ -66,6 +70,7 @@ public interface MessagingService {
    * @return the {@link TopicMetadata} of the given topic.
    * @throws TopicNotFoundException if the topic doesn't exist
    * @throws IOException if failed to retrieve topic metadata.
+   * @throws ServiceUnavailableException if the messaging service is not available
    */
   TopicMetadata getTopic(TopicId topicId) throws TopicNotFoundException, IOException;
 
@@ -75,6 +80,7 @@ public interface MessagingService {
    * @param namespaceId the namespace to list topics under it
    * @return a {@link List} of {@link TopicId}.
    * @throws IOException if failed to retrieve topics.
+   * @throws ServiceUnavailableException if the messaging service is not available
    */
   List<TopicId> listTopics(NamespaceId namespaceId) throws IOException;
 
@@ -85,6 +91,7 @@ public interface MessagingService {
    * @return a {@link MessageFetcher} for setting up parameters for fetching messages from the messaging system
    * @throws TopicNotFoundException if the topic doesn't exist
    * @throws IOException if failed to fetch messages
+   * @throws ServiceUnavailableException if the messaging service is not available
    */
   MessageFetcher prepareFetch(TopicId topicId) throws TopicNotFoundException, IOException;
 
@@ -96,6 +103,7 @@ public interface MessagingService {
    *         information for rollback; otherwise {@code null} will be returned.
    * @throws TopicNotFoundException if the topic doesn't exist
    * @throws IOException if failed to publish messages
+   * @throws ServiceUnavailableException if the messaging service is not available
    */
   @Nullable
   RollbackDetail publish(StoreRequest request) throws TopicNotFoundException, IOException;
@@ -106,6 +114,7 @@ public interface MessagingService {
    * @param request the {@link StoreRequest} containing messages to be stored
    * @throws TopicNotFoundException if the topic doesn't exist
    * @throws IOException if failed to store messages
+   * @throws ServiceUnavailableException if the messaging service is not available
    */
   void storePayload(StoreRequest request) throws TopicNotFoundException, IOException;
 
@@ -118,6 +127,7 @@ public interface MessagingService {
    *                     which contains information needed for the rollback
    * @throws TopicNotFoundException if the topic doesn't exist
    * @throws IOException if failed to rollback changes
+   * @throws ServiceUnavailableException if the messaging service is not available
    */
   void rollback(TopicId topicId, RollbackDetail rollbackDetail) throws TopicNotFoundException, IOException;
 }

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/client/ClientMessagingService.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/client/ClientMessagingService.java
@@ -294,7 +294,7 @@ public final class ClientMessagingService implements MessagingService {
   private URL createURL(String path) throws MalformedURLException {
     Discoverable discoverable = endpointStrategy.get().pick(DISCOVERY_PICK_TIMEOUT_SECS, TimeUnit.SECONDS);
     if (discoverable == null) {
-      throw new ServiceUnavailableException("No endpoint available for messaging service");
+      throw new ServiceUnavailableException(Constants.Service.MESSAGING_SERVICE);
     }
 
     InetSocketAddress address = discoverable.getSocketAddress();


### PR DESCRIPTION
Adding a way to configure a retry policy for programs and using
that policy when a service is unavailable. Each program type has
its own default policy that can be set in the cdap configuration.
The default policy can be overridden for a specific program run
using runtime arguments.

ServiceDiscoverer, StreamWriter, Admin, and DatasetContext.getDataset
methods have been changed to use the retry policy.