### PR TITLE
CDAP-8133 Account for overflow when doing metadata search

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
@@ -424,7 +424,8 @@ public class DefaultMetadataStore implements MetadataStore {
         maxEndIndex = 0;
       } else {
         startIndex = offset;
-        maxEndIndex = offset + limit;
+        // account for overflow
+        maxEndIndex = (int) Math.min(Integer.MAX_VALUE, (long) offset + limit);
       }
     } else {
       // offset has already been applied, only apply limit, and update total count

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/MetadataStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/MetadataStoreTest.java
@@ -400,6 +400,14 @@ public class MetadataStoreTest {
       ImmutableList.<MetadataSearchResultRecord>of(),
       ImmutableList.copyOf(stripMetadata(response.getResults()))
     );
+
+    // ensure overflow bug is squashed (JIRA: CDAP-8133)
+    response = search(ns.getNamespace(), "tag*", 1, Integer.MAX_VALUE, 0);
+    Assert.assertEquals(3, response.getTotal());
+    Assert.assertEquals(
+      ImmutableList.of(streamSearchResult, flowSearchResult),
+      ImmutableList.copyOf(stripMetadata(response.getResults()))
+    );
   }
 
   @AfterClass


### PR DESCRIPTION
Prior to this, maxEndIndex would overflow when recieving an offset n
where 0 < n <= totalElements. This fixes that bug.

JIRA: https://issues.cask.co/browse/CDAP-8133
Bamboo: http://builds.cask.co/browse/CDAP-DUT5301