### PR TITLE
[CDAP-8257] Introduce permissions for Tables through dataset properties

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/FileSetProperties.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/FileSetProperties.java
@@ -249,7 +249,7 @@ public class FileSetProperties {
    * @return the default permissions for files and directories
    */
   @Beta
-  public static String getPermissions(Map<String, String> properties) {
+  public static String getFilePermissions(Map<String, String> properties) {
     return properties.get(PROPERTY_FILES_PERMISSIONS);
   }
 
@@ -257,7 +257,7 @@ public class FileSetProperties {
    * @return the name of the group for files and directories
    */
   @Beta
-  public static String getGroup(Map<String, String> properties) {
+  public static String getFileGroup(Map<String, String> properties) {
     return properties.get(PROPERTY_FILES_GROUP);
   }
 
@@ -477,7 +477,7 @@ public class FileSetProperties {
      * Set the default permissions for files and directories
      */
     @Beta
-    public Builder setPermissions(String permissions) {
+    public Builder setFilePermissions(String permissions) {
       add(PROPERTY_FILES_PERMISSIONS, permissions);
       return this;
     }
@@ -486,7 +486,7 @@ public class FileSetProperties {
      * Set the name of the group for files and directories
      */
     @Beta
-    public Builder setGroup(String group) {
+    public Builder setFileGroup(String group) {
       add(PROPERTY_FILES_GROUP, group);
       return this;
     }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetAdmin.java
@@ -91,8 +91,8 @@ public class FileSetAdmin implements DatasetAdmin, Updatable {
         throw new IOException(String.format(
           "Base location for file set '%s' at %s already exists", spec.getName(), baseLocation));
       }
-      String permissions = FileSetProperties.getPermissions(spec.getProperties());
-      String group = FileSetProperties.getGroup(spec.getProperties());
+      String permissions = FileSetProperties.getFilePermissions(spec.getProperties());
+      String group = FileSetProperties.getFileGroup(spec.getProperties());
       group = group != null ? group : UserGroupInformation.getCurrentUser().getPrimaryGroupName();
 
       // we can't simply mkdirs() the base location, because we need to set the group id on

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetDataset.java
@@ -107,9 +107,9 @@ public final class FileSetDataset implements FileSet, DatasetOutputCommitter {
     this.outputFormatClassName = FileSetProperties.getOutputFormat(spec.getProperties());
 
     // runtime arguments can override permissions
-    this.permissions = FileSetProperties.getPermissions(runtimeArguments) != null
-      ? FileSetProperties.getPermissions(runtimeArguments)
-      : FileSetProperties.getPermissions(spec.getProperties());
+    this.permissions = FileSetProperties.getFilePermissions(runtimeArguments) != null
+      ? FileSetProperties.getFilePermissions(runtimeArguments)
+      : FileSetProperties.getFilePermissions(spec.getProperties());
   }
 
   /**
@@ -262,7 +262,7 @@ public final class FileSetDataset implements FileSet, DatasetOutputCommitter {
     }
     // runtime arguments may override the permissions property
     Map<String, String> outputArguments = FileSetProperties.getOutputProperties(runtimeArguments);
-    String outputPermissions = FileSetProperties.getPermissions(outputArguments);
+    String outputPermissions = FileSetProperties.getFilePermissions(outputArguments);
     if (outputPermissions == null) {
       outputPermissions = this.permissions;
     }

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/FileSetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/dataset2/lib/FileSetTest.java
@@ -138,8 +138,8 @@ public class FileSetTest {
     DatasetId datasetId = OTHER_NAMESPACE.dataset("testPermFS");
     dsFrameworkUtil.createInstance("fileSet", datasetId, FileSetProperties.builder()
       .setBasePath("perm/test/path")
-      .setPermissions(fsPermissions)
-      .setGroup(group)
+      .setFilePermissions(fsPermissions)
+      .setFileGroup(group)
       .build());
     FileSet fs = dsFrameworkUtil.getInstance(datasetId);
 

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/AbstractHBaseTableUtilTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/AbstractHBaseTableUtilTest.java
@@ -102,6 +102,26 @@ public abstract class AbstractHBaseTableUtilTest {
   }
 
   @Test
+  public void testGrant() throws Exception {
+    String namespace = "perm";
+    TableId tableId = TableId.from("perm", "priv");
+
+    // create a namespace and table
+    if (namespacesSupported()) {
+      createNamespace(namespace);
+    }
+    create(tableId);
+    Assert.assertTrue(exists(tableId));
+
+    // assign some privileges to the table
+    getTableUtil().grantPrivileges(ddlExecutor, tableId, ImmutableMap.of("joe", "RWX", "@readers", "RX"));
+
+    // clean up
+    drop(tableId);
+    deleteNamespace(namespace);
+  }
+
+  @Test
   public void testTableSizeMetrics() throws Exception {
     HBaseTableUtil tableUtil = getTableUtil();
     // namespace should not exist

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase98DDLExecutor.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase98DDLExecutor.java
@@ -19,11 +19,20 @@ package co.cask.cdap.data2.util.hbase;
 import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import co.cask.cdap.spi.hbase.TableDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.security.access.Permission;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map;
 
 /**
  * Implementation of the {@link HBaseDDLExecutor} for HBase 0.98
  */
 public class DefaultHBase98DDLExecutor extends DefaultHBaseDDLExecutor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultHBase98DDLExecutor.class);
+
   @Override
   public HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
     return HBase98TableDescriptorUtil.getHTableDescriptor(descriptor);
@@ -32,5 +41,28 @@ public class DefaultHBase98DDLExecutor extends DefaultHBaseDDLExecutor {
   @Override
   public TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
     return HBase98TableDescriptorUtil.getTableDescriptor(descriptor);
+  }
+
+  @Override
+  protected void doGrantPermissions(String namespace, String name, Map<String, Permission.Action[]> permissions) {
+    // no-op, not called
+  }
+
+  @Override
+  public void grantPermissions(String namespace, String name, Map<String, String> permissions) throws IOException {
+    StringBuilder statements = new StringBuilder();
+    for (Map.Entry<String, String> entry : permissions.entrySet()) {
+      String user = entry.getKey();
+      String actions = entry.getValue();
+      try {
+        toActions(actions);
+      } catch (IllegalArgumentException e) {
+        throw new IOException(String.format("Invalid permissions '%s' for table %s:%s and user %s: %s",
+                                            actions, namespace, name, user, e.getMessage()));
+      }
+      statements.append(String.format("\ngrant '%s', '%s', '%s:%s'", user, actions.toUpperCase(), namespace, name));
+    }
+    LOG.warn("Granting permissions is not implemented for HBase 0.98. " +
+               "Please grant these permissions manually in the hbase shell: {}", statements);
   }
 }

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase10CDH550DDLExecutor.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase10CDH550DDLExecutor.java
@@ -18,14 +18,27 @@ package co.cask.cdap.data2.util.hbase;
 
 import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import co.cask.cdap.spi.hbase.TableDescriptor;
+import com.google.common.base.Throwables;
 import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.security.access.AccessControlClient;
+import org.apache.hadoop.hbase.security.access.Permission;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
 
 /**
  * Implementation of the {@link HBaseDDLExecutor} for HBase 1.0 CDH 5.5.0
  */
 public class DefaultHBase10CDH550DDLExecutor extends DefaultHBaseDDLExecutor {
 
-  @Override
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultHBase10CDH550DDLExecutor.class);
+
   public HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
     return HBase10CDH550TableDescriptorUtil.getHTableDescriptor(descriptor);
   }
@@ -33,5 +46,29 @@ public class DefaultHBase10CDH550DDLExecutor extends DefaultHBaseDDLExecutor {
   @Override
   public TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
     return HBase10CDH550TableDescriptorUtil.getTableDescriptor(descriptor);
+  }
+
+  @Override
+  protected void doGrantPermissions(String namespace, String name,
+                                    Map<String, Permission.Action[]> permissions) throws IOException {
+    TableName table = TableName.valueOf(namespace, name);
+    try (Connection connection = ConnectionFactory.createConnection(admin.getConfiguration())) {
+      if (!AccessControlClient.isAccessControllerRunning(connection)) {
+        LOG.debug("Access control is off. Not granting privileges. ");
+        return;
+      }
+      for (Map.Entry<String, Permission.Action[]> entry : permissions.entrySet()) {
+        String user = entry.getKey();
+        Permission.Action[] actions = entry.getValue();
+        LOG.info("Granting {} for table {}:{} and user {}", Arrays.toString(actions), namespace, name, user);
+        try {
+          AccessControlClient.grant(connection, table, user, null, null, actions);
+        } catch (Throwable t) {
+          Throwables.propagateIfInstanceOf(t, IOException.class);
+          throw new IOException(String.format("Error while granting %s for table %s:%s and user %s",
+                                              Arrays.toString(actions), namespace, name, user), t);
+        }
+      }
+    }
   }
 }

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase10DDLExecutor.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase10DDLExecutor.java
@@ -18,12 +18,26 @@ package co.cask.cdap.data2.util.hbase;
 
 import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import co.cask.cdap.spi.hbase.TableDescriptor;
+import com.google.common.base.Throwables;
 import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.security.access.AccessControlClient;
+import org.apache.hadoop.hbase.security.access.Permission;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
 
 /**
  * Implementation of the {@link HBaseDDLExecutor} for HBase version 1.0
  */
 public class DefaultHBase10DDLExecutor extends DefaultHBaseDDLExecutor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultHBase10DDLExecutor.class);
 
   @Override
   public HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
@@ -33,5 +47,29 @@ public class DefaultHBase10DDLExecutor extends DefaultHBaseDDLExecutor {
   @Override
   public TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
     return HBase10TableDescriptorUtil.getTableDescriptor(descriptor);
+  }
+
+  @Override
+  protected void doGrantPermissions(String namespace, String name,
+                                    Map<String, Permission.Action[]> permissions) throws IOException {
+    TableName table = TableName.valueOf(namespace, name);
+    try (Connection connection = ConnectionFactory.createConnection(admin.getConfiguration())) {
+      if (!AccessControlClient.isAccessControllerRunning(connection)) {
+        LOG.debug("Access control is off. Not granting privileges. ");
+        return;
+      }
+      for (Map.Entry<String, Permission.Action[]> entry : permissions.entrySet()) {
+        String user = entry.getKey();
+        Permission.Action[] actions = entry.getValue();
+        LOG.info("Granting {} for table {}:{} and user {}", Arrays.toString(actions), namespace, name, user);
+        try {
+          AccessControlClient.grant(connection, table, user, null, null, actions);
+        } catch (Throwable t) {
+          Throwables.propagateIfInstanceOf(t, IOException.class);
+          throw new IOException(String.format("Error while granting %s for table %s:%s and user %s",
+                                              Arrays.toString(actions), namespace, name, user), t);
+        }
+      }
+    }
   }
 }

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase11DDLExecutor.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase11DDLExecutor.java
@@ -18,12 +18,26 @@ package co.cask.cdap.data2.util.hbase;
 
 import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import co.cask.cdap.spi.hbase.TableDescriptor;
+import com.google.common.base.Throwables;
 import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.security.access.AccessControlClient;
+import org.apache.hadoop.hbase.security.access.Permission;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
 
 /**
  * Implementation of the {@link HBaseDDLExecutor} for HBase 1.1
  */
 public class DefaultHBase11DDLExecutor extends DefaultHBaseDDLExecutor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultHBase11DDLExecutor.class);
 
   @Override
   public HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
@@ -33,5 +47,29 @@ public class DefaultHBase11DDLExecutor extends DefaultHBaseDDLExecutor {
   @Override
   public TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
     return HBase11TableDescriptorUtil.getTableDescriptor(descriptor);
+  }
+
+  @Override
+  protected void doGrantPermissions(String namespace, String name,
+                                    Map<String, Permission.Action[]> permissions) throws IOException {
+    TableName table = TableName.valueOf(namespace, name);
+    try (Connection connection = ConnectionFactory.createConnection(admin.getConfiguration())) {
+      if (!AccessControlClient.isAccessControllerRunning(connection)) {
+        LOG.debug("Access control is off. Not granting privileges. ");
+        return;
+      }
+      for (Map.Entry<String, Permission.Action[]> entry : permissions.entrySet()) {
+        String user = entry.getKey();
+        Permission.Action[] actions = entry.getValue();
+        LOG.info("Granting {} for table {}:{} and user {}", Arrays.toString(actions), namespace, name, user);
+        try {
+          AccessControlClient.grant(connection, table, user, null, null, actions);
+        } catch (Throwable t) {
+          Throwables.propagateIfInstanceOf(t, IOException.class);
+          throw new IOException(String.format("Error while granting %s for table %s:%s and user %s",
+                                              Arrays.toString(actions), namespace, name, user), t);
+        }
+      }
+    }
   }
 }

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase12CDH570DDLExecutor.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase12CDH570DDLExecutor.java
@@ -18,12 +18,27 @@ package co.cask.cdap.data2.util.hbase;
 
 import co.cask.cdap.spi.hbase.HBaseDDLExecutor;
 import co.cask.cdap.spi.hbase.TableDescriptor;
+import com.google.common.base.Throwables;
 import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.security.access.AccessControlClient;
+import org.apache.hadoop.hbase.security.access.Permission;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
 
 /**
  * Implementation of the {@link HBaseDDLExecutor} for HBase 1.2 CDH 5.7.0
  */
 public class DefaultHBase12CDH570DDLExecutor extends DefaultHBaseDDLExecutor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultHBase12CDH570DDLExecutor.class);
+
   @Override
   public HTableDescriptor getHTableDescriptor(TableDescriptor descriptor) {
     return HBase12CDH570TableDescriptorUtil.getHTableDescriptor(descriptor);
@@ -32,5 +47,29 @@ public class DefaultHBase12CDH570DDLExecutor extends DefaultHBaseDDLExecutor {
   @Override
   public TableDescriptor getTableDescriptor(HTableDescriptor descriptor) {
     return HBase12CDH570TableDescriptorUtil.getTableDescriptor(descriptor);
+  }
+
+  @Override
+  protected void doGrantPermissions(String namespace, String name,
+                                    Map<String, Permission.Action[]> permissions) throws IOException {
+    TableName table = TableName.valueOf(namespace, name);
+    try (Connection connection = ConnectionFactory.createConnection(admin.getConfiguration())) {
+      if (!AccessControlClient.isAccessControllerRunning(connection)) {
+        LOG.debug("Access control is off. Not granting privileges. ");
+        return;
+      }
+      for (Map.Entry<String, Permission.Action[]> entry : permissions.entrySet()) {
+        String user = entry.getKey();
+        Permission.Action[] actions = entry.getValue();
+        LOG.info("Granting {} for table {}:{} and user {}", Arrays.toString(actions), namespace, name, user);
+        try {
+          AccessControlClient.grant(connection, table, user, null, null, actions);
+        } catch (Throwable t) {
+          Throwables.propagateIfInstanceOf(t, IOException.class);
+          throw new IOException(String.format("Error while granting %s for table %s:%s and user %s",
+                                              Arrays.toString(actions), namespace, name, user), t);
+        }
+      }
+    }
   }
 }

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
@@ -488,7 +488,7 @@ public abstract class HBaseTableUtil {
   }
 
   /**
-   * Truncates a table
+   * Truncates a table.
    * @param ddlExecutor the {@link HBaseDDLExecutor} to use to communicate with HBase
    * @param tableId  {@link TableId} for the specified table
    * @throws IOException
@@ -496,6 +496,21 @@ public abstract class HBaseTableUtil {
   public void truncateTable(HBaseDDLExecutor ddlExecutor, TableId tableId) throws IOException {
     TableName tableName = HTableNameConverter.toTableName(getTablePrefix(cConf), tableId);
     ddlExecutor.truncateTable(tableName.getNamespaceAsString(), tableName.getQualifierAsString());
+  }
+
+  /**
+   * Grants permissions on a table.
+   * @param ddlExecutor the {@link HBaseDDLExecutor} to use to communicate with HBase
+   * @param tableId  {@link TableId} for the specified table
+   * @param permissions A map from user or group name to the permissions for that user or group, given as a string
+   *                    containing only characters 'a'(Admin), 'c'(Create), 'r'(Read), 'w'(Write), and 'x'(Execute).
+   *                    Group names must be prefixed with the character '@'.
+   * @throws IOException
+   */
+  public void grantPrivileges(HBaseDDLExecutor ddlExecutor, TableId tableId,
+                              Map<String, String> permissions) throws IOException {
+    TableName tableName = HTableNameConverter.toTableName(getTablePrefix(cConf), tableId);
+    ddlExecutor.grantPermissions(tableName.getNamespaceAsString(), tableName.getQualifierAsString(), permissions);
   }
 
   /**

--- a/cdap-hbase-spi/src/main/java/co/cask/cdap/spi/hbase/HBaseDDLExecutor.java
+++ b/cdap-hbase-spi/src/main/java/co/cask/cdap/spi/hbase/HBaseDDLExecutor.java
@@ -21,6 +21,7 @@ import co.cask.cdap.api.annotation.Beta;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -109,4 +110,16 @@ public interface HBaseDDLExecutor extends Closeable {
    * @throws IllegalStateException if the specified table is not disabled
    */
   void deleteTableIfExists(String namespace, String name) throws IOException;
+
+  /**
+   * Grant permissions on a table to users or groups.
+   *
+   * @param namespace the namespace of the table
+   * @param name the name of the table
+   * @param permissions A map from user or group name to the permissions for that user or group, given as a string
+   *                    containing only characters 'a'(Admin), 'c'(Create), 'r'(Read), 'w'(Write), and 'x'(Execute).
+   *                    Group names must be prefixed with the character '@'.
+   * @throws IOException if anything goes wrong
+   */
+  void grantPermissions(String namespace, String name, Map<String, String> permissions) throws IOException;
 }


### PR DESCRIPTION
- implemented as a series of grants in HBase
- HBase 0.96 and 0.98 do not have support in their APIs for that. Therefore it is not implemented in these compat modules. Instead they will log a warning as follows
  ```
  2017-02-01 12:34:59,317 - WARN  [main:c.c.c.d.u.h.DefaultHBase98DDLExecutor@65] - Granting permissions is not implemented for HBase 0.98. Please grant these permissions manually in the hbase shell: 
  grant 'joe', 'RWX', 'perm:priv'
  grant '@readers', 'RX', 'perm:priv'
  ```
- If an invalid permission string is given, the error message is:
  ```
  java.io.IOException: Error granting permissions 'RWt' for table perm:priv to user joe: Unknown Action 't'
  ```