### PR TITLE
[HYDRATOR-1263] Remove 'Template Gallery' & '+' button in Hydrator left panel

### DIFF
--- a/cdap-ui/app/directives/group-side-panel/group-side-panel.html
+++ b/cdap-ui/app/directives/group-side-panel/group-side-panel.html
@@ -15,8 +15,8 @@
 -->
 
 <div class="side-panel text-center left">
-  <div class="hydrator-filter clearfix">
-    <input class="form-control pull-left" placeholder="Filter" type="text" ng-model="MySidePanel.searchText" />
+  <div class="hydrator-filter text-left">
+    <input class="form-control" placeholder="Filter" type="text" ng-model="MySidePanel.searchText" />
     <div class="btn-group">
       <div class="btn btn-default btn-sm"
             ng-class="{'active': MySidePanel.view === 'list'}"

--- a/cdap-ui/app/hydrator/leftpanel.less
+++ b/cdap-ui/app/hydrator/leftpanel.less
@@ -86,14 +86,17 @@ body.theme-cdap.state-hydrator-create {
 
           .hydrator-filter {
             min-height: 50px;
+            padding: 9px 5px 9px 10px;
             .btn-group,
             input.form-control {
-              display: block;
+              display: inline-block;
               height: 32px;
+              vertical-align: top;
               margin: 0;
             }
             input.form-control {
               border: 1px solid #dfe2e9;
+              width: 175px;
             }
             .btn-group {
               display: inline-block;
@@ -479,13 +482,15 @@ body.theme-cdap.state-hydrator-create {
 
       }
       .hydrator-filter {
-        padding: 9px 5px 9px 10px;
+        padding: 6px 5px 9px 5px;
         background: #eeeeee;
         min-height: 41px;
 
-        .btn-group,
-        input.form-control {
+        .btn-group {
           display: none;
+        }
+        input.form-control {
+          width: 90px;
         }
 
       }

--- a/cdap-ui/app/hydrator/templates/create/leftpanel.html
+++ b/cdap-ui/app/hydrator/templates/create/leftpanel.html
@@ -22,8 +22,8 @@
   </select>
 
   <div class="import-section">
-    <a class="btn btn-default" href="" ng-click="HydratorPlusPlusLeftPanelCtrl.showTemplates()">Template Gallery</a>
     <a class="btn btn-default" href="" ng-click="HydratorPlusPlusLeftPanelCtrl.openFileBrowser()">Import Pipeline</a>
+    <a class="btn btn-default" href="" ng-click="HydratorPlusPlusLeftPanelCtrl.loadArtifact();">Add Plugin</a>
   </div>
 </div>
 <my-side-panel
@@ -40,10 +40,10 @@
 </my-side-panel>
 
 <div class="btn btn-default btn-left-panel-toggle btn-sm pull-right" ng-click="HydratorPlusPlusStudioCtrl.toggleSidebar();">
-  <span ng-class="{'fa-angle-double-left': HydratorPlusPlusStudioCtrl.isExpanded === true, 'fa-angle-double-right': HydratorPlusPlusStudioCtrl.isExpanded === false}" class="fa "></span>
-</div>
-<div class="btn btn-default btn-left-panel-add-plugin btn-sm pull-right" ng-click="HydratorPlusPlusLeftPanelCtrl.loadArtifact();">
-  <span class="fa fa-plus"></span>
+  <span
+    ng-class="{'fa-angle-double-left': HydratorPlusPlusStudioCtrl.isExpanded === true, 'fa-angle-double-right': HydratorPlusPlusStudioCtrl.isExpanded === false}"
+    class="fa">
+  </span>
 </div>
 
 <my-file-select class="sr-only"


### PR DESCRIPTION
- Renamed '+' button in Hydrator studio left panel to 'Add Plugin' and placed it in the position of 'Template Gallery'
- Removed 'Template Gallery' as everything under it can be done through Cask Market.

JIRA: https://issues.cask.co/browse/HYDRATOR-1263
Bamboo build: http://builds.cask.co/browse/CDAP-DRC5374-1