### PR TITLE
CDAP-8137 Prevent interpreting asterisk

### DIFF
--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -69,7 +69,7 @@ test -f "${CDAP_CONF}"/cdap-env.sh && source "${CDAP_CONF}"/cdap-env.sh
 case ${1} in
   auth-server|kafka-server|master|router|ui) CDAP_SERVICE=${1}; shift; cdap_service ${CDAP_SERVICE} ${@}; __ret=${?} ;;
   classpath) cdap_service master classpath; __ret=${?} ;;
-  cli) shift; cdap_cli ${@}; __ret=${?} ;;
+  cli) shift; cdap_cli "${@}"; __ret=${?} ;;
   config-tool) shift; cdap_config_tool ${@}; __ret=${?} ;;
   upgrade) shift; cdap_upgrade_tool ${@}; __ret=${?} ;;
   run) shift; cdap_run_class ${@}; __ret=${?} ;;

--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -985,7 +985,7 @@ cdap_cli() {
   elif [[ -d ${__path}/conf ]]; then
     CLASSPATH=${CLASSPATH}:"${__path}"/conf/
   fi
-  "${JAVA}" ${JAVA_OPTS} -cp ${CLASSPATH} -Dscript=${__script} ${__class} ${@}
+  "${JAVA}" ${JAVA_OPTS} -cp ${CLASSPATH} -Dscript=${__script} ${__class} "${@}"
 }
 
 #


### PR DESCRIPTION
Due to passing positional parameters through a couple layers of shell, we need to prevent asterisks from being interpreted. Otherwise, the SQL statement gets filled with information from the local file-system... Also, due to CDAP-8139, we need to ensure our query is passed as a single positional parameter.

Before:
```
$ bin/cdap cli execute "\"select * from dataset_results where league='nfl' and season=2012 order by winnerpoints-loserpoints desc limit 3\""
Successfully connected to CDAP instance at http://localhost:11015/default
Error: co.cask.cdap.explore.service.ExploreException: Cannot execute query. Reason: Response code: 400, message: 'Bad Request', body: '[SQLState 42000] Error while compiling statement: FAILED: ParseException line 1:23 missing EOF at 'VERSION' near 'README''
```

After (I don't have this dataset, this is just the same query as CDAP-8137):
```
$ bin/cdap cli execute "\"select * from dataset_results where league='nfl' and season=2012 order by winnerpoints-loserpoints desc limit 3\""
Successfully connected to CDAP instance at http://localhost:11015/default
Error: co.cask.cdap.explore.service.ExploreException: Cannot execute query. Reason: Response code: 400, message: 'Bad Request', body: '[SQLState 42S02] Error while compiling statement: FAILED: SemanticException [Error 10001]: Line 1:14 Table not found 'dataset_results''
```