### PR TITLE
Cherry-pick of change in release/3.5.3 to fix doc build.

### DIFF
--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright © 2016 Cask Data, Inc.
+# Copyright © 2016-2017 Cask Data, Inc.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -235,19 +235,20 @@ function build_docs_cli() {
 }
 
 function build_docs_inner_level() {
-# Change to each manual, and run the local ./build.sh from there.
-# Each manual can (and does) have a customised build script, using the common-build.sh as a base.
-local build_target=${1}
-local errors
+  # Change to each manual, and run the local ./build.sh from there.
+  # Each manual can (and does) have a customised build script, using the common-build.sh as a base.
+  local build_target=${1}
+  pushd $(pwd) > /dev/null
   for i in ${MANUALS}; do
     echo "========================================================"
     echo "Building \"${i}\", target \"${build_target}\"..."
     echo "--------------------------------------------------------"
     echo
-    cd $SCRIPT_PATH/${i}
+    cd ${SCRIPT_PATH}/${i}
     ./build.sh ${build_target}
     echo
   done
+  popd > /dev/null
 }
 
 function build_docs_outer_level() {
@@ -257,6 +258,7 @@ function build_docs_outer_level() {
   fi
   local title="Building outer-level docs...tag code ${1}"
   display_start_title "${title}"
+  cd ${SCRIPT_PATH}
   clean_outer_level
   set_version
   # Copies placeholder file and renames it

--- a/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/flows.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/flows.rst
@@ -1,0 +1,5 @@
+.. redirect page; include a reference in the toctree (hidden) of the index page
+
+.. raw:: html
+
+   <script language="javascript">window.location.href = "index.html"</script>

--- a/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/index.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/flows-flowlets/index.rst
@@ -23,7 +23,11 @@ Flows and Flowlets
     Flowlets and Instances <flowlets-instances>
     Partitioning Strategies <partitioning-strategies>
 
+.. toctree::
+   :hidden:
 
+   flows
+   
 *Flows* are user-implemented real-time stream processors. They are comprised of one or
 more *Flowlets* that are wired together into a directed acyclic graph or DAG. Flowlets
 pass data between one another; each flowlet is able to perform custom logic and execute

--- a/cdap-docs/developers-manual/source/building-blocks/index.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/index.rst
@@ -34,6 +34,12 @@ Building Blocks
     Namespaces <namespaces>
     Transaction System <transaction-system>
 
+.. toctree::
+   :hidden:
+
+   mapreduce-jobs
+   spark-jobs
+
 This section covers the :doc:`core abstractions <core>` in the Cask Data Application Platform
 (CDAP): **Data** and **Applications.**
 

--- a/cdap-docs/developers-manual/source/building-blocks/mapreduce-jobs.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/mapreduce-jobs.rst
@@ -1,0 +1,5 @@
+.. redirect page; include a reference in the toctree (hidden) of the index page
+
+.. raw:: html
+
+   <script language="javascript">window.location.href = "spark-programs.html"</script>

--- a/cdap-docs/developers-manual/source/building-blocks/spark-jobs.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/spark-jobs.rst
@@ -1,0 +1,5 @@
+.. redirect page; include a reference in the toctree (hidden) of the index page
+
+.. raw:: html
+
+   <script language="javascript">window.location.href = "mapreduce-programs.html"</script>

--- a/cdap-docs/developers-manual/source/getting-started/standalone/docker.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/docker.rst
@@ -134,7 +134,7 @@ started correctly.
      > docker-machine stop cdap
 
 #. For a full list of Docker Commands, see the `Docker Command Line Documentation.
-   <https://docs.docker.com/reference/commandline/cli/>`__
+   <https://docs.docker.com/engine/reference/commandline/cli/>`__
 
 
 .. _docker-kitematic:

--- a/cdap-docs/reference-manual/source/release-notes.rst
+++ b/cdap-docs/reference-manual/source/release-notes.rst
@@ -1976,7 +1976,7 @@ Bug Fixes
 - `CDAP-3498 <https://issues.cask.co/browse/CDAP-3498>`__ - Upgraded CDAP to use
   Apache Twill ``0.7.0-incubating`` with numerous new features, improvements, and bug
   fixes. See the `Apache Twill release notes
-  <http://twill.apache.org/releases/0.7.0-incubating.html>`__ for details.
+  <http://twill.apache.org/releases/>`__ for details.
 
 - `CDAP-3584 <https://issues.cask.co/browse/CDAP-3584>`__ - Upon transaction rollback, a
   ``PartitionedFileSet`` now rolls back the files for the partitions that were added and/or


### PR DESCRIPTION
Fixes missing links (linked from other repos) and fixes broken link(s)
in the outer level manual.
Commit df76fc573ba695366c529aad811217c43a173769; PR CDAP-7655

Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB231-1 (passes.)