### PR TITLE
CDAP-5129 Add entity-id format description to CLI commands

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
@@ -142,14 +142,14 @@ public enum ArgumentName {
 
   public static final String ENTITY_DESCRIPTION_STRING = String.format("'<%s>' " +
     "is of the form '<entity-type>:<entity-id>', where '<entity-type>' is one of " +
-    "'artifact', 'app', 'dataset', 'program', 'stream', or 'view'. For artifacts and apps, " +
+    "'artifact', 'app', 'dataset', 'program', 'stream', or 'view'.\n\n    For artifacts and apps, " +
     "'<entity-id>' is composed of the namespace, entity name, and version, such as " +
     "'<namespace-name>.<artifact-name>.<artifact-version>' or " +
-    "'<namespace-name>.<app-name>.<app-version>'. For programs, '<entity-id>' includes the " +
+    "'<namespace-name>.<app-name>.<app-version>'.\n\n    For programs, '<entity-id>' includes the " +
     "application name and the program type: " +
     "'<namespace-name>.<app-name>.<program-type>.<program-name>'. '<program-type>' is one of " +
-    "flow, mapreduce, service, spark, worker, or workflow. For datasets and streams, " +
+    "flow, mapreduce, service, spark, worker, or workflow.\n\n    For datasets and streams, " +
     "'<entity-id>' is the namespace and entity names, such as '<namespace-name>.<dataset-name>' " +
-    "or '<namespace-name>.<stream-name>'. For (stream) views, '<entity-id>' includes the stream " +
+    "or '<namespace-name>.<stream-name>'.\n\n    For (stream) views, '<entity-id>' includes the stream " +
     "that they were created from: '<namespace-name>.<stream-name>.<view-name>'.", ENTITY);
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
@@ -140,7 +140,7 @@ public enum ArgumentName {
     return name;
   }
 
-  public static final String ENTITY_DESCRIPTION_STRING = String.format("'<%s>' 
+  public static final String ENTITY_DESCRIPTION_STRING = String.format("'<%s>' " +
     "is of the form '<entity-type>:<entity-id>', where '<entity-type>' is one of " +
     "'artifact', 'app', 'dataset', 'program', 'stream', or 'view'. For artifacts and apps, " +
     "'<entity-id>' is composed of the namespace, entity name, and version, such as " +

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2016 Cask Data, Inc.
+ * Copyright © 2012-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -109,14 +109,14 @@ public enum ArgumentName {
 
   INSTANCE_URI("cdap-instance-uri"),
   VERIFY_SSL_CERT("verify-ssl-cert"),
-  ENTITY("entity-id"),
 
   /**
    * Metadata
    */
+  ENTITY("entity-id"),
+  METADATA_SCOPE("scope"),
   SEARCH_QUERY("search-query"),
   TARGET_TYPE("target-type"),
-  METADATA_SCOPE("scope"),
 
   /**
    * Authorization

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
@@ -109,7 +109,7 @@ public enum ArgumentName {
 
   INSTANCE_URI("cdap-instance-uri"),
   VERIFY_SSL_CERT("verify-ssl-cert"),
-  ENTITY("entity-id"),
+  ENTITY("entity"),
 
   /**
    * Metadata
@@ -140,7 +140,16 @@ public enum ArgumentName {
     return name;
   }
 
-  public static final String ENTITY_DESCRIPTION_STRING = String.format("'<%s>' is of the form " +
-    "'<entity-type>:<namespace-id>.<entity-name>', where '<entity-type>' is one of " +
-    "'artifact', 'app', 'dataset', 'program', 'stream', or 'view'.", ENTITY);
+  public static final String ENTITY_DESCRIPTION_STRING = String.format("'<%s>' 
+    "is of the form '<entity-type>:<entity-id>', where '<entity-type>' is one of " +
+    "'artifact', 'app', 'dataset', 'program', 'stream', or 'view'. For artifacts and apps, " +
+    "'<entity-id>' is composed of the namespace, entity name, and version, such as " +
+    "'<namespace-name>.<artifact-name>.<artifact-version>' or " +
+    "'<namespace-name>.<app-name>.<app-version>'. For programs, '<entity-id>' includes the " +
+    "application name and the program type: " +
+    "'<namespace-name>.<app-name>.<program-type>.<program-name>'. '<program-type>' is one of " +
+    "flow, mapreduce, service, spark, worker, or workflow. For datasets and streams, " +
+    "'<entity-id>' is the namespace and entity names, such as '<namespace-name>.<dataset-name>' " +
+    "or '<namespace-name>.<stream-name>'. For (stream) views, '<entity-id>' includes the stream " +
+    "that they were created from: '<namespace-name>.<stream-name>.<view-name>'.", ENTITY);
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
@@ -109,11 +109,11 @@ public enum ArgumentName {
 
   INSTANCE_URI("cdap-instance-uri"),
   VERIFY_SSL_CERT("verify-ssl-cert"),
+  ENTITY("entity-id"),
 
   /**
    * Metadata
    */
-  ENTITY("entity-id"),
   METADATA_SCOPE("scope"),
   SEARCH_QUERY("search-query"),
   TARGET_TYPE("target-type"),
@@ -139,4 +139,8 @@ public enum ArgumentName {
   public String toString() {
     return name;
   }
+
+  public static final String ENTITY_DESCRIPTION_STRING = String.format("'<%s>' is of the form " +
+    "'<entity-type>:<namespace-id>.<entity-name>', where '<entity-type>' is one of " +
+    "'artifact', 'app', 'dataset', 'program', 'stream', or 'view'.", ENTITY);
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateNamespaceCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateNamespaceCommand.java
@@ -77,6 +77,6 @@ public class CreateNamespaceCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Creates a %s in CDAP.", ElementType.NAMESPACE.getName());
+    return String.format("Creates a %s in CDAP", ElementType.NAMESPACE.getName());
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteRouteConfigCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteRouteConfigCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteRouteConfigCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteRouteConfigCommand.java
@@ -59,7 +59,7 @@ public class DeleteRouteConfigCommand extends AbstractAuthCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Delete the route configuration for %s.",
+    return String.format("Delete the route configuration for %s",
                          Fragment.of(Article.A, ElementType.SERVICE.getName()));
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteWorkflowLocalDatasetsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteWorkflowLocalDatasetsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteWorkflowLocalDatasetsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteWorkflowLocalDatasetsCommand.java
@@ -65,6 +65,7 @@ public class DeleteWorkflowLocalDatasetsCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Deletes the local datasets associated with the workflow for a given run ID";
+    return String.format("Deletes the local datasets associated with the workflow for a given '<%s>'",
+                         ArgumentName.RUN_ID);
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ExecuteQueryCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ExecuteQueryCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ExecuteQueryCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ExecuteQueryCommand.java
@@ -126,7 +126,7 @@ public class ExecuteQueryCommand extends AbstractAuthCommand implements Categori
 
   @Override
   public String getDescription() {
-    return String.format("Executes %s with optional <%s> in minutes (default is no timeout).",
+    return String.format("Executes %s with optional '<%s>' in minutes (default is no timeout)",
                          Fragment.of(Article.A, ElementType.QUERY.getName()), ArgumentName.TIMEOUT);
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRunsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRunsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRunsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetProgramRunsCommand.java
@@ -98,6 +98,6 @@ public class GetProgramRunsCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Gets the run history of %s.", Fragment.of(Article.A, elementType.getName()));
+    return String.format("Gets the run history of %s", Fragment.of(Article.A, elementType.getName()));
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetRouteConfigCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetRouteConfigCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetRouteConfigCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetRouteConfigCommand.java
@@ -59,6 +59,6 @@ public class GetRouteConfigCommand extends AbstractAuthCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Get the route configuration for %s.", Fragment.of(Article.A, ElementType.SERVICE.getName()));
+    return String.format("Get the route configuration for %s", Fragment.of(Article.A, ElementType.SERVICE.getName()));
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowCurrentRunCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowCurrentRunCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowCurrentRunCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowCurrentRunCommand.java
@@ -82,6 +82,6 @@ public class GetWorkflowCurrentRunCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Gets the currently running nodes of a workflow for a given run ID";
+    return String.format("Gets the currently running nodes of a workflow for a given '<%s>'", ArgumentName.RUN_ID);
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowLocalDatasetsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowLocalDatasetsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowLocalDatasetsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowLocalDatasetsCommand.java
@@ -72,7 +72,8 @@ public class GetWorkflowLocalDatasetsCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Gets the local datasets associated with the workflow for a given run ID";
+    return String.format("Gets the local datasets associated with the workflow for a given '<%s>'",
+                         ArgumentName.RUN_ID);
   }
 
   private Table getWorkflowLocalDatasets(ProgramRunId programRunId)

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowStateCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowStateCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowStateCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowStateCommand.java
@@ -74,7 +74,8 @@ public class GetWorkflowStateCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Gets the state of all nodes associated with the workflow for a given run id.";
+    return String.format("Gets the state of all nodes associated with the workflow for a given '<%s>'",
+                         ArgumentName.RUN_ID);
   }
 
   private Table getWorkflowNodeStates(ProgramRunId programRunId)

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowTokenCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowTokenCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowTokenCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetWorkflowTokenCommand.java
@@ -97,7 +97,8 @@ public class GetWorkflowTokenCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Gets the workflow token of a workflow for a given run ID";
+    return String.format("Gets the workflow token of a workflow for a given '<%s>'",
+                         ArgumentName.RUN_ID);
   }
 
   private Table getWorkflowToken(ProgramRunId runId, WorkflowToken.Scope workflowTokenScope, String key)

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/LoadStreamCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/LoadStreamCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/LoadStreamCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/LoadStreamCommand.java
@@ -96,11 +96,11 @@ public class LoadStreamCommand extends AbstractAuthCommand implements Categorize
   public String getDescription() {
     return String.format("Loads a file to %s. The contents of the file will " +
                          "become multiple events in the %s, " +
-                         "based on the content type (%s). If '<%s>' is not provided, " +
+                         "based on the content type ('%s'). If '<%s>' is not provided, " +
                          "it will be detected by the file extension. Supported file extensions: '%s'.",
                          Fragment.of(Article.A, ElementType.STREAM.getName()),
                          ElementType.STREAM.getName(),
-                         Joiner.on(", ").join(ImmutableSet.copyOf(CONTENT_TYPE_MAP.values())),
+                         Joiner.on("', '").join(ImmutableSet.copyOf(CONTENT_TYPE_MAP.values())),
                          ArgumentName.CONTENT_TYPE,
                          Joiner.on("', '").join(CONTENT_TYPE_MAP.keySet()));
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamFormatCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamFormatCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamFormatCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamFormatCommand.java
@@ -101,8 +101,8 @@ public class SetStreamFormatCommand extends AbstractAuthCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Sets the format of %s. Valid '<%s>'s are '%s'. '<%s>' is a SQL-like schema " +
-      "'column_name data_type, ...' or an Avro-like JSON schema and '<%s>' is specified in the format " +
+    return String.format("Sets the format of %s. A valid '<%s>' is one of '%s'. A '<%s>' is an SQL-like schema " +
+      "'column_name data_type, ...' or an Avro-like JSON schema. A '<%s>' is specified in the format " +
       "'key1=v1 key2=v2'.",
       Fragment.of(Article.A, ElementType.STREAM.getName()), ArgumentName.FORMAT, Joiner.on("', '").join(Formats.ALL),
       ArgumentName.SCHEMA, ArgumentName.SETTINGS);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/CreateAppCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/CreateAppCommand.java
@@ -89,10 +89,10 @@ public class CreateAppCommand extends AbstractAuthCommand {
   @Override
   public String getDescription() {
     return String.format("Creates %s from an artifact, optionally with a version. If the version is not given, " +
-                           "a default version %s will be used. A configuration is also optional. If a configuration " +
-                           "is needed, it must be given as a file whose contents are a JSON object containing the" +
-                           " application config. For example, the file contents could contain:" +
-                           " '{ \"config\": { \"stream\": \"purchases\" } }'. In this case, the application would " +
+                           "a default version '%s' will be used. A configuration is also optional. If a " +
+                           "configuration is needed, it must be given as a file whose contents are a JSON object " +
+                           "containing the application config. For example, the file contents could contain: " +
+                           "'{ \"config\": { \"stream\": \"purchases\" } }'. In this case, the application would " +
                            "receive '{ \"stream\": \"purchases\" }' as its config object.",
       Fragment.of(Article.A, ElementType.APP.getName()), ApplicationId.DEFAULT_VERSION);
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/CreateAppCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/CreateAppCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2015 Cask Data, Inc.
+ * Copyright © 2012-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/DeleteAppCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/DeleteAppCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/DeleteAppCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/DeleteAppCommand.java
@@ -57,7 +57,7 @@ public class DeleteAppCommand extends AbstractAuthCommand {
   @Override
   public String getDescription() {
     return String.format("Deletes %s with an optional version. If version is not provided, default version '%s' " +
-                           "will be used", Fragment.of(Article.A, ElementType.APP.getName()),
+                           "will be used.", Fragment.of(Article.A, ElementType.APP.getName()),
                          ApplicationId.DEFAULT_VERSION);
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/DeleteAppCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/DeleteAppCommand.java
@@ -56,7 +56,7 @@ public class DeleteAppCommand extends AbstractAuthCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Deletes %s with an optional version. If version is not provided, default version \"%s\" " +
+    return String.format("Deletes %s with an optional version. If version is not provided, default version '%s' " +
                            "will be used", Fragment.of(Article.A, ElementType.APP.getName()),
                          ApplicationId.DEFAULT_VERSION);
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/DescribeAppCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/DescribeAppCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2014 Cask Data, Inc.
+ * Copyright © 2012-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/DescribeAppCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/DescribeAppCommand.java
@@ -71,7 +71,7 @@ public class DescribeAppCommand extends AbstractAuthCommand {
   @Override
   public String getDescription() {
     return String.format("Describes %s with an optional version. If version is not provided, default version '%s' " +
-                           "will be used", Fragment.of(Article.A, ElementType.APP.getName()),
+                           "will be used.", Fragment.of(Article.A, ElementType.APP.getName()),
                          ApplicationId.DEFAULT_VERSION);
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/DescribeAppCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/DescribeAppCommand.java
@@ -70,7 +70,7 @@ public class DescribeAppCommand extends AbstractAuthCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Describes %s with an optional version. If version is not provided, default version \"%s\" " +
+    return String.format("Describes %s with an optional version. If version is not provided, default version '%s' " +
                            "will be used", Fragment.of(Article.A, ElementType.APP.getName()),
                          ApplicationId.DEFAULT_VERSION);
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/ListAppVersionsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/ListAppVersionsCommand.java
@@ -1,6 +1,5 @@
 /*
- *
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/ListAppVersionsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/app/ListAppVersionsCommand.java
@@ -67,6 +67,6 @@ public class ListAppVersionsCommand extends AbstractAuthCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Lists all versions of a specific %s.", ElementType.APP.getName());
+    return String.format("Lists all versions of a specific %s", ElementType.APP.getName());
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DescribeArtifactCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DescribeArtifactCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DescribeArtifactCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DescribeArtifactCommand.java
@@ -88,8 +88,8 @@ public class DescribeArtifactCommand extends AbstractAuthCommand {
   @Override
   public String getDescription() {
     return String.format("Describes %s, including information about the application and plugin classes contained in " +
-                         "the artifact. If no scope is provided, the artifact is looked for first in the SYSTEM " +
-                         "and then in the USER scope.",
+                         "the artifact. If no scope is provided, the artifact is looked for first in the 'SYSTEM' " +
+                         "and then in the 'USER' scope.",
                          Fragment.of(Article.A, ElementType.ARTIFACT.getName()));
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DescribeArtifactPluginCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DescribeArtifactPluginCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DescribeArtifactPluginCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/DescribeArtifactPluginCommand.java
@@ -88,7 +88,7 @@ public class DescribeArtifactPluginCommand extends AbstractAuthCommand {
   public String getDescription() {
     return String.format("Describes a plugin of a specific type and name available to a specific %s. " +
                          "Can return multiple details if there are multiple versions of the plugin. If no scope is " +
-                         "provided, plugins are looked for first in the SYSTEM and then in the USER scope.",
+                         "provided, plugins are looked for first in the 'SYSTEM' and then in the 'USER' scope.",
                          ElementType.ARTIFACT.getName());
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/GetArtifactPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/GetArtifactPropertiesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/GetArtifactPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/GetArtifactPropertiesCommand.java
@@ -90,7 +90,7 @@ public class GetArtifactPropertiesCommand extends AbstractAuthCommand {
   @Override
   public String getDescription() {
     return String.format("Gets the properties of %s. If no scope is provided, properties are looked for first in " +
-                         "the SYSTEM and then in the USER scope.",
+                         "the 'SYSTEM' and then in the 'USER' scope.",
                          Fragment.of(Article.A, ElementType.ARTIFACT.getName()));
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactPluginTypesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactPluginTypesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactPluginTypesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactPluginTypesCommand.java
@@ -80,7 +80,7 @@ public class ListArtifactPluginTypesCommand extends AbstractAuthCommand {
   @Override
   public String getDescription() {
     return String.format("Lists all plugin types usable by the specified %s. " +
-      "If no scope is provided, %s are looked for first in the SYSTEM and then in the USER scope.", 
+      "If no scope is provided, %s are looked for first in the 'SYSTEM' and then in the 'USER' scope.",
                          ElementType.ARTIFACT.getName(), ElementType.ARTIFACT.getNamePlural());
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactPluginsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactPluginsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactPluginsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactPluginsCommand.java
@@ -85,7 +85,7 @@ public class ListArtifactPluginsCommand extends AbstractAuthCommand {
   public String getDescription() {
     return String.format("Lists all plugins of a specific type available to a specific %s. " +
       "Returns the type, name, classname, and description of the plugin, as well as the %s the plugin came from. " +
-      "If no scope is provided, %s are looked for first in the SYSTEM and then in the USER scope.",
+      "If no scope is provided, %s are looked for first in the 'SYSTEM' and then in the 'USER' scope.",
       ElementType.ARTIFACT.getName(), ElementType.ARTIFACT.getName(), ElementType.ARTIFACT.getNamePlural());
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactVersionsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactVersionsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactVersionsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/artifact/ListArtifactVersionsCommand.java
@@ -76,7 +76,7 @@ public class ListArtifactVersionsCommand extends AbstractAuthCommand {
   @Override
   public String getDescription() {
     return String.format("Lists all versions of a specific %s. If no scope is provided, %s are looked " +
-                           "for first in the SYSTEM and then in the USER scope.",
+                           "for first in the 'SYSTEM' and then in the 'USER' scope.",
                          ElementType.ARTIFACT.getName(), ElementType.ARTIFACT.getNamePlural());
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/AddMetadataPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/AddMetadataPropertiesCommand.java
@@ -34,7 +34,7 @@ public class AddMetadataPropertiesCommand extends AbstractCommand {
 
   private final MetadataClient client;
 
-  public static String ENTITY_DESCRIPTION_STRING = String.format("'<%s>' is of the form " +
+  public static final String ENTITY_DESCRIPTION_STRING = String.format("'<%s>' is of the form " +
     "'<entity-type>:<namespace-id>.<entity-name>', where <entity-type> is one of " +
     "'artifact', 'app', 'dataset', 'program', 'stream', or 'view'.", ArgumentName.ENTITY);
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/AddMetadataPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/AddMetadataPropertiesCommand.java
@@ -35,7 +35,7 @@ public class AddMetadataPropertiesCommand extends AbstractCommand {
   private final MetadataClient client;
 
   public static final String ENTITY_DESCRIPTION_STRING = String.format("'<%s>' is of the form " +
-    "'<entity-type>:<namespace-id>.<entity-name>', where <entity-type> is one of " +
+    "'<entity-type>:<namespace-id>.<entity-name>', where '<entity-type>' is one of " +
     "'artifact', 'app', 'dataset', 'program', 'stream', or 'view'.", ArgumentName.ENTITY);
 
   @Inject

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/AddMetadataPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/AddMetadataPropertiesCommand.java
@@ -34,10 +34,6 @@ public class AddMetadataPropertiesCommand extends AbstractCommand {
 
   private final MetadataClient client;
 
-  public static final String ENTITY_DESCRIPTION_STRING = String.format("'<%s>' is of the form " +
-    "'<entity-type>:<namespace-id>.<entity-name>', where '<entity-type>' is one of " +
-    "'artifact', 'app', 'dataset', 'program', 'stream', or 'view'.", ArgumentName.ENTITY);
-
   @Inject
   public AddMetadataPropertiesCommand(CLIConfig cliConfig, MetadataClient client) {
     super(cliConfig);
@@ -59,6 +55,6 @@ public class AddMetadataPropertiesCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Adds metadata properties for an entity. " + ENTITY_DESCRIPTION_STRING;
+    return "Adds metadata properties for an entity. " + ArgumentName.ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/AddMetadataPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/AddMetadataPropertiesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -34,6 +34,10 @@ public class AddMetadataPropertiesCommand extends AbstractCommand {
 
   private final MetadataClient client;
 
+  public static String ENTITY_DESCRIPTION_STRING = String.format("'<%s>' is of the form " +
+    "'<entity-type>:<namespace-id>.<entity-name>', where <entity-type> is one of " +
+    "'artifact', 'app', 'dataset', 'program', 'stream', or 'view'.", ArgumentName.ENTITY);
+
   @Inject
   public AddMetadataPropertiesCommand(CLIConfig cliConfig, MetadataClient client) {
     super(cliConfig);
@@ -55,6 +59,6 @@ public class AddMetadataPropertiesCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Adds metadata properties for an entity";
+    return "Adds metadata properties for an entity. " + ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/AddMetadataTagsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/AddMetadataTagsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -56,6 +56,6 @@ public class AddMetadataTagsCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Adds metadata tags for an entity. " + AddMetadataPropertiesCommand.ENTITY_DESCRIPTION_STRING;
+    return "Adds metadata tags for an entity. " + ArgumentName.ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/AddMetadataTagsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/AddMetadataTagsCommand.java
@@ -56,6 +56,6 @@ public class AddMetadataTagsCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Adds metadata tags for an entity";
+    return "Adds metadata tags for an entity. " + AddMetadataPropertiesCommand.ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -83,6 +83,6 @@ public class GetMetadataCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Gets the metadata of an entity";
+    return "Gets the metadata of an entity. " + AddMetadataPropertiesCommand.ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataCommand.java
@@ -83,6 +83,6 @@ public class GetMetadataCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Gets the metadata of an entity. " + AddMetadataPropertiesCommand.ENTITY_DESCRIPTION_STRING;
+    return "Gets the metadata of an entity. " + ArgumentName.ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataPropertiesCommand.java
@@ -77,6 +77,6 @@ public class GetMetadataPropertiesCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Gets the metadata properties of an entity. " + AddMetadataPropertiesCommand.ENTITY_DESCRIPTION_STRING;
+    return "Gets the metadata properties of an entity. " + ArgumentName.ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataPropertiesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -77,6 +77,6 @@ public class GetMetadataPropertiesCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Gets the metadata properties of an entity";
+    return "Gets the metadata properties of an entity. " + AddMetadataPropertiesCommand.ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataTagsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataTagsCommand.java
@@ -77,6 +77,6 @@ public class GetMetadataTagsCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Gets the metadata tags of an entity";
+    return "Gets the metadata tags of an entity. " + AddMetadataPropertiesCommand.ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataTagsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/GetMetadataTagsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -77,6 +77,6 @@ public class GetMetadataTagsCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Gets the metadata tags of an entity. " + AddMetadataPropertiesCommand.ENTITY_DESCRIPTION_STRING;
+    return "Gets the metadata tags of an entity. " + ArgumentName.ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -53,6 +53,6 @@ public class RemoveMetadataCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Removes metadata for an entity";
+    return "Removes metadata for an entity. " + AddMetadataPropertiesCommand.ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataCommand.java
@@ -53,6 +53,6 @@ public class RemoveMetadataCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Removes metadata for an entity. " + AddMetadataPropertiesCommand.ENTITY_DESCRIPTION_STRING;
+    return "Removes metadata for an entity. " + ArgumentName.ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataPropertiesCommand.java
@@ -53,6 +53,6 @@ public class RemoveMetadataPropertiesCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Removes all metadata properties for an entity. " + AddMetadataPropertiesCommand.ENTITY_DESCRIPTION_STRING;
+    return "Removes all metadata properties for an entity. " + ArgumentName.ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataPropertiesCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -53,6 +53,6 @@ public class RemoveMetadataPropertiesCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Removes all metadata properties for an entity";
+    return "Removes all metadata properties for an entity. " + AddMetadataPropertiesCommand.ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataPropertyCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataPropertyCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -54,6 +54,7 @@ public class RemoveMetadataPropertyCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Removes a specific metadata property for an entity";
+    return "Removes a specific metadata property for an entity. " +
+      AddMetadataPropertiesCommand.ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataPropertyCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataPropertyCommand.java
@@ -54,7 +54,6 @@ public class RemoveMetadataPropertyCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Removes a specific metadata property for an entity. " +
-      AddMetadataPropertiesCommand.ENTITY_DESCRIPTION_STRING;
+    return "Removes a specific metadata property for an entity. " + ArgumentName.ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataTagCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataTagCommand.java
@@ -54,6 +54,6 @@ public class RemoveMetadataTagCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Removes a specific metadata tag for an entity. " + AddMetadataPropertiesCommand.ENTITY_DESCRIPTION_STRING;
+    return "Removes a specific metadata tag for an entity. " + ArgumentName.ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataTagCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataTagCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -54,6 +54,6 @@ public class RemoveMetadataTagCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Removes a specific metadata tag for an entity";
+    return "Removes a specific metadata tag for an entity. " + AddMetadataPropertiesCommand.ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataTagsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataTagsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -53,6 +53,6 @@ public class RemoveMetadataTagsCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Removes all metadata tags for an entity";
+    return "Removes all metadata tags for an entity. " + AddMetadataPropertiesCommand.ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataTagsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/RemoveMetadataTagsCommand.java
@@ -53,6 +53,6 @@ public class RemoveMetadataTagsCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return "Removes all metadata tags for an entity. " + AddMetadataPropertiesCommand.ENTITY_DESCRIPTION_STRING;
+    return "Removes all metadata tags for an entity. " + ArgumentName.ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/SearchMetadataCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/SearchMetadataCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/SearchMetadataCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/SearchMetadataCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2017 Cask Data, Inc.
+ * Copyright © 2016 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/GrantActionCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/GrantActionCommand.java
@@ -69,6 +69,6 @@ public class GrantActionCommand extends AbstractAuthCommand {
   @Override
   public String getDescription() {
     return "Grants a principal permission to perform certain actions on an entity. " +
-      "'<actions>' is a comma-separated list.";
+      "'<actions>' is a comma-separated list. " + ArgumentName.ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/RevokeActionForPrincipalCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/RevokeActionForPrincipalCommand.java
@@ -41,6 +41,6 @@ public class RevokeActionForPrincipalCommand extends RevokeActionCommand {
   @Override
   public String getDescription() {
     return "Revokes a user's permission to perform certain actions on an entity. " +
-      "'<actions>' is a comma-separated list.";
+      "'<actions>' is a comma-separated list. " + ArgumentName.ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/RevokeEntityCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/security/RevokeEntityCommand.java
@@ -38,6 +38,6 @@ public class RevokeEntityCommand extends RevokeActionCommand {
 
   @Override
   public String getDescription() {
-    return "Revokes all privileges for all users on the entity";
+    return "Revokes all privileges for all users on the entity. " + ArgumentName.ENTITY_DESCRIPTION_STRING;
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/stream/view/CreateOrUpdateStreamViewCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/stream/view/CreateOrUpdateStreamViewCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/stream/view/CreateOrUpdateStreamViewCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/stream/view/CreateOrUpdateStreamViewCommand.java
@@ -81,8 +81,8 @@ public class CreateOrUpdateStreamViewCommand extends AbstractAuthCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Creates or updates a stream-view. Valid '<%s>'s are '%s'. '<%s>' is a SQL-like schema " +
-      "'column_name data_type, ...' or an Avro-like JSON schema and '<%s>' is specified in the format " +
+    return String.format("Creates or updates a stream-view. A valid '<%s>' is one of '%s'. A '<%s>' is an SQL-like " +
+      "schema 'column_name data_type, ...' or an Avro-like JSON schema. A '<%s>' is specified in the format " +
       "'key1=v1 key2=v2'.",
       ArgumentName.FORMAT, Joiner.on("', '").join(Formats.ALL), ArgumentName.SCHEMA, ArgumentName.SETTINGS);
   }

--- a/cdap-docs/tools/docs-cli-commands.py
+++ b/cdap-docs/tools/docs-cli-commands.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Copyright © 2016 Cask Data, Inc.
+# Copyright © 2016-2017 Cask Data, Inc.
 #
 # Used to generate a table in the CLI documentation from the output of CLI tools.
 # 
@@ -14,7 +14,7 @@ import os
 import sys
 from optparse import OptionParser
 
-VERSION = "0.0.3"
+VERSION = "0.0.4"
 
 LITERAL = '``'
 SPACE = ' '

--- a/cdap-docs/tools/docs-cli-commands.py
+++ b/cdap-docs/tools/docs-cli-commands.py
@@ -95,7 +95,7 @@ def create_parsed_line(line):
         i +=1 
         if c == QUOTE:
             if not in_literal:
-                if i and line[i-1] != SPACE: # Preceding character
+                if i and line[i-1] not in (SPACE, "("): # Preceding character
                     new_line += c
                 else:
                     new_line += opening_literal_quote


### PR DESCRIPTION
Fix for https://issues.cask.co/browse/CDAP-5129

Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB249-5 (this will fail, as develop was broken at the time this branch was created.)

Page of interest: CLI Documentation
http://builds.cask.co/artifact/CDAP-DQB249/shared/build-5/Docs-HTML/4.1.0-SNAPSHOT/en/reference-manual/cli-api.html#available-commands

I have done a pass over all of the documentation strings, and tried to make them as consistent as I could:
- Add quotes to format expression correctly.
- Added single quotes to improve formatting and reading of commands.
- Removed trailing periods on single-sentence descriptions.
- Fixed an error in the CLI rst builder that did not convert an expression enclosed with single-quotes if it began immediately after an opening parentheses.

The "rule" is that anything enclosed in single-quotes in a help description will be converted to a literal in the HTML version of the documentation, so that '\<artifact-id>' will become `'<artifact-id>' `.