### PR TITLE
Fix output schema widget to not show schema pop

### DIFF
--- a/cdap-ui/app/directives/plugin-functions/functions/get-schema/get-schema.html
+++ b/cdap-ui/app/directives/plugin-functions/functions/get-schema/get-schema.html
@@ -15,6 +15,7 @@
 -->
 
 <button class="btn btn-default pull-right"
+        type="button"
         ng-click="GetSchemaController.openModal()">
   Get Schema
 </button>

--- a/cdap-ui/app/directives/plugin-functions/functions/output-schema/output-schema.html
+++ b/cdap-ui/app/directives/plugin-functions/functions/output-schema/output-schema.html
@@ -15,6 +15,7 @@
 -->
 
 <button class="btn {{ OutputSchemaController.btnClass }} pull-right"
+        type="button"
         ng-disabled="OutputSchemaController.requiredProperties.indexOf('') !== -1"
         ng-click="OutputSchemaController.openModal()">
   <span ng-if="OutputSchemaController.requiredProperties.indexOf('') !== -1"

--- a/cdap-ui/app/directives/widget-container/widget-sql-conditions/widget-sql-conditions.html
+++ b/cdap-ui/app/directives/widget-container/widget-sql-conditions/widget-sql-conditions.html
@@ -33,6 +33,7 @@
 
     <div class="select-fields-group">
       <button class="delete-field-button btn btn-link"
+            type="button"
             ng-if="rule.hover && SqlConditions.rules.length !== 1 && !SqlConditions.disabled"
             ng-click="SqlConditions.deleteRule($index)">x</button>
 
@@ -63,6 +64,7 @@
 
       <button class="btn btn-sm btn-field-actions"
               ng-if="$last"
+              type="button"
               ng-click="SqlConditions.addRule()">
         <i class="fa fa-plus"></i>
       </button>

--- a/cdap-ui/app/directives/widget-container/widget-sql-select-fields/widget-sql-select-fields.html
+++ b/cdap-ui/app/directives/widget-container/widget-sql-select-fields/widget-sql-select-fields.html
@@ -18,11 +18,13 @@
 
   <div class="button-container">
     <button class="btn btn-sm btn-default"
+            type="button"
             ng-click="SqlSelector.toggleAll(SqlSelector.expandedButton)">
       <span ng-if="SqlSelector.expandedButton">Expand All</span>
       <span ng-if="!SqlSelector.expandedButton">Collapse All</span>
     </button>
     <button class="btn btn-sm btn-reset"
+            type="button"
             ng-click="SqlSelector.resetAll()">
       Reset All
     </button>
@@ -52,7 +54,10 @@
           <th>Name</th>
           <th class="checkbox-column">
             <div class="btn-group" uib-dropdown dropdown-append-to-body>
-              <button class="btn btn-default" uib-dropdown-toggle>
+              <button
+                class="btn btn-default"
+                type="button"
+                uib-dropdown-toggle>
                 Select <span class="fa fa-chevron-down"></span>
               </button>
               <ul class="dropdown-menu sql-select-dropwdown"


### PR DESCRIPTION
- Fixes output-schema & get-schema widgets used in hydrator to not show the schema popup when user hits ENTER when editing plugin configuration.
- The reason for this is, the plugin configuration properties are rendered inside a form and hitting ENTER communicates to the browser that the form should be submitted. 
- We can avoid this by declaring the type to `button`.  