### PR TITLE
CDAP-8261 using permissions in CDAP appender

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -682,6 +682,8 @@ public final class Constants {
 
     public static final String SERVICE_DESCRIPTION = "Service to collect and store logs.";
     public static final String MESSAGE_PROCESSOR_FACTORIES =  "log.saver.message.processor.factories";
+
+    public static final String PERMISSION = "log.saver.permission";
   }
 
   /**

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/framework/CDAPLogAppender.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/framework/CDAPLogAppender.java
@@ -21,6 +21,7 @@ import ch.qos.logback.core.AppenderBase;
 import ch.qos.logback.core.LogbackException;
 import ch.qos.logback.core.spi.FilterReply;
 import ch.qos.logback.core.status.WarnStatus;
+import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.logging.serialize.LogSchema;
 import co.cask.cdap.logging.write.FileMetaDataManager;
@@ -61,6 +62,9 @@ public class CDAPLogAppender extends AppenderBase<ILoggingEvent> implements Flus
   @Inject
   private LocationFactory locationFactory;
 
+  @Inject
+  private CConfiguration cConfiguration;
+
   private int syncIntervalBytes;
   private long maxFileLifetimeMs;
 
@@ -84,7 +88,7 @@ public class CDAPLogAppender extends AppenderBase<ILoggingEvent> implements Flus
   public void start() {
     super.start();
     this.logFileManager = new LogFileManager(maxFileLifetimeMs, syncIntervalBytes, LogSchema.LoggingEvent.SCHEMA,
-                                             fileMetaDataManager, locationFactory);
+                                             fileMetaDataManager, locationFactory, cConfiguration);
   }
 
   @Override
@@ -143,7 +147,7 @@ public class CDAPLogAppender extends AppenderBase<ILoggingEvent> implements Flus
 
     String namespaceId = propertyMap.get(TAG_NAMESPACE_ID);
 
-    if (namespaceId.equals(NamespaceId.SYSTEM)) {
+    if (namespaceId.equals(NamespaceId.SYSTEM.getNamespace())) {
       Preconditions.checkArgument(propertyMap.containsKey(TAG_SERVICE_ID),
                                   String.format("%s is expected but not found in the context %s",
                                                 TAG_SERVICE_ID, propertyMap));

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/framework/CDAPLogAppenderTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/framework/CDAPLogAppenderTest.java
@@ -81,7 +81,6 @@ public class CDAPLogAppenderTest {
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TMP_FOLDER.newFolder().getAbsolutePath());
     String logBaseDir = cConf.get(LoggingConfiguration.LOG_BASE_DIR) + "/" + CDAPLogAppender.class.getSimpleName();
     cConf.set(LoggingConfiguration.LOG_BASE_DIR, logBaseDir);
-
     injector = Guice.createInjector(
       new ConfigModule(cConf, hConf),
       new NonCustomLocationUnitTestModule().getModule(),
@@ -119,6 +118,8 @@ public class CDAPLogAppenderTest {
     FileMetaDataManager fileMetaDataManager = injector.getInstance(FileMetaDataManager.class);
     CDAPLogAppender cdapLogAppender = new CDAPLogAppender();
     injector.injectMembers(cdapLogAppender);
+    CConfiguration cConfiguration = injector.getInstance(CConfiguration.class);
+    cConfiguration.set(Constants.LogSaver.PERMISSION, "700");
     cdapLogAppender.setSyncIntervalBytes(syncInterval);
     cdapLogAppender.setMaxFileLifetimeMs(TimeUnit.DAYS.toMillis(1));
     cdapLogAppender.start();
@@ -154,6 +155,13 @@ public class CDAPLogAppenderTest {
       }
       logEventCloseableIterator.close();
       Assert.assertEquals(1, logCount);
+      // checking permission
+      String expectedPermissions = "rwx------";
+      for (LogLocation file : files) {
+        Location location = file.getLocation();
+        Assert.assertEquals(expectedPermissions, location.getPermissions());
+      }
+      cConfiguration.unset(Constants.LogSaver.PERMISSION);
     } catch (Exception e) {
       Assert.fail();
     } finally {
@@ -168,6 +176,8 @@ public class CDAPLogAppenderTest {
 
   @Test
   public void testCDAPLogAppenderRotation() throws Exception {
+    CConfiguration cConfiguration = injector.getInstance(CConfiguration.class);
+    cConfiguration.set(Constants.LogSaver.PERMISSION, "740");
     int syncInterval =
       injector.getInstance(CConfiguration.class).getInt(LoggingConfiguration.LOG_FILE_SYNC_INTERVAL_BYTES,
                                                         2 * 1024 * 1024);
@@ -213,6 +223,14 @@ public class CDAPLogAppenderTest {
       Assert.assertEquals(files.get(1).getEventTimeMs(), currentTimeMillisEvent1 + 1000);
       Assert.assertTrue(files.get(0).getFileCreationTimeMs() >= currentTimeMillisEvent1);
       Assert.assertTrue(files.get(1).getFileCreationTimeMs() >= currentTimeMillisEvent2);
+
+      // checking permission
+      String expectedPermissions = "rwxr-----";
+      for (LogLocation file : files) {
+        Location location = file.getLocation();
+        Assert.assertEquals(expectedPermissions, location.getPermissions());
+      }
+      cConfiguration.unset(Constants.LogSaver.PERMISSION);
     } catch (Exception e) {
       Assert.fail();
     } finally {


### PR DESCRIPTION
enable permission for cdap logging directory to be configurable and by default permission would be "rw" for cdap and no permission for group and other users. 
This default allows it to be read only by "cdap" user. ie only the log handler will be able to read these logs.
build : http://builds.cask.co/browse/CDAP-DUT5384-1