### PR TITLE
CDAP-8108 Log Appender Implementation

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/framework/CDAPLogAppender.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/framework/CDAPLogAppender.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.framework;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import ch.qos.logback.core.LogbackException;
+import ch.qos.logback.core.spi.FilterReply;
+import ch.qos.logback.core.status.WarnStatus;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.logging.serialize.LogSchema;
+import co.cask.cdap.logging.write.FileMetaDataManager;
+import co.cask.cdap.proto.id.NamespaceId;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.inject.Inject;
+import org.apache.twill.filesystem.LocationFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Flushable;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Log Appender implementation for CDAP Log framework
+ * TODO : Refactor package CDAP-8196
+ */
+public class CDAPLogAppender extends AppenderBase<ILoggingEvent> implements Flushable {
+  private static final Logger LOG = LoggerFactory.getLogger(CDAPLogAppender.class);
+  public static final String TAG_NAMESPACE_ID = ".namespaceId";
+  public static final String TAG_APPLICATION_ID = ".applicationId";
+  public static final String TAG_FLOW_ID = ".flowId";
+  public static final String TAG_SERVICE_ID = ".serviceId";
+  public static final String TAG_MAP_REDUCE_JOB_ID = ".mapReduceId";
+  public static final String TAG_SPARK_JOB_ID = ".sparkId";
+  public static final String TAG_USER_SERVICE_ID = ".userserviceid";
+  public static final String TAG_WORKER_ID = ".workerid";
+  public static final String TAG_WORKFLOW_ID = ".workflowId";
+
+  private LogFileManager logFileManager;
+
+  @Inject
+  private FileMetaDataManager fileMetaDataManager;
+  @Inject
+  private LocationFactory locationFactory;
+
+  private int syncIntervalBytes;
+  private long maxFileLifetimeMs;
+
+
+  /**
+   * TODO: start a separate cleanup thread to remove files that has passed the TTL
+   */
+  public CDAPLogAppender() {
+    setName(getClass().getName());
+  }
+
+  public void setSyncIntervalBytes(int syncIntervalBytes) {
+    this.syncIntervalBytes = syncIntervalBytes;
+  }
+
+  public void setMaxFileLifetimeMs(long maxFileLifetimeMs) {
+    this.maxFileLifetimeMs = maxFileLifetimeMs;
+  }
+
+  @Override
+  public void start() {
+    super.start();
+    try {
+      this.logFileManager = new LogFileManager(maxFileLifetimeMs, syncIntervalBytes, new LogSchema().getAvroSchema(),
+                                               fileMetaDataManager, locationFactory);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void doAppend(ILoggingEvent eventObject) throws LogbackException {
+    long timestamp = eventObject.getTimeStamp();
+    try {
+      // logic from AppenderBase
+      if (!this.started) {
+        addStatus(new WarnStatus(
+          "Attempted to append to non started appender [" + name + "].",
+          this));
+        return;
+      }
+
+      // logic from AppenderBase
+      if (getFilterChainDecision(eventObject) == FilterReply.DENY) {
+        return;
+      }
+
+      LogPathIdentifier logPathIdentifier = getLoggingPath(eventObject.getMDCPropertyMap());
+      LogFileOutputStream outputStream = logFileManager.getLogFileOutputStream(logPathIdentifier, timestamp);
+      outputStream.append(eventObject);
+    } catch (IllegalArgumentException iae) {
+      // this shouldn't happen
+      LOG.error("Unrecognized context ", iae);
+    } catch (IOException ioe) {
+      throw new LogbackException("Exception during append", ioe);
+    }
+  }
+
+  @Override
+  protected void append(ILoggingEvent eventObject) {
+    // no-op - this wont be called as we are overriding doAppend
+  }
+
+
+  @Override
+  public void flush() throws IOException {
+    logFileManager.flush();
+  }
+
+  @Override
+  public void stop() {
+    try {
+      logFileManager.close();
+    } finally {
+      super.stop();
+    }
+  }
+
+  @VisibleForTesting
+  LogPathIdentifier getLoggingPath(Map<String, String> propertyMap) throws IllegalArgumentException {
+    // from the property map, get namespace values
+    // if the namespace is system : get component-id and return that as path
+    // if the namespace is non-system : get "app" and "program-name" and return that as path
+
+    String namespaceId = propertyMap.get(TAG_NAMESPACE_ID);
+
+    if (namespaceId.equals(NamespaceId.SYSTEM)) {
+      Preconditions.checkArgument(propertyMap.containsKey(TAG_SERVICE_ID),
+                                  String.format("%s is expected but not found in the context %s",
+                                                TAG_SERVICE_ID, propertyMap));
+      // adding services to be consistent with the old format
+      return new LogPathIdentifier(namespaceId, Constants.Logging.COMPONENT_NAME, propertyMap.get(TAG_SERVICE_ID));
+    } else {
+      Preconditions.checkArgument(propertyMap.containsKey(TAG_APPLICATION_ID),
+                                  String.format("%s is expected but not found in the context %s",
+                                                TAG_APPLICATION_ID, propertyMap));
+      String application = propertyMap.get(TAG_APPLICATION_ID);
+
+      List<String> programIdKeys = Arrays.asList(TAG_FLOW_ID, TAG_MAP_REDUCE_JOB_ID, TAG_SPARK_JOB_ID,
+                                                 TAG_USER_SERVICE_ID, TAG_WORKER_ID, TAG_WORKFLOW_ID);
+      String program = null;
+      for (String programId : programIdKeys) {
+        if (propertyMap.containsKey(programId)) {
+          program = propertyMap.get(programId);
+          break;
+        }
+      }
+      Preconditions.checkArgument(program != null, String.format("Unrecognized program in the context %s",
+                                                                 propertyMap));
+      return new LogPathIdentifier(namespaceId, application, program);
+    }
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/framework/LogFileManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/framework/LogFileManager.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.framework;
+
+import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.logging.write.FileMetaDataManager;
+import com.google.common.io.Closeables;
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.apache.avro.Schema;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.Flushable;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Class including logic for getting log file to write to. Used by {@link CDAPLogAppender}
+ */
+class LogFileManager implements Flushable {
+  private static final Logger LOG = LoggerFactory.getLogger(LogFileManager.class);
+
+  private final long maxLifetimeMillis;
+  private final Map<LogPathIdentifier, LogFileOutputStream> outputStreamMap;
+  private final Location logsDirectoryLocation;
+  private final FileMetaDataManager fileMetaDataManager;
+  private final int syncIntervalBytes;
+  private final Schema schema;
+
+  LogFileManager(long maxFileLifetimeMs, int syncIntervalBytes, Schema schema,
+                 FileMetaDataManager fileMetaDataManager,
+                 LocationFactory locationFactory) {
+    this.maxLifetimeMillis = maxFileLifetimeMs;
+    this.syncIntervalBytes = syncIntervalBytes;
+    this.schema = schema;
+    this.fileMetaDataManager = fileMetaDataManager;
+    this.logsDirectoryLocation = locationFactory.create("logs");
+    this.outputStreamMap = new HashMap<>();
+  }
+
+  /**
+   * Get log file output stream for the give logging context and timestamp - return an already open file,
+   * or create and return a new file or rotate a file based on time and return the corresponding stream.
+   * @param logPathIdentifier identify logging context
+   * @param eventTimestamp timestamp from logging event
+   * @return LogFileOutputStream output stream to the log file
+   * @throws IOException if there is exception while getting location or while writing meta data
+   */
+  public LogFileOutputStream getLogFileOutputStream(LogPathIdentifier logPathIdentifier,
+                                                    long eventTimestamp) throws IOException {
+    LogFileOutputStream logFileOutputStream = outputStreamMap.get(logPathIdentifier);
+    if (logFileOutputStream == null) {
+      logFileOutputStream = createOutputStream(logPathIdentifier, eventTimestamp);
+    } else {
+      // rotate the file if needed (time has passed)
+      logFileOutputStream = rotateOutputStream(logFileOutputStream, logPathIdentifier, eventTimestamp);
+    }
+    return logFileOutputStream;
+  }
+
+  private LogFileOutputStream createOutputStream(final LogPathIdentifier identifier,
+                                                 long timestamp) throws IOException {
+    TimeStampLocation location = createLocation(identifier);
+    try {
+      fileMetaDataManager.writeMetaData(identifier, timestamp, location.getTimeStamp(), location.getLocation());
+    } catch (Throwable e) {
+      // delete created file as there was exception while writing meta data
+      Locations.deleteQuietly(location.getLocation());
+      throw new IOException(e);
+    }
+
+    LOG.info("Created Avro file at {}", location);
+    LogFileOutputStream logFileOutputStream = new LogFileOutputStream(
+      location.getLocation(), schema, syncIntervalBytes, location.getTimeStamp(), new Closeable() {
+      @Override
+      public void close() throws IOException {
+        outputStreamMap.remove(identifier);
+      }
+    });
+
+    outputStreamMap.put(identifier, logFileOutputStream);
+    return logFileOutputStream;
+  }
+
+
+  private TimeStampLocation createLocation(LogPathIdentifier logPathIdentifier) throws IOException {
+    // if createNew fails, we retry after sleeping for a milli second as we use current timestamp for fileName.
+    // this retry should succeed on any potential conflicts, though the likelihood of conflict is very small.
+    TimeStampLocation location = getLocation(logPathIdentifier);
+    // NOTE : we are creating a file before writing meta data, so if there are simultaneous write to same folder from
+    // multiple instance of log appender, they wouldn't overwrite the meta data and would fail early,
+    // so we can retry with different timestamp for file creation.
+    // however there is a possibility for the log.saver could crash after file was created
+    // but before meta data was written, log clean up should handle this scenario.
+    // log cleanup shouldn't rely on metadata table for cleaning up old files.
+    while (!location.getLocation().createNew()) {
+      Uninterruptibles.sleepUninterruptibly(1L, TimeUnit.MILLISECONDS);
+      location = getLocation(logPathIdentifier);
+    }
+    LOG.trace("created new file at Location {}", location);
+    return location;
+  }
+
+  private LogFileOutputStream rotateOutputStream(LogFileOutputStream logFileOutputStream,
+                                                 LogPathIdentifier identifier, long timestamp) throws IOException {
+    long currentTs = System.currentTimeMillis();
+    long timeSinceFileCreate = currentTs - logFileOutputStream.getCreateTime();
+    if (timeSinceFileCreate > maxLifetimeMillis) {
+      logFileOutputStream.close();
+      return createOutputStream(identifier, timestamp);
+    }
+    return logFileOutputStream;
+  }
+
+  /**
+   * closes all the open output streams in the map
+   */
+  public void close() {
+    // close all the files in outputStreamMap
+    // clear the map
+    Collection<LogFileOutputStream> streams = new ArrayList<>(outputStreamMap.values());
+    outputStreamMap.clear();
+
+    for (LogFileOutputStream stream : streams) {
+      Closeables.closeQuietly(stream);
+    }
+  }
+
+  /**
+   * flushes the contents of all the open log files
+   * @throws IOException
+   */
+  @Override
+  public void flush() throws IOException {
+    // perform flush on all the files in the outputStreamMap
+    for (LogFileOutputStream file : outputStreamMap.values()) {
+      file.flush();
+    }
+  }
+
+  void ensureDirectoryCheck(Location location) throws IOException {
+    if (!location.isDirectory() && !location.mkdirs() && !location.isDirectory()) {
+      throw new IOException(
+        String.format("File Exists at the logging location %s, Expected to be a directory", location));
+    }
+  }
+
+  private TimeStampLocation getLocation(LogPathIdentifier logPathIdentifier) throws IOException {
+    ensureDirectoryCheck(logsDirectoryLocation);
+    long currentTime = System.currentTimeMillis();
+    String date = new SimpleDateFormat("yyyy-MM-dd").format(new Date(currentTime));
+    Location contextLocation =
+      logsDirectoryLocation.append(logPathIdentifier.getNamespaceId())
+        .append(date)
+        .append(logPathIdentifier.getPathId1())
+        .append(logPathIdentifier.getPathId2());
+    ensureDirectoryCheck(contextLocation);
+
+
+    String fileName = String.format("%s.avro", currentTime);
+    return new TimeStampLocation(contextLocation.append(fileName), currentTime);
+  }
+
+  private class TimeStampLocation {
+    private final Location location;
+    private final long timeStamp;
+
+    private TimeStampLocation(final Location location, final long timeStamp) {
+      this.location = location;
+      this.timeStamp = timeStamp;
+    }
+    private Location getLocation() {
+      return location;
+    }
+    private long getTimeStamp() {
+      return timeStamp;
+    }
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/framework/LogFileOutputStream.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/framework/LogFileOutputStream.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.framework;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.google.common.io.Closeables;
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.fs.Syncable;
+import org.apache.twill.filesystem.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.Flushable;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Represents output stream for a log file.
+ *
+ * Since there is no way to check the state of the underlying file on an exception,
+ * all methods of this class assume that the file state is bad on any exception and close the file.
+ */
+
+class LogFileOutputStream implements Closeable, Flushable {
+  private static final Logger LOG = LoggerFactory.getLogger(LogFileOutputStream.class);
+
+  private final Location location;
+  private final long createTime;
+  private final Schema schema;
+  private final Closeable closeable;
+
+  private OutputStream outputStream;
+  private DataFileWriter<GenericRecord> dataFileWriter;
+
+  LogFileOutputStream(Location location, Schema schema, int syncIntervalBytes, long createTime,
+                      Closeable closeable) throws IOException {
+    this.location = location;
+    this.schema = schema;
+    this.closeable = closeable;
+    try {
+      this.outputStream = location.getOutputStream();
+      this.dataFileWriter = new DataFileWriter<>(new GenericDatumWriter<GenericRecord>(schema));
+      this.dataFileWriter.create(schema, outputStream);
+      this.dataFileWriter.setSyncInterval(syncIntervalBytes);
+      this.createTime = createTime;
+    } catch (IOException e) {
+      Closeables.closeQuietly(outputStream);
+      Closeables.closeQuietly(dataFileWriter);
+      throw e;
+    }
+  }
+
+  Location getLocation() {
+    return location;
+  }
+
+  void append(ILoggingEvent event) throws IOException {
+    dataFileWriter.append(co.cask.cdap.logging.serialize.LoggingEvent.encode(schema, event));
+  }
+
+  /**
+   * get create time of the file
+   * @return create time
+   */
+  long getCreateTime() {
+    return createTime;
+  }
+
+  @Override
+  public void flush() throws IOException {
+    dataFileWriter.flush();
+    if (outputStream instanceof Syncable) {
+      ((Syncable) outputStream).hsync();
+    } else {
+      outputStream.flush();
+    }
+  }
+
+
+  @Override
+  public void close() throws IOException {
+    LOG.trace("Closing file {}", location);
+    try {
+      dataFileWriter.close();
+    } finally {
+      closeable.close();
+    }
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/framework/LogPathIdentifier.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/framework/LogPathIdentifier.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.framework;
+
+/**
+ * Identifier for CDAP Logging Context
+ */
+public class LogPathIdentifier {
+  private static final String META_SEPARATOR = ":";
+  private final String namespaceId;
+  private final String pathId1;
+  private final String pathId2;
+
+  public LogPathIdentifier(String namespaceId, String pathId1, String pathId2) {
+    this.namespaceId = namespaceId;
+    this.pathId1 = pathId1;
+    this.pathId2 = pathId2;
+  }
+
+  /**
+   * NamespaceId String
+   * @return namespace string
+   */
+  public String getNamespaceId() {
+    return namespaceId;
+  }
+
+  /**
+   * first part of path id
+   * @return first path id of logging context in a namespace
+   */
+  String getPathId1() {
+    return pathId1;
+  }
+
+  /**
+   * second part of path id - used by {@link LogFileManager} to create directory
+   * @return second path id of logging context in a namespace
+   */
+  String getPathId2() {
+    return pathId2;
+  }
+
+  /**
+   * Rowkey combining the namespace and log file identifier separated by separator ":"
+   * @return rowkey string
+   */
+  public String getRowKey() {
+    return String.format("%s%s%s%s%s", namespaceId, META_SEPARATOR, pathId1, META_SEPARATOR, pathId2);
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/FileMetaDataManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/FileMetaDataManager.java
@@ -30,6 +30,7 @@ import co.cask.cdap.data2.transaction.Transactions;
 import co.cask.cdap.logging.LoggingConfiguration;
 import co.cask.cdap.logging.context.GenericLoggingContext;
 import co.cask.cdap.logging.context.LoggingContextHelper;
+import co.cask.cdap.logging.framework.LogPathIdentifier;
 import co.cask.cdap.logging.save.LogSaverTableUtil;
 import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.base.Preconditions;
@@ -43,6 +44,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
@@ -56,7 +59,7 @@ import javax.annotation.Nullable;
  */
 public final class FileMetaDataManager {
   private static final Logger LOG = LoggerFactory.getLogger(FileMetaDataManager.class);
-
+  private static final byte[] COLUMN_PREFIX_VERSION = new byte[] {1};
   private static final byte[] ROW_KEY_PREFIX = Bytes.toBytes(200);
   private static final byte[] ROW_KEY_PREFIX_END = Bytes.toBytes(201);
   private static final NavigableMap<?, ?> EMPTY_MAP = Maps.unmodifiableNavigableMap(new TreeMap());
@@ -95,6 +98,31 @@ public final class FileMetaDataManager {
                             final long startTimeMs,
                             final Location location) throws Exception {
     writeMetaData(loggingContext.getLogPartition(), startTimeMs, location);
+  }
+
+  /**
+   * Persists meta data associated with a log file.
+   *
+   * @param identifier logging context identifier.
+   * @param eventTimeMs start log time associated with the file.
+   * @param currentTimeMs current time during file creation.
+   * @param location log file location.
+   */
+  public void writeMetaData(final LogPathIdentifier identifier,
+                            final long eventTimeMs,
+                            final long currentTimeMs,
+                            final Location location) throws Exception {
+    LOG.debug("Writing meta data for logging context {} with startTimeMs {} sequence Id {} and location {}",
+               identifier.getRowKey(), eventTimeMs, currentTimeMs, location);
+
+    execute(new TransactionExecutor.Procedure<Table>() {
+      @Override
+      public void apply(Table table) throws Exception {
+        // add column version prefix for new format
+        byte[] columnKey = Bytes.add(COLUMN_PREFIX_VERSION, Bytes.toBytes(eventTimeMs), Bytes.toBytes(currentTimeMs));
+        table.put(getRowKey(identifier), columnKey, Bytes.toBytes(location.toURI().toString()));
+      }
+    });
   }
 
   /**
@@ -150,6 +178,51 @@ public final class FileMetaDataManager {
             return null;
           }
         });
+        return files;
+      }
+    });
+  }
+
+  /**
+   * // TODO refactor this with the above method after Log handler changes.
+   * Returns a list of log files for a logging context.
+   *
+   * @param logPathIdentifier logging context identifier.
+   * @return List of {@link LogLocation}
+   */
+  public List<LogLocation> listFiles(final LogPathIdentifier logPathIdentifier) throws Exception {
+    return execute(new TransactionExecutor.Function<Table, List<LogLocation>>() {
+      @Override
+      public List<LogLocation> apply(Table table) throws Exception {
+        final Row cols = table.get(getRowKey(logPathIdentifier));
+
+        if (cols.isEmpty()) {
+          //noinspection unchecked
+          return new ArrayList<>();
+        }
+
+        final List<LogLocation> files = new ArrayList<>();
+
+        for (Map.Entry<byte[], byte[]> entry : cols.getColumns().entrySet()) {
+          // the location can be any location from on the filesystem for custom mapped namespaces
+          if (entry.getKey().length == 8) {
+            // old format
+            files.add(new LogLocation(LogLocation.VERSION_0,
+                                      Bytes.toLong(entry.getKey()),
+                                      // use 0 as sequence id for the old format
+                                      0,
+                                      rootLocationFactory.create(new URI(Bytes.toString(entry.getValue()))),
+                                      logPathIdentifier.getNamespaceId(), impersonator));
+          } else if  (entry.getKey().length == 17) {
+            // new format
+            files.add(new LogLocation(LogLocation.VERSION_1,
+                                      // skip the first (version) byte
+                                      Bytes.toLong(entry.getKey(), 1, Bytes.SIZEOF_LONG),
+                                      Bytes.toLong(entry.getKey(), 9, Bytes.SIZEOF_LONG),
+                                      rootLocationFactory.create(new URI(Bytes.toString(entry.getValue()))),
+                                      logPathIdentifier.getNamespaceId(), impersonator));
+          }
+        }
         return files;
       }
     });
@@ -349,6 +422,10 @@ public final class FileMetaDataManager {
 
   private byte[] getRowKey(String logPartition) {
     return Bytes.add(ROW_KEY_PREFIX, Bytes.toBytes(logPartition));
+  }
+
+  private byte[] getRowKey(LogPathIdentifier logPathIdentifier) {
+    return Bytes.add(ROW_KEY_PREFIX, logPathIdentifier.getRowKey().getBytes());
   }
 
   private byte [] getMaxKey(Map<byte[], byte[]> map) {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/LogLocation.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/write/LogLocation.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.write;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.io.SeekableInputStream;
+import co.cask.cdap.common.security.Impersonator;
+import co.cask.cdap.logging.filter.Filter;
+import co.cask.cdap.logging.read.LogEvent;
+import co.cask.cdap.logging.read.LogOffset;
+import co.cask.cdap.logging.serialize.LogSchema;
+import co.cask.cdap.logging.serialize.LoggingEvent;
+import co.cask.cdap.proto.id.NamespaceId;
+import com.google.common.base.Throwables;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.SeekableInput;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.twill.filesystem.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.NoSuchElementException;
+import java.util.concurrent.Callable;
+
+/**
+ * LogLocation representing a log file and methods to read the file's contents.
+ */
+public class LogLocation {
+  private static final Logger LOG = LoggerFactory.getLogger(LogLocation.class);
+
+  // old version
+  public static final String VERSION_0 = "V0";
+  // new version
+  public static final String VERSION_1 = "V1";
+  private final String frameworkVersion;
+  private final long eventTimeMs;
+  private final long fileCreationTimeMs;
+  private final Location location;
+  private final NamespaceId namespaceId;
+  private final Impersonator impersonator;
+
+  public LogLocation(String frameworkVersion, long eventTimeMs, long fileCreationTimeMs, Location location,
+                     String namespaceId, Impersonator impersonator) {
+    this.frameworkVersion = frameworkVersion;
+    this.eventTimeMs = eventTimeMs;
+    this.fileCreationTimeMs = fileCreationTimeMs;
+    this.location = location;
+    this.namespaceId = new NamespaceId(namespaceId);
+    this.impersonator = impersonator;
+  }
+
+  /**
+   * get logging framework version
+   * @return version string, currently V0 or V1
+   */
+  public String getFrameworkVersion() {
+    return frameworkVersion;
+  }
+
+  /**
+   * get start eventTimeMs for this logging file
+   * @return eventTimeMs in long
+   */
+  public long getEventTimeMs() {
+    return eventTimeMs;
+  }
+
+  /**
+   * get location of log file
+   * @return Location
+   */
+  public Location getLocation() {
+    return location;
+  }
+
+  /**
+   * get the timestamp associated with the file
+   * @return
+   */
+  public long getFileCreationTimeMs() {
+    return fileCreationTimeMs;
+  }
+
+  /**
+   * Return closeable iterator of {@link LogEvent}
+   * @param logFilter filter
+   * @param fromTimeMs start timestamp in millis
+   * @param toTimeMs end timestamp in millis
+   * @param maxEvents max events to return
+   * @return closeable iterator of log events
+   */
+  public CloseableIterator<LogEvent> readLog(Filter logFilter, long fromTimeMs, long toTimeMs, int maxEvents) {
+    return new LogEventIterator(logFilter, fromTimeMs, toTimeMs, maxEvents);
+  }
+
+  private final class LogEventIterator implements CloseableIterator<LogEvent> {
+
+    private final Filter logFilter;
+    private final long fromTimeMs;
+    private final long toTimeMs;
+    private final long maxEvents;
+
+    private DataFileReader<GenericRecord> dataFileReader;
+
+    private ILoggingEvent loggingEvent;
+    private GenericRecord datum;
+
+    private int count = 0;
+    private long prevTimestamp = -1;
+
+    private LogEvent next;
+
+    LogEventIterator(Filter logFilter, long fromTimeMs, long toTimeMs, long maxEvents) {
+      this.logFilter = logFilter;
+      this.fromTimeMs = fromTimeMs;
+      this.toTimeMs = toTimeMs;
+      this.maxEvents = maxEvents;
+
+      try {
+        dataFileReader = createReader();
+        if (dataFileReader.hasNext()) {
+          datum = dataFileReader.next();
+          loggingEvent = LoggingEvent.decode(datum);
+          long prevPrevSyncPos = 0;
+          long prevSyncPos = 0;
+          // Seek to time fromTimeMs
+          while (loggingEvent.getTimeStamp() < fromTimeMs && dataFileReader.hasNext()) {
+            // Seek to the next sync point
+            long curPos = dataFileReader.tell();
+            prevPrevSyncPos = prevSyncPos;
+            prevSyncPos = dataFileReader.previousSync();
+            LOG.trace("Syncing to pos {}", curPos);
+            dataFileReader.sync(curPos);
+            if (dataFileReader.hasNext()) {
+              loggingEvent = LoggingEvent.decode(dataFileReader.next(datum));
+            }
+          }
+
+          // We're now likely past the record with fromTimeMs, rewind to the previous sync point
+          dataFileReader.sync(prevPrevSyncPos);
+          LOG.trace("Final sync pos {}", prevPrevSyncPos);
+        }
+
+        // populate the first element
+        computeNext();
+
+      } catch (Exception e) {
+        // we want to ignore invalid or missing log files
+        LOG.error("Got exception while reading log file {}", location.getName(), e);
+      }
+    }
+
+    // will compute the next LogEvent and set the field 'next', unless its already set
+    private void computeNext() {
+      try {
+        // read events from file
+        while (next == null && dataFileReader.hasNext()) {
+          loggingEvent = LoggingEvent.decode(dataFileReader.next(datum));
+          if (loggingEvent.getTimeStamp() >= fromTimeMs && logFilter.match(loggingEvent)) {
+            ++count;
+            if ((count > maxEvents || loggingEvent.getTimeStamp() >= toTimeMs)
+              && loggingEvent.getTimeStamp() != prevTimestamp) {
+              break;
+            }
+            next = new LogEvent(loggingEvent,
+                                new LogOffset(LogOffset.INVALID_KAFKA_OFFSET, loggingEvent.getTimeStamp()));
+          }
+          prevTimestamp = loggingEvent.getTimeStamp();
+        }
+      } catch (Exception e) {
+        // We want to ignore invalid or missing log files.
+        // If the 'next' variable wasn't set by this method call, then the 'hasNext' method
+        // will return false, and no more events will be read from this file.
+        LOG.error("Got exception while reading log file {}", location.getName(), e);
+      }
+    }
+
+    @Override
+    public void close() {
+      try {
+        dataFileReader.close();
+      } catch (IOException e) {
+        LOG.error("Got exception while closing log file {}", location.getName(), e);
+      }
+    }
+
+    @Override
+    public boolean hasNext() {
+      return next != null;
+    }
+
+    @Override
+    public LogEvent next() {
+      if (this.next == null) {
+        throw new NoSuchElementException();
+      }
+      LogEvent toReturn = this.next;
+      this.next = null;
+      computeNext();
+      return toReturn;
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException("Remove not supported");
+    }
+  }
+
+  private DataFileReader<GenericRecord> createReader() throws IOException {
+    boolean shouldImpersonate = this.getFrameworkVersion().equals(VERSION_0);
+    return new DataFileReader<>(new LocationSeekableInput(location, namespaceId, impersonator, shouldImpersonate),
+                                new GenericDatumReader<GenericRecord>(new LogSchema().getAvroSchema()));
+  }
+
+  /**
+   * An implementation of Avro SeekableInput over Location.
+   */
+  private static final class LocationSeekableInput implements SeekableInput {
+
+    private final SeekableInputStream is;
+    private final long len;
+
+    LocationSeekableInput(final Location location,
+                          NamespaceId namespaceId, Impersonator impersonator,
+                          boolean shouldImpersonate) throws IOException {
+      try {
+        if (shouldImpersonate) {
+          this.is = impersonator.doAs(namespaceId, new Callable<SeekableInputStream>() {
+            @Override
+            public SeekableInputStream call() throws Exception {
+              return Locations.newInputSupplier(location).getInput();
+            }
+          });
+        } else {
+          // impersonation is not required for V1 version.
+          this.is = Locations.newInputSupplier(location).getInput();
+        }
+      } catch (IOException e) {
+        throw e;
+      } catch (Exception e) {
+        // should not happen
+        throw Throwables.propagate(e);
+      }
+
+      this.len = location.length();
+    }
+
+    @Override
+    public void seek(long p) throws IOException {
+      is.seek(p);
+    }
+
+    @Override
+    public long tell() throws IOException {
+      return is.getPos();
+    }
+
+    @Override
+    public long length() throws IOException {
+      return len;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      return is.read(b, off, len);
+    }
+
+    @Override
+    public void close() throws IOException {
+      is.close();
+    }
+  }
+}

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/framework/CDAPLogAppenderTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/framework/CDAPLogAppenderTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.framework;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import co.cask.cdap.api.dataset.lib.CloseableIterator;
+import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.guice.ConfigModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
+import co.cask.cdap.common.logging.ApplicationLoggingContext;
+import co.cask.cdap.common.logging.NamespaceLoggingContext;
+import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
+import co.cask.cdap.common.namespace.SimpleNamespaceQueryAdmin;
+import co.cask.cdap.common.security.UGIProvider;
+import co.cask.cdap.common.security.UnsupportedUGIProvider;
+import co.cask.cdap.data.runtime.DataSetsModules;
+import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
+import co.cask.cdap.logging.LoggingConfiguration;
+import co.cask.cdap.logging.context.FlowletLoggingContext;
+import co.cask.cdap.logging.filter.Filter;
+import co.cask.cdap.logging.guice.LoggingModules;
+import co.cask.cdap.logging.read.LogEvent;
+import co.cask.cdap.logging.write.FileMetaDataManager;
+import co.cask.cdap.logging.write.LogLocation;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
+import co.cask.cdap.security.authorization.AuthorizationTestModule;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.tephra.TransactionManager;
+import org.apache.tephra.runtime.TransactionModules;
+import org.apache.twill.filesystem.Location;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class CDAPLogAppenderTest {
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+  private static Injector injector;
+  private static TransactionManager txManager;
+
+  @BeforeClass
+  public static void setUpContext() throws Exception {
+    Configuration hConf = HBaseConfiguration.create();
+    final CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, TMP_FOLDER.newFolder().getAbsolutePath());
+    String logBaseDir = cConf.get(LoggingConfiguration.LOG_BASE_DIR) + "/" + CDAPLogAppender.class.getSimpleName();
+    cConf.set(LoggingConfiguration.LOG_BASE_DIR, logBaseDir);
+
+    injector = Guice.createInjector(
+      new ConfigModule(cConf, hConf),
+      new NonCustomLocationUnitTestModule().getModule(),
+      new TransactionModules().getInMemoryModules(),
+      new LoggingModules().getInMemoryModules(),
+      new DataSetsModules().getInMemoryModules(),
+      new SystemDatasetRuntimeModule().getInMemoryModules(),
+      new AuthorizationTestModule(),
+      new AuthorizationEnforcementModule().getInMemoryModules(),
+      new AuthenticationContextModules().getNoOpModule(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class);
+          bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
+          bind(NamespaceQueryAdmin.class).to(SimpleNamespaceQueryAdmin.class);
+        }
+      }
+    );
+
+    txManager = injector.getInstance(TransactionManager.class);
+    txManager.startAndWait();
+  }
+
+  @AfterClass
+  public static void cleanUp() throws Exception {
+    txManager.stopAndWait();
+  }
+
+  @Test
+  public void testCDAPLogAppender() throws Exception {
+    int syncInterval =
+      injector.getInstance(CConfiguration.class).getInt(LoggingConfiguration.LOG_FILE_SYNC_INTERVAL_BYTES,
+                                                        2 * 1024 * 1024);
+    FileMetaDataManager fileMetaDataManager = injector.getInstance(FileMetaDataManager.class);
+    CDAPLogAppender cdapLogAppender = new CDAPLogAppender();
+    injector.injectMembers(cdapLogAppender);
+    cdapLogAppender.setSyncIntervalBytes(syncInterval);
+    cdapLogAppender.setMaxFileLifetimeMs(TimeUnit.DAYS.toMillis(1));
+    cdapLogAppender.start();
+
+    LoggingEvent event =
+      new LoggingEvent("co.cask.Test",
+                       (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME),
+                       Level.ERROR , "test message", null, null);
+    Map<String, String> properties = new HashMap<>();
+    properties.put(NamespaceLoggingContext.TAG_NAMESPACE_ID, "default");
+    properties.put(ApplicationLoggingContext.TAG_APPLICATION_ID, "testApp");
+    properties.put(FlowletLoggingContext.TAG_FLOW_ID, "testFlow");
+    properties.put(FlowletLoggingContext.TAG_FLOWLET_ID, "testFlowet");
+
+    event.setMDCPropertyMap(properties);
+
+    cdapLogAppender.doAppend(event);
+    cdapLogAppender.stop();
+
+    try {
+      List<LogLocation> files = fileMetaDataManager.listFiles(cdapLogAppender.getLoggingPath(properties));
+      Assert.assertEquals(1, files.size());
+      LogLocation logLocation = files.get(0);
+      Assert.assertEquals(LogLocation.VERSION_1, logLocation.getFrameworkVersion());
+      Assert.assertTrue(logLocation.getLocation().exists());
+      CloseableIterator<LogEvent> logEventCloseableIterator =
+        logLocation.readLog(Filter.EMPTY_FILTER, 0, Long.MAX_VALUE, Integer.MAX_VALUE);
+      int logCount = 0;
+      while (logEventCloseableIterator.hasNext()) {
+        logCount++;
+        LogEvent logEvent = logEventCloseableIterator.next();
+        Assert.assertEquals(event.getMessage(), logEvent.getLoggingEvent().getMessage());
+      }
+      logEventCloseableIterator.close();
+      Assert.assertEquals(1, logCount);
+    } catch (Exception e) {
+      Assert.fail();
+    } finally {
+      fileMetaDataManager.cleanMetaData(Long.MAX_VALUE, new FileMetaDataManager.DeleteCallback() {
+        @Override
+        public void handle(NamespaceId namespaceId, Location location, String namespacedLogBaseDir) {
+          // no-op
+        }
+      });
+    }
+  }
+
+  @Test
+  public void testCDAPLogAppenderRotation() throws Exception {
+    int syncInterval =
+      injector.getInstance(CConfiguration.class).getInt(LoggingConfiguration.LOG_FILE_SYNC_INTERVAL_BYTES,
+                                                        2 * 1024 * 1024);
+    FileMetaDataManager fileMetaDataManager = injector.getInstance(FileMetaDataManager.class);
+    CDAPLogAppender cdapLogAppender = new CDAPLogAppender();
+    injector.injectMembers(cdapLogAppender);
+    cdapLogAppender.setSyncIntervalBytes(syncInterval);
+    cdapLogAppender.setMaxFileLifetimeMs(500);
+    cdapLogAppender.start();
+
+    Map<String, String> properties = new HashMap<>();
+    properties.put(NamespaceLoggingContext.TAG_NAMESPACE_ID, "testRotation");
+    properties.put(ApplicationLoggingContext.TAG_APPLICATION_ID, "testApp");
+    properties.put(FlowletLoggingContext.TAG_FLOW_ID, "testFlow");
+    properties.put(FlowletLoggingContext.TAG_FLOWLET_ID, "testFlowet");
+
+    long currentTimeMillisEvent1 = System.currentTimeMillis();
+
+    LoggingEvent event1 =
+      getLoggingEvent("co.cask.Test1",
+                      (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME),
+                      Level.ERROR , "test message 1", properties);
+
+    event1.setTimeStamp(currentTimeMillisEvent1);
+    cdapLogAppender.doAppend(event1);
+
+    TimeUnit.MILLISECONDS.sleep(10);
+    long currentTimeMillisEvent2 = System.currentTimeMillis();
+
+    LoggingEvent event2 = getLoggingEvent("co.cask.Test2",
+                                          (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(
+                                            Logger.ROOT_LOGGER_NAME), Level.ERROR , "test message 2", properties);
+    event2.setTimeStamp(currentTimeMillisEvent1 + 1000);
+    cdapLogAppender.doAppend(event2);
+    cdapLogAppender.stop();
+
+    try {
+      List<LogLocation> files = fileMetaDataManager.listFiles(cdapLogAppender.getLoggingPath(properties));
+      Assert.assertEquals(2, files.size());
+      assertLogEventDetails(event1, files.get(0));
+      assertLogEventDetails(event2, files.get(1));
+      Assert.assertEquals(files.get(0).getEventTimeMs(), currentTimeMillisEvent1);
+      Assert.assertEquals(files.get(1).getEventTimeMs(), currentTimeMillisEvent1 + 1000);
+      Assert.assertTrue(files.get(0).getFileCreationTimeMs() >= currentTimeMillisEvent1);
+      Assert.assertTrue(files.get(1).getFileCreationTimeMs() >= currentTimeMillisEvent2);
+    } catch (Exception e) {
+      Assert.fail();
+    } finally {
+      fileMetaDataManager.cleanMetaData(Long.MAX_VALUE, new FileMetaDataManager.DeleteCallback() {
+        @Override
+        public void handle(NamespaceId namespaceId, Location location, String namespacedLogBaseDir) {
+          // no-op
+        }
+      });
+    }
+  }
+
+  private void assertLogEventDetails(LoggingEvent expectedLoggingEvent, LogLocation logLocation) throws IOException {
+    Assert.assertEquals(LogLocation.VERSION_1, logLocation.getFrameworkVersion());
+    Assert.assertTrue(logLocation.getLocation().exists());
+    CloseableIterator<LogEvent> logEventCloseableIterator =
+      logLocation.readLog(Filter.EMPTY_FILTER, 0, Long.MAX_VALUE, Integer.MAX_VALUE);
+    int logCount = 0;
+    while (logEventCloseableIterator.hasNext()) {
+      logCount++;
+      LogEvent logEvent = logEventCloseableIterator.next();
+      Assert.assertEquals(expectedLoggingEvent.getMessage(), logEvent.getLoggingEvent().getMessage());
+    }
+    logEventCloseableIterator.close();
+    Assert.assertEquals(1, logCount);
+  }
+
+  private LoggingEvent getLoggingEvent(String fqcn, Logger logger, Level level, String message,
+                                       Map<String, String> mdcMap) {
+    LoggingEvent event =
+      new LoggingEvent(fqcn, logger, level , message, null, null);
+    event.setMDCPropertyMap(mdcMap);
+    return event;
+  }
+}
+


### PR DESCRIPTION
CDAP Log Framework's implementation using the Logback's Log Appender API. 

This involves mostly refactoring existing logic from Avro File Writer and Avro File reader and small metadata changes. This code is only used in testing currently. 

Avro File reader/writer classes will be removed once we have the log framework implementation in place. 

Build : http://builds.cask.co/browse/CDAP-DUT5310-1