### PR TITLE
Add testing of a documentation build without running Sphinx.

### DIFF
--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -1,4 +1,4 @@
-# Copyright © 2014-2016 Cask Data, Inc.
+# Copyright © 2014-2017 Cask Data, Inc.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -128,6 +128,7 @@ function build_docs() {
   fi
   if [[ ${USE_SPHINX_BUILD} == ${FALSE} ]]; then
     echo "Not building using Sphinx."
+    mkdir -p ${TARGET}/${HTML}
   else
     echo "Building using Sphinx."
     ${SPHINX_BUILD} -w ${TARGET}/${SPHINX_MESSAGES} ${google_tag} ${SOURCE} ${TARGET}/${HTML}

--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -86,6 +86,7 @@ function usage() {
   echo "    docs             alias for 'build-docs'"
   echo "    docs-local       Clean build of docs (no extras or Javadocs), using local copies of downloaded files"
   echo
+  echo "    check            Runs build without running Sphinx, to check all downloads and includes"
   echo "    license-pdfs     Clean build of License Dependency PDFs"
   echo "    check-includes   Check if included files have changed from source"
   echo "    version          Print the version information"
@@ -125,7 +126,12 @@ function build_docs() {
   if [[ ${errors} -ne 0 ]]; then
     echo_set_message "Error in check_includes: ${errors}"
   fi
-  ${SPHINX_BUILD} -w ${TARGET}/${SPHINX_MESSAGES} ${google_tag} ${SOURCE} ${TARGET}/${HTML}
+  if [[ ${USE_SPHINX_BUILD} == ${FALSE} ]]; then
+    echo "Not building using Sphinx."
+  else
+    echo "Building using Sphinx."
+    ${SPHINX_BUILD} -w ${TARGET}/${SPHINX_MESSAGES} ${google_tag} ${SOURCE} ${TARGET}/${HTML}
+  fi  
   build_extras
   consolidate_messages
 }
@@ -146,6 +152,13 @@ function build_extras() {
   # Currently performed in reference-manual
   echo "No extras being built or copied."
 }
+
+function check() {
+  USE_SPHINX_BUILD="${FALSE}"
+  export USE_SPHINX_BUILD
+  build_docs
+}
+
 
 function check_build_rst() {
   pushd ${PROJECT_PATH} > /dev/null
@@ -547,11 +560,12 @@ function rewrite() {
 function run_command() {
   set_version
   case ${1} in
-    build-web|build-docs)            "${1/-/_}";;
-    check-includes|display-version)  "${1/-/_}";;
-    license-pdfs)                    "build_license_pdfs";;
-    docs)                            "build_docs";;
-    docs-local)                      "build_docs_local";;
-    *)                               usage;;
+    build-web|build-docs)  "${1/-/_}";;
+    check|check-includes)  "${1/-/_}";;
+    display-version)       "${1/-/_}";;
+    license-pdfs)          "build_license_pdfs";;
+    docs)                  "build_docs";;
+    docs-local)            "build_docs_local";;
+    *)                     usage;;
   esac
 }

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -54,12 +54,15 @@ function usage() {
   echo "    javadocs-all      Build Javadocs for all modules"
   echo "    licenses          Clean build of License Dependency PDFs"
   echo "    version           Print the version information"
+  echo
+  echo "    check             Runs build without running Sphinx, to check all downloads and includes"
   echo 
   return ${warnings}
 }
 
 function run_command() {
   case ${1} in
+    check )             build_docs_check; warnings=$?;;
     clean )             clean_targets;;
     docs )              build_docs_only; warnings=$?;;
     docs-all )          build_docs_set; warnings=$?;;
@@ -100,6 +103,12 @@ function display_end_title_bell() {
   echo "========================================================"
   echo "========================================================"
   echo
+}
+
+function build_docs_check() {
+  USE_SPHINX_BUILD="${FALSE}"
+  export USE_SPHINX_BUILD
+  build_docs_only
 }
 
 function build_docs_set() {
@@ -271,8 +280,12 @@ function build_docs_outer_level() {
   cp ${SCRIPT_PATH}/${COMMON_HIGHLEVEL_PY}  ${TARGET_PATH}/${SOURCE}/conf.py
   cp -R ${SCRIPT_PATH}/${COMMON_IMAGES}     ${TARGET_PATH}/${SOURCE}/
   cp ${SCRIPT_PATH}/${COMMON_SOURCE}/*.rst  ${TARGET_PATH}/${SOURCE}/
-  
-  ${SPHINX_BUILD} -w ${TARGET}/${SPHINX_MESSAGES} ${google_options} ${TARGET_PATH}/${SOURCE} ${TARGET_PATH}/${HTML}
+  if [[ ${USE_SPHINX_BUILD} == ${FALSE} ]]; then
+    echo "Not building using Sphinx."
+  else
+    echo "Building using Sphinx."
+    ${SPHINX_BUILD} -w ${TARGET}/${SPHINX_MESSAGES} ${google_options} ${TARGET_PATH}/${SOURCE} ${TARGET_PATH}/${HTML}
+  fi
   consolidate_messages
   echo
 }

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright © 2016 Cask Data, Inc.
+# Copyright © 2016-2017 Cask Data, Inc.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -282,6 +282,7 @@ function build_docs_outer_level() {
   cp ${SCRIPT_PATH}/${COMMON_SOURCE}/*.rst  ${TARGET_PATH}/${SOURCE}/
   if [[ ${USE_SPHINX_BUILD} == ${FALSE} ]]; then
     echo "Not building using Sphinx."
+    mkdir -p ${TARGET_PATH}/${HTML}
   else
     echo "Building using Sphinx."
     ${SPHINX_BUILD} -w ${TARGET}/${SPHINX_MESSAGES} ${google_options} ${TARGET_PATH}/${SOURCE} ${TARGET_PATH}/${HTML}
@@ -307,11 +308,16 @@ function copy_docs_inner_level() {
   else
     project_dir=${PROJECT_VERSION}
   fi
-  local source_404="${TARGET_PATH}/${HTML}/404.html"
-  rewrite ${source_404} "src=\"_static"  "src=\"/cdap/${project_dir}/en/_static"
-  rewrite ${source_404} "src=\"_images"  "src=\"/cdap/${project_dir}/en/_images"
-  rewrite ${source_404} "/href=\"http/!s|href=\"|href=\"/cdap/${project_dir}/en/|g"
-  rewrite ${source_404} "action=\"search.html"  "action=\"/cdap/${project_dir}/en/search.html"
+  if [[ ${USE_SPHINX_BUILD} == ${FALSE} ]]; then
+    echo "Not building using Sphinx. Skipping re-writing 404 file."
+  else
+    echo "Rewriting 404 file."
+    local source_404="${TARGET_PATH}/${HTML}/404.html"
+    rewrite ${source_404} "src=\"_static"  "src=\"/cdap/${project_dir}/en/_static"
+    rewrite ${source_404} "src=\"_images"  "src=\"/cdap/${project_dir}/en/_images"
+    rewrite ${source_404} "/href=\"http/!s|href=\"|href=\"/cdap/${project_dir}/en/|g"
+    rewrite ${source_404} "action=\"search.html"  "action=\"/cdap/${project_dir}/en/search.html"
+  fi
   echo
 }
 

--- a/cdap-docs/reference-manual/build.sh
+++ b/cdap-docs/reference-manual/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright © 2014-2016 Cask Data, Inc.
+# Copyright © 2014-2017 Cask Data, Inc.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -33,16 +33,20 @@ CLI_TABLE_RST="cdap-cli-table.rst"
 CHECK_INCLUDES=${TRUE}
 
 function download_includes() {
-  local target_includes_dir=${1}
-  echo "Copying CLI Docs: building rst file from cli-docs results..." 
-  python "${CLI_DOC_TOOL}" "${CLI_INPUT_TXT}" "${target_includes_dir}/${CLI_TABLE_RST}"
-  warnings=$?
-  if [[ ${warnings} -eq 0 ]]; then
-    echo "CLI rst file written to ${CLI_TABLE_RST}"
+  if [[ ${USE_SPHINX_BUILD} == ${FALSE} ]]; then
+    echo "Not building using Sphinx: skipping building rst file from cli-docs results."
   else
-    local m="Error ${warnings} building CLI docs table"
-    echo_red_bold "${m}"
-    set_message "${m}"
+    local target_includes_dir=${1}
+    echo "Copying CLI Docs: building rst file from cli-docs results..." 
+    python "${CLI_DOC_TOOL}" "${CLI_INPUT_TXT}" "${target_includes_dir}/${CLI_TABLE_RST}"
+    warnings=$?
+    if [[ ${warnings} -eq 0 ]]; then
+      echo "CLI rst file written to ${CLI_TABLE_RST}"
+    else
+      local m="Error ${warnings} building CLI docs table"
+      echo_red_bold "${m}"
+      set_message "${m}"
+    fi
   fi
   return ${warnings}
 }
@@ -69,6 +73,11 @@ function build_extras() {
   else
     echo "Not using Javadocs."
   fi
+
+  if [[ ${USE_SPHINX_BUILD} == ${FALSE} ]]; then
+    echo "Not building using Sphinx: creating license directory."
+    mkdir -p ${TARGET_PATH}/html/licenses
+  fi  
 
   if [ -d ${TARGET_PATH}/html/licenses ]; then
     cp ${SCRIPT_PATH}/licenses-pdf/*.pdf ${TARGET_PATH}/html/licenses

--- a/cdap-docs/reference-manual/build.sh
+++ b/cdap-docs/reference-manual/build.sh
@@ -70,12 +70,19 @@ function build_extras() {
     echo "Not using Javadocs."
   fi
 
-  cp ${SCRIPT_PATH}/licenses-pdf/*.pdf ${TARGET_PATH}/html/licenses
-  warnings=$?
-  if [[ ${warnings} -eq 0 ]]; then
-    echo "Copied license PDFs."
+  if [ -d ${TARGET_PATH}/html/licenses ]; then
+    cp ${SCRIPT_PATH}/licenses-pdf/*.pdf ${TARGET_PATH}/html/licenses
+    warnings=$?
+    if [[ ${warnings} -eq 0 ]]; then
+      echo "Copied license PDFs."
+    else
+      local m="Error ${warnings} copying license PDFs."
+      echo_red_bold "${m}"
+      set_message "${m}"
+      return ${warnings}
+    fi
   else
-    local m="Error ${warnings} copying license PDFs."
+    local m="Error TARGET_PATH ${TARGET_PATH}/html/licenses does not exist."
     echo_red_bold "${m}"
     set_message "${m}"
     return ${warnings}


### PR DESCRIPTION
Tests that all included files pass the guards and can be downloaded successfully.

You run this from a command line using:
```
$ ./build.sh check