### PR TITLE
CDAP-8211 Fix formatting and display for virtual-machine.

### DIFF
--- a/cdap-docs/developers-manual/source/getting-started/standalone/virtual-machine.rst
+++ b/cdap-docs/developers-manual/source/getting-started/standalone/virtual-machine.rst
@@ -32,7 +32,7 @@ It has pre-installed all the software that you need to run and develop CDAP appl
 - Maven is installed and configured to work for CDAP.
 - Both IntelliJ IDEA and Eclipse IDE are installed and available through desktop links once the
   virtual machine has started.
-- Links on the desktop are provided to the CDAP SDK, CDAP UI, and CDAP documentation.
+- Links on the desktop are provided to the CDAP SDK, CDAP UI, CDAP Examples, and CDAP documentation.
 - The Chromium web browser is included. The default page for the CDAP UI, available through a desktop link, is
   :cdap-ui:`http://localhost:11011/ <>`.
 
@@ -41,19 +41,37 @@ remove software, the admin user and password are both ``cdap``.
 
 .. include:: ../dev-env.rst  
    :start-line: 7
-   :end-line: 23
+   :end-line: 22
 
-.. tabbed-parsed-literal::
-   :tabs: "Linux Virtual Machine"
-   :independent:
+.. ifconfig:: snapshot_version
 
-   $ mvn archetype:generate \
-       -DarchetypeGroupId=co.cask.cdap \
-       -DarchetypeArtifactId=cdap-app-archetype \
-       -DarchetypeVersion=\ |release|
+  .. tabbed-parsed-literal::
+    :tabs: "Linux Virtual Machine"
+    :independent:
+  
+    $ mvn archetype:generate \
+        -DarchetypeGroupId=co.cask.cdap \
+        -DarchetypeArtifactId=cdap-app-archetype \
+        |archetype-repository| \
+        |archetype-version| \
+        -DartifactId=myExampleApp \
+        -DgroupId=org.example.app
+
+.. ifconfig:: not snapshot_version
+
+  .. tabbed-parsed-literal::
+    :tabs: "Linux Virtual Machine"
+    :independent:
+
+    $ mvn archetype:generate \
+        -DarchetypeGroupId=co.cask.cdap \
+        -DarchetypeArtifactId=cdap-app-archetype \
+        |archetype-version| \
+        -DartifactId=myExampleApp \
+        -DgroupId=org.example.app
 
 .. include:: ../dev-env.rst  
-   :start-line: 30
+   :start-line: 46
 
 Starting and Stopping Standalone CDAP
 =====================================


### PR DESCRIPTION
Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB235-1 (failed, but unrelated to this PR. Fixed already in develop.)

Page of interest: http://builds.cask.co/artifact/CDAP-DQB235/shared/build-1/Docs-HTML/4.1.0-SNAPSHOT/en/developers-manual/getting-started/standalone/virtual-machine.html