### PR TITLE
implement FileSetLocation.toString

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetDataset.java
@@ -587,6 +587,11 @@ public final class FileSetDataset implements FileSet, DatasetOutputCommitter {
     public int hashCode() {
       return delegate.hashCode();
     }
+
+    @Override
+    public String toString() {
+      return delegate.toString();
+    }
   }
 
   private final class FileSetLocationFactory extends ForwardingLocationFactory {


### PR DESCRIPTION
It appears that some hydrator plugins set the input of a MapReduce to Location.toString. It should be location.getPath(), and it was just working by coincidence in the past... Anyway this should fix the broken build in http://builds.cask.co/browse/CDAP-BUT-746.