### PR TITLE
Implementation of the descriptors for table, column, and coprocessor.

### DIFF
--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase96DDLExecutor.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase96DDLExecutor.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
+import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
+import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
+import co.cask.cdap.spi.hbase.TableDescriptor;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.io.compress.Compression;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Implementation of the {@link HBaseDDLExecutor} for HBase 0.96
+ */
+public class DefaultHBase96DDLExecutor extends DefaultHBaseDDLExecutor {
+
+  public DefaultHBase96DDLExecutor(Configuration hConf) {
+    super(hConf);
+  }
+
+  private HColumnDescriptor getHColumnDesciptor(ColumnFamilyDescriptor descriptor) {
+    HColumnDescriptor hFamily = new HColumnDescriptor(descriptor.getName());
+    hFamily.setMaxVersions(descriptor.getMaxVersions());
+    hFamily.setCompressionType(Compression.Algorithm.valueOf(descriptor.getCompressionType().name()));
+    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(
+      descriptor.getBloomType().name()));
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      hFamily.setValue(property.getKey(), property.getValue());
+    }
+    return hFamily;
+  }
+
+  public HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
+    TableName tableName = TableName.valueOf(descriptor.getNamespace(), descriptor.getName());
+    HTableDescriptor htd = new HTableDescriptor(tableName);
+    for (Map.Entry<String, ColumnFamilyDescriptor> family : descriptor.getFamilies().entrySet()) {
+      htd.addFamily(getHColumnDesciptor(family.getValue()));
+    }
+
+    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
+      CoprocessorDescriptor cpd = coprocessor.getValue();
+      try {
+        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
+      } catch (IOException e) {
+        LOG.error("Error adding coprocessor.", e);
+      }
+    }
+
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      // TODO: should not add coprocessor related properties since those were already be added
+      // using addCoprocessor call.
+      htd.setValue(property.getKey(), property.getValue());
+    }
+    return htd;
+  }
+
+  public TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
+    Set<ColumnFamilyDescriptor> families = new HashSet<>();
+    for (HColumnDescriptor family : descriptor.getColumnFamilies()) {
+      families.add(getColumnFamilyDescriptor(family));
+    }
+
+    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
+    coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+
+    // TODO: should add configurations as well
+    return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),
+                               descriptor.getTableName().getQualifierAsString(), families, coprocessors, properties);
+  }
+
+  private ColumnFamilyDescriptor getColumnFamilyDescriptor(HColumnDescriptor descriptor) {
+    String name = descriptor.getNameAsString();
+    int maxVersions = descriptor.getMaxVersions();
+    ColumnFamilyDescriptor.CompressionType compressionType
+      = ColumnFamilyDescriptor.CompressionType.valueOf(descriptor.getCompressionType().getName().toUpperCase());
+    ColumnFamilyDescriptor.BloomType bloomType
+      = ColumnFamilyDescriptor.BloomType.valueOf(descriptor.getBloomFilterType().name().toUpperCase());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+  }
+}

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableUtil.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableUtil.java
@@ -23,6 +23,7 @@ import co.cask.cdap.data2.transaction.messaging.coprocessor.hbase96.PayloadTable
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase96.DequeueScanObserver;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase96.HBaseQueueRegionObserver;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -45,6 +46,11 @@ import java.util.List;
 public class HBase96TableUtil extends HBaseTableUtil {
 
   private final HTableNameConverter nameConverter = new HTableNameConverter();
+
+  @Override
+  public HBaseDDLExecutor getHBaseDDLExecutor(Configuration hConf) {
+    return new DefaultHBase96DDLExecutor(hConf);
+  }
 
   @Override
   public HTable createHTable(Configuration conf, TableId tableId) throws IOException {

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase98DDLExecutor.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase98DDLExecutor.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
+import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
+import co.cask.cdap.spi.hbase.TableDescriptor;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.io.compress.Compression;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Implementation of the {@link HBaseDDLExecutor} for HBase 0.98
+ */
+public class DefaultHBase98DDLExecutor extends DefaultHBaseDDLExecutor {
+
+  public DefaultHBase98DDLExecutor(Configuration hConf) {
+    super(hConf);
+  }
+
+  private HColumnDescriptor getHColumnDesciptor(ColumnFamilyDescriptor descriptor) {
+    HColumnDescriptor hFamily = new HColumnDescriptor(descriptor.getName());
+    hFamily.setMaxVersions(descriptor.getMaxVersions());
+    hFamily.setCompressionType(Compression.Algorithm.valueOf(descriptor.getCompressionType().name()));
+    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(
+      descriptor.getBloomType().name()));
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      hFamily.setValue(property.getKey(), property.getValue());
+    }
+    return hFamily;
+  }
+
+  public HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
+    TableName tableName = TableName.valueOf(descriptor.getNamespace(), descriptor.getName());
+    HTableDescriptor htd = new HTableDescriptor(tableName);
+    for (Map.Entry<String, ColumnFamilyDescriptor> family : descriptor.getFamilies().entrySet()) {
+      htd.addFamily(getHColumnDesciptor(family.getValue()));
+    }
+
+    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
+      CoprocessorDescriptor cpd = coprocessor.getValue();
+      try {
+        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
+      } catch (IOException e) {
+        LOG.error("Error adding coprocessor.", e);
+      }
+    }
+
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      // TODO: should not add coprocessor related properties since those were already be added
+      // using addCoprocessor call.
+      htd.setValue(property.getKey(), property.getValue());
+    }
+    return htd;
+  }
+
+  public TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
+    Set<ColumnFamilyDescriptor> families = new HashSet<>();
+    for (HColumnDescriptor family : descriptor.getColumnFamilies()) {
+      families.add(getColumnFamilyDescriptor(family));
+    }
+
+    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
+    coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+
+    // TODO: should add configurations as well
+    return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),
+                               descriptor.getTableName().getQualifierAsString(), families, coprocessors, properties);
+  }
+
+  private ColumnFamilyDescriptor getColumnFamilyDescriptor(HColumnDescriptor descriptor) {
+    String name = descriptor.getNameAsString();
+    int maxVersions = descriptor.getMaxVersions();
+    ColumnFamilyDescriptor.CompressionType compressionType
+      = ColumnFamilyDescriptor.CompressionType.valueOf(descriptor.getCompressionType().getName().toUpperCase());
+    ColumnFamilyDescriptor.BloomType bloomType
+      = ColumnFamilyDescriptor.BloomType.valueOf(descriptor.getBloomFilterType().name().toUpperCase());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+  }
+}

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableUtil.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableUtil.java
@@ -23,6 +23,7 @@ import co.cask.cdap.data2.transaction.messaging.coprocessor.hbase98.PayloadTable
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase98.DequeueScanObserver;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase98.HBaseQueueRegionObserver;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -45,6 +46,11 @@ import java.util.List;
 public class HBase98TableUtil extends HBaseTableUtil {
 
   private final HTableNameConverter nameConverter = new HTableNameConverter();
+
+  @Override
+  public HBaseDDLExecutor getHBaseDDLExecutor(Configuration hConf) {
+    return new DefaultHBase98DDLExecutor(hConf);
+  }
 
   @Override
   public HTable createHTable(Configuration conf, TableId tableId) throws IOException {

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase10CDHDDLExecutor.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase10CDHDDLExecutor.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
+import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
+import co.cask.cdap.spi.hbase.TableDescriptor;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.io.compress.Compression;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Implementation of {@link HBaseDDLExecutor} for HBase version 1.0 CDH
+ */
+public class DefaultHBase10CDHDDLExecutor extends DefaultHBaseDDLExecutor {
+
+  public DefaultHBase10CDHDDLExecutor(Configuration hConf) {
+    super(hConf);
+  }
+
+  private HColumnDescriptor getHColumnDesciptor(ColumnFamilyDescriptor descriptor) {
+    HColumnDescriptor hFamily = new HColumnDescriptor(descriptor.getName());
+    hFamily.setMaxVersions(descriptor.getMaxVersions());
+    hFamily.setCompressionType(Compression.Algorithm.valueOf(descriptor.getCompressionType().name()));
+    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(
+      descriptor.getBloomType().name()));
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      hFamily.setValue(property.getKey(), property.getValue());
+    }
+    return hFamily;
+  }
+
+  public HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
+    TableName tableName = TableName.valueOf(descriptor.getNamespace(), descriptor.getName());
+    HTableDescriptor htd = new HTableDescriptor(tableName);
+    for (Map.Entry<String, ColumnFamilyDescriptor> family : descriptor.getFamilies().entrySet()) {
+      htd.addFamily(getHColumnDesciptor(family.getValue()));
+    }
+
+    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
+      CoprocessorDescriptor cpd = coprocessor.getValue();
+      try {
+        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
+      } catch (IOException e) {
+        LOG.error("Error adding coprocessor.", e);
+      }
+    }
+
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      // TODO: should not add coprocessor related properties since those were already be added
+      // using addCoprocessor call.
+      htd.setValue(property.getKey(), property.getValue());
+    }
+    return htd;
+  }
+
+  public TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
+    Set<ColumnFamilyDescriptor> families = new HashSet<>();
+    for (HColumnDescriptor family : descriptor.getColumnFamilies()) {
+      families.add(getColumnFamilyDescriptor(family));
+    }
+
+    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
+    coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+
+    // TODO: should add configurations as well
+    return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),
+                               descriptor.getTableName().getQualifierAsString(), families, coprocessors, properties);
+  }
+
+  private ColumnFamilyDescriptor getColumnFamilyDescriptor(HColumnDescriptor descriptor) {
+    String name = descriptor.getNameAsString();
+    int maxVersions = descriptor.getMaxVersions();
+    ColumnFamilyDescriptor.CompressionType compressionType
+      = ColumnFamilyDescriptor.CompressionType.valueOf(descriptor.getCompressionType().getName().toUpperCase());
+    ColumnFamilyDescriptor.BloomType bloomType
+      = ColumnFamilyDescriptor.BloomType.valueOf(descriptor.getBloomFilterType().name().toUpperCase());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableUtil.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableUtil.java
@@ -23,6 +23,7 @@ import co.cask.cdap.data2.transaction.messaging.coprocessor.hbase10cdh.PayloadTa
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase10cdh.DequeueScanObserver;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase10cdh.HBaseQueueRegionObserver;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -45,6 +46,11 @@ import java.util.List;
 public class HBase10CDHTableUtil extends HBaseTableUtil {
 
   private final HTableNameConverter nameConverter = new HTableNameConverter();
+
+  @Override
+  public HBaseDDLExecutor getHBaseDDLExecutor(Configuration hConf) {
+    return new DefaultHBase10CDHDDLExecutor(hConf);
+  }
 
   @Override
   public HTable createHTable(Configuration conf, TableId tableId) throws IOException {

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase10CDH550DDLExecutor.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase10CDH550DDLExecutor.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
+import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
+import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
+import co.cask.cdap.spi.hbase.TableDescriptor;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.io.compress.Compression;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Implementation of the {@link HBaseDDLExecutor} for HBase 1.0 CDH 5.5.0
+ */
+public class DefaultHBase10CDH550DDLExecutor extends DefaultHBaseDDLExecutor {
+
+  public DefaultHBase10CDH550DDLExecutor(Configuration hConf) {
+    super(hConf);
+  }
+
+  private HColumnDescriptor getHColumnDesciptor(ColumnFamilyDescriptor descriptor) {
+    HColumnDescriptor hFamily = new HColumnDescriptor(descriptor.getName());
+    hFamily.setMaxVersions(descriptor.getMaxVersions());
+    hFamily.setCompressionType(Compression.Algorithm.valueOf(descriptor.getCompressionType().name()));
+    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(
+      descriptor.getBloomType().name()));
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      hFamily.setValue(property.getKey(), property.getValue());
+    }
+    return hFamily;
+  }
+
+  public HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
+    TableName tableName = TableName.valueOf(descriptor.getNamespace(), descriptor.getName());
+    HTableDescriptor htd = new HTableDescriptor(tableName);
+    for (Map.Entry<String, ColumnFamilyDescriptor> family : descriptor.getFamilies().entrySet()) {
+      htd.addFamily(getHColumnDesciptor(family.getValue()));
+    }
+
+    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
+      CoprocessorDescriptor cpd = coprocessor.getValue();
+      try {
+        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
+      } catch (IOException e) {
+        LOG.error("Error adding coprocessor.", e);
+      }
+    }
+
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      // TODO: should not add coprocessor related properties since those were already be added
+      // using addCoprocessor call.
+      htd.setValue(property.getKey(), property.getValue());
+    }
+    return htd;
+  }
+
+  public TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
+    Set<ColumnFamilyDescriptor> families = new HashSet<>();
+    for (HColumnDescriptor family : descriptor.getColumnFamilies()) {
+      families.add(getColumnFamilyDescriptor(family));
+    }
+
+    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
+    coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+
+    // TODO: should add configurations as well
+    return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),
+                               descriptor.getTableName().getQualifierAsString(), families, coprocessors, properties);
+  }
+
+  private ColumnFamilyDescriptor getColumnFamilyDescriptor(HColumnDescriptor descriptor) {
+    String name = descriptor.getNameAsString();
+    int maxVersions = descriptor.getMaxVersions();
+    ColumnFamilyDescriptor.CompressionType compressionType
+      = ColumnFamilyDescriptor.CompressionType.valueOf(descriptor.getCompressionType().getName().toUpperCase());
+    ColumnFamilyDescriptor.BloomType bloomType
+      = ColumnFamilyDescriptor.BloomType.valueOf(descriptor.getBloomFilterType().name().toUpperCase());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDH550TableUtil.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDH550TableUtil.java
@@ -23,6 +23,7 @@ import co.cask.cdap.data2.transaction.messaging.coprocessor.hbase10cdh550.Payloa
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase10cdh550.DequeueScanObserver;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase10cdh550.HBaseQueueRegionObserver;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -45,6 +46,11 @@ import java.util.List;
 public class HBase10CDH550TableUtil extends HBaseTableUtil {
 
   private final HTableNameConverter nameConverter = new HTableNameConverter();
+
+  @Override
+  public HBaseDDLExecutor getHBaseDDLExecutor(Configuration hConf) {
+    return new DefaultHBase10CDH550DDLExecutor(hConf);
+  }
 
   @Override
   public HTable createHTable(Configuration conf, TableId tableId) throws IOException {

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase10DDLExecutor.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase10DDLExecutor.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
+import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
+import co.cask.cdap.spi.hbase.TableDescriptor;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.io.compress.Compression;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Implementation of the {@link HBaseDDLExecutor} for HBase version 1.0
+ */
+public class DefaultHBase10DDLExecutor extends DefaultHBaseDDLExecutor {
+
+  public DefaultHBase10DDLExecutor(Configuration hConf) {
+    super(hConf);
+  }
+
+  private HColumnDescriptor getHColumnDesciptor(ColumnFamilyDescriptor descriptor) {
+    HColumnDescriptor hFamily = new HColumnDescriptor(descriptor.getName());
+    hFamily.setMaxVersions(descriptor.getMaxVersions());
+    hFamily.setCompressionType(Compression.Algorithm.valueOf(descriptor.getCompressionType().name()));
+    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(
+      descriptor.getBloomType().name()));
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      hFamily.setValue(property.getKey(), property.getValue());
+    }
+    return hFamily;
+  }
+
+  public HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
+    TableName tableName = TableName.valueOf(descriptor.getNamespace(), descriptor.getName());
+    HTableDescriptor htd = new HTableDescriptor(tableName);
+    for (Map.Entry<String, ColumnFamilyDescriptor> family : descriptor.getFamilies().entrySet()) {
+      htd.addFamily(getHColumnDesciptor(family.getValue()));
+    }
+
+    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
+      CoprocessorDescriptor cpd = coprocessor.getValue();
+      try {
+        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
+      } catch (IOException e) {
+        LOG.error("Error adding coprocessor.", e);
+      }
+    }
+
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      // TODO: should not add coprocessor related properties since those were already be added
+      // using addCoprocessor call.
+      htd.setValue(property.getKey(), property.getValue());
+    }
+    return htd;
+  }
+
+  public TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
+    Set<ColumnFamilyDescriptor> families = new HashSet<>();
+    for (HColumnDescriptor family : descriptor.getColumnFamilies()) {
+      families.add(getColumnFamilyDescriptor(family));
+    }
+
+    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
+    coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+
+    // TODO: should add configurations as well
+    return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),
+                               descriptor.getTableName().getQualifierAsString(), families, coprocessors, properties);
+  }
+
+  private ColumnFamilyDescriptor getColumnFamilyDescriptor(HColumnDescriptor descriptor) {
+    String name = descriptor.getNameAsString();
+    int maxVersions = descriptor.getMaxVersions();
+    ColumnFamilyDescriptor.CompressionType compressionType
+      = ColumnFamilyDescriptor.CompressionType.valueOf(descriptor.getCompressionType().getName().toUpperCase());
+    ColumnFamilyDescriptor.BloomType bloomType
+      = ColumnFamilyDescriptor.BloomType.valueOf(descriptor.getBloomFilterType().name().toUpperCase());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+  }
+}

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableUtil.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableUtil.java
@@ -23,6 +23,7 @@ import co.cask.cdap.data2.transaction.messaging.coprocessor.hbase10.PayloadTable
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase10.DequeueScanObserver;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase10.HBaseQueueRegionObserver;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -49,6 +50,11 @@ import java.util.List;
 public class HBase10TableUtil extends HBaseTableUtil {
 
   private final HTableNameConverter nameConverter = new HTableNameConverter();
+
+  @Override
+  public HBaseDDLExecutor getHBaseDDLExecutor(Configuration hConf) {
+    return new DefaultHBase10DDLExecutor(hConf);
+  }
 
   @Override
   public HTable createHTable(Configuration conf, TableId tableId) throws IOException {

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase11DDLExecutor.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase11DDLExecutor.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
+import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
+import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
+import co.cask.cdap.spi.hbase.TableDescriptor;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.io.compress.Compression;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Implementation of the {@link HBaseDDLExecutor} for HBase 1.1
+ */
+public class DefaultHBase11DDLExecutor extends DefaultHBaseDDLExecutor {
+
+  public DefaultHBase11DDLExecutor(Configuration hConf) {
+    super(hConf);
+  }
+
+  private HColumnDescriptor getHColumnDesciptor(ColumnFamilyDescriptor descriptor) {
+    HColumnDescriptor hFamily = new HColumnDescriptor(descriptor.getName());
+    hFamily.setMaxVersions(descriptor.getMaxVersions());
+    hFamily.setCompressionType(Compression.Algorithm.valueOf(descriptor.getCompressionType().name()));
+    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(
+      descriptor.getBloomType().name()));
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      hFamily.setValue(property.getKey(), property.getValue());
+    }
+    return hFamily;
+  }
+
+  public HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
+    TableName tableName = TableName.valueOf(descriptor.getNamespace(), descriptor.getName());
+    HTableDescriptor htd = new HTableDescriptor(tableName);
+    for (Map.Entry<String, ColumnFamilyDescriptor> family : descriptor.getFamilies().entrySet()) {
+      htd.addFamily(getHColumnDesciptor(family.getValue()));
+    }
+
+    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
+      CoprocessorDescriptor cpd = coprocessor.getValue();
+      try {
+        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
+      } catch (IOException e) {
+        LOG.error("Error adding coprocessor.", e);
+      }
+    }
+
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      // TODO: should not add coprocessor related properties since those were already be added
+      // using addCoprocessor call.
+      htd.setValue(property.getKey(), property.getValue());
+    }
+    return htd;
+  }
+
+  public TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
+    Set<ColumnFamilyDescriptor> families = new HashSet<>();
+    for (HColumnDescriptor family : descriptor.getColumnFamilies()) {
+      families.add(getColumnFamilyDescriptor(family));
+    }
+
+    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
+    coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+
+    // TODO: should add configurations as well
+    return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),
+                               descriptor.getTableName().getQualifierAsString(), families, coprocessors, properties);
+  }
+
+  private ColumnFamilyDescriptor getColumnFamilyDescriptor(HColumnDescriptor descriptor) {
+    String name = descriptor.getNameAsString();
+    int maxVersions = descriptor.getMaxVersions();
+    ColumnFamilyDescriptor.CompressionType compressionType
+      = ColumnFamilyDescriptor.CompressionType.valueOf(descriptor.getCompressionType().getName().toUpperCase());
+    ColumnFamilyDescriptor.BloomType bloomType
+      = ColumnFamilyDescriptor.BloomType.valueOf(descriptor.getBloomFilterType().name().toUpperCase());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+  }
+}

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/HBase11TableUtil.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/HBase11TableUtil.java
@@ -23,6 +23,7 @@ import co.cask.cdap.data2.transaction.messaging.coprocessor.hbase11.PayloadTable
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase11.DequeueScanObserver;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase11.HBaseQueueRegionObserver;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -49,6 +50,11 @@ import java.util.List;
 public class HBase11TableUtil extends HBaseTableUtil {
 
   private final HTableNameConverter nameConverter = new HTableNameConverter();
+
+  @Override
+  public HBaseDDLExecutor getHBaseDDLExecutor(Configuration hConf) {
+    return new DefaultHBase11DDLExecutor(hConf);
+  }
 
   @Override
   public HTable createHTable(Configuration conf, TableId tableId) throws IOException {

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase12CDH570DDLExecutor.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase12CDH570DDLExecutor.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
+import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
+import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
+import co.cask.cdap.spi.hbase.TableDescriptor;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.io.compress.Compression;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Implementation of the {@link HBaseDDLExecutor} for HBase 1.2 CDH 5.7.0
+ */
+public class DefaultHBase12CDH570DDLExecutor extends DefaultHBaseDDLExecutor {
+
+  public DefaultHBase12CDH570DDLExecutor(Configuration hConf) {
+    super(hConf);
+  }
+
+  private HColumnDescriptor getHColumnDesciptor(ColumnFamilyDescriptor descriptor) {
+    HColumnDescriptor hFamily = new HColumnDescriptor(descriptor.getName());
+    hFamily.setMaxVersions(descriptor.getMaxVersions());
+    hFamily.setCompressionType(Compression.Algorithm.valueOf(descriptor.getCompressionType().name()));
+    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(
+      descriptor.getBloomType().name()));
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      hFamily.setValue(property.getKey(), property.getValue());
+    }
+    return hFamily;
+  }
+
+  public HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
+    TableName tableName = TableName.valueOf(descriptor.getNamespace(), descriptor.getName());
+    HTableDescriptor htd = new HTableDescriptor(tableName);
+    for (Map.Entry<String, ColumnFamilyDescriptor> family : descriptor.getFamilies().entrySet()) {
+      htd.addFamily(getHColumnDesciptor(family.getValue()));
+    }
+
+    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
+      CoprocessorDescriptor cpd = coprocessor.getValue();
+      try {
+        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
+      } catch (IOException e) {
+        LOG.error("Error adding coprocessor.", e);
+      }
+    }
+
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      // TODO: should not add coprocessor related properties since those were already be added
+      // using addCoprocessor call.
+      htd.setValue(property.getKey(), property.getValue());
+    }
+    return htd;
+  }
+
+  public TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
+    Set<ColumnFamilyDescriptor> families = new HashSet<>();
+    for (HColumnDescriptor family : descriptor.getColumnFamilies()) {
+      families.add(getColumnFamilyDescriptor(family));
+    }
+
+    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
+    coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+
+    // TODO: should add configurations as well
+    return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),
+                               descriptor.getTableName().getQualifierAsString(), families, coprocessors, properties);
+  }
+
+  private ColumnFamilyDescriptor getColumnFamilyDescriptor(HColumnDescriptor descriptor) {
+    String name = descriptor.getNameAsString();
+    int maxVersions = descriptor.getMaxVersions();
+    ColumnFamilyDescriptor.CompressionType compressionType
+      = ColumnFamilyDescriptor.CompressionType.valueOf(descriptor.getCompressionType().getName().toUpperCase());
+    ColumnFamilyDescriptor.BloomType bloomType
+      = ColumnFamilyDescriptor.BloomType.valueOf(descriptor.getBloomFilterType().name().toUpperCase());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570TableUtil.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570TableUtil.java
@@ -23,6 +23,7 @@ import co.cask.cdap.data2.transaction.messaging.coprocessor.hbase12cdh570.Payloa
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase12cdh570.DequeueScanObserver;
 import co.cask.cdap.data2.transaction.queue.coprocessor.hbase12cdh570.HBaseQueueRegionObserver;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -49,6 +50,11 @@ import java.util.List;
 public class HBase12CDH570TableUtil extends HBaseTableUtil {
 
   private final HTableNameConverter nameConverter = new HTableNameConverter();
+
+  @Override
+  public HBaseDDLExecutor getHBaseDDLExecutor(Configuration hConf) {
+    return new DefaultHBase12CDH570DDLExecutor(hConf);
+  }
 
   @Override
   public HTable createHTable(Configuration conf, TableId tableId) throws IOException {

--- a/cdap-hbase-compat-base/pom.xml
+++ b/cdap-hbase-compat-base/pom.xml
@@ -36,6 +36,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-hbase-spi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/CoprocessorUtil.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/CoprocessorUtil.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
+import com.google.common.collect.Maps;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.Coprocessor;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+
+/**
+ * Utility class for dealing with HBase coprocessors.
+ */
+public final class CoprocessorUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(CoprocessorUtil.class);
+  private CoprocessorUtil() {
+
+  }
+
+  /**
+   * Returns information for all coprocessor configured for the table.
+   *
+   * @return a Map from coprocessor class name to {@link CoprocessorDescriptor}
+   */
+  public static Map<String, CoprocessorDescriptor> getCoprocessors(HTableDescriptor tableDescriptor) {
+    Map<String, CoprocessorDescriptor> info = Maps.newHashMap();
+
+    // Extract information about existing data janitor coprocessor
+    // The following logic is copied from RegionCoprocessorHost in HBase
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> entry: tableDescriptor.getValues().entrySet()) {
+      String key = Bytes.toString(entry.getKey().get()).trim();
+      String spec = Bytes.toString(entry.getValue().get()).trim();
+
+      if (!HConstants.CP_HTD_ATTR_KEY_PATTERN.matcher(key).matches()) {
+        continue;
+      }
+
+      try {
+        Matcher matcher = HConstants.CP_HTD_ATTR_VALUE_PATTERN.matcher(spec);
+        if (!matcher.matches()) {
+          continue;
+        }
+
+        String className = matcher.group(2).trim();
+        Path path = matcher.group(1).trim().isEmpty() ? null : new Path(matcher.group(1).trim());
+        int priority = matcher.group(3).trim().isEmpty() ? Coprocessor.PRIORITY_USER
+          : Integer.valueOf(matcher.group(3));
+        String cfgSpec = null;
+        try {
+          cfgSpec = matcher.group(4);
+        } catch (IndexOutOfBoundsException ex) {
+          // ignore
+        }
+
+        Map<String, String> properties = Maps.newHashMap();
+        if (cfgSpec != null) {
+          cfgSpec = cfgSpec.substring(cfgSpec.indexOf('|') + 1);
+          // do an explicit deep copy of the passed configuration
+          Matcher m = HConstants.CP_HTD_ATTR_VALUE_PARAM_PATTERN.matcher(cfgSpec);
+          while (m.find()) {
+            properties.put(m.group(1), m.group(2));
+          }
+        }
+        info.put(className, new CoprocessorDescriptor(className, path.toUri(), priority, properties));
+      } catch (Exception ex) {
+        LOG.warn("Coprocessor attribute '{}' has invalid coprocessor specification '{}'", key, spec, ex);
+      }
+    }
+
+    return info;
+  }
+}

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBaseDDLExecutor.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBaseDDLExecutor.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
+import co.cask.cdap.spi.hbase.TableDescriptor;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.NamespaceDescriptor;
+import org.apache.hadoop.hbase.NamespaceNotFoundException;
+import org.apache.hadoop.hbase.TableExistsException;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.TableNotDisabledException;
+import org.apache.hadoop.hbase.TableNotEnabledException;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Default implementation of the {@link HBaseDDLExecutor}.
+ */
+public abstract class DefaultHBaseDDLExecutor implements HBaseDDLExecutor {
+  public static final Logger LOG = LoggerFactory.getLogger(DefaultHBaseDDLExecutor.class);
+  public static final long MAX_CREATE_TABLE_WAIT = 5000L;    // Maximum wait of 5 seconds for table creation.
+  private final Configuration hConf;
+
+  public DefaultHBaseDDLExecutor(Configuration hConf) {
+    this.hConf = hConf;
+  }
+
+  /**
+   * Encode a HBase entity name to ASCII encoding using {@link URLEncoder}.
+   * @param entityName entity string to be encoded
+   * @return encoded string
+   */
+  private String encodeHBaseEntity(String entityName) {
+    try {
+      return URLEncoder.encode(entityName, "ASCII");
+    } catch (UnsupportedEncodingException e) {
+      // this can never happen - we know that ASCII is a supported character set!
+      throw new RuntimeException(e);
+    }
+  }
+  
+  private boolean hasNamespace(HBaseAdmin admin, String name) throws IOException {
+    Preconditions.checkArgument(admin != null, "HBaseAdmin should not be null");
+    Preconditions.checkArgument(name != null, "Namespace should not be null.");
+    try {
+      admin.getNamespaceDescriptor(encodeHBaseEntity(name));
+      return true;
+    } catch (NamespaceNotFoundException e) {
+      return false;
+    }
+  }
+
+  @Override
+  public void createNamespaceIfNotExists(String name) throws IOException {
+    Preconditions.checkArgument(name != null, "Namespace should not be null.");
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      if (!hasNamespace(admin, name)) {
+        NamespaceDescriptor namespaceDescriptor =
+          NamespaceDescriptor.create(encodeHBaseEntity(name)).build();
+        admin.createNamespace(namespaceDescriptor);
+      }
+    }
+  }
+
+  @Override
+  public void deleteNamespaceIfExists(String name) throws IOException {
+    Preconditions.checkArgument(name != null, "Namespace should not be null.");
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      if (hasNamespace(admin, name)) {
+        admin.deleteNamespace(encodeHBaseEntity(name));
+      }
+    }
+  }
+
+  public abstract HTableDescriptor getHTableDescriptor(TableDescriptor descriptor);
+
+  public abstract TableDescriptor getTableDescriptor(HTableDescriptor descriptor);
+
+  @Override
+  public void createTableIfNotExists(TableDescriptor descriptor, @Nullable byte[][] splitKeys)
+    throws IOException {
+    HTableDescriptor htd = getHTableDescriptor(descriptor);
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      if (admin.tableExists(htd.getName())) {
+        return;
+      }
+      try {
+        LOG.debug("Attempting to create table '{}' if it does not exist", Bytes.toString(htd.getName()));
+        admin.createTable(htd, splitKeys);
+        LOG.info("Table created '{}'", Bytes.toString(htd.getName()));
+      } catch (TableExistsException e) {
+        // table may exist because someone else is creating it at the same
+        // time. But it may not be available yet, and opening it might fail.
+        LOG.debug("Table '{}' already exists.", Bytes.toString(htd.getName()), e);
+      }
+
+      // Wait for table to materialize
+      try {
+        Stopwatch stopwatch = new Stopwatch();
+        stopwatch.start();
+        long sleepTime = TimeUnit.MILLISECONDS.toNanos(5000L) / 10;
+        sleepTime = sleepTime <= 0 ? 1 : sleepTime;
+        do {
+          if (admin.tableExists(descriptor.getName())) {
+            LOG.info("Table '{}' exists now. Assuming that another process concurrently created it.",
+                     Bytes.toString(htd.getName()));
+            return;
+          } else {
+            TimeUnit.NANOSECONDS.sleep(sleepTime);
+          }
+        } while (stopwatch.elapsedTime(TimeUnit.MILLISECONDS) < 5000L);
+      } catch (InterruptedException e) {
+        LOG.warn("Sleeping thread interrupted.");
+      }
+      LOG.error("Table '{}' does not exist after waiting {} ms. Giving up.", Bytes.toString(htd.getName()),
+                MAX_CREATE_TABLE_WAIT);
+    }
+  }
+
+  @Override
+  public void enableTableIfDisabled(String namespace, String name) throws IOException {
+    Preconditions.checkArgument(namespace != null, "Namespace should not be null");
+    Preconditions.checkArgument(name != null, "Table name should not be null.");
+
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      admin.enableTable(TableName.valueOf(namespace, encodeHBaseEntity(name)));
+    } catch (TableNotDisabledException e) {
+      LOG.debug("Attempt to enable already enabled table {} in the namespace {}.", name, namespace);
+    }
+  }
+
+  @Override
+  public void disableTableIfEnabled(String namespace, String name) throws IOException {
+    Preconditions.checkArgument(namespace != null, "Namespace should not be null");
+    Preconditions.checkArgument(name != null, "Table name should not be null.");
+
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      admin.disableTable(TableName.valueOf(namespace, encodeHBaseEntity(name)));
+    } catch (TableNotEnabledException e) {
+      LOG.debug("Attempt to disable already disabled table {} in the namespace {}.", name, namespace);
+    }
+  }
+
+  @Override
+  public void modifyTable(String namespace, String name, TableDescriptor descriptor)
+    throws IOException {
+    Preconditions.checkArgument(namespace != null, "Namespace should not be null");
+    Preconditions.checkArgument(name != null, "Table name should not be null.");
+    Preconditions.checkArgument(descriptor != null, "Descriptor should not be null.");
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      HTableDescriptor htd = getHTableDescriptor(descriptor);
+      admin.modifyTable(htd.getTableName(), htd);
+    }
+  }
+
+  @Override
+  public void truncateTable(String namespace, String name) throws IOException {
+    Preconditions.checkArgument(namespace != null, "Namespace should not be null");
+    Preconditions.checkArgument(name != null, "Table name should not be null.");
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      HTableDescriptor descriptor = admin.getTableDescriptor(TableName.valueOf(namespace, encodeHBaseEntity(name)));
+      TableDescriptor tbd = getTableDescriptor(descriptor);
+      disableTableIfEnabled(namespace, name);
+      deleteTableIfExists(namespace, name);
+      createTableIfNotExists(tbd, null);
+    }
+  }
+
+  @Override
+  public void deleteTableIfExists(String namespace, String name) throws IOException {
+    Preconditions.checkArgument(namespace != null, "Namespace should not be null");
+    Preconditions.checkArgument(name != null, "Table name should not be null.");
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      admin.deleteTable(TableName.valueOf(namespace, encodeHBaseEntity(name)));
+    }
+  }
+}

--- a/cdap-hbase-spi/pom.xml
+++ b/cdap-hbase-spi/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 2017 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>cdap</artifactId>
+    <groupId>co.cask.cdap</groupId>
+    <version>4.1.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>cdap-hbase-spi</artifactId>
+  <name>CDAP HBase SPI</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/cdap-hbase-spi/src/main/java/co/cask/cdap/spi/hbase/ColumnFamilyDescriptor.java
+++ b/cdap-hbase-spi/src/main/java/co/cask/cdap/spi/hbase/ColumnFamilyDescriptor.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spi.hbase;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Descripbes HBase table column family.
+ */
+public final class ColumnFamilyDescriptor {
+
+  private final String name;
+  private final int maxVersions;
+  private final CompressionType compressionType;
+  private final BloomType bloomType;
+  private final Map<String, String> properties;
+
+  /**
+   * Represents the compression types supported for HBase tables.
+   */
+  public enum CompressionType {
+    LZO, SNAPPY, GZIP, NONE
+  }
+
+  /**
+   * Represents the bloom filter types supported for HBase tables.
+   */
+  public enum BloomType {
+    ROW, ROWCOL, NONE
+  }
+
+  public ColumnFamilyDescriptor(String name, int maxVersions, CompressionType compressionType,
+                                BloomType bloomType, Map<String, String> properties) {
+    this.name = name;
+    this.maxVersions = maxVersions;
+    this.compressionType = compressionType;
+    this.bloomType = bloomType;
+    this.properties = properties == null ? Collections.<String, String>emptyMap()
+      : Collections.unmodifiableMap(properties);
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public int getMaxVersions() {
+    return maxVersions;
+  }
+
+  public CompressionType getCompressionType() {
+    return compressionType;
+  }
+
+  public BloomType getBloomType() {
+    return bloomType;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  /**
+   * Builder for {@link ColumnFamilyDescriptor}.
+   */
+  public static class Builder {
+    private final String name;
+    private final Map<String, String> properties;
+
+    private int maxVersions;
+    private CompressionType compressionType;
+    private BloomType bloomType;
+
+    public Builder(String name) {
+      this.name = name;
+      this.properties = new HashMap<>();
+
+      // Default maxVersions is 1
+      this.maxVersions = 1;
+      // Default compression type
+      this.compressionType = CompressionType.SNAPPY;
+      // Default bloom type
+      this.bloomType = BloomType.ROW;
+    }
+
+    public Builder setMaxVersions(int n) {
+      this.maxVersions = n;
+      return this;
+    }
+
+    public Builder setCompressionType(CompressionType compressionType) {
+      this.compressionType = compressionType;
+      return this;
+    }
+
+    public Builder setBloomType(BloomType bloomType) {
+      this.bloomType = bloomType;
+      return this;
+    }
+
+    public Builder addProperty(String key, String value) {
+      this.properties.put(key, value);
+      return this;
+    }
+
+    public ColumnFamilyDescriptor build() {
+      return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+    }
+  }
+}

--- a/cdap-hbase-spi/src/main/java/co/cask/cdap/spi/hbase/CoprocessorDescriptor.java
+++ b/cdap-hbase-spi/src/main/java/co/cask/cdap/spi/hbase/CoprocessorDescriptor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spi.hbase;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Describes HBase coprocessor.
+ */
+public final class CoprocessorDescriptor {
+
+  private final String className;
+  private final URI path;
+  private final int priority;
+  private final Map<String, String> properties;
+
+  public CoprocessorDescriptor(String className, URI path, int priority, Map<String, String> properties) {
+    this.className = className;
+    this.path = path;
+    this.priority = priority;
+    this.properties = properties == null ? Collections.<String, String>emptyMap()
+      : Collections.unmodifiableMap(properties);
+  }
+
+  public String getClassName() {
+    return className;
+  }
+
+  public URI getPath() {
+    return path;
+  }
+
+  public int getPriority() {
+    return priority;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+}

--- a/cdap-hbase-spi/src/main/java/co/cask/cdap/spi/hbase/HBaseDDLExecutor.java
+++ b/cdap-hbase-spi/src/main/java/co/cask/cdap/spi/hbase/HBaseDDLExecutor.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spi.hbase;
+
+
+import java.io.IOException;
+import javax.annotation.Nullable;
+
+/**
+ * Interface providing the HBase DDL operations.
+ */
+public interface HBaseDDLExecutor {
+  /**
+   * Create the specified namespace if it does not exist.
+   *
+   * @param name the namespace to create
+   * @throws IOException if a remote or network exception occurs
+   */
+  void createNamespaceIfNotExists(String name) throws IOException;
+
+  /**
+   * Delete the specified namespace if it exists.
+   *
+   * @param name the namespace to delete
+   * @throws IOException if a remote or network exception occurs
+   * @throws IllegalStateException if there are tables in the namespace
+   */
+  void deleteNamespaceIfExists(String name) throws IOException;
+
+  /**
+   * Create the specified table if it does not exist.
+   *
+   * @param descriptor the descriptor for the table to create
+   * @param splitKeys the initial split keys for the table
+   * @throws IOException if a remote or network exception occurs
+   */
+  void createTableIfNotExists(TableDescriptor descriptor, @Nullable byte[][] splitKeys)
+    throws IOException;
+
+  /**
+   * Enable the specified table if it is disabled.
+   *
+   * @param namespace the namespace of the table to enable
+   * @param name the name of the table to enable
+   * @throws IOException if a remote or network exception occurs
+   */
+  void enableTableIfDisabled(String namespace, String name) throws IOException;
+
+  /**
+   * Disable the specified table if it is enabled.
+   *
+   * @param namespace the namespace of the table to disable
+   * @param name the name of the table to disable
+   * @throws IOException if a remote or network exception occurs
+   */
+  void disableTableIfEnabled(String namespace, String name) throws IOException;
+
+  /**
+   * Modify the specified table. The table must be disabled.
+   *
+   * @param namespace the namespace of the table to modify
+   * @param name the name of the table to modify
+   * @param descriptor the descriptor for the table
+   * @throws IOException if a remote or network exception occurs
+   * @throws IllegalStateException if the specified table is not disabled
+   */
+  void modifyTable(String namespace, String name, TableDescriptor descriptor) throws IOException;
+
+  /**
+   * Truncate the specified table. The table must be disabled.
+   *
+   * @param namespace the namespace of the table to truncate
+   * @param name the name of the table to truncate
+   * @throws IOException if a remote or network exception occurs
+   * @throws IllegalStateException if the specified table is not disabled
+   */
+  void truncateTable(String namespace, String name) throws IOException;
+
+  /**
+   * Delete the table if it exists. The table must be disabled.
+   *
+   * @param namespace the namespace of the table to delete
+   * @param name the table to delete
+   * @throws IOException if a remote or network exception occurs
+   * @throws IllegalStateException if the specified table is not disabled
+   */
+  void deleteTableIfExists(String namespace, String name) throws IOException;
+}

--- a/cdap-hbase-spi/src/main/java/co/cask/cdap/spi/hbase/TableDescriptor.java
+++ b/cdap-hbase-spi/src/main/java/co/cask/cdap/spi/hbase/TableDescriptor.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.spi.hbase;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Describes an HBase table.
+ */
+public final class TableDescriptor {
+
+  private final String namespace;
+  private final String name;
+  private final Map<String, ColumnFamilyDescriptor> families;
+  private final Map<String, CoprocessorDescriptor> coprocessors;
+  private final Map<String, String> properties;
+
+  public TableDescriptor(String namespace, String name, Set<ColumnFamilyDescriptor> families,
+                         Set<CoprocessorDescriptor> coprocessors, Map<String, String> properties) {
+    this.namespace = namespace;
+    this.name = name;
+
+    this.families = new HashMap<>();
+    for (ColumnFamilyDescriptor family : families) {
+      this.families.put(family.getName(), family);
+    }
+
+    this.coprocessors = new HashMap<>();
+    for (CoprocessorDescriptor coprocessor : coprocessors) {
+      this.coprocessors.put(coprocessor.getClassName(), coprocessor);
+    }
+
+    this.properties = properties == null ? Collections.<String, String>emptyMap()
+      : Collections.unmodifiableMap(properties);
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Map<String, ColumnFamilyDescriptor> getFamilies() {
+    return Collections.unmodifiableMap(families);
+  }
+
+  public Map<String, CoprocessorDescriptor> getCoprocessors() {
+    return Collections.unmodifiableMap(coprocessors);
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  /**
+   * A Builder to construct TableDescriptor.
+   */
+  public static class Builder {
+    private final String namespace;
+    private final String tableName;
+
+    private Set<ColumnFamilyDescriptor> families = new HashSet<>();
+    private Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
+    private final Map<String, String> properties;
+
+    // TODO should we call tableName as qualifier
+    // TODO should caller always set prefix and cdap version in properties
+    public Builder(String namespace, String tableName) {
+      this.namespace = namespace;
+      this.tableName = tableName;
+      this.properties = new HashMap<>();
+    }
+
+    public Builder addCoprocessor(CoprocessorDescriptor coprocessor) {
+      this.coprocessors.add(coprocessor);
+      return this;
+    }
+
+    public Builder addColumnFamily(ColumnFamilyDescriptor family) {
+      this.families.add(family);
+      return this;
+    }
+
+    public Builder addProperty(String key, String value) {
+      this.properties.put(key, value);
+      return this;
+    }
+
+    public TableDescriptor build() {
+      return new TableDescriptor(namespace, tableName, families, coprocessors, properties);
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -2512,6 +2512,7 @@
         <module>cdap-hbase-compat-1.0</module>
         <module>cdap-hbase-compat-1.1</module>
         <module>cdap-hbase-compat-1.2-cdh5.7.0</module>
+        <module>cdap-hbase-spi</module>
         <module>cdap-common</module>
         <module>cdap-docs-gen</module>
         <module>cdap-watchdog-api</module>


### PR DESCRIPTION
Build is green here https://builds.cask.co/browse/CDAP-DUT5306-1
Breaking the PR #7604 for easier test and review. 
This PR contains following changes
1. HBaseDDLExecutor and corresponding implementation in the hbase compat modules.
2. Implementation of TableDescriptor, ColumnDescriptor, and CoprocessorDescriptor.
