### PR TITLE
[CDAP-7897] Fixes interaction in SendEventAction Fast Action in Home page

### DIFF
--- a/cdap-ui/app/cdap/components/FastAction/SendEventAction/SendEventAction.scss
+++ b/cdap-ui/app/cdap/components/FastAction/SendEventAction/SendEventAction.scss
@@ -46,7 +46,13 @@
         }
 
         .send-event-button {
+          display: flex;
+          justify-content: space-between;
           margin-top: 10px;
+
+          .btn:last-child {
+            margin-left: 10px;
+          }
 
           .fa-spinner {
             margin-right: 10px;

--- a/cdap-ui/app/cdap/components/FastAction/SendEventAction/SendEventModal.js
+++ b/cdap-ui/app/cdap/components/FastAction/SendEventAction/SendEventModal.js
@@ -1,0 +1,239 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, {Component, PropTypes} from 'react';
+import {Modal, ModalHeader, ModalBody} from 'reactstrap';
+import FileDataUpload from 'components/FileDataUpload';
+import classnames from 'classnames';
+import {MyStreamApi} from 'api/stream';
+import UploadDataActionCreator from 'services/WizardStores/UploadData/ActionCreator';
+import Rx from 'rx';
+import cookie from 'react-cookie';
+import NamespaceStore from 'services/NamespaceStore';
+import isEmpty from 'lodash/isEmpty';
+
+import T from 'i18n-react';
+
+export default class SendEventModal extends Component {
+  constructor(props) {
+    super(props);
+    this.state = this.getDefaultState();
+    this.sendEvents = this.sendEvents.bind(this);
+    this.handleTextInput = this.handleTextInput.bind(this);
+    this.onDrop = this.onDrop.bind(this);
+    this.noInputYet = this.noInputYet.bind(this);
+    this.clearEvents = this.clearEvents.bind(this);
+  }
+
+  getDefaultState() {
+    return {
+      loading: false,
+      statusMessage: '',
+      extendedMessage: '',
+      textInput: '',
+      droppedFile: {},
+      tooltipOpen: false,
+      responseStatus: '',
+      reset: 0
+    };
+  }
+
+  clearEvents() {
+    let finalState = Object.assign({}, this.getDefaultState(), {
+      modal: true,
+      reset: ++this.state.reset
+    });
+    this.setState(finalState);
+  }
+
+  sendEvents(e) {
+    e.stopPropagation();
+    e.preventDefault();
+    e.nativeEvent.stopImmediatePropagation();
+    this.setState({loading: true});
+    let namespace = NamespaceStore.getState().selectedNamespace;
+    let streamId = this.props.entity.id;
+    let params = {
+      namespace
+    };
+    let subscriptions = [];
+    if (isEmpty(this.state.droppedFile)) {
+      let events = this.state.textInput.replace(/\r\n/g, '\n').split('\n');
+      params.streamId = streamId;
+      events.forEach(event => {
+        subscriptions.push(
+          MyStreamApi.sendEvent(params, event)
+        );
+      });
+      this.setState({
+        loading: true
+      });
+      let mergedOb = Rx.Observable.merge.apply(null, subscriptions);
+      mergedOb.subscribe(
+        () => {
+          this.setState(Object.assign({}, this.getDefaultState(), {
+            modal: true,
+            responseStatus: 200,
+            reset: ++this.state.reset,
+            statusMessage: T.translate('features.FastAction.sendEventsSuccess')
+          }));
+        },
+        (err) => {
+          this.setState(Object.assign({}, this.getDefaultState(), {
+            modal: true,
+            responseStatus: 500,
+            reset: ++this.state.reset,
+            statusMessage: T.translate('features.FastAction.sendEventsFailed'),
+            extendedMessage: err,
+          }));
+        }
+      );
+      return false;
+    }
+
+    let url = `/namespaces/${namespace}/streams/${streamId}/batch`;
+    let fileContents = this.state.droppedFile;
+    let filename = this.state.droppedFile.name;
+    let filetype = 'text/' + filename.split('.').pop();
+    let authToken = cookie.load('CDAP_Auth_Token');
+    this.setState({
+      loading: true
+    });
+    return UploadDataActionCreator
+      .uploadData({
+        url,
+        fileContents,
+        headers: {
+          filename,
+          filetype,
+          authToken
+        }
+      })
+      .subscribe(() => {
+        this.setState(Object.assign({}, this.getDefaultState(), {
+          modal: true,
+          reset: ++this.state.reset,
+          responseStatus: 200,
+          statusMessage: T.translate('features.FastAction.sendEventsSuccess')
+        }));
+      }, (err) => {
+        this.setState(Object.assign({}, this.getDefaultState(), {
+          modal: true,
+          responseStatus: 500,
+          statusMessage: T.translate('features.FastAction.sendEventsFailed'),
+          extendedMessage: err
+        }));
+      });
+  }
+
+  onDrop(file) {
+    this.setState({droppedFile : file});
+  }
+
+  noInputYet() {
+    return isEmpty(this.state.droppedFile) && this.state.textInput === '';
+  }
+
+  handleTextInput(input) {
+    this.setState({
+      textInput : input
+    });
+  }
+
+  render() {
+    const actionLabel = T.translate('features.FastAction.sendEventsLabel');
+    const headerTitle = `${actionLabel} to ${this.props.entity.id}`;
+    return (
+      <Modal
+        isOpen={true}
+        toggle={this.props.onClose}
+        className="confirmation-modal stream-send-events"
+        size="lg"
+      >
+        <ModalHeader>
+          <div className="float-xs-left">
+            {headerTitle}
+          </div>
+          <div className="float-xs-right">
+            <div
+              className="close-modal-btn"
+              onClick={this.props.onClose}
+            >
+              <span className={"button-icon fa fa-times"}></span>
+            </div>
+          </div>
+        </ModalHeader>
+        <ModalBody className="modal-body">
+          <div className="events-drop-container">
+            <FileDataUpload
+              onDataUpload={this.onDrop}
+              onTextInput={this.handleTextInput}
+              reset={this.state.reset}
+            />
+            <div className="send-event-button">
+              <span>
+                {
+                  this.state.responseStatus ?
+                    <span className={classnames({
+                        'text-danger': this.state.responseStatus !== 200,
+                        'text-success': this.state.responseStatus === 200
+                      })}
+                    >
+                    {this.state.statusMessage}
+                    </span>
+                  :
+                    null
+                }
+              </span>
+
+              <div>
+                <button
+                  className="btn btn-default"
+                  onClick={this.clearEvents}
+                  disabled={(this.noInputYet() || this.state.loading) ? 'disabled' : null}
+                >
+                  <span>{T.translate('features.FastAction.clearEventsButtonLabel')}</span>
+                </button>
+                <button
+                  className="btn btn-primary"
+                  onClick={this.sendEvents}
+                  disabled={(this.noInputYet() || this.state.loading) ? 'disabled' : null}
+                >
+                  {
+                    this.state.loading ?
+                      <span className="fa fa-spinner fa-spin"></span>
+                    :
+                      null
+                  }
+                  <span>{T.translate('features.FastAction.sendEventsButtonLabel')}</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </ModalBody>
+      </Modal>
+    );
+  }
+}
+
+SendEventModal.propTypes = {
+  entity: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    uniqueId: PropTypes.string,
+    type: PropTypes.oneOf(['datasetinstance', 'stream']).isRequired,
+  }),
+  onClose: PropTypes.func
+};

--- a/cdap-ui/app/cdap/components/FastAction/SendEventAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/SendEventAction/index.js
@@ -15,43 +15,23 @@
  */
 
 import React, {Component, PropTypes} from 'react';
-import NamespaceStore from 'services/NamespaceStore';
 import FastActionButton from '../FastActionButton';
 import T from 'i18n-react';
-import { Modal, Tooltip, ModalHeader, ModalBody } from 'reactstrap';
-import isEmpty from 'lodash/isEmpty';
-import {MyStreamApi} from 'api/stream';
-import FileDataUpload from 'components/FileDataUpload';
-import UploadDataActionCreator from 'services/WizardStores/UploadData/ActionCreator';
+import { Tooltip } from 'reactstrap';
+import SendEventModal from 'components/FastAction/SendEventAction/SendEventModal';
 require('./SendEventAction.scss');
-
-import cookie from 'react-cookie';
-import Rx from 'rx';
 
 export default class SendEventAction extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      modal: false,
-      loading: false,
-      errorMessage: '',
-      extendedMessage: '',
-      textarea: false,
-      textInput: '',
-      droppedFile: {},
-      tooltipOpen: false,
-      error: ''
+      modal: false
     };
 
     this.eventText = '';
-    this.action = this.action.bind(this);
     this.toggleModal = this.toggleModal.bind(this);
-    this.handleTextInput = this.handleTextInput.bind(this);
-    this.onDrop = this.onDrop.bind(this);
-    this.toggleTextareaOff = this.toggleTextareaOff.bind(this);
     this.toggleTooltip = this.toggleTooltip.bind(this);
-    this.noInputYet = this.noInputYet.bind(this);
   }
 
   toggleTooltip() {
@@ -61,12 +41,6 @@ export default class SendEventAction extends Component {
   toggleModal(event) {
     this.setState({
       modal: !this.state.modal,
-      loading: false,
-      errorMessage: '',
-      extendedMessage: '',
-      textarea: false,
-      textInput: '',
-      droppedFile: {}
     });
     if (event) {
       event.stopPropagation();
@@ -74,85 +48,7 @@ export default class SendEventAction extends Component {
     }
   }
 
-  action(e) {
-    e.stopPropagation();
-    e.preventDefault();
-    e.nativeEvent.stopImmediatePropagation();
-    this.setState({loading: true});
-    let namespace = NamespaceStore.getState().selectedNamespace;
-    let streamId = this.props.entity.id;
-    let params = {
-      namespace
-    };
-    let subscriptions = [];
-    if (isEmpty(this.state.droppedFile)) {
-      let events = this.state.textInput.replace(/\r\n/g, '\n').split('\n');
-      params.streamId = streamId;
-      events.forEach(event => {
-        subscriptions.push(
-          MyStreamApi.sendEvent(params, event)
-        );
-      });
-      this.setState({
-        loading: true
-      });
-      let mergedOb = Rx.Observable.merge.apply(null, subscriptions);
-      mergedOb.subscribe(this.props.onSuccess.bind(this));
-      return false;
-    }
-
-    let url = `/namespaces/${namespace}/streams/${streamId}/batch`;
-    let fileContents = this.state.droppedFile;
-    let filename = this.state.droppedFile.name;
-    let filetype = 'text/' + filename.split('.').pop();
-    let authToken = cookie.load('CDAP_Auth_Token');
-    this.setState({
-      loading: true
-    });
-    return UploadDataActionCreator
-      .uploadData({
-        url,
-        fileContents,
-        headers: {
-          filename,
-          filetype,
-          authToken
-        }
-      })
-      .subscribe(this.props.onSuccess, (err) => {
-        this.setState({
-          loading: false,
-          errorMessage: T.translate('features.FastAction.sendEventsFailed', {entityId: this.props.entity.id}),
-          extendedMessage: err
-        });
-      });
-  }
-
-  handleTextInput(input) {
-    this.setState({
-      textInput : input
-    });
-  }
-
-  toggleTextareaOff(e) {
-    if (this.state.loading) { return; }
-    e.preventDefault();
-    this.setState({
-      textarea : false
-    });
-  }
-
-  onDrop(file) {
-    this.setState({droppedFile : file});
-  }
-
-  noInputYet() {
-    return isEmpty(this.state.droppedFile) && this.state.textInput === '';
-  }
-
   render() {
-    const actionLabel = T.translate('features.FastAction.sendEventsLabel');
-    const headerTitle = `${actionLabel} to ${this.props.entity.id}`;
     let tooltipID = `${this.props.entity.uniqueId}-sendevents`;
     return (
       <span>
@@ -173,56 +69,10 @@ export default class SendEventAction extends Component {
 
         {
           this.state.modal ? (
-            <Modal
-              isOpen={this.state.modal}
-              toggle={this.toggleModal}
-              className="confirmation-modal stream-send-events"
-              size="lg"
-            >
-              <ModalHeader>
-                <div className="float-xs-left">
-                  {headerTitle}
-                </div>
-                <div className="float-xs-right">
-                  <div className="close-modal-btn"
-                    onClick={this.toggleModal.bind(this)}
-                  >
-                    <span
-                      className={"button-icon fa fa-times"}
-                    />
-                  </div>
-                </div>
-              </ModalHeader>
-              <ModalBody
-                className="modal-body"
-                onClick={this.toggleTextareaOff}
-              >
-                <div className="events-drop-container">
-                  <FileDataUpload onDataUpload={this.onDrop} onTextInput={this.handleTextInput}/>
-                  <div className="clearfix send-event-button">
-                    {
-                      this.state.error ?
-                        <span className="float-xs-left text-danger"></span>
-                      :
-                        null
-                    }
-                    <button
-                      className="btn btn-primary float-xs-right"
-                      onClick={this.action}
-                      disabled={(this.noInputYet() || this.state.loading) ? 'disabled' : null}
-                    >
-                      {
-                        this.state.loading ?
-                          <span className="fa fa-spinner fa-spin"></span>
-                        :
-                          null
-                      }
-                      <span>{T.translate('features.FastAction.sendEventsButtonLabel')}</span>
-                    </button>
-                  </div>
-                </div>
-              </ModalBody>
-            </Modal>
+            <SendEventModal
+              entity={this.props.entity}
+              onClose={this.toggleModal}
+            />
           ) : null
         }
       </span>

--- a/cdap-ui/app/cdap/components/FileDataUpload/index.js
+++ b/cdap-ui/app/cdap/components/FileDataUpload/index.js
@@ -24,15 +24,27 @@ export default class FileDataUpload extends Component {
   constructor(props) {
     super(props);
 
-    this.state = {
-      textarea: false,
-      wranglerInput: '',
-      file: ''
-    };
+    this.state = this.getDefaultState();
 
     this.onContainerClick = this.onContainerClick.bind(this);
     this.handleTextInput = this.handleTextInput.bind(this);
     this.onTextInputBlur = this.onTextInputBlur.bind(this);
+  }
+
+  getDefaultState() {
+    return {
+      textarea: false,
+      textInput: '',
+      file: {
+        name: ''
+      }
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.reset !== this.props.reset) {
+      this.setState(this.getDefaultState());
+    }
   }
 
   preventPropagation (e) {
@@ -42,7 +54,7 @@ export default class FileDataUpload extends Component {
 
   handleTextInput(e) {
     this.props.onTextInput(e.target.value);
-    this.setState({wranglerInput: e.target.value});
+    this.setState({textInput: e.target.value});
   }
 
   onContainerClick() {
@@ -50,7 +62,7 @@ export default class FileDataUpload extends Component {
   }
 
   onTextInputBlur() {
-    if (this.state.wranglerInput) { return; }
+    if (this.state.textInput) { return; }
     this.setState({textarea: false});
   }
 
@@ -62,12 +74,9 @@ export default class FileDataUpload extends Component {
       >
         {
           (!this.state.textarea || this.state.file.name) ?
-            (<div
-              className="file-data-metadata-container"
-            >
-              <div
-                className="file-data-metadata"
-              >
+            (
+              <div className="file-data-metadata-container">
+                <div className="file-data-metadata">
                 <div
                   className="upload-data"
                   onClick={(e) => this.preventPropagation(e)}
@@ -85,7 +94,7 @@ export default class FileDataUpload extends Component {
                         null
                       :
                         (
-                          <i className="plus-button fa fa-plus-circle"></i>
+                          <i className="plus-button fa fa-upload"></i>
                         )
                     }
                   </Dropzone>
@@ -100,7 +109,7 @@ export default class FileDataUpload extends Component {
                       <div>
                         <h4>
                           {T.translate('features.Wrangler.InputScreen.HelperText.click')}
-                          <span className="fa fa-plus-circle" />
+                          <span className="fa fa-upload" />
                           {T.translate('features.Wrangler.InputScreen.HelperText.upload')}
                         </h4>
                         <h5>{T.translate('features.Wrangler.InputScreen.HelperText.or')}</h5>
@@ -110,10 +119,12 @@ export default class FileDataUpload extends Component {
                   }
                 </div>
               </div>
-            </div>)
+              </div>
+            )
           :
             (
               <textarea
+                value={this.state.textInput}
                 className="form-control"
                 onChange={this.handleTextInput}
                 autoFocus={true}
@@ -126,8 +137,14 @@ export default class FileDataUpload extends Component {
   }
 }
 
-FileDataUpload.propTypes = {
-  onDataUpload: PropTypes.func,
-  onTextInput: PropTypes.func
+FileDataUpload.defaultProps = {
+  file: {
+    name: ''
+  }
 };
 
+FileDataUpload.propTypes = {
+  onDataUpload: PropTypes.func,
+  onTextInput: PropTypes.func,
+  reset: PropTypes.number
+};

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -136,7 +136,7 @@ features:
     setPreferencesActionLabel: Set Preferences
     setPreferencesAppDescriptionLabel: Specify new or override existing system or namespace preferences. These preferences will be accessible in all programs within this application.
     setPreferencesProgramDescriptionLabel: Specify new or override existing system, namespace, or application preferences. These preferences will only be accessible within this program.
-    setPreferencesButtonLabel: 
+    setPreferencesButtonLabel:
       saveAndClose: Save & Close
       saving: Saving
     setPreferencesInheritedPrefsLabel: Inherited Preferences
@@ -149,8 +149,10 @@ features:
     start: Start
     stop: Stop
     sendEventsButtonLabel: Send
+    clearEventsButtonLabel: Clear
     sendEventsClickLabel: Click to input events.
     sendEventsFailed: Error - Send Events Failed.
+    sendEventsSuccess: Success - Events uploaded successfully.
     startConfirmLabel: Start
     stopConfirmLabel: Stop
     startConfirmation: "Are you sure you want to start the program: *_{entityId}_*?"


### PR DESCRIPTION
- Fixes the ability to switch between Text input & file upload and clear either one easily if it can be ignored.
- Separates SendEventModal from SendEventAction to be consistent with other FastActions.

Bamboo build: http://builds.cask.co/browse/CDAP-DRC5385/latest
JIRA: https://issues.cask.co/browse/CDAP-7897