### PR TITLE
[CDAP-8125] Temporarily remove Spotlight Search component from new UI

### DIFF
--- a/cdap-ui/app/cdap/components/Header/Header.less
+++ b/cdap-ui/app/cdap/components/Header/Header.less
@@ -63,8 +63,6 @@
     .environment {
       display: inline-block;
       line-height: @height-of-header;
-      position: absolute;
-      right: 335px;
       color: rgba(117, 117, 117, 0.7);
     }
 

--- a/cdap-ui/app/cdap/components/HeaderActions/HeaderActions.less
+++ b/cdap-ui/app/cdap/components/HeaderActions/HeaderActions.less
@@ -26,8 +26,6 @@
       .navbar-list {
         .navbar-item {
           &.environment {
-            position: absolute;
-            right: 410px;
             color: rgba(117, 117, 117, 0.7);
             font-size: 13px;
             color: hsla(0,0%,46%,.7);

--- a/cdap-ui/app/cdap/components/HeaderActions/index.js
+++ b/cdap-ui/app/cdap/components/HeaderActions/index.js
@@ -19,7 +19,8 @@ import { Dropdown, DropdownMenu, DropdownItem } from 'reactstrap';
 import PlusButton from '../PlusButton';
 import T from 'i18n-react';
 import NamespaceStore from 'services/NamespaceStore';
-import SpotlightSearch from 'components/SpotlightSearch';
+// FIXME: CDAP-8125 - We will add this back when we have detailed view of entities.
+// import SpotlightSearch from 'components/SpotlightSearch';
 require('./HeaderActions.less');
 var classNames = require('classnames');
 import NamespaceDropdown from 'components/NamespaceDropdown';
@@ -95,9 +96,13 @@ export default class HeaderActions extends Component {
             </span>
             <span className={classNames("fa", {'fa-unlock': !mode.secured, 'fa-lock': mode.secured})}></span>
           </div>
-          <div className="navbar-item">
-            <SpotlightSearch />
-          </div>
+          {/*
+            FIXME: CDAP-8125 -
+            We will add this back when we have detailed view of entities.
+            <div className="navbar-item">
+              <SpotlightSearch />
+            </div>
+          */}
           {
             // FIXME: Add this later.
             // <div className="navbar-item">


### PR DESCRIPTION
- Since the user cannot do anything beyond just search we are hiding this for now. 
- We will surface this back when we have detailed view of all entities in CDAP new UI.