### PR TITLE
HBase DDL operation interface and its default implementation.

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
@@ -202,8 +202,8 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
                                                                  NamespaceId.SYSTEM.getNamespace()));
   }
 
-  protected CoprocessorDescriptor addCoprocessor(Class<? extends Coprocessor> coprocessor, Location jarFile,
-                                                 Integer priority) throws IOException {
+  protected CoprocessorDescriptor getCoprocessorDescriptor(Class<? extends Coprocessor> coprocessor, Location jarFile,
+                                                           Integer priority) throws IOException {
     if (priority == null) {
       priority = Coprocessor.PRIORITY_USER;
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
@@ -26,6 +26,7 @@ import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
 import co.cask.cdap.data2.dataset2.lib.table.TableProperties;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
+import co.cask.cdap.hbase.ddl.TableDescriptor;
 import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
@@ -126,7 +127,8 @@ public class HBaseTableAdmin extends AbstractHBaseDataSetAdmin implements Updata
     }
 
     try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
-      tableUtil.createTableIfNotExists(admin, tableId, tableDescriptor.build(), splits);
+      TableDescriptor tbd = TableDescriptor.fromHTableDescriptor(tableDescriptor.build());
+      tableUtil.createTableIfNotExists(admin, tableId, tbd, splits);
     }
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
@@ -38,6 +38,8 @@ import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.tephra.TxConstants;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Map;
@@ -50,7 +52,7 @@ public class HBaseTableAdmin extends AbstractHBaseDataSetAdmin implements Updata
   public static final String PROPERTY_SPLITS = "hbase.splits";
 
   private static final Gson GSON = new Gson();
-
+  private static final Logger LOG = LoggerFactory.getLogger(HBaseTableAdmin.class);
   private final DatasetSpecification spec;
   // todo: datasets should not depend on cdap configuration!
   private final CConfiguration conf;
@@ -116,6 +118,8 @@ public class HBaseTableAdmin extends AbstractHBaseDataSetAdmin implements Updata
     CoprocessorJar coprocessorJar = createCoprocessorJar();
 
     for (Class<? extends Coprocessor> coprocessor : coprocessorJar.getCoprocessors()) {
+      LOG.info("SAGAR ----- {}, {}, {}, {}.", tableDescriptor, coprocessor, coprocessorJar.getJarLocation(),
+               coprocessorJar.getPriority(coprocessor));
       addCoprocessor(tableDescriptor, coprocessor, coprocessorJar.getJarLocation(),
                      coprocessorJar.getPriority(coprocessor));
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/MetricHBaseTableUtil.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/MetricHBaseTableUtil.java
@@ -18,6 +18,7 @@ package co.cask.cdap.data2.dataset2.lib.table.hbase;
 
 import co.cask.cdap.common.utils.ProjectInfo;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.hbase.ddl.CoprocessorDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
 
 import java.util.Map;
@@ -62,7 +63,7 @@ public class MetricHBaseTableUtil {
       return Version.VERSION_2_8_OR_HIGHER;
     }
 
-    Map<String, HBaseTableUtil.CoprocessorInfo> cpsInfo = HBaseTableUtil.getCoprocessorInfo(tableDescriptor);
+    Map<String, CoprocessorDescriptor> cpsInfo = CoprocessorDescriptor.getCoprocessors(tableDescriptor);
     if (cpsInfo.containsKey(tableUtil.getIncrementHandlerClassForVersion().getName())) {
       // note: if the version is 2.8 or higher, it would have cdap.version property
       return Version.VERSION_2_7;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueAdmin.java
@@ -536,8 +536,8 @@ public class HBaseQueueAdmin extends AbstractQueueAdmin implements ProgramContex
       // Add coprocessors
       CoprocessorJar coprocessorJar = createCoprocessorJar();
       for (Class<? extends Coprocessor> coprocessor : coprocessorJar.getCoprocessors()) {
-        tbdBuilder.addCoprocessor(addCoprocessor(coprocessor, coprocessorJar.getJarLocation(),
-                                                 coprocessorJar.getPriority(coprocessor)));
+        tbdBuilder.addCoprocessor(getCoprocessorDescriptor(coprocessor, coprocessorJar.getJarLocation(),
+                                                           coprocessorJar.getPriority(coprocessor)));
       }
 
       // Create queue table with splits. The distributor bucket size is the same as splits.

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/ConfigurationTable.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/util/hbase/ConfigurationTable.java
@@ -19,11 +19,12 @@ package co.cask.cdap.data2.util.hbase;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.hbase.ddl.ColumnFamilyDescriptor;
+import co.cask.cdap.hbase.ddl.TableDescriptor;
 import co.cask.cdap.proto.id.NamespaceId;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.TableNotFoundException;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
@@ -75,9 +76,10 @@ public class ConfigurationTable {
     try {
       HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
       TableId tableId = tableUtil.createHTableId(NamespaceId.SYSTEM, TABLE_NAME);
-      HTableDescriptorBuilder htd = tableUtil.buildHTableDescriptor(tableId);
-      htd.addFamily(new HColumnDescriptor(FAMILY));
-      tableUtil.createTableIfNotExists(admin, tableId, htd.build());
+      TableDescriptor.Builder tbdBuilder = new TableDescriptor.Builder(cConf, tableId);
+      ColumnFamilyDescriptor.Builder cfdBuilder = new ColumnFamilyDescriptor.Builder(hbaseConf, Bytes.toString(FAMILY));
+      tbdBuilder.addColumnFamily(cfdBuilder.build());
+      tableUtil.createTableIfNotExists(admin, tableId, tbdBuilder.build());
 
       long now = System.currentTimeMillis();
       long previous = now - 1;

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/AbstractHBaseTableUtilTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/AbstractHBaseTableUtilTest.java
@@ -26,6 +26,8 @@ import co.cask.cdap.common.utils.Tasks;
 import co.cask.cdap.data.hbase.HBaseTestBase;
 import co.cask.cdap.data.hbase.HBaseTestFactory;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.hbase.ddl.ColumnFamilyDescriptor;
+import co.cask.cdap.hbase.ddl.TableDescriptor;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.base.Predicate;
@@ -431,9 +433,10 @@ public abstract class AbstractHBaseTableUtilTest {
   private void create(TableId tableId) throws IOException {
     HBaseTableUtil tableUtil = getTableUtil();
     TableId htableId = tableUtil.createHTableId(new NamespaceId(tableId.getNamespace()), tableId.getTableName());
-    HTableDescriptorBuilder desc = tableUtil.buildHTableDescriptor(htableId);
-    desc.addFamily(new HColumnDescriptor("d"));
-    tableUtil.createTableIfNotExists(hAdmin, htableId, desc.build());
+    TableDescriptor.Builder tbdBuilder = new TableDescriptor.Builder(cConf, htableId);
+    ColumnFamilyDescriptor.Builder cfdBuilder = new ColumnFamilyDescriptor.Builder(hAdmin.getConfiguration(), "d");
+    tbdBuilder.addColumnFamily(cfdBuilder.build());
+    tableUtil.createTableIfNotExists(hAdmin, htableId, tbdBuilder.build());
   }
 
   private ListenableFuture<TableId> createAsync(final TableId tableId) {

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableUtil.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableUtil.java
@@ -23,6 +23,7 @@ import co.cask.cdap.data2.transaction.messaging.coprocessor.hbase96.PayloadTable
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase96.DequeueScanObserver;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase96.HBaseQueueRegionObserver;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.hbase.ddl.HBaseDDLExecutor;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -45,6 +46,11 @@ import java.util.List;
 public class HBase96TableUtil extends HBaseTableUtil {
 
   private final HTableNameConverter nameConverter = new HTableNameConverter();
+
+  @Override
+  public HBaseDDLExecutor getHBaseDDLExecutor() {
+    return null;
+  }
 
   @Override
   public HTable createHTable(Configuration conf, TableId tableId) throws IOException {

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableUtil.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableUtil.java
@@ -84,61 +84,6 @@ public class HBase96TableUtil extends HBaseTableUtil {
   }
 
   @Override
-  public void createNamespaceIfNotExists(HBaseAdmin admin, String namespace) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
-    if (!hasNamespace(admin, namespace)) {
-      NamespaceDescriptor namespaceDescriptor =
-        NamespaceDescriptor.create(nameConverter.encodeHBaseEntity(namespace)).build();
-      admin.createNamespace(namespaceDescriptor);
-    }
-  }
-
-  @Override
-  public void deleteNamespaceIfExists(HBaseAdmin admin, String namespace) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
-    if (hasNamespace(admin, namespace)) {
-      admin.deleteNamespace(nameConverter.encodeHBaseEntity(namespace));
-    }
-  }
-
-  @Override
-  public void disableTable(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.disableTable(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public void enableTable(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.enableTable(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public boolean tableExists(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    return admin.tableExists(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public void deleteTable(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.deleteTable(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public void modifyTable(HBaseAdmin admin, HTableDescriptor tableDescriptor) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableDescriptor != null, "Table decsriptor should not be null.");
-    admin.modifyTable(tableDescriptor.getTableName(), tableDescriptor);
-  }
-
-  @Override
   public List<HRegionInfo> getTableRegions(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
@@ -168,75 +113,6 @@ public class HBase96TableUtil extends HBaseTableUtil {
       }
     }
     return tableIds;
-  }
-
-  @Override
-  public void setCompression(HColumnDescriptor columnDescriptor, CompressionType type) {
-    switch (type) {
-      case LZO:
-        columnDescriptor.setCompressionType(Compression.Algorithm.LZO);
-        break;
-      case SNAPPY:
-        columnDescriptor.setCompressionType(Compression.Algorithm.SNAPPY);
-        break;
-      case GZIP:
-        columnDescriptor.setCompressionType(Compression.Algorithm.GZ);
-        break;
-      case NONE:
-        columnDescriptor.setCompressionType(Compression.Algorithm.NONE);
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported compression type: " + type);
-    }
-  }
-
-  @Override
-  public void setBloomFilter(HColumnDescriptor columnDescriptor, BloomType type) {
-    switch (type) {
-      case ROW:
-        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.ROW);
-        break;
-      case ROWCOL:
-        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.ROWCOL);
-        break;
-      case NONE:
-        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.NONE);
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported bloom filter type: " + type);
-    }
-  }
-
-  @Override
-  public CompressionType getCompression(HColumnDescriptor columnDescriptor) {
-    Compression.Algorithm type = columnDescriptor.getCompressionType();
-    switch (type) {
-      case LZO:
-        return CompressionType.LZO;
-      case SNAPPY:
-        return CompressionType.SNAPPY;
-      case GZ:
-        return CompressionType.GZIP;
-      case NONE:
-        return CompressionType.NONE;
-      default:
-        throw new IllegalArgumentException("Unsupported compression type: " + type);
-    }
-  }
-
-  @Override
-  public BloomType getBloomFilter(HColumnDescriptor columnDescriptor) {
-    org.apache.hadoop.hbase.regionserver.BloomType type = columnDescriptor.getBloomFilterType();
-    switch (type) {
-      case ROW:
-        return BloomType.ROW;
-      case ROWCOL:
-        return BloomType.ROWCOL;
-      case NONE:
-        return BloomType.NONE;
-      default:
-        throw new IllegalArgumentException("Unsupported bloom filter type: " + type);
-    }
   }
 
   @Override

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableUtil.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableUtil.java
@@ -23,6 +23,7 @@ import co.cask.cdap.data2.transaction.messaging.coprocessor.hbase96.PayloadTable
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase96.DequeueScanObserver;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase96.HBaseQueueRegionObserver;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.hbase.ddl.DefaultHBase96DDLExecutor;
 import co.cask.cdap.hbase.ddl.HBaseDDLExecutor;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -48,8 +49,8 @@ public class HBase96TableUtil extends HBaseTableUtil {
   private final HTableNameConverter nameConverter = new HTableNameConverter();
 
   @Override
-  public HBaseDDLExecutor getHBaseDDLExecutor() {
-    return null;
+  public HBaseDDLExecutor getHBaseDDLExecutor(Configuration hConf) {
+    return new DefaultHBase96DDLExecutor(hConf);
   }
 
   @Override

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/hbase/ddl/DefaultHBase96DDLExecutor.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/hbase/ddl/DefaultHBase96DDLExecutor.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.hbase.ddl;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.io.compress.Compression;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Implementation of the {@link HBaseDDLExecutor} for HBase 0.98
+ */
+public class DefaultHBase96DDLExecutor extends DefaultHBaseDDLExecutor {
+
+  public DefaultHBase96DDLExecutor(Configuration hConf) {
+    super(hConf);
+  }
+
+  private HColumnDescriptor getHColumnDesciptor(ColumnFamilyDescriptor descriptor) {
+    HColumnDescriptor hFamily = new HColumnDescriptor(descriptor.getName());
+    hFamily.setMaxVersions(descriptor.getMaxVersions());
+    hFamily.setCompressionType(Compression.Algorithm.valueOf(descriptor.getCompressionType().name()));
+    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(
+      descriptor.getBloomType().name()));
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      hFamily.setValue(property.getKey(), property.getValue());
+    }
+    return hFamily;
+  }
+
+  @Override
+  public HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
+    TableName tableName = TableName.valueOf(descriptor.getNamespace(), descriptor.getName());
+    HTableDescriptor htd = new HTableDescriptor(tableName);
+    for (Map.Entry<String, ColumnFamilyDescriptor> family : descriptor.getFamilies().entrySet()) {
+      htd.addFamily(getHColumnDesciptor(family.getValue()));
+    }
+
+    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
+      CoprocessorDescriptor cpd = coprocessor.getValue();
+      try {
+        htd.addCoprocessor(cpd.getClassName(), cpd.getPath(), cpd.getPriority(), cpd.getProperties());
+      } catch (IOException e) {
+        LOG.error("Error adding coprocessor.", e);
+      }
+    }
+
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      // TODO: should not add coprocessor related properties since those were already be added
+      // using addCoprocessor call.
+      htd.setValue(property.getKey(), property.getValue());
+    }
+    return htd;
+  }
+
+  @Override
+  public TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
+    Set<ColumnFamilyDescriptor> families = new HashSet<>();
+    for (HColumnDescriptor family : descriptor.getColumnFamilies()) {
+      families.add(getColumnFamilyDescriptor(family));
+    }
+
+    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
+    coprocessors.addAll(CoprocessorDescriptor.getCoprocessors(descriptor).values());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(Bytes.toString(value.getKey().get()), Bytes.toString(value.getValue().get()));
+    }
+
+    // TODO: should add configurations as well!
+
+    return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),
+                               descriptor.getTableName().getQualifierAsString(), families, coprocessors, properties);
+
+  }
+
+  private ColumnFamilyDescriptor getColumnFamilyDescriptor(HColumnDescriptor descriptor) {
+    String name = descriptor.getNameAsString();
+    int maxVersions = descriptor.getMaxVersions();
+    // TODO check this
+
+    LOG.info("SAGAR--------- compression {}, {}, {}", descriptor.getCompression().getName(),
+             descriptor.getCompressionType().getName(), descriptor.getCompressionType().getName().toUpperCase());
+    ColumnFamilyDescriptor.CompressionType compressionType
+      = ColumnFamilyDescriptor.CompressionType.valueOf(descriptor.getCompressionType().getName().toUpperCase());
+    ColumnFamilyDescriptor.BloomType bloomType
+      = ColumnFamilyDescriptor.BloomType.valueOf(descriptor.getBloomFilterType().name().toUpperCase());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(Bytes.toString(value.getKey().get()), Bytes.toString(value.getValue().get()));
+    }
+    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+  }
+}

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableUtil.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableUtil.java
@@ -23,6 +23,8 @@ import co.cask.cdap.data2.transaction.messaging.coprocessor.hbase98.PayloadTable
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase98.DequeueScanObserver;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase98.HBaseQueueRegionObserver;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.hbase.ddl.DefaultHBase98DDLExecutor;
+import co.cask.cdap.hbase.ddl.HBaseDDLExecutor;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -45,6 +47,11 @@ import java.util.List;
 public class HBase98TableUtil extends HBaseTableUtil {
 
   private final HTableNameConverter nameConverter = new HTableNameConverter();
+
+  @Override
+  public HBaseDDLExecutor getHBaseDDLExecutor(Configuration hConf) {
+    return new DefaultHBase98DDLExecutor(hConf);
+  }
 
   @Override
   public HTable createHTable(Configuration conf, TableId tableId) throws IOException {

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableUtil.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableUtil.java
@@ -84,61 +84,6 @@ public class HBase98TableUtil extends HBaseTableUtil {
   }
 
   @Override
-  public void createNamespaceIfNotExists(HBaseAdmin admin, String namespace) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
-    if (!hasNamespace(admin, namespace)) {
-      NamespaceDescriptor namespaceDescriptor =
-        NamespaceDescriptor.create(nameConverter.encodeHBaseEntity(namespace)).build();
-      admin.createNamespace(namespaceDescriptor);
-    }
-  }
-
-  @Override
-  public void deleteNamespaceIfExists(HBaseAdmin admin, String namespace) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
-    if (hasNamespace(admin, namespace)) {
-      admin.deleteNamespace(nameConverter.encodeHBaseEntity(namespace));
-    }
-  }
-
-  @Override
-  public void disableTable(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.disableTable(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public void enableTable(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.enableTable(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public boolean tableExists(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    return admin.tableExists(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public void deleteTable(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.deleteTable(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public void modifyTable(HBaseAdmin admin, HTableDescriptor tableDescriptor) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableDescriptor != null, "Table descriptor should not be null.");
-    admin.modifyTable(tableDescriptor.getTableName(), tableDescriptor);
-  }
-
-  @Override
   public List<HRegionInfo> getTableRegions(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
@@ -168,75 +113,6 @@ public class HBase98TableUtil extends HBaseTableUtil {
       }
     }
     return tableIds;
-  }
-
-  @Override
-  public void setCompression(HColumnDescriptor columnDescriptor, CompressionType type) {
-    switch (type) {
-      case LZO:
-        columnDescriptor.setCompressionType(Compression.Algorithm.LZO);
-        break;
-      case SNAPPY:
-        columnDescriptor.setCompressionType(Compression.Algorithm.SNAPPY);
-        break;
-      case GZIP:
-        columnDescriptor.setCompressionType(Compression.Algorithm.GZ);
-        break;
-      case NONE:
-        columnDescriptor.setCompressionType(Compression.Algorithm.NONE);
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported compression type: " + type);
-    }
-  }
-
-  @Override
-  public void setBloomFilter(HColumnDescriptor columnDescriptor, BloomType type) {
-    switch (type) {
-      case ROW:
-        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.ROW);
-        break;
-      case ROWCOL:
-        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.ROWCOL);
-        break;
-      case NONE:
-        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.NONE);
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported bloom filter type: " + type);
-    }
-  }
-
-  @Override
-  public CompressionType getCompression(HColumnDescriptor columnDescriptor) {
-    Compression.Algorithm type = columnDescriptor.getCompressionType();
-    switch (type) {
-      case LZO:
-        return CompressionType.LZO;
-      case SNAPPY:
-        return CompressionType.SNAPPY;
-      case GZ:
-        return CompressionType.GZIP;
-      case NONE:
-        return CompressionType.NONE;
-      default:
-        throw new IllegalArgumentException("Unsupported compression type: " + type);
-    }
-  }
-
-  @Override
-  public BloomType getBloomFilter(HColumnDescriptor columnDescriptor) {
-    org.apache.hadoop.hbase.regionserver.BloomType type = columnDescriptor.getBloomFilterType();
-    switch (type) {
-      case ROW:
-        return BloomType.ROW;
-      case ROWCOL:
-        return BloomType.ROWCOL;
-      case NONE:
-        return BloomType.NONE;
-      default:
-        throw new IllegalArgumentException("Unsupported bloom filter type: " + type);
-    }
   }
 
   @Override

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/hbase/ddl/DefaultHBase98DDLExecutor.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/hbase/ddl/DefaultHBase98DDLExecutor.java
@@ -31,11 +31,11 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Implementation of the {@link HBaseDDLExecutor} for HBase 0.96
+ * Implementation of the {@link HBaseDDLExecutor} for HBase 0.98
  */
-public class DefaultHBase96DDLExecutor extends DefaultHBaseDDLExecutor {
+public class DefaultHBase98DDLExecutor  extends DefaultHBaseDDLExecutor {
 
-  public DefaultHBase96DDLExecutor(Configuration hConf) {
+  public DefaultHBase98DDLExecutor(Configuration hConf) {
     super(hConf);
   }
 
@@ -117,3 +117,4 @@ public class DefaultHBase96DDLExecutor extends DefaultHBaseDDLExecutor {
     return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
   }
 }
+

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableUtil.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableUtil.java
@@ -23,6 +23,8 @@ import co.cask.cdap.data2.transaction.messaging.coprocessor.hbase10cdh.PayloadTa
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase10cdh.DequeueScanObserver;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase10cdh.HBaseQueueRegionObserver;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.hbase.ddl.DefaultHBase10CDHDDLExecutor;
+import co.cask.cdap.hbase.ddl.HBaseDDLExecutor;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -45,6 +47,11 @@ import java.util.List;
 public class HBase10CDHTableUtil extends HBaseTableUtil {
 
   private final HTableNameConverter nameConverter = new HTableNameConverter();
+
+  @Override
+  public HBaseDDLExecutor getHBaseDDLExecutor(Configuration hConf) {
+    return new DefaultHBase10CDHDDLExecutor(hConf);
+  }
 
   @Override
   public HTable createHTable(Configuration conf, TableId tableId) throws IOException {

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableUtil.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableUtil.java
@@ -84,61 +84,6 @@ public class HBase10CDHTableUtil extends HBaseTableUtil {
   }
 
   @Override
-  public void createNamespaceIfNotExists(HBaseAdmin admin, String namespace) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
-    if (!hasNamespace(admin, namespace)) {
-      NamespaceDescriptor namespaceDescriptor =
-        NamespaceDescriptor.create(nameConverter.encodeHBaseEntity(namespace)).build();
-      admin.createNamespace(namespaceDescriptor);
-    }
-  }
-
-  @Override
-  public void deleteNamespaceIfExists(HBaseAdmin admin, String namespace) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
-    if (hasNamespace(admin, namespace)) {
-      admin.deleteNamespace(nameConverter.encodeHBaseEntity(namespace));
-    }
-  }
-
-  @Override
-  public void disableTable(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.disableTable(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public void enableTable(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.enableTable(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public boolean tableExists(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    return admin.tableExists(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public void deleteTable(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.deleteTable(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public void modifyTable(HBaseAdmin admin, HTableDescriptor tableDescriptor) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableDescriptor != null, "Table descriptor should not be null.");
-    admin.modifyTable(tableDescriptor.getTableName(), tableDescriptor);
-  }
-
-  @Override
   public List<HRegionInfo> getTableRegions(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
@@ -168,75 +113,6 @@ public class HBase10CDHTableUtil extends HBaseTableUtil {
       }
     }
     return tableIds;
-  }
-
-  @Override
-  public void setCompression(HColumnDescriptor columnDescriptor, CompressionType type) {
-    switch (type) {
-      case LZO:
-        columnDescriptor.setCompressionType(Compression.Algorithm.LZO);
-        break;
-      case SNAPPY:
-        columnDescriptor.setCompressionType(Compression.Algorithm.SNAPPY);
-        break;
-      case GZIP:
-        columnDescriptor.setCompressionType(Compression.Algorithm.GZ);
-        break;
-      case NONE:
-        columnDescriptor.setCompressionType(Compression.Algorithm.NONE);
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported compression type: " + type);
-    }
-  }
-
-  @Override
-  public void setBloomFilter(HColumnDescriptor columnDescriptor, BloomType type) {
-    switch (type) {
-      case ROW:
-        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.ROW);
-        break;
-      case ROWCOL:
-        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.ROWCOL);
-        break;
-      case NONE:
-        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.NONE);
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported bloom filter type: " + type);
-    }
-  }
-
-  @Override
-  public CompressionType getCompression(HColumnDescriptor columnDescriptor) {
-    Compression.Algorithm type = columnDescriptor.getCompressionType();
-    switch (type) {
-      case LZO:
-        return CompressionType.LZO;
-      case SNAPPY:
-        return CompressionType.SNAPPY;
-      case GZ:
-        return CompressionType.GZIP;
-      case NONE:
-        return CompressionType.NONE;
-      default:
-        throw new IllegalArgumentException("Unsupported compression type: " + type);
-    }
-  }
-
-  @Override
-  public BloomType getBloomFilter(HColumnDescriptor columnDescriptor) {
-    org.apache.hadoop.hbase.regionserver.BloomType type = columnDescriptor.getBloomFilterType();
-    switch (type) {
-      case ROW:
-        return BloomType.ROW;
-      case ROWCOL:
-        return BloomType.ROWCOL;
-      case NONE:
-        return BloomType.NONE;
-      default:
-        throw new IllegalArgumentException("Unsupported bloom filter type: " + type);
-    }
   }
 
   @Override

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/hbase/ddl/DefaultHBase10CDHDDLExecutor.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/hbase/ddl/DefaultHBase10CDHDDLExecutor.java
@@ -31,11 +31,11 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Implementation of the {@link HBaseDDLExecutor} for HBase 0.96
+ * Implementation of {@link HBaseDDLExecutor} for HBase version 1.0 CDH
  */
-public class DefaultHBase96DDLExecutor extends DefaultHBaseDDLExecutor {
+public class DefaultHBase10CDHDDLExecutor extends DefaultHBaseDDLExecutor {
 
-  public DefaultHBase96DDLExecutor(Configuration hConf) {
+  public DefaultHBase10CDHDDLExecutor(Configuration hConf) {
     super(hConf);
   }
 

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDH550TableUtil.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDH550TableUtil.java
@@ -23,6 +23,8 @@ import co.cask.cdap.data2.transaction.messaging.coprocessor.hbase10cdh550.Payloa
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase10cdh550.DequeueScanObserver;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase10cdh550.HBaseQueueRegionObserver;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.hbase.ddl.DefaultHBase10CDH550DDLExecutor;
+import co.cask.cdap.hbase.ddl.HBaseDDLExecutor;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -45,6 +47,11 @@ import java.util.List;
 public class HBase10CDH550TableUtil extends HBaseTableUtil {
 
   private final HTableNameConverter nameConverter = new HTableNameConverter();
+
+  @Override
+  public HBaseDDLExecutor getHBaseDDLExecutor(Configuration hConf) {
+    return new DefaultHBase10CDH550DDLExecutor(hConf);
+  }
 
   @Override
   public HTable createHTable(Configuration conf, TableId tableId) throws IOException {

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDH550TableUtil.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDH550TableUtil.java
@@ -84,61 +84,6 @@ public class HBase10CDH550TableUtil extends HBaseTableUtil {
   }
 
   @Override
-  public void createNamespaceIfNotExists(HBaseAdmin admin, String namespace) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
-    if (!hasNamespace(admin, namespace)) {
-      NamespaceDescriptor namespaceDescriptor =
-        NamespaceDescriptor.create(nameConverter.encodeHBaseEntity(namespace)).build();
-      admin.createNamespace(namespaceDescriptor);
-    }
-  }
-
-  @Override
-  public void deleteNamespaceIfExists(HBaseAdmin admin, String namespace) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
-    if (hasNamespace(admin, namespace)) {
-      admin.deleteNamespace(nameConverter.encodeHBaseEntity(namespace));
-    }
-  }
-
-  @Override
-  public void disableTable(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.disableTable(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public void enableTable(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.enableTable(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public boolean tableExists(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    return admin.tableExists(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public void deleteTable(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.deleteTable(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public void modifyTable(HBaseAdmin admin, HTableDescriptor tableDescriptor) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableDescriptor != null, "Table descriptor should not be null.");
-    admin.modifyTable(tableDescriptor.getTableName(), tableDescriptor);
-  }
-
-  @Override
   public List<HRegionInfo> getTableRegions(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
@@ -168,75 +113,6 @@ public class HBase10CDH550TableUtil extends HBaseTableUtil {
       }
     }
     return tableIds;
-  }
-
-  @Override
-  public void setCompression(HColumnDescriptor columnDescriptor, CompressionType type) {
-    switch (type) {
-      case LZO:
-        columnDescriptor.setCompressionType(Compression.Algorithm.LZO);
-        break;
-      case SNAPPY:
-        columnDescriptor.setCompressionType(Compression.Algorithm.SNAPPY);
-        break;
-      case GZIP:
-        columnDescriptor.setCompressionType(Compression.Algorithm.GZ);
-        break;
-      case NONE:
-        columnDescriptor.setCompressionType(Compression.Algorithm.NONE);
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported compression type: " + type);
-    }
-  }
-
-  @Override
-  public void setBloomFilter(HColumnDescriptor columnDescriptor, BloomType type) {
-    switch (type) {
-      case ROW:
-        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.ROW);
-        break;
-      case ROWCOL:
-        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.ROWCOL);
-        break;
-      case NONE:
-        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.NONE);
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported bloom filter type: " + type);
-    }
-  }
-
-  @Override
-  public CompressionType getCompression(HColumnDescriptor columnDescriptor) {
-    Compression.Algorithm type = columnDescriptor.getCompressionType();
-    switch (type) {
-      case LZO:
-        return CompressionType.LZO;
-      case SNAPPY:
-        return CompressionType.SNAPPY;
-      case GZ:
-        return CompressionType.GZIP;
-      case NONE:
-        return CompressionType.NONE;
-      default:
-        throw new IllegalArgumentException("Unsupported compression type: " + type);
-    }
-  }
-
-  @Override
-  public BloomType getBloomFilter(HColumnDescriptor columnDescriptor) {
-    org.apache.hadoop.hbase.regionserver.BloomType type = columnDescriptor.getBloomFilterType();
-    switch (type) {
-      case ROW:
-        return BloomType.ROW;
-      case ROWCOL:
-        return BloomType.ROWCOL;
-      case NONE:
-        return BloomType.NONE;
-      default:
-        throw new IllegalArgumentException("Unsupported bloom filter type: " + type);
-    }
   }
 
   @Override

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/hbase/ddl/DefaultHBase10CDH550DDLExecutor.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/hbase/ddl/DefaultHBase10CDH550DDLExecutor.java
@@ -31,11 +31,11 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Implementation of the {@link HBaseDDLExecutor} for HBase 0.96
+ * Implementation of the {@link HBaseDDLExecutor} for HBase 1.0 CDH 5.5.0
  */
-public class DefaultHBase96DDLExecutor extends DefaultHBaseDDLExecutor {
+public class DefaultHBase10CDH550DDLExecutor extends DefaultHBaseDDLExecutor {
 
-  public DefaultHBase96DDLExecutor(Configuration hConf) {
+  public DefaultHBase10CDH550DDLExecutor(Configuration hConf) {
     super(hConf);
   }
 

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableUtil.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableUtil.java
@@ -88,61 +88,6 @@ public class HBase10TableUtil extends HBaseTableUtil {
   }
 
   @Override
-  public void createNamespaceIfNotExists(HBaseAdmin admin, String namespace) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
-    if (!hasNamespace(admin, namespace)) {
-      NamespaceDescriptor namespaceDescriptor =
-        NamespaceDescriptor.create(nameConverter.encodeHBaseEntity(namespace)).build();
-      admin.createNamespace(namespaceDescriptor);
-    }
-  }
-
-  @Override
-  public void deleteNamespaceIfExists(HBaseAdmin admin, String namespace) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
-    if (hasNamespace(admin, namespace)) {
-      admin.deleteNamespace(nameConverter.encodeHBaseEntity(namespace));
-    }
-  }
-
-  @Override
-  public void disableTable(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.disableTable(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public void enableTable(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.enableTable(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public boolean tableExists(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    return admin.tableExists(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public void deleteTable(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.deleteTable(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public void modifyTable(HBaseAdmin admin, HTableDescriptor tableDescriptor) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableDescriptor != null, "Table descriptor should not be null.");
-    admin.modifyTable(tableDescriptor.getTableName(), tableDescriptor);
-  }
-
-  @Override
   public List<HRegionInfo> getTableRegions(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
@@ -172,75 +117,6 @@ public class HBase10TableUtil extends HBaseTableUtil {
       }
     }
     return tableIds;
-  }
-
-  @Override
-  public void setCompression(HColumnDescriptor columnDescriptor, CompressionType type) {
-    switch (type) {
-      case LZO:
-        columnDescriptor.setCompressionType(Compression.Algorithm.LZO);
-        break;
-      case SNAPPY:
-        columnDescriptor.setCompressionType(Compression.Algorithm.SNAPPY);
-        break;
-      case GZIP:
-        columnDescriptor.setCompressionType(Compression.Algorithm.GZ);
-        break;
-      case NONE:
-        columnDescriptor.setCompressionType(Compression.Algorithm.NONE);
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported compression type: " + type);
-    }
-  }
-
-  @Override
-  public void setBloomFilter(HColumnDescriptor columnDescriptor, BloomType type) {
-    switch (type) {
-      case ROW:
-        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.ROW);
-        break;
-      case ROWCOL:
-        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.ROWCOL);
-        break;
-      case NONE:
-        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.NONE);
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported bloom filter type: " + type);
-    }
-  }
-
-  @Override
-  public CompressionType getCompression(HColumnDescriptor columnDescriptor) {
-    Compression.Algorithm type = columnDescriptor.getCompressionType();
-    switch (type) {
-      case LZO:
-        return CompressionType.LZO;
-      case SNAPPY:
-        return CompressionType.SNAPPY;
-      case GZ:
-        return CompressionType.GZIP;
-      case NONE:
-        return CompressionType.NONE;
-      default:
-        throw new IllegalArgumentException("Unsupported compression type: " + type);
-    }
-  }
-
-  @Override
-  public BloomType getBloomFilter(HColumnDescriptor columnDescriptor) {
-    org.apache.hadoop.hbase.regionserver.BloomType type = columnDescriptor.getBloomFilterType();
-    switch (type) {
-      case ROW:
-        return BloomType.ROW;
-      case ROWCOL:
-        return BloomType.ROWCOL;
-      case NONE:
-        return BloomType.NONE;
-      default:
-        throw new IllegalArgumentException("Unsupported bloom filter type: " + type);
-    }
   }
 
   @Override

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableUtil.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableUtil.java
@@ -23,6 +23,7 @@ import co.cask.cdap.data2.transaction.messaging.coprocessor.hbase10.PayloadTable
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase10.DequeueScanObserver;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase10.HBaseQueueRegionObserver;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.hbase.ddl.DefaultHBase10DDLExecutor;
 import co.cask.cdap.hbase.ddl.HBaseDDLExecutor;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -52,8 +53,8 @@ public class HBase10TableUtil extends HBaseTableUtil {
   private final HTableNameConverter nameConverter = new HTableNameConverter();
 
   @Override
-  public HBaseDDLExecutor getHBaseDDLExecutor() {
-    return null;
+  public HBaseDDLExecutor getHBaseDDLExecutor(Configuration hConf) {
+    return new DefaultHBase10DDLExecutor(hConf);
   }
 
   @Override

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableUtil.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableUtil.java
@@ -23,6 +23,7 @@ import co.cask.cdap.data2.transaction.messaging.coprocessor.hbase10.PayloadTable
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase10.DequeueScanObserver;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase10.HBaseQueueRegionObserver;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.hbase.ddl.HBaseDDLExecutor;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -49,6 +50,11 @@ import java.util.List;
 public class HBase10TableUtil extends HBaseTableUtil {
 
   private final HTableNameConverter nameConverter = new HTableNameConverter();
+
+  @Override
+  public HBaseDDLExecutor getHBaseDDLExecutor() {
+    return null;
+  }
 
   @Override
   public HTable createHTable(Configuration conf, TableId tableId) throws IOException {

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/hbase/ddl/DefaultHBase10DDLExecutor.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/hbase/ddl/DefaultHBase10DDLExecutor.java
@@ -31,11 +31,11 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Implementation of the {@link HBaseDDLExecutor} for HBase 0.96
+ * Implementation of the {@link HBaseDDLExecutor} for HBase version 1.0
  */
-public class DefaultHBase96DDLExecutor extends DefaultHBaseDDLExecutor {
+public class DefaultHBase10DDLExecutor extends DefaultHBaseDDLExecutor {
 
-  public DefaultHBase96DDLExecutor(Configuration hConf) {
+  public DefaultHBase10DDLExecutor(Configuration hConf) {
     super(hConf);
   }
 
@@ -117,3 +117,4 @@ public class DefaultHBase96DDLExecutor extends DefaultHBaseDDLExecutor {
     return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
   }
 }
+

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/HBase11TableUtil.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/HBase11TableUtil.java
@@ -23,6 +23,8 @@ import co.cask.cdap.data2.transaction.messaging.coprocessor.hbase11.PayloadTable
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase11.DequeueScanObserver;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase11.HBaseQueueRegionObserver;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.hbase.ddl.DefaultHBase11DDLExecutor;
+import co.cask.cdap.hbase.ddl.HBaseDDLExecutor;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -49,6 +51,11 @@ import java.util.List;
 public class HBase11TableUtil extends HBaseTableUtil {
 
   private final HTableNameConverter nameConverter = new HTableNameConverter();
+
+  @Override
+  public HBaseDDLExecutor getHBaseDDLExecutor(Configuration hConf) {
+    return new DefaultHBase11DDLExecutor(hConf);
+  }
 
   @Override
   public HTable createHTable(Configuration conf, TableId tableId) throws IOException {

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/HBase11TableUtil.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/HBase11TableUtil.java
@@ -88,61 +88,6 @@ public class HBase11TableUtil extends HBaseTableUtil {
   }
 
   @Override
-  public void createNamespaceIfNotExists(HBaseAdmin admin, String namespace) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
-    if (!hasNamespace(admin, namespace)) {
-      NamespaceDescriptor namespaceDescriptor =
-        NamespaceDescriptor.create(nameConverter.encodeHBaseEntity(namespace)).build();
-      admin.createNamespace(namespaceDescriptor);
-    }
-  }
-
-  @Override
-  public void deleteNamespaceIfExists(HBaseAdmin admin, String namespace) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
-    if (hasNamespace(admin, namespace)) {
-      admin.deleteNamespace(nameConverter.encodeHBaseEntity(namespace));
-    }
-  }
-
-  @Override
-  public void disableTable(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.disableTable(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public void enableTable(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.enableTable(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public boolean tableExists(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    return admin.tableExists(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public void deleteTable(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.deleteTable(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public void modifyTable(HBaseAdmin admin, HTableDescriptor tableDescriptor) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableDescriptor != null, "Table descriptor should not be null.");
-    admin.modifyTable(tableDescriptor.getTableName(), tableDescriptor);
-  }
-
-  @Override
   public List<HRegionInfo> getTableRegions(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
@@ -172,75 +117,6 @@ public class HBase11TableUtil extends HBaseTableUtil {
       }
     }
     return tableIds;
-  }
-
-  @Override
-  public void setCompression(HColumnDescriptor columnDescriptor, CompressionType type) {
-    switch (type) {
-      case LZO:
-        columnDescriptor.setCompressionType(Compression.Algorithm.LZO);
-        break;
-      case SNAPPY:
-        columnDescriptor.setCompressionType(Compression.Algorithm.SNAPPY);
-        break;
-      case GZIP:
-        columnDescriptor.setCompressionType(Compression.Algorithm.GZ);
-        break;
-      case NONE:
-        columnDescriptor.setCompressionType(Compression.Algorithm.NONE);
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported compression type: " + type);
-    }
-  }
-
-  @Override
-  public void setBloomFilter(HColumnDescriptor columnDescriptor, BloomType type) {
-    switch (type) {
-      case ROW:
-        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.ROW);
-        break;
-      case ROWCOL:
-        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.ROWCOL);
-        break;
-      case NONE:
-        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.NONE);
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported bloom filter type: " + type);
-    }
-  }
-
-  @Override
-  public CompressionType getCompression(HColumnDescriptor columnDescriptor) {
-    Compression.Algorithm type = columnDescriptor.getCompressionType();
-    switch (type) {
-      case LZO:
-        return CompressionType.LZO;
-      case SNAPPY:
-        return CompressionType.SNAPPY;
-      case GZ:
-        return CompressionType.GZIP;
-      case NONE:
-        return CompressionType.NONE;
-      default:
-        throw new IllegalArgumentException("Unsupported compression type: " + type);
-    }
-  }
-
-  @Override
-  public BloomType getBloomFilter(HColumnDescriptor columnDescriptor) {
-    org.apache.hadoop.hbase.regionserver.BloomType type = columnDescriptor.getBloomFilterType();
-    switch (type) {
-      case ROW:
-        return BloomType.ROW;
-      case ROWCOL:
-        return BloomType.ROWCOL;
-      case NONE:
-        return BloomType.NONE;
-      default:
-        throw new IllegalArgumentException("Unsupported bloom filter type: " + type);
-    }
   }
 
   @Override

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/hbase/ddl/DefaultHBase11DDLExecutor.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/hbase/ddl/DefaultHBase11DDLExecutor.java
@@ -31,11 +31,11 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Implementation of the {@link HBaseDDLExecutor} for HBase 0.96
+ * Implementation of the {@link HBaseDDLExecutor} for HBase 1.1
  */
-public class DefaultHBase96DDLExecutor extends DefaultHBaseDDLExecutor {
+public class DefaultHBase11DDLExecutor extends DefaultHBaseDDLExecutor {
 
-  public DefaultHBase96DDLExecutor(Configuration hConf) {
+  public DefaultHBase11DDLExecutor(Configuration hConf) {
     super(hConf);
   }
 
@@ -117,3 +117,4 @@ public class DefaultHBase96DDLExecutor extends DefaultHBaseDDLExecutor {
     return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
   }
 }
+

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570TableUtil.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570TableUtil.java
@@ -88,61 +88,6 @@ public class HBase12CDH570TableUtil extends HBaseTableUtil {
   }
 
   @Override
-  public void createNamespaceIfNotExists(HBaseAdmin admin, String namespace) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
-    if (!hasNamespace(admin, namespace)) {
-      NamespaceDescriptor namespaceDescriptor =
-        NamespaceDescriptor.create(nameConverter.encodeHBaseEntity(namespace)).build();
-      admin.createNamespace(namespaceDescriptor);
-    }
-  }
-
-  @Override
-  public void deleteNamespaceIfExists(HBaseAdmin admin, String namespace) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(namespace != null, "Namespace should not be null.");
-    if (hasNamespace(admin, namespace)) {
-      admin.deleteNamespace(nameConverter.encodeHBaseEntity(namespace));
-    }
-  }
-
-  @Override
-  public void disableTable(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.disableTable(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public void enableTable(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.enableTable(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public boolean tableExists(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    return admin.tableExists(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public void deleteTable(HBaseAdmin admin, TableId tableId) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
-    admin.deleteTable(nameConverter.toTableName(tablePrefix, tableId));
-  }
-
-  @Override
-  public void modifyTable(HBaseAdmin admin, HTableDescriptor tableDescriptor) throws IOException {
-    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
-    Preconditions.checkArgument(tableDescriptor != null, "Table descriptor should not be null.");
-    admin.modifyTable(tableDescriptor.getTableName(), tableDescriptor);
-  }
-
-  @Override
   public List<HRegionInfo> getTableRegions(HBaseAdmin admin, TableId tableId) throws IOException {
     Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
     Preconditions.checkArgument(tableId != null, "Table Id should not be null.");
@@ -172,75 +117,6 @@ public class HBase12CDH570TableUtil extends HBaseTableUtil {
       }
     }
     return tableIds;
-  }
-
-  @Override
-  public void setCompression(HColumnDescriptor columnDescriptor, CompressionType type) {
-    switch (type) {
-      case LZO:
-        columnDescriptor.setCompressionType(Compression.Algorithm.LZO);
-        break;
-      case SNAPPY:
-        columnDescriptor.setCompressionType(Compression.Algorithm.SNAPPY);
-        break;
-      case GZIP:
-        columnDescriptor.setCompressionType(Compression.Algorithm.GZ);
-        break;
-      case NONE:
-        columnDescriptor.setCompressionType(Compression.Algorithm.NONE);
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported compression type: " + type);
-    }
-  }
-
-  @Override
-  public void setBloomFilter(HColumnDescriptor columnDescriptor, BloomType type) {
-    switch (type) {
-      case ROW:
-        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.ROW);
-        break;
-      case ROWCOL:
-        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.ROWCOL);
-        break;
-      case NONE:
-        columnDescriptor.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.NONE);
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported bloom filter type: " + type);
-    }
-  }
-
-  @Override
-  public CompressionType getCompression(HColumnDescriptor columnDescriptor) {
-    Compression.Algorithm type = columnDescriptor.getCompressionType();
-    switch (type) {
-      case LZO:
-        return CompressionType.LZO;
-      case SNAPPY:
-        return CompressionType.SNAPPY;
-      case GZ:
-        return CompressionType.GZIP;
-      case NONE:
-        return CompressionType.NONE;
-      default:
-        throw new IllegalArgumentException("Unsupported compression type: " + type);
-    }
-  }
-
-  @Override
-  public BloomType getBloomFilter(HColumnDescriptor columnDescriptor) {
-    org.apache.hadoop.hbase.regionserver.BloomType type = columnDescriptor.getBloomFilterType();
-    switch (type) {
-      case ROW:
-        return BloomType.ROW;
-      case ROWCOL:
-        return BloomType.ROWCOL;
-      case NONE:
-        return BloomType.NONE;
-      default:
-        throw new IllegalArgumentException("Unsupported bloom filter type: " + type);
-    }
   }
 
   @Override

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570TableUtil.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570TableUtil.java
@@ -23,6 +23,8 @@ import co.cask.cdap.data2.transaction.messaging.coprocessor.hbase12cdh570.Payloa
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase12cdh570.DequeueScanObserver;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase12cdh570.HBaseQueueRegionObserver;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.hbase.ddl.DefaultHBase12CDH570Executor;
+import co.cask.cdap.hbase.ddl.HBaseDDLExecutor;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -49,6 +51,11 @@ import java.util.List;
 public class HBase12CDH570TableUtil extends HBaseTableUtil {
 
   private final HTableNameConverter nameConverter = new HTableNameConverter();
+
+  @Override
+  public HBaseDDLExecutor getHBaseDDLExecutor(Configuration hConf) {
+    return new DefaultHBase12CDH570Executor(hConf);
+  }
 
   @Override
   public HTable createHTable(Configuration conf, TableId tableId) throws IOException {

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/hbase/ddl/DefaultHBase12CDH570Executor.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/hbase/ddl/DefaultHBase12CDH570Executor.java
@@ -31,11 +31,11 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Implementation of the {@link HBaseDDLExecutor} for HBase 0.96
+ * Implementation of the {@link HBaseDDLExecutor} for HBase version 1.2 CDH 5.7.0
  */
-public class DefaultHBase96DDLExecutor extends DefaultHBaseDDLExecutor {
+public class DefaultHBase12CDH570Executor extends DefaultHBaseDDLExecutor {
 
-  public DefaultHBase96DDLExecutor(Configuration hConf) {
+  public DefaultHBase12CDH570Executor(Configuration hConf) {
     super(hConf);
   }
 
@@ -117,3 +117,5 @@ public class DefaultHBase96DDLExecutor extends DefaultHBaseDDLExecutor {
     return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
   }
 }
+
+

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/hbase/ddl/ColumnFamilyDescriptor.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/hbase/ddl/ColumnFamilyDescriptor.java
@@ -23,6 +23,8 @@ import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.io.compress.Compression;
 import org.apache.hadoop.hbase.regionserver.BloomType;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -32,6 +34,7 @@ import java.util.Map;
  */
 public final class ColumnFamilyDescriptor {
 
+  private static final Logger LOG = LoggerFactory.getLogger(ColumnFamilyDescriptor.class);
   public static final CompressionType DEFAULT_COMPRESSION_TYPE = CompressionType.SNAPPY;
   public static final String CFG_HBASE_TABLE_COMPRESSION = "hbase.table.compression.default";
 
@@ -88,8 +91,11 @@ public final class ColumnFamilyDescriptor {
     String name = family.getNameAsString();
     int maxVersions = family.getMaxVersions();
     // TODO check this
-    CompressionType compressionType = CompressionType.valueOf(family.getCompressionType().getName());
-    BloomType bloomType = BloomType.valueOf(family.getBloomFilterType().name());
+
+    LOG.info("SAGAR--------- compression {}, {}, {}", family.getCompression().getName(),
+             family.getCompressionType().getName(), family.getCompressionType().getName().toUpperCase());
+    CompressionType compressionType = CompressionType.valueOf(family.getCompressionType().getName().toUpperCase());
+    BloomType bloomType = BloomType.valueOf(family.getBloomFilterType().name().toUpperCase());
 
     Map<String, String> properties = new HashMap<>();
     for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : family.getValues().entrySet()) {
@@ -117,7 +123,7 @@ public final class ColumnFamilyDescriptor {
     private int maxVersions;
     private CompressionType compressionType;
     private BloomType bloomType;
-    private Map<String, String> properties;
+    private final Map<String, String> properties;
 
     public Builder(Configuration hConf, String name) {
       this.name = name;
@@ -125,6 +131,7 @@ public final class ColumnFamilyDescriptor {
       this.compressionType = CompressionType.valueOf(compression);
       this.bloomType = BloomType.ROW;
       this.maxVersions = 1;
+      this.properties = new HashMap<>();
     }
 
     public Builder setMaxVersions(int n) {

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/hbase/ddl/ColumnFamilyDescriptor.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/hbase/ddl/ColumnFamilyDescriptor.java
@@ -58,7 +58,7 @@ public final class ColumnFamilyDescriptor {
     ROW, ROWCOL, NONE
   }
 
-  private ColumnFamilyDescriptor(String name, int maxVersions, CompressionType compressionType,
+  public ColumnFamilyDescriptor(String name, int maxVersions, CompressionType compressionType,
                                  BloomType bloomType, Map<String, String> properties) {
     this.name = name;
     this.maxVersions = maxVersions;
@@ -85,34 +85,6 @@ public final class ColumnFamilyDescriptor {
 
   public Map<String, String> getProperties() {
     return properties;
-  }
-
-  public static ColumnFamilyDescriptor fromHColumnDescriptor(HColumnDescriptor family) {
-    String name = family.getNameAsString();
-    int maxVersions = family.getMaxVersions();
-    // TODO check this
-
-    LOG.info("SAGAR--------- compression {}, {}, {}", family.getCompression().getName(),
-             family.getCompressionType().getName(), family.getCompressionType().getName().toUpperCase());
-    CompressionType compressionType = CompressionType.valueOf(family.getCompressionType().getName().toUpperCase());
-    BloomType bloomType = BloomType.valueOf(family.getBloomFilterType().name().toUpperCase());
-
-    Map<String, String> properties = new HashMap<>();
-    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : family.getValues().entrySet()) {
-      properties.put(Bytes.toString(value.getKey().get()), Bytes.toString(value.getValue().get()));
-    }
-    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
-  }
-
-  public static HColumnDescriptor toHColumnDescriptor(ColumnFamilyDescriptor family) {
-    HColumnDescriptor hFamily = new HColumnDescriptor(family.getName());
-    hFamily.setMaxVersions(family.getMaxVersions());
-    hFamily.setCompressionType(Compression.Algorithm.valueOf(family.getCompressionType().name()));
-    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(family.getBloomType().name()));
-    for (Map.Entry<String, String> property : family.getProperties().entrySet()) {
-      hFamily.setValue(property.getKey(), property.getValue());
-    }
-    return hFamily;
   }
 
   /**

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/hbase/ddl/ColumnFamilyDescriptor.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/hbase/ddl/ColumnFamilyDescriptor.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.hbase.ddl;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.io.compress.Compression;
+import org.apache.hadoop.hbase.regionserver.BloomType;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Descripbes HBase table column family.
+ */
+public final class ColumnFamilyDescriptor {
+
+  public static final CompressionType DEFAULT_COMPRESSION_TYPE = CompressionType.SNAPPY;
+  public static final String CFG_HBASE_TABLE_COMPRESSION = "hbase.table.compression.default";
+
+  private final String name;
+  private final int maxVersions;
+  private final CompressionType compressionType;
+  private final BloomType bloomType;
+  private final Map<String, String> properties;
+
+  /**
+   * Represents the compression types supported for HBase tables.
+   */
+  public enum CompressionType {
+    LZO, SNAPPY, GZIP, NONE
+  }
+
+  /**
+   * Represents the bloom filter types supported for HBase tables.
+   */
+  public enum BloomType {
+    ROW, ROWCOL, NONE
+  }
+
+  private ColumnFamilyDescriptor(String name, int maxVersions, CompressionType compressionType,
+                                 BloomType bloomType, Map<String, String> properties) {
+    this.name = name;
+    this.maxVersions = maxVersions;
+    this.compressionType = compressionType;
+    this.bloomType = bloomType;
+    this.properties = ImmutableMap.copyOf(properties);
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public int getMaxVersions() {
+    return maxVersions;
+  }
+
+  public CompressionType getCompressionType() {
+    return compressionType;
+  }
+
+  public BloomType getBloomType() {
+    return bloomType;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  public static ColumnFamilyDescriptor fromHColumnDescriptor(HColumnDescriptor family) {
+    String name = family.getNameAsString();
+    int maxVersions = family.getMaxVersions();
+    // TODO check this
+    CompressionType compressionType = CompressionType.valueOf(family.getCompressionType().getName());
+    BloomType bloomType = BloomType.valueOf(family.getBloomFilterType().name());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : family.getValues().entrySet()) {
+      properties.put(Bytes.toString(value.getKey().get()), Bytes.toString(value.getValue().get()));
+    }
+    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+  }
+
+  public static HColumnDescriptor toHColumnDescriptor(ColumnFamilyDescriptor family) {
+    HColumnDescriptor hFamily = new HColumnDescriptor(family.getName());
+    hFamily.setMaxVersions(family.getMaxVersions());
+    hFamily.setCompressionType(Compression.Algorithm.valueOf(family.getCompressionType().name()));
+    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(family.getBloomType().name()));
+    for (Map.Entry<String, String> property : family.getProperties().entrySet()) {
+      hFamily.setValue(property.getKey(), property.getValue());
+    }
+    return hFamily;
+  }
+
+  /**
+   * Builder for {@link ColumnFamilyDescriptor}.
+   */
+  public static class Builder {
+    private final String name;
+    private int maxVersions;
+    private CompressionType compressionType;
+    private BloomType bloomType;
+    private Map<String, String> properties;
+
+    public Builder(Configuration hConf, String name) {
+      this.name = name;
+      String compression = hConf.get(CFG_HBASE_TABLE_COMPRESSION, DEFAULT_COMPRESSION_TYPE.name());
+      this.compressionType = CompressionType.valueOf(compression);
+      this.bloomType = BloomType.ROW;
+      this.maxVersions = 1;
+    }
+
+    public Builder setMaxVersions(int n) {
+      this.maxVersions = n;
+      return this;
+    }
+
+    public Builder setCompressionType(CompressionType compressionType) {
+      this.compressionType = compressionType;
+      return this;
+    }
+
+    public Builder setBloomType(BloomType bloomType) {
+      this.bloomType = bloomType;
+      return this;
+    }
+
+    public Builder addProperty(String key, String value) {
+      this.properties.put(key, value);
+      return this;
+    }
+
+    public ColumnFamilyDescriptor build() {
+      return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+    }
+  }
+}

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/hbase/ddl/CoprocessorDescriptor.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/hbase/ddl/CoprocessorDescriptor.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.hbase.ddl;
+
+import co.cask.cdap.api.common.Bytes;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.Coprocessor;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+
+/**
+ * Describes an HBase table descriptor.
+ */
+public final class CoprocessorDescriptor {
+  private static final Logger LOG = LoggerFactory.getLogger(CoprocessorDescriptor.class);
+
+  private final String className;
+  private final Path path;
+  private final int priority;
+  private final Map<String, String> properties;
+
+  public CoprocessorDescriptor(String className, Path path, int priority, Map<String, String> properties) {
+    this.className = className;
+    this.path = path;
+    this.priority = priority;
+    this.properties = ImmutableMap.copyOf(properties);
+  }
+
+  public String getClassName() {
+    return className;
+  }
+
+  public Path getPath() {
+    return path;
+  }
+
+  public int getPriority() {
+    return priority;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  /**
+   * Returns information for all coprocessor configured for the table.
+   *
+   * @return a Map from coprocessor class name to {@link CoprocessorDescriptor}
+   */
+  public static Map<String, CoprocessorDescriptor> getCoprocessors(HTableDescriptor tableDescriptor) {
+    Map<String, CoprocessorDescriptor> info = Maps.newHashMap();
+
+    // Extract information about existing data janitor coprocessor
+    // The following logic is copied from RegionCoprocessorHost in HBase
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> entry: tableDescriptor.getValues().entrySet()) {
+      String key = Bytes.toString(entry.getKey().get()).trim();
+      String spec = Bytes.toString(entry.getValue().get()).trim();
+
+      if (!HConstants.CP_HTD_ATTR_KEY_PATTERN.matcher(key).matches()) {
+        continue;
+      }
+
+      try {
+        Matcher matcher = HConstants.CP_HTD_ATTR_VALUE_PATTERN.matcher(spec);
+        if (!matcher.matches()) {
+          continue;
+        }
+
+        String className = matcher.group(2).trim();
+        Path path = matcher.group(1).trim().isEmpty() ? null : new Path(matcher.group(1).trim());
+        int priority = matcher.group(3).trim().isEmpty() ? Coprocessor.PRIORITY_USER
+          : Integer.valueOf(matcher.group(3));
+        String cfgSpec = null;
+        try {
+          cfgSpec = matcher.group(4);
+        } catch (IndexOutOfBoundsException ex) {
+          // ignore
+        }
+
+        Map<String, String> properties = Maps.newHashMap();
+        if (cfgSpec != null) {
+          cfgSpec = cfgSpec.substring(cfgSpec.indexOf('|') + 1);
+          // do an explicit deep copy of the passed configuration
+          Matcher m = HConstants.CP_HTD_ATTR_VALUE_PARAM_PATTERN.matcher(cfgSpec);
+          while (m.find()) {
+            properties.put(m.group(1), m.group(2));
+          }
+        }
+        info.put(className, new CoprocessorDescriptor(className, path, priority, properties));
+      } catch (Exception ex) {
+        LOG.warn("Coprocessor attribute '{}' has invalid coprocessor specification '{}'", key, spec, ex);
+      }
+    }
+
+    return info;
+  }
+}

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/hbase/ddl/CoprocessorDescriptor.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/hbase/ddl/CoprocessorDescriptor.java
@@ -45,7 +45,7 @@ public final class CoprocessorDescriptor {
     this.className = className;
     this.path = path;
     this.priority = priority;
-    this.properties = ImmutableMap.copyOf(properties);
+    this.properties = properties == null ? ImmutableMap.<String, String>of() : ImmutableMap.copyOf(properties);
   }
 
   public String getClassName() {

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/hbase/ddl/DefaultHBaseDDLExecutor.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/hbase/ddl/DefaultHBaseDDLExecutor.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.hbase.ddl;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.common.NotFoundException;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.NamespaceDescriptor;
+import org.apache.hadoop.hbase.NamespaceNotFoundException;
+import org.apache.hadoop.hbase.TableExistsException;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.TableNotDisabledException;
+import org.apache.hadoop.hbase.TableNotEnabledException;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Default implementation of the {@link HBaseDDLExecutor}.
+ */
+public final class DefaultHBaseDDLExecutor implements HBaseDDLExecutor {
+  public static final Logger LOG = LoggerFactory.getLogger(DefaultHBaseDDLExecutor.class);
+  public static final long MAX_CREATE_TABLE_WAIT = 5000L;    // Maximum wait of 5 seconds for table creation.
+  private final Configuration hConf;
+
+  public DefaultHBaseDDLExecutor(Configuration hConf) {
+    this.hConf = hConf;
+  }
+
+  /**
+   * Encode a HBase entity name to ASCII encoding using {@link URLEncoder}.
+   * @param entityName entity string to be encoded
+   * @return encoded string
+   */
+  private String encodeHBaseEntity(String entityName) {
+    try {
+      return URLEncoder.encode(entityName, "ASCII");
+    } catch (UnsupportedEncodingException e) {
+      // this can never happen - we know that ASCII is a supported character set!
+      throw new RuntimeException(e);
+    }
+  }
+  private boolean hasNamespace(HBaseAdmin admin, String name) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(name != null, "Namespace should not be null.");
+    try {
+      admin.getNamespaceDescriptor(encodeHBaseEntity(name));
+      return true;
+    } catch (NamespaceNotFoundException e) {
+      return false;
+    }
+  }
+
+  @Override
+  public void createNamespaceIfNotExists(String name) throws IOException {
+    Preconditions.checkArgument(name != null, "Namespace should not be null.");
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      if (!hasNamespace(admin, name)) {
+        NamespaceDescriptor namespaceDescriptor =
+          NamespaceDescriptor.create(encodeHBaseEntity(name)).build();
+        admin.createNamespace(namespaceDescriptor);
+      }
+    }
+  }
+
+  @Override
+  public void deleteNamespaceIfExists(String name) throws IOException {
+    Preconditions.checkArgument(name != null, "Namespace should not be null.");
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      if (hasNamespace(admin, name)) {
+        admin.deleteNamespace(encodeHBaseEntity(name));
+      }
+    }
+  }
+
+  @Override
+  public void createTableIfNotExists(TableDescriptor descriptor, @Nullable byte[][] splitKeys)
+    throws IOException {
+    HTableDescriptor htd = TableDescriptor.toHTableDescriptor(descriptor);
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      if (admin.tableExists(htd.getName())) {
+        return;
+      }
+      try {
+        LOG.debug("Attempting to create table '{}' if it does not exist", Bytes.toString(htd.getName()));
+        admin.createTable(htd, splitKeys);
+        LOG.info("Table created '{}'", Bytes.toString(htd.getName()));
+      } catch (TableExistsException e) {
+        // table may exist because someone else is creating it at the same
+        // time. But it may not be available yet, and opening it might fail.
+        LOG.debug("Table '{}' already exists.", Bytes.toString(htd.getName()), e);
+      }
+
+      // Wait for table to materialize
+      try {
+        Stopwatch stopwatch = new Stopwatch();
+        stopwatch.start();
+        long sleepTime = TimeUnit.MILLISECONDS.toNanos(5000L) / 10;
+        sleepTime = sleepTime <= 0 ? 1 : sleepTime;
+        do {
+          if (admin.tableExists(descriptor.getName())) {
+            LOG.info("Table '{}' exists now. Assuming that another process concurrently created it.",
+                     Bytes.toString(htd.getName()));
+            return;
+          } else {
+            TimeUnit.NANOSECONDS.sleep(sleepTime);
+          }
+        } while (stopwatch.elapsedTime(TimeUnit.MILLISECONDS) < 5000L);
+      } catch (InterruptedException e) {
+        LOG.warn("Sleeping thread interrupted.");
+      }
+      LOG.error("Table '{}' does not exist after waiting {} ms. Giving up.", Bytes.toString(htd.getName()),
+                MAX_CREATE_TABLE_WAIT);
+    }
+  }
+
+  @Override
+  public void enableTableIfDisabled(String namespace, String name) throws IOException, NotFoundException {
+    Preconditions.checkArgument(namespace != null, "Namespace should not be null");
+    Preconditions.checkArgument(name != null, "Table name should not be null.");
+
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      admin.enableTable(TableName.valueOf(namespace, encodeHBaseEntity(name)));
+    } catch (TableNotDisabledException e) {
+      LOG.debug("Attempt to enable already enabled table {} in the namespace {}.", name, namespace);
+    }
+  }
+
+  @Override
+  public void disableTableIfEnabled(String namespace, String name) throws IOException, NotFoundException {
+    Preconditions.checkArgument(namespace != null, "Namespace should not be null");
+    Preconditions.checkArgument(name != null, "Table name should not be null.");
+
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      admin.disableTable(TableName.valueOf(namespace, encodeHBaseEntity(name)));
+    } catch (TableNotEnabledException e) {
+      LOG.debug("Attempt to disable already disabled table {} in the namespace {}.", name, namespace);
+    }
+  }
+
+  @Override
+  public void modifyTable(String namespace, String name, TableDescriptor descriptor)
+    throws IOException, NotFoundException {
+    Preconditions.checkArgument(namespace != null, "Namespace should not be null");
+    Preconditions.checkArgument(name != null, "Table name should not be null.");
+    Preconditions.checkArgument(descriptor != null, "Descriptor should not be null.");
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      HTableDescriptor htd = TableDescriptor.toHTableDescriptor(descriptor);
+      admin.modifyTable(htd.getTableName(), htd);
+    }
+  }
+
+  @Override
+  public void truncateTable(String namespace, String name) throws IOException, NotFoundException {
+    Preconditions.checkArgument(namespace != null, "Namespace should not be null");
+    Preconditions.checkArgument(name != null, "Table name should not be null.");
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      HTableDescriptor descriptor = admin.getTableDescriptor(TableName.valueOf(namespace, encodeHBaseEntity(name)));
+      TableDescriptor tbd = TableDescriptor.fromHTableDescriptor(descriptor);
+      disableTableIfEnabled(namespace, name);
+      deleteTableIfExists(namespace, name);
+      createTableIfNotExists(tbd, null);
+    }
+  }
+
+  @Override
+  public void deleteTableIfExists(String namespace, String name) throws IOException, NotFoundException {
+    Preconditions.checkArgument(namespace != null, "Namespace should not be null");
+    Preconditions.checkArgument(name != null, "Table name should not be null.");
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      admin.deleteTable(TableName.valueOf(namespace, encodeHBaseEntity(name)));
+    }
+  }
+}

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/hbase/ddl/HBaseDDLExecutor.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/hbase/ddl/HBaseDDLExecutor.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.hbase.ddl;
+
+import co.cask.cdap.common.NotFoundException;
+
+import java.io.IOException;
+import javax.annotation.Nullable;
+
+/**
+ * Interface providing the HBase DDL operations.
+ */
+public interface HBaseDDLExecutor {
+  /**
+   * Create the specified namespace if it does not exist.
+   *
+   * @param name the namespace to create
+   * @throws IOException if a remote or network exception occurs
+   */
+  void createNamespaceIfNotExists(String name) throws IOException;
+
+  /**
+   * Delete the specified namespace if it exists.
+   *
+   * @param name the namespace to delete
+   * @throws IOException if a remote or network exception occurs
+   * @throws IllegalStateException if there are tables in the namespace
+   */
+  void deleteNamespaceIfExists(String name) throws IOException;
+
+  /**
+   * Create the specified table if it does not exist.
+   *
+   * @param descriptor the descriptor for the table to create
+   * @param splitKeys the initial split keys for the table
+   * @throws IOException if a remote or network exception occurs
+   */
+  void createTableIfNotExists(TableDescriptor descriptor, @Nullable byte[][] splitKeys)
+    throws IOException;
+
+  /**
+   * Enable the specified table.
+   *
+   * @param namespace the namespace of the table to enable
+   * @param name the name of the table to enable
+   * @throws IOException if a remote or network exception occurs
+   * @throws NotFoundException if the specified table does not exist
+   */
+  void enableTableIfDisabled(String namespace, String name) throws IOException, NotFoundException;
+
+  /**
+   * Disable the specified table.
+   *
+   * @param namespace the namespace of the table to disable
+   * @param name the name of the table to disable
+   * @throws IOException if a remote or network exception occurs
+   * @throws NotFoundException if the specified table does not exist
+   */
+  void disableTableIfEnabled(String namespace, String name) throws IOException, NotFoundException;
+
+  /**
+   * Modify the specified table. The table must be disabled.
+   *
+   * @param namespace the namespace of the table to modify
+   * @param name the name of the table to modify
+   * @param descriptor the descriptor for the table
+   * @throws IOException if a remote or network exception occurs
+   * @throws NotFoundException if the specified table does not exist
+   * @throws IllegalStateException if the specified table is not disabled
+   */
+  void modifyTable(String namespace, String name, TableDescriptor descriptor) throws IOException, NotFoundException;
+
+  /**
+   * Truncate the specified table. The table must be disabled.
+   *
+   * @param namespace the namespace of the table to truncate
+   * @param name the name of the table to truncate
+   * @throws IOException if a remote or network exception occurs
+   * @throws NotFoundException if the specified table does not exist
+   * @throws IllegalStateException if the specified table is not disabled
+   */
+  void truncateTable(String namespace, String name) throws IOException, NotFoundException;
+
+  /**
+   * Delete the table if it exists. The table must be disabled.
+   *
+   * @param namespace the namespace of the table to delete
+   * @param name the table to delete
+   * @throws IOException if a remote or network exception occurs
+   * @throws NotFoundException if the namespace for the specified table does not exist
+   * @throws IllegalStateException if the specified table is not disabled
+   */
+  void deleteTableIfExists(String namespace, String name) throws IOException, NotFoundException;
+}

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/hbase/ddl/TableDescriptor.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/hbase/ddl/TableDescriptor.java
@@ -65,7 +65,6 @@ public final class TableDescriptor {
     }
 
     this.properties = ImmutableMap.copyOf(properties);
-    this.properties.put(CDAP_VERSION, ProjectInfo.getVersion().toString());
   }
 
   public String getNamespace() {
@@ -151,16 +150,18 @@ public final class TableDescriptor {
   public static class Builder {
     private Set<ColumnFamilyDescriptor> families = new HashSet<>();
     private Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
-    private Map<String, String> properties;
+    private final Map<String, String> properties;
 
-    private final CConfiguration cConf;
     private final TableId tableId;
+    private final String tablePrefix;
     private final HTableNameConverter nameConverter = new HTableNameConverter();
 
     public Builder(CConfiguration cConf, TableId tableId) {
-      this.cConf = cConf;
       this.tableId = tableId;
-
+      this.properties = new HashMap<>();
+      properties.put(CDAP_VERSION, ProjectInfo.getVersion().toString());
+      this.tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
+      properties.put(Constants.Dataset.TABLE_PREFIX, tablePrefix);
     }
 
     public Builder addCoprocessor(CoprocessorDescriptor coprocessor) {
@@ -179,8 +180,6 @@ public final class TableDescriptor {
     }
 
     public TableDescriptor build() {
-      String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
-      properties.put(Constants.Dataset.TABLE_PREFIX, tablePrefix);
       TableName tableName = nameConverter.toTableName(tablePrefix, tableId);
       return new TableDescriptor(tableName.getNamespaceAsString(), tableName.getQualifierAsString(), families,
                                  coprocessors, properties);

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/hbase/ddl/TableDescriptor.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/hbase/ddl/TableDescriptor.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright © 2014-2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.hbase.ddl;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.utils.ProjectInfo;
+import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.HTableNameConverter;
+import com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Describes an HBase table.
+ */
+public final class TableDescriptor {
+  public static final String CDAP_VERSION = "cdap.version";
+  private static final Logger LOG = LoggerFactory.getLogger(TableDescriptor.class);
+
+  private final String namespace;
+  private final String name;
+  private final Map<String, ColumnFamilyDescriptor> families;
+  private final Map<String, CoprocessorDescriptor> coprocessors;
+  private final Map<String, String> properties;
+
+  private TableDescriptor(String namespace, String name, Set<ColumnFamilyDescriptor> families,
+                         Set<CoprocessorDescriptor> coprocessors, Map<String, String> properties) {
+    this.namespace = namespace;
+    this.name = name;
+
+    this.families = new HashMap<>();
+    for (ColumnFamilyDescriptor family : families) {
+      this.families.put(family.getName(), family);
+    }
+
+    this.coprocessors = new HashMap<>();
+    for (CoprocessorDescriptor coprocessor : coprocessors) {
+      this.coprocessors.put(coprocessor.getClassName(), coprocessor);
+    }
+
+    this.properties = ImmutableMap.copyOf(properties);
+    this.properties.put(CDAP_VERSION, ProjectInfo.getVersion().toString());
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Map<String, ColumnFamilyDescriptor> getFamilies() {
+    return ImmutableMap.copyOf(families);
+  }
+
+  public Map<String, CoprocessorDescriptor> getCoprocessors() {
+    return ImmutableMap.copyOf(coprocessors);
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  public ProjectInfo.Version getCDAPVersion() {
+    return new ProjectInfo.Version(properties.get(CDAP_VERSION));
+  }
+
+  public String getTablePrefix() {
+    return properties.get(Constants.Dataset.TABLE_PREFIX);
+  }
+
+  /**
+   * // TODO Might required to make hbase version specifix
+   * @param htd
+   * @return
+   */
+  public static TableDescriptor fromHTableDescriptor(HTableDescriptor htd) {
+    Set<ColumnFamilyDescriptor> families = new HashSet<>();
+    for (HColumnDescriptor family : htd.getColumnFamilies()) {
+      families.add(ColumnFamilyDescriptor.fromHColumnDescriptor(family));
+    }
+
+    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
+    coprocessors.addAll(CoprocessorDescriptor.getCoprocessors(htd).values());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : htd.getValues().entrySet()) {
+      properties.put(Bytes.toString(value.getKey().get()), Bytes.toString(value.getValue().get()));
+    }
+
+    // TODO: should add configurations as well!
+
+    return new TableDescriptor(htd.getTableName().getNamespaceAsString(), htd.getTableName().getQualifierAsString(),
+                               families, coprocessors, properties);
+  }
+
+  public static HTableDescriptor toHTableDescriptor(TableDescriptor tbd) {
+    TableName tableName = TableName.valueOf(tbd.namespace, tbd.getName());
+    HTableDescriptor htd = new HTableDescriptor(tableName);
+    for (Map.Entry<String, ColumnFamilyDescriptor> family : tbd.getFamilies().entrySet()) {
+      htd.addFamily(ColumnFamilyDescriptor.toHColumnDescriptor(family.getValue()));
+    }
+
+    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : tbd.getCoprocessors().entrySet()) {
+      CoprocessorDescriptor cpd = coprocessor.getValue();
+      try {
+        htd.addCoprocessor(cpd.getClassName(), cpd.getPath(), cpd.getPriority(), cpd.getProperties());
+      } catch (IOException e) {
+        LOG.error("Error adding coprocessor.", e);
+      }
+    }
+
+    for (Map.Entry<String, String> property : tbd.getProperties().entrySet()) {
+      // TODO: should not add coprocessor related properties since those were already be added
+      // using addCoprocessor call.
+      htd.setValue(property.getKey(), property.getValue());
+    }
+    return htd;
+  }
+
+  /**
+   * A Builder to construct TableDescriptor.
+   */
+  public static class Builder {
+    private Set<ColumnFamilyDescriptor> families = new HashSet<>();
+    private Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
+    private Map<String, String> properties;
+
+    private final CConfiguration cConf;
+    private final TableId tableId;
+    private final HTableNameConverter nameConverter = new HTableNameConverter();
+
+    public Builder(CConfiguration cConf, TableId tableId) {
+      this.cConf = cConf;
+      this.tableId = tableId;
+
+    }
+
+    public Builder addCoprocessor(CoprocessorDescriptor coprocessor) {
+      this.coprocessors.add(coprocessor);
+      return this;
+    }
+
+    public Builder addColumnFamily(ColumnFamilyDescriptor family) {
+      this.families.add(family);
+      return this;
+    }
+
+    public Builder addProperty(String key, String value) {
+      this.properties.put(key, value);
+      return this;
+    }
+
+    public TableDescriptor build() {
+      String tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
+      properties.put(Constants.Dataset.TABLE_PREFIX, tablePrefix);
+      TableName tableName = nameConverter.toTableName(tablePrefix, tableId);
+      return new TableDescriptor(tableName.getNamespaceAsString(), tableName.getQualifierAsString(), families,
+                                 coprocessors, properties);
+    }
+  }
+}

--- a/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseMessageTableTestRun.java
+++ b/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseMessageTableTestRun.java
@@ -25,6 +25,7 @@ import co.cask.cdap.data.hbase.HBaseTestBase;
 import co.cask.cdap.data2.util.hbase.ConfigurationTable;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.hbase.ddl.ColumnFamilyDescriptor;
 import co.cask.cdap.messaging.store.MessageTable;
 import co.cask.cdap.messaging.store.MessageTableTest;
 import co.cask.cdap.messaging.store.MetadataTable;
@@ -68,8 +69,8 @@ public class HBaseMessageTableTestRun extends MessageTableTest {
     cConf.set(Constants.CFG_HDFS_USER, System.getProperty("user.name"));
 
     hBaseAdmin = HBASE_TEST_BASE.getHBaseAdmin();
-    hBaseAdmin.getConfiguration().set(HBaseTableUtil.CFG_HBASE_TABLE_COMPRESSION,
-                                      HBaseTableUtil.CompressionType.NONE.name());
+    hBaseAdmin.getConfiguration().set(ColumnFamilyDescriptor.CFG_HBASE_TABLE_COMPRESSION,
+                                      ColumnFamilyDescriptor.CompressionType.NONE.name());
     tableUtil = new HBaseTableUtilFactory(cConf).get();
     tableUtil.createNamespaceIfNotExists(hBaseAdmin, tableUtil.getHBaseNamespace(NamespaceId.SYSTEM));
 

--- a/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseMetadataTableTestRun.java
+++ b/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseMetadataTableTestRun.java
@@ -23,6 +23,7 @@ import co.cask.cdap.common.guice.NamespaceClientUnitTestModule;
 import co.cask.cdap.data.hbase.HBaseTestBase;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.hbase.ddl.ColumnFamilyDescriptor;
 import co.cask.cdap.messaging.store.MetadataTable;
 import co.cask.cdap.messaging.store.MetadataTableTest;
 import co.cask.cdap.messaging.store.TableFactory;
@@ -57,8 +58,8 @@ public class HBaseMetadataTableTestRun extends MetadataTableTest {
   public static void setupBeforeClass() throws Exception {
     hConf = HBASE_TEST_BASE.getConfiguration();
     hBaseAdmin = HBASE_TEST_BASE.getHBaseAdmin();
-    hBaseAdmin.getConfiguration().set(HBaseTableUtil.CFG_HBASE_TABLE_COMPRESSION,
-                                      HBaseTableUtil.CompressionType.NONE.name());
+    hBaseAdmin.getConfiguration().set(ColumnFamilyDescriptor.CFG_HBASE_TABLE_COMPRESSION,
+                                      ColumnFamilyDescriptor.CompressionType.NONE.name());
     tableUtil = new HBaseTableUtilFactory(cConf).get();
     tableUtil.createNamespaceIfNotExists(hBaseAdmin, tableUtil.getHBaseNamespace(NamespaceId.SYSTEM));
 

--- a/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBasePayloadTableTestRun.java
+++ b/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBasePayloadTableTestRun.java
@@ -25,6 +25,7 @@ import co.cask.cdap.data.hbase.HBaseTestBase;
 import co.cask.cdap.data2.util.hbase.ConfigurationTable;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.hbase.ddl.ColumnFamilyDescriptor;
 import co.cask.cdap.messaging.store.MetadataTable;
 import co.cask.cdap.messaging.store.PayloadTable;
 import co.cask.cdap.messaging.store.PayloadTableTest;
@@ -68,8 +69,8 @@ public class HBasePayloadTableTestRun extends PayloadTableTest {
     cConf.set(Constants.CFG_HDFS_USER, System.getProperty("user.name"));
 
     hBaseAdmin = HBASE_TEST_BASE.getHBaseAdmin();
-    hBaseAdmin.getConfiguration().set(HBaseTableUtil.CFG_HBASE_TABLE_COMPRESSION,
-                                      HBaseTableUtil.CompressionType.NONE.name());
+    hBaseAdmin.getConfiguration().set(ColumnFamilyDescriptor.CFG_HBASE_TABLE_COMPRESSION,
+                                      ColumnFamilyDescriptor.CompressionType.NONE.name());
     tableUtil = new HBaseTableUtilFactory(cConf).get();
     tableUtil.createNamespaceIfNotExists(hBaseAdmin, tableUtil.getHBaseNamespace(NamespaceId.SYSTEM));
 

--- a/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseTableCoprocessorTestRun.java
+++ b/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseTableCoprocessorTestRun.java
@@ -29,6 +29,7 @@ import co.cask.cdap.data2.util.TableId;
 import co.cask.cdap.data2.util.hbase.ConfigurationTable;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import co.cask.cdap.hbase.ddl.ColumnFamilyDescriptor;
 import co.cask.cdap.messaging.TopicMetadata;
 import co.cask.cdap.messaging.store.DataCleanupTest;
 import co.cask.cdap.messaging.store.MessageTable;
@@ -110,8 +111,8 @@ public class HBaseTableCoprocessorTestRun extends DataCleanupTest {
     cConf.set(Constants.MessagingSystem.COPROCESSOR_METADATA_CACHE_EXPIRATION_SECONDS, Long.toString(CACHE_EXPIRY));
 
     hBaseAdmin = HBASE_TEST_BASE.getHBaseAdmin();
-    hBaseAdmin.getConfiguration().set(HBaseTableUtil.CFG_HBASE_TABLE_COMPRESSION,
-                                      HBaseTableUtil.CompressionType.NONE.name());
+    hBaseAdmin.getConfiguration().set(ColumnFamilyDescriptor.CFG_HBASE_TABLE_COMPRESSION,
+                                      ColumnFamilyDescriptor.CompressionType.NONE.name());
     tableUtil = new HBaseTableUtilFactory(cConf).get();
     tableUtil.createNamespaceIfNotExists(hBaseAdmin, tableUtil.getHBaseNamespace(NamespaceId.SYSTEM));
 


### PR DESCRIPTION
Design is documented here - https://wiki.cask.co/display/CE/HBase+DDL+SPI

This PR contains following changes:
1. Move HBase DDL operations to the common base class HBaseTableUtil from compat modules.
2. HBaseDDLExecutor interface and its default implementation.
3. Implementation of classes `TableDescriptor`, `ColumnFamilyDescriptor`, and `CoprocessorDescriptor`.
4. Using TableDescriptor instead of HTableDescriptor for create operation of the table.

Followup PR will include similar changes for the other HBase DDL operation such as modify. Which will also include removal of the redundant code set/get bloom type, set/get version from the HBaseTableUtil since it is already moved to `ColumnFamilyDescriptor`.