### PR TITLE
[CDAP-8126] Fix node server to handle ssl enabled router

### DIFF
--- a/cdap-ui/server.js
+++ b/cdap-ui/server.js
@@ -50,7 +50,7 @@ log.info("Starting CDAP UI ...");
 parser.extractConfig('cdap')
   .then(function (c) {
     cdapConfig = c;
-    if (cdapConfig['ssl.enabled'] === 'true') {
+    if (cdapConfig['ssl.external.enabled'] === 'true') {
       log.debug("CDAP Security has been enabled");
       return parser.extractConfig('security');
     }
@@ -63,10 +63,9 @@ parser.extractConfig('cdap')
 
   .then(function (app) {
     var port, server;
-
-    if (cdapConfig['ssl.enabled'] === 'true') {
-
+    if (cdapConfig['ssl.external.enabled'] === 'true') {
       if (cdapConfig['dashboard.ssl.disable.cert.check'] === 'true') {
+
         // For self signed certs: see https://github.com/mikeal/request/issues/418
         process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
       }

--- a/cdap-ui/server/config/development/cdap.json
+++ b/cdap-ui/server/config/development/cdap.json
@@ -5,7 +5,7 @@
   "router.server.port": "11015",
   "dashboard.ssl.bind.port": "9443",
   "dashboard.ssl.disable.cert.check": "false",
-  "ssl.enabled": "false",
+  "ssl.external.enabled": "false",
   "router.server.address": "127.0.0.1",
   "dashboard.bind.port": "11011",
   "enable.preview": "true",

--- a/cdap-ui/server/config/router-check.js
+++ b/cdap-ui/server/config/router-check.js
@@ -57,7 +57,7 @@ AuthAddress.prototype.doPing = function (cdapConfig) {
       url = cdapConfig['router.server.address'],
       checkTimeout = cdapConfig['dashboard.router.check.timeout.secs'];
 
-  if (cdapConfig['ssl.enabled'] === "true") {
+  if (cdapConfig['ssl.external.enabled'] === "true") {
     url = 'https://' + url + ':' + cdapConfig['router.ssl.server.port'];
   } else {
     url = 'http://' + url + ':' + cdapConfig['router.server.port'];

--- a/cdap-ui/server/express.js
+++ b/cdap-ui/server/express.js
@@ -103,7 +103,7 @@ function makeApp (authAddress, cdapConfig, uiSettings) {
       hydrator: {
         previewEnabled: cdapConfig['enable.preview'] === 'true'
       },
-      sslEnabled: cdapConfig['ssl.enabled'] === 'true',
+      sslEnabled: cdapConfig['ssl.external.enabled'] === 'true',
       securityEnabled: authAddress.enabled,
       isEnterprise: process.env.NODE_ENV === 'production'
     });
@@ -227,12 +227,12 @@ function makeApp (authAddress, cdapConfig, uiSettings) {
   app.post('/namespaces/:namespace/:path(*)', function (req, res) {
     var protocol,
         port;
-    if (cdapConfig['ssl.enabled'] === 'true') {
+    if (cdapConfig['ssl.external.enabled'] === 'true') {
       protocol = 'https://';
     } else {
       protocol = 'http://';
     }
-    if (cdapConfig['ssl.enabled'] === 'true') {
+    if (cdapConfig['ssl.external.enabled'] === 'true') {
       port = cdapConfig['router.ssl.bind.port'];
     } else {
       port = cdapConfig['router.server.port'];
@@ -335,7 +335,8 @@ function makeApp (authAddress, cdapConfig, uiSettings) {
     request(opts,
       function (nerr, nres, nbody) {
         if (nerr || nres.statusCode !== 200) {
-          res.status(nres.statusCode).send(nbody);
+          var statusCode = (nres ? nres.statusCode : 500) || 500;
+          res.status(statusCode).send(nbody);
         } else {
           res.send(nbody);
         }
@@ -372,13 +373,13 @@ function makeApp (authAddress, cdapConfig, uiSettings) {
     function (req, res) {
       var protocol,
           port;
-      if (cdapConfig['ssl.enabled'] === 'true') {
+      if (cdapConfig['ssl.external.enabled'] === 'true') {
         protocol = 'https://';
       } else {
         protocol = 'http://';
       }
 
-      if (cdapConfig['ssl.enabled'] === 'true') {
+      if (cdapConfig['ssl.external.enabled'] === 'true') {
         port = cdapConfig['router.ssl.bind.port'];
       } else {
         port = cdapConfig['router.server.port'];
@@ -572,7 +573,7 @@ function makeApp (authAddress, cdapConfig, uiSettings) {
       hydrator: {
         previewEnabled: cdapConfig['enable.alpha.preview'] === 'true'
       },
-      sslEnabled: cdapConfig['ssl.enabled'] === 'true',
+      sslEnabled: cdapConfig['ssl.external.enabled'] === 'true',
       securityEnabled: authAddress.enabled,
       isEnterprise: process.env.NODE_ENV === 'production'
     });


### PR DESCRIPTION
- Fix node server for ssl enabled environment as we changed `ssl.enabled` property in `cdap-site.xml` to `ssl.external.enabled` but didn't do corresponding change in UI.


Bamboo build: http://builds.cask.co/browse/CDAP-DRC5347/latest
JIRA: https://issues.cask.co/browse/CDAP-8126