### PR TITLE
[CDAP-8074] Adds ViewSwitch to switch between Table and Cards

### DIFF
--- a/cdap-ui/app/cdap/components/AppDetailedView/AppDetailedView.scss
+++ b/cdap-ui/app/cdap/components/AppDetailedView/AppDetailedView.scss
@@ -52,7 +52,7 @@
   }
 
   .overview-tab {
-    .nav-tabs {
+    > .nav-tabs {
       .nav-item {
         .nav-link {
           float: left;

--- a/cdap-ui/app/cdap/components/DatasetStreamCards/DataStreamCards.scss
+++ b/cdap-ui/app/cdap/components/DatasetStreamCards/DataStreamCards.scss
@@ -13,19 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
-.schema-tab {
-  padding: 10px;
-  height: calc(100% - 26px);
-
-  .disable-schema {
-    .fa-trash,
-    .fa-plus {
-      display: none;
-    }
-  }
-
-  .schema-body .schema-row.nested > .field-name:before {
-    background-color: rgba(238, 238, 238, 1);
-  }
+.dataentity-cards {
+  padding-top: 10px;
 }

--- a/cdap-ui/app/cdap/components/DatasetStreamCards/index.js
+++ b/cdap-ui/app/cdap/components/DatasetStreamCards/index.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import React, {PropTypes} from 'react';
+import EntityCard from 'components/EntityCard';
+import {parseMetadata} from 'services/metadata-parser';
+import shortid from 'shortid';
+require('./DataStreamCards.scss');
+
+export default function DatasetStreamCards({dataEntities}) {
+  let data = dataEntities.map( dataEntity => {
+    let entity = {
+      entityId: dataEntity.entityId,
+      metadata: {
+        SYSTEM: {}
+      }
+    };
+    entity = parseMetadata(entity);
+    entity.uniqueId = shortid.generate();
+    return entity;
+  });
+  return (
+    <div className="dataentity-cards">
+      {
+        data.map(dataEntity => (
+          <EntityCard
+            className="entity-card-container"
+            entity={dataEntity}
+            key={dataEntity.uniqueId}
+          />
+        ))
+      }
+    </div>
+  );
+}
+
+DatasetStreamCards.propTypes = {
+  dataEntities: PropTypes.arrayOf(PropTypes.object)
+};

--- a/cdap-ui/app/cdap/components/DatasetStreamTable/DatasetStreamTable.scss
+++ b/cdap-ui/app/cdap/components/DatasetStreamTable/DatasetStreamTable.scss
@@ -13,19 +13,15 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
-.schema-tab {
-  padding: 10px;
-  height: calc(100% - 26px);
-
-  .disable-schema {
-    .fa-trash,
-    .fa-plus {
-      display: none;
-    }
+.dataentity-table {
+  padding-top: 10px;
+  .fast-actions-container .btn-link {
+    color: #4f5050;
   }
-
-  .schema-body .schema-row.nested > .field-name:before {
-    background-color: rgba(238, 238, 238, 1);
+  .table {
+    [class^="icon-"].fa,
+    [class*=" icon-"].fa {
+      margin-right: 5px;
+    }
   }
 }

--- a/cdap-ui/app/cdap/components/DatasetStreamTable/index.js
+++ b/cdap-ui/app/cdap/components/DatasetStreamTable/index.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import React, {PropTypes} from 'react';
+import classnames from 'classnames';
+import FastActions from 'components/EntityCard/FastActions';
+require('./DatasetStreamTable.scss');
+import T from 'i18n-react';
+export default function DatasetStreamTable({dataEntities}) {
+  return (
+    <div className="dataentity-table">
+      <table className="table table-bordered table-sm">
+        <thead>
+          <tr>
+            <th>{T.translate('features.ViewSwitch.nameLabel')}</th>
+            <th>{T.translate('features.ViewSwitch.typeLabel')}</th>
+            <th>{T.translate('features.ViewSwitch.DatasetStreamTable.readsLabel')}</th>
+            <th>{T.translate('features.ViewSwitch.DatasetStreamTable.writesLabel')}</th>
+            <th>{T.translate('features.ViewSwitch.DatasetStreamTable.eventsLabel')}</th>
+            <th>{T.translate('features.ViewSwitch.DatasetStreamTable.sizeLabel')}</th>
+            <th>{T.translate('features.ViewSwitch.actionsLabel')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {
+            dataEntities.map(dataEntity => {
+              let icon = dataEntity.type === 'datasetinstance' ? 'icon-datasets' : 'icon-streams';
+              let type = dataEntity.type === 'datasetinstance' ? 'Dataset' : 'Stream';
+              return (
+                <tr key={dataEntity.uniqueId}>
+                  <td>{dataEntity.name}</td>
+                  <td>
+                    <i className={classnames('fa', icon)}></i>
+                    <span>{type}</span>
+                  </td>
+                  <td>{dataEntity.reads}</td>
+                  <td>{dataEntity.writes}</td>
+                  <td>{dataEntity.events}</td>
+                  <td>{dataEntity.bytes}</td>
+                  <td>
+                    <div className="fast-actions-container">
+                      <FastActions
+                        className="text-xs-left"
+                        entity={dataEntity}
+                      />
+                    </div>
+                  </td>
+                </tr>
+              );
+            })
+          }
+        </tbody>
+      </table>
+    </div>
+  );
+}
+DatasetStreamTable.propTypes = {
+  dataEntities: PropTypes.arrayOf(PropTypes.object)
+};

--- a/cdap-ui/app/cdap/components/EntityCard/FastActions/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/FastActions/index.js
@@ -16,7 +16,6 @@
 
 import React, {Component, PropTypes} from 'react';
 import FastAction from 'components/FastAction';
-import classnames from 'classnames';
 
 export default class FastActions extends Component {
   constructor(props) {
@@ -62,9 +61,9 @@ export default class FastActions extends Component {
 
   render () {
     const fastActions = this.listOfFastActions();
-
+    let className = this.props.className || 'text-xs-center';
     return (
-      <h4 className={classnames("text-xs-center", this.props.className)}>
+      <h4 className={className}>
         <span>
           {
             fastActions.map((action) => {

--- a/cdap-ui/app/cdap/components/Overview/AppOverview/AppOverview.scss
+++ b/cdap-ui/app/cdap/components/Overview/AppOverview/AppOverview.scss
@@ -14,18 +14,6 @@
  * the License.
  */
 
-.schema-tab {
-  padding: 10px;
-  height: calc(100% - 26px);
-
-  .disable-schema {
-    .fa-trash,
-    .fa-plus {
-      display: none;
-    }
-  }
-
-  .schema-body .schema-row.nested > .field-name:before {
-    background-color: rgba(238, 238, 238, 1);
-  }
+.app-overview {
+  height: inherit;
 }

--- a/cdap-ui/app/cdap/components/Overview/AppOverview/AppOverviewTab.js
+++ b/cdap-ui/app/cdap/components/Overview/AppOverview/AppOverviewTab.js
@@ -70,14 +70,24 @@ export default class AppOverviewTab extends Component {
             <TabPane tabId="1">
               <Row>
                 <Col sm="12">
-                  <ProgramTab entity={this.state.entity} />
+                  {
+                    this.state.activeTab === '1' ?
+                      <ProgramTab entity={this.state.entity} />
+                    :
+                      null
+                  }
                 </Col>
               </Row>
             </TabPane>
             <TabPane tabId="2">
               <Row>
                 <Col sm="12">
-                  <DatasetTab entity={this.state.entity} />
+                  {
+                    this.state.activeTab === '2' ?
+                      <DatasetTab entity={this.state.entity} />
+                    :
+                      null
+                  }
                 </Col>
               </Row>
             </TabPane>

--- a/cdap-ui/app/cdap/components/Overview/AppOverview/index.js
+++ b/cdap-ui/app/cdap/components/Overview/AppOverview/index.js
@@ -24,6 +24,7 @@ import NamespaceStore from 'services/NamespaceStore';
 import {objectQuery} from 'services/helpers';
 import shortid from 'shortid';
 import T from 'i18n-react';
+require('./AppOverview.scss');
 
 export default class AppOverview extends Component {
   constructor(props) {

--- a/cdap-ui/app/cdap/components/Overview/DatasetOverview/DatasetOverviewTab.js
+++ b/cdap-ui/app/cdap/components/Overview/DatasetOverview/DatasetOverviewTab.js
@@ -72,7 +72,12 @@ export default class DatasetOverviewTab extends Component {
             <TabPane tabId="1">
               <Row>
                 <Col sm="12">
-                  <ProgramTab entity={this.state.entity} />
+                  {
+                    this.state.activeTab === '1'?
+                      <ProgramTab entity={this.state.entity} />
+                    :
+                      null
+                  }
                 </Col>
               </Row>
             </TabPane>
@@ -80,7 +85,12 @@ export default class DatasetOverviewTab extends Component {
             <TabPane tabId="2">
               <Row>
                 <Col sm="12">
-                  <SchemaTab entity={this.state.entity} />
+                  {
+                    this.state.activeTab === '2'?
+                      <SchemaTab entity={this.state.entity} />
+                    :
+                      null
+                  }
                 </Col>
               </Row>
             </TabPane>

--- a/cdap-ui/app/cdap/components/Overview/DatasetOverview/index.js
+++ b/cdap-ui/app/cdap/components/Overview/DatasetOverview/index.js
@@ -72,15 +72,20 @@ export default class DatasetOverview extends Component {
       MyMetadataApi.getProperties(metadataParams)
         .combineLatest(MyDatasetApi.getPrograms(datasetParams))
         .subscribe((res) => {
+          let appId;
           let programs = res[1].map((program) => {
             program.uniqueId = shortid.generate();
-            program.app = program.application.applicationId;
+            appId = program.application.applicationId;
+            program.app = appId;
+            program.name = program.id;
             return program;
           });
 
           let entityDetail = {
             programs,
-            schema: res[0].schema
+            schema: res[0].schema,
+            name: appId, // FIXME: Finalize on entity detail for fast action
+            app: appId
           };
 
           this.setState({

--- a/cdap-ui/app/cdap/components/Overview/StreamOverview/StreamOverviewTab.js
+++ b/cdap-ui/app/cdap/components/Overview/StreamOverview/StreamOverviewTab.js
@@ -22,7 +22,7 @@ import classnames from 'classnames';
 import isNil from 'lodash/isNil';
 require('../Tabs/OverviewTab.scss');
 
-export default class DatasetOverviewTab extends Component {
+export default class StreamOverviewTab extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -72,7 +72,12 @@ export default class DatasetOverviewTab extends Component {
             <TabPane tabId="1">
               <Row>
                 <Col sm="12">
-                  <ProgramTab entity={this.state.entity} />
+                  {
+                    this.state.activeTab === '1' ?
+                      <ProgramTab entity={this.state.entity} />
+                    :
+                      null
+                  }
                 </Col>
               </Row>
             </TabPane>
@@ -80,7 +85,12 @@ export default class DatasetOverviewTab extends Component {
             <TabPane tabId="2">
               <Row>
                 <Col sm="12">
-                  <SchemaTab entity={this.state.entity} />
+                  {
+                    this.state.activeTab === '2' ?
+                      <SchemaTab entity={this.state.entity} />
+                    :
+                      null
+                  }
                 </Col>
               </Row>
             </TabPane>
@@ -92,6 +102,6 @@ export default class DatasetOverviewTab extends Component {
     return null;
   }
 }
-DatasetOverviewTab.propTypes = {
+StreamOverviewTab.propTypes = {
   entity: PropTypes.object
 };

--- a/cdap-ui/app/cdap/components/Overview/StreamOverview/index.js
+++ b/cdap-ui/app/cdap/components/Overview/StreamOverview/index.js
@@ -74,15 +74,20 @@ export default class StreamOverview extends Component {
       MyMetadataApi.getProperties(metadataParams)
         .combineLatest(MyStreamApi.getPrograms(streamParams))
         .subscribe((res) => {
+          let appId;
           let programs = res[1].map((program) => {
             program.uniqueId = shortid.generate();
-            program.app = program.application.applicationId;
+            appId = program.application.applicationId;
+            program.app = appId;
+            program.name = program.id;
             return program;
           });
 
           let entityDetail = {
             programs,
-            schema: res[0].schema
+            schema: res[0].schema,
+            name: appId, // FIXME: Finalize on entity detail for fast action
+            app: appId
           };
 
           this.setState({

--- a/cdap-ui/app/cdap/components/Overview/Tabs/DatasetTab/DatasetTab.scss
+++ b/cdap-ui/app/cdap/components/Overview/Tabs/DatasetTab/DatasetTab.scss
@@ -15,8 +15,7 @@
  */
 .dataset-tab {
   padding: 10px;
-  overflow-y: auto;
-  height: 100%;
+  height: calc(100% - 26px);
 
   .message-section {
     margin-left: 5px;

--- a/cdap-ui/app/cdap/components/Overview/Tabs/DatasetTab/index.js
+++ b/cdap-ui/app/cdap/components/Overview/Tabs/DatasetTab/index.js
@@ -16,79 +16,154 @@
 import React, {Component, PropTypes} from 'react';
 import T from 'i18n-react';
 require('./DatasetTab.scss');
-import {parseMetadata} from 'services/metadata-parser';
-import EntityCard from 'components/EntityCard';
 import {objectQuery} from 'services/helpers';
-import shortid from 'shortid';
+import ViewSwitch from 'components/ViewSwitch';
+import DatasetStreamCards from 'components/DatasetStreamCards';
+import DatasetStreamTable from 'components/DatasetStreamTable';
+import NamespaceStore from 'services/NamespaceStore';
+import {MyMetricApi} from 'api/metric';
+import {MyDatasetApi} from 'api/dataset';
+import {MyStreamApi} from 'api/stream';
+import {humanReadableNumber, HUMANREADABLESTORAGE_NODECIMAL} from 'services/helpers';
 
 export default class DatasetTab extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      entity: this.props.entity
+      entity: this.props.entity,
+      entitiesForTable: this.getEntitiesForTable(this.props.entity)
     };
+    this.state.entity.datasets.forEach(this.addDatasetMetrics.bind(this));
+    this.state.entity.streams.forEach(this.addStreamMetrics.bind(this));
   }
   componentWillReceiveProps(nextProps) {
     let entitiesMatch = objectQuery(nextProps, 'entity', 'name') === objectQuery(this.props, 'entity', 'name');
     if (!entitiesMatch) {
       this.setState({
-        entity: nextProps.entity
+        entity: nextProps.entity,
+        entitiesForTable: this.getEntitiesForTable(nextProps.entity)
       });
+      this.state.entity.datasets.forEach(this.addDatasetMetrics.bind(this));
+      this.state.entity.streams.forEach(this.addStreamMetrics.bind(this));
     }
+  }
+  getEntitiesForTable({datasets, streams}) {
+    return datasets
+      .map(dataset => Object.assign({}, dataset, {type: 'datasetinstance', id: dataset.name}))
+      .concat(
+        streams
+        .map(stream => Object.assign({}, stream, {type: 'stream', id: stream.name}))
+      );
+  }
+  addStreamMetrics(stream) {
+    let currentNamespace = NamespaceStore.getState().selectedNamespace;
+    const streamParams = {
+      namespace: currentNamespace,
+      streamId: this.props.entity.name
+    };
+    const metricsParams = {
+      tag: [`namespace:${currentNamespace}`, `stream:${stream}`],
+      metric: ['system.collect.events', 'system.collect.bytes'],
+      aggregate: true
+    };
+
+    MyMetricApi.query(metricsParams)
+      .combineLatest(MyStreamApi.getPrograms(streamParams))
+      .subscribe((res) => {
+        let events = 0,
+            bytes = 0;
+        if (res[0].series.length > 0) {
+          res[0].series.forEach((metric) => {
+            if (metric.metricName === 'system.collect.events') {
+              events = humanReadableNumber(metric.data[0].value);
+            } else if (metric.metricName === 'system.collect.bytes') {
+              bytes = humanReadableNumber(metric.data[0].value, HUMANREADABLESTORAGE_NODECIMAL);
+            }
+          });
+        }
+
+        let entities = this.state.entitiesForTable
+          .map(e => {
+            if (e.name === stream.name) {
+              return Object.assign({}, e, {
+                events,
+                reads: 'n/a',
+                writes: 'n/a',
+                bytes,
+                programs: res[1].length,
+                loading: false
+              });
+            }
+            return e;
+          });
+        this.setState({
+          entitiesForTable: entities
+        });
+      });
+  }
+  addDatasetMetrics(dataset) {
+    let currentNamespace = NamespaceStore.getState().selectedNamespace;
+    const datasetParams = {
+      namespace: currentNamespace,
+      datasetId: this.props.entity.name
+    };
+    const metricsParams = {
+      tag: [`namespace:${currentNamespace}`, `dataset:${dataset.name}`],
+      metric: ['system.dataset.store.bytes', 'system.dataset.store.ops', 'system.dataset.store.writes', 'system.dataset.store.reads'],
+      aggregate: true
+    };
+
+    MyMetricApi.query(metricsParams)
+      .combineLatest(MyDatasetApi.getPrograms(datasetParams))
+      .subscribe((res) => {
+        let ops = 0,
+            writes = 0,
+            bytes = 0,
+            reads = 0;
+        if (res[0].series.length > 0) {
+          res[0].series.forEach((metric) => {
+            if (metric.metricName === 'system.dataset.store.ops') {
+              ops = metric.data[0].value;
+            } else if (metric.metricName === 'system.dataset.store.writes') {
+              writes = metric.data[0].value;
+            } else if (metric.metricName === 'system.dataset.store.bytes') {
+              bytes = metric.data[0].value;
+            } else if (metric.metricName === 'system.dataset.store.reads') {
+              reads = metric.data[0].value;
+            }
+          });
+        }
+
+        let entities = this.state.entitiesForTable
+          .map(e => {
+            if (e.name === dataset.name) {
+              return Object.assign({}, e, {
+                events: ops,
+                writes,
+                reads,
+                bytes,
+                programs: res[1].length,
+                loading: false
+              });
+            }
+            return e;
+          });
+        this.setState({
+          entitiesForTable: entities
+        });
+      });
   }
   render() {
     return (
       <div className="dataset-tab">
-        <div className="message-section">
+        <div className="message-section float-xs-left">
           <strong> {T.translate('features.Overview.DatasetTab.title', {appId: this.state.entity.name})} </strong>
         </div>
         {
-          this.state
-              .entity
-              .datasets
-              .map( dataset => {
-                let entity = {
-                  entityId: dataset.entityId,
-                  metadata: {
-                    SYSTEM: {}
-                  }
-                };
-                entity = parseMetadata(entity);
-                let uniqueId = shortid.generate();
-                entity.uniqueId = uniqueId;
-                dataset.uniqueId = uniqueId;
-                return (
-                  <EntityCard
-                    className="entity-card-container"
-                    entity={entity}
-                    key={dataset.uniqueId}
-                  />
-                );
-              })
-        }
-        {
-          this.state
-              .entity
-              .streams
-              .map( stream => {
-                let entity = {
-                  entityId: stream.entityId,
-                  metadata: {
-                    SYSTEM: {}
-                  }
-                };
-                entity = parseMetadata(entity);
-                let uniqueId = shortid.generate();
-                entity.uniqueId = uniqueId;
-                stream.uniqueId = uniqueId;
-                return (
-                  <EntityCard
-                    className="entity-card-container"
-                    entity={entity}
-                    key={stream.uniqueId}
-                  />
-                );
-              })
+          <ViewSwitch>
+            <DatasetStreamCards dataEntities={this.state.entity.datasets.concat(this.state.entity.streams)} />
+            <DatasetStreamTable dataEntities={this.state.entitiesForTable} />
+          </ViewSwitch>
         }
       </div>
     );

--- a/cdap-ui/app/cdap/components/Overview/Tabs/OverviewTab.scss
+++ b/cdap-ui/app/cdap/components/Overview/Tabs/OverviewTab.scss
@@ -40,6 +40,8 @@
     }
   }
   .tab-content {
+    overflow: auto;
+    overflow-x: hidden;
     height: calc(100% - 33px);
     .tab-pane,
     .row,

--- a/cdap-ui/app/cdap/components/Overview/Tabs/ProgramTab/ProgramTab.scss
+++ b/cdap-ui/app/cdap/components/Overview/Tabs/ProgramTab/ProgramTab.scss
@@ -15,8 +15,7 @@
  */
 .program-tab {
   padding: 10px;
-  overflow-y: auto;
-  height: 100%;
+  height: calc(100% - 26px);
 
   .message-section {
     margin-left: 5px;

--- a/cdap-ui/app/cdap/components/Overview/Tabs/ProgramTab/index.js
+++ b/cdap-ui/app/cdap/components/Overview/Tabs/ProgramTab/index.js
@@ -15,16 +15,16 @@
  */
 
 import React, {PropTypes, Component} from 'react';
-import EntityCard from 'components/EntityCard';
-import {parseMetadata} from 'services/metadata-parser';
 import {objectQuery} from 'services/helpers';
 import isNil from 'lodash/isNil';
 import T from 'i18n-react';
 import {MyProgramApi} from 'api/program';
 import NamespaceStore from 'services/NamespaceStore';
 import {convertProgramToApi} from 'services/program-api-converter';
-import shortid from 'shortid';
-
+import ViewSwitch from 'components/ViewSwitch';
+import ProgramCards from 'components/ProgramCards';
+import ProgramTable from 'components/ProgramTable';
+import isEmpty from 'lodash/isEmpty';
 require('./ProgramTab.scss');
 
 export default class ProgramsTab extends Component {
@@ -35,7 +35,12 @@ export default class ProgramsTab extends Component {
       runningPrograms: []
     };
     this.statusSubscriptions = [];
-    this.setRunninPrograms();
+    if (
+      !isNil(this.props.entity) &&
+      !isEmpty(this.props.entity)
+    ) {
+      this.setRunninPrograms();
+    }
   }
   componentWillReceiveProps(nextProps) {
     let entitiesMatch = objectQuery(nextProps, 'entity', 'name') === objectQuery(this.props, 'entity', 'name');
@@ -44,7 +49,7 @@ export default class ProgramsTab extends Component {
         entity: nextProps.entity,
         runningPrograms: []
       });
-      this.statusSubscriptions.forEach(sub => sub());
+      this.statusSubscriptions.forEach(sub => sub.dispose());
       this.setRunninPrograms();
     }
   }
@@ -54,28 +59,39 @@ export default class ProgramsTab extends Component {
         .entity
         .programs
         .forEach(program => {
-          let sub = MyProgramApi
-            .pollStatus({
+          let subscription =  MyProgramApi
+            .pollRuns({
               namespace,
               appId: this.state.entity.name,
               programType: convertProgramToApi(program.type),
               programId: program.id
             })
+            .combineLatest(
+              MyProgramApi
+                .pollStatus({
+                  namespace,
+                  appId: this.state.entity.name,
+                  programType: convertProgramToApi(program.type),
+                  programId: program.id
+                })
+            )
             .subscribe(res => {
               let runningPrograms = this.state.runningPrograms;
               let programState = runningPrograms.filter(prog => prog.name === program.id);
               if (programState.length) {
                 runningPrograms = runningPrograms.filter(prog => prog.name !== program.id);
               }
-              runningPrograms.push({
-                name: program.id,
-                status: res.status === 'RUNNING' ? 1 : 0
-              });
+              runningPrograms.push(Object.assign({}, !isEmpty(programState) ? programState[0] : {}, {
+                latestRun: objectQuery(res, 0, 0) || {},
+                status: res[1].status === 'RUNNING' ? 1 : 0,
+                backendStatus: res[1].status,
+                name: program.id
+              }));
               this.setState({
                 runningPrograms
               });
             });
-          this.statusSubscriptions.push(sub);
+          this.statusSubscriptions.push(subscription);
         });
   }
   componentWillUnmount() {
@@ -83,57 +99,44 @@ export default class ProgramsTab extends Component {
   }
   render() {
     let runningProgramsCount = 0;
+    let programsForTable = this.state.entity.programs;
     if (this.state.runningPrograms.length) {
       runningProgramsCount = this.state
         .runningPrograms
         .map(runningProgram => runningProgram.status)
         .reduce((prev, curr) => prev + curr);
+      programsForTable = this.state.entity.programs.map(program => {
+        let matchedProg = this.state.runningPrograms.find(prog => prog.name === program.id) || null;
+        return !matchedProg ?
+          program
+        :
+          Object.assign({}, program, {
+            status: matchedProg.backendStatus,
+            latestRun: matchedProg.latestRun
+          });
+      });
     }
     if (!isNil(this.state.entity)) {
-      return (
-        <div className="program-tab">
-          <div className="message-section">
-            <strong> {T.translate('features.Overview.ProgramTab.title', {appId: this.state.entity.name})} </strong>
-            <div>{T.translate('features.Overview.ProgramTab.runningProgramLabel', {programCount: runningProgramsCount})}</div>
+      if (this.state.entity.programs.length) {
+        return (
+          <div className="program-tab clearfix">
+            <div className="message-section float-xs-left">
+              <strong> {T.translate('features.Overview.ProgramTab.title', {appId: this.state.entity.name})} </strong>
+              <div>{T.translate('features.Overview.ProgramTab.runningProgramLabel', {programCount: runningProgramsCount})}</div>
+            </div>
+            <ViewSwitch>
+              <ProgramCards programs={this.state.entity.programs} />
+              <ProgramTable programs={programsForTable} />
+            </ViewSwitch>
           </div>
-          {
-            this.state.entity.programs.length ?
-              this.state
-                  .entity
-                  .programs
-                  .map( program => {
-                    let entity = {
-                      entityId: {
-                        id: {
-                          id: program.id,
-                          application: {
-                            applicationId: program.app
-                          },
-                          type: program.type
-                        },
-                        type: 'program',
-                      },
-                      metadata: {
-                        SYSTEM: {}
-                      }
-                    };
-                    entity = parseMetadata(entity);
-                    let uniqueId = shortid.generate();
-                    entity.uniqueId = uniqueId;
-                    program.uniqueId = uniqueId;
-                    return (
-                      <EntityCard
-                        className="entity-card-container"
-                        entity={entity}
-                        key={program.uniqueId}
-                      />
-                    );
-                  })
-            :
-              <i>{T.translate('features.Overview.ProgramTab.emptyMessage')}</i>
-          }
-        </div>
-      );
+        );
+      } else {
+        return (
+          <div className="program-tab clearfix">
+            <i>{T.translate('features.Overview.ProgramTab.emptyMessage')}</i>
+          </div>
+        );
+      }
     }
     return null;
   }

--- a/cdap-ui/app/cdap/components/ProgramCards/ProgramCards.scss
+++ b/cdap-ui/app/cdap/components/ProgramCards/ProgramCards.scss
@@ -13,19 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
-.schema-tab {
-  padding: 10px;
-  height: calc(100% - 26px);
-
-  .disable-schema {
-    .fa-trash,
-    .fa-plus {
-      display: none;
-    }
-  }
-
-  .schema-body .schema-row.nested > .field-name:before {
-    background-color: rgba(238, 238, 238, 1);
-  }
+.program-cards {
+  padding-top: 5px;
 }

--- a/cdap-ui/app/cdap/components/ProgramCards/index.js
+++ b/cdap-ui/app/cdap/components/ProgramCards/index.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, {PropTypes} from 'react';
+import EntityCard from 'components/EntityCard';
+import {parseMetadata} from 'services/metadata-parser';
+import shortid from 'shortid';
+require('./ProgramCards.scss');
+
+export default function ProgramCards({programs}) {
+  return (
+    <div className="program-cards">
+      {
+        programs
+          .map( program => {
+            let entity = {
+              entityId: {
+                id: {
+                  id: program.id,
+                  application: {
+                    applicationId: program.app
+                  },
+                  type: program.type
+                },
+                type: 'program',
+              },
+              metadata: {
+                SYSTEM: {}
+              }
+            };
+            entity = parseMetadata(entity);
+            let uniqueId = shortid.generate();
+            entity.uniqueId = uniqueId;
+            program.uniqueId = uniqueId;
+            return (
+              <EntityCard
+                className="entity-card-container"
+                entity={entity}
+                key={program.uniqueId}
+              />
+            );
+          })
+      }
+    </div>
+  );
+}
+ProgramCards.propTypes = {
+  programs: PropTypes.arrayOf(PropTypes.object)
+};

--- a/cdap-ui/app/cdap/components/ProgramTable/ProgramTable.scss
+++ b/cdap-ui/app/cdap/components/ProgramTable/ProgramTable.scss
@@ -14,18 +14,9 @@
  * the License.
  */
 
-.schema-tab {
-  padding: 10px;
-  height: calc(100% - 26px);
-
-  .disable-schema {
-    .fa-trash,
-    .fa-plus {
-      display: none;
-    }
-  }
-
-  .schema-body .schema-row.nested > .field-name:before {
-    background-color: rgba(238, 238, 238, 1);
+.program-table {
+  padding-top: 10px;
+  .fast-actions-container .btn-link {
+    color: #4f5050;
   }
 }

--- a/cdap-ui/app/cdap/components/ProgramTable/index.js
+++ b/cdap-ui/app/cdap/components/ProgramTable/index.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, {PropTypes} from 'react';
+import FastActions from 'components/EntityCard/FastActions';
+import shortid from 'shortid';
+import {humanReadableDate} from 'services/helpers';
+require('./ProgramTable.scss');
+import T from 'i18n-react';
+import isEmpty from 'lodash/isEmpty';
+
+export default function ProgramTable({programs}) {
+  let entities = programs.map(prog => {
+    return Object.assign({}, prog, {
+      applicationId: prog.app,
+      programType: prog.type,
+      type: 'program',
+      id: prog.id,
+      uniqueId: shortid.generate()
+    });
+  });
+  return (
+    <div className="program-table">
+      <table className="table table-bordered">
+      <thead>
+        <tr>
+          <th>{T.translate('features.ViewSwitch.nameLabel')}</th>
+          <th>{T.translate('features.ViewSwitch.typeLabel')}</th>
+          <th>{T.translate('features.ViewSwitch.ProgramTable.lastStartedLabel')}</th>
+          <th>{T.translate('features.ViewSwitch.ProgramTable.statusLabel')}</th>
+          <th>{T.translate('features.ViewSwitch.actionsLabel')}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {
+          entities.map(program => {
+            return (
+              <tr key={program.name}>
+                <td>{program.name}</td>
+                <td>{program.type}</td>
+                <td>{
+                  !isEmpty(program.latestRun) ? humanReadableDate(program.latestRun.start) : 'n/a'
+                }</td>
+                <td>{program.status}</td>
+                <td>
+                  <div className="fast-actions-container">
+                    <FastActions
+                      className="text-xs-left"
+                      entity={program}
+                    />
+                  </div>
+                </td>
+              </tr>
+            );
+          })
+        }
+      </tbody>
+      </table>
+    </div>
+  );
+}
+ProgramTable.propTypes = {
+  programs: PropTypes.arrayOf(PropTypes.object)
+};

--- a/cdap-ui/app/cdap/components/ViewSwitch/ViewSwitch.scss
+++ b/cdap-ui/app/cdap/components/ViewSwitch/ViewSwitch.scss
@@ -14,18 +14,24 @@
  * the License.
  */
 
-.schema-tab {
-  padding: 10px;
-  height: calc(100% - 26px);
-
-  .disable-schema {
-    .fa-trash,
-    .fa-plus {
-      display: none;
+.view-switch {
+  height: inherit;
+  .nav.nav-tabs {
+    .nav-item {
+      margin: 0;
+      .nav-link {
+        margin: 0;
+        border: 0;
+        border-radius: 0;
+        &.active {
+          font-weight: bold;
+          background: darkgray;
+          border: 0;
+        }
+        &.active:hover {
+          border-bottom: 0;
+        }
+      }
     }
-  }
-
-  .schema-body .schema-row.nested > .field-name:before {
-    background-color: rgba(238, 238, 238, 1);
   }
 }

--- a/cdap-ui/app/cdap/components/ViewSwitch/index.js
+++ b/cdap-ui/app/cdap/components/ViewSwitch/index.js
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, {Component, PropTypes} from 'react';
+import { Nav, NavItem, NavLink, TabContent, TabPane} from 'reactstrap';
+import classnames from 'classnames';
+require('./ViewSwitch.scss');
+import cookie from 'react-cookie';
+
+export default class ViewSwitch extends Component {
+  constructor(props) {
+    super(props);
+    let defaultView = cookie.load('ViewSwitchDefault');
+    this.state = {
+      list: this.props.list,
+      activeTab: defaultView || 'card'
+    };
+  }
+  toggleView(tab) {
+    if (this.state.activeTab !== tab) {
+      cookie.save('ViewSwitchDefault', tab);
+      this.setState({
+        activeTab: tab
+      });
+    }
+  }
+  render() {
+    return (
+      <div className="view-switch">
+        <div className="clearfix">
+          <Nav className="float-xs-right" tabs>
+            <NavItem>
+              <NavLink
+                className={classnames({ active: this.state.activeTab === 'card' })}
+                onClick={() => {this.toggleView('card');}}>
+                <span className="fa fa-th-large"></span>
+              </NavLink>
+            </NavItem>
+            <NavItem>
+              <NavLink
+                className={classnames({ active: this.state.activeTab === 'list' })}
+                onClick={() => {this.toggleView('list');}}>
+                <span className="fa fa-list"></span>
+              </NavLink>
+            </NavItem>
+          </Nav>
+        </div>
+        <TabContent activeTab={this.state.activeTab}>
+          <TabPane tabId="card">
+            { this.state.activeTab === 'card' ? this.props.children[0] : null}
+          </TabPane>
+          <TabPane tabId="list">
+            { this.state.activeTab === 'list' ? this.props.children[1] : null}
+          </TabPane>
+        </TabContent>
+      </div>
+    );
+  }
+}
+ViewSwitch.propTypes = {
+  list: PropTypes.arrayOf(PropTypes.object),
+  children: PropTypes.node
+};

--- a/cdap-ui/app/cdap/styles/variables.scss
+++ b/cdap-ui/app/cdap/styles/variables.scss
@@ -58,9 +58,7 @@ $nav-tabs-justified-active-link-border-color: $body-bg;            // #ebecf1
 
 
 // TOOLTIPS
-$tooltip-bg:            rgb(255, 255, 255);     // #fff, white
 $tooltip-color:         $gray-dark;             // #333
-$tooltip-arrow-color:   rgb(255, 255, 255);     // #fff, white
 
 
 // Popovers

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -717,4 +717,16 @@ features:
   Description:
     label: Description
     nodescription: No Description available
+  ViewSwitch:
+    nameLabel: Name
+    typeLabel: Type
+    actionsLabel: Actions
+    DatasetStreamTable:
+      readsLabel: Reads
+      writesLabel: Writes
+      eventsLabel: Events
+      sizeLabel: Size
+    ProgramTable:
+      lastStartedLabel: Last Started
+      statusLabel: Status
 ...


### PR DESCRIPTION
- Adds,
  - `ViewSwitch`: Switches between Table and Cards view
  - `ProgramCard`: Higher-order component to show a list of programs as cards
  - `ProgramTable`: Higher-order component to show programs in tabular view
  - `DatasetStreamCards`: Higher-order component to show a list of datasets as cards
  - `DatasetStreamTable`: Higher-order component to show datasets in tabular view
- Adds sort-of lazyloading to tabs show in overview and detailed view
- Fixes tooltip styling
- Fixes vertical scrolling in overview & detailed view tabs

JIRA: https://issues.cask.co/browse/CDAP-8074
Bamboo build: http://builds.cask.co/browse/CDAP-DRC5477/latest

### Note:
- There are a number of duplicate calls we make today for status and runs. This is happening because of frequent mounting and un-mounting of components in each tab for updating run counts. This should be fixed. Since its a bigger change it will come in a separate PR.
- Program cards showing latest run is not there yet.
