### PR TITLE
CDAP-8036 add a fat coprocessor jar to hbase compat packages

### DIFF
--- a/BUILD.rst
+++ b/BUILD.rst
@@ -84,7 +84,7 @@ Standalone and Distributed CDAP
 - Build distributions (rpm, deb, tgz)::
 
     MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean package -DskipTests \
-    -P examples,templates,dist,coprocessors,release,rpm-prepare,rpm,deb-prepare,deb,tgz,unit-tests
+    -P examples,templates,dist,release,rpm-prepare,rpm,deb-prepare,deb,tgz,unit-tests
 
 - Build Cloudera Manager parcel::
 

--- a/BUILD.rst
+++ b/BUILD.rst
@@ -84,7 +84,7 @@ Standalone and Distributed CDAP
 - Build distributions (rpm, deb, tgz)::
 
     MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m" mvn clean package -DskipTests \
-    -P examples,templates,dist,release,rpm-prepare,rpm,deb-prepare,deb,tgz,unit-tests
+    -P examples,templates,dist,coprocessors,release,rpm-prepare,rpm,deb-prepare,deb,tgz,unit-tests
 
 - Build Cloudera Manager parcel::
 

--- a/cdap-hbase-compat-0.96/pom.xml
+++ b/cdap-hbase-compat-0.96/pom.xml
@@ -203,6 +203,22 @@
     </profile>
 
     <profile>
+      <id>coprocessors</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>rpm-prepare</id>
       <build>
         <plugins>

--- a/cdap-hbase-compat-0.96/pom.xml
+++ b/cdap-hbase-compat-0.96/pom.xml
@@ -195,24 +195,68 @@
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-resources-plugin</artifactId>
-            <version>2.6</version>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>coprocessors</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>hbase-compat-fat-jar</id>
+                <phase>package</phase>
+                <configuration>
+                  <createDependencyReducedPom>false</createDependencyReducedPom>
+                  <minimizeJar>true</minimizeJar>
+                  <shadedArtifactAttached>true</shadedArtifactAttached>
+                  <shadedClassifierName>fat</shadedClassifierName>
+                  <artifactSet>
+                    <includes>
+                      <!-- mirrors the includes in CoprocessorManager's ensureCoprocessorExists method -->
+                      <include>co.cask.*:*</include>
+                      <include>org.apache.tephra:*</include>
+                      <include>it.unimi.dsi:fastutil</include>
+                      <include>com.google.code.gson:gson</include>
+                    </includes>
+                  </artifactSet>
+                  <filters>
+                    <filter>
+                      <artifact>*:*</artifact>
+                      <excludes>
+                        <exclude>META-INF/*.SF</exclude>
+                        <exclude>META-INF/*.DSA</exclude>
+                        <exclude>META-INF/*.RSA</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
+                </configuration>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-opt</id>
+              </execution>
+              <execution>
+                <id>copy-hbase-compat-fat</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${stage.coprocessor.dir}</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${project.build.directory}</directory>
+                      <includes>
+                        <include>${project.artifactId}-${project.version}-fat.jar</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/cdap-hbase-compat-0.98/pom.xml
+++ b/cdap-hbase-compat-0.98/pom.xml
@@ -203,6 +203,22 @@
     </profile>
 
     <profile>
+      <id>coprocessors</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>rpm-prepare</id>
       <build>
         <plugins>

--- a/cdap-hbase-compat-0.98/pom.xml
+++ b/cdap-hbase-compat-0.98/pom.xml
@@ -195,24 +195,68 @@
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-resources-plugin</artifactId>
-            <version>2.6</version>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>coprocessors</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>hbase-compat-fat-jar</id>
+                <phase>package</phase>
+                <configuration>
+                  <createDependencyReducedPom>false</createDependencyReducedPom>
+                  <minimizeJar>true</minimizeJar>
+                  <shadedArtifactAttached>true</shadedArtifactAttached>
+                  <shadedClassifierName>fat</shadedClassifierName>
+                  <artifactSet>
+                    <includes>
+                      <!-- mirrors the includes in CoprocessorManager's ensureCoprocessorExists method -->
+                      <include>co.cask.*:*</include>
+                      <include>org.apache.tephra:*</include>
+                      <include>it.unimi.dsi:fastutil</include>
+                      <include>com.google.code.gson:gson</include>
+                    </includes>
+                  </artifactSet>
+                  <filters>
+                    <filter>
+                      <artifact>*:*</artifact>
+                      <excludes>
+                        <exclude>META-INF/*.SF</exclude>
+                        <exclude>META-INF/*.DSA</exclude>
+                        <exclude>META-INF/*.RSA</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
+                </configuration>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-opt</id>
+              </execution>
+              <execution>
+                <id>copy-hbase-compat-fat</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${stage.coprocessor.dir}</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${project.build.directory}</directory>
+                      <includes>
+                        <include>${project.artifactId}-${project.version}-fat.jar</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/cdap-hbase-compat-1.0-cdh/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh/pom.xml
@@ -224,6 +224,22 @@
     </profile>
 
     <profile>
+      <id>coprocessors</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>rpm-prepare</id>
       <build>
         <plugins>

--- a/cdap-hbase-compat-1.0-cdh/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh/pom.xml
@@ -216,24 +216,68 @@
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-resources-plugin</artifactId>
-            <version>2.6</version>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>coprocessors</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>hbase-compat-fat-jar</id>
+                <phase>package</phase>
+                <configuration>
+                  <createDependencyReducedPom>false</createDependencyReducedPom>
+                  <minimizeJar>true</minimizeJar>
+                  <shadedArtifactAttached>true</shadedArtifactAttached>
+                  <shadedClassifierName>fat</shadedClassifierName>
+                  <artifactSet>
+                    <includes>
+                      <!-- mirrors the includes in CoprocessorManager's ensureCoprocessorExists method -->
+                      <include>co.cask.*:*</include>
+                      <include>org.apache.tephra:*</include>
+                      <include>it.unimi.dsi:fastutil</include>
+                      <include>com.google.code.gson:gson</include>
+                    </includes>
+                  </artifactSet>
+                  <filters>
+                    <filter>
+                      <artifact>*:*</artifact>
+                      <excludes>
+                        <exclude>META-INF/*.SF</exclude>
+                        <exclude>META-INF/*.DSA</exclude>
+                        <exclude>META-INF/*.RSA</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
+                </configuration>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-opt</id>
+              </execution>
+              <execution>
+                <id>copy-hbase-compat-fat</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${stage.coprocessor.dir}</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${project.build.directory}</directory>
+                      <includes>
+                        <include>${project.artifactId}-${project.version}-fat.jar</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/cdap-hbase-compat-1.0-cdh5.5.0/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/pom.xml
@@ -224,6 +224,22 @@
     </profile>
 
     <profile>
+      <id>coprocessors</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>rpm-prepare</id>
       <build>
         <plugins>

--- a/cdap-hbase-compat-1.0-cdh5.5.0/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/pom.xml
@@ -216,24 +216,68 @@
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-resources-plugin</artifactId>
-            <version>2.6</version>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>coprocessors</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>hbase-compat-fat-jar</id>
+                <phase>package</phase>
+                <configuration>
+                  <createDependencyReducedPom>false</createDependencyReducedPom>
+                  <minimizeJar>true</minimizeJar>
+                  <shadedArtifactAttached>true</shadedArtifactAttached>
+                  <shadedClassifierName>fat</shadedClassifierName>
+                  <artifactSet>
+                    <includes>
+                      <!-- mirrors the includes in CoprocessorManager's ensureCoprocessorExists method -->
+                      <include>co.cask.*:*</include>
+                      <include>org.apache.tephra:*</include>
+                      <include>it.unimi.dsi:fastutil</include>
+                      <include>com.google.code.gson:gson</include>
+                    </includes>
+                  </artifactSet>
+                  <filters>
+                    <filter>
+                      <artifact>*:*</artifact>
+                      <excludes>
+                        <exclude>META-INF/*.SF</exclude>
+                        <exclude>META-INF/*.DSA</exclude>
+                        <exclude>META-INF/*.RSA</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
+                </configuration>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-opt</id>
+              </execution>
+              <execution>
+                <id>copy-hbase-compat-fat</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${stage.coprocessor.dir}</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${project.build.directory}</directory>
+                      <includes>
+                        <include>${project.artifactId}-${project.version}-fat.jar</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/cdap-hbase-compat-1.0/pom.xml
+++ b/cdap-hbase-compat-1.0/pom.xml
@@ -202,24 +202,68 @@
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-resources-plugin</artifactId>
-            <version>2.6</version>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>coprocessors</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>hbase-compat-fat-jar</id>
+                <phase>package</phase>
+                <configuration>
+                  <createDependencyReducedPom>false</createDependencyReducedPom>
+                  <minimizeJar>true</minimizeJar>
+                  <shadedArtifactAttached>true</shadedArtifactAttached>
+                  <shadedClassifierName>fat</shadedClassifierName>
+                  <artifactSet>
+                    <includes>
+                      <!-- mirrors the includes in CoprocessorManager's ensureCoprocessorExists method -->
+                      <include>co.cask.*:*</include>
+                      <include>org.apache.tephra:*</include>
+                      <include>it.unimi.dsi:fastutil</include>
+                      <include>com.google.code.gson:gson</include>
+                    </includes>
+                  </artifactSet>
+                  <filters>
+                    <filter>
+                      <artifact>*:*</artifact>
+                      <excludes>
+                        <exclude>META-INF/*.SF</exclude>
+                        <exclude>META-INF/*.DSA</exclude>
+                        <exclude>META-INF/*.RSA</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
+                </configuration>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-opt</id>
+              </execution>
+              <execution>
+                <id>copy-hbase-compat-fat</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${stage.coprocessor.dir}</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${project.build.directory}</directory>
+                      <includes>
+                        <include>${project.artifactId}-${project.version}-fat.jar</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/cdap-hbase-compat-1.0/pom.xml
+++ b/cdap-hbase-compat-1.0/pom.xml
@@ -210,6 +210,22 @@
     </profile>
 
     <profile>
+      <id>coprocessors</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>rpm-prepare</id>
       <build>
         <plugins>

--- a/cdap-hbase-compat-1.1/pom.xml
+++ b/cdap-hbase-compat-1.1/pom.xml
@@ -202,24 +202,68 @@
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-resources-plugin</artifactId>
-            <version>2.6</version>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>coprocessors</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>hbase-compat-fat-jar</id>
+                <phase>package</phase>
+                <configuration>
+                  <createDependencyReducedPom>false</createDependencyReducedPom>
+                  <minimizeJar>true</minimizeJar>
+                  <shadedArtifactAttached>true</shadedArtifactAttached>
+                  <shadedClassifierName>fat</shadedClassifierName>
+                  <artifactSet>
+                    <includes>
+                      <!-- mirrors the includes in CoprocessorManager's ensureCoprocessorExists method -->
+                      <include>co.cask.*:*</include>
+                      <include>org.apache.tephra:*</include>
+                      <include>it.unimi.dsi:fastutil</include>
+                      <include>com.google.code.gson:gson</include>
+                    </includes>
+                  </artifactSet>
+                  <filters>
+                    <filter>
+                      <artifact>*:*</artifact>
+                      <excludes>
+                        <exclude>META-INF/*.SF</exclude>
+                        <exclude>META-INF/*.DSA</exclude>
+                        <exclude>META-INF/*.RSA</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
+                </configuration>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-opt</id>
+              </execution>
+              <execution>
+                <id>copy-hbase-compat-fat</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${stage.coprocessor.dir}</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${project.build.directory}</directory>
+                      <includes>
+                        <include>${project.artifactId}-${project.version}-fat.jar</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/cdap-hbase-compat-1.1/pom.xml
+++ b/cdap-hbase-compat-1.1/pom.xml
@@ -210,6 +210,22 @@
     </profile>
 
     <profile>
+      <id>coprocessors</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>rpm-prepare</id>
       <build>
         <plugins>

--- a/cdap-hbase-compat-1.2-cdh5.7.0/pom.xml
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/pom.xml
@@ -213,6 +213,22 @@
     </profile>
 
     <profile>
+      <id>coprocessors</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>rpm-prepare</id>
       <build>
         <plugins>

--- a/cdap-hbase-compat-1.2-cdh5.7.0/pom.xml
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/pom.xml
@@ -205,24 +205,68 @@
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-resources-plugin</artifactId>
-            <version>2.6</version>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>coprocessors</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>hbase-compat-fat-jar</id>
+                <phase>package</phase>
+                <configuration>
+                  <createDependencyReducedPom>false</createDependencyReducedPom>
+                  <minimizeJar>true</minimizeJar>
+                  <shadedArtifactAttached>true</shadedArtifactAttached>
+                  <shadedClassifierName>fat</shadedClassifierName>
+                  <artifactSet>
+                    <includes>
+                      <!-- mirrors the includes in CoprocessorManager's ensureCoprocessorExists method -->
+                      <include>co.cask.*:*</include>
+                      <include>org.apache.tephra:*</include>
+                      <include>it.unimi.dsi:fastutil</include>
+                      <include>com.google.code.gson:gson</include>
+                    </includes>
+                  </artifactSet>
+                  <filters>
+                    <filter>
+                      <artifact>*:*</artifact>
+                      <excludes>
+                        <exclude>META-INF/*.SF</exclude>
+                        <exclude>META-INF/*.DSA</exclude>
+                        <exclude>META-INF/*.RSA</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
+                </configuration>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-opt</id>
+              </execution>
+              <execution>
+                <id>copy-hbase-compat-fat</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${stage.coprocessor.dir}</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${project.build.directory}</directory>
+                      <includes>
+                        <include>${project.artifactId}-${project.version}-fat.jar</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1863,6 +1863,83 @@
       </build>
     </profile>
 
+    <!-- Profile for building and prepping fat coprocessor jars -->
+    <profile>
+      <id>coprocessors</id>
+      <properties>
+        <stage.coprocessor.dir>${project.build.directory}/stage-packaging/opt/cdap/${package.name}/coprocessor</stage.coprocessor.dir>
+      </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-shade-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>hbase-compat-fat-jar</id>
+                  <phase>package</phase>
+                  <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <minimizeJar>true</minimizeJar>
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                    <shadedClassifierName>fat</shadedClassifierName>
+                    <artifactSet>
+                      <includes>
+                        <!-- mirrors the includes in CoprocessorManager's ensureCoprocessorExists method -->
+                        <include>co.cask.*:*</include>
+                        <include>org.apache.tephra:*</include>
+                        <include>it.unimi.dsi:fastutil</include>
+                        <include>com.google.code.gson:gson</include>
+                      </includes>
+                    </artifactSet>
+                    <filters>
+                      <filter>
+                        <artifact>*:*</artifact>
+                        <excludes>
+                          <exclude>META-INF/*.SF</exclude>
+                          <exclude>META-INF/*.DSA</exclude>
+                          <exclude>META-INF/*.RSA</exclude>
+                        </excludes>
+                      </filter>
+                    </filters>
+                  </configuration>
+                  <goals>
+                    <goal>shade</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-resources-plugin</artifactId>
+              <version>2.6</version>
+              <executions>
+                <execution>
+                  <id>copy-hbase-compat-fat</id>
+                  <phase>package</phase>
+                  <goals>
+                    <goal>copy-resources</goal>
+                  </goals>
+                  <configuration>
+                    <outputDirectory>${stage.coprocessor.dir}</outputDirectory>
+                    <resources>
+                      <resource>
+                        <directory>${project.build.directory}</directory>
+                        <includes>
+                          <include>${project.artifactId}-${project.version}-fat.jar</include>
+                        </includes>
+                      </resource>
+                    </resources>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+
     <!-- Profile for dist -->
     <profile>
       <id>dist</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1863,83 +1863,6 @@
       </build>
     </profile>
 
-    <!-- Profile for building and prepping fat coprocessor jars -->
-    <profile>
-      <id>coprocessors</id>
-      <properties>
-        <stage.coprocessor.dir>${project.build.directory}/stage-packaging/opt/cdap/${package.name}/coprocessor</stage.coprocessor.dir>
-      </properties>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-shade-plugin</artifactId>
-              <executions>
-                <execution>
-                  <id>hbase-compat-fat-jar</id>
-                  <phase>package</phase>
-                  <configuration>
-                    <createDependencyReducedPom>false</createDependencyReducedPom>
-                    <minimizeJar>true</minimizeJar>
-                    <shadedArtifactAttached>true</shadedArtifactAttached>
-                    <shadedClassifierName>fat</shadedClassifierName>
-                    <artifactSet>
-                      <includes>
-                        <!-- mirrors the includes in CoprocessorManager's ensureCoprocessorExists method -->
-                        <include>co.cask.*:*</include>
-                        <include>org.apache.tephra:*</include>
-                        <include>it.unimi.dsi:fastutil</include>
-                        <include>com.google.code.gson:gson</include>
-                      </includes>
-                    </artifactSet>
-                    <filters>
-                      <filter>
-                        <artifact>*:*</artifact>
-                        <excludes>
-                          <exclude>META-INF/*.SF</exclude>
-                          <exclude>META-INF/*.DSA</exclude>
-                          <exclude>META-INF/*.RSA</exclude>
-                        </excludes>
-                      </filter>
-                    </filters>
-                  </configuration>
-                  <goals>
-                    <goal>shade</goal>
-                  </goals>
-                </execution>
-              </executions>
-            </plugin>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-resources-plugin</artifactId>
-              <version>2.6</version>
-              <executions>
-                <execution>
-                  <id>copy-hbase-compat-fat</id>
-                  <phase>package</phase>
-                  <goals>
-                    <goal>copy-resources</goal>
-                  </goals>
-                  <configuration>
-                    <outputDirectory>${stage.coprocessor.dir}</outputDirectory>
-                    <resources>
-                      <resource>
-                        <directory>${project.build.directory}</directory>
-                        <includes>
-                          <include>${project.artifactId}-${project.version}-fat.jar</include>
-                        </includes>
-                      </resource>
-                    </resources>
-                  </configuration>
-                </execution>
-              </executions>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
-
     <!-- Profile for dist -->
     <profile>
       <id>dist</id>
@@ -1954,6 +1877,7 @@
         <stage.opt.dir>${stage.dir}/opt/cdap/${package.name}</stage.opt.dir>
         <stage.lib.dir>${stage.opt.dir}/lib</stage.lib.dir>
         <stage.plugins.dir>${stage.opt.dir}/plugins</stage.plugins.dir>
+        <stage.coprocessor.dir>${stage.opt.dir}/coprocessor</stage.coprocessor.dir>
         <package.deb.depends>--depends cdap</package.deb.depends>
         <package.rpm.depends>--depends cdap</package.rpm.depends>
         <package.deb.arch>all</package.deb.arch>


### PR DESCRIPTION
Added a fat jar containing all the CDAP coprocessors to every
hbase compat package in a new 'coprocessor' directory. It is
meant to be used in CDAP setups where the replication status
tool is required, or setups where 'master.manage.hbase.coprocessors'
is set to false in order to enable rolling hbase upgrades.