### PR TITLE
CDAP-7280 Update to verification information

### DIFF
--- a/cdap-docs/admin-manual/source/operations/index.rst
+++ b/cdap-docs/admin-manual/source/operations/index.rst
@@ -82,27 +82,55 @@ Command Line Interface. See :ref:`reference:cli` in the
 .. highlight:: console
 
 Administrators can check the health of various services in the system.
-(In these examples, substitute for ``<host>`` the host name or IP address of the CDAP server.)
+(In these examples, substitute for ``<host>`` the host name or IP address of the CDAP server.
+Substitute the correct ports if they have been changed from the default values shown.)
 
-- To retrieve the **health check of the CDAP UI**, make a GET request to the URI::
+- To retrieve the **health check of the CDAP UI**, make a GET request to the URI (at the
+  ``dashboard.bind.port``)::
 
     http://<host>:9999/status
+  
+  Such as (for Standalone CDAP):
+   
+  .. tabbed-parsed-literal::
 
-- To retrieve the **health check of the CDAP Router**, make a GET request to the URI::
+    $ curl -w"\n" -X GET "http://localhost:9999/status"
+
+
+- To retrieve the **health check of the CDAP Router**, make a GET request to the URI (at
+  the ``router.bind.port``)::
 
     http://<host>:10000/status
 
+  Such as (for Standalone CDAP):
+   
+  .. tabbed-parsed-literal::
+
+    $ curl -w"\n" -X GET "http://localhost:10000/status"
+
 - To retrieve the **health check of the CDAP Authentication Server**, make a GET request to
-  the URI::
+  the URI (at the ``security.auth.server.bind.port``)::
   
     http://<host>:10009/status
 
-On success, the calls return a valid HTTP response with a 200 code.
+  Such as (for Standalone CDAP):
+   
+  .. tabbed-parsed-literal::
+
+    $ curl -w"\n" -X GET "http://localhost:10009/status"
+
+On success, these calls return a valid HTTP response with a 200 code.
 
 - To retrieve the **health check of all the services running in YARN**, make a GET request
-  to the URI::
+  to the URI (at the ``router.bind.port``)::
   
     http://<host>:10000/v3/system/services
+
+  Such as (for Standalone CDAP):
+   
+  .. tabbed-parsed-literal::
+
+    $ curl -w"\n" -X GET "http://localhost:10000/v3/system/services"
 
   On success, the call returns a JSON string with component names and their corresponding 
   statuses (reformatted to fit)::

--- a/cdap-docs/admin-manual/source/operations/index.rst
+++ b/cdap-docs/admin-manual/source/operations/index.rst
@@ -81,16 +81,17 @@ Command Line Interface. See :ref:`reference:cli` in the
 
 .. highlight:: console
 
-Administrators can check the health of various services in the system.
-(In these examples, substitute for ``<host>`` the host name or IP address of the CDAP server.
-Substitute the correct ports if they have been changed from the default values shown.)
+Administrators can check the health of various services in the system. (In these examples,
+substitute for ``<host>`` the host name or IP address of the CDAP server. Substitute the
+correct ports if they have been changed from the default values shown.) On success, these
+calls return a valid HTTP response with a 200 code.
 
 - To retrieve the **health check of the CDAP UI**, make a GET request to the URI (at the
   ``dashboard.bind.port``)::
 
     http://<host>:9999/status
   
-  Such as (for Standalone CDAP):
+  Such as (for the Standalone CDAP):
    
   .. tabbed-parsed-literal::
 
@@ -102,7 +103,7 @@ Substitute the correct ports if they have been changed from the default values s
 
     http://<host>:10000/status
 
-  Such as (for Standalone CDAP):
+  Such as (for the Standalone CDAP):
    
   .. tabbed-parsed-literal::
 
@@ -113,20 +114,18 @@ Substitute the correct ports if they have been changed from the default values s
   
     http://<host>:10009/status
 
-  Such as (for Standalone CDAP):
+  Such as (for the Standalone CDAP):
    
   .. tabbed-parsed-literal::
 
     $ curl -w"\n" -X GET "http://localhost:10009/status"
 
-On success, these calls return a valid HTTP response with a 200 code.
-
-- To retrieve the **health check of all the services running in YARN**, make a GET request
+- To retrieve a **list of health checks of all the services running in YARN**, make a GET request
   to the URI (at the ``router.bind.port``)::
   
     http://<host>:10000/v3/system/services
 
-  Such as (for Standalone CDAP):
+  Such as (for the Standalone CDAP):
    
   .. tabbed-parsed-literal::
 
@@ -151,3 +150,28 @@ On success, these calls return a valid HTTP response with a 200 code.
       ingestion.","status":"OK","logs":"OK","min":1,"max":1,"requested":1,"provisioned":1},
      {"name":"transaction","description":"Service that maintains transaction
       states.","status":"OK","logs":"NOTOK","min":1,"max":1,"requested":1,"provisioned":1}]
+
+- To retrieve a **health check of all the services running in YARN**, make a GET request
+  to the URI (at the ``router.bind.port``)::
+  
+    http://<host>:10000/v3/system/services/status
+
+  Such as (for the Standalone CDAP):
+   
+  .. tabbed-parsed-literal::
+
+    $ curl -w"\n" -X GET "http://localhost:10000/v3/system/services/status"
+
+- To retrieve a **health check of a particular service running in YARN**, make a GET request
+  to the URI (at the ``router.bind.port``), substituting for ``<service-id>``, as 
+  shown in the :ref:`Monitor HTTP RESTful API <checking-the-status-of-a-system-service>`::
+  
+    http://<host>:10000/v3/system/services/<service-id>/status
+
+  Such as (for the metrics service of the Standalone CDAP):
+   
+  .. tabbed-parsed-literal::
+
+    $ curl -w"\n" -X GET "http://localhost:10000/v3/system/services/metrics/status"
+
+

--- a/cdap-docs/admin-manual/source/operations/index.rst
+++ b/cdap-docs/admin-manual/source/operations/index.rst
@@ -120,7 +120,7 @@ calls return a valid HTTP response with a 200 code.
 
     $ curl -w"\n" -X GET "http://localhost:10009/status"
 
-- To retrieve a **list of health checks of all the services running in YARN**, make a GET request
+- To retrieve a **list of health checks of all the CDAP system services running in YARN**, make a GET request
   to the URI (at the ``router.bind.port``)::
   
     http://<host>:10000/v3/system/services

--- a/cdap-docs/admin-manual/source/operations/index.rst
+++ b/cdap-docs/admin-manual/source/operations/index.rst
@@ -131,8 +131,8 @@ calls return a valid HTTP response with a 200 code.
 
     $ curl -w"\n" -X GET "http://localhost:10000/v3/system/services"
 
-  On success, the call returns a JSON string with component names and their corresponding 
-  statuses (reformatted to fit)::
+  On success, the call returns a JSON string with component names, their corresponding 
+  statuses, and details of the services (reformatted to fit)::
   
     [{"name":"appfabric","description":"Service for managing application
       lifecycle.","status":"OK","logs":"OK","min":1,"max":1,"requested":1,"provisioned":1},
@@ -151,7 +151,7 @@ calls return a valid HTTP response with a 200 code.
      {"name":"transaction","description":"Service that maintains transaction
       states.","status":"OK","logs":"NOTOK","min":1,"max":1,"requested":1,"provisioned":1}]
 
-- To retrieve a **health check of all the services running in YARN**, make a GET request
+- To retrieve a **health check of all the CDAP system services running in YARN**, make a GET request
   to the URI (at the ``router.bind.port``)::
   
     http://<host>:10000/v3/system/services/status
@@ -162,7 +162,7 @@ calls return a valid HTTP response with a 200 code.
 
     $ curl -w"\n" -X GET "http://localhost:10000/v3/system/services/status"
 
-- To retrieve a **health check of a particular service running in YARN**, make a GET request
+- To retrieve a **health check of a particular CDAP system service running in YARN**, make a GET request
   to the URI (at the ``router.bind.port``), substituting for ``<service-id>``, as 
   shown in the :ref:`Monitor HTTP RESTful API <checking-the-status-of-a-system-service>`::
   

--- a/cdap-docs/reference-manual/source/http-restful-api/monitor.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/monitor.rst
@@ -73,6 +73,7 @@ To check the status of all the CDAP system services, use::
    * - ``200 OK``
      - The event successfully called the method, and the body contains the results
 
+.. _checking-the-status-of-a-system-service:
 
 Checking the Status of a System Service
 =======================================


### PR DESCRIPTION
Update to the verification step information.

Fix for https://issues.cask.co/browse/CDAP-7280

Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB246-4 (passes)

Page of interest: http://builds.cask.co/artifact/CDAP-DQB246/shared/build-4/Docs-HTML/html/admin-manual/verification.html