### PR TITLE
Adding rolling location log appender

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/plugins/FixedWindowRollingPolicy.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/plugins/FixedWindowRollingPolicy.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.plugins;
+
+import ch.qos.logback.core.CoreConstants;
+import ch.qos.logback.core.rolling.RolloverFailure;
+import ch.qos.logback.core.rolling.helper.FileNamePattern;
+import ch.qos.logback.core.rolling.helper.IntegerTokenConverter;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.logging.framework.AppenderContext;
+import org.apache.twill.filesystem.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import javax.annotation.Nullable;
+
+/**
+ * When rolling over, renames files according to a fixed window algorithm.
+ */
+public class FixedWindowRollingPolicy extends LocationRollingPolicyBase {
+  private static final Logger LOG = LoggerFactory.getLogger(FixedWindowRollingPolicy.class);
+
+  private static final String FNP_NOT_SET =
+    "The \"FileNamePattern\" property must be set before using FixedWindowRollingPolicy. ";
+
+  // TODO CDAP-8369 - Support compression
+  private int minIndex;
+  private int maxIndex;
+
+  private int processedIndex;
+
+  /**
+   * It's almost always a bad idea to have a large window size, say over 20.
+   */
+  private static final int MAX_WINDOW_SIZE = 20;
+
+  public FixedWindowRollingPolicy() {
+    minIndex = 1;
+    maxIndex = 7;
+  }
+
+  @Override
+  public void start() {
+    if (fileNamePatternStr != null) {
+      if (context instanceof AppenderContext) {
+        AppenderContext context = (AppenderContext) this.context;
+        fileNamePatternStr = fileNamePatternStr.replace("instanceId", Integer.toString(context.getInstanceId()));
+      } else if (!Boolean.TRUE.equals(context.getObject(Constants.Logging.PIPELINE_VALIDATION))) {
+        throw new IllegalStateException("Expected logger context instance of " + AppenderContext.class.getName() +
+                                          " but got " + context.getClass().getName());
+      }
+
+      fileNamePattern = new FileNamePattern(fileNamePatternStr, this.context);
+    } else {
+      LOG.error(FNP_NOT_SET);
+      throw new IllegalStateException(FNP_NOT_SET + CoreConstants.SEE_FNP_NOT_SET);
+    }
+
+    if (maxIndex < minIndex) {
+      LOG.warn("MaxIndex {} cannot be smaller than MinIndex {}.", maxIndex, minIndex);
+      maxIndex = minIndex;
+    }
+
+    if ((maxIndex - minIndex) > MAX_WINDOW_SIZE) {
+      LOG.warn("Large window sizes are not allowed.");
+      maxIndex = minIndex + MAX_WINDOW_SIZE;
+      LOG.warn("MaxIndex reduced to " + maxIndex);
+    }
+
+    IntegerTokenConverter itc = fileNamePattern.getIntegerTokenConverter();
+
+    if (itc == null) {
+      throw new IllegalStateException("FileNamePattern ["
+                                        + fileNamePattern.getPattern()
+                                        + "] does not contain a valid IntegerToken");
+    }
+    processedIndex = maxIndex;
+    super.start();
+  }
+
+  @Override
+  public void rollover() throws RolloverFailure {
+    Location parentLocation = getParent(activeFileLocation);
+
+    if (parentLocation == null) {
+      return;
+    }
+
+    // If maxIndex <= 0, then there is no file renaming to be done.
+    if (maxIndex >= 0) {
+      try {
+        // close outputstream of active location
+        closeable.close();
+
+        String fileName = fileNamePattern.convertInt(maxIndex);
+        // Delete the oldest file. If processedIndex is not pointing to maxIndex, that means there was some
+        // exception while doing rename of files in previous rollover. So do not delete the existing file with
+        // maximum index otherwise we will end up deleting rolled over file
+        if (processedIndex == maxIndex) {
+          Location deleteLocation = parentLocation.append(fileName);
+          // no need to proceed further if we are not able to delete location so throw exception
+          if (deleteLocation.exists() && !deleteLocation.delete()) {
+            LOG.warn("Failed to delete location: {}", deleteLocation.toURI().toString());
+            throw new RolloverFailure(String.format("Not able to delete file: %s", deleteLocation.toURI().toString()));
+          }
+          processedIndex--;
+        }
+
+        for (int i = processedIndex; i >= minIndex; i--, processedIndex--) {
+          String toRenameStr = fileNamePattern.convertInt(i);
+          Location toRename = parentLocation.append(toRenameStr);
+
+          // no point in trying to rename an non existent file
+          if (toRename.exists()) {
+            Location newName = parentLocation.append(fileNamePattern.convertInt(i + 1));
+            // throw exception if rename fails, so that in next iteration of rollover, it will be retried
+            if (toRename.renameTo(newName) == null) {
+              LOG.warn("Failed to rename {} to {}", toRename.toURI().toString(), newName.toURI().toString());
+              throw new RolloverFailure(String.format("Failed to rename %s to %s", toRename.toURI().toString(),
+                                                      newName.toURI().toString()));
+            }
+          } else {
+            LOG.trace("Skipping roll-over for inexistent file {}", toRename.toURI().toString());
+          }
+        }
+
+        if (activeFileLocation.renameTo(parentLocation.append(fileNamePattern.convertInt(minIndex))) == null) {
+          LOG.warn("Failed to rename location: {}", activeFileLocation.toURI().toString());
+          throw new RolloverFailure(String.format("Not able to rename file: %s",
+                                                  activeFileLocation.toURI().toString()));
+        }
+
+        // reset max processed index after rename of active location has been processed successfully
+        processedIndex = maxIndex;
+      } catch (IOException e) {
+        RolloverFailure f = new RolloverFailure(e.getMessage());
+        f.addSuppressed(e);
+        throw f;
+      }
+    }
+  }
+
+  /**
+   * Return the value of the parent's RawFile property.
+   */
+  public String getActiveFileName() {
+    return activeFileLocation.getName();
+  }
+
+  public int getMaxIndex() {
+    return maxIndex;
+  }
+
+  public int getMinIndex() {
+    return minIndex;
+  }
+
+  public void setMaxIndex(int maxIndex) {
+    this.maxIndex = maxIndex;
+  }
+
+  public void setMinIndex(int minIndex) {
+    this.minIndex = minIndex;
+  }
+
+  /**
+   * Creates a {@link Location} instance which represents the parent of the given location.
+   *
+   * @param location location to extra parent from.
+   * @return an instance representing the parent location or {@code null} if there is no parent.
+   */
+  @Nullable
+  private static Location getParent(Location location) {
+    URI source = location.toURI();
+
+    // If it is root, return null
+    if ("/".equals(source.getPath())) {
+      return null;
+    }
+
+    URI resolvedParent = URI.create(source.toString() + "/..").normalize();
+    // NOTE: if there is a trailing slash at the end, rename(), getName() and other operations on file
+    // does not work in MapR. so we remove the trailing slash (if any) at the end.
+    if (resolvedParent.toString().endsWith("/")) {
+      String parent = resolvedParent.toString();
+      resolvedParent = URI.create(parent.substring(0, parent.length() - 1));
+    }
+    return location.getLocationFactory().create(resolvedParent);
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/plugins/LocationIdentifier.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/plugins/LocationIdentifier.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.plugins;
+
+import java.util.Objects;
+
+/**
+ * Identifier for location of logs
+ */
+public class LocationIdentifier {
+  private final String namespaceId;
+  private final String applicationId;
+
+  public LocationIdentifier(String namespaceId, String applicationId) {
+    this.namespaceId = namespaceId;
+    this.applicationId = applicationId;
+  }
+
+  public String getNamespaceId() {
+    return namespaceId;
+  }
+
+  public String getApplicationId() {
+    return applicationId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    LocationIdentifier that = (LocationIdentifier) o;
+
+    return (Objects.equals(namespaceId, that.namespaceId) && Objects.equals(applicationId, that.applicationId));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(namespaceId, applicationId);
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/plugins/LocationManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/plugins/LocationManager.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.plugins;
+
+import co.cask.cdap.common.conf.Constants;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.io.ByteStreams;
+import com.google.common.io.Closeables;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.Flushable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Manage locations for {@link RollingLocationLogAppender}
+ */
+public class LocationManager implements Flushable, Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(LocationManager.class);
+  protected static final String TAG_NAMESPACE_ID = Constants.Logging.TAG_NAMESPACE_ID;
+  protected static final String TAG_APPLICATION_ID = Constants.Logging.TAG_APPLICATION_ID;
+
+  private final Location logBaseDir;
+  private final String filePermissions;
+  private final String dirPermissions;
+  private final Map<LocationIdentifier, LocationOutputStream> activeLocations;
+  private LocationOutputStream invalidOutputStream;
+
+  public LocationManager(LocationFactory locationFactory, String basePath, String dirPermissions,
+                         String filePermissions) {
+    this.logBaseDir = locationFactory.create(basePath);
+    this.dirPermissions = dirPermissions;
+    this.filePermissions = filePermissions;
+    this.activeLocations = new HashMap<>();
+  }
+
+  /**
+   * Creates {@link LocationIdentifier} from propertymap
+   *
+   * @param propertyMap MDC property map which contains namespace id and application id
+   * @return returns {@link LocationIdentifier}
+   * @throws IllegalArgumentException application id is not present in the property map
+   */
+  LocationIdentifier getLocationIdentifier(Map<String, String> propertyMap) {
+
+    String namespaceId = propertyMap.get(TAG_NAMESPACE_ID);
+    String applicationId = propertyMap.get(TAG_APPLICATION_ID);
+
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(applicationId),
+                                String.format("%s is expected but not found in the context %s",
+                                              TAG_APPLICATION_ID, propertyMap));
+
+    return new LocationIdentifier(namespaceId, applicationId);
+  }
+
+  /**
+   * Returns outpustream for log file created as: <basePath>/namespaceId/applicationId/<filePath>
+   *
+   * @param locationIdentifier location identifier for this event
+   * @param filePath           filePath for this event
+   * @return returns {@link LocationOutputStream} for an event
+   * @throws IOException throws exception while creating a file
+   */
+  OutputStream getLocationOutputStream(LocationIdentifier locationIdentifier, String filePath) throws IOException {
+    if (activeLocations.containsKey(locationIdentifier)) {
+      return activeLocations.get(locationIdentifier);
+    }
+
+    Location logFile = getLogLocation(locationIdentifier).append(filePath);
+    Location logDir = getParent(logFile);
+
+    if (logDir == null) {
+      // this should never happen
+      LOG.error("Parent Directory for {} is null", logFile.toURI().toString());
+      throw new IOException(String.format("Parent Directory for %s is null", logFile.toURI().toString()));
+    }
+
+    // check if parent directories exist
+    mkdirsIfNotExists(logDir, dirPermissions);
+
+
+    if (logFile.exists()) {
+      // The file name for a given application exists if the appender was stopped and then started again but file was
+      // not rolled over. In this case, since the roll over size is typically small, we can rename the old file and
+      // copy its contents to new file and delete old file.
+      long now = System.currentTimeMillis();
+
+      // rename existing file to temp file
+      Location tempLocation = logFile.renameTo(logDir.append("temp-" + Long.toString(now)));
+
+      if (tempLocation == null) {
+        throw new IOException(String.format("Can not rename file %s", logFile.toURI().toString()));
+      }
+
+      try (InputStream inputStream = tempLocation.getInputStream()) {
+        // create new file and open outputstream on it
+        logFile.createNew(filePermissions);
+        // TODO: Handle existing file in a better way rather than copying it over
+        OutputStream outputStream = new LocationOutputStream(logFile, logFile.getOutputStream());
+        activeLocations.put(locationIdentifier, (LocationOutputStream) outputStream);
+        ByteStreams.copy(inputStream, outputStream);
+        outputStream.flush();
+      } catch (IOException e) {
+        activeLocations.remove(locationIdentifier);
+        throw e;
+      }
+
+      deleteTempFiles(logDir, tempLocation);
+
+    } else {
+      // create file with correct permissions
+      logFile.createNew(filePermissions);
+      activeLocations.put(locationIdentifier, new LocationOutputStream(logFile, logFile.getOutputStream()));
+    }
+
+    return activeLocations.get(locationIdentifier);
+  }
+
+  private void deleteTempFiles(Location logDir, Location tempLocation) {
+    try {
+      // clean up all the temp files for which deletion failed
+      tempLocation.delete();
+      for (Location location : logDir.list()) {
+        if (location.getName().startsWith("temp-")) {
+          location.delete();
+        }
+      }
+    } catch (IOException e) {
+      // do not throw any exception while deleting temp directory
+      LOG.warn("Not able to delete temp location, will be retried later", e);
+    }
+  }
+
+  /**
+   * Closes all open output streams and clears cache
+   */
+  public void close() {
+    Collection<LocationOutputStream> locations = activeLocations.values();
+    activeLocations.clear();
+
+    for (LocationOutputStream locationOutputStream : locations) {
+      // we do not want to throw any exception rather close all the open output streams. so close quietly
+      Closeables.closeQuietly(locationOutputStream);
+    }
+  }
+
+  /**
+   * Flushes all the open output streams
+   */
+  @Override
+  public void flush() throws IOException {
+    Collection<LocationOutputStream> locations = activeLocations.values();
+    for (LocationOutputStream locationOutputStream : locations) {
+      locationOutputStream.flush();
+    }
+  }
+
+  /**
+   * Appends information from location identifier to logBaseDir
+   */
+  Location getLogLocation(LocationIdentifier locationIdentifier) throws IOException {
+    return logBaseDir.append(locationIdentifier.getNamespaceId()).append(locationIdentifier.getApplicationId());
+  }
+
+  @VisibleForTesting
+  Map<LocationIdentifier, LocationOutputStream> getActiveLocations() {
+    return activeLocations;
+  }
+
+  @Nullable
+  LocationOutputStream getInvalidOutputStream() {
+    return invalidOutputStream;
+  }
+
+  void setInvalidOutputStream(@Nullable  LocationOutputStream invalidOutputStream) {
+    this.invalidOutputStream = invalidOutputStream;
+  }
+
+  /**
+   * Creates a {@link Location} instance which represents the parent of the given location.
+   *
+   * @param location location to extra parent from.
+   * @return an instance representing the parent location or {@code null} if there is no parent.
+   */
+  @Nullable
+  private static Location getParent(Location location) {
+    URI source = location.toURI();
+
+    // If it is root, return null
+    if ("/".equals(source.getPath())) {
+      return null;
+    }
+
+    URI resolvedParent = URI.create(source.toString() + "/..").normalize();
+    // NOTE: if there is a trailing slash at the end, rename(), getName() and other operations on file
+    // does not work in MapR. so we remove the trailing slash (if any) at the end.
+    if (resolvedParent.toString().endsWith("/")) {
+      String parent = resolvedParent.toString();
+      resolvedParent = URI.create(parent.substring(0, parent.length() - 1));
+    }
+    return location.getLocationFactory().create(resolvedParent);
+  }
+
+  /**
+   * Create the directory represented by the location with provided permissions if not exists.
+   * @param location the location for the directory.
+   * @param permissions permissions on directory
+   * @throws IOException If the location cannot be created
+   */
+  private static void mkdirsIfNotExists(Location location, String permissions) throws IOException {
+    // Need to check && mkdir && check to deal with race condition
+    if (!location.isDirectory() && !location.mkdirs(permissions) && !location.isDirectory()) {
+      throw new IOException("Failed to create directory at " + location);
+    }
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/plugins/LocationOutputStream.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/plugins/LocationOutputStream.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.plugins;
+
+import org.apache.hadoop.fs.Syncable;
+import org.apache.twill.filesystem.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Location outputstream used by {@link LocationManager} which holds location, number of bytes written to a location
+ * and its open outputstream
+ */
+public class LocationOutputStream extends FilterOutputStream {
+  private static final Logger LOG = LoggerFactory.getLogger(LocationOutputStream.class);
+
+  private Location location;
+  private long numOfBytes;
+
+  public LocationOutputStream(Location location, OutputStream outputStream) {
+    super(outputStream);
+    this.location = location;
+  }
+
+  public Location getLocation() {
+    return location;
+  }
+
+  public OutputStream getOutputStream() {
+    return out;
+  }
+
+  public long getNumOfBytes() {
+    return numOfBytes;
+  }
+
+  @Override
+  public void write(byte[] b) throws IOException {
+    out.write(b);
+    long length = location.length();
+
+    if (numOfBytes < length) {
+      numOfBytes = length;
+    }
+    numOfBytes = numOfBytes + b.length;
+  }
+
+  @Override
+  public void flush() throws IOException {
+    out.flush();
+    if (out instanceof Syncable) {
+      ((Syncable) out).hsync();
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    LOG.trace("Closing file {}", location);
+    out.close();
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/plugins/LocationRollingPolicy.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/plugins/LocationRollingPolicy.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.plugins;
+
+import ch.qos.logback.core.rolling.RollingPolicy;
+import org.apache.twill.filesystem.Location;
+
+import java.io.Closeable;
+
+/**
+ * Location rolling policy
+ */
+public interface LocationRollingPolicy extends RollingPolicy {
+   /**
+   * Update Active file location
+   *
+   * @param activeFileLocation Current open file to be rolled over
+   * @param closeable closeable to close location before renaming for rollover
+   */
+  void setLocation(Location activeFileLocation, Closeable closeable);
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/plugins/LocationRollingPolicyBase.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/plugins/LocationRollingPolicyBase.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.plugins;
+
+import ch.qos.logback.core.FileAppender;
+import ch.qos.logback.core.rolling.helper.CompressionMode;
+import ch.qos.logback.core.rolling.helper.FileNamePattern;
+import ch.qos.logback.core.spi.ContextAwareBase;
+import org.apache.twill.filesystem.Location;
+
+import java.io.Closeable;
+
+
+/**
+ * Location rolling policy base which provides
+ */
+public abstract class LocationRollingPolicyBase extends ContextAwareBase implements LocationRollingPolicy {
+
+  private CompressionMode compressionMode = CompressionMode.NONE;
+  protected FileNamePattern fileNamePattern;
+  // fileNamePatternStr is always slashified, see setter
+  protected String fileNamePatternStr;
+  private FileAppender parent;
+
+
+  protected Location activeFileLocation;
+  protected Closeable closeable;
+  private boolean started;
+
+  //logback calls these methods, so do not remove
+  public void setFileNamePattern(String fnp) {
+    fileNamePatternStr = fnp;
+  }
+
+  public String getFileNamePattern() {
+    return fileNamePatternStr;
+  }
+
+  /**
+   * This interface is part of {@link ch.qos.logback.core.rolling.RollingPolicy}
+   * @return
+   */
+  public CompressionMode getCompressionMode() {
+    return compressionMode;
+  }
+
+  public boolean isStarted() {
+    return started;
+  }
+
+  public void start() {
+    started = true;
+  }
+
+  public void stop() {
+    started = false;
+  }
+
+  public void setParent(FileAppender appender) {
+    this.parent = appender;
+  }
+
+  public void setLocation(Location activeFileLocation, Closeable closeable) {
+    this.activeFileLocation = activeFileLocation;
+    this.closeable = closeable;
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/plugins/LocationTriggeringPolicy.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/plugins/LocationTriggeringPolicy.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.plugins;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.rolling.TriggeringPolicy;
+import org.apache.twill.filesystem.Location;
+
+/**
+ * A TriggeringPolicy for locations
+ */
+public interface LocationTriggeringPolicy extends TriggeringPolicy<ILoggingEvent> {
+  /**
+   * Should roll-over be triggered at this time?
+   *
+   * @param event which {@link LocationTriggeringPolicy#setLocation(Location)}
+   * @return true if a roll-over should occur.
+   */
+  boolean isTriggeringEvent(final ILoggingEvent event);
+
+  /**
+   * set location of Rolling policy
+   *
+   * @param location location which can trigger roll over
+   */
+  void setLocation(Location location);
+
+  /**
+   * set {@link Location} size
+   * @param size size of the location
+   */
+  void setActiveLocationSize(long size);
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/plugins/LocationTriggeringPolicyBase.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/plugins/LocationTriggeringPolicyBase.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.plugins;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.LogbackException;
+import ch.qos.logback.core.spi.ContextAwareBase;
+import org.apache.twill.filesystem.Location;
+
+import java.io.File;
+
+/**
+ * Location triggering policy base class
+ */
+public abstract class LocationTriggeringPolicyBase extends ContextAwareBase implements LocationTriggeringPolicy {
+  private Location activeLocation;
+  private long activeLocationSize;
+  private boolean start;
+
+  public void start() {
+    start = true;
+  }
+
+  public void stop() {
+    start = false;
+  }
+
+  public boolean isStarted() {
+    return start;
+  }
+
+  public void setLocation(Location location) {
+    activeLocation = location;
+  }
+
+  public Location getActiveLocation() {
+    return activeLocation;
+  }
+
+  public boolean isTriggeringEvent(final File activeFile, final ILoggingEvent event) throws LogbackException {
+    return isTriggeringEvent(event);
+  }
+
+  public void setActiveLocationSize(long size) {
+    activeLocationSize = size;
+  }
+
+  public long getActiveLocationSize() {
+    return activeLocationSize;
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/plugins/RollingLocationLogAppender.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/plugins/RollingLocationLogAppender.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.plugins;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.FileAppender;
+import ch.qos.logback.core.LogbackException;
+import ch.qos.logback.core.rolling.RollingPolicy;
+import ch.qos.logback.core.rolling.RolloverFailure;
+import ch.qos.logback.core.rolling.TriggeringPolicy;
+import ch.qos.logback.core.spi.FilterReply;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.logging.framework.AppenderContext;
+import co.cask.cdap.proto.id.NamespaceId;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import org.apache.twill.filesystem.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.Flushable;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Rolling Appender for {@link Location}
+ */
+public class RollingLocationLogAppender extends FileAppender<ILoggingEvent> implements Flushable {
+  private static final Logger LOG = LoggerFactory.getLogger(RollingLocationLogAppender.class);
+
+  private TriggeringPolicy<ILoggingEvent> triggeringPolicy;
+  private RollingPolicy rollingPolicy;
+
+  // used as cache to avoid type casting of triggeringPolicy on every event
+  private LocationTriggeringPolicy locationTriggeringPolicy;
+  // used as cache to avoid type casting of triggeringPolicy on every event
+  private LocationRollingPolicy locationRollingPolicy;
+
+  // log file path will be created by this appender as: <basePath>/namespaceId/applicationId/<filePath>
+  private String basePath;
+  private String filePath;
+  private String filePermissions;
+  private String dirPermissions;
+  private LocationManager locationManager;
+
+  public RollingLocationLogAppender() {
+    setName(getClass().getName());
+  }
+
+  @Override
+  public void start() {
+    // These should all passed. The settings are from the custom-log-pipeline.xml and
+    // the context must be AppenderContext
+    Preconditions.checkState(basePath != null, "Property basePath must be base directory.");
+    Preconditions.checkState(filePath != null, "Property filePath must be filePath along with filename.");
+    Preconditions.checkState(triggeringPolicy != null, "Property triggeringPolicy must be specified.");
+    Preconditions.checkState(rollingPolicy != null, "Property rollingPolicy must be specified");
+    Preconditions.checkState(encoder != null, "Property encoder must be specified.");
+    Preconditions.checkState(dirPermissions != null, "Property dirPermissions cannot be null");
+    Preconditions.checkState(filePermissions != null, "Property filePermissions cannot be null");
+
+    if (context instanceof AppenderContext) {
+      AppenderContext context = (AppenderContext) this.context;
+      locationManager = new LocationManager(context.getLocationFactory(), basePath, dirPermissions, filePermissions);
+      filePath = filePath.replace("instanceId", Integer.toString(context.getInstanceId()));
+    } else if (!Boolean.TRUE.equals(context.getObject(Constants.Logging.PIPELINE_VALIDATION))) {
+      throw new IllegalStateException("Expected logger context instance of " + AppenderContext.class.getName() +
+                                        " but got " + context.getClass().getName());
+    }
+
+    started = true;
+  }
+
+  @Override
+  public void doAppend(ILoggingEvent eventObject) throws LogbackException {
+    try {
+      // logic from AppenderBase
+      if (!this.started) {
+        LOG.warn("Attempted to append to non started appender {}", this.getName());
+        return;
+      }
+
+      // logic from AppenderBase
+      if (getFilterChainDecision(eventObject) == FilterReply.DENY) {
+        return;
+      }
+
+      String namespaceId = eventObject.getMDCPropertyMap().get(LocationManager.TAG_NAMESPACE_ID);
+
+      if (namespaceId != null && !namespaceId.equals(NamespaceId.SYSTEM.getNamespace())) {
+        LocationIdentifier logLocationIdentifier = locationManager.getLocationIdentifier(eventObject
+                                                                                           .getMDCPropertyMap());
+        rollover(logLocationIdentifier, eventObject);
+        OutputStream locationOutputStream = locationManager.getLocationOutputStream(logLocationIdentifier, filePath);
+        setOutputStream(locationOutputStream);
+        writeOut(eventObject);
+      }
+    } catch (IllegalArgumentException iae) {
+      // this shouldn't happen
+      LOG.error("Unrecognized context ", iae);
+    } catch (IOException ioe) {
+      throw new LogbackException("Exception while appending event. ", ioe);
+    } catch (RolloverFailure rolloverFailure) {
+      throw new LogbackException("Exception while rolling over. ", rolloverFailure);
+    }
+  }
+
+  private void rollover(final LocationIdentifier identifier, ILoggingEvent event) throws RolloverFailure, IOException {
+    // Close unclosed outputstream before proceeding further
+    closeInvalidStream();
+
+    if (!locationManager.getActiveLocations().containsKey(identifier)) {
+      return;
+    }
+
+    final LocationOutputStream locationOutputStream = locationManager.getActiveLocations().get(identifier);
+
+    if (triggeringPolicy instanceof LocationTriggeringPolicy) {
+      // no need to type cast on every event
+      if (locationTriggeringPolicy == null) {
+        locationTriggeringPolicy = ((LocationTriggeringPolicy) triggeringPolicy);
+      }
+
+      locationTriggeringPolicy.setLocation(locationOutputStream.getLocation());
+      // set number of bytes written to locationOutputStream, we need to do this because HDFS does not provide
+      // correct size of the file
+      locationTriggeringPolicy.setActiveLocationSize(locationOutputStream.getNumOfBytes());
+
+      if (locationTriggeringPolicy.isTriggeringEvent(event)) {
+          if (rollingPolicy instanceof LocationRollingPolicy) {
+            // no need to type cast on every event
+            if (locationRollingPolicy == null) {
+              locationRollingPolicy = ((LocationRollingPolicy) rollingPolicy);
+            }
+
+            locationRollingPolicy.setLocation(locationOutputStream.getLocation(), new Closeable() {
+              @Override
+              public void close() throws IOException {
+                locationManager.getActiveLocations().remove(identifier);
+                try {
+                  locationOutputStream.close();
+                } catch (IOException e) {
+                  // If there is an exception while closing the outputstream, remember it and throw an exception so
+                  // that it can be closed on another event append
+                  locationManager.setInvalidOutputStream(locationOutputStream);
+                  LOG.trace("Exception while closing the output stream for {}, will retry to close it later",
+                           identifier, e);
+                  throw e;
+                }
+              }
+            });
+
+            locationRollingPolicy.rollover();
+          }
+      }
+    }
+  }
+
+  private void closeInvalidStream() throws IOException {
+    if (locationManager.getInvalidOutputStream() != null) {
+      LocationOutputStream invalidOutputStream = locationManager.getInvalidOutputStream();
+      try {
+        invalidOutputStream.close();
+        LOG.info("Successfully closed output stream {}", invalidOutputStream.getLocation());
+        // because close was successful make this output stream null
+        locationManager.setInvalidOutputStream(null);
+      } catch (IOException e) {
+        LOG.warn("Exception while closing invalid output stream for {}, will retry to close it later",
+                 invalidOutputStream.getLocation().toURI().toString(), e);
+        throw e;
+      }
+    }
+  }
+
+  @Override
+  public void flush() throws IOException {
+    locationManager.flush();
+  }
+
+  @Override
+  public void stop() {
+    try {
+      LOG.info("Stopping appender {}", this.name);
+      locationManager.close();
+      if (encoder != null) {
+        encoder.close();
+      }
+    } catch (IOException ioe) {
+      LOG.error("Failed to write footer for appender named {}", this.getName(), ioe);
+    } finally {
+      this.started = false;
+    }
+  }
+
+  // override this method to setOutputStream for every event since this appender is appending to multiple files
+  @Override
+  public void setOutputStream(OutputStream outputStream) {
+    if (encoder == null) {
+      LOG.warn("Encoder has not been set. Cannot invoke its init method.");
+      return;
+    }
+
+    try {
+      encoder.init(outputStream);
+    } catch (IOException ioe) {
+      this.started = false;
+      LOG.error("Failed to initialize encoder for appender named {}", name, ioe);
+    }
+  }
+
+  // Since this appender does not support prudent mode, we override writeOut method from FileAppender
+  @Override
+  protected void writeOut(ILoggingEvent event) throws IOException {
+    this.encoder.doEncode(event);
+  }
+
+  @VisibleForTesting
+  LocationManager getLocationManager() {
+    return locationManager;
+  }
+
+  public void setRollingPolicy(RollingPolicy policy) {
+    rollingPolicy = policy;
+  }
+
+  public void setTriggeringPolicy(TriggeringPolicy<ILoggingEvent> policy) {
+    triggeringPolicy = policy;
+  }
+
+  public String getBasePath() {
+    return basePath;
+  }
+
+  public void setBasePath(String basePath) {
+    this.basePath = basePath;
+  }
+
+  public String getFilePermissions() {
+    return filePermissions;
+  }
+
+  public void setFilePermissions(String filePermissions) {
+    this.filePermissions = filePermissions;
+  }
+
+  public String getFilePath() {
+    return filePath;
+  }
+
+  public void setFilePath(String filePath) {
+    this.filePath = filePath;
+  }
+
+  public String getDirPermissions() {
+    return dirPermissions;
+  }
+
+  public void setDirPermissions(String dirPermissions) {
+    this.dirPermissions = dirPermissions;
+  }
+}

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/plugins/SizeBasedTriggeringPolicy.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/plugins/SizeBasedTriggeringPolicy.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.plugins;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.LogbackException;
+import ch.qos.logback.core.util.FileSize;
+
+/**
+ * SizeBasedTriggeringPolicy looks at size of the file being currently written
+ * to. If it grows bigger than the specified size, the {@link RollingLocationLogAppender} using the
+ * SizeBasedTriggeringPolicy rolls the file and creates a new one.
+ */
+public class SizeBasedTriggeringPolicy extends LocationTriggeringPolicyBase {
+  /**
+   * The default maximum file size.
+   */
+  private static final long DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+
+  private String maxFileSizeAsString = Long.toString(DEFAULT_MAX_FILE_SIZE);
+  private FileSize maxFileSize;
+
+  public SizeBasedTriggeringPolicy() {
+  }
+
+  public SizeBasedTriggeringPolicy(final String maxFileSize) {
+    setMaxFileSize(maxFileSize);
+  }
+
+  public boolean isTriggeringEvent(final ILoggingEvent event) throws LogbackException {
+    return (getActiveLocationSize() >= maxFileSize.getSize());
+  }
+
+  public String getMaxFileSize() {
+    return maxFileSizeAsString;
+  }
+
+  public void setMaxFileSize(String maxFileSize) {
+    this.maxFileSizeAsString = maxFileSize;
+    this.maxFileSize = FileSize.valueOf(maxFileSize);
+  }
+}

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/framework/CDAPLogAppenderTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/framework/CDAPLogAppenderTest.java
@@ -333,4 +333,3 @@ public class CDAPLogAppenderTest {
     return event;
   }
 }
-

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/plugins/RollingLocationLogAppenderTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/plugins/RollingLocationLogAppenderTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.logging.plugins;
+
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.util.StatusPrinter;
+import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.guice.ConfigModule;
+import co.cask.cdap.common.guice.NonCustomLocationUnitTestModule;
+import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.kerberos.NoOpOwnerAdmin;
+import co.cask.cdap.common.kerberos.OwnerAdmin;
+import co.cask.cdap.common.logging.ApplicationLoggingContext;
+import co.cask.cdap.common.logging.NamespaceLoggingContext;
+import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
+import co.cask.cdap.common.namespace.SimpleNamespaceQueryAdmin;
+import co.cask.cdap.data.runtime.DataSetsModules;
+import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.logging.LoggingConfiguration;
+import co.cask.cdap.logging.context.FlowletLoggingContext;
+import co.cask.cdap.logging.context.MapReduceLoggingContext;
+import co.cask.cdap.logging.framework.AppenderContext;
+import co.cask.cdap.logging.framework.LocalAppenderContext;
+import co.cask.cdap.logging.guice.LoggingModules;
+import co.cask.cdap.security.auth.context.AuthenticationContextModules;
+import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
+import co.cask.cdap.security.authorization.AuthorizationTestModule;
+import co.cask.cdap.security.impersonation.UGIProvider;
+import co.cask.cdap.security.impersonation.UnsupportedUGIProvider;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.tephra.TransactionManager;
+import org.apache.tephra.TransactionSystemClient;
+import org.apache.tephra.runtime.TransactionModules;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.MDC;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Map;
+
+/**
+ * Unit test for {@link RollingLocationLogAppender}
+ */
+public class RollingLocationLogAppenderTest {
+
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+  private static Injector injector;
+  private static TransactionManager txManager;
+
+  @BeforeClass
+  public static void setUpContext() throws Exception {
+    Configuration hConf = HBaseConfiguration.create();
+    final CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, TMP_FOLDER.newFolder().getAbsolutePath());
+    String logBaseDir = cConf.get(LoggingConfiguration.LOG_BASE_DIR) + "/" +
+      RollingLocationLogAppender.class.getSimpleName();
+    cConf.set(LoggingConfiguration.LOG_BASE_DIR, logBaseDir);
+
+    injector = Guice.createInjector(
+      new ConfigModule(cConf, hConf),
+      new NonCustomLocationUnitTestModule().getModule(),
+      new TransactionModules().getInMemoryModules(),
+      new LoggingModules().getInMemoryModules(),
+      new DataSetsModules().getInMemoryModules(),
+      new SystemDatasetRuntimeModule().getInMemoryModules(),
+      new AuthorizationTestModule(),
+      new AuthorizationEnforcementModule().getInMemoryModules(),
+      new AuthenticationContextModules().getNoOpModule(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class);
+          bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
+          bind(NamespaceQueryAdmin.class).to(SimpleNamespaceQueryAdmin.class);
+          bind(OwnerAdmin.class).to(NoOpOwnerAdmin.class);
+        }
+      }
+    );
+
+    txManager = injector.getInstance(TransactionManager.class);
+    txManager.startAndWait();
+  }
+
+  @AfterClass
+  public static void cleanUp() throws Exception {
+    txManager.stopAndWait();
+  }
+
+  @Test
+  public void testRollingLocationLogAppender() throws Exception {
+    // assume SLF4J is bound to logback in the current environment
+    AppenderContext appenderContext = new LocalAppenderContext(injector.getInstance(DatasetFramework.class),
+                                                               injector.getInstance(TransactionSystemClient.class),
+                                                               injector.getInstance(LocationFactory.class),
+                                                               new NoOpMetricsCollectionService());
+
+    JoranConfigurator configurator = new JoranConfigurator();
+    configurator.setContext(appenderContext);
+    // Call context.reset() to clear any previous configuration, e.g. default
+    // configuration. For multi-step configuration, omit calling context.reset().
+    appenderContext.reset();
+
+    configurator.doConfigure(getClass().getResourceAsStream("/rolling-appender-logback-test.xml"));
+    StatusPrinter.printInCaseOfErrorsOrWarnings(appenderContext);
+
+    RollingLocationLogAppender rollingAppender =
+      (RollingLocationLogAppender) appenderContext.getLogger(RollingLocationLogAppenderTest.class)
+        .getAppender("rollingAppender");
+
+    addTagsToMdc("testNamespace", "testApp");
+    Logger logger = appenderContext.getLogger(RollingLocationLogAppenderTest.class);
+    ingestLogs(logger, 5);
+    Map<LocationIdentifier, LocationOutputStream> activeFiles = rollingAppender.getLocationManager()
+      .getActiveLocations();
+    Assert.assertEquals(1, activeFiles.size());
+    verifyFileOutput(activeFiles, 5);
+
+    // different program should go to different directory
+    addTagsToMdc("testNamespace", "testApp1");
+    ingestLogs(logger, 5);
+    activeFiles = rollingAppender.getLocationManager().getActiveLocations();
+    Assert.assertEquals(2, activeFiles.size());
+    verifyFileOutput(activeFiles, 5);
+
+    // different program should go to different directory because namespace is different
+    addTagsToMdc("testNamespace1", "testApp1");
+    ingestLogs(logger, 5);
+    activeFiles = rollingAppender.getLocationManager().getActiveLocations();
+    Assert.assertEquals(3, activeFiles.size());
+    verifyFileOutput(activeFiles, 5);
+  }
+
+  @Test
+  public void testRollOver() throws Exception {
+    // assume SLF4J is bound to logback in the current environment
+    AppenderContext appenderContext = new LocalAppenderContext(injector.getInstance(DatasetFramework.class),
+                                                               injector.getInstance(TransactionSystemClient.class),
+                                                               injector.getInstance(LocationFactory.class),
+                                                               new NoOpMetricsCollectionService());
+
+    JoranConfigurator configurator = new JoranConfigurator();
+    configurator.setContext(appenderContext);
+    // Call context.reset() to clear any previous configuration, e.g. default
+    // configuration. For multi-step configuration, omit calling context.reset().
+    appenderContext.reset();
+
+    configurator.doConfigure(getClass().getResourceAsStream("/rolling-appender-logback-test.xml"));
+    StatusPrinter.printInCaseOfErrorsOrWarnings(appenderContext);
+
+    RollingLocationLogAppender rollingAppender =
+      (RollingLocationLogAppender) appenderContext.getLogger(RollingLocationLogAppenderTest.class)
+        .getAppender("rollingAppender");
+
+    addTagsToMdc("testNs", "testApp");
+    Logger logger = appenderContext.getLogger(RollingLocationLogAppenderTest.class);
+    ingestLogs(logger, 20000);
+    Map<LocationIdentifier, LocationOutputStream> activeFiles = rollingAppender.getLocationManager()
+      .getActiveLocations();
+    Assert.assertEquals(1, activeFiles.size());
+    LocationOutputStream locationOutputStream = activeFiles.get(new LocationIdentifier("testNs", "testApp"));
+    Location parentDir = Locations.getParent(locationOutputStream.getLocation());
+    Assert.assertEquals(10, parentDir.list().size());
+
+    // different program should go to different directory
+    addTagsToMdc("testNs", "testApp1");
+    ingestLogs(logger, 20000);
+    activeFiles = rollingAppender.getLocationManager().getActiveLocations();
+    Assert.assertEquals(2, activeFiles.size());
+    locationOutputStream = activeFiles.get(new LocationIdentifier("testNs", "testApp1"));
+    parentDir = Locations.getParent(locationOutputStream.getLocation());
+    Assert.assertEquals(10, parentDir.list().size());
+
+    // different program should go to different directory because namespace is different
+    addTagsToMdc("testNs1", "testApp1");
+    ingestLogs(logger, 20000);
+    activeFiles = rollingAppender.getLocationManager().getActiveLocations();
+    Assert.assertEquals(3, activeFiles.size());
+    locationOutputStream = activeFiles.get(new LocationIdentifier("testNs1", "testApp1"));
+    parentDir = Locations.getParent(locationOutputStream.getLocation());
+    Assert.assertEquals(10, parentDir.list().size());
+  }
+
+  private void ingestLogs(Logger logger, int entries) {
+    for (int i = 0; i < entries; i++) {
+      logger.info("Testing Application log: " + i);
+    }
+  }
+
+  private void verifyFileOutput(Map<LocationIdentifier, LocationOutputStream> activeFilesToLocation, int entries) throws
+    IOException {
+    for (LocationOutputStream locationOutputStream : activeFilesToLocation.values()) {
+      BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(
+        locationOutputStream.getLocation().getInputStream(), "UTF-8"));
+
+      int count = 0;
+      while ((bufferedReader.readLine()) != null) {
+        count++;
+      }
+      Assert.assertEquals(entries, count);
+    }
+  }
+
+  private void addTagsToMdc(String namespace, String applicationName) {
+    MDC.put(NamespaceLoggingContext.TAG_NAMESPACE_ID, namespace);
+    MDC.put(ApplicationLoggingContext.TAG_APPLICATION_ID, applicationName);
+    MDC.put(FlowletLoggingContext.TAG_FLOW_ID, "testFlow");
+    MDC.put(FlowletLoggingContext.TAG_FLOWLET_ID, "testFlowet");
+    MDC.put(MapReduceLoggingContext.TAG_MAP_REDUCE_JOB_ID, "testMapRed1");
+    MDC.put(MapReduceLoggingContext.TAG_INSTANCE_ID, "testMapRedInst1");
+    MDC.put(MapReduceLoggingContext.TAG_RUN_ID, "testMapRedRunId1");
+  }
+}

--- a/cdap-watchdog/src/test/resources/rolling-appender-logback-test.xml
+++ b/cdap-watchdog/src/test/resources/rolling-appender-logback-test.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright © 2017 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <property name="cdap.log.saver.instance.id" value="instanceId"/>
+
+  <appender name="rollingAppender" class="co.cask.cdap.logging.plugins.RollingLocationLogAppender">
+    <!--log file path will be created by appender as: <basePath>/namespaceId/applicationId/<filePath>-->
+    <basePath>plugins/applogs</basePath>
+    <filePath>securityLogs/logFile-${cdap.log.saver.instance.id}.log</filePath>
+    <!--cdap is the owner of log files, so cdap will get read/write permissions.
+    Log files will be read-only for others-->
+    <dirPermissions>744</dirPermissions>
+    <!--cdap is the owner of log files, so cdap will get read/write permissions.
+    Log files will be read-only for others-->
+    <filePermissions>644</filePermissions>
+    <rollingPolicy class="co.cask.cdap.logging.plugins.FixedWindowRollingPolicy">
+      <!--Only specify file name without directory, appender will use appropriate directory specified in filePath-->
+      <fileNamePattern>logFile-${cdap.log.saver.instance.id}.log.%i</fileNamePattern>
+      <minIndex>1</minIndex>
+      <maxIndex>9</maxIndex>
+    </rollingPolicy>
+
+    <triggeringPolicy class="co.cask.cdap.logging.plugins.SizeBasedTriggeringPolicy">
+      <maxFileSize>5KB</maxFileSize>
+    </triggeringPolicy>
+
+    <encoder>
+      <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
+      <!--Do not flush on every event-->
+      <immediateFlush>false</immediateFlush>
+    </encoder>
+  </appender>
+
+  <logger name="co.cask.cdap.logging.plugins.RollingLocationLogAppenderTest" level="INFO">
+    <appender-ref ref="rollingAppender"/>
+  </logger>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT"/>
+  </root>
+
+</configuration>


### PR DESCRIPTION
Adding custom HDFS rolling log appender using Logback apis. This includes `RollingLocationAppender` with `FixedWindowRollingPolicy` along with `SizeBasedTriggeringPolicy`.

Remaining:
- Compression after rollover 

Limitation:
- Prudent mode is not supported in this appender

Will create a separate PR for remaining work. 

Going to add unit tests for file permissions and if the log file already exists

Build:  http://builds.cask.co/browse/CDAP-RUT480-14