### PR TITLE
CDAP-7930 Fix incorrect metadata search total

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/SearchResults.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/SearchResults.java
@@ -25,11 +25,13 @@ import java.util.List;
 public class SearchResults {
   private final List<MetadataEntry> results;
   private final List<String> cursors;
+  private final List<MetadataEntry> allResults;
 
 
-  SearchResults(List<MetadataEntry> results, List<String> cursors) {
+  SearchResults(List<MetadataEntry> results, List<String> cursors, List<MetadataEntry> allResults) {
     this.results = results;
     this.cursors = cursors;
+    this.allResults = allResults;
   }
 
   public List<MetadataEntry> getResults() {
@@ -38,5 +40,9 @@ public class SearchResults {
 
   public List<String> getCursors() {
     return cursors;
+  }
+
+  public List<MetadataEntry> getAllResults() {
+    return allResults;
   }
 }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
@@ -1085,56 +1085,58 @@ public class MetadataDatasetTest {
         // first 2 in ascending order
         searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 2, 0, null, false);
         Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry), searchResults.getResults());
+        Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry, appEntry), searchResults.getAllResults());
         // return 2 with offset 1 in ascending order
         searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 1, 2, 0, null, false);
         Assert.assertEquals(ImmutableList.of(dsEntry, appEntry), searchResults.getResults());
+        Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry, appEntry), searchResults.getAllResults());
         // descending sort by name. offset and filter should be respected.
         SortInfo nameDesc = new SortInfo(AbstractSystemMetadataWriter.ENTITY_NAME_KEY, SortInfo.SortOrder.DESC);
         // first 2 in descending order
         searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 0, 2, 0, null, false);
         Assert.assertEquals(ImmutableList.of(appEntry, dsEntry), searchResults.getResults());
+        Assert.assertEquals(ImmutableList.of(appEntry, dsEntry, flowEntry), searchResults.getAllResults());
         // last 1 in descending order
         searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 2, 1, 0, null, false);
         Assert.assertEquals(ImmutableList.of(flowEntry), searchResults.getResults());
+        Assert.assertEquals(ImmutableList.of(appEntry, dsEntry, flowEntry), searchResults.getAllResults());
         // limit 0 should return empty
         searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 2, 0, 0, null, false);
         Assert.assertTrue(searchResults.getResults().isEmpty());
+        Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry, appEntry), searchResults.getAllResults());
         searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 1, 0, 0, null, false);
         Assert.assertTrue(searchResults.getResults().isEmpty());
+        Assert.assertEquals(ImmutableList.of(appEntry, dsEntry, flowEntry), searchResults.getAllResults());
         // offset greater than total search results should return empty
         searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 4, 0, 0, null, false);
         Assert.assertTrue(searchResults.getResults().isEmpty());
+        Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry, appEntry), searchResults.getAllResults());
         searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 100, 0, 0, null, false);
         Assert.assertTrue(searchResults.getResults().isEmpty());
+        Assert.assertEquals(ImmutableList.of(appEntry, dsEntry, flowEntry), searchResults.getAllResults());
 
         // test cursors
         searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 1, 3, null, false);
-        // limit is 1, but we return 3 because 3 cursors are desired.
-        Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry, appEntry), searchResults.getResults());
+        Assert.assertEquals(ImmutableList.of(flowEntry), searchResults.getResults());
         // only 2 cursors are returned even though we requested 3 because we do not have enough data to return
         Assert.assertEquals(ImmutableList.of(dsName, appName), searchResults.getCursors());
 
         // use first cursor returned in the previous query. the rest of the parameters stay the same
         searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 1, 3, searchResults.getCursors().get(0),
                                        false);
-        // limit is 1, but we return 2 because 3 cursors are desired, however only 2 are available starting
-        // at the cursor.
-        Assert.assertEquals(ImmutableList.of(dsEntry, appEntry), searchResults.getResults());
+        Assert.assertEquals(ImmutableList.of(dsEntry), searchResults.getResults());
         // only 1 cursor is returned even though we requested 3 because we do not have enough data to return
         Assert.assertEquals(ImmutableList.of(appName), searchResults.getCursors());
 
         // use first cursor returned in the previous query. the rest of the parameters stay the same
         searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 1, 3, searchResults.getCursors().get(0),
                                        false);
-        // limit is 1, and even though 3 cursors are desired, we return only 1 result, because the after the cursor we
-        // do not have enough data for 3 further cursors
         Assert.assertEquals(ImmutableList.of(appEntry), searchResults.getResults());
         // no cursors are returned even though we requested 3 because we do not have enough data
         Assert.assertEquals(ImmutableList.of(), searchResults.getCursors());
 
         searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 2, 3, null, false);
-        // limit is 2, we return 3 because 3 cursors are desired
-        Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry, appEntry), searchResults.getResults());
+        Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry), searchResults.getResults());
         // only 1 cursor is returned even though we requested 3 because we do not have enough data to return
         Assert.assertEquals(ImmutableList.of(appName), searchResults.getCursors());
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/MetadataStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/MetadataStoreTest.java
@@ -427,9 +427,15 @@ public class MetadataStoreTest {
   private MetadataSearchResponse search(String ns, String searchQuery,
                                         int offset, int limit, int numCursors, boolean showHidden)
     throws BadRequestException {
+    return search(ns, searchQuery, offset, limit, numCursors, showHidden, SortInfo.DEFAULT);
+  }
+
+  private MetadataSearchResponse search(String ns, String searchQuery,
+                                        int offset, int limit, int numCursors, boolean showHidden, SortInfo sortInfo)
+    throws BadRequestException {
     return store.search(
       ns, searchQuery, EnumSet.allOf(EntityTypeSimpleName.class),
-      SortInfo.DEFAULT, offset, limit, numCursors, null, showHidden);
+      sortInfo, offset, limit, numCursors, "", showHidden);
   }
 
   private void generateMetadataUpdates() {


### PR DESCRIPTION
Fixes the following:

* An incorrect total would be returned if an offset > number of results
  was specified while doing a query with non-default sort order.

* If offset > number of results, limit does not restrict the number of
  results appropriately.

* ArrayList was being used where LinkedList would be more efficient.

* A negative offset or limit was unchecked and could potentially cause
  problems.

JIRA: https://issues.cask.co/browse/CDAP-7930
Bamboo: http://builds.cask.co/browse/CDAP-DUT5420-1