### PR TITLE
[CDAP-8308] Upon Namespace creation, assign C(reate) permissions for the group to the HBase namespace

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -160,6 +160,8 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
       validateCustomMapping(metadata);
     }
 
+    LOG.info("Creating namespace {} with {}.", metadata.getNamespaceId(), metadata.getConfig());
+
     // Namespace can be created. Check if the user is authorized now.
     Principal principal = authenticationContext.getPrincipal();
     privilegesManager.grant(namespace, principal, EnumSet.allOf(Action.class));
@@ -193,6 +195,7 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
       privilegesManager.revoke(namespace);
       throw new NamespaceCannotBeCreatedException(namespace, t);
     }
+    LOG.info("Namespace {} created.", metadata.getNamespaceId());
   }
 
   private void validateCustomMapping(NamespaceMeta metadata) throws Exception {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/table/hbase/HBaseTableAdmin.java
@@ -130,7 +130,7 @@ public class HBaseTableAdmin extends AbstractHBaseDataSetAdmin implements Updata
       try {
         Map<String, String> permissions = TableProperties.getTablePermissions(spec.getProperties());
         if (permissions != null && !permissions.isEmpty()) {
-          tableUtil.grantPrivileges(ddlExecutor, tableId, permissions);
+          tableUtil.grantPermissions(ddlExecutor, tableId, permissions);
         }
       } catch (IOException | RuntimeException e) {
         try {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/AbstractHBaseTableUtilTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/util/hbase/AbstractHBaseTableUtilTest.java
@@ -113,8 +113,24 @@ public abstract class AbstractHBaseTableUtilTest {
     create(tableId);
     Assert.assertTrue(exists(tableId));
 
+    // attempt to assign invalid permissions to the namespace or the table
+    try {
+      ddlExecutor.grantPermissions(tableId.getNamespace(), null, ImmutableMap.of("joe", "iii"));
+      Assert.fail("Grant should have failed with invalid permissions");
+    } catch (IOException e) {
+      Assert.assertTrue(e.getMessage().contains("Unknown Action"));
+    }
+    try {
+      getTableUtil().grantPermissions(ddlExecutor, tableId, ImmutableMap.of("@readers", "RXT"));
+      Assert.fail("Grant should have failed with invalid permissions");
+    } catch (IOException e) {
+      Assert.assertTrue(e.getMessage().contains("Unknown Action"));
+    }
+
+    // assign some privileges to the namespace
+    ddlExecutor.grantPermissions(tableId.getNamespace(), null, ImmutableMap.of("joe", "RX", "@readers", "CA"));
     // assign some privileges to the table
-    getTableUtil().grantPrivileges(ddlExecutor, tableId, ImmutableMap.of("joe", "RWX", "@readers", "RX"));
+    getTableUtil().grantPermissions(ddlExecutor, tableId, ImmutableMap.of("joe", "RWX", "@readers", "RX"));
 
     // clean up
     drop(tableId);

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase96DDLExecutor.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase96DDLExecutor.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Implementation of the {@link HBaseDDLExecutor} for HBase 0.96
@@ -44,12 +45,14 @@ public class DefaultHBase96DDLExecutor extends DefaultHBaseDDLExecutor {
   }
 
   @Override
-  protected void doGrantPermissions(String namespace, String name, Map<String, Permission.Action[]> permissions) {
+  protected void doGrantPermissions(String namespace, @Nullable String table,
+                                    Map<String, Permission.Action[]> permissions) {
     // no-op, not called
   }
 
   @Override
-  public void grantPermissions(String namespace, String name, Map<String, String> permissions) throws IOException {
+  public void grantPermissions(String namespace, @Nullable String table, Map<String, String> permissions)
+    throws IOException {
     StringBuilder statements = new StringBuilder();
     for (Map.Entry<String, String> entry : permissions.entrySet()) {
       String user = entry.getKey();
@@ -57,10 +60,12 @@ public class DefaultHBase96DDLExecutor extends DefaultHBaseDDLExecutor {
       try {
         toActions(actions);
       } catch (IllegalArgumentException e) {
-        throw new IOException(String.format("Invalid permissions '%s' for table %s:%s and user %s: %s",
-                                            actions, namespace, name, user, e.getMessage()));
+        String entity = table == null ? "namespace " + namespace : "table " + namespace + ":" + table;
+        String userOrGroup = user.startsWith("@") ? "group " + user.substring(1) : "user " + user;
+        throw new IOException(String.format("Invalid permissions '%s' for %s and %s: %s",
+                                            actions, entity, userOrGroup, e.getMessage()));
       }
-      statements.append(String.format("\ngrant '%s', '%s', '%s:%s'", user, actions.toUpperCase(), namespace, name));
+      statements.append(String.format("\ngrant '%s', '%s', '%s:%s'", user, actions.toUpperCase(), namespace, table));
     }
     LOG.warn("Granting permissions is not implemented for HBase 0.96. " +
                "Please grant these permissions manually in the hbase shell: {}", statements);

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase10CDHDDLExecutor.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase10CDHDDLExecutor.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Implementation of {@link HBaseDDLExecutor} for HBase version 1.0 CDH
@@ -50,24 +51,29 @@ public class DefaultHBase10CDHDDLExecutor extends DefaultHBaseDDLExecutor {
   }
 
   @Override
-  protected void doGrantPermissions(String namespace, String name,
+  protected void doGrantPermissions(String namespace, @Nullable String table,
                                     Map<String, Permission.Action[]> permissions) throws IOException {
-    TableName table = TableName.valueOf(namespace, name);
+    String entity = table == null ? "namespace " + namespace : "table " + namespace + ":" + table;
     try (Connection connection = ConnectionFactory.createConnection(admin.getConfiguration())) {
       if (!AccessControlClient.isAccessControllerRunning(connection)) {
-        LOG.debug("Access control is off. Not granting privileges. ");
+        LOG.debug("Access control is off. Not granting privileges for {}. ", entity);
         return;
       }
       for (Map.Entry<String, Permission.Action[]> entry : permissions.entrySet()) {
         String user = entry.getKey();
+        String userOrGroup = user.startsWith("@") ? "group " + user.substring(1) : "user " + user;
         Permission.Action[] actions = entry.getValue();
-        LOG.info("Granting {} for table {}:{} and user {}", Arrays.toString(actions), namespace, name, user);
         try {
-          AccessControlClient.grant(connection, table, user, null, null, actions);
+          LOG.info("Granting {} for {} to {}", Arrays.toString(actions), entity, userOrGroup);
+          if (table != null) {
+            AccessControlClient.grant(connection, TableName.valueOf(namespace, table), user, null, null, actions);
+          } else {
+            AccessControlClient.grant(connection, namespace, user, actions);
+          }
         } catch (Throwable t) {
           Throwables.propagateIfInstanceOf(t, IOException.class);
-          throw new IOException(String.format("Error while granting %s for table %s:%s and user %s",
-                                              Arrays.toString(actions), namespace, name, user), t);
+          throw new IOException(String.format("Error while granting %s for %s to %s",
+                                              Arrays.toString(actions), entity, userOrGroup), t);
         }
       }
     }

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase10CDH550DDLExecutor.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase10CDH550DDLExecutor.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Implementation of the {@link HBaseDDLExecutor} for HBase 1.0 CDH 5.5.0
@@ -49,24 +50,29 @@ public class DefaultHBase10CDH550DDLExecutor extends DefaultHBaseDDLExecutor {
   }
 
   @Override
-  protected void doGrantPermissions(String namespace, String name,
+  protected void doGrantPermissions(String namespace, @Nullable String table,
                                     Map<String, Permission.Action[]> permissions) throws IOException {
-    TableName table = TableName.valueOf(namespace, name);
+    String entity = table == null ? "namespace " + namespace : "table " + namespace + ":" + table;
     try (Connection connection = ConnectionFactory.createConnection(admin.getConfiguration())) {
       if (!AccessControlClient.isAccessControllerRunning(connection)) {
-        LOG.debug("Access control is off. Not granting privileges. ");
+        LOG.debug("Access control is off. Not granting privileges for {}. ", entity);
         return;
       }
       for (Map.Entry<String, Permission.Action[]> entry : permissions.entrySet()) {
         String user = entry.getKey();
+        String userOrGroup = user.startsWith("@") ? "group " + user.substring(1) : "user " + user;
         Permission.Action[] actions = entry.getValue();
-        LOG.info("Granting {} for table {}:{} and user {}", Arrays.toString(actions), namespace, name, user);
         try {
-          AccessControlClient.grant(connection, table, user, null, null, actions);
+          LOG.info("Granting {} for {} to {}", Arrays.toString(actions), entity, userOrGroup);
+          if (table != null) {
+            AccessControlClient.grant(connection, TableName.valueOf(namespace, table), user, null, null, actions);
+          } else {
+            AccessControlClient.grant(connection, namespace, user, actions);
+          }
         } catch (Throwable t) {
           Throwables.propagateIfInstanceOf(t, IOException.class);
-          throw new IOException(String.format("Error while granting %s for table %s:%s and user %s",
-                                              Arrays.toString(actions), namespace, name, user), t);
+          throw new IOException(String.format("Error while granting %s for %s to %s",
+                                              Arrays.toString(actions), entity, userOrGroup), t);
         }
       }
     }

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase11DDLExecutor.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase11DDLExecutor.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Implementation of the {@link HBaseDDLExecutor} for HBase 1.1
@@ -50,24 +51,29 @@ public class DefaultHBase11DDLExecutor extends DefaultHBaseDDLExecutor {
   }
 
   @Override
-  protected void doGrantPermissions(String namespace, String name,
+  protected void doGrantPermissions(String namespace, @Nullable String table,
                                     Map<String, Permission.Action[]> permissions) throws IOException {
-    TableName table = TableName.valueOf(namespace, name);
+    String entity = table == null ? "namespace " + namespace : "table " + namespace + ":" + table;
     try (Connection connection = ConnectionFactory.createConnection(admin.getConfiguration())) {
       if (!AccessControlClient.isAccessControllerRunning(connection)) {
-        LOG.debug("Access control is off. Not granting privileges. ");
+        LOG.debug("Access control is off. Not granting privileges for {}. ", entity);
         return;
       }
       for (Map.Entry<String, Permission.Action[]> entry : permissions.entrySet()) {
         String user = entry.getKey();
+        String userOrGroup = user.startsWith("@") ? "group " + user.substring(1) : "user " + user;
         Permission.Action[] actions = entry.getValue();
-        LOG.info("Granting {} for table {}:{} and user {}", Arrays.toString(actions), namespace, name, user);
         try {
-          AccessControlClient.grant(connection, table, user, null, null, actions);
+          LOG.info("Granting {} for {} to {}", Arrays.toString(actions), entity, userOrGroup);
+          if (table != null) {
+            AccessControlClient.grant(connection, TableName.valueOf(namespace, table), user, null, null, actions);
+          } else {
+            AccessControlClient.grant(connection, namespace, user, actions);
+          }
         } catch (Throwable t) {
           Throwables.propagateIfInstanceOf(t, IOException.class);
-          throw new IOException(String.format("Error while granting %s for table %s:%s and user %s",
-                                              Arrays.toString(actions), namespace, name, user), t);
+          throw new IOException(String.format("Error while granting %s for %s to %s",
+                                              Arrays.toString(actions), entity, userOrGroup), t);
         }
       }
     }

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase12CDH570DDLExecutor.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/DefaultHBase12CDH570DDLExecutor.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Implementation of the {@link HBaseDDLExecutor} for HBase 1.2 CDH 5.7.0
@@ -50,24 +51,29 @@ public class DefaultHBase12CDH570DDLExecutor extends DefaultHBaseDDLExecutor {
   }
 
   @Override
-  protected void doGrantPermissions(String namespace, String name,
+  protected void doGrantPermissions(String namespace, @Nullable String table,
                                     Map<String, Permission.Action[]> permissions) throws IOException {
-    TableName table = TableName.valueOf(namespace, name);
+    String entity = table == null ? "namespace " + namespace : "table " + namespace + ":" + table;
     try (Connection connection = ConnectionFactory.createConnection(admin.getConfiguration())) {
       if (!AccessControlClient.isAccessControllerRunning(connection)) {
-        LOG.debug("Access control is off. Not granting privileges. ");
+        LOG.debug("Access control is off. Not granting privileges for {}. ", entity);
         return;
       }
       for (Map.Entry<String, Permission.Action[]> entry : permissions.entrySet()) {
         String user = entry.getKey();
+        String userOrGroup = user.startsWith("@") ? "group " + user.substring(1) : "user " + user;
         Permission.Action[] actions = entry.getValue();
-        LOG.info("Granting {} for table {}:{} and user {}", Arrays.toString(actions), namespace, name, user);
         try {
-          AccessControlClient.grant(connection, table, user, null, null, actions);
+          LOG.info("Granting {} for {} to {}", Arrays.toString(actions), entity, userOrGroup);
+          if (table != null) {
+            AccessControlClient.grant(connection, TableName.valueOf(namespace, table), user, null, null, actions);
+          } else {
+            AccessControlClient.grant(connection, namespace, user, actions);
+          }
         } catch (Throwable t) {
           Throwables.propagateIfInstanceOf(t, IOException.class);
-          throw new IOException(String.format("Error while granting %s for table %s:%s and user %s",
-                                              Arrays.toString(actions), namespace, name, user), t);
+          throw new IOException(String.format("Error while granting %s for %s to %s",
+                                              Arrays.toString(actions), entity, userOrGroup), t);
         }
       }
     }

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/HBaseTableUtil.java
@@ -507,8 +507,8 @@ public abstract class HBaseTableUtil {
    *                    Group names must be prefixed with the character '@'.
    * @throws IOException
    */
-  public void grantPrivileges(HBaseDDLExecutor ddlExecutor, TableId tableId,
-                              Map<String, String> permissions) throws IOException {
+  public void grantPermissions(HBaseDDLExecutor ddlExecutor, TableId tableId,
+                               Map<String, String> permissions) throws IOException {
     TableName tableName = HTableNameConverter.toTableName(getTablePrefix(cConf), tableId);
     ddlExecutor.grantPermissions(tableName.getNamespaceAsString(), tableName.getQualifierAsString(), permissions);
   }

--- a/cdap-hbase-spi/src/main/java/co/cask/cdap/spi/hbase/HBaseDDLExecutor.java
+++ b/cdap-hbase-spi/src/main/java/co/cask/cdap/spi/hbase/HBaseDDLExecutor.java
@@ -39,9 +39,10 @@ public interface HBaseDDLExecutor extends Closeable {
    * Create the specified namespace if it does not exist.
    *
    * @param name the namespace to create
+   * @return whether the namespace was created
    * @throws IOException if a remote or network exception occurs
    */
-  void createNamespaceIfNotExists(String name) throws IOException;
+  boolean createNamespaceIfNotExists(String name) throws IOException;
 
   /**
    * Delete the specified namespace if it exists.
@@ -112,14 +113,14 @@ public interface HBaseDDLExecutor extends Closeable {
   void deleteTableIfExists(String namespace, String name) throws IOException;
 
   /**
-   * Grant permissions on a table to users or groups.
+   * Grant permissions on a table or namespace to users or groups.
    *
    * @param namespace the namespace of the table
-   * @param name the name of the table
+   * @param table the name of the. If null, then the permissions are applied to the namespace
    * @param permissions A map from user or group name to the permissions for that user or group, given as a string
    *                    containing only characters 'a'(Admin), 'c'(Create), 'r'(Read), 'w'(Write), and 'x'(Execute).
    *                    Group names must be prefixed with the character '@'.
    * @throws IOException if anything goes wrong
    */
-  void grantPermissions(String namespace, String name, Map<String, String> permissions) throws IOException;
+  void grantPermissions(String namespace, @Nullable String table, Map<String, String> permissions) throws IOException;
 }


### PR DESCRIPTION
This is needed so that members of the group, when impersonating apps, can create their HBase tables in the namespace.

Only the last commit needs review; The other commits are part of https://github.com/caskdata/cdap/pull/7773 which has not been merged yet (pending build success).

