### PR TITLE
Revert "only support 3.4 now, due to INFRA-38"

### DIFF
--- a/cdap-distributions/src/hdinsight/pkg/createUiDefinition.json
+++ b/cdap-distributions/src/hdinsight/pkg/createUiDefinition.json
@@ -4,6 +4,6 @@
   "clusterFilters": {
     "types": [ "HBase" ],
     "tiers": [ "Standard" ],
-    "versions": [ "3.4" ]
+    "versions": [ "3.4", "3.5" ]
   }
 }


### PR DESCRIPTION
This reverts commit 7ed0d38d14152f8d2e142a2520a48a20a02cbeef.

Fix in place for INFRA-38, and integration tests have passed for HDInsight 3.5, so including it in release.