### PR TITLE
CDAP-7683 add a tool to upload coprocessor jars

### DIFF
--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -74,6 +74,7 @@ case ${1} in
   upgrade) shift; cdap_upgrade_tool ${@}; __ret=${?} ;;
   run) shift; cdap_run_class ${@}; __ret=${?} ;;
   sdk) shift; cdap_sdk ${@}; __ret=${?} ;;
+  setup) shift; cdap_setup_tool ${@}; __ret=${?} ;;
   debug) shift; cdap_debug ${@}; __ret=${?} ;;
   *)
     echo
@@ -92,6 +93,7 @@ case ${1} in
     echo "    classpath    - Returns the Java CLASSPATH of the CDAP Master service"
     echo "    run          - Runs a given class with arguments using the CDAP Master CLASSPATH and environment"
     echo "    upgrade      - Runs the CDAP Upgrade with optional arguments"
+    echo "    setup        - Ensures CDAP coprocessors are present on HDFS"
     echo
     else
     echo "    sdk          - Sends the arguments (start/stop/etc.) to the Standalone CDAP service on this host"

--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -74,7 +74,7 @@ case ${1} in
   upgrade) shift; cdap_upgrade_tool ${@}; __ret=${?} ;;
   run) shift; cdap_run_class ${@}; __ret=${?} ;;
   sdk) shift; cdap_sdk ${@}; __ret=${?} ;;
-  setup) shift; cdap_setup_tool ${@}; __ret=${?} ;;
+  setup) shift; cdap_hbase_setup ${@}; __ret=${?} ;;
   debug) shift; cdap_debug ${@}; __ret=${?} ;;
   *)
     echo
@@ -93,7 +93,7 @@ case ${1} in
     echo "    classpath    - Returns the Java CLASSPATH of the CDAP Master service"
     echo "    run          - Runs a given class with arguments using the CDAP Master CLASSPATH and environment"
     echo "    upgrade      - Runs the CDAP Upgrade with optional arguments"
-    echo "    setup        - Ensures CDAP coprocessors are present on HDFS"
+    echo "    setup        - Ensures HBase coprocessors required by CDAP are present on HDFS"
     echo
     else
     echo "    sdk          - Sends the arguments (start/stop/etc.) to the Standalone CDAP service on this host"

--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -74,7 +74,7 @@ case ${1} in
   upgrade) shift; cdap_upgrade_tool ${@}; __ret=${?} ;;
   run) shift; cdap_run_class ${@}; __ret=${?} ;;
   sdk) shift; cdap_sdk ${@}; __ret=${?} ;;
-  setup) shift; cdap_hbase_setup ${@}; __ret=${?} ;;
+  setup) shift; cdap_setup ${@}; __ret=${?} ;;
   debug) shift; cdap_debug ${@}; __ret=${?} ;;
   *)
     echo
@@ -93,7 +93,8 @@ case ${1} in
     echo "    classpath    - Returns the Java CLASSPATH of the CDAP Master service"
     echo "    run          - Runs a given class with arguments using the CDAP Master CLASSPATH and environment"
     echo "    upgrade      - Runs the CDAP Upgrade with optional arguments"
-    echo "    setup        - Ensures HBase coprocessors required by CDAP are present on HDFS"
+    echo
+    echo "    setup        - Setup the specified component (coprocessors) required by CDAP at runtime"
     echo
     else
     echo "    sdk          - Sends the arguments (start/stop/etc.) to the Standalone CDAP service on this host"

--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -645,11 +645,7 @@ cdap_start_java() {
     __startup_checks=${CDAP_STARTUP_CHECKS:-$(cdap_get_conf "master.startup.checks.enabled" "${CDAP_CONF}"/cdap-site.xml true)}
 
     # Build and upload coprocessor jars
-    logecho "$(date) Ensuring required HBase coprocessors are on HDFS"
-    "${JAVA}" ${JAVA_HEAPMAX} ${OPTS} -cp ${CLASSPATH} co.cask.cdap.data.tools.CoprocessorBuildTool </dev/null >>${__logfile} 2>&1
-    if [ $? -ne 0 ]; then
-      die "Unable to build and upload coprocessors to HDFS. Please check ${__logfile} for more information."
-    fi
+    cdap_hbase_setup || die "Could not setup HBase coprocessors required by CDAP"
 
     if [[ ${__startup_checks} == true ]]; then
       logecho "$(date) Running CDAP Master startup checks -- this may take a few minutes"
@@ -1088,11 +1084,12 @@ cdap_upgrade_tool() {
 }
 
 #
-# cdap_setup_tool [arguments]
+# cdap_hbase_setup [arguments]
 #
-cdap_setup_tool() {
+cdap_hbase_setup() {
   local readonly __ret __class=co.cask.cdap.data.tools.CoprocessorBuildTool
 
+  logecho "$(date) Ensuring required HBase coprocessors are on HDFS"
   cdap_run_class ${__class} ${@}
   __ret=${?}
   return ${__ret}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/QueueConstants.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/QueueConstants.java
@@ -26,15 +26,12 @@ public final class QueueConstants {
    * Configuration keys for queues in HBase.
    */
   public static final class ConfigKeys {
-    public static final String QUEUE_TABLE_COPROCESSOR_DIR = "data.queue.table.coprocessor.dir";
     public static final String QUEUE_TABLE_PRESPLITS = "data.queue.table.presplits";
     public static final String DEQUEUE_TX_PERCENT = "data.queue.dequeue.tx.percent";
   }
 
   // This is a hardcoded value for the row key distributor bucket size before CDAP-1946
   public static final int DEFAULT_ROW_KEY_BUCKETS = 16;
-
-  public static final String DEFAULT_QUEUE_TABLE_COPROCESSOR_DIR = "/queue";
 
   public static final long MAX_CREATE_TABLE_WAIT = 5000L;    // Maximum wait of 5 seconds for table creation.
 

--- a/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/WordCount.java
+++ b/cdap-examples/WordCount/src/main/java/co/cask/cdap/examples/wordcount/WordCount.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.data.stream.Stream;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
 import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.api.dataset.table.TableProperties;
 
 /**
  * Word count sample Application. Includes a configuration class which can be used to pass in a configuration during
@@ -96,7 +97,10 @@ public class WordCount extends AbstractApplication<WordCount.WordCountConfig> {
 
     // Store processed data in Datasets
     createDataset(config.getWordStatsTable(), Table.class,
-                  DatasetProperties.builder().setDescription("Stats of total counts and lengths of words").build());
+                  TableProperties.builder()
+                    .setReadlessIncrementSupport(true)
+                    .setDescription("Stats of total counts and lengths of words")
+                    .build());
     createDataset(config.getWordCountTable(), KeyValueTable.class,
                   DatasetProperties.builder().setDescription("Words and corresponding counts").build());
     createDataset(config.getUniqueCountTable(), UniqueCountTable.class,

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/CoprocessorManager.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/CoprocessorManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/CoprocessorManager.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/CoprocessorManager.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.utils.ProjectInfo;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+import com.google.common.io.Files;
+import com.google.common.io.OutputSupplier;
+import org.apache.hadoop.hbase.Coprocessor;
+import org.apache.twill.api.ClassAcceptor;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.apache.twill.internal.utils.Dependencies;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+/**
+ * Manages HBase coprocessors for Tables and Queues.
+ */
+public class CoprocessorManager {
+  private static final Logger LOG = LoggerFactory.getLogger(CoprocessorManager.class);
+  protected final Location jarDir;
+  private final Map<Type, Set<Class<? extends Coprocessor>>> coprocessors;
+
+  /**
+   * Type of coprocessor.
+   */
+  public enum Type {
+    TABLE,
+    QUEUE,
+    MESSAGING
+  }
+
+  public CoprocessorManager(CConfiguration cConf, LocationFactory locationFactory, HBaseTableUtil tableUtil) {
+    this.jarDir = locationFactory.create(cConf.get(Constants.CFG_HDFS_LIB_DIR));
+    this.coprocessors = ImmutableMap.<Type, Set<Class<? extends Coprocessor>>>of(
+      Type.TABLE, ImmutableSet.of(tableUtil.getTransactionDataJanitorClassForVersion(),
+                                  tableUtil.getIncrementHandlerClassForVersion()),
+      Type.QUEUE, ImmutableSet.of(tableUtil.getQueueRegionObserverClassForVersion(),
+                                  tableUtil.getDequeueScanObserverClassForVersion()),
+      Type.MESSAGING, ImmutableSet.of(tableUtil.getMessageTableRegionObserverClassForVersion(),
+                                      tableUtil.getPayloadTableRegionObserverClassForVersion()));
+  }
+
+  /**
+   * Get the location of the specified type of coprocessor and ensure it exists.
+   * In distributed mode, the coprocessor jars are loaded onto hdfs by the CoprocessBuildTool,
+   * but in other modes it is still useful to create the jar on demand.
+   *
+   * @param type the type of coprocessor
+   * @return the location of the coprocessor
+   * @throws IOException if there was an issue accessing the location
+   * @throws IllegalStateException if the coprocessor jar does not exist
+   */
+  public synchronized Location ensureCoprocessorExists(Type type) throws IOException {
+
+    final Location targetPath = jarDir.append(String.format("%s-coprocessor-%s-%s.jar",
+                                                            type.name().toLowerCase(),
+                                                            ProjectInfo.getVersion(),
+                                                            HBaseVersion.get().toString()));
+    if (targetPath.exists()) {
+      return targetPath;
+    }
+
+    // ensure the jar directory exists
+    Locations.mkdirsIfNotExists(jarDir);
+
+    Set<Class<? extends Coprocessor>> classes = coprocessors.get(type);
+    StringBuilder buf = new StringBuilder();
+    for (Class<? extends Coprocessor> c : classes) {
+      buf.append(c.getName()).append(", ");
+    }
+    if (buf.length() == 0) {
+      return null;
+    }
+
+    LOG.debug("Creating jar file for coprocessor classes: " + buf.toString());
+    final Hasher hasher = Hashing.md5().newHasher();
+    final byte[] buffer = new byte[4 * 1024];
+
+    final Map<String, URL> dependentClasses = new HashMap<>();
+    for (Class<? extends Coprocessor> clz : classes) {
+      Dependencies.findClassDependencies(clz.getClassLoader(), new ClassAcceptor() {
+        @Override
+        public boolean accept(String className, final URL classUrl, URL classPathUrl) {
+          // Assuming the endpoint and protocol class doesn't have dependencies
+          // other than those comes with HBase, Java and fastutil.
+          if (className.startsWith("co.cask") || className.startsWith("it.unimi.dsi.fastutil")
+            || className.startsWith("org.apache.tephra")) {
+            if (!dependentClasses.containsKey(className)) {
+              dependentClasses.put(className, classUrl);
+            }
+            return true;
+          }
+          return false;
+        }
+      }, clz.getName());
+    }
+
+    if (dependentClasses.isEmpty()) {
+      return null;
+    }
+
+    // create the coprocessor jar on local filesystem
+    LOG.debug("Adding " + dependentClasses.size() + " classes to jar");
+    File jarFile = File.createTempFile(type.name().toLowerCase(), ".jar");
+    try (JarOutputStream jarOutput = new JarOutputStream(new FileOutputStream(jarFile))) {
+      for (Map.Entry<String, URL> entry : dependentClasses.entrySet()) {
+        jarOutput.putNextEntry(new JarEntry(entry.getKey().replace('.', File.separatorChar) + ".class"));
+
+        try (InputStream inputStream = entry.getValue().openStream()) {
+          int len = inputStream.read(buffer);
+          while (len >= 0) {
+            hasher.putBytes(buffer, 0, len);
+            jarOutput.write(buffer, 0, len);
+            len = inputStream.read(buffer);
+          }
+        }
+      }
+    } catch (IOException e) {
+      LOG.error("Unable to create temporary local coprocessor jar {}.", jarFile.getAbsolutePath(), e);
+      if (!jarFile.delete()) {
+        LOG.warn("Unable to clean up temporary local coprocessor jar {}.", jarFile.getAbsolutePath());
+      }
+      throw e;
+    }
+
+    // copy the local jar file to the filesystem (HDFS)
+    // copies to a tmp location then renames the tmp location to the target location in case
+    // multiple CoprocessorManagers we called at the same time. This should never be the case in distributed
+    // mode, as coprocessors should all be loaded beforehand using the CoprocessorBuildTool.
+    final Location tmpLocation = jarDir.getTempFile(".jar");
+    try {
+      // Copy jar file into filesystem (HDFS)
+      Files.copy(jarFile, new OutputSupplier<OutputStream>() {
+        @Override
+        public OutputStream getOutput() throws IOException {
+          return tmpLocation.getOutputStream();
+        }
+      });
+    } catch (IOException e) {
+      LOG.error("Unable to copy local coprocessor jar to filesystem at {}.", tmpLocation, e);
+      if (tmpLocation.exists()) {
+        LOG.info("Deleting partially copied coprocessor jar at {}.", tmpLocation);
+        try {
+          if (!tmpLocation.delete()) {
+            LOG.error("Unable to delete partially copied coprocessor jar at {}.", tmpLocation, e);
+          }
+        } catch (IOException e1) {
+          LOG.error("Unable to delete partially copied coprocessor jar at {}.", tmpLocation, e1);
+          e.addSuppressed(e1);
+        }
+      }
+      throw e;
+    } finally {
+      if (!jarFile.delete()) {
+        LOG.warn("Unable to clean up temporary local coprocessor jar {}.", jarFile.getAbsolutePath());
+      }
+    }
+
+    tmpLocation.renameTo(targetPath);
+    return targetPath;
+  }
+}

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -50,7 +50,6 @@ import co.cask.cdap.data.stream.StreamAdminModules;
 import co.cask.cdap.data.view.ViewAdminModules;
 import co.cask.cdap.data2.audit.AuditModule;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
-import co.cask.cdap.data2.transaction.queue.QueueConstants;
 import co.cask.cdap.data2.util.hbase.ConfigurationTable;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
@@ -250,8 +249,6 @@ public class MasterServiceMain extends DaemonMain {
   public void start() throws Exception {
     logAppenderInitializer.initialize();
     createDirectory("twill");
-    createDirectory(cConf.get(QueueConstants.ConfigKeys.QUEUE_TABLE_COPROCESSOR_DIR,
-                              QueueConstants.DEFAULT_QUEUE_TABLE_COPROCESSOR_DIR));
     createDirectory(cConf.get(Constants.MessagingSystem.COPROCESSOR_DIR));
     createSystemHBaseNamespace();
     updateConfigurationTable();

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/CoprocessorBuildTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/CoprocessorBuildTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -66,8 +66,6 @@ public class CoprocessorBuildTool {
         @Singleton
         private LocationFactory providesLocationFactory(Configuration hConf, CConfiguration cConf, FileContext fc) {
           final String namespace = cConf.get(Constants.CFG_HDFS_NAMESPACE);
-          LOG.info("HDFS namespace is {}",  namespace);
-
           return new FileContextLocationFactory(hConf, fc, namespace);
         }
       }

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/CoprocessorBuildTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/CoprocessorBuildTool.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data.tools;
+
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.guice.ConfigModule;
+import co.cask.cdap.common.guice.FileContextProvider;
+import co.cask.cdap.common.kerberos.SecurityUtil;
+import co.cask.cdap.data2.util.hbase.CoprocessorManager;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
+import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.PrivateModule;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileContext;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.twill.filesystem.FileContextLocationFactory;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Tool to build and upload required HBase coprocessors. Should be run before the CDAP master starts up.
+ * Should also be run on slave clusters to ensure that the required coprocessors exist on HDFS.
+ */
+public class CoprocessorBuildTool {
+  private static final Logger LOG = LoggerFactory.getLogger(CoprocessorBuildTool.class);
+
+  public static void main(final String[] args) {
+    CConfiguration cConf = CConfiguration.create();
+    Configuration hConf = HBaseConfiguration.create();
+
+    Injector injector = Guice.createInjector(
+      new ConfigModule(cConf, hConf),
+      // for LocationFactory
+      new PrivateModule() {
+        @Override
+        protected void configure() {
+          bind(FileContext.class).toProvider(FileContextProvider.class).in(Scopes.SINGLETON);
+          expose(LocationFactory.class);
+        }
+
+        @Provides
+        @Singleton
+        private LocationFactory providesLocationFactory(Configuration hConf, CConfiguration cConf, FileContext fc) {
+          final String namespace = cConf.get(Constants.CFG_HDFS_NAMESPACE);
+          LOG.info("HDFS namespace is {}",  namespace);
+
+          return new FileContextLocationFactory(hConf, fc, namespace);
+        }
+      }
+    );
+
+    try {
+      SecurityUtil.loginForMasterService(cConf);
+    } catch (Exception e) {
+      LOG.error("Failed to login as CDAP user", e);
+      System.exit(1);
+    }
+
+    LocationFactory locationFactory = injector.getInstance(LocationFactory.class);
+    HBaseTableUtil tableUtil = new HBaseTableUtilFactory(cConf).get();
+    CoprocessorManager coprocessorManager = new CoprocessorManager(cConf, locationFactory, tableUtil);
+
+    try {
+      for (CoprocessorManager.Type type : CoprocessorManager.Type.values()) {
+        Location location = coprocessorManager.ensureCoprocessorExists(type);
+        LOG.info("{} coprocessor exists at {}.", type, location);
+      }
+    } catch (IOException e) {
+      LOG.error("Unable to build and upload coprocessor jars.", e);
+      System.exit(1);
+    }
+  }
+
+}

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
@@ -26,6 +26,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTableAdmin;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.CoprocessorManager;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
@@ -131,11 +132,12 @@ public class DatasetUpgrader extends AbstractUpgrader {
 
     final boolean supportsIncrement = HBaseTableAdmin.supportsReadlessIncrements(desc);
     final boolean transactional = HBaseTableAdmin.isTransactional(desc);
+    final CoprocessorManager coprocessorManager = new CoprocessorManager(cConf, locationFactory, hBaseTableUtil);
     DatasetAdmin admin = new AbstractHBaseDataSetAdmin(tableId, hConf, cConf, hBaseTableUtil) {
       @Override
       protected CoprocessorJar createCoprocessorJar() throws IOException {
         return HBaseTableAdmin.createCoprocessorJarInternal(cConf,
-                                                            locationFactory,
+                                                            coprocessorManager,
                                                             hBaseTableUtil,
                                                             transactional,
                                                             supportsIncrement);


### PR DESCRIPTION
Added a tool that will build and upload coprocessor jars to HDFS.
The tool will run before the master starts, and can also be
run on its own. It can be used on a slave cluster to ensure that
required coprocessor jars are on HDFS even though CDAP is not
running on the cluster.

Refactored the logic around building coprocessors so that
HBaseTableAdmin and HBaseQueueAdmin no longer build their required
coprocessor on demand, but just assume the coprocessor exists at
a pre-defined location. Logic for building the actual jar was
just moved from HBaseTableUtil to a new CoprocessorManager class.