### PR TITLE
CDAP-7685 Added util classes for conversion between TableDescriptor and HTableDescriptor.

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.data2.dataset2.lib.table.hbase;
 
+import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.DatasetContext;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.Updatable;
@@ -25,10 +26,12 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
+import co.cask.cdap.data2.util.hbase.ColumnFamilyDescriptorBuilder;
 import co.cask.cdap.data2.util.hbase.CoprocessorManager;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
+import co.cask.cdap.data2.util.hbase.TableDescriptorBuilder;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
 import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
@@ -72,50 +75,51 @@ public class HBaseTableAdmin extends AbstractHBaseDataSetAdmin implements Updata
 
   @Override
   public void create() throws IOException {
-    HColumnDescriptor columnDescriptor =
-      new HColumnDescriptor(TableProperties.getColumnFamilyBytes(spec.getProperties()));
+    String columnFamily = Bytes.toString(TableProperties.getColumnFamilyBytes(spec.getProperties()));
+    ColumnFamilyDescriptorBuilder cfdBuilder = HBaseTableUtil.getColumnFamilyDescriptorBuilder(columnFamily, hConf);
 
     if (TableProperties.getReadlessIncrementSupport(spec.getProperties())) {
-      columnDescriptor.setMaxVersions(Integer.MAX_VALUE);
+      cfdBuilder.setMaxVersions(Integer.MAX_VALUE);
     } else if (DatasetsUtil.isTransactional(spec.getProperties())) {
       // NOTE: we cannot limit number of versions as there's no hard limit on # of excluded from read txs
-      columnDescriptor.setMaxVersions(Integer.MAX_VALUE);
+      cfdBuilder.setMaxVersions(Integer.MAX_VALUE);
     } else {
-      columnDescriptor.setMaxVersions(1);
+      cfdBuilder.setMaxVersions(1);
     }
 
-    tableUtil.setBloomFilter(columnDescriptor, HBaseTableUtil.BloomType.ROW);
+    cfdBuilder.setBloomType(ColumnFamilyDescriptor.BloomType.ROW);
 
     Long ttl = TableProperties.getTTL(spec.getProperties());
     if (ttl != null) {
       // convert ttl from seconds to milli-seconds
       ttl = TimeUnit.SECONDS.toMillis(ttl);
-      columnDescriptor.setValue(TxConstants.PROPERTY_TTL, String.valueOf(ttl));
+      cfdBuilder.addProperty(TxConstants.PROPERTY_TTL, String.valueOf(ttl));
     }
 
-    final HTableDescriptorBuilder tableDescriptor = tableUtil.buildHTableDescriptor(tableId);
-    tableDescriptor.addFamily(columnDescriptor);
+    final TableDescriptorBuilder tdBuilder = HBaseTableUtil.getTableDescriptorBuilder(tableId, cConf);
 
     // if the dataset is configured for read-less increments, then set the table property to support upgrades
     boolean supportsReadlessIncrements = TableProperties.getReadlessIncrementSupport(spec.getProperties());
     if (supportsReadlessIncrements) {
-      tableDescriptor.setValue(Table.PROPERTY_READLESS_INCREMENT, "true");
+      tdBuilder.addProperty(Table.PROPERTY_READLESS_INCREMENT, "true");
     }
 
     // if the dataset is configured to be non-transactional, then set the table property to support upgrades
     if (!DatasetsUtil.isTransactional(spec.getProperties())) {
-      tableDescriptor.setValue(Constants.Dataset.TABLE_TX_DISABLED, "true");
+      tdBuilder.addProperty(Constants.Dataset.TABLE_TX_DISABLED, "true");
       if (supportsReadlessIncrements) {
         // read-less increments CPs by default assume that table is transactional
-        columnDescriptor.setValue("dataset.table.readless.increment.transactional", "false");
+        cfdBuilder.addProperty("dataset.table.readless.increment.transactional", "false");
       }
     }
+
+    tdBuilder.addColumnFamily(cfdBuilder.build());
 
     CoprocessorJar coprocessorJar = createCoprocessorJar();
 
     for (Class<? extends Coprocessor> coprocessor : coprocessorJar.getCoprocessors()) {
-      addCoprocessor(tableDescriptor, coprocessor, coprocessorJar.getJarLocation(),
-                     coprocessorJar.getPriority(coprocessor));
+      tdBuilder.addCoprocessor(getCoprocessorDescriptor(coprocessor, coprocessorJar.getJarLocation(),
+                                                        coprocessorJar.getPriority(coprocessor)));
     }
 
     byte[][] splits = null;
@@ -124,8 +128,8 @@ public class HBaseTableAdmin extends AbstractHBaseDataSetAdmin implements Updata
       splits = GSON.fromJson(splitsProperty, byte[][].class);
     }
 
-    try (HBaseDDLExecutor executor = ddlExecutorFactory.get()) {
-      tableUtil.createTableIfNotExists(executor, tableId, tableDescriptor.build(), splits);
+    try (HBaseDDLExecutor ddlExecutor = ddlExecutorFactory.get()) {
+      ddlExecutor.createTableIfNotExists(tdBuilder.build(), splits);
     }
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/QueueConstants.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/QueueConstants.java
@@ -33,8 +33,6 @@ public final class QueueConstants {
   // This is a hardcoded value for the row key distributor bucket size before CDAP-1946
   public static final int DEFAULT_ROW_KEY_BUCKETS = 16;
 
-  public static final long MAX_CREATE_TABLE_WAIT = 5000L;    // Maximum wait of 5 seconds for table creation.
-
   // How frequently (in seconds) to update the ConsumerConfigCache data for the HBaseQueueRegionObserver
   public static final String QUEUE_CONFIG_UPDATE_FREQUENCY = "data.queue.config.update.interval";
   public static final Long DEFAULT_QUEUE_CONFIG_UPDATE_FREQUENCY = 5L; // default to 5 seconds

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerStateStoreFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/hbase/HBaseStreamConsumerStateStoreFactory.java
@@ -15,39 +15,40 @@
  */
 package co.cask.cdap.data2.transaction.stream.hbase;
 
+import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data.stream.StreamUtils;
-import co.cask.cdap.data2.transaction.queue.QueueConstants;
 import co.cask.cdap.data2.transaction.queue.QueueEntryRow;
 import co.cask.cdap.data2.transaction.stream.StreamConfig;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStore;
 import co.cask.cdap.data2.transaction.stream.StreamConsumerStateStoreFactory;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.ColumnFamilyDescriptorBuilder;
 import co.cask.cdap.data2.util.hbase.HBaseDDLExecutorFactory;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
-import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
+import co.cask.cdap.data2.util.hbase.TableDescriptorBuilder;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import com.google.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.client.HTable;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Factory for creating {@link StreamConsumerStateStore} in HBase.
  */
 public final class HBaseStreamConsumerStateStoreFactory implements StreamConsumerStateStoreFactory {
+  private final CConfiguration cConf;
   private final Configuration hConf;
   private final HBaseTableUtil tableUtil;
   private final HBaseDDLExecutorFactory ddlExecutorFactory;
 
   @Inject
   HBaseStreamConsumerStateStoreFactory(CConfiguration cConf, Configuration hConf, HBaseTableUtil tableUtil) {
+    this.cConf = cConf;
     this.hConf = hConf;
     this.tableUtil = tableUtil;
     this.ddlExecutorFactory = new HBaseDDLExecutorFactory(cConf, hConf);
@@ -59,19 +60,21 @@ public final class HBaseStreamConsumerStateStoreFactory implements StreamConsume
     TableId streamStateStoreTableId = StreamUtils.getStateStoreTableId(namespace);
     TableId hbaseTableId = tableUtil.createHTableId(new NamespaceId(streamStateStoreTableId.getNamespace()),
                                                     streamStateStoreTableId.getTableName());
-    try (HBaseDDLExecutor executor = ddlExecutorFactory.get();
-         // TODO should tableExists be part of HBaseDDLExecutor??
-         HBaseAdmin admin = new HBaseAdmin(hConf)) {
-      if (!tableUtil.tableExists(admin, hbaseTableId)) {
 
-        HTableDescriptorBuilder htd = tableUtil.buildHTableDescriptor(hbaseTableId);
+    boolean tableExist;
+    try (HBaseAdmin admin = new HBaseAdmin(hConf)) {
+      tableExist = tableUtil.tableExists(admin, hbaseTableId);
+    }
 
-        HColumnDescriptor hcd = new HColumnDescriptor(QueueEntryRow.COLUMN_FAMILY);
-        htd.addFamily(hcd);
-        hcd.setMaxVersions(1);
+    if (!tableExist) {
+      try (HBaseDDLExecutor ddlExecutor = ddlExecutorFactory.get()) {
+        TableDescriptorBuilder tdBuilder = HBaseTableUtil.getTableDescriptorBuilder(hbaseTableId, cConf);
 
-        tableUtil.createTableIfNotExists(executor, hbaseTableId, htd.build(), null,
-                                         QueueConstants.MAX_CREATE_TABLE_WAIT, TimeUnit.MILLISECONDS);
+        ColumnFamilyDescriptorBuilder cfdBuilder =
+          HBaseTableUtil.getColumnFamilyDescriptorBuilder(Bytes.toString(QueueEntryRow.COLUMN_FAMILY), hConf);
+
+        tdBuilder.addColumnFamily(cfdBuilder.build());
+        ddlExecutor.createTableIfNotExists(tdBuilder.build(), null);
       }
     }
 

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase96DDLExecutor.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase96DDLExecutor.java
@@ -16,98 +16,22 @@
 
 package co.cask.cdap.data2.util.hbase;
 
-import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
-import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
 import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import co.cask.cdap.spi.hbase.TableDescriptor;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
-import org.apache.hadoop.hbase.io.compress.Compression;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Implementation of the {@link HBaseDDLExecutor} for HBase 0.96
  */
 public class DefaultHBase96DDLExecutor extends DefaultHBaseDDLExecutor {
 
-  private HColumnDescriptor getHColumnDesciptor(ColumnFamilyDescriptor descriptor) {
-    HColumnDescriptor hFamily = new HColumnDescriptor(descriptor.getName());
-    hFamily.setMaxVersions(descriptor.getMaxVersions());
-    hFamily.setCompressionType(Compression.Algorithm.valueOf(descriptor.getCompressionType().name()));
-    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(
-      descriptor.getBloomType().name()));
-    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
-      hFamily.setValue(property.getKey(), property.getValue());
-    }
-    return hFamily;
-  }
-
+  @Override
   public HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
-    TableName tableName = TableName.valueOf(descriptor.getNamespace(), descriptor.getName());
-    HTableDescriptor htd = new HTableDescriptor(tableName);
-    for (Map.Entry<String, ColumnFamilyDescriptor> family : descriptor.getFamilies().entrySet()) {
-      htd.addFamily(getHColumnDesciptor(family.getValue()));
-    }
-
-    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
-      CoprocessorDescriptor cpd = coprocessor.getValue();
-      try {
-        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
-      } catch (IOException e) {
-        LOG.error("Error adding coprocessor.", e);
-      }
-    }
-
-    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
-      // TODO: should not add coprocessor related properties since those were already be added
-      // using addCoprocessor call.
-      htd.setValue(property.getKey(), property.getValue());
-    }
-    return htd;
+    return HBase96TableDescriptorUtil.getHTableDescriptor(descriptor);
   }
 
+  @Override
   public TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
-    Set<ColumnFamilyDescriptor> families = new HashSet<>();
-    for (HColumnDescriptor family : descriptor.getColumnFamilies()) {
-      families.add(getColumnFamilyDescriptor(family));
-    }
-
-    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
-    coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
-
-    Map<String, String> properties = new HashMap<>();
-    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
-      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
-                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
-    }
-
-    // TODO: should add configurations as well
-    return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),
-                               descriptor.getTableName().getQualifierAsString(), families, coprocessors, properties);
-  }
-
-  private ColumnFamilyDescriptor getColumnFamilyDescriptor(HColumnDescriptor descriptor) {
-    String name = descriptor.getNameAsString();
-    int maxVersions = descriptor.getMaxVersions();
-    ColumnFamilyDescriptor.CompressionType compressionType
-      = ColumnFamilyDescriptor.CompressionType.valueOf(descriptor.getCompressionType().getName().toUpperCase());
-    ColumnFamilyDescriptor.BloomType bloomType
-      = ColumnFamilyDescriptor.BloomType.valueOf(descriptor.getBloomFilterType().name().toUpperCase());
-
-    Map<String, String> properties = new HashMap<>();
-    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
-      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
-                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
-    }
-    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+    return HBase96TableDescriptorUtil.getTableDescriptor(descriptor);
   }
 }

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableDescriptorUtil.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableDescriptorUtil.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
+import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
+import co.cask.cdap.spi.hbase.TableDescriptor;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.io.compress.Compression;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Provides utility methods for {@link TableDescriptor}.
+ */
+public class HBase96TableDescriptorUtil {
+
+  public static final Logger LOG = LoggerFactory.getLogger(HBase96TableDescriptorUtil.class);
+
+  private HBase96TableDescriptorUtil() {
+  }
+
+  private static HColumnDescriptor getHColumnDesciptor(ColumnFamilyDescriptor descriptor) {
+    HColumnDescriptor hFamily = new HColumnDescriptor(descriptor.getName());
+    hFamily.setMaxVersions(descriptor.getMaxVersions());
+    hFamily.setCompressionType(Compression.Algorithm.valueOf(descriptor.getCompressionType().name()));
+    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(
+      descriptor.getBloomType().name()));
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      hFamily.setValue(property.getKey(), property.getValue());
+    }
+    return hFamily;
+  }
+
+  public static HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
+    TableName tableName = TableName.valueOf(descriptor.getNamespace(), descriptor.getName());
+    HTableDescriptor htd = new HTableDescriptor(tableName);
+    for (Map.Entry<String, ColumnFamilyDescriptor> family : descriptor.getFamilies().entrySet()) {
+      htd.addFamily(getHColumnDesciptor(family.getValue()));
+    }
+
+    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
+      CoprocessorDescriptor cpd = coprocessor.getValue();
+      try {
+        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
+      } catch (IOException e) {
+        LOG.error("Error adding coprocessor.", e);
+      }
+    }
+
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      // TODO: should not add coprocessor related properties since those were already be added
+      // using addCoprocessor call.
+      htd.setValue(property.getKey(), property.getValue());
+    }
+    return htd;
+  }
+
+  public static TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
+    Set<ColumnFamilyDescriptor> families = new HashSet<>();
+    for (HColumnDescriptor family : descriptor.getColumnFamilies()) {
+      families.add(getColumnFamilyDescriptor(family));
+    }
+
+    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
+    coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+
+    // TODO: should add configurations as well
+    return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),
+                               descriptor.getTableName().getQualifierAsString(), families, coprocessors, properties);
+
+  }
+
+  private static ColumnFamilyDescriptor getColumnFamilyDescriptor(HColumnDescriptor descriptor) {
+    String name = descriptor.getNameAsString();
+    int maxVersions = descriptor.getMaxVersions();
+    ColumnFamilyDescriptor.CompressionType compressionType
+      = ColumnFamilyDescriptor.CompressionType.valueOf(descriptor.getCompressionType().getName().toUpperCase());
+    ColumnFamilyDescriptor.BloomType bloomType
+      = ColumnFamilyDescriptor.BloomType.valueOf(descriptor.getBloomFilterType().name().toUpperCase());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+  }
+}

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableUtil.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableUtil.java
@@ -103,8 +103,7 @@ public class HBase96TableUtil extends HBaseTableUtil {
     Preconditions.checkArgument(ddlExecutor != null, "HBaseDDLExecutor should not be null");
     Preconditions.checkArgument(tableDescriptor != null, "Table decsriptor should not be null.");
     TableName tableName = tableDescriptor.getTableName();
-    // TODO This will be fixed in the next PR when we pass TableDescriptor to the modifyTable method.
-    TableDescriptor tbd = ((DefaultHBaseDDLExecutor) ddlExecutor).getTableDescriptor(tableDescriptor);
+    TableDescriptor tbd = HBase96TableDescriptorUtil.getTableDescriptor(tableDescriptor);
     ddlExecutor.modifyTable(tableName.getNamespaceAsString(), tableName.getQualifierAsString(), tbd);
   }
 

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase98DDLExecutor.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase98DDLExecutor.java
@@ -16,97 +16,21 @@
 
 package co.cask.cdap.data2.util.hbase;
 
-import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
-import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
+import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import co.cask.cdap.spi.hbase.TableDescriptor;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
-import org.apache.hadoop.hbase.io.compress.Compression;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Implementation of the {@link HBaseDDLExecutor} for HBase 0.98
  */
 public class DefaultHBase98DDLExecutor extends DefaultHBaseDDLExecutor {
-
-  private HColumnDescriptor getHColumnDesciptor(ColumnFamilyDescriptor descriptor) {
-    HColumnDescriptor hFamily = new HColumnDescriptor(descriptor.getName());
-    hFamily.setMaxVersions(descriptor.getMaxVersions());
-    hFamily.setCompressionType(Compression.Algorithm.valueOf(descriptor.getCompressionType().name()));
-    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(
-      descriptor.getBloomType().name()));
-    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
-      hFamily.setValue(property.getKey(), property.getValue());
-    }
-    return hFamily;
-  }
-
+  @Override
   public HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
-    TableName tableName = TableName.valueOf(descriptor.getNamespace(), descriptor.getName());
-    HTableDescriptor htd = new HTableDescriptor(tableName);
-    for (Map.Entry<String, ColumnFamilyDescriptor> family : descriptor.getFamilies().entrySet()) {
-      htd.addFamily(getHColumnDesciptor(family.getValue()));
-    }
-
-    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
-      CoprocessorDescriptor cpd = coprocessor.getValue();
-      try {
-        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
-      } catch (IOException e) {
-        LOG.error("Error adding coprocessor.", e);
-      }
-    }
-
-    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
-      // TODO: should not add coprocessor related properties since those were already be added
-      // using addCoprocessor call.
-      htd.setValue(property.getKey(), property.getValue());
-    }
-    return htd;
+    return HBase98TableDescriptorUtil.getHTableDescriptor(descriptor);
   }
 
+  @Override
   public TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
-    Set<ColumnFamilyDescriptor> families = new HashSet<>();
-    for (HColumnDescriptor family : descriptor.getColumnFamilies()) {
-      families.add(getColumnFamilyDescriptor(family));
-    }
-
-    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
-    coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
-
-    Map<String, String> properties = new HashMap<>();
-    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
-      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
-                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
-    }
-
-    // TODO: should add configurations as well
-    return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),
-                               descriptor.getTableName().getQualifierAsString(), families, coprocessors, properties);
-  }
-
-  private ColumnFamilyDescriptor getColumnFamilyDescriptor(HColumnDescriptor descriptor) {
-    String name = descriptor.getNameAsString();
-    int maxVersions = descriptor.getMaxVersions();
-    ColumnFamilyDescriptor.CompressionType compressionType
-      = ColumnFamilyDescriptor.CompressionType.valueOf(descriptor.getCompressionType().getName().toUpperCase());
-    ColumnFamilyDescriptor.BloomType bloomType
-      = ColumnFamilyDescriptor.BloomType.valueOf(descriptor.getBloomFilterType().name().toUpperCase());
-
-    Map<String, String> properties = new HashMap<>();
-    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
-      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
-                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
-    }
-    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+    return HBase98TableDescriptorUtil.getTableDescriptor(descriptor);
   }
 }

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableDescriptorUtil.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableDescriptorUtil.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
+import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
+import co.cask.cdap.spi.hbase.TableDescriptor;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.io.compress.Compression;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Provides utility methods for {@link TableDescriptor}.
+ */
+public class HBase98TableDescriptorUtil {
+
+  public static final Logger LOG = LoggerFactory.getLogger(HBase98TableDescriptorUtil.class);
+
+  private HBase98TableDescriptorUtil() {
+  }
+
+  private static HColumnDescriptor getHColumnDesciptor(ColumnFamilyDescriptor descriptor) {
+    HColumnDescriptor hFamily = new HColumnDescriptor(descriptor.getName());
+    hFamily.setMaxVersions(descriptor.getMaxVersions());
+    hFamily.setCompressionType(Compression.Algorithm.valueOf(descriptor.getCompressionType().name()));
+    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(
+      descriptor.getBloomType().name()));
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      hFamily.setValue(property.getKey(), property.getValue());
+    }
+    return hFamily;
+  }
+
+  public static HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
+    TableName tableName = TableName.valueOf(descriptor.getNamespace(), descriptor.getName());
+    HTableDescriptor htd = new HTableDescriptor(tableName);
+    for (Map.Entry<String, ColumnFamilyDescriptor> family : descriptor.getFamilies().entrySet()) {
+      htd.addFamily(getHColumnDesciptor(family.getValue()));
+    }
+
+    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
+      CoprocessorDescriptor cpd = coprocessor.getValue();
+      try {
+        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
+      } catch (IOException e) {
+        LOG.error("Error adding coprocessor.", e);
+      }
+    }
+
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      // TODO: should not add coprocessor related properties since those were already be added
+      // using addCoprocessor call.
+      htd.setValue(property.getKey(), property.getValue());
+    }
+    return htd;
+  }
+
+  public static TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
+    Set<ColumnFamilyDescriptor> families = new HashSet<>();
+    for (HColumnDescriptor family : descriptor.getColumnFamilies()) {
+      families.add(getColumnFamilyDescriptor(family));
+    }
+
+    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
+    coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+
+    // TODO: should add configurations as well
+    return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),
+                               descriptor.getTableName().getQualifierAsString(), families, coprocessors, properties);
+  }
+
+  private static ColumnFamilyDescriptor getColumnFamilyDescriptor(HColumnDescriptor descriptor) {
+    String name = descriptor.getNameAsString();
+    int maxVersions = descriptor.getMaxVersions();
+    ColumnFamilyDescriptor.CompressionType compressionType
+      = ColumnFamilyDescriptor.CompressionType.valueOf(descriptor.getCompressionType().getName().toUpperCase());
+    ColumnFamilyDescriptor.BloomType bloomType
+      = ColumnFamilyDescriptor.BloomType.valueOf(descriptor.getBloomFilterType().name().toUpperCase());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+  }
+}

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableUtil.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableUtil.java
@@ -103,8 +103,7 @@ public class HBase98TableUtil extends HBaseTableUtil {
     Preconditions.checkArgument(ddlExecutor != null, "HBaseDDLExecutor should not be null");
     Preconditions.checkArgument(tableDescriptor != null, "Table descriptor should not be null.");
     TableName tableName = tableDescriptor.getTableName();
-    // TODO This will be fixed in the next PR when we pass TableDescriptor to the modifyTable method.
-    TableDescriptor tbd = ((DefaultHBaseDDLExecutor) ddlExecutor).getTableDescriptor(tableDescriptor);
+    TableDescriptor tbd = HBase98TableDescriptorUtil.getTableDescriptor(tableDescriptor);
     ddlExecutor.modifyTable(tableName.getNamespaceAsString(), tableName.getQualifierAsString(), tbd);
   }
 

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase10CDHDDLExecutor.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase10CDHDDLExecutor.java
@@ -16,97 +16,21 @@
 
 package co.cask.cdap.data2.util.hbase;
 
-import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
-import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
+import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import co.cask.cdap.spi.hbase.TableDescriptor;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
-import org.apache.hadoop.hbase.io.compress.Compression;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Implementation of {@link HBaseDDLExecutor} for HBase version 1.0 CDH
  */
 public class DefaultHBase10CDHDDLExecutor extends DefaultHBaseDDLExecutor {
-
-  private HColumnDescriptor getHColumnDesciptor(ColumnFamilyDescriptor descriptor) {
-    HColumnDescriptor hFamily = new HColumnDescriptor(descriptor.getName());
-    hFamily.setMaxVersions(descriptor.getMaxVersions());
-    hFamily.setCompressionType(Compression.Algorithm.valueOf(descriptor.getCompressionType().name()));
-    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(
-      descriptor.getBloomType().name()));
-    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
-      hFamily.setValue(property.getKey(), property.getValue());
-    }
-    return hFamily;
-  }
-
+  @Override
   public HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
-    TableName tableName = TableName.valueOf(descriptor.getNamespace(), descriptor.getName());
-    HTableDescriptor htd = new HTableDescriptor(tableName);
-    for (Map.Entry<String, ColumnFamilyDescriptor> family : descriptor.getFamilies().entrySet()) {
-      htd.addFamily(getHColumnDesciptor(family.getValue()));
-    }
-
-    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
-      CoprocessorDescriptor cpd = coprocessor.getValue();
-      try {
-        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
-      } catch (IOException e) {
-        LOG.error("Error adding coprocessor.", e);
-      }
-    }
-
-    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
-      // TODO: should not add coprocessor related properties since those were already be added
-      // using addCoprocessor call.
-      htd.setValue(property.getKey(), property.getValue());
-    }
-    return htd;
+    return HBase10CDHTableDescriptorUtil.getHTableDescriptor(descriptor);
   }
 
+  @Override
   public TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
-    Set<ColumnFamilyDescriptor> families = new HashSet<>();
-    for (HColumnDescriptor family : descriptor.getColumnFamilies()) {
-      families.add(getColumnFamilyDescriptor(family));
-    }
-
-    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
-    coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
-
-    Map<String, String> properties = new HashMap<>();
-    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
-      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
-                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
-    }
-
-    // TODO: should add configurations as well
-    return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),
-                               descriptor.getTableName().getQualifierAsString(), families, coprocessors, properties);
-  }
-
-  private ColumnFamilyDescriptor getColumnFamilyDescriptor(HColumnDescriptor descriptor) {
-    String name = descriptor.getNameAsString();
-    int maxVersions = descriptor.getMaxVersions();
-    ColumnFamilyDescriptor.CompressionType compressionType
-      = ColumnFamilyDescriptor.CompressionType.valueOf(descriptor.getCompressionType().getName().toUpperCase());
-    ColumnFamilyDescriptor.BloomType bloomType
-      = ColumnFamilyDescriptor.BloomType.valueOf(descriptor.getBloomFilterType().name().toUpperCase());
-
-    Map<String, String> properties = new HashMap<>();
-    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
-      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
-                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
-    }
-    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+    return HBase10CDHTableDescriptorUtil.getTableDescriptor(descriptor);
   }
 }

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableDescriptorUtil.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableDescriptorUtil.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
+import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
+import co.cask.cdap.spi.hbase.TableDescriptor;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.io.compress.Compression;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Provides utility methods for {@link TableDescriptor}.
+ */
+public class HBase10CDHTableDescriptorUtil {
+
+  public static final Logger LOG = LoggerFactory.getLogger(HBase10CDHTableDescriptorUtil.class);
+
+  private HBase10CDHTableDescriptorUtil() {
+  }
+
+  private static HColumnDescriptor getHColumnDesciptor(ColumnFamilyDescriptor descriptor) {
+    HColumnDescriptor hFamily = new HColumnDescriptor(descriptor.getName());
+    hFamily.setMaxVersions(descriptor.getMaxVersions());
+    hFamily.setCompressionType(Compression.Algorithm.valueOf(descriptor.getCompressionType().name()));
+    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(
+      descriptor.getBloomType().name()));
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      hFamily.setValue(property.getKey(), property.getValue());
+    }
+    return hFamily;
+  }
+
+  public static HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
+    TableName tableName = TableName.valueOf(descriptor.getNamespace(), descriptor.getName());
+    HTableDescriptor htd = new HTableDescriptor(tableName);
+    for (Map.Entry<String, ColumnFamilyDescriptor> family : descriptor.getFamilies().entrySet()) {
+      htd.addFamily(getHColumnDesciptor(family.getValue()));
+    }
+
+    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
+      CoprocessorDescriptor cpd = coprocessor.getValue();
+      try {
+        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
+      } catch (IOException e) {
+        LOG.error("Error adding coprocessor.", e);
+      }
+    }
+
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      // TODO: should not add coprocessor related properties since those were already be added
+      // using addCoprocessor call.
+      htd.setValue(property.getKey(), property.getValue());
+    }
+    return htd;
+  }
+
+  public static TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
+    Set<ColumnFamilyDescriptor> families = new HashSet<>();
+    for (HColumnDescriptor family : descriptor.getColumnFamilies()) {
+      families.add(getColumnFamilyDescriptor(family));
+    }
+
+    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
+    coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+
+    // TODO: should add configurations as well
+    return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),
+                               descriptor.getTableName().getQualifierAsString(), families, coprocessors, properties);
+  }
+
+  private static ColumnFamilyDescriptor getColumnFamilyDescriptor(HColumnDescriptor descriptor) {
+    String name = descriptor.getNameAsString();
+    int maxVersions = descriptor.getMaxVersions();
+    ColumnFamilyDescriptor.CompressionType compressionType
+      = ColumnFamilyDescriptor.CompressionType.valueOf(descriptor.getCompressionType().getName().toUpperCase());
+    ColumnFamilyDescriptor.BloomType bloomType
+      = ColumnFamilyDescriptor.BloomType.valueOf(descriptor.getBloomFilterType().name().toUpperCase());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableUtil.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableUtil.java
@@ -103,8 +103,7 @@ public class HBase10CDHTableUtil extends HBaseTableUtil {
     Preconditions.checkArgument(ddlExecutor != null, "HBaseDDLExecutor should not be null");
     Preconditions.checkArgument(tableDescriptor != null, "Table descriptor should not be null.");
     TableName tableName = tableDescriptor.getTableName();
-    // TODO This will be fixed in the next PR when we pass TableDescriptor to the modifyTable method.
-    TableDescriptor tbd = ((DefaultHBaseDDLExecutor) ddlExecutor).getTableDescriptor(tableDescriptor);
+    TableDescriptor tbd = HBase10CDHTableDescriptorUtil.getTableDescriptor(tableDescriptor);
     ddlExecutor.modifyTable(tableName.getNamespaceAsString(), tableName.getQualifierAsString(), tbd);
   }
 

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase10CDH550DDLExecutor.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase10CDH550DDLExecutor.java
@@ -16,98 +16,22 @@
 
 package co.cask.cdap.data2.util.hbase;
 
-import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
-import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
 import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import co.cask.cdap.spi.hbase.TableDescriptor;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
-import org.apache.hadoop.hbase.io.compress.Compression;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Implementation of the {@link HBaseDDLExecutor} for HBase 1.0 CDH 5.5.0
  */
 public class DefaultHBase10CDH550DDLExecutor extends DefaultHBaseDDLExecutor {
 
-  private HColumnDescriptor getHColumnDesciptor(ColumnFamilyDescriptor descriptor) {
-    HColumnDescriptor hFamily = new HColumnDescriptor(descriptor.getName());
-    hFamily.setMaxVersions(descriptor.getMaxVersions());
-    hFamily.setCompressionType(Compression.Algorithm.valueOf(descriptor.getCompressionType().name()));
-    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(
-      descriptor.getBloomType().name()));
-    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
-      hFamily.setValue(property.getKey(), property.getValue());
-    }
-    return hFamily;
-  }
-
+  @Override
   public HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
-    TableName tableName = TableName.valueOf(descriptor.getNamespace(), descriptor.getName());
-    HTableDescriptor htd = new HTableDescriptor(tableName);
-    for (Map.Entry<String, ColumnFamilyDescriptor> family : descriptor.getFamilies().entrySet()) {
-      htd.addFamily(getHColumnDesciptor(family.getValue()));
-    }
-
-    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
-      CoprocessorDescriptor cpd = coprocessor.getValue();
-      try {
-        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
-      } catch (IOException e) {
-        LOG.error("Error adding coprocessor.", e);
-      }
-    }
-
-    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
-      // TODO: should not add coprocessor related properties since those were already be added
-      // using addCoprocessor call.
-      htd.setValue(property.getKey(), property.getValue());
-    }
-    return htd;
+    return HBase10CDH550TableDescriptorUtil.getHTableDescriptor(descriptor);
   }
 
+  @Override
   public TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
-    Set<ColumnFamilyDescriptor> families = new HashSet<>();
-    for (HColumnDescriptor family : descriptor.getColumnFamilies()) {
-      families.add(getColumnFamilyDescriptor(family));
-    }
-
-    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
-    coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
-
-    Map<String, String> properties = new HashMap<>();
-    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
-      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
-                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
-    }
-
-    // TODO: should add configurations as well
-    return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),
-                               descriptor.getTableName().getQualifierAsString(), families, coprocessors, properties);
-  }
-
-  private ColumnFamilyDescriptor getColumnFamilyDescriptor(HColumnDescriptor descriptor) {
-    String name = descriptor.getNameAsString();
-    int maxVersions = descriptor.getMaxVersions();
-    ColumnFamilyDescriptor.CompressionType compressionType
-      = ColumnFamilyDescriptor.CompressionType.valueOf(descriptor.getCompressionType().getName().toUpperCase());
-    ColumnFamilyDescriptor.BloomType bloomType
-      = ColumnFamilyDescriptor.BloomType.valueOf(descriptor.getBloomFilterType().name().toUpperCase());
-
-    Map<String, String> properties = new HashMap<>();
-    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
-      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
-                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
-    }
-    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+    return HBase10CDH550TableDescriptorUtil.getTableDescriptor(descriptor);
   }
 }

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDH550TableDescriptorUtil.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDH550TableDescriptorUtil.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
+import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
+import co.cask.cdap.spi.hbase.TableDescriptor;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.io.compress.Compression;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Provides utility methods for {@link TableDescriptor}.
+ */
+public class HBase10CDH550TableDescriptorUtil {
+
+  public static final Logger LOG = LoggerFactory.getLogger(HBase10CDH550TableDescriptorUtil.class);
+
+  private HBase10CDH550TableDescriptorUtil() {
+  }
+
+  private static HColumnDescriptor getHColumnDesciptor(ColumnFamilyDescriptor descriptor) {
+    HColumnDescriptor hFamily = new HColumnDescriptor(descriptor.getName());
+    hFamily.setMaxVersions(descriptor.getMaxVersions());
+    hFamily.setCompressionType(Compression.Algorithm.valueOf(descriptor.getCompressionType().name()));
+    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(
+      descriptor.getBloomType().name()));
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      hFamily.setValue(property.getKey(), property.getValue());
+    }
+    return hFamily;
+  }
+
+  public static HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
+    TableName tableName = TableName.valueOf(descriptor.getNamespace(), descriptor.getName());
+    HTableDescriptor htd = new HTableDescriptor(tableName);
+    for (Map.Entry<String, ColumnFamilyDescriptor> family : descriptor.getFamilies().entrySet()) {
+      htd.addFamily(getHColumnDesciptor(family.getValue()));
+    }
+
+    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
+      CoprocessorDescriptor cpd = coprocessor.getValue();
+      try {
+        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
+      } catch (IOException e) {
+        LOG.error("Error adding coprocessor.", e);
+      }
+    }
+
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      // TODO: should not add coprocessor related properties since those were already be added
+      // using addCoprocessor call.
+      htd.setValue(property.getKey(), property.getValue());
+    }
+    return htd;
+  }
+
+  public static TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
+    Set<ColumnFamilyDescriptor> families = new HashSet<>();
+    for (HColumnDescriptor family : descriptor.getColumnFamilies()) {
+      families.add(getColumnFamilyDescriptor(family));
+    }
+
+    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
+    coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+
+    // TODO: should add configurations as well
+    return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),
+                               descriptor.getTableName().getQualifierAsString(), families, coprocessors, properties);
+  }
+
+  private static ColumnFamilyDescriptor getColumnFamilyDescriptor(HColumnDescriptor descriptor) {
+    String name = descriptor.getNameAsString();
+    int maxVersions = descriptor.getMaxVersions();
+    ColumnFamilyDescriptor.CompressionType compressionType
+      = ColumnFamilyDescriptor.CompressionType.valueOf(descriptor.getCompressionType().getName().toUpperCase());
+    ColumnFamilyDescriptor.BloomType bloomType
+      = ColumnFamilyDescriptor.BloomType.valueOf(descriptor.getBloomFilterType().name().toUpperCase());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+  }
+}

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDH550TableUtil.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDH550TableUtil.java
@@ -103,8 +103,7 @@ public class HBase10CDH550TableUtil extends HBaseTableUtil {
     Preconditions.checkArgument(ddlExecutor != null, "HBaseDDLExecutor should not be null");
     Preconditions.checkArgument(tableDescriptor != null, "Table descriptor should not be null.");
     TableName tableName = tableDescriptor.getTableName();
-    // TODO This will be fixed in the next PR when we pass TableDescriptor to the modifyTable method.
-    TableDescriptor tbd = ((DefaultHBaseDDLExecutor) ddlExecutor).getTableDescriptor(tableDescriptor);
+    TableDescriptor tbd = HBase10CDH550TableDescriptorUtil.getTableDescriptor(tableDescriptor);
     ddlExecutor.modifyTable(tableName.getNamespaceAsString(), tableName.getQualifierAsString(), tbd);
   }
 

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase10DDLExecutor.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase10DDLExecutor.java
@@ -16,97 +16,22 @@
 
 package co.cask.cdap.data2.util.hbase;
 
-import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
-import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
+import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import co.cask.cdap.spi.hbase.TableDescriptor;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
-import org.apache.hadoop.hbase.io.compress.Compression;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Implementation of the {@link HBaseDDLExecutor} for HBase version 1.0
  */
 public class DefaultHBase10DDLExecutor extends DefaultHBaseDDLExecutor {
 
-  private HColumnDescriptor getHColumnDesciptor(ColumnFamilyDescriptor descriptor) {
-    HColumnDescriptor hFamily = new HColumnDescriptor(descriptor.getName());
-    hFamily.setMaxVersions(descriptor.getMaxVersions());
-    hFamily.setCompressionType(Compression.Algorithm.valueOf(descriptor.getCompressionType().name()));
-    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(
-      descriptor.getBloomType().name()));
-    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
-      hFamily.setValue(property.getKey(), property.getValue());
-    }
-    return hFamily;
-  }
-
+  @Override
   public HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
-    TableName tableName = TableName.valueOf(descriptor.getNamespace(), descriptor.getName());
-    HTableDescriptor htd = new HTableDescriptor(tableName);
-    for (Map.Entry<String, ColumnFamilyDescriptor> family : descriptor.getFamilies().entrySet()) {
-      htd.addFamily(getHColumnDesciptor(family.getValue()));
-    }
-
-    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
-      CoprocessorDescriptor cpd = coprocessor.getValue();
-      try {
-        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
-      } catch (IOException e) {
-        LOG.error("Error adding coprocessor.", e);
-      }
-    }
-
-    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
-      // TODO: should not add coprocessor related properties since those were already be added
-      // using addCoprocessor call.
-      htd.setValue(property.getKey(), property.getValue());
-    }
-    return htd;
+    return HBase10TableDescriptorUtil.getHTableDescriptor(descriptor);
   }
 
+  @Override
   public TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
-    Set<ColumnFamilyDescriptor> families = new HashSet<>();
-    for (HColumnDescriptor family : descriptor.getColumnFamilies()) {
-      families.add(getColumnFamilyDescriptor(family));
-    }
-
-    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
-    coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
-
-    Map<String, String> properties = new HashMap<>();
-    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
-      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
-                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
-    }
-
-    // TODO: should add configurations as well
-    return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),
-                               descriptor.getTableName().getQualifierAsString(), families, coprocessors, properties);
-  }
-
-  private ColumnFamilyDescriptor getColumnFamilyDescriptor(HColumnDescriptor descriptor) {
-    String name = descriptor.getNameAsString();
-    int maxVersions = descriptor.getMaxVersions();
-    ColumnFamilyDescriptor.CompressionType compressionType
-      = ColumnFamilyDescriptor.CompressionType.valueOf(descriptor.getCompressionType().getName().toUpperCase());
-    ColumnFamilyDescriptor.BloomType bloomType
-      = ColumnFamilyDescriptor.BloomType.valueOf(descriptor.getBloomFilterType().name().toUpperCase());
-
-    Map<String, String> properties = new HashMap<>();
-    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
-      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
-                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
-    }
-    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+    return HBase10TableDescriptorUtil.getTableDescriptor(descriptor);
   }
 }

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableDescriptorUtil.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableDescriptorUtil.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
+import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
+import co.cask.cdap.spi.hbase.TableDescriptor;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.io.compress.Compression;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Provides utility methods for {@link TableDescriptor}.
+ */
+public class HBase10TableDescriptorUtil {
+
+  public static final Logger LOG = LoggerFactory.getLogger(HBase10TableDescriptorUtil.class);
+
+  private HBase10TableDescriptorUtil() {
+  }
+
+  private static HColumnDescriptor getHColumnDesciptor(ColumnFamilyDescriptor descriptor) {
+    HColumnDescriptor hFamily = new HColumnDescriptor(descriptor.getName());
+    hFamily.setMaxVersions(descriptor.getMaxVersions());
+    hFamily.setCompressionType(Compression.Algorithm.valueOf(descriptor.getCompressionType().name()));
+    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(
+      descriptor.getBloomType().name()));
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      hFamily.setValue(property.getKey(), property.getValue());
+    }
+    return hFamily;
+  }
+
+  public static HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
+    TableName tableName = TableName.valueOf(descriptor.getNamespace(), descriptor.getName());
+    HTableDescriptor htd = new HTableDescriptor(tableName);
+    for (Map.Entry<String, ColumnFamilyDescriptor> family : descriptor.getFamilies().entrySet()) {
+      htd.addFamily(getHColumnDesciptor(family.getValue()));
+    }
+
+    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
+      CoprocessorDescriptor cpd = coprocessor.getValue();
+      try {
+        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
+      } catch (IOException e) {
+        LOG.error("Error adding coprocessor.", e);
+      }
+    }
+
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      // TODO: should not add coprocessor related properties since those were already be added
+      // using addCoprocessor call.
+      htd.setValue(property.getKey(), property.getValue());
+    }
+    return htd;
+  }
+
+  public static TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
+    Set<ColumnFamilyDescriptor> families = new HashSet<>();
+    for (HColumnDescriptor family : descriptor.getColumnFamilies()) {
+      families.add(getColumnFamilyDescriptor(family));
+    }
+
+    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
+    coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+
+    // TODO: should add configurations as well
+    return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),
+                               descriptor.getTableName().getQualifierAsString(), families, coprocessors, properties);
+  }
+
+  private static ColumnFamilyDescriptor getColumnFamilyDescriptor(HColumnDescriptor descriptor) {
+    String name = descriptor.getNameAsString();
+    int maxVersions = descriptor.getMaxVersions();
+    ColumnFamilyDescriptor.CompressionType compressionType
+      = ColumnFamilyDescriptor.CompressionType.valueOf(descriptor.getCompressionType().getName().toUpperCase());
+    ColumnFamilyDescriptor.BloomType bloomType
+      = ColumnFamilyDescriptor.BloomType.valueOf(descriptor.getBloomFilterType().name().toUpperCase());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+  }
+}

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableUtil.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableUtil.java
@@ -107,8 +107,7 @@ public class HBase10TableUtil extends HBaseTableUtil {
     Preconditions.checkArgument(ddlExecutor != null, "HBaseDDLExecutor should not be null");
     Preconditions.checkArgument(tableDescriptor != null, "Table descriptor should not be null.");
     TableName tableName = tableDescriptor.getTableName();
-    // TODO This will be fixed in the next PR when we pass TableDescriptor to the modifyTable method.
-    TableDescriptor tbd = ((DefaultHBaseDDLExecutor) ddlExecutor).getTableDescriptor(tableDescriptor);
+    TableDescriptor tbd = HBase10TableDescriptorUtil.getTableDescriptor(tableDescriptor);
     ddlExecutor.modifyTable(tableName.getNamespaceAsString(), tableName.getQualifierAsString(), tbd);
   }
 

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase11DDLExecutor.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase11DDLExecutor.java
@@ -16,98 +16,22 @@
 
 package co.cask.cdap.data2.util.hbase;
 
-import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
-import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
 import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import co.cask.cdap.spi.hbase.TableDescriptor;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
-import org.apache.hadoop.hbase.io.compress.Compression;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Implementation of the {@link HBaseDDLExecutor} for HBase 1.1
  */
 public class DefaultHBase11DDLExecutor extends DefaultHBaseDDLExecutor {
 
-  private HColumnDescriptor getHColumnDesciptor(ColumnFamilyDescriptor descriptor) {
-    HColumnDescriptor hFamily = new HColumnDescriptor(descriptor.getName());
-    hFamily.setMaxVersions(descriptor.getMaxVersions());
-    hFamily.setCompressionType(Compression.Algorithm.valueOf(descriptor.getCompressionType().name()));
-    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(
-      descriptor.getBloomType().name()));
-    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
-      hFamily.setValue(property.getKey(), property.getValue());
-    }
-    return hFamily;
-  }
-
+  @Override
   public HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
-    TableName tableName = TableName.valueOf(descriptor.getNamespace(), descriptor.getName());
-    HTableDescriptor htd = new HTableDescriptor(tableName);
-    for (Map.Entry<String, ColumnFamilyDescriptor> family : descriptor.getFamilies().entrySet()) {
-      htd.addFamily(getHColumnDesciptor(family.getValue()));
-    }
-
-    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
-      CoprocessorDescriptor cpd = coprocessor.getValue();
-      try {
-        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
-      } catch (IOException e) {
-        LOG.error("Error adding coprocessor.", e);
-      }
-    }
-
-    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
-      // TODO: should not add coprocessor related properties since those were already be added
-      // using addCoprocessor call.
-      htd.setValue(property.getKey(), property.getValue());
-    }
-    return htd;
+    return HBase11TableDescriptorUtil.getHTableDescriptor(descriptor);
   }
 
+  @Override
   public TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
-    Set<ColumnFamilyDescriptor> families = new HashSet<>();
-    for (HColumnDescriptor family : descriptor.getColumnFamilies()) {
-      families.add(getColumnFamilyDescriptor(family));
-    }
-
-    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
-    coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
-
-    Map<String, String> properties = new HashMap<>();
-    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
-      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
-                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
-    }
-
-    // TODO: should add configurations as well
-    return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),
-                               descriptor.getTableName().getQualifierAsString(), families, coprocessors, properties);
-  }
-
-  private ColumnFamilyDescriptor getColumnFamilyDescriptor(HColumnDescriptor descriptor) {
-    String name = descriptor.getNameAsString();
-    int maxVersions = descriptor.getMaxVersions();
-    ColumnFamilyDescriptor.CompressionType compressionType
-      = ColumnFamilyDescriptor.CompressionType.valueOf(descriptor.getCompressionType().getName().toUpperCase());
-    ColumnFamilyDescriptor.BloomType bloomType
-      = ColumnFamilyDescriptor.BloomType.valueOf(descriptor.getBloomFilterType().name().toUpperCase());
-
-    Map<String, String> properties = new HashMap<>();
-    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
-      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
-                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
-    }
-    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+    return HBase11TableDescriptorUtil.getTableDescriptor(descriptor);
   }
 }

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/HBase11TableDescriptorUtil.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/HBase11TableDescriptorUtil.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
+import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
+import co.cask.cdap.spi.hbase.TableDescriptor;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.io.compress.Compression;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Provides utility methods for {@link TableDescriptor}.
+ */
+public class HBase11TableDescriptorUtil {
+
+  public static final Logger LOG = LoggerFactory.getLogger(HBase11TableDescriptorUtil.class);
+
+  private HBase11TableDescriptorUtil() {
+  }
+
+  private static HColumnDescriptor getHColumnDesciptor(ColumnFamilyDescriptor descriptor) {
+    HColumnDescriptor hFamily = new HColumnDescriptor(descriptor.getName());
+    hFamily.setMaxVersions(descriptor.getMaxVersions());
+    hFamily.setCompressionType(Compression.Algorithm.valueOf(descriptor.getCompressionType().name()));
+    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(
+      descriptor.getBloomType().name()));
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      hFamily.setValue(property.getKey(), property.getValue());
+    }
+    return hFamily;
+  }
+
+  public static HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
+    TableName tableName = TableName.valueOf(descriptor.getNamespace(), descriptor.getName());
+    HTableDescriptor htd = new HTableDescriptor(tableName);
+    for (Map.Entry<String, ColumnFamilyDescriptor> family : descriptor.getFamilies().entrySet()) {
+      htd.addFamily(getHColumnDesciptor(family.getValue()));
+    }
+
+    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
+      CoprocessorDescriptor cpd = coprocessor.getValue();
+      try {
+        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
+      } catch (IOException e) {
+        LOG.error("Error adding coprocessor.", e);
+      }
+    }
+
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      // TODO: should not add coprocessor related properties since those were already be added
+      // using addCoprocessor call.
+      htd.setValue(property.getKey(), property.getValue());
+    }
+    return htd;
+  }
+
+  public static TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
+    Set<ColumnFamilyDescriptor> families = new HashSet<>();
+    for (HColumnDescriptor family : descriptor.getColumnFamilies()) {
+      families.add(getColumnFamilyDescriptor(family));
+    }
+
+    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
+    coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+
+    // TODO: should add configurations as well
+    return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),
+                               descriptor.getTableName().getQualifierAsString(), families, coprocessors, properties);
+  }
+
+  private static ColumnFamilyDescriptor getColumnFamilyDescriptor(HColumnDescriptor descriptor) {
+    String name = descriptor.getNameAsString();
+    int maxVersions = descriptor.getMaxVersions();
+    ColumnFamilyDescriptor.CompressionType compressionType
+      = ColumnFamilyDescriptor.CompressionType.valueOf(descriptor.getCompressionType().getName().toUpperCase());
+    ColumnFamilyDescriptor.BloomType bloomType
+      = ColumnFamilyDescriptor.BloomType.valueOf(descriptor.getBloomFilterType().name().toUpperCase());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+  }
+}

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/HBase11TableUtil.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/HBase11TableUtil.java
@@ -107,8 +107,7 @@ public class HBase11TableUtil extends HBaseTableUtil {
     Preconditions.checkArgument(ddlExecutor != null, "HBaseDDLExecutor should not be null");
     Preconditions.checkArgument(tableDescriptor != null, "Table descriptor should not be null.");
     TableName tableName = tableDescriptor.getTableName();
-    // TODO This will be fixed in the next PR when we pass TableDescriptor to the modifyTable method.
-    TableDescriptor tbd = ((DefaultHBaseDDLExecutor) ddlExecutor).getTableDescriptor(tableDescriptor);
+    TableDescriptor tbd = HBase11TableDescriptorUtil.getTableDescriptor(tableDescriptor);
     ddlExecutor.modifyTable(tableName.getNamespaceAsString(), tableName.getQualifierAsString(), tbd);
   }
 

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase12CDH570DDLExecutor.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase12CDH570DDLExecutor.java
@@ -16,98 +16,21 @@
 
 package co.cask.cdap.data2.util.hbase;
 
-import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
-import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
 import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import co.cask.cdap.spi.hbase.TableDescriptor;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
-import org.apache.hadoop.hbase.io.compress.Compression;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Implementation of the {@link HBaseDDLExecutor} for HBase 1.2 CDH 5.7.0
  */
 public class DefaultHBase12CDH570DDLExecutor extends DefaultHBaseDDLExecutor {
-
-  private HColumnDescriptor getHColumnDesciptor(ColumnFamilyDescriptor descriptor) {
-    HColumnDescriptor hFamily = new HColumnDescriptor(descriptor.getName());
-    hFamily.setMaxVersions(descriptor.getMaxVersions());
-    hFamily.setCompressionType(Compression.Algorithm.valueOf(descriptor.getCompressionType().name()));
-    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(
-      descriptor.getBloomType().name()));
-    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
-      hFamily.setValue(property.getKey(), property.getValue());
-    }
-    return hFamily;
-  }
-
+  @Override
   public HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
-    TableName tableName = TableName.valueOf(descriptor.getNamespace(), descriptor.getName());
-    HTableDescriptor htd = new HTableDescriptor(tableName);
-    for (Map.Entry<String, ColumnFamilyDescriptor> family : descriptor.getFamilies().entrySet()) {
-      htd.addFamily(getHColumnDesciptor(family.getValue()));
-    }
-
-    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
-      CoprocessorDescriptor cpd = coprocessor.getValue();
-      try {
-        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
-      } catch (IOException e) {
-        LOG.error("Error adding coprocessor.", e);
-      }
-    }
-
-    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
-      // TODO: should not add coprocessor related properties since those were already be added
-      // using addCoprocessor call.
-      htd.setValue(property.getKey(), property.getValue());
-    }
-    return htd;
+    return HBase12CDH570TableDescriptorUtil.getHTableDescriptor(descriptor);
   }
 
+  @Override
   public TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
-    Set<ColumnFamilyDescriptor> families = new HashSet<>();
-    for (HColumnDescriptor family : descriptor.getColumnFamilies()) {
-      families.add(getColumnFamilyDescriptor(family));
-    }
-
-    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
-    coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
-
-    Map<String, String> properties = new HashMap<>();
-    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
-      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
-                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
-    }
-
-    // TODO: should add configurations as well
-    return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),
-                               descriptor.getTableName().getQualifierAsString(), families, coprocessors, properties);
-  }
-
-  private ColumnFamilyDescriptor getColumnFamilyDescriptor(HColumnDescriptor descriptor) {
-    String name = descriptor.getNameAsString();
-    int maxVersions = descriptor.getMaxVersions();
-    ColumnFamilyDescriptor.CompressionType compressionType
-      = ColumnFamilyDescriptor.CompressionType.valueOf(descriptor.getCompressionType().getName().toUpperCase());
-    ColumnFamilyDescriptor.BloomType bloomType
-      = ColumnFamilyDescriptor.BloomType.valueOf(descriptor.getBloomFilterType().name().toUpperCase());
-
-    Map<String, String> properties = new HashMap<>();
-    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
-      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
-                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
-    }
-    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+    return HBase12CDH570TableDescriptorUtil.getTableDescriptor(descriptor);
   }
 }

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570TableDescriptorUtil.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570TableDescriptorUtil.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
+import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
+import co.cask.cdap.spi.hbase.TableDescriptor;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.io.compress.Compression;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Provides utility methods for {@link TableDescriptor}.
+ */
+public class HBase12CDH570TableDescriptorUtil {
+
+  public static final Logger LOG = LoggerFactory.getLogger(HBase12CDH570TableDescriptorUtil.class);
+
+  private HBase12CDH570TableDescriptorUtil() {
+  }
+
+  private static HColumnDescriptor getHColumnDesciptor(ColumnFamilyDescriptor descriptor) {
+    HColumnDescriptor hFamily = new HColumnDescriptor(descriptor.getName());
+    hFamily.setMaxVersions(descriptor.getMaxVersions());
+    hFamily.setCompressionType(Compression.Algorithm.valueOf(descriptor.getCompressionType().name()));
+    hFamily.setBloomFilterType(org.apache.hadoop.hbase.regionserver.BloomType.valueOf(
+      descriptor.getBloomType().name()));
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      hFamily.setValue(property.getKey(), property.getValue());
+    }
+    return hFamily;
+  }
+
+  public static HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
+    TableName tableName = TableName.valueOf(descriptor.getNamespace(), descriptor.getName());
+    HTableDescriptor htd = new HTableDescriptor(tableName);
+    for (Map.Entry<String, ColumnFamilyDescriptor> family : descriptor.getFamilies().entrySet()) {
+      htd.addFamily(getHColumnDesciptor(family.getValue()));
+    }
+
+    for (Map.Entry<String, CoprocessorDescriptor> coprocessor : descriptor.getCoprocessors().entrySet()) {
+      CoprocessorDescriptor cpd = coprocessor.getValue();
+      try {
+        htd.addCoprocessor(cpd.getClassName(), new Path(cpd.getPath()), cpd.getPriority(), cpd.getProperties());
+      } catch (IOException e) {
+        LOG.error("Error adding coprocessor.", e);
+      }
+    }
+
+    for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
+      // TODO: should not add coprocessor related properties since those were already be added
+      // using addCoprocessor call.
+      htd.setValue(property.getKey(), property.getValue());
+    }
+    return htd;
+  }
+
+  public static TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
+    Set<ColumnFamilyDescriptor> families = new HashSet<>();
+    for (HColumnDescriptor family : descriptor.getColumnFamilies()) {
+      families.add(getColumnFamilyDescriptor(family));
+    }
+
+    Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
+    coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+
+    // TODO: should add configurations as well
+    return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),
+                               descriptor.getTableName().getQualifierAsString(), families, coprocessors, properties);
+  }
+
+  private static ColumnFamilyDescriptor getColumnFamilyDescriptor(HColumnDescriptor descriptor) {
+    String name = descriptor.getNameAsString();
+    int maxVersions = descriptor.getMaxVersions();
+    ColumnFamilyDescriptor.CompressionType compressionType
+      = ColumnFamilyDescriptor.CompressionType.valueOf(descriptor.getCompressionType().getName().toUpperCase());
+    ColumnFamilyDescriptor.BloomType bloomType
+      = ColumnFamilyDescriptor.BloomType.valueOf(descriptor.getBloomFilterType().name().toUpperCase());
+
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
+      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
+                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
+    }
+    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+  }
+}

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570TableUtil.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570TableUtil.java
@@ -107,8 +107,7 @@ public class HBase12CDH570TableUtil extends HBaseTableUtil {
     Preconditions.checkArgument(ddlExecutor != null, "HBaseDDLExecutor should not be null");
     Preconditions.checkArgument(tableDescriptor != null, "Table descriptor should not be null.");
     TableName tableName = tableDescriptor.getTableName();
-    // TODO This will be fixed in the next PR when we pass TableDescriptor to the modifyTable method.
-    TableDescriptor tbd = ((DefaultHBaseDDLExecutor) ddlExecutor).getTableDescriptor(tableDescriptor);
+    TableDescriptor tbd = HBase12CDH570TableDescriptorUtil.getTableDescriptor(tableDescriptor);
     ddlExecutor.modifyTable(tableName.getNamespaceAsString(), tableName.getQualifierAsString(), tbd);
   }
 

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/ColumnFamilyDescriptorBuilder.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/ColumnFamilyDescriptorBuilder.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Builder for {@link ColumnFamilyDescriptor}.
+ */
+public class ColumnFamilyDescriptorBuilder {
+  private final String name;
+  private final Map<String, String> properties;
+
+  private int maxVersions;
+  private ColumnFamilyDescriptor.CompressionType compressionType;
+  private ColumnFamilyDescriptor.BloomType bloomType;
+
+  public ColumnFamilyDescriptorBuilder(String name) {
+    this.name = name;
+    this.properties = new HashMap<>();
+
+    // Default maxVersions is 1
+    this.maxVersions = 1;
+    // Default compression type
+    this.compressionType = ColumnFamilyDescriptor.CompressionType.SNAPPY;
+    // Default bloom type
+    this.bloomType = ColumnFamilyDescriptor.BloomType.ROW;
+  }
+
+  public ColumnFamilyDescriptorBuilder setMaxVersions(int n) {
+    this.maxVersions = n;
+    return this;
+  }
+
+  public ColumnFamilyDescriptorBuilder setCompressionType(ColumnFamilyDescriptor.CompressionType compressionType) {
+    this.compressionType = compressionType;
+    return this;
+  }
+
+  public ColumnFamilyDescriptorBuilder setBloomType(ColumnFamilyDescriptor.BloomType bloomType) {
+    this.bloomType = bloomType;
+    return this;
+  }
+
+  public ColumnFamilyDescriptorBuilder addProperty(String key, String value) {
+    this.properties.put(key, value);
+    return this;
+  }
+
+  public ColumnFamilyDescriptor build() {
+    return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
+  }
+}

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBaseDDLExecutor.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBaseDDLExecutor.java
@@ -107,9 +107,9 @@ public abstract class DefaultHBaseDDLExecutor implements HBaseDDLExecutor {
     }
   }
 
-  public abstract HTableDescriptor getHTableDescriptor(TableDescriptor descriptor);
+  protected abstract HTableDescriptor getHTableDescriptor(TableDescriptor descriptor);
 
-  public abstract TableDescriptor getTableDescriptor(HTableDescriptor descriptor);
+  protected abstract TableDescriptor getTableDescriptor(HTableDescriptor descriptor);
 
   @Override
   public void createTableIfNotExists(TableDescriptor descriptor, @Nullable byte[][] splitKeys)
@@ -136,7 +136,7 @@ public abstract class DefaultHBaseDDLExecutor implements HBaseDDLExecutor {
       long sleepTime = TimeUnit.MILLISECONDS.toNanos(5000L) / 10;
       sleepTime = sleepTime <= 0 ? 1 : sleepTime;
       do {
-        if (admin.tableExists(descriptor.getName())) {
+        if (admin.tableExists(htd.getName())) {
           LOG.info("Table '{}' exists now. Assuming that another process concurrently created it.",
                    Bytes.toString(htd.getName()));
           return;

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/TableDescriptorBuilder.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/TableDescriptorBuilder.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.util.hbase;
+
+import co.cask.cdap.spi.hbase.ColumnFamilyDescriptor;
+import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
+import co.cask.cdap.spi.hbase.TableDescriptor;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Builder for {@link TableDescriptor}.
+ */
+public class TableDescriptorBuilder {
+  private final String namespace;
+  private final String tableName;
+
+  private Set<ColumnFamilyDescriptor> families = new HashSet<>();
+  private Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
+  private final Map<String, String> properties;
+
+  public TableDescriptorBuilder(String namespace, String tableName) {
+    this.namespace = namespace;
+    this.tableName = tableName;
+    this.properties = new HashMap<>();
+  }
+
+  public TableDescriptorBuilder(TableDescriptor descriptor) {
+    this.namespace = descriptor.getNamespace();
+    this.tableName = descriptor.getName();
+    this.properties = descriptor.getProperties();
+    this.families.addAll(descriptor.getFamilies().values());
+    this.coprocessors.addAll(descriptor.getCoprocessors().values());
+  }
+
+  public TableDescriptorBuilder addCoprocessor(CoprocessorDescriptor coprocessor) {
+    this.coprocessors.add(coprocessor);
+    return this;
+  }
+
+  public TableDescriptorBuilder addColumnFamily(ColumnFamilyDescriptor family) {
+    this.families.add(family);
+    return this;
+  }
+
+  public TableDescriptorBuilder addProperty(String key, String value) {
+    this.properties.put(key, value);
+    return this;
+  }
+
+  public TableDescriptor build() {
+    return new TableDescriptor(namespace, tableName, families, coprocessors, properties);
+  }
+}
+
+

--- a/cdap-hbase-spi/src/main/java/co/cask/cdap/spi/hbase/ColumnFamilyDescriptor.java
+++ b/cdap-hbase-spi/src/main/java/co/cask/cdap/spi/hbase/ColumnFamilyDescriptor.java
@@ -17,11 +17,10 @@
 package co.cask.cdap.spi.hbase;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Descripbes HBase table column family.
+ * Describes HBase table column family.
  */
 public final class ColumnFamilyDescriptor {
 
@@ -73,53 +72,5 @@ public final class ColumnFamilyDescriptor {
 
   public Map<String, String> getProperties() {
     return properties;
-  }
-
-  /**
-   * Builder for {@link ColumnFamilyDescriptor}.
-   */
-  public static class Builder {
-    private final String name;
-    private final Map<String, String> properties;
-
-    private int maxVersions;
-    private CompressionType compressionType;
-    private BloomType bloomType;
-
-    public Builder(String name) {
-      this.name = name;
-      this.properties = new HashMap<>();
-
-      // Default maxVersions is 1
-      this.maxVersions = 1;
-      // Default compression type
-      this.compressionType = CompressionType.SNAPPY;
-      // Default bloom type
-      this.bloomType = BloomType.ROW;
-    }
-
-    public Builder setMaxVersions(int n) {
-      this.maxVersions = n;
-      return this;
-    }
-
-    public Builder setCompressionType(CompressionType compressionType) {
-      this.compressionType = compressionType;
-      return this;
-    }
-
-    public Builder setBloomType(BloomType bloomType) {
-      this.bloomType = bloomType;
-      return this;
-    }
-
-    public Builder addProperty(String key, String value) {
-      this.properties.put(key, value);
-      return this;
-    }
-
-    public ColumnFamilyDescriptor build() {
-      return new ColumnFamilyDescriptor(name, maxVersions, compressionType, bloomType, properties);
-    }
   }
 }

--- a/cdap-hbase-spi/src/main/java/co/cask/cdap/spi/hbase/TableDescriptor.java
+++ b/cdap-hbase-spi/src/main/java/co/cask/cdap/spi/hbase/TableDescriptor.java
@@ -18,7 +18,6 @@ package co.cask.cdap.spi.hbase;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -70,44 +69,5 @@ public final class TableDescriptor {
 
   public Map<String, String> getProperties() {
     return properties;
-  }
-
-  /**
-   * A Builder to construct TableDescriptor.
-   */
-  public static class Builder {
-    private final String namespace;
-    private final String tableName;
-
-    private Set<ColumnFamilyDescriptor> families = new HashSet<>();
-    private Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
-    private final Map<String, String> properties;
-
-    // TODO should we call tableName as qualifier
-    // TODO should caller always set prefix and cdap version in properties
-    public Builder(String namespace, String tableName) {
-      this.namespace = namespace;
-      this.tableName = tableName;
-      this.properties = new HashMap<>();
-    }
-
-    public Builder addCoprocessor(CoprocessorDescriptor coprocessor) {
-      this.coprocessors.add(coprocessor);
-      return this;
-    }
-
-    public Builder addColumnFamily(ColumnFamilyDescriptor family) {
-      this.families.add(family);
-      return this;
-    }
-
-    public Builder addProperty(String key, String value) {
-      this.properties.put(key, value);
-      return this;
-    }
-
-    public TableDescriptor build() {
-      return new TableDescriptor(namespace, tableName, families, coprocessors, properties);
-    }
   }
 }

--- a/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseMessageTableTestRun.java
+++ b/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseMessageTableTestRun.java
@@ -58,7 +58,6 @@ public class HBaseMessageTableTestRun extends MessageTableTest {
   private static final CConfiguration cConf = CConfiguration.create();
 
   private static Configuration hConf;
-  private static HBaseAdmin hBaseAdmin;
   private static HBaseTableUtil tableUtil;
   private static TableFactory tableFactory;
   private static HBaseDDLExecutor ddlExecutor;
@@ -66,19 +65,17 @@ public class HBaseMessageTableTestRun extends MessageTableTest {
   @BeforeClass
   public static void setupBeforeClass() throws Exception {
     hConf = HBASE_TEST_BASE.getConfiguration();
+    hConf.set(HBaseTableUtil.CFG_HBASE_TABLE_COMPRESSION, HBaseTableUtil.CompressionType.NONE.name());
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
     cConf.set(Constants.CFG_HDFS_NAMESPACE, cConf.get(Constants.CFG_LOCAL_DATA_DIR));
     cConf.set(Constants.CFG_HDFS_USER, System.getProperty("user.name"));
 
-    hBaseAdmin = HBASE_TEST_BASE.getHBaseAdmin();
-    hBaseAdmin.getConfiguration().set(HBaseTableUtil.CFG_HBASE_TABLE_COMPRESSION,
-                                      HBaseTableUtil.CompressionType.NONE.name());
     tableUtil = new HBaseTableUtilFactory(cConf).get();
-    ddlExecutor = new HBaseDDLExecutorFactory(cConf, hBaseAdmin.getConfiguration()).get();
+    ddlExecutor = new HBaseDDLExecutorFactory(cConf, hConf).get();
     ddlExecutor.createNamespaceIfNotExists(tableUtil.getHBaseNamespace(NamespaceId.SYSTEM));
 
     LocationFactory locationFactory = getInjector().getInstance(LocationFactory.class);
-    tableFactory = new HBaseTableFactory(cConf, hBaseAdmin.getConfiguration(), tableUtil, locationFactory);
+    tableFactory = new HBaseTableFactory(cConf, hConf, tableUtil, locationFactory);
 
     ConfigurationTable configTable = new ConfigurationTable(hConf);
     configTable.write(ConfigurationTable.Type.DEFAULT, cConf);
@@ -89,7 +86,6 @@ public class HBaseMessageTableTestRun extends MessageTableTest {
     tableUtil.deleteAllInNamespace(ddlExecutor, tableUtil.getHBaseNamespace(NamespaceId.SYSTEM));
     ddlExecutor.deleteNamespaceIfExists(tableUtil.getHBaseNamespace(NamespaceId.SYSTEM));
     ddlExecutor.close();
-    hBaseAdmin.close();
   }
 
   @Override

--- a/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseMetadataTableTestRun.java
+++ b/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseMetadataTableTestRun.java
@@ -32,7 +32,6 @@ import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.twill.filesystem.LocationFactory;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -51,7 +50,6 @@ public class HBaseMetadataTableTestRun extends MetadataTableTest {
   private static final CConfiguration cConf = CConfiguration.create();
 
   private static Configuration hConf;
-  private static HBaseAdmin hBaseAdmin;
   private static HBaseTableUtil tableUtil;
   private static TableFactory tableFactory;
   private static HBaseDDLExecutor ddlExecutor;
@@ -59,15 +57,14 @@ public class HBaseMetadataTableTestRun extends MetadataTableTest {
   @BeforeClass
   public static void setupBeforeClass() throws Exception {
     hConf = HBASE_TEST_BASE.getConfiguration();
-    hBaseAdmin = HBASE_TEST_BASE.getHBaseAdmin();
-    hBaseAdmin.getConfiguration().set(HBaseTableUtil.CFG_HBASE_TABLE_COMPRESSION,
-                                      HBaseTableUtil.CompressionType.NONE.name());
+    hConf.set(HBaseTableUtil.CFG_HBASE_TABLE_COMPRESSION, HBaseTableUtil.CompressionType.NONE.name());
+
     tableUtil = new HBaseTableUtilFactory(cConf).get();
-    ddlExecutor = new HBaseDDLExecutorFactory(cConf, hBaseAdmin.getConfiguration()).get();
+    ddlExecutor = new HBaseDDLExecutorFactory(cConf, hConf).get();
     ddlExecutor.createNamespaceIfNotExists(tableUtil.getHBaseNamespace(NamespaceId.SYSTEM));
 
     LocationFactory locationFactory = getInjector().getInstance(LocationFactory.class);
-    tableFactory = new HBaseTableFactory(cConf, hBaseAdmin.getConfiguration(), tableUtil, locationFactory);
+    tableFactory = new HBaseTableFactory(cConf, hConf, tableUtil, locationFactory);
   }
 
   @AfterClass
@@ -75,7 +72,6 @@ public class HBaseMetadataTableTestRun extends MetadataTableTest {
     tableUtil.deleteAllInNamespace(ddlExecutor, tableUtil.getHBaseNamespace(NamespaceId.SYSTEM));
     ddlExecutor.deleteNamespaceIfExists(tableUtil.getHBaseNamespace(NamespaceId.SYSTEM));
     ddlExecutor.close();
-    hBaseAdmin.close();
   }
 
   @Override

--- a/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseTableCoprocessorTestRun.java
+++ b/cdap-tms-tests/src/test/java/co/cask/cdap/messaging/store/hbase/HBaseTableCoprocessorTestRun.java
@@ -111,6 +111,8 @@ public class HBaseTableCoprocessorTestRun extends DataCleanupTest {
   @BeforeClass
   public static void setupBeforeClass() throws Exception {
     hConf = HBASE_TEST_BASE.getConfiguration();
+    hConf.set(HBaseTableUtil.CFG_HBASE_TABLE_COMPRESSION, HBaseTableUtil.CompressionType.NONE.name());
+
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
     cConf.set(Constants.CFG_HDFS_NAMESPACE, cConf.get(Constants.CFG_LOCAL_DATA_DIR));
     cConf.set(Constants.CFG_HDFS_USER, System.getProperty("user.name"));
@@ -121,7 +123,7 @@ public class HBaseTableCoprocessorTestRun extends DataCleanupTest {
     hBaseAdmin.getConfiguration().set(HBaseTableUtil.CFG_HBASE_TABLE_COMPRESSION,
                                       HBaseTableUtil.CompressionType.NONE.name());
     tableUtil = new HBaseTableUtilFactory(cConf).get();
-    ddlExecutor = new HBaseDDLExecutorFactory(cConf, hBaseAdmin.getConfiguration()).get();
+    ddlExecutor = new HBaseDDLExecutorFactory(cConf, hConf).get();
     ddlExecutor.createNamespaceIfNotExists(tableUtil.getHBaseNamespace(NamespaceId.SYSTEM));
 
     LocationFactory locationFactory = getInjector().getInstance(LocationFactory.class);


### PR DESCRIPTION
1. Added HBase version specific util classes to help conversion between `HTableDescriptor` and `TableDescriptor`.
2. `HBaseTableUtil.createTableIfNotExists` now takes `TableDescriptor` instance instead of `HTableDescriptor`
3. `HBaseTableUtil.modifyTable` still takes `HTableDescriptor`, however implementation converts it to `TableDescriptor` before calling `HBaseDDLExecutor`.

 Ideally `HBaseTableUtil.modifyTable` should accept `TableDescriptor` but this involves some risky refactoring.