### PR TITLE
CDAP-8037 setting to control whether CDAP manages coprocessors

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -110,6 +110,7 @@ public final class Constants {
    */
   public static final class HBase {
     public static final String AUTH_KEY_UPDATE_INTERVAL = "hbase.auth.key.update.interval";
+    public static final String MANAGE_COPROCESSORS = "master.manage.hbase.coprocessors";
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -96,6 +96,16 @@
   </property>
 
   <property>
+    <name>master.manage.hbase.coprocessors</name>
+    <value>true</value>
+    <description>
+      Whether CDAP master should manage HBase coprocessors. This should only
+      be set to false if you are managing coprocessors yourself in order to
+      support rolling HBase upgrades
+    </description>
+  </property>
+
+  <property>
     <name>master.startup.checks.classes</name>
     <value></value>
     <description>

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="63e604f66cfc70c795da8a48a8b1869f"
+DEFAULT_XML_MD5_HASH="968187ef73ecad8971d91d7ba7c74551"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableDescriptorUtil.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableDescriptorUtil.java
@@ -66,7 +66,8 @@ public class HBase96TableDescriptorUtil {
     for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
       CoprocessorDescriptor cpd = coprocessor.getValue();
       try {
-        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
+        Path path = cpd.getPath() == null ? null : new Path(cpd.getPath());
+        htd.addCoprocessor(cpd.getClassName(), path, cpd.getPriority(), cpd.getProperties());
       } catch (IOException e) {
         LOG.error("Error adding coprocessor.", e);
       }

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableDescriptorUtil.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableDescriptorUtil.java
@@ -66,7 +66,8 @@ public class HBase98TableDescriptorUtil {
     for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
       CoprocessorDescriptor cpd = coprocessor.getValue();
       try {
-        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
+        Path path = cpd.getPath() == null ? null : new Path(cpd.getPath());
+        htd.addCoprocessor(cpd.getClassName(), path, cpd.getPriority(), cpd.getProperties());
       } catch (IOException e) {
         LOG.error("Error adding coprocessor.", e);
       }

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableDescriptorUtil.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableDescriptorUtil.java
@@ -66,7 +66,8 @@ public class HBase10CDHTableDescriptorUtil {
     for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
       CoprocessorDescriptor cpd = coprocessor.getValue();
       try {
-        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
+        Path path = cpd.getPath() == null ? null : new Path(cpd.getPath());
+        htd.addCoprocessor(cpd.getClassName(), path, cpd.getPriority(), cpd.getProperties());
       } catch (IOException e) {
         LOG.error("Error adding coprocessor.", e);
       }

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDH550TableDescriptorUtil.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDH550TableDescriptorUtil.java
@@ -66,7 +66,8 @@ public class HBase10CDH550TableDescriptorUtil {
     for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
       CoprocessorDescriptor cpd = coprocessor.getValue();
       try {
-        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
+        Path path = cpd.getPath() == null ? null : new Path(cpd.getPath());
+        htd.addCoprocessor(cpd.getClassName(), path, cpd.getPriority(), cpd.getProperties());
       } catch (IOException e) {
         LOG.error("Error adding coprocessor.", e);
       }

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableDescriptorUtil.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableDescriptorUtil.java
@@ -66,7 +66,8 @@ public class HBase10TableDescriptorUtil {
     for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
       CoprocessorDescriptor cpd = coprocessor.getValue();
       try {
-        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
+        Path path = cpd.getPath() == null ? null : new Path(cpd.getPath());
+        htd.addCoprocessor(cpd.getClassName(), path, cpd.getPriority(), cpd.getProperties());
       } catch (IOException e) {
         LOG.error("Error adding coprocessor.", e);
       }

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/HBase11TableDescriptorUtil.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/HBase11TableDescriptorUtil.java
@@ -66,7 +66,8 @@ public class HBase11TableDescriptorUtil {
     for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
       CoprocessorDescriptor cpd = coprocessor.getValue();
       try {
-        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
+        Path path = cpd.getPath() == null ? null : new Path(cpd.getPath());
+        htd.addCoprocessor(cpd.getClassName(), path, cpd.getPriority(), cpd.getProperties());
       } catch (IOException e) {
         LOG.error("Error adding coprocessor.", e);
       }

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570TableDescriptorUtil.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570TableDescriptorUtil.java
@@ -66,7 +66,8 @@ public class HBase12CDH570TableDescriptorUtil {
     for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
       CoprocessorDescriptor cpd = coprocessor.getValue();
       try {
-        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
+        Path path = cpd.getPath() == null ? null : new Path(cpd.getPath());
+        htd.addCoprocessor(cpd.getClassName(), path, cpd.getPriority(), cpd.getProperties());
       } catch (IOException e) {
         LOG.error("Error adding coprocessor.", e);
       }

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/CoprocessorUtil.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/CoprocessorUtil.java
@@ -83,7 +83,8 @@ public final class CoprocessorUtil {
             properties.put(m.group(1), m.group(2));
           }
         }
-        info.put(className, new CoprocessorDescriptor(className, path.toUri(), priority, properties));
+        String pathStr = path == null ? null : path.toUri().getPath();
+        info.put(className, new CoprocessorDescriptor(className, pathStr, priority, properties));
       } catch (Exception ex) {
         LOG.warn("Coprocessor attribute '{}' has invalid coprocessor specification '{}'", key, spec, ex);
       }

--- a/cdap-hbase-spi/src/main/java/co/cask/cdap/spi/hbase/CoprocessorDescriptor.java
+++ b/cdap-hbase-spi/src/main/java/co/cask/cdap/spi/hbase/CoprocessorDescriptor.java
@@ -16,9 +16,9 @@
 
 package co.cask.cdap.spi.hbase;
 
-import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Describes HBase coprocessor.
@@ -26,11 +26,11 @@ import java.util.Map;
 public final class CoprocessorDescriptor {
 
   private final String className;
-  private final URI path;
+  private final String path;
   private final int priority;
   private final Map<String, String> properties;
 
-  public CoprocessorDescriptor(String className, URI path, int priority, Map<String, String> properties) {
+  public CoprocessorDescriptor(String className, @Nullable String path, int priority, Map<String, String> properties) {
     this.className = className;
     this.path = path;
     this.priority = priority;
@@ -42,7 +42,8 @@ public final class CoprocessorDescriptor {
     return className;
   }
 
-  public URI getPath() {
+  @Nullable
+  public String getPath() {
     return path;
   }
 


### PR DESCRIPTION
When the setting is set to false, no path to the coprocessor
will be set when creating HBase tables. In this mode, it is
assumed cluster admins will install the CDAP coprocessors on
all regionservers and ensure that they are present on the
regionserver classpath. Doing this would allow that cluster to
perform an HBase rolling upgrade without bringing CDAP down.