### PR TITLE
[CDAP-8257] Rename dataset permission properties and move them to FileSetProperties

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/DatasetProperties.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/DatasetProperties.java
@@ -27,21 +27,6 @@ import javax.annotation.Nullable;
 public final class DatasetProperties {
 
   /**
-   * The permissions for the dataset. The value for this property must be given either as a
-   * 9-character String such as "rwxr-x---" or as an octal-base number such as 750. Permissions
-   * will be applied by each dataset depending on the access control paradigm of the storage
-   * engine.
-   */
-  public static final String PROPERTY_PERMISSIONS = "dataset.permissions";
-
-  /**
-   * The group name that the permission are assigned to. For file-based datasets, this group
-   * name is used as the group for created files and directories; for table-based datasets,
-   * group privileges will be granted to this group.
-   */
-  public static final String PROPERTY_PERMISSIONS_GROUP = "dataset.permissions.group";
-
-  /**
    * Empty properties.
    */
   public static final DatasetProperties EMPTY = builder().build();

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/FileSetProperties.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/FileSetProperties.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.api.dataset.lib;
 
+import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.dataset.ExploreProperties;
 
 import java.util.Collections;
@@ -108,6 +109,23 @@ public class FileSetProperties {
    * Prefix used to store additional table properties for Hive.
    */
   public static final String PROPERTY_EXPLORE_TABLE_PROPERTY_PREFIX = "explore.table.property.";
+
+  /**
+   * The permissions for the dataset. The value for this property must be given either as a
+   * 9-character String such as "rwxr-x---" or as an octal-base number such as 750. Permissions
+   * will be applied by each dataset depending on the access control paradigm of the storage
+   * engine.
+   */
+  @Beta
+  public static final String PROPERTY_FILES_PERMISSIONS = "dataset.files.permissions";
+
+  /**
+   * The group name that the permission are assigned to. For file-based datasets, this group
+   * name is used as the group for created files and directories; for table-based datasets,
+   * group privileges will be granted to this group.
+   */
+  @Beta
+  public static final String PROPERTY_FILES_GROUP = "dataset.files.group";
 
   public static Builder builder() {
     return new Builder();
@@ -225,6 +243,22 @@ public class FileSetProperties {
    */
   public static String getExploreOutputFormat(Map<String, String> properties) {
     return properties.get(PROPERTY_EXPLORE_OUTPUT_FORMAT);
+  }
+
+  /**
+   * @return the default permissions for files and directories
+   */
+  @Beta
+  public static String getPermissions(Map<String, String> properties) {
+    return properties.get(PROPERTY_FILES_PERMISSIONS);
+  }
+
+  /**
+   * @return the name of the group for files and directories
+   */
+  @Beta
+  public static String getGroup(Map<String, String> properties) {
+    return properties.get(PROPERTY_FILES_GROUP);
   }
 
   /**
@@ -436,6 +470,24 @@ public class FileSetProperties {
      */
     public Builder setTableProperty(String name, String value) {
       add(PROPERTY_EXPLORE_TABLE_PROPERTY_PREFIX + name, value);
+      return this;
+    }
+
+    /**
+     * Set the default permissions for files and directories
+     */
+    @Beta
+    public Builder setPermissions(String permissions) {
+      add(PROPERTY_FILES_PERMISSIONS, permissions);
+      return this;
+    }
+
+    /**
+     * Set the name of the group for files and directories
+     */
+    @Beta
+    public Builder setGroup(String group) {
+      add(PROPERTY_FILES_GROUP, group);
       return this;
     }
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetAdmin.java
@@ -18,7 +18,6 @@ package co.cask.cdap.data2.dataset2.lib.file;
 
 import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetContext;
-import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.Updatable;
 import co.cask.cdap.api.dataset.lib.FileSetProperties;
@@ -92,8 +91,8 @@ public class FileSetAdmin implements DatasetAdmin, Updatable {
         throw new IOException(String.format(
           "Base location for file set '%s' at %s already exists", spec.getName(), baseLocation));
       }
-      String permissions = spec.getProperties().get(DatasetProperties.PROPERTY_PERMISSIONS);
-      String group = spec.getProperties().get(DatasetProperties.PROPERTY_PERMISSIONS_GROUP);
+      String permissions = FileSetProperties.getPermissions(spec.getProperties());
+      String group = FileSetProperties.getGroup(spec.getProperties());
       group = group != null ? group : UserGroupInformation.getCurrentUser().getPrimaryGroupName();
 
       // we can't simply mkdirs() the base location, because we need to set the group id on

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetDataset.java
@@ -21,7 +21,6 @@ import co.cask.cdap.api.annotation.WriteOnly;
 import co.cask.cdap.api.data.batch.DatasetOutputCommitter;
 import co.cask.cdap.api.dataset.DataSetException;
 import co.cask.cdap.api.dataset.DatasetContext;
-import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.DatasetSpecification;
 import co.cask.cdap.api.dataset.lib.FileSet;
 import co.cask.cdap.api.dataset.lib.FileSetArguments;
@@ -108,9 +107,9 @@ public final class FileSetDataset implements FileSet, DatasetOutputCommitter {
     this.outputFormatClassName = FileSetProperties.getOutputFormat(spec.getProperties());
 
     // runtime arguments can override permissions
-    this.permissions = runtimeArguments.containsKey(DatasetProperties.PROPERTY_PERMISSIONS)
-      ? runtimeArguments.get(DatasetProperties.PROPERTY_PERMISSIONS)
-      : spec.getProperty(DatasetProperties.PROPERTY_PERMISSIONS);
+    this.permissions = FileSetProperties.getPermissions(runtimeArguments) != null
+      ? FileSetProperties.getPermissions(runtimeArguments)
+      : FileSetProperties.getPermissions(spec.getProperties());
   }
 
   /**
@@ -263,7 +262,7 @@ public final class FileSetDataset implements FileSet, DatasetOutputCommitter {
     }
     // runtime arguments may override the permissions property
     Map<String, String> outputArguments = FileSetProperties.getOutputProperties(runtimeArguments);
-    String outputPermissions = outputArguments.get(DatasetProperties.PROPERTY_PERMISSIONS);
+    String outputPermissions = FileSetProperties.getPermissions(outputArguments);
     if (outputPermissions == null) {
       outputPermissions = this.permissions;
     }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/FileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/FileSetTest.java
@@ -138,8 +138,8 @@ public class FileSetTest {
     DatasetId datasetId = OTHER_NAMESPACE.dataset("testPermFS");
     dsFrameworkUtil.createInstance("fileSet", datasetId, FileSetProperties.builder()
       .setBasePath("perm/test/path")
-      .add(DatasetProperties.PROPERTY_PERMISSIONS, fsPermissions)
-      .add(DatasetProperties.PROPERTY_PERMISSIONS_GROUP, group)
+      .setPermissions(fsPermissions)
+      .setGroup(group)
       .build());
     FileSet fs = dsFrameworkUtil.getInstance(datasetId);
 
@@ -179,7 +179,7 @@ public class FileSetTest {
 
     // instantiate the dataset with custom permissions in the runtime arguments
     fs = dsFrameworkUtil.getInstance(datasetId, ImmutableMap.of(
-      DatasetProperties.PROPERTY_PERMISSIONS, customPermissions));
+      FileSetProperties.PROPERTY_FILES_PERMISSIONS, customPermissions));
 
     // create an empty file with custom permissions and validate them
     base = fs.getBaseLocation();


### PR DESCRIPTION
- also use helper methods instead of the actual property where possible.

This is because permissions for Tables are ACL-based and require different properties