### PR TITLE
[CDAP-8059] Prevent App overview from closing from when using fast action

### DIFF
--- a/cdap-ui/app/cdap/components/AppOverview/Tabs/DatasetsTab.js
+++ b/cdap-ui/app/cdap/components/AppOverview/Tabs/DatasetsTab.js
@@ -18,6 +18,7 @@ import React, {Component, PropTypes} from 'react';
 import EntityCard from 'components/EntityCard';
 import {parseMetadata} from 'services/metadata-parser';
 require('./DatasetsTab.scss');
+import shortid from 'shortid';
 
 export default class DatasetsTab extends Component {
   constructor(props) {
@@ -38,6 +39,7 @@ export default class DatasetsTab extends Component {
                   }
                 };
                 entity = parseMetadata(entity);
+                entity.uniqueId = shortid.generate();
                 return (
                   <EntityCard
                     className="entity-card-container"
@@ -59,6 +61,7 @@ export default class DatasetsTab extends Component {
                   }
                 };
                 entity = parseMetadata(entity);
+                entity.uniqueId = shortid.generate();
                 return (
                   <EntityCard
                     className="entity-card-container"

--- a/cdap-ui/app/cdap/components/AppOverview/Tabs/MainTab.js
+++ b/cdap-ui/app/cdap/components/AppOverview/Tabs/MainTab.js
@@ -18,6 +18,7 @@ import React, {Component, PropTypes} from 'react';
 import EntityCard from 'components/EntityCard';
 import {parseMetadata} from 'services/metadata-parser';
 require('./MainTab.scss');
+import shortid from 'shortid';
 
 export default class MainTab extends Component {
   constructor(props) {
@@ -48,6 +49,7 @@ export default class MainTab extends Component {
                     }
                   };
                   entity = parseMetadata(entity);
+                  entity.uniqueId = shortid.generate();
                   return (
                     <EntityCard
                       className="entity-card-container"

--- a/cdap-ui/app/cdap/components/AppOverview/index.js
+++ b/cdap-ui/app/cdap/components/AppOverview/index.js
@@ -44,9 +44,12 @@ export default class AppOverview extends Component {
       },
       dimension: {}
     };
-    this.documentClickEventListener$ = Rx.Observable.fromEvent(document, 'click')
+    this.documentClickEventListener$ = Rx.Observable.fromEvent(document.querySelector('.entity-list-view'), 'click')
       .subscribe((e) => {
-        if (isDescendant(this.overviewRef, e.target)) {
+        if (
+          isDescendant(this.overviewRef, e.target) ||
+          isDescendant(document.querySelector('.modal'), e.target)
+        ) {
           return;
         }
         if (this.props.onClose) {

--- a/cdap-ui/app/cdap/components/EntityCard/FastActions/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/FastActions/index.js
@@ -49,7 +49,9 @@ export default class FastActions extends Component {
   onSuccess(action) {
     if (action === 'startStop') { return; }
 
-    this.props.onUpdate();
+    if (this.props.onUpdate) {
+      this.props.onUpdate();
+    }
   }
 
   render () {

--- a/cdap-ui/app/cdap/components/FastAction/DeleteAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/DeleteAction/index.js
@@ -83,7 +83,13 @@ export default class DeleteAction extends Component {
     }
 
     api(params)
-      .subscribe(this.props.onSuccess, (err) => {
+      .subscribe((res) => {
+        this.props.onSuccess(res);
+        this.setState({
+          loading: false,
+          modal: false
+        });
+      }, (err) => {
         this.setState({
           loading: false,
           errorMessage: T.translate('features.FastAction.deleteFailed', {entityId: this.props.entity.id}),

--- a/cdap-ui/app/cdap/components/FastAction/StartStopAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/StartStopAction/index.js
@@ -129,13 +129,13 @@ export default class StartStopAction extends Component {
       this.startStop = 'stop';
       icon = 'fa fa-stop text-danger';
       confirmBtnText = "stopConfirmLabel";
-      headerText = T.translate('features.FastAction.startProgramHeader');
+      headerText = T.translate('features.FastAction.stopProgramHeader');
       confirmationText = T.translate('features.FastAction.stopConfirmation', {entityId: this.props.entity.id});
     } else {
       this.startStop = 'start';
       icon = 'fa fa-play text-success';
       confirmBtnText = "startConfirmLabel";
-      headerText = T.translate('features.FastAction.stopProgramHeader');
+      headerText = T.translate('features.FastAction.startProgramHeader');
       confirmationText = T.translate('features.FastAction.startConfirmation', {entityId: this.props.entity.id});
     }
 

--- a/cdap-ui/app/cdap/components/FastAction/TruncateAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/TruncateAction/index.js
@@ -68,7 +68,13 @@ export default class TruncateAction extends Component {
     }
 
     api(params)
-      .subscribe(this.props.onSuccess, (err) => {
+      .subscribe((res) => {
+        this.props.onSuccess(res);
+        this.setState({
+          loading: false,
+          modal: false
+        });
+      }, (err) => {
         this.setState({
           loading: false,
           errorMessage: T.translate('features.FastAction.truncateFailed', {entityId: this.props.entity.id}),


### PR DESCRIPTION
- The app overview popup closes when the user interacts with some fast actions.
- The fix would be to listen to specific descendants to close the overview instead of all descendants to app overview container
- Fixed 'Start' & 'Stop' confirmation modal titles
- Fixed `TruncateAction` & `DeleteAction` to close the confirmation modal after success response.

Build: http://builds.cask.co/browse/CDAP-DRC5361-1
JIRA: https://issues.cask.co/browse/CDAP-8059