### PR TITLE
[CDAP-7468] Modifies config parser to log everything that is thrown in stderr

### DIFF
--- a/cdap-ui/server/config/parser.js
+++ b/cdap-ui/server/config/parser.js
@@ -123,6 +123,6 @@ function configRead (data) {
 function configReadFail (data) {
   var textChunk = decoder.write(data);
   if (textChunk) {
-    log.error('Failed to extract configuration');
+    log.error(textChunk);
   }
 }


### PR DESCRIPTION
- Right now we show a default message of `Failed to extract configuration` which might not always be true as the `config-tool` could throw logs when log level is changed.  Hence the change to just log whatever the node server gets.