### PR TITLE
support only HDInsights 3.4

### DIFF
--- a/cdap-distributions/src/hdinsight/pkg/createUiDefinition.json
+++ b/cdap-distributions/src/hdinsight/pkg/createUiDefinition.json
@@ -4,6 +4,6 @@
   "clusterFilters": {
     "types": [ "HBase" ],
     "tiers": [ "Standard" ],
-    "versions": [ "3.4", "3.5" ]
+    "versions": [ "3.4" ]
   }
 }


### PR DESCRIPTION
Restrict HDInsight compatibility to 3.4, until https://issues.cask.co/browse/INFRA-38 is resolved.