### PR TITLE
update HDInsight installer for 3.5.3

### DIFF
--- a/cdap-distributions/src/hdinsight/pkg/install.sh
+++ b/cdap-distributions/src/hdinsight/pkg/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2016 Cask Data, Inc.
+# Copyright © 2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -22,9 +22,9 @@
 # The git branch to clone
 CDAP_BRANCH='release/3.5'
 # Optional tag to checkout - All released versions of this script should set this
-CDAP_TAG=''
+CDAP_TAG='v3.5.3'
 # The CDAP package version passed to Chef
-CDAP_VERSION='3.5.1-1'
+CDAP_VERSION='3.5.3-1'
 # The version of Chef to install
 CHEF_VERSION='12.10.24'
 # cdap-site.xml configuration parameters

--- a/cdap-distributions/src/hdinsight/pkg/mainTemplate.json
+++ b/cdap-distributions/src/hdinsight/pkg/mainTemplate.json
@@ -50,12 +50,12 @@
       },
       "installScriptActions": [{
         "name": "[concat('cdap-pageblob-configure-v0','-' ,uniquestring(variables('applicationName')))]",
-        "uri": "http://downloads.cask.co/hdinsight/pageblob-configure-3.5.1.sh",
+        "uri": "http://downloads.cask.co/hdinsight/pageblob-configure-3.5.3.sh",
         "roles": ["edgenode"]
       },
       {
         "name": "[concat('cdap-install-v0','-' ,uniquestring(variables('applicationName')))]",
-        "uri": "http://downloads.cask.co/hdinsight/install-3.5.1.sh",
+        "uri": "http://downloads.cask.co/hdinsight/install-3.5.3.sh",
         "roles": ["edgenode"]
       }],
       "uninstallScriptActions": [],


### PR DESCRIPTION
update HDInsight installer to use 3.5.3 release.

``install.sh`` will normally get deployed by DA as ``install-3.5.3.sh``.  ``mainTemplate.json`` is then published to use it.