### PR TITLE
CDAP-8322 fix tms on hbase 1.1

### DIFF
--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/hbase/HBaseTableFactory.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/hbase/HBaseTableFactory.java
@@ -300,8 +300,8 @@ public final class HBaseTableFactory implements TableFactory {
       CoprocessorDescriptor coprocessorDescriptor =
         coprocessorManager.getCoprocessorDescriptor(coprocessor, Coprocessor.PRIORITY_USER);
       Path path = coprocessorDescriptor.getPath() == null ? null : new Path(coprocessorDescriptor.getPath());
-      tableDescriptor.addCoprocessor(coprocessorDescriptor.getClassName(), path, coprocessorDescriptor.getPriority(),
-                                     coprocessorDescriptor.getProperties());
+      newDescriptor.addCoprocessor(coprocessorDescriptor.getClassName(), path, coprocessorDescriptor.getPriority(),
+                                   coprocessorDescriptor.getProperties());
 
       // Update CDAP version, table prefix
       HBaseTableUtil.setVersion(newDescriptor);


### PR DESCRIPTION
This broke during refactoring. When removing a method, the
variable names got mixed up.