### PR TITLE
Corrects spelling of HBase

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -247,7 +247,7 @@
     <name>dataset.unchecked.upgrade</name>
     <value>false</value>
     <description>
-      By default, any changes made to existing datasets are not deployed
+      If false, any changes made to existing datasets are not deployed
       when an app is redeployed; setting this value to true allows the
       dataset changes to be deployed upon app redeployment
     </description>
@@ -486,7 +486,7 @@
     <name>data.tx.bind.port</name>
     <value>0</value>
     <description>
-      Transaction service bind port; binds to a random port by default
+      Transaction service bind port; if 0 binds to a random port
     </description>
   </property>
 
@@ -1345,7 +1345,7 @@
     <name>messaging.coprocessor.metadata.cache.expiration.seconds</name>
     <value>120</value>
     <description>
-      The default value of expiration time in seconds for metadata cache in hbase data tables coprocessors
+      Number of seconds after which the metadata cache in HBase data table coprocessors will expire
     </description>
   </property>
 
@@ -2257,10 +2257,10 @@
     <description>
       A comma-separated list of users for whom admin privileges are to be granted on the
       CDAP instance during CDAP startup, so that these users can create namespaces. These
-      users are also granted admin privileges on the default namespace, so that they can
-      manage privileges on the default namespace. This provides a method to bootstrap CDAP on
-      an authorization-enabled cluster. The default is empty, in which case no users have
-      access to creating namespaces or to managing privileges on the default namespace.
+      users are also granted admin privileges on the 'default' namespace, so that they can
+      manage privileges on the 'default' namespace. This provides a method to bootstrap CDAP on
+      an authorization-enabled cluster. The default value is empty, in which case no users have
+      access to creating namespaces or to managing privileges on the 'default' namespace.
       In that scenario, authorization in CDAP has to be bootstrapped externally using interfaces
       provided by the configured authorization extension.
     </description>

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="303c787d8c3d9b8767cfc75cfbba0cf5"
+DEFAULT_XML_MD5_HASH="e07311195957f5b76936c6446612bb6b"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
Corrects spelling of HBase. Removes many uses of the word "default", as once this file is used as a template, the values may change and the meaning mis-understood.

Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB252-1 (fails, but unrelated to this PR)

Page of interest: http://builds.cask.co/artifact/CDAP-DQB252/shared/build-1/Docs-HTML/html/admin-manual/appendices/cdap-site.html