### PR TITLE
Cleanup whitespace and variable declaration

### DIFF
--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -801,12 +801,12 @@ cdap_sdk_start() {
 
   eval split_jvm_opts ${CDAP_SDK_DEFAULT_JVM_OPTS} ${CDAP_SDK_OPTS} ${JAVA_OPTS}
   if [[ -f ${__pidfile} ]]; then
-    local readonly __pid=$(<${__pidfile})
+    __pid=$(<${__pidfile})
     if kill -0 ${__pid} >/dev/null 2>&1; then
-      echo "Standalone process with process id ${__pid} is already running." 
+      echo "Standalone process with process id ${__pid} is already running."
       return 0
     fi
-  fi 
+  fi
 
   cdap_create_local_dir || die "Failed to create LOCAL_DIR: ${LOCAL_DIR}"
   cdap_create_log_dir || die "Failed to create LOG_DIR: ${LOG_DIR}"


### PR DESCRIPTION
Remove redundant `local readonly` on variable assignment and clean up some whitespace.