### PR TITLE
update hdinsights git tag

### DIFF
--- a/cdap-distributions/src/hdinsight/pkg/install.sh
+++ b/cdap-distributions/src/hdinsight/pkg/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2016 Cask Data, Inc.
+# Copyright © 2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -22,7 +22,7 @@
 # The git branch to clone
 CDAP_BRANCH='release/4.0'
 # Optional tag to checkout - All released versions of this script should set this
-CDAP_TAG='v4.0.0'
+CDAP_TAG='v4.0.1'
 # The CDAP package version passed to Chef
 CDAP_VERSION='4.0.1-1'
 # The version of Chef to install


### PR DESCRIPTION
Updates the checkout tag used by the HDInsight installer script.  This is mostly for consistency for pending HDInsight release.  This tag protects the versions of the cdap-distribution module used by the installer script.