### PR TITLE
CDAP-7984 Correct descriptions in cdap-defaults.xml

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1549,10 +1549,11 @@
     <name>metrics.messaging.topic.num</name>
     <value>10</value>
     <description>
-      Number of topics for metrics in messaging. This property controls how many topics in messaging
-      that metrics are sent to, and the number of threads used to fetch from the messaging service
-      and process metrics in parallel. With the default value of 10, ten topics will be created for metrics
-      with the names ${metrics.topic.prefix}0, ${metrics.topic.prefix}1, ... and ${metrics.topic.prefix}9.
+      Number of topics for metrics messages. This property also sets the number of threads
+      used to fetch and process metrics in parallel from the messaging service. For a
+      value of N, topics will be created for metrics with names beginning at
+      ${metrics.topic.prefix}0, ${metrics.topic.prefix}1, up to
+      ${metrics.topic.prefix}(N-1).
     </description>
   </property>
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -101,7 +101,7 @@
     <description>
       Whether CDAP master should manage HBase coprocessors. This should only
       be set to false if you are managing coprocessors yourself in order to
-      support rolling HBase upgrades
+      support rolling HBase upgrades.
     </description>
   </property>
 
@@ -915,8 +915,8 @@
     <name>kafka.server.log.flush.interval.messages</name>
     <value>10000</value>
     <description>
-      The interval length (in number of messages) at which to force an fsync of data
-      written to the log
+      The interval length (in number of messages in the CDAP Kafka service) at which to
+      force an fsync of data written to the log 
     </description>
   </property>
 
@@ -924,7 +924,9 @@
     <name>kafka.server.log.retention.hours</name>
     <value>24</value>
     <description>
-      The number of hours to keep a log file before deleting it
+      The number of hours to keep a log file before deleting it; this is the time-to-live
+      in the CDAP Kafka service, while a log is in-flight between the container and the
+      CDAP log saver
     </description>
   </property>
 
@@ -932,7 +934,7 @@
     <name>kafka.server.num.partitions</name>
     <value>10</value>
     <description>
-      Default number of partitions for a topic
+      Default number of partitions for a topic in the CDAP Kafka service
     </description>
   </property>
 
@@ -948,7 +950,7 @@
     <name>kafka.server.zookeeper.connection.timeout.ms</name>
     <value>1000000</value>
     <description>
-      Maximum time in milliseconds that the client will wait to
+      Maximum time in milliseconds that the CDAP Kafka service will wait to
       establish a connection to ZooKeeper
     </description>
   </property>
@@ -1022,7 +1024,7 @@
     <name>log.retention.duration.days</name>
     <value>7</value>
     <description>
-      Duration in days of log file HDFS retention
+      Duration (the time-to-live) in days of saved log files in HDFS retention
     </description>
   </property>
 
@@ -1108,8 +1110,8 @@
     <value>ERROR</value>
     <description>
       The log level of application container logs that are streamed back to
-      the CDAP Master process log. The levels supported are [ ALL, TRACE,
-      DEBUG, INFO, WARN, ERROR, OFF ].
+      the CDAP Master process log. The levels supported are "ALL", "TRACE",
+      "DEBUG", "INFO", "WARN", "ERROR", and "OFF".
     </description>
   </property>
 
@@ -1210,7 +1212,8 @@
     <name>messaging.local.data.cleanup.frequency.secs</name>
     <value>3600</value>
     <description>
-      Scheduling frequency of TTL cleanup thread in seconds (only used in Standalone CDAP)
+      Scheduling frequency of time-to-live cleanup thread in seconds (only used in
+      Standalone CDAP)
     </description>
   </property>
 
@@ -1320,7 +1323,7 @@
       Multiple topics sharing the same prefix and distinguished by different numerical suffices
       can be specified with the syntax &lt;common.prefix&gt;:&lt;total.topic.number&gt;,
       where the &lt;total.topic.number&gt; is the total number of topics sharing the &lt;common.prefix&gt;,
-      and the numerical suffices will range from 0 to (&lt;total.topic.number&gt; - 1)
+      and the numerical suffices will range from 0 to (&lt;total.topic.number&gt; - 1).
     </description>
   </property>
 
@@ -1528,9 +1531,9 @@
     <name>metrics.messaging.fetcher.limit</name>
     <value>200</value>
     <description>
-      Maximum limit on number of metrics messages to be fetched from messaging fetcher at once.
-      It's also the maximum number of MetricValues to be persisted in metrics store after the
-      number of fetched messages reaches the limit
+      Maximum number of metrics messages to be fetched from the messaging fetcher at once.
+      It is also the maximum number of metric values to be persisted in the metrics store after the
+      number of fetched messages reaches the limit.
     </description>
   </property>
   
@@ -1546,10 +1549,10 @@
     <name>metrics.messaging.topic.num</name>
     <value>10</value>
     <description>
-      Number of topics for metrics in messaging. This number controls how many topics in messaging
-      which metrics are sent to, and the number of threads fetching from messaging service
-      and processing metrics in parallel. With the default value 10, 10 topics will be created for metrics
-      with names: ${metrics.topic.prefix}0, ${metrics.topic.prefix}1, ... ${metrics.topic.prefix}9
+      Number of topics for metrics in messaging. This property controls how many topics in messaging
+      that metrics are sent to, and the number of threads used to fetch from the messaging service
+      and process metrics in parallel. With the default value of 10, ten topics will be created for metrics
+      with the names ${metrics.topic.prefix}0, ${metrics.topic.prefix}1, ... and ${metrics.topic.prefix}9.
     </description>
   </property>
 
@@ -1862,7 +1865,7 @@
     <name>mapreduce.retry.policy.type</name>
     <value>exponential.backoff</value>
     <description>
-      The type of retry policy for mapreduce
+      The type of retry policy for MapReduce programs
     </description>
   </property>
 
@@ -1942,7 +1945,7 @@
     <name>spark.retry.policy.type</name>
     <value>exponential.backoff</value>
     <description>
-      The type of retry policy for spark
+      The type of retry policy for Spark programs
     </description>
   </property>
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="968187ef73ecad8971d91d7ba7c74551"
+DEFAULT_XML_MD5_HASH="47352bba4edbdd0c4788b1ddacb747d4"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="47352bba4edbdd0c4788b1ddacb747d4"
+DEFAULT_XML_MD5_HASH="303c787d8c3d9b8767cfc75cfbba0cf5"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-docs/admin-manual/source/appendices/cdap-site.rst
+++ b/cdap-docs/admin-manual/source/appendices/cdap-site.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014-2016 Cask Data, Inc.
+    :copyright: Copyright © 2014-2017 Cask Data, Inc.
 
 .. _appendix-cdap-default.xml:
 .. _appendix-cdap-site.xml:
@@ -21,11 +21,23 @@ Any of the default values (with the exception of those marked :ref:`[Final]
 ``cdap-site.xml`` file, located (by default) either in ``<CDAP-SDK-HOME>/conf/cdap-site.xml`` 
 (Standalone mode) or ``/etc/cdap/conf/cdap-site.xml`` (Distributed mode).
 
-Below are the parameters that can be defined in the ``cdap-site.xml`` file, their default
-values (obtained from ``cdap-default.xml``), descriptions, and notes. 
+The section below are the parameters that can be defined in the ``cdap-site.xml`` file, their default
+values (obtained from ``cdap-default.xml``) and their descriptions. 
 
-For information on configuring the ``cdap-site.xml`` file and CDAP for security,
-see the :ref:`admin-security` section.
+.. rubric:: Notes
+
+.. _cdap-site-xml-note-final:
+
+- **[Final]:** Properties marked as *[Final]* indicates that their value cannot be changed, even
+  with a setting in the ``cdap-site.xml``.
+
+- **Kafka Server:** All properties that begin with ``kafka.server.`` are passed to the CDAP
+  Kafka service when it is started up.
+
+- **Security:** For information on configuring the ``cdap-site.xml`` file, its
+  :ref:`security section <appendix-cdap-default-security>`, and CDAP for security, see the
+  documentation :ref:`admin-security` section.
+
 
 .. include:: ../../target/_includes/cdap-default-table.rst
 
@@ -41,11 +53,3 @@ will be removed in a future release. Replacement properties are listed as noted.
 
 .. include:: ../../target/_includes/cdap-default-deprecated-table.rst
       :start-after: ---------------------
-
-
-.. _cdap-site-xml-note-final:
-
-Notes
------
-**[Final]:** Properties marked as *[Final]* indicates that their value cannot be changed, even
-with a setting in the ``cdap-site.xml``.


### PR DESCRIPTION
Changes to cdap-default.xml descriptions. Re-organizes the appendix page to have the notes at the top, and adds a note about the Kafka service properties.
Fixes errors in the building of the rst file; fixes issues with the use of
HTML entity-equivalents in the descriptions, and adds a method to enclose
phrases that start with "${" or "<" with literals. Updates the MD5 hash.

In particular, it fixes the description of `messaging.system.topics`.

Building as a Quick Build: http://builds.cask.co/browse/CDAP-DQB250-1

Page of interest: http://builds.cask.co/artifact/CDAP-DQB250/shared/build-1/Docs-HTML/html/admin-manual/appendices/cdap-site.html

Fix for: https://issues.cask.co/browse/CDAP-7984
(`kafka.server.log.retention.hours` and `log.retention.duration.days`)