### PR TITLE
CDAP-8236 revert some service discovery timeouts

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/internal/remote/RemoteOpsClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/internal/remote/RemoteOpsClient.java
@@ -50,6 +50,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
@@ -88,7 +89,7 @@ public class RemoteOpsClient {
   }
 
   private String resolve(String resource) {
-    Discoverable discoverable = endpointStrategySupplier.get().pick();
+    Discoverable discoverable = endpointStrategySupplier.get().pick(1L, TimeUnit.SECONDS);
     if (discoverable == null) {
       throw new ServiceUnavailableException(discoverableServiceName);
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -70,6 +70,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
@@ -389,7 +390,7 @@ class DatasetServiceClient {
   }
 
   private String resolve(String resource) throws DatasetManagementException {
-    Discoverable discoverable = endpointStrategySupplier.get().pick();
+    Discoverable discoverable = endpointStrategySupplier.get().pick(1L, TimeUnit.SECONDS);
     if (discoverable == null) {
       throw new ServiceUnavailableException("DatasetService");
     }


### PR DESCRIPTION
Adding back some of the service discovery timeouts used in
by internal services since removing it seems to have made
discovery more flaky.