### PR TITLE
TWILL-210 Copy the fix for TWILL-210 into the copy of ServiceMain in CDAP

### DIFF
--- a/cdap-app-fabric/src/main/java/org/apache/twill/internal/ServiceMain.java
+++ b/cdap-app-fabric/src/main/java/org/apache/twill/internal/ServiceMain.java
@@ -153,7 +153,14 @@ public abstract class ServiceMain {
         @Override
         public Location run() throws Exception {
           Configuration hConf = new Configuration(conf);
-          URI defaultURI = new URI(appDir.getScheme(), appDir.getAuthority(), null, null, null);
+          final URI defaultURI;
+          if (appDir.getAuthority() == null || appDir.getAuthority().isEmpty()) {
+            // some FileSystems do not have authority. E.g. maprfs or s3 (similar to file:///)
+            // need to handle URI differently for those
+            defaultURI = new URI(appDir.getScheme(), "", "/", null, null);
+          } else {
+            defaultURI = new URI(appDir.getScheme(), appDir.getAuthority(), null, null, null);
+          }
           hConf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, defaultURI.toString());
           return new FileContextLocationFactory(hConf).create(appDir);
         }


### PR DESCRIPTION
[TWILL-210](https://issues.apache.org/jira/browse/TWILL-210) Copy the fix for TWILL-210 into the copy of ServiceMain in CDAP. Effectively a cherry-pick of https://github.com/apache/twill/pull/28.

Otherwise, we see this error in AM of `master.services` on MapR clusters:
```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/data/hadoop/nm-local-dir/usercache/cdap/appcache/application_1485944893743_0001/container_1485944893743_0001_02_000001/application.jar/lib/ch.qos.logback.logback-classic-1.0.9.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/data/hadoop/nm-local-dir/usercache/cdap/appcache/application_1485944893743_0001/container_1485944893743_0001_02_000001/twill.jar/lib/ch.qos.logback.logback-classic-1.0.9.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/data/mapr/hadoop/hadoop-2.7.0/share/hadoop/common/lib/slf4j-log4j12-1.7.12.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/opt/mapr/lib/slf4j-log4j12-1.7.12.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [ch.qos.logback.classic.util.ContextSelectorStaticBinder]
Exception in thread "main" java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at org.apache.twill.launcher.TwillLauncher.main(TwillLauncher.java:74)
Caused by: java.lang.reflect.UndeclaredThrowableException
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1610)
        at org.apache.twill.internal.ServiceMain.createAppLocation(ServiceMain.java:152)
        at org.apache.twill.internal.appmaster.ApplicationMasterMain.main(ApplicationMasterMain.java:85)
        ... 5 more
Caused by: java.net.URISyntaxException: Expected scheme-specific part at index 7: maprfs:
        at java.net.URI$Parser.fail(URI.java:2829)
        at java.net.URI$Parser.failExpecting(URI.java:2835)
        at java.net.URI$Parser.parse(URI.java:3038)
        at java.net.URI.<init>(URI.java:753)
        at org.apache.twill.internal.ServiceMain$2.run(ServiceMain.java:156)
        at org.apache.twill.internal.ServiceMain$2.run(ServiceMain.java:152)
        at java.security.AccessController.doPrivileged(Native Method)
        at javax.security.auth.Subject.doAs(Subject.java:415)
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1595)
        ... 7 more
```

http://builds.cask.co/browse/CDAP-DUT5386-1