### PR TITLE
[HYDRATOR-1197] Adds a default value for BatchInterval in real time pipeline

### DIFF
--- a/cdap-ui/app/directives/my-card/my-card.html
+++ b/cdap-ui/app/directives/my-card/my-card.html
@@ -15,13 +15,17 @@
 -->
 
 <div class="panel panel-default">
-  <a href="" class="panel-heading" ng-click="MyCardCtrl.dominimize()">
+  <a href=""
+     class="panel-heading"
+     title=""
+     ng-click="MyCardCtrl.dominimize()">
     <div class="panel-title">
       <div class="panel-content-holder">
         <span>
           <span class="fa fa-info-circle"
                 ng-if="MyCardCtrl.tooltip"
                 uib-tooltip="{{MyCardCtrl.tooltip}}"
+                tooltip-placement="bottom"
                 tooltip-append-to-body="true">
           </span>
           {{::MyCardCtrl.title}}

--- a/cdap-ui/app/directives/my-pipeline-settings/my-datastreams-pipeline-settings/my-datastreams-pipeline-settings.html
+++ b/cdap-ui/app/directives/my-pipeline-settings/my-datastreams-pipeline-settings/my-datastreams-pipeline-settings.html
@@ -15,7 +15,9 @@
 -->
 <fieldset ng-disabled="MyDataStreamsPipelineSettingsCtrl._isDisabled">
   <div class="pipeline-settings-content">
-    <my-card title="Batch Interval" class="batch-interval">
+    <my-card title="Batch Interval"
+             class="batch-interval"
+             tooltip="'Batch Interval specifies the frequency at which the sources will create new micro batches of data. It must be a number followed by a time unit, with \'s\' for seconds, \'m\' for minutes, and \'h\' for hours. e.g. \'10s\' will be interpreted as ten seconds. This means that every ten seconds, a new micro batch of data will be generated.'">
       <div class="batchinterval-wrapper">
         <input type="text"
                ng-model="MyDataStreamsPipelineSettingsCtrl.batchInterval"

--- a/cdap-ui/app/hydrator/module.js
+++ b/cdap-ui/app/hydrator/module.js
@@ -26,6 +26,7 @@ angular.module(PKG.name + '.feature.hydrator', [
   })
   .constant('HYDRATOR_DEFAULT_VALUES', {
     instance: 1,
+    batchInterval: '1s',
     schedule: '0 * * * *',
     resources: {
       virtualCores: 1,

--- a/cdap-ui/app/hydrator/services/create/stores/config-store.js
+++ b/cdap-ui/app/hydrator/services/create/stores/config-store.js
@@ -99,6 +99,7 @@ class HydratorPlusPlusConfigStore {
       resources: angular.copy(this.HYDRATOR_DEFAULT_VALUES.resources),
       driverResources: angular.copy(this.HYDRATOR_DEFAULT_VALUES.resources),
       connections: [],
+      batchInterval: this.HYDRATOR_DEFAULT_VALUES.batchInterval,
       comments: [],
       postActions: []
     };
@@ -653,7 +654,11 @@ class HydratorPlusPlusConfigStore {
     return this.getState().config.batchInterval;
   }
   setBatchInterval(interval) {
-    this.state.config.batchInterval = interval;
+    if (!interval) {
+      this.state.config.batchInterval = this.getDefaultConfig().batchInterval;
+    } else {
+      this.state.config.batchInterval = interval;
+    }
   }
   getInstance() {
     return this.getState().config.instances;


### PR DESCRIPTION
[HYDRATOR-901](https://issues.cask.co/browse/HYDRATOR-901) - Add tooltip to BatchInterval property explaining what it is
[HYDRATOR-1197](https://issues.cask.co/browse/HYDRATOR-1197) - Make sure there is a default value for BatchInterval property while creating a realtime pipeline in hydrator

Bamboo build: http://builds.cask.co/browse/CDAP-DRC5379/latest