### PR TITLE
Clean map after every table update

### DIFF
--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/replication/TableUpdater.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/replication/TableUpdater.java
@@ -94,6 +94,8 @@ public abstract class TableUpdater {
           if (!cachedUpdates.isEmpty()) {
             LOG.debug("Update Replication State table now. {} entries.", cachedUpdates.size());
             writeState(cachedUpdates);
+            // Clear the Map so stale updates are never written
+            cachedUpdates.clear();
           }
         } catch (IOException ioe) {
           LOG.error("Put to Replication State Table failed.", ioe);


### PR DESCRIPTION
CDAP-8314: While cleaning up state, any updates in the in-memory map can write invalid state to the replication-state table. 