### PR TITLE
[HYDRATOR-1154] Adds backend heartbeat status to CDAP

### DIFF
--- a/cdap-ui/.eslintrc.json
+++ b/cdap-ui/.eslintrc.json
@@ -43,6 +43,7 @@
     "getAbsUIUrl": true,
     "_": true,
     "describe": true,
+    "jasmine": true,
     "it": true,
     "expect": true,
     "jest": true,

--- a/cdap-ui/app/cdap/components/Alert/Alert.less
+++ b/cdap-ui/app/cdap/components/Alert/Alert.less
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+@import "../../styles/variables.less";
+
+.global-alert {
+  &.modal-dialog {
+    margin-top: 50px;
+    width: 100%;
+
+    .modal-content {
+      border-radius: 0;
+      .success,
+      .error,
+      .info {
+        padding: 10px;
+        display: flex;
+        color: white;
+        justify-content: space-between;
+      }
+      .success {
+        background-color: @brand-success;
+      }
+      .error {
+        background-color: @brand-danger;
+      }
+      .fa.fa-times {
+        cursor: pointer;
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/Alert/__tests__/Alert.test.js
+++ b/cdap-ui/app/cdap/components/Alert/__tests__/Alert.test.js
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import {mount} from 'enzyme';
+import Alert from 'components/Alert';
+
+const defaultAlertMessage = "Alert Message 1";
+let alert;
+
+describe('Alert Unit tests', () => {
+  beforeEach(() => {
+    jasmine.clock().install();
+    let alertType = 'success';
+    let alertMessage = defaultAlertMessage;
+    alert = mount(
+      <Alert
+        showAlert={true}
+        type={alertType}
+        message={alertMessage}
+      />
+    );
+  });
+  afterEach( () => {
+    alert.unmount();
+    jasmine.clock().uninstall();
+  });
+
+  it('Should render', () => {
+    jasmine.clock().tick(500);
+    expect(document.getElementsByClassName('modal').length).toBe(1);
+    expect(document.getElementsByClassName('global-alert').length).toBe(1);
+    expect(document.getElementsByClassName('message').length).toBe(1);
+    expect(document.querySelector('.modal .global-alert .modal-content .fa')).not.toBe(null);
+    expect(alert.props().showAlert).toBe(true);
+    expect(alert.props().type).toBe('success');
+  });
+
+  it('Should have a valid state', () => {
+    jasmine.clock().tick(500);
+    expect(alert.state().message).toBe(defaultAlertMessage);
+    expect(alert.state().type).toBe('success');
+    expect(alert.state().showAlert).toBe(true);
+  });
+
+  it('Should have a valid state on alert type/message change', () => {
+    let alertType = 'success';
+    let alertMessage = defaultAlertMessage;
+    jasmine.clock().tick(500);
+    expect(alert.state().message).toBe(defaultAlertMessage);
+    expect(alert.state().type).toBe(alertType);
+    expect(alert.state().showAlert).toBe(true);
+
+    alertType = 'error';
+    alertMessage = 'Error Message';
+    alert.setProps({type: alertType, message: alertMessage});
+
+    jasmine.clock().tick(500);
+    expect(alert.state().message).toBe(alertMessage);
+    expect(alert.state().type).toBe(alertType);
+    expect(alert.state().showAlert).toBe(true);
+
+  });
+
+  it('Should close when clicked on the close button', () => {
+    jasmine.clock().tick(500);
+    let closeBtn = document.querySelector('.global-alert .fa.fa-times');
+    closeBtn.click();
+    jasmine.clock().tick(500);
+    expect(document.getElementsByClassName('global-alert').length).toBe(0);
+  });
+
+  it('Should close when 3s has elapsed since showing the alert', () => {
+    setTimeout(() => {
+      expect(document.getElementsByClassName('global-alert').length).toBe(0);
+    }, 4000);
+  });
+});

--- a/cdap-ui/app/cdap/components/Alert/index.js
+++ b/cdap-ui/app/cdap/components/Alert/index.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, {Component, PropTypes} from 'react';
+import {Modal} from 'reactstrap';
+require('./Alert.less');
+
+export default class Alert extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      showAlert: false || props.showAlert,
+      message: props.message,
+      type: props.type
+    };
+  }
+  componentWillReceiveProps(nextProps) {
+    let {showAlert, type, message} = nextProps;
+    if (
+      showAlert !== this.state.showAlert ||
+      type !== this.state.type ||
+      message !== this.state.message
+    ) {
+      this.setState({
+        showAlert,
+        type,
+        message
+      });
+    }
+  }
+  render() {
+    return (
+      <Modal
+        isOpen={this.state.showAlert}
+        toggle={() => {}}
+        backdrop={false}
+        className="global-alert">
+        <div className={this.state.type}>
+          <span className="message">{this.state.message}</span>
+          <span className="fa fa-times" onClick={() => this.setState({showAlert: false, message: '', type: ''})}></span>
+        </div>
+      </Modal>
+    );
+  }
+}
+Alert.propTypes = {
+  showAlert: PropTypes.bool,
+  message: PropTypes.string,
+  type: PropTypes.oneOf([
+    'success',
+    'error',
+    'info'
+  ])
+};

--- a/cdap-ui/app/cdap/components/Header/Header.less
+++ b/cdap-ui/app/cdap/components/Header/Header.less
@@ -32,7 +32,7 @@
     color: white;
     border: 0;
     font-weight: 500;
-    z-index: 10000;
+    z-index: 1000;
     margin-bottom: 0;
 
     &.cdap { .product-navbar-mixins(@cdap-orange, @cdap-orange); }

--- a/cdap-ui/app/cdap/components/LoadingIndicator/LoadingIndicator.less
+++ b/cdap-ui/app/cdap/components/LoadingIndicator/LoadingIndicator.less
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+@import '../../styles/variables.less';
+
+.loading-indicator {
+  &.modal-dialog {
+    top: 36%;
+
+    .modal-content {
+      padding: 10px;
+
+      .fa {
+        font-size: 84px;
+
+        @-webkit-keyframes color_change {
+          from { color: white; }
+          to { color: @cdap-orange; }
+        }
+
+        @-moz-keyframes color_change {
+          from { color: white; }
+          to { color: @cdap-orange; }
+        }
+
+        @-ms-keyframes color_change {
+          from { color: white; }
+          to { color: @cdap-orange; }
+        }
+
+        @-o-keyframes color_change {
+          from { color: white; }
+          to { color: @cdap-orange; }
+        }
+
+        @keyframes color_change {
+          from { color: white; }
+          to { color: @cdap-orange; }
+        }
+
+        animation: color_change 0.2s infinite alternate;
+      }
+      h2 {
+        margin-top: 10px;
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/LoadingIndicator/LoadingIndicatorStore.js
+++ b/cdap-ui/app/cdap/components/LoadingIndicator/LoadingIndicatorStore.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import {combineReducers, createStore} from 'redux';
+
+const defaultLoadingState = {
+  status: 'BACKENDUP',
+  message: '',
+  subtitle: ''
+};
+const defaultAction = {
+  action : '',
+  payload : {}
+};
+const BACKENDSTATUS = {
+  STATUSUPDATE: 'STATUSUPDATE',
+  BACKENDUP: 'BACKENDUP',
+  NODESERVERDOWN: 'NODESERVERDOWN',
+  NODESERVERUP: 'NODESERVERUP',
+  BACKENDDOWN: 'BACKENDDOWN'
+};
+const LOADINGSTATUS = {
+  SHOWLOADING: 'SHOWLOADING',
+  HIDELOADING: 'HIDELOADING'
+};
+
+const loading = (state = defaultLoadingState, action = defaultAction) => {
+  switch (action.type) {
+    case 'STATUSUPDATE':
+      {
+        let {status = LOADINGSTATUS.HIDELOADING, message = '', subtitle = ''} = action.payload;
+        return Object.assign({}, state, {
+          status,
+          message,
+          subtitle
+        });}
+    default:
+      return state;
+  }
+};
+
+const LoadingIndicatorStore = createStore(
+  combineReducers({
+    loading
+  }),
+  {loading: defaultLoadingState},
+  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+);
+
+export default LoadingIndicatorStore;
+export {BACKENDSTATUS, LOADINGSTATUS};

--- a/cdap-ui/app/cdap/components/LoadingIndicator/__tests__/LoadingIndicator.test.js
+++ b/cdap-ui/app/cdap/components/LoadingIndicator/__tests__/LoadingIndicator.test.js
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React from 'react';
+import {mount} from 'enzyme';
+
+import LoadigIndicator from 'components/LoadingIndicator';
+import LoadingIndicatorStore, {LOADINGSTATUS} from 'components/LoadingIndicator/LoadingIndicatorStore';
+
+let loadingIndicator;
+let defaultMessage = 'Loading Message 1';
+let defaultSubtitle = 'Loading Message Subtitle';
+
+const showLoadingIndicator = (message, subtitle) => (
+  LoadingIndicatorStore.dispatch({
+    type: 'STATUSUPDATE',
+    payload: {
+      status: LOADINGSTATUS.SHOWLOADING,
+      message: message || defaultMessage,
+      subtitle: subtitle || defaultSubtitle
+    }
+  })
+);
+const hideLoadingIndicator = () => (
+  LoadingIndicatorStore.dispatch({
+    type: 'STATUSUPDATE',
+    payload: {
+      status: LOADINGSTATUS.HIDELOADING
+    }
+  })
+);
+describe('LoadingIndicator Unit Tests', () => {
+  beforeEach(() => {
+    jasmine.clock().install();
+    loadingIndicator = mount(
+      <LoadigIndicator />
+    );
+  });
+
+  afterEach(() => {
+    hideLoadingIndicator();
+    jasmine.clock().tick(300);
+    jasmine.clock().uninstall();
+    loadingIndicator.unmount();
+  });
+
+  it('Should render', () => {
+    showLoadingIndicator();
+    jasmine.clock().tick(500);
+    expect(document.getElementsByClassName('modal').length).toBe(1);
+    expect(document.getElementsByClassName('loading-indicator').length).toBe(1);
+  });
+
+  it('Should update state appropriately', () => {
+    showLoadingIndicator();
+    jasmine.clock().tick(500);
+    expect(loadingIndicator.state().showLoading).toBe(true);
+    expect(loadingIndicator.state().message).toBe(defaultMessage);
+    expect(loadingIndicator.state().subtitle).toBe(defaultSubtitle);
+  });
+
+  it('Should update message and subtitle', () => {
+    showLoadingIndicator();
+    jasmine.clock().tick(500);
+    expect(loadingIndicator.state().showLoading).toBe(true);
+    expect(loadingIndicator.state().message).toBe(defaultMessage);
+    expect(loadingIndicator.state().subtitle).toBe(defaultSubtitle);
+    let newMessage = 'LoadingIndicator Message 2';
+    let newSubtitle = 'LoadingIndicator Subtitle Message 2';
+    showLoadingIndicator(newMessage, newSubtitle);
+    expect(loadingIndicator.state().message).toBe(newMessage);
+    expect(loadingIndicator.state().subtitle).toBe(newSubtitle);
+  });
+
+  it('Should close on update in state', () => {
+    showLoadingIndicator();
+    jasmine.clock().tick(500);
+    hideLoadingIndicator();
+    jasmine.clock().tick(500);
+    expect(document.getElementsByClassName('modal').length).toBe(0);
+    expect(document.getElementsByClassName('loading-indicator').length).toBe(0);
+  });
+
+  it('Should render default icon', () => {
+    showLoadingIndicator();
+    expect(loadingIndicator.props().icon).toBe('icon-fist');
+  });
+
+  it('Should render icon passed as props', () => {
+    let customIcon = "icon-hydrator";
+    let loading = mount(
+      <LoadigIndicator
+        icon={customIcon}
+      />
+    );
+    expect(loading.props().icon).toBe(customIcon);
+  });
+});

--- a/cdap-ui/app/cdap/components/LoadingIndicator/index.js
+++ b/cdap-ui/app/cdap/components/LoadingIndicator/index.js
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React, {Component, PropTypes} from 'react';
+import classnames from 'classnames';
+import LoadingIndicatorStore, {BACKENDSTATUS, LOADINGSTATUS} from 'components/LoadingIndicator/LoadingIndicatorStore';
+import T from 'i18n-react';
+import {Modal} from 'reactstrap';
+
+require('./LoadingIndicator.less');
+
+export default class LoadingIndicator extends Component {
+  constructor(props) {
+    super(props);
+    let {message = '', subtitle = ''} = this.props;
+    this.state = {
+      showLoading: false,
+      message,
+      subtitle
+    };
+  }
+  componentDidMount() {
+    this.loadingIndicatorStoreSubscription = LoadingIndicatorStore.subscribe(() => {
+      let {status, message = '', subtitle = ''} = LoadingIndicatorStore.getState().loading;
+      let showLoading;
+      if ([BACKENDSTATUS.BACKENDUP, BACKENDSTATUS.NODESERVERUP, LOADINGSTATUS.HIDELOADING].indexOf(status) !== -1) {
+        showLoading = false;
+      }
+      if ([LOADINGSTATUS.SHOWLOADING, BACKENDSTATUS.NODESERVERDOWN, BACKENDSTATUS.BACKENDDOWN].indexOf(status) !== -1) {
+        showLoading = true;
+      }
+      this.setState({
+        showLoading,
+        message,
+        subtitle
+      });
+    });
+  }
+  componentWillUnmount() {
+    this.loadingIndicatorStoreSubscription();
+  }
+  render() {
+    return this.state.showLoading ?
+      (
+        <Modal
+          isOpen={this.state.showLoading}
+          toggle={() =>{}}
+          className="loading-indicator"
+        >
+          <div className="text-center">
+            <div className={classnames('fa', this.props.icon)}></div>
+            <h2> {this.state.message} </h2>
+            <h4>{this.state.subtitle}</h4>
+          </div>
+        </Modal>
+      )
+    :
+      null;
+  }
+}
+LoadingIndicator.defaultProps = {
+  icon: 'icon-fist',
+  message: T.translate('features.LoadingIndicator.defaultMessage')
+};
+
+LoadingIndicator.propTypes = {
+  message: PropTypes.string,
+  subtitle: PropTypes.string,
+  icon: PropTypes.string
+};

--- a/cdap-ui/app/cdap/components/MarketPlaceEntity/MarketPlaceEntity.less
+++ b/cdap-ui/app/cdap/components/MarketPlaceEntity/MarketPlaceEntity.less
@@ -70,8 +70,6 @@
     color: white;
     background-color: #ff6600;
     text-shadow: 0px 1px 2px #bbbbbb;
-    -webkit-box-shadow: 0px 2px 4px #888888;
-    -moz-box-shadow: 0px 2px 4px #888888;
     box-shadow: 0px 2px 4px #888888;
     font-size: 12px;
     display: block;

--- a/cdap-ui/app/cdap/components/MarketPlaceUsecaseEntity/MarketPlaceUsecaseEntity.less
+++ b/cdap-ui/app/cdap/components/MarketPlaceUsecaseEntity/MarketPlaceUsecaseEntity.less
@@ -24,10 +24,8 @@
     position: relative;
     color: white;
     background-color: #ff6600;
-    text-shadow: 0px 1px 2px #bbb;
-    -webkit-box-shadow: 0px 2px 4px #888;
-    -moz-box-shadow: 0px 2px 4px #888;
-    box-shadow: 0px 2px 4px #888;
+    text-shadow: 0px 1px 2px #bbbbbb;
+    box-shadow: 0px 2px 4px #888888;
     font-size: 12px;
     display: block;
   }
@@ -100,9 +98,6 @@
         width: 100%;
         box-shadow: 1px 2px 10px 0 rgba(0, 0, 0, 0.3);
         user-select: none;
-        -moz-user-select: none;
-        -webkit-user-select: none;
-        -ms-user-select: none;
         z-index: 1;
         margin-bottom: 10px;
       }

--- a/cdap-ui/app/cdap/components/StatusAlertMessage/StatusAlertMessageStore.js
+++ b/cdap-ui/app/cdap/components/StatusAlertMessage/StatusAlertMessageStore.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import {combineReducers, createStore} from 'redux';
+
+const defaultAction = {
+  type: '',
+  payload: {}
+};
+
+const defaultViewState = false;
+
+const view = (state = defaultViewState, action = defaultAction) => {
+  switch (action.type) {
+    case 'VIEWUPDATE':
+      return action.payload.view;
+    default:
+      return state;
+  }
+};
+
+const StatusAlertMessageStore = createStore(
+  combineReducers({
+    view
+  }),
+  {view: defaultViewState},
+  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+);
+
+export default StatusAlertMessageStore;

--- a/cdap-ui/app/cdap/components/StatusAlertMessage/index.js
+++ b/cdap-ui/app/cdap/components/StatusAlertMessage/index.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import React, {Component} from 'react';
+import StatusAlertMessageStore from 'components/StatusAlertMessage/StatusAlertMessageStore';
+import Alert from 'components/Alert';
+import T from 'i18n-react';
+
+
+export default class StatusAlertMessage extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      showMessage: false
+    };
+  }
+  componentWillMount() {
+    window.StatusAlertMessageStore = StatusAlertMessageStore;
+    StatusAlertMessageStore.subscribe(() => {
+      let showMessage = StatusAlertMessageStore.getState().view;
+      this.setState({
+        showMessage
+      });
+      if (showMessage) {
+        setTimeout(() => {
+          StatusAlertMessageStore.dispatch({
+            type: 'VIEWUPDATE',
+            payload: {
+              view: false
+            }
+          });
+        }, 3000);
+      }
+    });
+  }
+  componentWillUnmount() {
+    StatusAlertMessageStore.dispatch({
+      type: 'VIEWUPDATE',
+      payload: {
+        view: false
+      }
+    });
+  }
+  render() {
+    return (
+      <Alert
+        showAlert={this.state.showMessage}
+        message={T.translate('features.StatusAlertMessage.message')}
+        type="success"
+      />
+    );
+  }
+}

--- a/cdap-ui/app/cdap/main.js
+++ b/cdap-ui/app/cdap/main.js
@@ -45,6 +45,9 @@ import SchemaEditor from 'components/SchemaEditor';
 import MyCDAPVersionApi from 'api/version.js';
 import VersionStore from 'services/VersionStore';
 import VersionActions from 'services/VersionStore/VersionActions';
+import StatusFactory from 'services/StatusFactory';
+import LoadingIndicator from 'components/LoadingIndicator';
+import StatusAlertMessage from 'components/StatusAlertMessage';
 
 class CDAP extends Component {
   constructor(props) {
@@ -82,17 +85,20 @@ class CDAP extends Component {
         }
       );
 
-      if (!VersionStore.getState().version) {
-        MyCDAPVersionApi.get().subscribe((res) => {
-          this.setState({ version : res.version });
-          VersionStore.dispatch({
-            type: VersionActions.updateVersion,
-            payload: {
-              version: res.version
-            }
-          });
+    StatusFactory.startPolling();
+
+    if (!VersionStore.getState().version) {
+      MyCDAPVersionApi.get().subscribe((res) => {
+        this.setState({ version : res.version });
+        VersionStore.dispatch({
+          type: VersionActions.updateVersion,
+          payload: {
+            version: res.version
+          }
         });
-      }
+      });
+    }
+
   }
 
   render() {
@@ -105,6 +111,8 @@ class CDAP extends Component {
           />
           <CdapHeader />
           <SplashScreen openVideo={this.openCaskVideo}/>
+          <LoadingIndicator />
+          <StatusAlertMessage />
           <div className="container-fluid">
             <Match exactly pattern="/" component={RouteToNamespace} />
             <Match exactly pattern="/notfound" component={Missed} />

--- a/cdap-ui/app/cdap/services/StatusFactory.js
+++ b/cdap-ui/app/cdap/services/StatusFactory.js
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import 'whatwg-fetch';
+import LoadingIndicatorStore, {BACKENDSTATUS} from 'components/LoadingIndicator/LoadingIndicatorStore';
+import StatusAlertMessageStore from 'components/StatusAlertMessage/StatusAlertMessageStore';
+import debounce from 'lodash/debounce';
+import T from 'i18n-react';
+
+let isPollingEnabled = true;
+let pollCycleInProgress = false;
+let errorStateCount = 0;
+const poll = () => {
+  fetch('/backendstatus')
+    .then(response => {
+      /*
+        We handle,
+          - 1XX Information
+          - 2XX Success
+          - 3XX Redirection Status codes
+      */
+      if (response.status <= 399) {
+        let loadingState = LoadingIndicatorStore.getState().loading;
+        if ([BACKENDSTATUS.NODESERVERDOWN].indexOf(loadingState.status) !== -1) {
+          window.location.reload();
+        }
+        if ([BACKENDSTATUS.BACKENDDOWN].indexOf(loadingState.status) !== -1) {
+          StatusAlertMessageStore.dispatch({
+            type: 'VIEWUPDATE',
+            payload: {
+              view: true
+            }
+          });
+        }
+        errorStateCount = 0;
+        LoadingIndicatorStore.dispatch({
+          type: BACKENDSTATUS.STATUSUPDATE,
+          payload: {
+            status: BACKENDSTATUS.BACKENDUP
+          }
+        });
+      } else {
+        // This is to sort of avoid the flipping of hiding and showing the
+        // backend down message. Just verify twice before showing that the backend is down.
+        if (errorStateCount === 2) {
+          LoadingIndicatorStore.dispatch({
+            type: BACKENDSTATUS.STATUSUPDATE,
+            payload: {
+              status: BACKENDSTATUS.BACKENDDOWN,
+              message: T.translate('features.LoadingIndicator.backendDown'),
+              subtitle: T.translate('features.LoadingIndicator.backendDownSubtitle')
+            }
+          });
+        }
+        errorStateCount += 1;
+      }
+      pollCycleInProgress = false;
+      startPolling();
+    })
+    .catch(() => {
+      LoadingIndicatorStore.dispatch({
+        type: BACKENDSTATUS.STATUSUPDATE,
+        payload: {
+          status: BACKENDSTATUS.NODESERVERDOWN,
+          message: T.translate('features.LoadingIndicator.nodeserverDown'),
+          subtitle: T.translate('features.LoadingIndicator.backendDownSubtitle')
+        }
+      });
+      pollCycleInProgress = false;
+      startPolling();
+    });
+};
+const startPolling = () => {
+  if (isPollingEnabled && !pollCycleInProgress) {
+    pollCycleInProgress = true;
+    debounce(poll, 2000)();
+  }
+};
+
+const stopPolling = () => {
+  isPollingEnabled = false;
+  pollCycleInProgress = false;
+};
+
+export default {
+  startPolling,
+  stopPolling
+};

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -661,4 +661,12 @@ features:
       undo: Undo
 
     parsing: "Parsing..."
+  LoadingIndicator:
+    defaultMessage: 'Loading...'
+    # backendDown: 'CDAP Services are not available',
+    backendDown: 'Unable to connect to CDAP Router'
+    backendDownSubtitle: 'Attempting to connect...'
+    nodeserverDown: 'User interface service is down'
+  StatusAlertMessage:
+    message: 'Services are back online'
 ...

--- a/cdap-ui/app/tracker/main.js
+++ b/cdap-ui/app/tracker/main.js
@@ -322,8 +322,5 @@ angular
       $window.location.reload();
     });
 
-    // $rootScope.$on('$stateChangeError', function () {
-    //   $state.go('login');
-    // });
     console.timeEnd(PKG.name);
   });

--- a/cdap-ui/app/tracker/tracker.html
+++ b/cdap-ui/app/tracker/tracker.html
@@ -35,6 +35,7 @@
   </main>
 
   <div class="alerts" id="alerts"></div>
+  <loading-icon></loading-icon>
   <footer>
     <div class="container">
       <div class="row text-muted" ng-cloak>


### PR DESCRIPTION
- Adds `LoadingIndicator` component to show a generic loading component
- Adds `StatusAlertMessage & Alert` components to show status update messages & generic alert messages
- Adds `StatusFactory` service to poll for `backendstatus` in Nodejs server to check backend status


#### Note:
- Right now I am adding an extra error checking in `StatusFactory` to make sure the response for `backendStatus` endpoint is non-200 response to avoid flipping the loading indicator repeatedly backend and forth. 