### PR TITLE
[CDAP-8128] Disables creating pipeline drafts from Market when pipeline name is empty

### DIFF
--- a/cdap-ui/app/cdap/components/CaskWizards/PublishPipeline/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/PublishPipeline/index.js
@@ -32,10 +32,22 @@ export default class PublishPipelineWizard extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      showWizard: this.props.isOpen
+      showWizard: this.props.isOpen,
+      pipelineNameIsEmpty: false
     };
 
     this.setDefaultConfig();
+
+    PublishPipelineWizardStore.subscribe(() => {
+      let pipelineName = PublishPipelineWizardStore.getState().pipelinemetadata.name;
+      if (pipelineName === "") {
+        this.setState({pipelineNameIsEmpty: true});
+      } else {
+        if (this.state.pipelineNameIsEmpty) {
+          this.setState({pipelineNameIsEmpty: false});
+        }
+      }
+    });
   }
 
   setDefaultConfig() {
@@ -137,7 +149,9 @@ export default class PublishPipelineWizard extends Component {
                 wizardType="PublishPipeline"
                 onSubmit={this.publishPipeline.bind(this)}
                 onClose={this.toggleWizard.bind(this)}
-                store={PublishPipelineWizardStore}/>
+                store={PublishPipelineWizardStore}
+                finishButtonDisabled={this.state.pipelineNameIsEmpty}
+              />
             </WizardModal>
           :
             null

--- a/cdap-ui/app/cdap/components/Wizard/index.js
+++ b/cdap-ui/app/cdap/components/Wizard/index.js
@@ -46,7 +46,7 @@ export default class Wizard extends Component {
       activeStep: this.props.wizardConfig.steps[0].id,
       success: false,
       loading: false,
-      error: ''
+      error: '',
     };
   }
   getChildContext() {
@@ -97,10 +97,8 @@ export default class Wizard extends Component {
           }
         );
     }
-
   }
   render() {
-
     const getNavigationButtons = function getNavigationButtons(matchedStep) {
       let matchedIndex = currentStepIndex(this.props.wizardConfig.steps, matchedStep.id);
       let navButtons;
@@ -126,6 +124,7 @@ export default class Wizard extends Component {
         <button
           className="btn btn-primary"
           onClick={this.submitForm.bind(this)}
+          disabled={this.props.finishButtonDisabled ? 'disabled' : null}
         >
           Finish
         </button>
@@ -308,5 +307,6 @@ Wizard.propTypes = {
     replaceReducer: PropTypes.func
   }).isRequired,
   onSubmit: PropTypes.func.isRequired,
-  onClose: PropTypes.func.isRequired
+  onClose: PropTypes.func.isRequired,
+  finishButtonDisabled: PropTypes.bool
 };


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-8128
Bamboo: http://builds.cask.co/browse/CDAP-DRC5359

I noticed that right now, you can also have empty Destination Name when creating Datapacks in Cask Market. Let me know if this is a bug, so I can fix it in this PR too (and maybe try a more general approach).