### PR TITLE
Fix links

### DIFF
--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -239,6 +239,7 @@ function build_docs_cli() {
 function build_docs_inner_level() {
 # Change to each manual, and run the local ./build.sh from there.
 # Each manual can (and does) have a customised build script, using the common-build.sh as a base.
+  pushd $(pwd) > /dev/null
   for i in ${MANUALS}; do
     echo "========================================================"
     echo "Building \"${i}\", target \"${1}\"..."
@@ -248,6 +249,7 @@ function build_docs_inner_level() {
     ./build.sh ${1}
     echo
   done
+  popd > /dev/null
 }
 
 function build_docs_outer_level() {

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -245,7 +245,7 @@ function build_docs_inner_level() {
     echo "Building \"${i}\", target \"${1}\"..."
     echo "--------------------------------------------------------"
     echo
-    cd $SCRIPT_PATH/${i}
+    cd ${SCRIPT_PATH}/${i}
     ./build.sh ${1}
     echo
   done
@@ -259,6 +259,7 @@ function build_docs_outer_level() {
   fi
   local title="Building outer-level docs...tag code ${1}"
   display_start_title "${title}"
+  cd ${SCRIPT_PATH}
   clean_outer_level
   set_version
   # Copies placeholder file and renames it

--- a/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/flows.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/flows.rst
@@ -1,0 +1,5 @@
+.. redirect page; include a reference in the toctree (hidden) of the index page
+
+.. raw:: html
+
+   <script language="javascript">window.location.href = "index.html"</script>

--- a/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/index.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/index.rst
@@ -23,7 +23,11 @@ Flows and Flowlets
     Flowlets and Instances <flowlets-instances>
     Partitioning Strategies <partitioning-strategies>
 
+.. toctree::
+   :hidden:
 
+   flows
+   
 *Flows* are user-implemented real-time stream processors. They are comprised of one or
 more *Flowlets* that are wired together into a directed acyclic graph or DAG. Flowlets
 pass data between one another; each flowlet is able to perform custom logic and execute

--- a/cdap-docs/developers-manual/source/building-blocks/index.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/index.rst
@@ -33,6 +33,12 @@ Building Blocks
     Namespaces <namespaces>
     Transaction System <transaction-system>
 
+.. toctree::
+   :hidden:
+
+   mapreduce-jobs
+   spark-jobs
+
 This section covers the :doc:`core abstractions <core>` in the Cask Data Application Platform
 (CDAP): **Data** and **Applications.**
 

--- a/cdap-docs/developers-manual/source/building-blocks/mapreduce-jobs.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/mapreduce-jobs.rst
@@ -1,0 +1,5 @@
+.. redirect page; include a reference in the toctree (hidden) of the index page
+
+.. raw:: html
+
+   <script language="javascript">window.location.href = "spark-programs.html"</script>

--- a/cdap-docs/developers-manual/source/building-blocks/spark-jobs.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/spark-jobs.rst
@@ -1,0 +1,5 @@
+.. redirect page; include a reference in the toctree (hidden) of the index page
+
+.. raw:: html
+
+   <script language="javascript">window.location.href = "mapreduce-programs.html"</script>

--- a/cdap-docs/developers-manual/source/getting-started/standalone/docker.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/docker.rst
@@ -134,7 +134,7 @@ started correctly.
      > docker-machine stop cdap
 
 #. For a full list of Docker Commands, see the `Docker Command Line Documentation.
-   <https://docs.docker.com/reference/commandline/cli/>`__
+   <https://docs.docker.com/engine/reference/commandline/cli/>`__
 
 
 .. _docker-kitematic:

--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -1210,7 +1210,7 @@ Bug Fixes
 - `CDAP-3498 <https://issues.cask.co/browse/CDAP-3498>`__ - Upgraded CDAP to use
   Apache Twill ``0.7.0-incubating`` with numerous new features, improvements, and bug
   fixes. See the `Apache Twill release notes
-  <http://twill.incubator.apache.org/releases/0.7.0-incubating.html>`__ for details.
+  <http://twill.incubator.apache.org/releases/>`__ for details.
 
 - `CDAP-3584 <https://issues.cask.co/browse/CDAP-3584>`__ - Upon transaction rollback, a
   ``PartitionedFileSet`` now rolls back the files for the partitions that were added and/or


### PR DESCRIPTION
Fixes an error in the doc build causing links on the first page to be incorrect. Fixes two other broken links and adds three redirects for pages referenced in other repos.

Running as a Quick Build: https://builds.cask.co/browse/CDAP-DQB230-3

On the initial page: https://builds.cask.co/artifact/CDAP-DQB230/shared/build-2/Docs-HTML/3.5.3/en/index.html links correctly (search for _CDAP SDK_) links correctly; the same link on http://docs.cask.co/cdap/current/en/index.html is broken...
