### PR TITLE
CDAP-8288 improvements to prebuilt coprocessors

### DIFF
--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -1107,7 +1107,7 @@ cdap_setup() {
 cdap_setup_coprocessors() {
   local readonly __ret __class=co.cask.cdap.data.tools.CoprocessorBuildTool
 
-  cdap_run_class ${__class} ${@}
+  cdap_run_class ${__class} check ${@}
   __ret=${?}
   return ${__ret}
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
@@ -222,9 +222,7 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
                                 Integer priority) throws IOException {
     CoprocessorDescriptor descriptor = coprocessorManager.getCoprocessorDescriptor(coprocessor, priority);
     Path path = descriptor.getPath() == null ? null : new Path(descriptor.getPath());
-    tableDescriptor.addCoprocessor(descriptor.getClassName(),
-                                   path,
-                                   descriptor.getPriority(),
+    tableDescriptor.addCoprocessor(descriptor.getClassName(), path, descriptor.getPriority(),
                                    descriptor.getProperties());
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/hbase/AbstractHBaseDataSetAdmin.java
@@ -20,6 +20,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.utils.ProjectInfo;
 import co.cask.cdap.data2.util.TableId;
+import co.cask.cdap.data2.util.hbase.CoprocessorManager;
 import co.cask.cdap.data2.util.hbase.HBaseDDLExecutorFactory;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HTableDescriptorBuilder;
@@ -41,6 +42,7 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.TableNotEnabledException;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,23 +71,23 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
     }
   };
 
-  private final boolean manageCoprocessors;
   protected final TableId tableId;
   protected final Configuration hConf;
   protected final CConfiguration cConf;
   protected final HBaseTableUtil tableUtil;
   protected final HBaseDDLExecutorFactory ddlExecutorFactory;
   protected final String tablePrefix;
+  protected final CoprocessorManager coprocessorManager;
 
   protected AbstractHBaseDataSetAdmin(TableId tableId, Configuration hConf, CConfiguration cConf,
-                                      HBaseTableUtil tableUtil) {
+                                      HBaseTableUtil tableUtil, LocationFactory locationFactory) {
     this.tableId = tableId;
     this.hConf = hConf;
     this.cConf = cConf;
     this.tableUtil = tableUtil;
     this.tablePrefix = cConf.get(Constants.Dataset.TABLE_PREFIX);
     this.ddlExecutorFactory = new HBaseDDLExecutorFactory(cConf, hConf);
-    this.manageCoprocessors = cConf.getBoolean(Constants.HBase.MANAGE_COPROCESSORS);
+    this.coprocessorManager = new CoprocessorManager(cConf, locationFactory, tableUtil);
   }
 
   @Override
@@ -162,15 +164,15 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
       for (Class<? extends Coprocessor> coprocessor : coprocessorJar.getCoprocessors()) {
         HBaseTableUtil.CoprocessorInfo info = coprocessorInfo.get(coprocessor.getName());
         if (info != null) {
-          // The same coprocessor has been configured, check by the file name hash to see if they are the same.
+          // The same coprocessor has been configured, check by the file name to see if they are the same.
           if (!jarLocation.getName().equals(info.getPath().getName())) {
             // Remove old one and add the new one.
             newDescriptor.removeCoprocessor(info.getClassName());
-            addCoprocessor(newDescriptor, coprocessor, jarLocation, coprocessorJar.getPriority(coprocessor));
+            addCoprocessor(newDescriptor, coprocessor, coprocessorJar.getPriority(coprocessor));
           }
         } else {
           // The coprocessor is missing from the table, add it.
-          addCoprocessor(newDescriptor, coprocessor, jarLocation, coprocessorJar.getPriority(coprocessor));
+          addCoprocessor(newDescriptor, coprocessor, coprocessorJar.getPriority(coprocessor));
         }
       }
 
@@ -217,24 +219,13 @@ public abstract class AbstractHBaseDataSetAdmin implements DatasetAdmin {
   }
 
   protected void addCoprocessor(HTableDescriptorBuilder tableDescriptor, Class<? extends Coprocessor> coprocessor,
-                                Location jarFile, Integer priority) throws IOException {
-    if (priority == null) {
-      priority = Coprocessor.PRIORITY_USER;
-    }
-    // if coprocessors are not managed by CDAP, it is up to the cluster admin to install them on every regionserver
-    // and ensure they are in the classpath for every regionserver
-    Path path = manageCoprocessors ? new Path(jarFile.toURI().getPath()) : null;
-    tableDescriptor.addCoprocessor(coprocessor.getName(), path, priority, null);
-  }
-
-  protected CoprocessorDescriptor getCoprocessorDescriptor(Class<? extends  Coprocessor> coprocessor, Location jarFile,
-                                                           Integer priority) throws IOException {
-    if (priority == null) {
-      priority = Coprocessor.PRIORITY_USER;
-    }
-
-    String jarPath = manageCoprocessors ? jarFile.toURI().getPath() : null;
-    return new CoprocessorDescriptor(coprocessor.getName(), jarPath, priority, null);
+                                Integer priority) throws IOException {
+    CoprocessorDescriptor descriptor = coprocessorManager.getCoprocessorDescriptor(coprocessor, priority);
+    Path path = descriptor.getPath() == null ? null : new Path(descriptor.getPath());
+    tableDescriptor.addCoprocessor(descriptor.getClassName(),
+                                   path,
+                                   descriptor.getPriority(),
+                                   descriptor.getProperties());
   }
 
   protected abstract CoprocessorJar createCoprocessorJar() throws IOException;

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/CoprocessorManager.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/CoprocessorManager.java
@@ -20,7 +20,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.utils.ProjectInfo;
-import com.google.common.collect.ImmutableMap;
+import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Files;
 import com.google.common.io.OutputSupplier;
@@ -43,67 +43,88 @@ import java.util.Map;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
+import javax.annotation.Nullable;
 
 /**
  * Manages HBase coprocessors for Tables and Queues.
  */
 public class CoprocessorManager {
   private static final Logger LOG = LoggerFactory.getLogger(CoprocessorManager.class);
+  private static final String INCLUDE_BUILD_IN_PATH = "master.coprocessors.include.build.in.path";
+  private final boolean manageCoprocessors;
+  private final boolean includeBuildInPath;
   private final Location jarDir;
-  private final Map<Type, Set<Class<? extends Coprocessor>>> coprocessors;
-
-  /**
-   * Type of coprocessor.
-   */
-  public enum Type {
-    TABLE,
-    QUEUE,
-    MESSAGING
-  }
+  private final Set<Class<? extends Coprocessor>> coprocessors;
 
   public CoprocessorManager(CConfiguration cConf, LocationFactory locationFactory, HBaseTableUtil tableUtil) {
+    this.manageCoprocessors = cConf.getBoolean(Constants.HBase.MANAGE_COPROCESSORS);
+    // this is really only useful in a development setting, so not putting the default in cdap-default.xml
+    this.includeBuildInPath = cConf.getBoolean(INCLUDE_BUILD_IN_PATH, true);
     this.jarDir = locationFactory.create(cConf.get(Constants.CFG_HDFS_LIB_DIR));
-    this.coprocessors = ImmutableMap.<Type, Set<Class<? extends Coprocessor>>>of(
-      Type.TABLE, ImmutableSet.of(tableUtil.getTransactionDataJanitorClassForVersion(),
-                                  tableUtil.getIncrementHandlerClassForVersion()),
-      Type.QUEUE, ImmutableSet.of(tableUtil.getQueueRegionObserverClassForVersion(),
-                                  tableUtil.getDequeueScanObserverClassForVersion()),
-      Type.MESSAGING, ImmutableSet.of(tableUtil.getMessageTableRegionObserverClassForVersion(),
-                                      tableUtil.getPayloadTableRegionObserverClassForVersion()));
+    //noinspection unchecked
+    this.coprocessors = ImmutableSet.of(
+      tableUtil.getTransactionDataJanitorClassForVersion(),
+      tableUtil.getIncrementHandlerClassForVersion(),
+      tableUtil.getQueueRegionObserverClassForVersion(),
+      tableUtil.getDequeueScanObserverClassForVersion(),
+      tableUtil.getMessageTableRegionObserverClassForVersion(),
+      tableUtil.getPayloadTableRegionObserverClassForVersion());
+  }
+
+
+  /**
+   * Get the descriptor for a single coprocessor that uses the pre-built coprocessor jar.
+   */
+  public CoprocessorDescriptor getCoprocessorDescriptor(Class<? extends  Coprocessor> coprocessor,
+                                                        @Nullable Integer priority) throws IOException {
+    if (priority == null) {
+      priority = Coprocessor.PRIORITY_USER;
+    }
+
+    Location jarFile = ensureCoprocessorExists();
+    String jarPath = manageCoprocessors ? jarFile.toURI().getPath() : null;
+    return new CoprocessorDescriptor(coprocessor.getName(), jarPath, priority, null);
   }
 
   /**
-   * Get the location of the specified type of coprocessor and ensure it exists.
-   * In distributed mode, the coprocessor jars are loaded onto hdfs by the CoprocessorBuildTool,
+   * Get the location of the coprocessor and ensure it exists.
+   * In distributed mode, the coprocessor jar is loaded onto hdfs by the CoprocessorBuildTool,
    * but in other modes it is still useful to create the jar on demand.
    *
-   * @param type the type of coprocessor
    * @return the location of the coprocessor
    * @throws IOException if there was an issue accessing the location
    */
-  public synchronized Location ensureCoprocessorExists(Type type) throws IOException {
+  public synchronized Location ensureCoprocessorExists() throws IOException {
+    return ensureCoprocessorExists(false);
+  }
 
-    final Location targetPath = jarDir.append(String.format("%s-coprocessor-%s-%s.jar",
-                                                            type.name().toLowerCase(),
-                                                            ProjectInfo.getVersion(),
-                                                            HBaseVersion.get().toString()));
-    if (targetPath.exists()) {
+  /**
+   * Get the location of the coprocessor and ensure it exists. If a coprocessor already exists, it will be overwritten.
+   * In distributed mode, the coprocessor jar is loaded onto hdfs by the CoprocessorBuildTool,
+   * but in other modes it is still useful to create the jar on demand.
+   *
+   * @return the location of the coprocessor
+   * @throws IOException if there was an issue accessing the location
+   */
+  public synchronized Location ensureCoprocessorExists(boolean overwrite) throws IOException {
+
+    final Location targetPath = jarDir.append(getCoprocessorName());
+    if (!overwrite && targetPath.exists()) {
       return targetPath;
     }
 
     // ensure the jar directory exists
     Locations.mkdirsIfNotExists(jarDir);
 
-    Set<Class<? extends Coprocessor>> classes = coprocessors.get(type);
     StringBuilder buf = new StringBuilder();
-    for (Class<? extends Coprocessor> c : classes) {
+    for (Class<? extends Coprocessor> c : coprocessors) {
       buf.append(c.getName()).append(", ");
     }
 
     LOG.debug("Creating jar file for coprocessor classes: {}", buf.toString());
 
     final Map<String, URL> dependentClasses = new HashMap<>();
-    for (Class<? extends Coprocessor> clz : classes) {
+    for (Class<? extends Coprocessor> clz : coprocessors) {
       Dependencies.findClassDependencies(clz.getClassLoader(), new ClassAcceptor() {
         @Override
         public boolean accept(String className, final URL classUrl, URL classPathUrl) {
@@ -127,7 +148,7 @@ public class CoprocessorManager {
 
     // create the coprocessor jar on local filesystem
     LOG.debug("Adding " + dependentClasses.size() + " classes to jar");
-    File jarFile = File.createTempFile(type.name().toLowerCase(), ".jar");
+    File jarFile = File.createTempFile("coprocessor", ".jar");
     byte[] buffer = new byte[4 * 1024];
     try (JarOutputStream jarOutput = new JarOutputStream(new FileOutputStream(jarFile))) {
       for (Map.Entry<String, URL> entry : dependentClasses.entrySet()) {
@@ -184,5 +205,23 @@ public class CoprocessorManager {
 
     tmpLocation.renameTo(targetPath);
     return targetPath;
+  }
+
+  private String getCoprocessorName() {
+    ProjectInfo.Version cdapVersion = ProjectInfo.getVersion();
+    StringBuilder name = new StringBuilder()
+      .append("coprocessor-")
+      .append(cdapVersion.getMajor()).append('.')
+      .append(cdapVersion.getMinor()).append('.')
+      .append(cdapVersion.getFix());
+    if (cdapVersion.isSnapshot()) {
+      name.append("-SNAPSHOT");
+    }
+    if (includeBuildInPath) {
+      name.append("-").append(cdapVersion.getBuildTime());
+    }
+
+    name.append("-").append(HBaseVersion.get()).append(".jar");
+    return name.toString();
   }
 }

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/CoprocessorManager.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/CoprocessorManager.java
@@ -99,10 +99,11 @@ public class CoprocessorManager {
   }
 
   /**
-   * Get the location of the coprocessor and ensure it exists. If a coprocessor already exists, it will be overwritten.
+   * Get the location of the coprocessor and ensure it exists, optionally overwriting it if it exists.
    * In distributed mode, the coprocessor jar is loaded onto hdfs by the CoprocessorBuildTool,
    * but in other modes it is still useful to create the jar on demand.
    *
+   * @param overwrite whether to overwrite the coprocessor if it already exists
    * @return the location of the coprocessor
    * @throws IOException if there was an issue accessing the location
    */

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DatasetUpgrader.java
@@ -26,7 +26,6 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.lib.hbase.AbstractHBaseDataSetAdmin;
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTableAdmin;
 import co.cask.cdap.data2.util.TableId;
-import co.cask.cdap.data2.util.hbase.CoprocessorManager;
 import co.cask.cdap.data2.util.hbase.HBaseDDLExecutorFactory;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtil;
 import co.cask.cdap.data2.util.hbase.HTableNameConverter;
@@ -135,8 +134,7 @@ public class DatasetUpgrader extends AbstractUpgrader {
 
     final boolean supportsIncrement = HBaseTableAdmin.supportsReadlessIncrements(desc);
     final boolean transactional = HBaseTableAdmin.isTransactional(desc);
-    final CoprocessorManager coprocessorManager = new CoprocessorManager(cConf, locationFactory, hBaseTableUtil);
-    DatasetAdmin admin = new AbstractHBaseDataSetAdmin(tableId, hConf, cConf, hBaseTableUtil) {
+    DatasetAdmin admin = new AbstractHBaseDataSetAdmin(tableId, hConf, cConf, hBaseTableUtil, locationFactory) {
       @Override
       protected CoprocessorJar createCoprocessorJar() throws IOException {
         return HBaseTableAdmin.createCoprocessorJarInternal(cConf,

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeTool.java
@@ -314,9 +314,7 @@ public class UpgradeTool {
     LOG.info("Initializing Dataset Framework...");
     initializeDSFramework(cConf, dsFramework, includeNewDatasets);
     LOG.info("Building and uploading new HBase coprocessors...");
-    for (CoprocessorManager.Type type : CoprocessorManager.Type.values()) {
-      coprocessorManager.ensureCoprocessorExists(type);
-    }
+    coprocessorManager.ensureCoprocessorExists();
   }
 
   /**

--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/hbase/HBaseTableFactory.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/hbase/HBaseTableFactory.java
@@ -87,7 +87,6 @@ public final class HBaseTableFactory implements TableFactory {
   private final Map<TableId, HTableDescriptor> tableDescriptors;
   private final CoprocessorManager coprocessorManager;
   private final HBaseDDLExecutorFactory ddlExecutorFactory;
-  private final boolean manageCoprocessors;
 
   @Inject
   HBaseTableFactory(CConfiguration cConf, Configuration hConf, HBaseTableUtil tableUtil,
@@ -97,7 +96,6 @@ public final class HBaseTableFactory implements TableFactory {
     this.tableUtil = tableUtil;
     this.tableDescriptors = new ConcurrentHashMap<>();
     this.coprocessorManager = new CoprocessorManager(cConf, locationFactory, tableUtil);
-    this.manageCoprocessors = cConf.getBoolean(Constants.HBase.MANAGE_COPROCESSORS);
 
     RejectedExecutionHandler callerRunsPolicy = new RejectedExecutionHandler() {
       @Override
@@ -302,9 +300,7 @@ public final class HBaseTableFactory implements TableFactory {
       CoprocessorDescriptor coprocessorDescriptor =
         coprocessorManager.getCoprocessorDescriptor(coprocessor, Coprocessor.PRIORITY_USER);
       Path path = coprocessorDescriptor.getPath() == null ? null : new Path(coprocessorDescriptor.getPath());
-      tableDescriptor.addCoprocessor(coprocessorDescriptor.getClassName(),
-                                     path,
-                                     coprocessorDescriptor.getPriority(),
+      tableDescriptor.addCoprocessor(coprocessorDescriptor.getClassName(), path, coprocessorDescriptor.getPriority(),
                                      coprocessorDescriptor.getProperties());
 
       // Update CDAP version, table prefix


### PR DESCRIPTION
Some refactoring and simplification to the pre-built coprocessors.
Instead of a coprocessor per table type, just using a single
coprocessor jar with all the coprocessor classes in them. This
makes it simpler and mirrors what would happen in a cluster
setup where the coprocessor jar is deployed to all regionservers.
Also some refactoring to move duplicate logic around the
CoprocessorDescriptor to a single place.

Another change was to remove the cdap build time from the
coprocessor path for non-snapshot versions of cdap. There is
also a setting that can be set to false to omit it entirely. This
is purely to make testing easier on clusters that have different
build times for the same cdap snapshot.

Also adding an option to the coprocessor build tool to overwrite
any jar that already exists.