### PR TITLE
[CDAP-7955] Fix Splash Screen to show only once

### DIFF
--- a/cdap-ui/app/cdap/components/EntityListView/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/index.js
@@ -465,10 +465,12 @@ class EntityListView extends Component {
   }
 
   dismissSplash() {
-    let updateObj = Object.assign({}, this.state.userStoreObj);
-    updateObj.property = updateObj.property || {};
-    updateObj.property['user-has-visited'] = true;
-    MyUserStoreApi.set({}, updateObj.property);
+    MyUserStoreApi
+      .get()
+      .subscribe(res => {
+        res.property['user-has-visited'] = true;
+        MyUserStoreApi.set({}, res.property);
+      });
     this.setState({
       showSplash: true
     });

--- a/cdap-ui/app/cdap/components/HeaderActions/index.js
+++ b/cdap-ui/app/cdap/components/HeaderActions/index.js
@@ -26,6 +26,7 @@ var classNames = require('classnames');
 import NamespaceDropdown from 'components/NamespaceDropdown';
 import ProductsDrawer from 'components/ProductsDrawer';
 import RedirectToLogin from 'services/redirect-to-login';
+import cookie from 'react-cookie';
 
 export default class HeaderActions extends Component {
   constructor(props) {
@@ -38,6 +39,7 @@ export default class HeaderActions extends Component {
     this.toggleSettingsDropdown = this.toggleSettingsDropdown.bind(this);
   }
   logout() {
+    cookie.remove('show-splash-screen-for-session', {path: '/'});
     RedirectToLogin({statusCode: 401});
   }
   toggleSettingsDropdown() {


### PR DESCRIPTION
- **Existing bug**: When selecting checkbox to not show splash screen anymore and clicking close and clicking on "Go to CDAP" in the home page overrides one over the other in the user store. This results in Splash screen appearing one more time. 
  - This is fixed by getting the updated user store from the backend whenever a user setting is about to be saved.
- Show Splash screen only once per session. When the user clicks on the 'X' button in the Splash screen the user shouldn't see it anymore unless they logout and log back in (or open a new session).

Bamboo build: http://builds.cask.co/browse/CDAP-DRC5368-1
JIRA: https://issues.cask.co/browse/CDAP-7955