### PR TITLE
CDAP-8298 fix for if two way replication is enabled

### DIFF
--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/replication/LastWriteTimeObserver.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/replication/LastWriteTimeObserver.java
@@ -58,10 +58,12 @@ public class LastWriteTimeObserver extends BaseWALObserver {
   @Override
   public void postWALWrite(ObserverContext<? extends WALCoprocessorEnvironment> ctx, HRegionInfo info,
                            WALKey logKey, WALEdit logEdit) throws IOException {
-    if (logKey.getScopes() == null || logKey.getScopes().size() == 0) {
+    if (logKey.getScopes() == null || logKey.getScopes().size() == 0 || !logKey.getClusterIds().isEmpty()) {
       //if replication scope is not set for this entry, do not update write time.
       // This is to save us from cases where some HBase tables do not have replication enabled.
       // Ideally, you would check scopes against REPLICATION_SCOPE_LOCAL, but cell.getFamily() is expensive.
+      // also ignore if this logkey was processed by another cluster,
+      // which means the write originated on another cluster
       return;
     }
     LOG.debug("Update LastWriteTimeObserver for Table {}:{} for region={}",

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/replication/LastWriteTimeObserver.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/replication/LastWriteTimeObserver.java
@@ -59,10 +59,12 @@ public class LastWriteTimeObserver extends BaseWALObserver {
   @Override
   public void postWALWrite(ObserverContext<? extends WALCoprocessorEnvironment> ctx, HRegionInfo info,
                            WALKey logKey, WALEdit logEdit) throws IOException {
-    if (logKey.getScopes() == null || logKey.getScopes().size() == 0) {
-      //if replication scope is not set for this entry, do not update write time.
+    if (logKey.getScopes() == null || logKey.getScopes().size() == 0 || !logKey.getClusterIds().isEmpty()) {
+      // if replication scope is not set for this entry, do not update write time.
       // This is to save us from cases where some HBase tables do not have replication enabled.
       // Ideally, you would check scopes against REPLICATION_SCOPE_LOCAL, but cell.getFamily() is expensive.
+      // also ignore if this logkey was processed by another cluster,
+      // which means the write originated on another cluster
       return;
     }
     LOG.debug("Update LastWriteTimeObserver for Table {}:{} for region={}",

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/replication/LastWriteTimeObserver.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/replication/LastWriteTimeObserver.java
@@ -58,10 +58,12 @@ public class LastWriteTimeObserver extends BaseWALObserver {
   @Override
   public void postWALWrite(ObserverContext<? extends WALCoprocessorEnvironment> ctx, HRegionInfo info,
                            WALKey logKey, WALEdit logEdit) throws IOException {
-    if (logKey.getScopes() == null || logKey.getScopes().size() == 0) {
+    if (logKey.getScopes() == null || logKey.getScopes().size() == 0 || !logKey.getClusterIds().isEmpty()) {
       //if replication scope is not set for this entry, do not update write time.
       // This is to save us from cases where some HBase tables do not have replication enabled.
       // Ideally, you would check scopes against REPLICATION_SCOPE_LOCAL, but cell.getFamily() is expensive.
+      // also ignore if this logkey was processed by another cluster,
+      // which means the write originated on another cluster
       return;
     }
     LOG.debug("Update LastWriteTimeObserver for Table {}:{} for region={}",

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/replication/LastWriteTimeObserver.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/replication/LastWriteTimeObserver.java
@@ -58,10 +58,12 @@ public class LastWriteTimeObserver extends BaseWALObserver {
   @Override
   public void postWALWrite(ObserverContext<? extends WALCoprocessorEnvironment> ctx, HRegionInfo info,
                            WALKey logKey, WALEdit logEdit) throws IOException {
-    if (logKey.getScopes() == null || logKey.getScopes().size() == 0) {
+    if (logKey.getScopes() == null || logKey.getScopes().size() == 0 || !logKey.getClusterIds().isEmpty()) {
       //if replication scope is not set for this entry, do not update write time.
       // This is to save us from cases where some HBase tables do not have replication enabled.
       // Ideally, you would check scopes against REPLICATION_SCOPE_LOCAL, but cell.getFamily() is expensive.
+      // also ignore if this logkey was processed by another cluster,
+      // which means the write originated on another cluster
       return;
     }
     LOG.debug("Update LastWriteTimeObserver for Table {}:{} for region={}",

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/replication/LastWriteTimeObserver.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/replication/LastWriteTimeObserver.java
@@ -59,10 +59,12 @@ public class LastWriteTimeObserver extends BaseWALObserver {
   @Override
   public void postWALWrite(ObserverContext<? extends WALCoprocessorEnvironment> ctx, HRegionInfo info,
                            WALKey logKey, WALEdit logEdit) throws IOException {
-    if (logKey.getScopes() == null || logKey.getScopes().size() == 0) {
+    if (logKey.getScopes() == null || logKey.getScopes().size() == 0 || !logKey.getClusterIds().isEmpty()) {
       //if replication scope is not set for this entry, do not update write time.
       // This is to save us from cases where some HBase tables do not have replication enabled.
       // Ideally, you would check scopes against REPLICATION_SCOPE_LOCAL, but cell.getFamily() is expensive.
+      // also ignore if this logkey was processed by another cluster,
+      // which means the write originated on another cluster
       return;
     }
     LOG.debug("Update LastWriteTimeObserver for Table {}:{} for region={}",


### PR DESCRIPTION
Fixes a case where tables are configured to replicate both ways,
so that writes originating from one cluster are not recorded
as writes originating on the slave.