### PR TITLE
CDAP-8110 Add support for namespace in entity types for persistence

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
@@ -25,13 +25,13 @@ import co.cask.cdap.common.entity.EntityExistenceVerifier;
 import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResponse;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
-import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.cdap.security.spi.authorization.AuthorizationEnforcer;
@@ -164,7 +164,7 @@ public class DefaultMetadataAdmin implements MetadataAdmin {
 
   @Override
   public MetadataSearchResponse search(String namespaceId, String searchQuery,
-                                       Set<MetadataSearchTargetType> types,
+                                       Set<EntityTypeSimpleName> types,
                                        SortInfo sortInfo, int offset, int limit,
                                        int numCursors, String cursor, boolean showHidden) throws Exception {
     return filterAuthorizedSearchResult(

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
@@ -19,11 +19,11 @@ package co.cask.cdap.metadata;
 import co.cask.cdap.common.InvalidMetadataException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
+import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResponse;
-import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 
 import java.util.Map;
 import java.util.Set;
@@ -154,7 +154,7 @@ public interface MetadataAdmin {
 
   /**
    * Executes a search for CDAP entities in the specified namespace with the specified search query and
-   * an optional set of {@link MetadataSearchTargetType entity types} in the specified {@link MetadataScope}.
+   * an optional set of {@link EntityTypeSimpleName entity types} in the specified {@link MetadataScope}.
    *
    * @param namespaceId the namespace id to filter the search by
    * @param searchQuery the search query
@@ -172,7 +172,7 @@ public interface MetadataAdmin {
    *                    or not.
    * @return the {@link MetadataSearchResponse} containing search results for the specified search query and filters
    */
-  MetadataSearchResponse search(String namespaceId, String searchQuery, Set<MetadataSearchTargetType> types,
+  MetadataSearchResponse search(String namespaceId, String searchQuery, Set<EntityTypeSimpleName> types,
                                 SortInfo sortInfo, int offset, int limit, int numCursors,
                                 String cursor, boolean showHidden) throws Exception;
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
@@ -24,6 +24,7 @@ import co.cask.cdap.common.security.AuditPolicy;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.codec.NamespacedEntityIdCodec;
+import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.DatasetId;
@@ -34,7 +35,6 @@ import co.cask.cdap.proto.id.StreamViewId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResponse;
-import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpResponder;
 import com.google.common.base.Charsets;
@@ -80,11 +80,11 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   private static final Type LIST_STRING_TYPE = new TypeToken<List<String>>() { }.getType();
   private static final Type SET_METADATA_RECORD_TYPE = new TypeToken<Set<MetadataRecord>>() { }.getType();
 
-  private static final Function<String, MetadataSearchTargetType> STRING_TO_TARGET_TYPE =
-    new Function<String, MetadataSearchTargetType>() {
+  private static final Function<String, EntityTypeSimpleName> STRING_TO_TARGET_TYPE =
+    new Function<String, EntityTypeSimpleName>() {
       @Override
-      public MetadataSearchTargetType apply(String input) {
-        return MetadataSearchTargetType.valueOf(input.toUpperCase());
+      public EntityTypeSimpleName apply(String input) {
+        return EntityTypeSimpleName.valueOf(input.toUpperCase());
       }
     };
 
@@ -856,7 +856,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
                              @QueryParam("numCursors") @DefaultValue("0") int numCursors,
                              @QueryParam("cursor") @DefaultValue("") String cursor,
                              @QueryParam("showHidden") @DefaultValue("false") boolean showHidden) throws Exception {
-    Set<MetadataSearchTargetType> types = Collections.emptySet();
+    Set<EntityTypeSimpleName> types = Collections.emptySet();
     if (targets != null) {
       types = ImmutableSet.copyOf(Iterables.transform(targets, STRING_TO_TARGET_TYPE));
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
@@ -24,8 +24,8 @@ import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.internal.AppFabricTestHelper;
 import co.cask.cdap.internal.app.services.AppFabricServer;
 import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.NamespaceId;
-import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;
@@ -77,7 +77,7 @@ public class MetadataAdminAuthorizationTest {
     SecurityRequestContext.setUserId(ALICE.getName());
     authorizer.grant(NamespaceId.DEFAULT, ALICE, Collections.singleton(Action.WRITE));
     AppFabricTestHelper.deployApplication(Id.Namespace.DEFAULT, AllProgramsApp.class, "{}", cConf);
-    EnumSet<MetadataSearchTargetType> types = EnumSet.allOf(MetadataSearchTargetType.class);
+    EnumSet<EntityTypeSimpleName> types = EnumSet.allOf(EntityTypeSimpleName.class);
     Assert.assertFalse(
       metadataAdmin.search(NamespaceId.DEFAULT.getNamespace(), "*", types,
                            SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 0, null, false).getResults().isEmpty());

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/DefaultCompleters.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/DefaultCompleters.java
@@ -31,8 +31,8 @@ import co.cask.cdap.cli.completer.element.ProgramIdCompleter;
 import co.cask.cdap.cli.completer.element.StreamIdCompleter;
 import co.cask.cdap.client.ApplicationClient;
 import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.metadata.MetadataScope;
-import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.cdap.proto.security.Principal;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMap;
@@ -72,7 +72,7 @@ public class DefaultCompleters implements Supplier<Map<String, Completer>> {
         .put(ArgumentName.COMMAND_CATEGORY.getName(), new EnumCompleter(CommandCategory.class))
         .put(ArgumentName.TABLE_RENDERER.getName(), new EnumCompleter(RenderAsCommand.Type.class))
         .put(ArgumentName.WORKFLOW_TOKEN_SCOPE.getName(), new EnumCompleter(WorkflowToken.Scope.class))
-        .put(ArgumentName.TARGET_TYPE.getName(), new EnumCompleter(MetadataSearchTargetType.class))
+        .put(ArgumentName.TARGET_TYPE.getName(), new EnumCompleter(EntityTypeSimpleName.class))
         .put(ArgumentName.METADATA_SCOPE.getName(), new EnumCompleter(MetadataScope.class))
         .put(ArgumentName.FORMAT.getName(), new StringsCompleter(Formats.ALL))
         .put(ArgumentName.PRINCIPAL_TYPE.getName(), new EnumCompleter(Principal.PrincipalType.class))

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/SearchMetadataCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/SearchMetadataCommand.java
@@ -22,9 +22,9 @@ import co.cask.cdap.cli.util.AbstractCommand;
 import co.cask.cdap.cli.util.RowMaker;
 import co.cask.cdap.cli.util.table.Table;
 import co.cask.cdap.client.MetadataClient;
+import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.metadata.MetadataSearchResponse;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
-import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.common.cli.Arguments;
 import com.google.common.base.Function;
 import com.google.common.base.Splitter;
@@ -42,11 +42,11 @@ import java.util.Set;
  */
 public class SearchMetadataCommand extends AbstractCommand {
 
-  private static final Function<String, MetadataSearchTargetType> STRING_TO_TARGET_TYPE =
-    new Function<String, MetadataSearchTargetType>() {
+  private static final Function<String, EntityTypeSimpleName> STRING_TO_TARGET_TYPE =
+    new Function<String, EntityTypeSimpleName>() {
       @Override
-      public MetadataSearchTargetType apply(String input) {
-        return MetadataSearchTargetType.valueOf(input.toUpperCase());
+      public EntityTypeSimpleName apply(String input) {
+        return EntityTypeSimpleName.valueOf(input.toUpperCase());
       }
     };
 
@@ -89,7 +89,7 @@ public class SearchMetadataCommand extends AbstractCommand {
       "'artifact', 'app', 'dataset', 'program', 'stream', or 'view'.";
   }
 
-  private Set<MetadataSearchTargetType> parseTargetType(String typeString) {
+  private Set<EntityTypeSimpleName> parseTargetType(String typeString) {
     if (typeString == null) {
       return ImmutableSet.of();
     }

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataHttpHandlerTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataHttpHandlerTestRun.java
@@ -44,6 +44,7 @@ import co.cask.cdap.proto.StreamProperties;
 import co.cask.cdap.proto.ViewSpecification;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.DatasetId;
@@ -58,7 +59,6 @@ import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResponse;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
-import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.common.http.HttpRequest;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
@@ -171,24 +171,24 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
       new MetadataSearchResultRecord(application)
     );
     Set<MetadataSearchResultRecord> searchProperties = searchMetadata(NamespaceId.DEFAULT, "aKey:aValue",
-                                                                      MetadataSearchTargetType.APP);
+                                                                      EntityTypeSimpleName.APP);
     Assert.assertEquals(expected, searchProperties);
-    searchProperties = searchMetadata(NamespaceId.DEFAULT, "multiword:wow1", MetadataSearchTargetType.APP);
+    searchProperties = searchMetadata(NamespaceId.DEFAULT, "multiword:wow1", EntityTypeSimpleName.APP);
     Assert.assertEquals(expected, searchProperties);
-    searchProperties = searchMetadata(NamespaceId.DEFAULT, "multiword:woW5", MetadataSearchTargetType.APP);
+    searchProperties = searchMetadata(NamespaceId.DEFAULT, "multiword:woW5", EntityTypeSimpleName.APP);
     Assert.assertEquals(expected, searchProperties);
-    searchProperties = searchMetadata(NamespaceId.DEFAULT, "WOW3", MetadataSearchTargetType.APP);
+    searchProperties = searchMetadata(NamespaceId.DEFAULT, "WOW3", EntityTypeSimpleName.APP);
     Assert.assertEquals(expected, searchProperties);
 
     // test search for stream
-    searchProperties = searchMetadata(NamespaceId.DEFAULT, "stKey:stValue", MetadataSearchTargetType.STREAM);
+    searchProperties = searchMetadata(NamespaceId.DEFAULT, "stKey:stValue", EntityTypeSimpleName.STREAM);
     expected = ImmutableSet.of(
       new MetadataSearchResultRecord(mystream));
     Assert.assertEquals(expected, searchProperties);
 
     // test search for view with lowercase key value when metadata was stored in mixed case
     searchProperties = searchMetadata(NamespaceId.DEFAULT,
-                                      "viewkey:viewvalue", MetadataSearchTargetType.VIEW);
+                                      "viewkey:viewvalue", EntityTypeSimpleName.VIEW);
     expected = ImmutableSet.of(
       new MetadataSearchResultRecord(myview)
     );
@@ -196,7 +196,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
 
     // test search for view with lowercase value when metadata was stored in mixed case
     searchProperties = searchMetadata(NamespaceId.DEFAULT,
-                                      "viewvalue", MetadataSearchTargetType.VIEW);
+                                      "viewvalue", EntityTypeSimpleName.VIEW);
     expected = ImmutableSet.of(
       new MetadataSearchResultRecord(myview)
     );
@@ -204,7 +204,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
 
     // test search for artifact
     searchProperties = searchMetadata(NamespaceId.DEFAULT,
-                                      "rKey:rValue", MetadataSearchTargetType.ARTIFACT);
+                                      "rKey:rValue", EntityTypeSimpleName.ARTIFACT);
     expected = ImmutableSet.of(
       new MetadataSearchResultRecord(artifactId)
     );
@@ -215,20 +215,20 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
       new MetadataSearchResultRecord(mystream)
     );
 
-    searchProperties = searchMetadata(NamespaceId.DEFAULT, "multiword:w*", MetadataSearchTargetType.ALL);
+    searchProperties = searchMetadata(NamespaceId.DEFAULT, "multiword:w*", EntityTypeSimpleName.ALL);
     Assert.assertEquals(2, searchProperties.size());
     Assert.assertEquals(expected, searchProperties);
 
-    searchProperties = searchMetadata(NamespaceId.DEFAULT, "multiword:*", MetadataSearchTargetType.ALL);
+    searchProperties = searchMetadata(NamespaceId.DEFAULT, "multiword:*", EntityTypeSimpleName.ALL);
     Assert.assertEquals(2, searchProperties.size());
     Assert.assertEquals(expected, searchProperties);
 
-    searchProperties = searchMetadata(NamespaceId.DEFAULT, "wo*", MetadataSearchTargetType.ALL);
+    searchProperties = searchMetadata(NamespaceId.DEFAULT, "wo*", EntityTypeSimpleName.ALL);
     Assert.assertEquals(2, searchProperties.size());
     Assert.assertEquals(expected, searchProperties);
 
     // test prefix search for service
-    searchProperties = searchMetadata(NamespaceId.DEFAULT, "sKey:s*", MetadataSearchTargetType.ALL);
+    searchProperties = searchMetadata(NamespaceId.DEFAULT, "sKey:s*", EntityTypeSimpleName.ALL);
     expected = ImmutableSet.of(
       new MetadataSearchResultRecord(pingService)
     );
@@ -331,13 +331,13 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     Assert.assertTrue(artifactTags.containsAll(tags));
     // test search for stream
     Set<MetadataSearchResultRecord> searchTags =
-      searchMetadata(NamespaceId.DEFAULT, "stT", MetadataSearchTargetType.STREAM);
+      searchMetadata(NamespaceId.DEFAULT, "stT", EntityTypeSimpleName.STREAM);
     Set<MetadataSearchResultRecord> expected = ImmutableSet.of(
       new MetadataSearchResultRecord(mystream)
     );
     Assert.assertEquals(expected, searchTags);
 
-    searchTags = searchMetadata(NamespaceId.DEFAULT, "Wow", MetadataSearchTargetType.STREAM);
+    searchTags = searchMetadata(NamespaceId.DEFAULT, "Wow", EntityTypeSimpleName.STREAM);
     expected = ImmutableSet.of(
       new MetadataSearchResultRecord(mystream)
     );
@@ -345,13 +345,13 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     Assert.assertEquals(expected, searchTags);
     // test search for view with lowercase tag when metadata was stored in mixed case
     searchTags =
-      searchMetadata(NamespaceId.DEFAULT, "viewtag", MetadataSearchTargetType.VIEW);
+      searchMetadata(NamespaceId.DEFAULT, "viewtag", EntityTypeSimpleName.VIEW);
     expected = ImmutableSet.of(
       new MetadataSearchResultRecord(myview)
     );
     Assert.assertEquals(expected, searchTags);
     // test prefix search, should match stream and application
-    searchTags = searchMetadata(NamespaceId.DEFAULT, "Wow*", MetadataSearchTargetType.ALL);
+    searchTags = searchMetadata(NamespaceId.DEFAULT, "Wow*", EntityTypeSimpleName.ALL);
     expected = ImmutableSet.of(
       new MetadataSearchResultRecord(application),
       new MetadataSearchResultRecord(mystream)
@@ -864,7 +864,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     // with target type as artifact
     Assert.assertEquals(
       ImmutableSet.of(new MetadataSearchResultRecord(systemId)),
-      searchMetadata(NamespaceId.DEFAULT, "system*", MetadataSearchTargetType.ARTIFACT)
+      searchMetadata(NamespaceId.DEFAULT, "system*", EntityTypeSimpleName.ARTIFACT)
     );
 
     // verify that user metadata can be deleted for system-scope artifacts
@@ -945,9 +945,9 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
 
     // Search for single target type
     Assert.assertEquals(ImmutableSet.of(new MetadataSearchResultRecord(appId)),
-                        searchMetadata(namespace, "utag*", MetadataSearchTargetType.APP));
+                        searchMetadata(namespace, "utag*", EntityTypeSimpleName.APP));
     Assert.assertEquals(ImmutableSet.of(new MetadataSearchResultRecord(datasetId)),
-                        searchMetadata(namespace, "utag*", MetadataSearchTargetType.DATASET));
+                        searchMetadata(namespace, "utag*", EntityTypeSimpleName.DATASET));
 
     // Search for multiple target types
     Assert.assertEquals(ImmutableSet.of(
@@ -956,8 +956,8 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
                         ),
                         searchMetadata(namespace, "utag*",
                                        ImmutableSet.of(
-                                         MetadataSearchTargetType.DATASET,
-                                         MetadataSearchTargetType.STREAM
+                                         EntityTypeSimpleName.DATASET,
+                                         EntityTypeSimpleName.STREAM
                                        )
                         ));
 
@@ -967,8 +967,8 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
                         ),
                         searchMetadata(namespace, "utag*",
                                        ImmutableSet.of(
-                                         MetadataSearchTargetType.APP,
-                                         MetadataSearchTargetType.DATASET
+                                         EntityTypeSimpleName.APP,
+                                         EntityTypeSimpleName.DATASET
                                        )
                         ));
 
@@ -978,7 +978,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
                           new MetadataSearchResultRecord(appId),
                           new MetadataSearchResultRecord(streamId)
                         ),
-                        searchMetadata(namespace, "utag*", MetadataSearchTargetType.ALL));
+                        searchMetadata(namespace, "utag*", EntityTypeSimpleName.ALL));
     Assert.assertEquals(ImmutableSet.of(
                           new MetadataSearchResultRecord(datasetId),
                           new MetadataSearchResultRecord(appId),
@@ -986,8 +986,8 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
                         ),
                         searchMetadata(namespace, "utag*",
                                        ImmutableSet.of(
-                                         MetadataSearchTargetType.DATASET,
-                                         MetadataSearchTargetType.ALL
+                                         EntityTypeSimpleName.DATASET,
+                                         EntityTypeSimpleName.ALL
                                        )
                         ));
   }
@@ -1015,7 +1015,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     expectedUserMetadata.put(streamId, new Metadata(props, tags));
 
     Set<MetadataSearchResultRecord> results =
-      super.searchMetadata(NamespaceId.DEFAULT, "value*", ImmutableSet.<MetadataSearchTargetType>of());
+      super.searchMetadata(NamespaceId.DEFAULT, "value*", ImmutableSet.<EntityTypeSimpleName>of());
 
     // Verify results
     Assert.assertEquals(expectedUserMetadata.keySet(), getEntities(results));
@@ -1150,7 +1150,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
   @Test
   public void testInvalidSearchParams() throws Exception {
     NamespaceId namespace = new NamespaceId("invalid");
-    Set<MetadataSearchTargetType> targets = EnumSet.allOf(MetadataSearchTargetType.class);
+    Set<EntityTypeSimpleName> targets = EnumSet.allOf(EntityTypeSimpleName.class);
     try {
       searchMetadata(namespace, "*", targets, AbstractSystemMetadataWriter.ENTITY_NAME_KEY);
       Assert.fail();
@@ -1212,7 +1212,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     );
 
     // search with bad sort param
-    EnumSet<MetadataSearchTargetType> targets = EnumSet.allOf(MetadataSearchTargetType.class);
+    EnumSet<EntityTypeSimpleName> targets = EnumSet.allOf(EntityTypeSimpleName.class);
 
     // test ascending order of entity name
     Set<MetadataSearchResultRecord> searchResults =
@@ -1285,7 +1285,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     // offset 1, limit 2, 2 cursors, should return 2nd result, with 0 cursors since we don't have enough data
     // set showHidden to true which will show the trackerDataset but will not be in search response since its not stream
     MetadataSearchResponse searchResponse = searchMetadata(namespace, "*",
-                                                           ImmutableSet.of(MetadataSearchTargetType.STREAM),
+                                                           ImmutableSet.of(EntityTypeSimpleName.STREAM),
                                                            sort, 1, 2, 2, null, true);
     List<MetadataSearchResultRecord> expectedResults = ImmutableList.of(new MetadataSearchResultRecord(stream2));
     List<String> expectedCursors = ImmutableList.of();
@@ -1294,7 +1294,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
 
     // offset 1, limit 2, 2 cursors, should return just the dataset created above other than trackerDataset even
     // though it was created before since showHidden is false and it should not affect pagination
-    searchResponse = searchMetadata(namespace, "*", ImmutableSet.of(MetadataSearchTargetType.DATASET),
+    searchResponse = searchMetadata(namespace, "*", ImmutableSet.of(EntityTypeSimpleName.DATASET),
                                     sort, 0, 2, 2, null);
     expectedResults = ImmutableList.of(new MetadataSearchResultRecord(mydataset));
     expectedCursors = ImmutableList.of();
@@ -1325,7 +1325,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     );
 
     // search with showHidden to true
-    EnumSet<MetadataSearchTargetType> targets = EnumSet.allOf(MetadataSearchTargetType.class);
+    EnumSet<EntityTypeSimpleName> targets = EnumSet.allOf(EntityTypeSimpleName.class);
     String sort = AbstractSystemMetadataWriter.ENTITY_NAME_KEY + " asc";
     // search to get all the above entities offset 0, limit interger max  and cursors 0
     MetadataSearchResponse searchResponse = searchMetadata(namespace, "*", targets, sort, 0, Integer.MAX_VALUE, 0,
@@ -1424,7 +1424,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     Assert.assertEquals(expected, results);
     results = searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.PLUGIN_NAME + ":" + AllProgramsApp.PLUGIN_TYPE);
     Assert.assertEquals(expected, results);
-    results = searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.PLUGIN_NAME, MetadataSearchTargetType.ARTIFACT);
+    results = searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.PLUGIN_NAME, EntityTypeSimpleName.ARTIFACT);
     Assert.assertEquals(expected, results);
     // add a user tag to the application with the same name as the plugin
     addTags(application, ImmutableSet.of(AllProgramsApp.PLUGIN_NAME));
@@ -1452,43 +1452,43 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
       searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.class.getSimpleName()));
     // using program names
     Assert.assertEquals(expected, searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.NoOpFlow.NAME,
-                                                 MetadataSearchTargetType.APP));
+                                                 EntityTypeSimpleName.APP));
     Assert.assertEquals(expected, searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.NoOpMR.NAME,
-                                                 MetadataSearchTargetType.APP));
+                                                 EntityTypeSimpleName.APP));
     Assert.assertEquals(expected, searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.NoOpService.NAME,
-                                                 MetadataSearchTargetType.APP));
+                                                 EntityTypeSimpleName.APP));
     Assert.assertEquals(expected, searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.NoOpSpark.NAME,
-                                                 MetadataSearchTargetType.APP));
+                                                 EntityTypeSimpleName.APP));
     Assert.assertEquals(expected, searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.NoOpWorker.NAME,
-                                                 MetadataSearchTargetType.APP));
+                                                 EntityTypeSimpleName.APP));
     Assert.assertEquals(expected, searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.NoOpWorkflow.NAME,
-                                                 MetadataSearchTargetType.APP));
+                                                 EntityTypeSimpleName.APP));
     // using program types
     Assert.assertEquals(
       expected, searchMetadata(NamespaceId.DEFAULT,
                                ProgramType.FLOW.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR + "*",
-                               MetadataSearchTargetType.APP));
+                               EntityTypeSimpleName.APP));
     Assert.assertEquals(
       expected, searchMetadata(NamespaceId.DEFAULT,
                                ProgramType.MAPREDUCE.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR + "*",
-                               MetadataSearchTargetType.APP));
+                               EntityTypeSimpleName.APP));
     Assert.assertEquals(
       ImmutableSet.builder().addAll(expected).add(new MetadataSearchResultRecord(application)).build(),
       searchMetadata(NamespaceId.DEFAULT,
                      ProgramType.SERVICE.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR + "*",
-                     MetadataSearchTargetType.APP));
+                     EntityTypeSimpleName.APP));
     Assert.assertEquals(
       expected, searchMetadata(NamespaceId.DEFAULT,
                                ProgramType.SPARK.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR + "*",
-                               MetadataSearchTargetType.APP));
+                               EntityTypeSimpleName.APP));
     Assert.assertEquals(
       expected, searchMetadata(NamespaceId.DEFAULT,
                                ProgramType.WORKER.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR + "*",
-                               MetadataSearchTargetType.APP));
+                               EntityTypeSimpleName.APP));
     Assert.assertEquals(
       expected, searchMetadata(NamespaceId.DEFAULT,
                                ProgramType.WORKFLOW.getPrettyName() + MetadataDataset.KEYVALUE_SEPARATOR + "*",
-                               MetadataSearchTargetType.APP));
+                               EntityTypeSimpleName.APP));
 
     // using schedule
     Assert.assertEquals(expected, searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.SCHEDULE_NAME));
@@ -1528,69 +1528,69 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
       ImmutableSet.of(
         new MetadataSearchResultRecord(
           app.flow(AllProgramsApp.NoOpFlow.NAME))),
-      searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.NoOpFlow.NAME, MetadataSearchTargetType.PROGRAM));
+      searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.NoOpFlow.NAME, EntityTypeSimpleName.PROGRAM));
     Assert.assertEquals(
       ImmutableSet.of(
         new MetadataSearchResultRecord(
           app.mr(AllProgramsApp.NoOpMR.NAME)),
         new MetadataSearchResultRecord(
           app.workflow(AllProgramsApp.NoOpWorkflow.NAME))),
-      searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.NoOpMR.NAME, MetadataSearchTargetType.PROGRAM));
+      searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.NoOpMR.NAME, EntityTypeSimpleName.PROGRAM));
     Assert.assertEquals(
       ImmutableSet.of(
         new MetadataSearchResultRecord(
           app.service(AllProgramsApp.NoOpService.NAME))),
-      searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.NoOpService.NAME, MetadataSearchTargetType.PROGRAM));
+      searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.NoOpService.NAME, EntityTypeSimpleName.PROGRAM));
     Assert.assertEquals(
       ImmutableSet.of(
         new MetadataSearchResultRecord(
           app.spark(AllProgramsApp.NoOpSpark.NAME))),
-      searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.NoOpSpark.NAME, MetadataSearchTargetType.PROGRAM));
+      searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.NoOpSpark.NAME, EntityTypeSimpleName.PROGRAM));
     Assert.assertEquals(
       ImmutableSet.of(
         new MetadataSearchResultRecord(
           app.worker(AllProgramsApp.NoOpWorker.NAME))),
-      searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.NoOpWorker.NAME, MetadataSearchTargetType.PROGRAM));
+      searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.NoOpWorker.NAME, EntityTypeSimpleName.PROGRAM));
     Assert.assertEquals(
       ImmutableSet.of(
         new MetadataSearchResultRecord(
           app.workflow(AllProgramsApp.NoOpWorkflow.NAME))),
-      searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.NoOpWorkflow.NAME, MetadataSearchTargetType.PROGRAM));
+      searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.NoOpWorkflow.NAME, EntityTypeSimpleName.PROGRAM));
 
     // using program types
     Assert.assertEquals(
       ImmutableSet.of(
         new MetadataSearchResultRecord(
           app.flow(AllProgramsApp.NoOpFlow.NAME))),
-      searchMetadata(NamespaceId.DEFAULT, ProgramType.FLOW.getPrettyName(), MetadataSearchTargetType.PROGRAM));
+      searchMetadata(NamespaceId.DEFAULT, ProgramType.FLOW.getPrettyName(), EntityTypeSimpleName.PROGRAM));
     Assert.assertEquals(
       ImmutableSet.of(
         new MetadataSearchResultRecord(
           app.mr(AllProgramsApp.NoOpMR.NAME)),
         new MetadataSearchResultRecord(
           app.mr(AllProgramsApp.NoOpMR2.NAME))),
-      searchMetadata(NamespaceId.DEFAULT, ProgramType.MAPREDUCE.getPrettyName(), MetadataSearchTargetType.PROGRAM));
+      searchMetadata(NamespaceId.DEFAULT, ProgramType.MAPREDUCE.getPrettyName(), EntityTypeSimpleName.PROGRAM));
     Assert.assertEquals(
       ImmutableSet.of(
         new MetadataSearchResultRecord(
           app.service(AllProgramsApp.NoOpService.NAME)),
         new MetadataSearchResultRecord(pingService)),
-      searchMetadata(NamespaceId.DEFAULT, ProgramType.SERVICE.getPrettyName(), MetadataSearchTargetType.PROGRAM));
+      searchMetadata(NamespaceId.DEFAULT, ProgramType.SERVICE.getPrettyName(), EntityTypeSimpleName.PROGRAM));
     Assert.assertEquals(
       ImmutableSet.of(
         new MetadataSearchResultRecord(
           app.spark(AllProgramsApp.NoOpSpark.NAME))),
-      searchMetadata(NamespaceId.DEFAULT, ProgramType.SPARK.getPrettyName(), MetadataSearchTargetType.PROGRAM));
+      searchMetadata(NamespaceId.DEFAULT, ProgramType.SPARK.getPrettyName(), EntityTypeSimpleName.PROGRAM));
     Assert.assertEquals(
       ImmutableSet.of(
         new MetadataSearchResultRecord(
           app.worker(AllProgramsApp.NoOpWorker.NAME))),
-      searchMetadata(NamespaceId.DEFAULT, ProgramType.WORKER.getPrettyName(), MetadataSearchTargetType.PROGRAM));
+      searchMetadata(NamespaceId.DEFAULT, ProgramType.WORKER.getPrettyName(), EntityTypeSimpleName.PROGRAM));
     Assert.assertEquals(
       ImmutableSet.of(
         new MetadataSearchResultRecord(
           app.workflow(AllProgramsApp.NoOpWorkflow.NAME))),
-      searchMetadata(NamespaceId.DEFAULT, ProgramType.WORKFLOW.getPrettyName(), MetadataSearchTargetType.PROGRAM));
+      searchMetadata(NamespaceId.DEFAULT, ProgramType.WORKFLOW.getPrettyName(), EntityTypeSimpleName.PROGRAM));
   }
 
   private void assertDataEntitySearch() throws Exception {
@@ -1702,15 +1702,15 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
       metadataSearchResultRecords);
 
     metadataSearchResultRecords = searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.STREAM_NAME,
-                                                 MetadataSearchTargetType.STREAM);
+                                                 EntityTypeSimpleName.STREAM);
     Assert.assertEquals(ImmutableSet.of(new MetadataSearchResultRecord(streamId)),
                         metadataSearchResultRecords);
     metadataSearchResultRecords = searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.STREAM_NAME,
-                                                 MetadataSearchTargetType.VIEW);
+                                                 EntityTypeSimpleName.VIEW);
     Assert.assertEquals(ImmutableSet.of(new MetadataSearchResultRecord(view)),
                         metadataSearchResultRecords);
     metadataSearchResultRecords = searchMetadata(NamespaceId.DEFAULT, "view",
-                                                 MetadataSearchTargetType.VIEW);
+                                                 EntityTypeSimpleName.VIEW);
     Assert.assertEquals(ImmutableSet.of(new MetadataSearchResultRecord(view)),
                         metadataSearchResultRecords);
     metadataSearchResultRecords = searchMetadata(NamespaceId.DEFAULT, AllProgramsApp.DATASET_NAME);
@@ -1765,12 +1765,12 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
   }
 
   private Set<MetadataSearchResultRecord> searchMetadata(NamespaceId namespaceId, String query,
-                                                         MetadataSearchTargetType target) throws Exception {
+                                                         EntityTypeSimpleName target) throws Exception {
     return searchMetadata(namespaceId, query, ImmutableSet.of(target));
   }
 
   private Set<MetadataSearchResultRecord> searchMetadata(NamespaceId namespaceId, String query) throws Exception {
-    return searchMetadata(namespaceId, query, ImmutableSet.<MetadataSearchTargetType>of());
+    return searchMetadata(namespaceId, query, ImmutableSet.<EntityTypeSimpleName>of());
   }
 
   /**
@@ -1778,7 +1778,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
    */
   @Override
   protected Set<MetadataSearchResultRecord> searchMetadata(NamespaceId namespaceId, String query,
-                                                           Set<MetadataSearchTargetType> targets) throws Exception {
+                                                           Set<EntityTypeSimpleName> targets) throws Exception {
     return searchMetadata(namespaceId, query, targets, null);
   }
 
@@ -1787,7 +1787,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
    */
   @Override
   protected Set<MetadataSearchResultRecord> searchMetadata(NamespaceId namespaceId, String query,
-                                                           Set<MetadataSearchTargetType> targets,
+                                                           Set<EntityTypeSimpleName> targets,
                                                            @Nullable String sort) throws Exception {
     return searchMetadata(namespaceId, query, targets, sort, 0, Integer.MAX_VALUE, 0, null).getResults();
   }
@@ -1797,7 +1797,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
    */
   @Override
   protected MetadataSearchResponse searchMetadata(NamespaceId namespaceId, String query,
-                                                  Set<MetadataSearchTargetType> targets,
+                                                  Set<EntityTypeSimpleName> targets,
                                                   @Nullable String sort, int offset, int limit,
                                                   int numCursors, @Nullable String cursor, boolean showHidden)
     throws Exception {
@@ -1813,7 +1813,7 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
   }
 
   private MetadataSearchResponse searchMetadata(NamespaceId namespaceId, String query,
-                                                Set<MetadataSearchTargetType> targets,
+                                                Set<EntityTypeSimpleName> targets,
                                                 @Nullable String sort, int offset, int limit,
                                                 int numCursors, @Nullable String cursor) throws Exception {
     return searchMetadata(namespaceId, query, targets, sort, offset, limit, numCursors, cursor, false);

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataTestBase.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataTestBase.java
@@ -19,6 +19,7 @@ package co.cask.cdap.client;
 import co.cask.cdap.client.common.ClientTestBase;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.proto.artifact.ArtifactRange;
+import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.DatasetId;
@@ -31,7 +32,6 @@ import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResponse;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
-import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.cdap.proto.metadata.lineage.CollapseType;
 import co.cask.cdap.proto.metadata.lineage.LineageRecord;
 import com.google.common.collect.Iterators;
@@ -458,21 +458,21 @@ public abstract class MetadataTestBase extends ClientTestBase {
   }
 
   protected Set<MetadataSearchResultRecord> searchMetadata(NamespaceId namespaceId, String query,
-                                                           Set<MetadataSearchTargetType> targets) throws Exception {
+                                                           Set<EntityTypeSimpleName> targets) throws Exception {
     // Note: Can't delegate this to the next method. This is because MetadataHttpHandlerTestRun overrides these two
     // methods, to strip out metadata from search results for easier assertions.
     return metadataClient.searchMetadata(namespaceId.toId(), query, targets).getResults();
   }
 
   protected Set<MetadataSearchResultRecord> searchMetadata(NamespaceId namespaceId, String query,
-                                                           Set<MetadataSearchTargetType> targets,
+                                                           Set<EntityTypeSimpleName> targets,
                                                            @Nullable String sort) throws Exception {
     return metadataClient.searchMetadata(namespaceId.toId(), query, targets,
                                          sort, 0, Integer.MAX_VALUE, 0, null, false).getResults();
   }
 
   protected MetadataSearchResponse searchMetadata(NamespaceId namespaceId, String query,
-                                                  Set<MetadataSearchTargetType> targets,
+                                                  Set<EntityTypeSimpleName> targets,
                                                   @Nullable String sort, int offset, int limit, int numCursors,
                                                   @Nullable String cursor, boolean showHiddden) throws Exception {
     return metadataClient.searchMetadata(namespaceId.toId(), query, targets, sort, offset, limit, numCursors,

--- a/cdap-common/src/main/java/co/cask/cdap/common/metadata/AbstractMetadataClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/metadata/AbstractMetadataClient.java
@@ -22,12 +22,12 @@ import co.cask.cdap.common.UnauthenticatedException;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.codec.NamespacedEntityIdCodec;
 import co.cask.cdap.proto.codec.NamespacedIdCodec;
+import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResponse;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
-import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
@@ -79,9 +79,9 @@ public abstract class AbstractMetadataClient {
    * @return the {@link MetadataSearchResponse} for the given query.
    */
   public MetadataSearchResponse searchMetadata(Id.Namespace namespace, String query,
-                                               @Nullable MetadataSearchTargetType target)
+                                               @Nullable EntityTypeSimpleName target)
     throws IOException, UnauthenticatedException, UnauthorizedException, BadRequestException {
-    Set<MetadataSearchTargetType> targets = ImmutableSet.of();
+    Set<EntityTypeSimpleName> targets = ImmutableSet.of();
     if (target != null) {
       targets = ImmutableSet.of(target);
     }
@@ -93,11 +93,11 @@ public abstract class AbstractMetadataClient {
    *
    * @param namespace the namespace to search in
    * @param query the query string with which to search
-   * @param targets {@link MetadataSearchTargetType}s to search. If empty, all possible types will be searched
+   * @param targets {@link EntityTypeSimpleName}s to search. If empty, all possible types will be searched
    * @return A set of {@link MetadataSearchResultRecord} for the given query.
    */
   public MetadataSearchResponse searchMetadata(Id.Namespace namespace, String query,
-                                               Set<MetadataSearchTargetType> targets)
+                                               Set<EntityTypeSimpleName> targets)
     throws IOException, UnauthenticatedException, UnauthorizedException, BadRequestException {
     return searchMetadata(namespace, query, targets, null, 0, Integer.MAX_VALUE, 0, null, false);
   }
@@ -107,7 +107,7 @@ public abstract class AbstractMetadataClient {
    *
    * @param namespace the namespace to search in
    * @param query the query string with which to search
-   * @param targets {@link MetadataSearchTargetType}s to search. If empty, all possible types will be searched
+   * @param targets {@link EntityTypeSimpleName}s to search. If empty, all possible types will be searched
    * @param sort specifies sort field and sort order. If {@code null}, the sort order is by relevance
    * @param offset the index to start with in the search results. To return results from the beginning, pass {@code 0}
    * @param limit the number of results to return, starting from #offset. To return all, pass {@link Integer#MAX_VALUE}
@@ -121,13 +121,13 @@ public abstract class AbstractMetadataClient {
    * @return A set of {@link MetadataSearchResultRecord} for the given query.
    */
   public MetadataSearchResponse searchMetadata(Id.Namespace namespace, String query,
-                                               Set<MetadataSearchTargetType> targets, @Nullable String sort,
+                                               Set<EntityTypeSimpleName> targets, @Nullable String sort,
                                                int offset, int limit, int numCursors,
                                                @Nullable String cursor, boolean showHidden)
     throws IOException, UnauthenticatedException, UnauthorizedException, BadRequestException {
 
     String path = String.format("metadata/search?query=%s", query);
-    for (MetadataSearchTargetType t : targets) {
+    for (EntityTypeSimpleName t : targets) {
       path += "&target=" + t;
     }
     if (sort != null) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/EntityIdKeyHelper.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/EntityIdKeyHelper.java
@@ -16,18 +16,19 @@
 
 package co.cask.cdap.data2.dataset2.lib.table;
 
+import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.FlowId;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.ServiceId;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.id.StreamViewId;
 import co.cask.cdap.proto.id.WorkflowId;
-import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
@@ -42,20 +43,24 @@ import java.util.Map;
 public final class EntityIdKeyHelper {
   public static final Map<Class<? extends NamespacedEntityId>, String> TYPE_MAP =
     ImmutableMap.<Class<? extends NamespacedEntityId>, String>builder()
-    .put(ArtifactId.class, MetadataSearchTargetType.ARTIFACT.getSerializedForm())
-    .put(ApplicationId.class, MetadataSearchTargetType.APP.getSerializedForm())
-    .put(ProgramId.class, MetadataSearchTargetType.PROGRAM.getSerializedForm())
-    .put(WorkflowId.class, MetadataSearchTargetType.PROGRAM.getSerializedForm())
-    .put(FlowId.class, MetadataSearchTargetType.PROGRAM.getSerializedForm())
-    .put(ServiceId.class, MetadataSearchTargetType.PROGRAM.getSerializedForm())
-    .put(DatasetId.class, MetadataSearchTargetType.DATASET.getSerializedForm())
-    .put(StreamId.class, MetadataSearchTargetType.STREAM.getSerializedForm())
-    .put(StreamViewId.class, MetadataSearchTargetType.VIEW.getSerializedForm())
-    .build();
+      .put(NamespaceId.class, EntityTypeSimpleName.NAMESPACE.getSerializedForm())
+      .put(ArtifactId.class, EntityTypeSimpleName.ARTIFACT.getSerializedForm())
+      .put(ApplicationId.class, EntityTypeSimpleName.APP.getSerializedForm())
+      .put(ProgramId.class, EntityTypeSimpleName.PROGRAM.getSerializedForm())
+      .put(WorkflowId.class, EntityTypeSimpleName.PROGRAM.getSerializedForm())
+      .put(FlowId.class, EntityTypeSimpleName.PROGRAM.getSerializedForm())
+      .put(ServiceId.class, EntityTypeSimpleName.PROGRAM.getSerializedForm())
+      .put(DatasetId.class, EntityTypeSimpleName.DATASET.getSerializedForm())
+      .put(StreamId.class, EntityTypeSimpleName.STREAM.getSerializedForm())
+      .put(StreamViewId.class, EntityTypeSimpleName.VIEW.getSerializedForm())
+      .build();
 
   public static void addTargetIdToKey(MDSKey.Builder builder, NamespacedEntityId namespacedEntityId) {
     String type = getTargetType(namespacedEntityId);
-    if (type.equals(TYPE_MAP.get(ProgramId.class))) {
+    if (type.equals(TYPE_MAP.get(NamespaceId.class))) {
+      NamespaceId namespaceId = (NamespaceId) namespacedEntityId;
+      builder.add(namespaceId.getNamespace());
+    } else if (type.equals(TYPE_MAP.get(ProgramId.class))) {
       ProgramId program = (ProgramId) namespacedEntityId;
       String namespaceId = program.getNamespace();
       String appId = program.getApplication();
@@ -105,7 +110,10 @@ public final class EntityIdKeyHelper {
   }
 
   public static NamespacedEntityId getTargetIdIdFromKey(MDSKey.Splitter keySplitter, String type) {
-    if (type.equals(TYPE_MAP.get(ProgramId.class))) {
+    if (type.equals(TYPE_MAP.get(NamespaceId.class))) {
+      String namespaceId = keySplitter.getString();
+      return new NamespaceId(namespaceId);
+    } else if (type.equals(TYPE_MAP.get(ProgramId.class))) {
       String namespaceId = keySplitter.getString();
       String appId = keySplitter.getString();
       String programType = keySplitter.getString();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
@@ -36,6 +36,7 @@ import co.cask.cdap.data2.metadata.indexer.SchemaIndexer;
 import co.cask.cdap.data2.metadata.indexer.ValueOnlyIndexer;
 import co.cask.cdap.data2.metadata.system.AbstractSystemMetadataWriter;
 import co.cask.cdap.proto.codec.NamespacedEntityIdCodec;
+import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -43,7 +44,6 @@ import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.metadata.MetadataScope;
-import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
@@ -537,12 +537,12 @@ public class MetadataDataset extends AbstractDataset {
 
   /**
    * Searches entities that match the specified search query in the specified namespace and {@link NamespaceId#SYSTEM}
-   * for the specified {@link MetadataSearchTargetType}.
+   * for the specified {@link EntityTypeSimpleName}.
    *
    * @param namespaceId the namespace to search in
    * @param searchQuery the search query, which could be of two forms: [key]:[value] or just [value] and can have '*'
    *                    at the end for a prefix search
-   * @param types the {@link MetadataSearchTargetType} to restrict the search to, if empty all types are searched
+   * @param types the {@link EntityTypeSimpleName} to restrict the search to, if empty all types are searched
    * @param sortInfo the {@link SortInfo} to sort the results by
    * @param offset index to start with in the search results. To return results from the beginning, pass {@code 0}.
    *               Only applies when #sortInfo is not {@link SortInfo#DEFAULT}
@@ -560,7 +560,7 @@ public class MetadataDataset extends AbstractDataset {
    *         {@link NamespacedEntityId} with its associated metadata. It also optionally contains a list of cursors
    *         for subsequent queries to start with, if the specified #sortInfo is not {@link SortInfo#DEFAULT}.
    */
-  public SearchResults search(String namespaceId, String searchQuery, Set<MetadataSearchTargetType> types,
+  public SearchResults search(String namespaceId, String searchQuery, Set<EntityTypeSimpleName> types,
                               SortInfo sortInfo, int offset, int limit, int numCursors,
                               @Nullable String cursor, boolean showHidden) {
     if (SortInfo.DEFAULT.equals(sortInfo)) {
@@ -570,7 +570,7 @@ public class MetadataDataset extends AbstractDataset {
   }
 
   private SearchResults searchByDefaultIndex(String namespaceId, String searchQuery,
-                                             Set<MetadataSearchTargetType> types, boolean showHidden) {
+                                             Set<EntityTypeSimpleName> types, boolean showHidden) {
     List<MetadataEntry> results = new ArrayList<>();
     for (String searchTerm : getSearchTerms(namespaceId, searchQuery)) {
       Scanner scanner;
@@ -599,7 +599,7 @@ public class MetadataDataset extends AbstractDataset {
     return new SearchResults(results, Collections.<String>emptyList());
   }
 
-  private SearchResults searchByCustomIndex(String namespaceId, Set<MetadataSearchTargetType> types,
+  private SearchResults searchByCustomIndex(String namespaceId, Set<EntityTypeSimpleName> types,
                                             SortInfo sortInfo, int offset, int limit, int numCursors,
                                             @Nullable String cursor, boolean showHidden) {
     List<MetadataEntry> results = new ArrayList<>();
@@ -652,7 +652,7 @@ public class MetadataDataset extends AbstractDataset {
   // there may not be a MetadataEntry in the row or it may for a different targetType (entityFilter),
   // so return an Optional
   private Optional<MetadataEntry> parseRow(Row rowToProcess, String indexColumn,
-                                           Set<MetadataSearchTargetType> entityFilter, boolean showHidden) {
+                                           Set<EntityTypeSimpleName> entityFilter, boolean showHidden) {
     String rowValue = rowToProcess.getString(indexColumn);
     if (rowValue == null) {
       return Optional.absent();
@@ -662,8 +662,8 @@ public class MetadataDataset extends AbstractDataset {
     String targetType = MdsKey.getTargetType(rowKey);
 
     // Filter on target type if not set to include all types
-    boolean includeAllTypes = entityFilter.isEmpty() || entityFilter.contains(MetadataSearchTargetType.ALL);
-    if (!includeAllTypes && !entityFilter.contains(MetadataSearchTargetType.valueOfSerializedForm(targetType))) {
+    boolean includeAllTypes = entityFilter.isEmpty() || entityFilter.contains(EntityTypeSimpleName.ALL);
+    if (!includeAllTypes && !entityFilter.contains(EntityTypeSimpleName.valueOfSerializedForm(targetType))) {
       return Optional.absent();
     }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/DefaultMetadataStore.java
@@ -33,6 +33,7 @@ import co.cask.cdap.data2.metadata.dataset.SearchResults;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.data2.transaction.Transactions;
 import co.cask.cdap.proto.audit.AuditType;
+import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
@@ -40,7 +41,6 @@ import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResponse;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
-import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -373,7 +373,7 @@ public class DefaultMetadataStore implements MetadataStore {
 
   @Override
   public MetadataSearchResponse search(String namespaceId, String searchQuery,
-                                       Set<MetadataSearchTargetType> types,
+                                       Set<EntityTypeSimpleName> types,
                                        SortInfo sortInfo, int offset, int limit,
                                        int numCursors, String cursor, boolean showHidden) throws BadRequestException {
     Set<MetadataScope> searchScopes = EnumSet.allOf(MetadataScope.class);
@@ -395,7 +395,7 @@ public class DefaultMetadataStore implements MetadataStore {
   }
 
   private MetadataSearchResponse search(Set<MetadataScope> scopes, String namespaceId,
-                                        String searchQuery, Set<MetadataSearchTargetType> types,
+                                        String searchQuery, Set<EntityTypeSimpleName> types,
                                         SortInfo sortInfo, int offset, int limit,
                                         int numCursors, String cursor, boolean showHidden) throws BadRequestException {
     List<MetadataEntry> results = new ArrayList<>();
@@ -450,7 +450,7 @@ public class DefaultMetadataStore implements MetadataStore {
   }
 
   private SearchResults getSearchResults(final MetadataScope scope, final String namespaceId,
-                                         final String searchQuery, final Set<MetadataSearchTargetType> types,
+                                         final String searchQuery, final Set<EntityTypeSimpleName> types,
                                          final SortInfo sortInfo, final int offset,
                                          final int limit, final int numCursors,
                                          final String cursor, final boolean showHidden) throws BadRequestException {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
@@ -19,11 +19,11 @@ package co.cask.cdap.data2.metadata.store;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
+import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResponse;
-import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 
 import java.util.Map;
 import java.util.Set;
@@ -165,7 +165,7 @@ public interface MetadataStore {
    *
    * @param namespaceId the namespace to search in
    * @param searchQuery the search query, which could be of two forms: [key]:[value] or just [value]
-   * @param types the {@link MetadataSearchTargetType} to restrict the search to, if empty all types are searched
+   * @param types the {@link EntityTypeSimpleName} to restrict the search to, if empty all types are searched
    * @param sortInfo represents sorting information. Use {@link SortInfo#DEFAULT} to return search results without
    *                 sorting (which implies that the sort order is by relevance to the search query)
    * @param offset the index to start with in the search results. To return results from the beginning, pass {@code 0}
@@ -180,7 +180,7 @@ public interface MetadataStore {
    * @return the {@link MetadataSearchResponse} containing search results for the specified search query and filters
    */
   MetadataSearchResponse search(String namespaceId, String searchQuery,
-                                Set<MetadataSearchTargetType> types,
+                                Set<EntityTypeSimpleName> types,
                                 SortInfo sortInfo, int offset, int limit,
                                 int numCursors, String cursor, boolean showHidden) throws BadRequestException;
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
@@ -16,12 +16,12 @@
 package co.cask.cdap.data2.metadata.store;
 
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
+import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResponse;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
-import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.Collections;
@@ -117,7 +117,7 @@ public class NoOpMetadataStore implements MetadataStore {
 
   @Override
   public MetadataSearchResponse search(String namespaceId, String searchQuery,
-                                       Set<MetadataSearchTargetType> types,
+                                       Set<EntityTypeSimpleName> types,
                                        SortInfo sort, int offset, int limit, int numCursors, String cursor,
                                        boolean showHidden) {
     return new MetadataSearchResponse(sort.toString(), offset, limit, numCursors, 0,

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
@@ -25,6 +25,7 @@ import co.cask.cdap.data2.metadata.indexer.Indexer;
 import co.cask.cdap.data2.metadata.indexer.InvertedValueIndexer;
 import co.cask.cdap.data2.metadata.system.AbstractSystemMetadataWriter;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.DatasetId;
@@ -34,7 +35,6 @@ import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.id.StreamViewId;
 import co.cask.cdap.proto.metadata.MetadataScope;
-import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -364,46 +364,46 @@ public class MetadataDatasetTest {
       @Override
       public void apply() throws Exception {
         List<MetadataEntry> results =
-          searchByDefaultIndex("ns1", "tags:*", ImmutableSet.of(MetadataSearchTargetType.ALL));
+          searchByDefaultIndex("ns1", "tags:*", ImmutableSet.of(EntityTypeSimpleName.ALL));
         // results for dataset1 - ns1:tags:tag12, ns1:tags:tag2, ns1:tags:tag3, ns1:tags:tag33, ns1:tags:tag12-tag33
         Assert.assertEquals(11, results.size());
 
         // Try to search for tag1*
-        results = searchByDefaultIndex("ns1", "tags:tag1*", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "tags:tag1*", ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertEquals(4, results.size());
 
         // Try to search for tag1 with spaces in search query and mixed case of tags keyword
-        results = searchByDefaultIndex("ns1", "  tAGS  :  tag1  ", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "  tAGS  :  tag1  ", ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertEquals(2, results.size());
 
         // Try to search for tag4
-        results = searchByDefaultIndex("ns1", "tags:tag4", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "tags:tag4", ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertEquals(1, results.size());
 
         // Try to search for tag33
-        results = searchByDefaultIndex("ns1", "tags:tag33", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "tags:tag33", ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertEquals(1, results.size());
 
         // Try to search for a tag which has - in it
-        results = searchByDefaultIndex("ns1", "tag12-tag33", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "tag12-tag33", ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertEquals(1, results.size());
 
         // Try to search for tag33 with spaces in query
-        results = searchByDefaultIndex("ns1", "  tag33  ", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "  tag33  ", ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertEquals(1, results.size());
 
         // Try to search for tag3
-        results = searchByDefaultIndex("ns1", "tags:tag3*", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "tags:tag3*", ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertEquals(3, results.size());
 
         // try search in another namespace
-        results = searchByDefaultIndex("ns2", "tags:tag1", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns2", "tags:tag1", ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertEquals(1, results.size());
 
-        results = searchByDefaultIndex("ns2", "tag3", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns2", "tag3", ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertEquals(1, results.size());
 
-        results = searchByDefaultIndex("ns2", "tag*", ImmutableSet.of(MetadataSearchTargetType.APP));
+        results = searchByDefaultIndex("ns2", "tag*", ImmutableSet.of(EntityTypeSimpleName.APP));
         // 9 due to matches of type ns2:tag1, ns2:tags:tag1, and splitting of tag3_more
         Assert.assertEquals(9, results.size());
 
@@ -424,7 +424,7 @@ public class MetadataDatasetTest {
       @Override
       public void apply() throws Exception {
         List<MetadataEntry> results =
-          searchByDefaultIndex("ns1", "tags:tag3*", ImmutableSet.of(MetadataSearchTargetType.ALL));
+          searchByDefaultIndex("ns1", "tags:tag3*", ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertEquals(0, results.size());
         Assert.assertEquals(0, dataset.getTags(app1).size());
         Assert.assertEquals(0, dataset.getTags(flow1).size());
@@ -455,31 +455,31 @@ public class MetadataDatasetTest {
       @Override
       public void apply() throws Exception {
         List<MetadataEntry> results =
-          searchByDefaultIndex("ns1", "value1", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+          searchByDefaultIndex("ns1", "value1", ImmutableSet.of(EntityTypeSimpleName.PROGRAM));
         Assert.assertEquals(ImmutableList.of(entry), results);
 
         // Search for it based on a word in value with spaces in search query
-        results = searchByDefaultIndex("ns1", "  aV1   ", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+        results = searchByDefaultIndex("ns1", "  aV1   ", ImmutableSet.of(EntityTypeSimpleName.PROGRAM));
         Assert.assertEquals(ImmutableList.of(multiWordEntry), results);
 
         // Search for it based split patterns to make sure nothing is matched
-        results = searchByDefaultIndex("ns1", "-", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "-", ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertTrue(results.isEmpty());
-        results = searchByDefaultIndex("ns1", ",", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", ",", ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertTrue(results.isEmpty());
-        results = searchByDefaultIndex("ns1", "_", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "_", ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertTrue(results.isEmpty());
-        results = searchByDefaultIndex("ns1", ", ,", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", ", ,", ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertTrue(results.isEmpty());
-        results = searchByDefaultIndex("ns1", ", - ,", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", ", - ,", ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertTrue(results.isEmpty());
 
         // Search for it based on a word in value
-        results = searchByDefaultIndex("ns1", "av5", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+        results = searchByDefaultIndex("ns1", "av5", ImmutableSet.of(EntityTypeSimpleName.PROGRAM));
         Assert.assertEquals(ImmutableList.of(multiWordEntry), results);
 
         // Case insensitive
-        results = searchByDefaultIndex("ns1", "ValUe1", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+        results = searchByDefaultIndex("ns1", "ValUe1", ImmutableSet.of(EntityTypeSimpleName.PROGRAM));
         Assert.assertEquals(ImmutableList.of(entry), results);
 
       }
@@ -495,7 +495,7 @@ public class MetadataDatasetTest {
       @Override
       public void apply() throws Exception {
         List<MetadataEntry> results =
-          searchByDefaultIndex("ns1", "value1", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+          searchByDefaultIndex("ns1", "value1", ImmutableSet.of(EntityTypeSimpleName.PROGRAM));
         Assert.assertEquals(2, results.size());
         for (MetadataEntry result : results) {
           Assert.assertEquals("value1", result.getValue());
@@ -514,13 +514,13 @@ public class MetadataDatasetTest {
       @Override
       public void apply() throws Exception {
         List<MetadataEntry> results =
-          searchByDefaultIndex("ns1", "value2*", ImmutableSet.of(MetadataSearchTargetType.ALL));
+          searchByDefaultIndex("ns1", "value2*", ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertEquals(2, results.size());
         for (MetadataEntry result : results) {
           Assert.assertTrue(result.getValue().startsWith("value2"));
         }
         // Search based on value prefix in the wrong namespace
-        results = searchByDefaultIndex("ns12", "value2*", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns12", "value2*", ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertTrue(results.isEmpty());
       }
     });
@@ -555,12 +555,12 @@ public class MetadataDatasetTest {
         // Search for it based on value
         List<MetadataEntry> results =
           searchByDefaultIndex("ns1", "key1" + MetadataDataset.KEYVALUE_SEPARATOR + "value1",
-                               ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+                               ImmutableSet.of(EntityTypeSimpleName.PROGRAM));
         Assert.assertEquals(ImmutableList.of(flowEntry1), results);
 
         // Search for it based on a word in value with spaces in search query
         results = searchByDefaultIndex("ns1", "  multiword" + MetadataDataset.KEYVALUE_SEPARATOR + "aV1   ",
-                                       ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+                                       ImmutableSet.of(EntityTypeSimpleName.PROGRAM));
 
         MetadataEntry flowMultiWordEntry = new MetadataEntry(flow1, multiWordKey, multiWordValue);
         Assert.assertEquals(ImmutableList.of(flowMultiWordEntry), results);
@@ -568,7 +568,7 @@ public class MetadataDatasetTest {
         // Search for it based on a word in value
         results =
           searchByDefaultIndex("ns1", multiWordKey + MetadataDataset.KEYVALUE_SEPARATOR + "aV5",
-                               ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+                               ImmutableSet.of(EntityTypeSimpleName.PROGRAM));
         Assert.assertEquals(ImmutableList.of(flowMultiWordEntry), results);
       }
     });
@@ -583,29 +583,29 @@ public class MetadataDatasetTest {
       public void apply() throws Exception {
         List<MetadataEntry> results =
           searchByDefaultIndex("ns1", multiWordKey + MetadataDataset.KEYVALUE_SEPARATOR + "aV5",
-                               ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+                               ImmutableSet.of(EntityTypeSimpleName.PROGRAM));
         // search results should be empty after removing this key as the indexes are deleted
         Assert.assertTrue(results.isEmpty());
 
         // Test wrong ns
         List<MetadataEntry> results2 =
           searchByDefaultIndex("ns12", "key1" + MetadataDataset.KEYVALUE_SEPARATOR + "value1",
-                               ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+                               ImmutableSet.of(EntityTypeSimpleName.PROGRAM));
         Assert.assertTrue(results2.isEmpty());
 
         // Test multi word query
-        results = searchByDefaultIndex("ns1", "  value1  av2 ", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "  value1  av2 ", ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertEquals(Sets.newHashSet(flowEntry1, streamEntry1), Sets.newHashSet(results));
 
-        results = searchByDefaultIndex("ns1", "  value1  sValue1 ", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "  value1  sValue1 ", ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertEquals(Sets.newHashSet(flowEntry1, streamEntry1, streamEntry2), Sets.newHashSet(results));
 
-        results = searchByDefaultIndex("ns1", "  valu*  sVal* ", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns1", "  valu*  sVal* ", ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertEquals(Sets.newHashSet(flowEntry1, flowEntry2, streamEntry1, streamEntry2),
                             Sets.newHashSet(results));
 
         // Using empty filter should also search for all target types
-        results = searchByDefaultIndex("ns1", "  valu*  sVal* ", ImmutableSet.<MetadataSearchTargetType>of());
+        results = searchByDefaultIndex("ns1", "  valu*  sVal* ", ImmutableSet.<EntityTypeSimpleName>of());
         Assert.assertEquals(Sets.newHashSet(flowEntry1, flowEntry2, streamEntry1, streamEntry2),
                             Sets.newHashSet(results));
       }
@@ -638,31 +638,31 @@ public class MetadataDatasetTest {
     txnl.execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {
-        List<MetadataEntry> results = searchByDefaultIndex("ns1", "aV5", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        List<MetadataEntry> results = searchByDefaultIndex("ns1", "aV5", ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertEquals(Sets.newHashSet(flowMultiWordEntry, systemArtifactEntry), Sets.newHashSet(results));
         // search only programs - should only return flow
         results = searchByDefaultIndex("ns1", multiWordKey + MetadataDataset.KEYVALUE_SEPARATOR + "aV5",
-                                       ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+                                       ImmutableSet.of(EntityTypeSimpleName.PROGRAM));
         Assert.assertEquals(ImmutableList.of(flowMultiWordEntry), results);
         // search only artifacts - should only return system artifact
         results = searchByDefaultIndex("ns1", multiWordKey + MetadataDataset.KEYVALUE_SEPARATOR + multiWordValue,
-                                       ImmutableSet.of(MetadataSearchTargetType.ARTIFACT));
+                                       ImmutableSet.of(EntityTypeSimpleName.ARTIFACT));
         // this query returns the system artifact 4 times, since the dataset returns a list with duplicates for scoring
         // purposes. Convert to a Set for comparison.
         Assert.assertEquals(Sets.newHashSet(systemArtifactEntry), Sets.newHashSet(results));
         // search all entities in namespace 'ns2' - should return the system artifact and the same artifact in ns2
         results = searchByDefaultIndex("ns2", multiWordKey + MetadataDataset.KEYVALUE_SEPARATOR + "aV4",
-                                       ImmutableSet.of(MetadataSearchTargetType.ALL));
+                                       ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertEquals(Sets.newHashSet(systemArtifactEntry, ns2ArtifactEntry), Sets.newHashSet(results));
         // search only programs in a namespace 'ns2'. Should return empty
-        results = searchByDefaultIndex("ns2", "aV*", ImmutableSet.of(MetadataSearchTargetType.PROGRAM));
+        results = searchByDefaultIndex("ns2", "aV*", ImmutableSet.of(EntityTypeSimpleName.PROGRAM));
         Assert.assertTrue(results.isEmpty());
         // search all entities in namespace 'ns3'. Should return only the system artifact
-        results = searchByDefaultIndex("ns3", "av*", ImmutableSet.of(MetadataSearchTargetType.ALL));
+        results = searchByDefaultIndex("ns3", "av*", ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertEquals(Sets.newHashSet(systemArtifactEntry), Sets.newHashSet(results));
         // search the system namespace for all entities. Should return only the system artifact
         results = searchByDefaultIndex(NamespaceId.SYSTEM.getEntityName(), "av*",
-                                       ImmutableSet.of(MetadataSearchTargetType.ALL));
+                                       ImmutableSet.of(EntityTypeSimpleName.ALL));
         Assert.assertEquals(Sets.newHashSet(systemArtifactEntry), Sets.newHashSet(results));
       }
     });
@@ -691,13 +691,13 @@ public class MetadataDatasetTest {
       public void apply() throws Exception {
         Assert.assertEquals(ImmutableList.of(new MetadataEntry(flow1, "key1", "value1")),
                             searchByDefaultIndex(flow1.getNamespace(), "value1",
-                                                 ImmutableSet.<MetadataSearchTargetType>of()));
+                                                 ImmutableSet.<EntityTypeSimpleName>of()));
         Assert.assertEquals(ImmutableList.of(new MetadataEntry(flow1, "key2", "value2")),
                             searchByDefaultIndex(flow1.getNamespace(), "value2",
-                                                 ImmutableSet.<MetadataSearchTargetType>of()));
+                                                 ImmutableSet.<EntityTypeSimpleName>of()));
         Assert.assertEquals(ImmutableList.of(new MetadataEntry(flow1, MetadataDataset.TAGS_KEY, "tag1,tag2")),
                             searchByDefaultIndex(flow1.getNamespace(), "tag2",
-                                                 ImmutableSet.<MetadataSearchTargetType>of()));
+                                                 ImmutableSet.<EntityTypeSimpleName>of()));
       }
     });
 
@@ -717,23 +717,23 @@ public class MetadataDatasetTest {
         // Searching for value1 should be empty
         Assert.assertEquals(ImmutableList.of(),
                             searchByDefaultIndex(flow1.getNamespace(), "value1",
-                                                 ImmutableSet.<MetadataSearchTargetType>of()));
+                                                 ImmutableSet.<EntityTypeSimpleName>of()));
         // Instead key1 has value value3 now
         Assert.assertEquals(ImmutableList.of(new MetadataEntry(flow1, "key1", "value3")),
                             searchByDefaultIndex(flow1.getNamespace(), "value3",
-                                                 ImmutableSet.<MetadataSearchTargetType>of()));
+                                                 ImmutableSet.<EntityTypeSimpleName>of()));
         // key2 was deleted
         Assert.assertEquals(ImmutableList.of(),
                             searchByDefaultIndex(flow1.getNamespace(), "value2",
-                                                 ImmutableSet.<MetadataSearchTargetType>of()));
+                                                 ImmutableSet.<EntityTypeSimpleName>of()));
         // tag2 was deleted
         Assert.assertEquals(
           ImmutableList.of(),
-          searchByDefaultIndex(flow1.getNamespace(), "tag2", ImmutableSet.<MetadataSearchTargetType>of()))
+          searchByDefaultIndex(flow1.getNamespace(), "tag2", ImmutableSet.<EntityTypeSimpleName>of()))
         ;
         Assert.assertEquals(
           ImmutableList.of(new MetadataEntry(flow1, MetadataDataset.TAGS_KEY, "tag1")),
-          searchByDefaultIndex(flow1.getNamespace(), "tag1", ImmutableSet.<MetadataSearchTargetType>of())
+          searchByDefaultIndex(flow1.getNamespace(), "tag1", ImmutableSet.<EntityTypeSimpleName>of())
         );
       }
     });
@@ -875,7 +875,7 @@ public class MetadataDatasetTest {
       }
     });
     final String namespaceId = flow1.getNamespace();
-    final Set<MetadataSearchTargetType> targetTypes = Collections.singleton(MetadataSearchTargetType.ALL);
+    final Set<EntityTypeSimpleName> targetTypes = Collections.singleton(EntityTypeSimpleName.ALL);
     txnl.execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {
@@ -954,7 +954,7 @@ public class MetadataDatasetTest {
       }
     });
     final String namespaceId = flow1.getNamespace();
-    final Set<MetadataSearchTargetType> targetTypes = Collections.singleton(MetadataSearchTargetType.ALL);
+    final Set<EntityTypeSimpleName> targetTypes = Collections.singleton(EntityTypeSimpleName.ALL);
     final MetadataEntry expectedFlowEntry = new MetadataEntry(flow1, "flowKey", "flowValue");
     final MetadataEntry expectedDatasetEntry = new MetadataEntry(dataset1, "datasetKey", "datasetValue");
     txnl.execute(new TransactionExecutor.Subroutine() {
@@ -1062,7 +1062,7 @@ public class MetadataDatasetTest {
       }
     });
     final String namespaceId = flow1.getNamespace();
-    final EnumSet<MetadataSearchTargetType> targets = EnumSet.allOf(MetadataSearchTargetType.class);
+    final EnumSet<EntityTypeSimpleName> targets = EnumSet.allOf(EntityTypeSimpleName.class);
     final MetadataEntry flowEntry = new MetadataEntry(flow1, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, flowName);
     final MetadataEntry dsEntry = new MetadataEntry(dataset1, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, dsName);
     final MetadataEntry appEntry = new MetadataEntry(app1, AbstractSystemMetadataWriter.ENTITY_NAME_KEY, appName);
@@ -1431,14 +1431,14 @@ public class MetadataDatasetTest {
   // should be called inside a transaction. This method does not start a transaction on its own, so that you can
   // have multiple invocations in the same transaction.
   private List<MetadataEntry> searchByDefaultIndex(String namespaceId, String searchQuery,
-                                                   Set<MetadataSearchTargetType> types) {
+                                                   Set<EntityTypeSimpleName> types) {
     return searchByDefaultIndex(dataset, namespaceId, searchQuery, types);
   }
 
   // should be called inside a transaction. This method does not start a transaction on its own, so that you can
   // have multiple invocations in the same transaction.
   private List<MetadataEntry> searchByDefaultIndex(MetadataDataset dataset, String namespaceId, String searchQuery,
-                                                   Set<MetadataSearchTargetType> types) {
+                                                   Set<EntityTypeSimpleName> types) {
     return dataset.search(namespaceId, searchQuery, types,
                           SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 1, null, false).getResults();
   }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/MetadataStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/MetadataStoreTest.java
@@ -31,6 +31,7 @@ import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.audit.AuditMessage;
 import co.cask.cdap.proto.audit.AuditType;
 import co.cask.cdap.proto.audit.payload.metadata.MetadataPayload;
+import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -41,7 +42,6 @@ import co.cask.cdap.proto.metadata.Metadata;
 import co.cask.cdap.proto.metadata.MetadataScope;
 import co.cask.cdap.proto.metadata.MetadataSearchResponse;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
-import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationTestModule;
@@ -428,7 +428,7 @@ public class MetadataStoreTest {
                                         int offset, int limit, int numCursors, boolean showHidden)
     throws BadRequestException {
     return store.search(
-      ns, searchQuery, EnumSet.allOf(MetadataSearchTargetType.class),
+      ns, searchQuery, EnumSet.allOf(EntityTypeSimpleName.class),
       SortInfo.DEFAULT, offset, limit, numCursors, null, showHidden);
   }
 

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemover.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemover.java
@@ -22,10 +22,10 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
 import co.cask.cdap.proto.NamespaceMeta;
+import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataSearchResultRecord;
-import co.cask.cdap.proto.metadata.MetadataSearchTargetType;
 import co.cask.cdap.store.NamespaceStore;
 import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
@@ -55,13 +55,13 @@ final class DeletedDatasetMetadataRemover {
     List<DatasetId> removedDatasets = new ArrayList<>();
     for (NamespaceMeta namespaceMeta : nsStore.list()) {
       Set<MetadataSearchResultRecord> searchResults =
-        metadataStore.search(namespaceMeta.getName(), "*", EnumSet.of(MetadataSearchTargetType.DATASET),
+        metadataStore.search(namespaceMeta.getName(), "*", EnumSet.of(EntityTypeSimpleName.DATASET),
                              SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 0, null, false).getResults();
       for (MetadataSearchResultRecord searchResult : searchResults) {
         NamespacedEntityId entityId = searchResult.getEntityId();
         Preconditions.checkState(entityId instanceof DatasetId,
                                  "Since search was filtered for %s, expected result to be a %s, but got a %s",
-                                 MetadataSearchTargetType.DATASET, DatasetId.class.getSimpleName(),
+                                 EntityTypeSimpleName.DATASET, DatasetId.class.getSimpleName(),
                                  entityId.getClass().getName());
         DatasetId datasetInstance = (DatasetId) entityId;
         if (!dsFramework.hasInstance(datasetInstance)) {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/element/EntityTypeSimpleName.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/element/EntityTypeSimpleName.java
@@ -13,18 +13,19 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package co.cask.cdap.proto.metadata;
+package co.cask.cdap.proto.element;
 
 import co.cask.cdap.api.annotation.Beta;
 
 /**
- * Supported types for metadata search.
+ * Simple names for various CDAP entities which can be used during entity serialization for persistence.
  */
 @Beta
-public enum MetadataSearchTargetType {
+public enum EntityTypeSimpleName {
   // the custom values are required because these value match the entity-type stored as
   // a part of MDS key.
   ALL("All"),
+  NAMESPACE("Namespace"),
   ARTIFACT("Artifact"),
   APP("Application"),
   PROGRAM("Program"),
@@ -34,17 +35,17 @@ public enum MetadataSearchTargetType {
 
   private final String serializedForm;
 
-  MetadataSearchTargetType(String serializedForm) {
+  EntityTypeSimpleName(String serializedForm) {
     this.serializedForm = serializedForm;
   }
 
   /**
-   * @return {@link MetadataSearchTargetType} of the given value.
+   * @return {@link EntityTypeSimpleName} of the given value.
    */
-  public static MetadataSearchTargetType valueOfSerializedForm(String value) {
-    for (MetadataSearchTargetType metadataSearchTargetType : values()) {
-      if (metadataSearchTargetType.serializedForm.equalsIgnoreCase(value)) {
-        return metadataSearchTargetType;
+  public static EntityTypeSimpleName valueOfSerializedForm(String value) {
+    for (EntityTypeSimpleName entityTypeSimpleName : values()) {
+      if (entityTypeSimpleName.serializedForm.equalsIgnoreCase(value)) {
+        return entityTypeSimpleName;
       }
     }
     throw new IllegalArgumentException(String.format("No enum constant for serialized form: %s", value));


### PR DESCRIPTION
- Moves the MetadataSearchTargetType class outside of metadata package to entity since its now used by OwnerStore too and will be used by other stores which store entityIds as key. 
- Rename for the same class
- Also added Namespace support in the above class since OwnerStore can store NamespaceIds too.

Build: http://builds.cask.co/browse/CDAP-DUT5382-1
ITM: http://builds.cask.co/browse/CDAP-ITM-97