### PR TITLE
Fix incorrect port number in documentation

### DIFF
--- a/cdap-docs/developers-manual/source/advanced/configuring-resources.rst
+++ b/cdap-docs/developers-manual/source/advanced/configuring-resources.rst
@@ -68,55 +68,55 @@ in the ``default`` namespace, and would like to set the memory used by its YARN 
 - To set the memory used by the mappers of *all* MapReduce jobs, in *all* namespaces, as ``2048 MB``, you would use::
 
     task.mapper.system.resources.memory = 2048
-  
+
   You could set this using the CDAP CLI:
-  
+
     .. tabbed-parsed-literal::
        :tabs: "CDAP CLI"
 
        |cdap >| set preferences instance 'task.mapper.system.resources.memory=2048'
-  
+
   or by using a ``curl`` call:
 
     .. tabbed-parsed-literal::
 
-      $ curl -w"\n" -X PUT "http://example.com:10000/v3/preferences" \
+      $ curl -w"\n" -X PUT "http://example.com:11015/v3/preferences" \
           -H 'Content-Type: application/json' -d '{ "task.mapper.system.resources.memory": 2048 }'
 
 - To set the memory used by the mapper of the *PurchaseHistoryBuilder* MapReduce job, you would use::
 
     task.mapper.system.resources.memory = 2048
-  
+
   You could set this using the CDAP CLI:
-  
+
     .. tabbed-parsed-literal::
        :tabs: "CDAP CLI"
 
        |cdap >| set preferences mapreduce 'task.mapper.system.resources.memory=2048' PurchaseHistory.PurchaseHistoryBuilder
-  
+
   or by using a ``curl`` call:
 
     .. tabbed-parsed-literal::
 
-      $ curl -w"\n" -X PUT "http://example.com:10000/v3/namespaces/default/apps/PurchaseHistory/mapreduce/PurchaseHistoryBuilder/preferences" \
+      $ curl -w"\n" -X PUT "http://example.com:11015/v3/namespaces/default/apps/PurchaseHistory/mapreduce/PurchaseHistoryBuilder/preferences" \
           -H 'Content-Type: application/json' -d '{ "task.mapper.system.resources.memory": 2048 }'
 
 - To set the memory used by the *collector* node of the *PurchaseFlow*, you would use::
 
     flowlet.collector.system.resources.memory = 1024
-  
+
   You could set this using the CDAP CLI:
-  
+
     .. tabbed-parsed-literal::
        :tabs: "CDAP CLI"
 
        |cdap >| set preferences flow 'flowlet.collector.system.resources.memory=1024' PurchaseHistory.PurchaseFlow
-  
+
   or by using a ``curl`` call:
 
     .. tabbed-parsed-literal::
 
-      $ curl -w"\n" -X PUT "http://example.com:10000/v3/namespaces/default/apps/PurchaseHistory/flows/PurchaseFlow/preferences" \
+      $ curl -w"\n" -X PUT "http://example.com:11015/v3/namespaces/default/apps/PurchaseHistory/flows/PurchaseFlow/preferences" \
           -H 'Content-Type: application/json' -d '{ "flowlet.collector.system.resources.memory": 1024 }'
 
 These configurations can also be set through the CDAP UI, either as preferences or runtime arguments.

--- a/cdap-docs/reference-manual/source/http-restful-api/routeconfig.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/routeconfig.rst
@@ -55,7 +55,7 @@ For example, to upload a route configuration for the service *MyService*, with d
 
 .. tabbed-parsed-literal::
 
-  $ curl -w"\n" -X PUT "http://example.com:10000/v3/namespaces/default/apps/MyApp/services/MyService/routeconfig" \
+  $ curl -w"\n" -X PUT "http://example.com:11015/v3/namespaces/default/apps/MyApp/services/MyService/routeconfig" \
     -H 'Content-Type: application/json' -d \
     '{
       "v1" : 50,
@@ -106,7 +106,7 @@ For example, to retrieve the route configuration of the service *MyService*, use
 
 .. tabbed-parsed-literal::
 
-  $ curl -w"\n" -X GET "http://example.com:10000/v3/namespaces/default/apps/MyApp/services/MyService/routeconfig"
+  $ curl -w"\n" -X GET "http://example.com:11015/v3/namespaces/default/apps/MyApp/services/MyService/routeconfig"
 
   { "v1" : 50, "v2" : 50 }
 
@@ -147,7 +147,7 @@ For example, to delete the route configuration of the service *MyService*, use:
 
 .. tabbed-parsed-literal::
 
-  $ curl -w"\n" -X DELETE "http://example.com:10000/v3/namespaces/default/apps/MyApp/services/MyService/routeconfig"
+  $ curl -w"\n" -X DELETE "http://example.com:11015/v3/namespaces/default/apps/MyApp/services/MyService/routeconfig"
 
 .. rubric:: HTTP Responses
 


### PR DESCRIPTION
This PR finishes up the work in f8f606d7d74bb4e34dbbc4bf53a70fbf16ffff31 and corrects some port numbers from 10000 to 11015.

Bamboo: http://builds.cask.co/browse/CDAP-DQB251-1

Pages Changed:
* http://builds.cask.co/artifact/CDAP-DQB251/shared/build-1/Docs-HTML/html/developers-manual/advanced/configuring-resources.html
* http://builds.cask.co/artifact/CDAP-DQB251/shared/build-1/Docs-HTML/html/reference-manual/http-restful-api/query.html