### PR TITLE
CDAP-8243 get raw cconf so no substitution occurs

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceContextConfig.java
@@ -223,7 +223,7 @@ public final class MapReduceContextConfig {
    * Returns the {@link CConfiguration} stored inside the job {@link Configuration}.
    */
   CConfiguration getCConf() {
-    String conf = hConf.get(HCONF_ATTR_CCONF);
+    String conf = hConf.getRaw(HCONF_ATTR_CCONF);
     Preconditions.checkArgument(conf != null, "No CConfiguration available");
     return CConfiguration.create(new ByteArrayInputStream(conf.getBytes(Charsets.UTF_8)));
   }


### PR DESCRIPTION
For some reason, substitution is now occuring on the serialized
cconf used for mapreduce jobs. This causes invalid xml due to
the <LOG_DIR> value that is in our config, which causes all
mapreduce jobs to fail.