### PR TITLE
[CDAP-8296] - Bug fixes in new UI

### DIFF
--- a/cdap-ui/app/cdap/api/stream.js
+++ b/cdap-ui/app/cdap/api/stream.js
@@ -27,5 +27,5 @@ export const MyStreamApi = {
   getPrograms: apiCreator(dataSrc, 'GET', 'REQUEST', `${basepath}/:streamId/programs`),
   delete: apiCreator(dataSrc, 'DELETE', 'REQUEST', `${basepath}/:streamId`),
   truncate: apiCreator(dataSrc, 'POST', 'REQUEST', `${basepath}/:streamId/truncate`),
-  sendEvent: apiCreator(dataSrc, 'POST', 'REQUEST', `${basepath}/:streamId`)
+  sendEvent: apiCreator(dataSrc, 'POST', 'REQUEST', `${basepath}/:streamId`, {json: false, suppressErrors: true})
 };

--- a/cdap-ui/app/cdap/components/AdminConfigurePane/index.js
+++ b/cdap-ui/app/cdap/components/AdminConfigurePane/index.js
@@ -23,7 +23,7 @@ require('./AdminConfigurePane.scss');
 
 export default function AdminConfigurePane({ openNamespaceWizard, openPreferenceModal, preferencesSavedState, closePreferencesSavedMessage }) {
   let setPreferencesLabel = T.translate('features.Management.Configure.buttons.set-system-preferences');
-  let setPreferenceSuccessLabel = T.translate('features.FastAction.setPreferencesSuccess.system');
+  let setPreferenceSuccessLabel = T.translate('features.FastAction.setPreferencesSuccess.default', {entityType: 'CDAP'});
   let addNSLabel = T.translate('features.Management.Configure.buttons.add-ns');
   let wrenchClasses = classnames('fa fa-wrench', {'preferences-saved-wrench': preferencesSavedState});
 

--- a/cdap-ui/app/cdap/components/AppDetailedView/Tabs/HistoryTab.js
+++ b/cdap-ui/app/cdap/components/AppDetailedView/Tabs/HistoryTab.js
@@ -123,9 +123,9 @@ export default class HistoryTab extends Component {
         } else {
           return (
             <div className="history-tab">
-              <h3 className="text-xs-center empty-message">
+              <i>
                 {T.translate('features.AppDetailedView.History.emptyMessage')}
-              </h3>
+              </i>
             </div>
           );
         }

--- a/cdap-ui/app/cdap/components/AppDetailedView/Tabs/HistoryTab.scss
+++ b/cdap-ui/app/cdap/components/AppDetailedView/Tabs/HistoryTab.scss
@@ -14,15 +14,22 @@
  * the License.
  */
 
+@import '../../../styles/variables.scss';
+
 .history-tab {
-  padding: 20px;
+  padding: 10px 20px;
+  height: calc(100% - 40px);
+  overflow-y: auto;
+
   &.table-bordered {
     width: calc(100% - 20px);
     margin: 10px;
   }
 
-  .empty-message {
-    margin-top: 15%;
-    color: gray;
+  table {
+    tr th,
+    tr td {
+      border-color: $custom_table-border-color;
+    }
   }
 }

--- a/cdap-ui/app/cdap/components/DatasetDetailedView/index.js
+++ b/cdap-ui/app/cdap/components/DatasetDetailedView/index.js
@@ -30,6 +30,10 @@ import T from 'i18n-react';
 import DatasetDetaildViewTab from 'components/DatasetDetailedView/Tabs';
 import {MySearchApi} from 'api/search';
 import {parseMetadata} from 'services/metadata-parser';
+import FastActionToMessage from 'services/fast-action-message-helper';
+import Redirect from 'react-router/Redirect';
+import capitalize from 'lodash/capitalize';
+
 
 export default class DatasetDetailedView extends Component {
   constructor(props) {
@@ -42,7 +46,9 @@ export default class DatasetDetailedView extends Component {
       },
       loading: true,
       entityMetadata: objectQuery(this.props, 'location', 'state', 'entityMetadata') || {},
-      isInvalid: false
+      isInvalid: false,
+      routeToHome: false,
+      successMessage: null
     };
   }
 
@@ -134,6 +140,31 @@ export default class DatasetDetailedView extends Component {
 
   }
 
+  goToHome(action) {
+    if (action === 'delete') {
+      let selectedNamespace = NamespaceStore.getState().selectedNamespace;
+      this.setState({
+        selectedNamespace,
+        routeToHome: true
+      });
+    }
+    let successMessage;
+    if (action === 'setPreferences') {
+      successMessage = FastActionToMessage(action, {entityType: capitalize(this.state.entityMetadata.type)});
+    } else {
+      successMessage = FastActionToMessage(action);
+    }
+    this.setState({
+      successMessage
+    }, () => {
+      setTimeout(() => {
+        this.setState({
+          successMessage: null
+        });
+      }, 3000);
+    });
+  }
+
   render() {
     if (this.state.loading) {
       return (
@@ -150,13 +181,24 @@ export default class DatasetDetailedView extends Component {
         <OverviewHeader
           icon="icon-datasets"
           title={title}
+          successMessage={this.state.successMessage}
         />
-        <OverviewMetaSection entity={this.state.entityMetadata} />
+        <OverviewMetaSection
+          entity={this.state.entityMetadata}
+          onFastActionSuccess={this.goToHome.bind(this)}
+          onFastActionUpdate={this.goToHome.bind(this)}
+        />
         <DatasetDetaildViewTab
           params={this.props.params}
           pathname={this.props.location.pathname}
           entity={this.state.entityDetail}
         />
+        {
+          this.state.routeToHome ?
+            <Redirect to={`/ns/${this.state.selectedNamespace}`} />
+          :
+            null
+        }
       </div>
     );
   }

--- a/cdap-ui/app/cdap/components/EntityCard/EntityCardHeader/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/EntityCardHeader/index.js
@@ -18,6 +18,7 @@ import React, {Component, PropTypes} from 'react';
 import T from 'i18n-react';
 require('./EntityCardHeader.scss');
 import classnames from 'classnames';
+import isEmpty from 'lodash/isEmpty';
 
 const classNames = require('classnames');
 
@@ -46,16 +47,13 @@ export default class EntityCardHeader extends Component {
     return (
       <div className="card-header-wrapper">
         {
-          this.props.successMessage ?
+          !isEmpty(this.props.successMessage) ?
             (
               <div className="entity-card-header success-message">
                 <h4>
                   <span>
                     {
-                      this.props.entity.type === 'program' ?
-                        T.translate(`features.FastAction.setPreferencesSuccess.program`)
-                      :
-                        T.translate(`features.FastAction.setPreferencesSuccess.application`)
+                      this.props.successMessage
                     }
                   </span>
                 </h4>
@@ -90,5 +88,5 @@ EntityCardHeader.propTypes = {
   systemTags: PropTypes.array,
   className: PropTypes.string,
   onClick: PropTypes.func,
-  successMessage: PropTypes.bool
+  successMessage: PropTypes.string
 };

--- a/cdap-ui/app/cdap/components/EntityCard/FastActions/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/FastActions/index.js
@@ -53,11 +53,14 @@ export default class FastActions extends Component {
       if (this.props.onSuccess) {
         this.props.onSuccess();
       }
-      return;
     }
-
+    if (action === 'delete') {
+      if (this.props.onSuccess) {
+        this.props.onSuccess(action);
+      }
+    }
     if (this.props.onUpdate) {
-      this.props.onUpdate();
+      this.props.onUpdate(action);
     }
   }
 

--- a/cdap-ui/app/cdap/components/EntityCard/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/index.js
@@ -25,6 +25,9 @@ import StreamMetrics from './StreamMetrics';
 import classnames from 'classnames';
 import FastActions from 'components/EntityCard/FastActions';
 import JumpButton from 'components/JumpButton';
+import FastActionToMessage from 'services/fast-action-message-helper';
+import isNil from 'lodash/isNil';
+import capitalize from 'lodash/capitalize';
 
 require('./EntityCard.scss');
 
@@ -32,7 +35,7 @@ export default class EntityCard extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      successMessage: false
+      successMessage: null
     };
     this.cardRef = null;
     this.onSuccess = this.onSuccess.bind(this);
@@ -46,10 +49,10 @@ export default class EntityCard extends Component {
     }
   }
 
-  onSuccess() {
-    this.setState({successMessage: true});
+  onSuccess(successMessage) {
+    this.setState({successMessage});
     setTimeout(() => {
-      this.setState({successMessage: false});
+      this.setState({successMessage: null});
     }, 3000);
   }
 
@@ -92,6 +95,21 @@ export default class EntityCard extends Component {
 
     if (this.props.onClick) {
       this.props.onClick();
+    }
+  }
+
+  onFastActionUpdate(action) {
+    let successMessage;
+    if (action === 'setPreferences') {
+      successMessage = FastActionToMessage(action, {entityType: capitalize(this.props.entity.type)});
+    } else {
+      successMessage = FastActionToMessage(action);
+    }
+    if (!isNil(successMessage)) {
+      this.onSuccess(successMessage);
+    }
+    if (this.props.onUpdate) {
+      this.props.onUpdate();
     }
   }
 
@@ -150,8 +168,8 @@ export default class EntityCard extends Component {
           <div className="fast-actions-container">
             <FastActions
               entity={this.props.entity}
-              onUpdate={this.props.onUpdate}
-              onSuccess={this.onSuccess}
+              onUpdate={this.onFastActionUpdate.bind(this)}
+              onSuccess={this.props.onFastActionSuccess}
             />
           </div>
         </Card>
@@ -168,7 +186,8 @@ EntityCard.defaultProps = {
 EntityCard.propTypes = {
   entity: PropTypes.object,
   poll: PropTypes.bool,
-  onUpdate: PropTypes.func,
+  onUpdate: PropTypes.func, // FIXME: Remove??
+  onFastActionSuccess: PropTypes.func,
   className: PropTypes.string,
   onClick: PropTypes.func,
   activeEntity: PropTypes.string

--- a/cdap-ui/app/cdap/components/EntityListView/EntityListHeader/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/EntityListHeader/index.js
@@ -80,6 +80,14 @@ export default class EntityListHeader extends Component {
       this.setState({sortDropdownTooltip: !this.state.sortDropdownTooltip});
     }
   }
+  onFilterClick(option) {
+    if (this.props.onFilterClick) {
+      this.props.onFilterClick(option);
+    }
+    this.setState({
+      isFilterExpanded: false
+    });
+  }
   render() {
 
     let tooltipId = 'filter-tooltip-target-id';
@@ -151,7 +159,7 @@ export default class EntityListHeader extends Component {
                         type="checkbox"
                         className="form-check-input"
                         checked={this.state.activeFilter.indexOf(option.id) !== -1}
-                        onChange={this.props.onFilterClick.bind(this, option)}
+                        onChange={this.onFilterClick.bind(this, option)}
                       />
                       {option.displayName}
                     </label>

--- a/cdap-ui/app/cdap/components/EntityListView/ListView/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/ListView/index.js
@@ -97,6 +97,7 @@ export default class HomeListView extends Component {
             key={entity.uniqueId}
             onClick={this.onClick.bind(this, entity)}
             entity={entity}
+            onFastActionSuccess={this.props.onFastActionSuccess}
             onUpdate={this.props.onUpdate}
           />
         );
@@ -124,6 +125,7 @@ HomeListView.propTypes = {
   loading: PropTypes.bool,
   onEntityClick: PropTypes.func,
   onUpdate: PropTypes.func,
+  onFastActionSuccess: PropTypes.func,
   errorMessage: PropTypes.string,
   errorStatusCode: PropTypes.number,
   className: PropTypes.string,

--- a/cdap-ui/app/cdap/components/EntityListView/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/index.js
@@ -140,7 +140,8 @@ class EntityListView extends Component {
 
   refreshSearchByCreationTime() {
     this.setState({
-      sortObj: this.sortOptions[4]
+      sortObj: this.sortOptions[4],
+      selectedEntity: null
     }, this.search.bind(this));
   }
 
@@ -319,7 +320,8 @@ class EntityListView extends Component {
     let offset = (currentPage - 1) * this.pageSize;
 
     this.setState({
-      loading : true
+      loading : true,
+      selectedEntity: null
     });
 
     let params = {
@@ -396,7 +398,8 @@ class EntityListView extends Component {
     }
 
     this.setState({
-      filter : filters
+      filter : filters,
+      selectedEntity: null
     }, () => {
       this.search(this.state.query, filters, this.state.sortObj);
     });
@@ -411,7 +414,8 @@ class EntityListView extends Component {
 
     this.setState({
       currentPage : pageNumber,
-      animationDirection : direction
+      animationDirection : direction,
+      selectedEntity: null
     }, () => this.search());
   }
 
@@ -419,7 +423,8 @@ class EntityListView extends Component {
     let isSearchDisabled = option.fullSort === 'none' ? false : true;
     this.setState({
       sortObj : option,
-      isSearchDisabled
+      isSearchDisabled,
+      selectedEntity: null
     }, () => {
       this.search(this.state.query, this.state.filter, option);
     });
@@ -430,7 +435,8 @@ class EntityListView extends Component {
     this.setState({
       query,
       isSortDisabled,
-      sortObj: this.sortOptions[0]
+      sortObj: this.sortOptions[0],
+      selectedEntity: null
     }, () => {
       this.search(query, this.state.filter, this.state.sortObj);
     });
@@ -490,7 +496,8 @@ class EntityListView extends Component {
 
   setAnimationDirection(direction) {
     this.setState({
-      animationDirection : direction
+      animationDirection : direction,
+      selectedEntity: null
     });
   }
 
@@ -513,6 +520,18 @@ class EntityListView extends Component {
         modalState: true
       }
     });
+  }
+
+  onOverviewCloseAndRefresh() {
+    this.setState({selectedEntity: null}, this.search.bind(this));
+  }
+
+  onFastActionSuccess() {
+    if (this.state.selectedEntity) {
+      this.onOverviewCloseAndRefresh();
+      return;
+    }
+    this.search();
   }
 
   render() {
@@ -556,7 +575,7 @@ class EntityListView extends Component {
               list={this.state.entities}
               loading={this.state.loading}
               onEntityClick={this.handleEntityClick.bind(this)}
-              onUpdate={this.search.bind(this)}
+              onFastActionSuccess={this.onFastActionSuccess.bind(this)}
               errorMessage={this.state.entityErr}
               errorStatusCode={this.state.errStatusCode}
               animationDirection={this.state.animationDirection}
@@ -567,6 +586,7 @@ class EntityListView extends Component {
               toggleOverview={!isNil(this.state.selectedEntity)}
               entity={this.state.selectedEntity}
               onClose={this.handleEntityClick.bind(this)}
+              onCloseAndRefresh={this.onOverviewCloseAndRefresh.bind(this)}
             />
           </div>
         </Pagination>

--- a/cdap-ui/app/cdap/components/FastAction/DeleteAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/DeleteAction/index.js
@@ -44,7 +44,11 @@ export default class DeleteAction extends Component {
   }
 
   toggleModal(event) {
-    this.setState({modal: !this.state.modal});
+    this.setState({
+      modal: !this.state.modal,
+      errorMessage: '',
+      extendedMessage: '',
+    });
     if (event) {
       event.stopPropagation();
       event.nativeEvent.stopImmediatePropagation();

--- a/cdap-ui/app/cdap/components/FastAction/TruncateAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/TruncateAction/index.js
@@ -22,6 +22,7 @@ import FastActionButton from '../FastActionButton';
 import ConfirmationModal from 'components/ConfirmationModal';
 import {Tooltip} from 'reactstrap';
 import T from 'i18n-react';
+import classnames from 'classnames';
 
 export default class TruncateAction extends Component {
   constructor(props) {
@@ -34,6 +35,7 @@ export default class TruncateAction extends Component {
       modal: false,
       loading: false,
       errorMessage: '',
+      success: false,
       extendedMessage: '',
       tooltipOpen: false
     };
@@ -49,6 +51,20 @@ export default class TruncateAction extends Component {
   }
   toggleTooltip() {
     this.setState({ tooltipOpen : !this.state.tooltipOpen });
+  }
+  onSuccess(res) {
+    this.setState({
+      success: true
+    }, () => {
+      if (this.props.onSuccess) {
+        this.props.onSuccess(res);
+      }
+      setTimeout(() => {
+        this.setState({
+          success: false
+        });
+      }, 3000);
+    });
   }
   action() {
     this.setState({loading: true});
@@ -69,7 +85,7 @@ export default class TruncateAction extends Component {
 
     api(params)
       .subscribe((res) => {
-        this.props.onSuccess(res);
+        this.onSuccess(res);
         this.setState({
           loading: false,
           modal: false
@@ -87,10 +103,11 @@ export default class TruncateAction extends Component {
     const actionLabel = T.translate('features.FastAction.truncateLabel');
     const headerTitle = `${actionLabel} ${this.props.entity.type}`;
     const tooltipID = `${this.props.entity.uniqueId}-truncate`;
+    let truncateActionClassNames = 'fa fa-scissors';
     return (
       <span>
         <FastActionButton
-          icon="fa fa-scissors"
+          icon={classnames(truncateActionClassNames, {'text-success': this.state.success})}
           action={this.toggleModal}
           id={tooltipID}
         />

--- a/cdap-ui/app/cdap/components/NamespaceDropdown/index.js
+++ b/cdap-ui/app/cdap/components/NamespaceDropdown/index.js
@@ -183,7 +183,7 @@ export default class NamespaceDropdown extends Component {
                   this.state.preferencesSavedMessage === true ?
                     (
                       <div className="preferences-saved-message text-white">
-                        <span>{T.translate('features.FastAction.setPreferencesSuccess.default')}</span>
+                        <span>{T.translate('features.FastAction.setPreferencesSuccess.default', {entityType: 'Namespace'})}</span>
                         <span
                           className='fa fa-times'
                           onClick={() => this.setState({preferencesSavedMessage: false})}

--- a/cdap-ui/app/cdap/components/Overview/AppOverview/index.js
+++ b/cdap-ui/app/cdap/components/Overview/AppOverview/index.js
@@ -24,7 +24,9 @@ import NamespaceStore from 'services/NamespaceStore';
 import {objectQuery} from 'services/helpers';
 import shortid from 'shortid';
 import T from 'i18n-react';
+import FastActionToMessage from 'services/fast-action-message-helper';
 require('./AppOverview.scss');
+import capitalize from 'lodash/capitalize';
 
 export default class AppOverview extends Component {
   constructor(props) {
@@ -33,7 +35,8 @@ export default class AppOverview extends Component {
       entity: this.props.entity,
       activeTab: '1',
       entityDetail: null,
-      loading: false
+      loading: false,
+      successMessage: null
     };
   }
   componentWillMount() {
@@ -99,6 +102,23 @@ export default class AppOverview extends Component {
         });
     }
   }
+  onFastActionSuccess(action) {
+    this.onFastActionUpdate(action);
+    if (this.props.onCloseAndRefresh) {
+      this.props.onCloseAndRefresh(action);
+    }
+  }
+  onFastActionUpdate(action) {
+    let successMessage;
+    if (action === 'setPreferences') {
+      successMessage = FastActionToMessage(action, {entityType: capitalize(this.props.entity.type)});
+    } else {
+      successMessage = FastActionToMessage(action);
+    }
+    this.setState({
+      successMessage
+    });
+  }
   render() {
     if (this.state.loading) {
       return (
@@ -122,9 +142,14 @@ export default class AppOverview extends Component {
               entityDetail: this.state.entityDetail
             }
           }}
+          successMessage={this.state.successMessage}
           onClose={this.props.onClose}
         />
-        <OverviewMetaSection entity={this.state.entity} />
+        <OverviewMetaSection
+          entity={this.state.entity}
+          onFastActionSuccess={this.onFastActionSuccess.bind(this)}
+          onFastActionUpdate={this.onFastActionUpdate.bind(this)}
+        />
         <AppOverviewTab entity={this.state.entityDetail} />
       </div>
     );
@@ -134,5 +159,6 @@ export default class AppOverview extends Component {
 AppOverview.propTypes = {
   toggleOverview: PropTypes.bool,
   entity: PropTypes.object,
-  onClose: PropTypes.func
+  onClose: PropTypes.func,
+  onCloseAndRefresh: PropTypes.func
 };

--- a/cdap-ui/app/cdap/components/Overview/DatasetOverview/index.js
+++ b/cdap-ui/app/cdap/components/Overview/DatasetOverview/index.js
@@ -25,6 +25,8 @@ import {MyDatasetApi} from 'api/dataset';
 import {MyMetadataApi} from 'api/metadata';
 import isNil from 'lodash/isNil';
 import T from 'i18n-react';
+import FastActionToMessage from 'services/fast-action-message-helper';
+import capitalize from 'lodash/capitalize';
 
 export default class DatasetOverview extends Component {
   constructor(props) {
@@ -33,7 +35,8 @@ export default class DatasetOverview extends Component {
     this.state = {
       entity: this.props.entity,
       entityDetail: null,
-      loading: false
+      loading: false,
+      successMessage: null
     };
   }
 
@@ -102,6 +105,22 @@ export default class DatasetOverview extends Component {
     }
   }
 
+  onFastActionSuccess(action) {
+    this.props.onCloseAndRefresh(action);
+  }
+
+  onFastActionUpdate(action) {
+    let successMessage;
+    if (action === 'truncate') {
+      successMessage = FastActionToMessage(action, {entityType: capitalize(this.props.entity.type)});
+    } else {
+      successMessage = FastActionToMessage(action);
+    }
+    this.setState({
+      successMessage
+    });
+  }
+
   render() {
     if (this.state.loading) {
       return (
@@ -123,8 +142,13 @@ export default class DatasetOverview extends Component {
             }
           }}
           onClose={this.props.onClose}
+          successMessage={this.state.successMessage}
         />
-        <OverviewMetaSection entity={this.state.entity} />
+        <OverviewMetaSection
+          entity={this.state.entity}
+          onFastActionSuccess={this.onFastActionSuccess.bind(this)}
+          onFastActionUpdate={this.onFastActionUpdate.bind(this)}
+        />
         <DatasetOverviewTab entity={this.state.entityDetail} />
       </div>
     );
@@ -134,5 +158,6 @@ export default class DatasetOverview extends Component {
 DatasetOverview.propTypes = {
   toggleOverview: PropTypes.bool,
   entity: PropTypes.object,
-  onClose: PropTypes.func
+  onClose: PropTypes.func,
+  onCloseAndRefresh: PropTypes.func
 };

--- a/cdap-ui/app/cdap/components/Overview/Overview.scss
+++ b/cdap-ui/app/cdap/components/Overview/Overview.scss
@@ -45,6 +45,10 @@
         margin-left: 50%;
         color: gray;
       }
+
+      .tab-content {
+        height: calc(100% - 12px);
+      }
     }
   }
 }

--- a/cdap-ui/app/cdap/components/Overview/OverviewHeader/OverviewHeader.scss
+++ b/cdap-ui/app/cdap/components/Overview/OverviewHeader/OverviewHeader.scss
@@ -20,6 +20,20 @@
   color: black;
   padding: 10px 16px 5px;
   background: white;
+  position: relative;
+
+  .success-message {
+    position: absolute;
+    width: 100%;
+    background: $success-message-bg;
+    top: 0;
+    left: 0;
+    color: white;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    padding-left: 10px;
+  }
 
   .header {
     flex: 1;

--- a/cdap-ui/app/cdap/components/Overview/OverviewHeader/index.js
+++ b/cdap-ui/app/cdap/components/Overview/OverviewHeader/index.js
@@ -14,45 +14,81 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import React, {PropTypes, Component} from 'react';
 import classnames from 'classnames';
 import {Link} from 'react-router';
 require('./OverviewHeader.scss');
 
-export default function OverviewHeader({icon, title, linkTo, onClose}) {
-  return (
-    <div className="overview-header">
-      <div className="header">
-        <i className={classnames("fa", icon)} />
-        <h4>{title}</h4>
+export default class OverviewHeader extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      successMessage: this.props.successMessage
+    };
+  }
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.successMessage !== this.state.successMessage) {
+      this.setState({
+        successMessage: nextProps.successMessage
+      }, () => {
+        setTimeout(() => {
+          this.setState({
+            successMessage: null
+          });
+        }, 3000);
+      });
+    }
+  }
+  render() {
+    return (
+      <div className="overview-header">
+        {
+          this.state.successMessage ?
+            <div className="overview-header success-message">
+              <h5>
+                <span>
+                  {
+                    this.state.successMessage
+                  }
+                </span>
+              </h5>
+            </div>
+          :
+            null
+        }
+        <div className="header">
+          <i className={classnames("fa", this.props.icon)} />
+          <h4>{this.props.title}</h4>
+        </div>
+        {
+          this.props.linkTo ?
+            <Link
+              className="link-to-detail"
+              to={this.props.linkTo}
+            >
+              View Details
+            </Link>
+          :
+            null
+        }
+        {
+          this.props.onClose ?
+            <span
+              className="fa fa-times"
+              onClick={this.props.onClose}
+            >
+            </span>
+          :
+            null
+        }
       </div>
-      {
-        linkTo ?
-          <Link
-            className="link-to-detail"
-            to={linkTo}
-          >
-            View Details
-          </Link>
-        :
-          null
-      }
-      {
-        onClose ?
-          <span
-            className="fa fa-times"
-            onClick={onClose}
-          >
-          </span>
-        :
-          null
-      }
-    </div>
-  );
+    );
+  }
 }
 OverviewHeader.propTypes = {
   icon: PropTypes.string,
   title: PropTypes.string,
   linkTo: PropTypes.object,
-  onClose: PropTypes.func
+  onClose: PropTypes.func,
+  successMessage: PropTypes.string
 };

--- a/cdap-ui/app/cdap/components/Overview/OverviewMetaSection/OverviewMetaSection.scss
+++ b/cdap-ui/app/cdap/components/Overview/OverviewMetaSection/OverviewMetaSection.scss
@@ -38,6 +38,9 @@
       &:not(:only-child) {
         margin-left: 10px;
       }
+      time {
+        margin-left: 5px;
+      }
       font-size: 10px;
       color: rgba(102, 102, 102, 1);
     }

--- a/cdap-ui/app/cdap/components/Overview/OverviewMetaSection/index.js
+++ b/cdap-ui/app/cdap/components/Overview/OverviewMetaSection/index.js
@@ -82,7 +82,18 @@ export default class OverviewMetaSection extends Component {
     );
   }
 
-  onFastActionsUpdate() {}
+  onFastActionSuccess(action) {
+    if (this.props.onFastActionSuccess) {
+      this.props.onFastActionSuccess(action);
+    }
+  }
+
+  onFastActionUpdate(action) {
+    if (this.props.onFastActionUpdate) {
+      this.props.onFastActionUpdate(action);
+    }
+  }
+
   render() {
     let creationTime = objectQuery(this.props, 'entity', 'metadata', 'metadata', 'SYSTEM', 'properties', 'creation-time');
     let description =  objectQuery(this.props, 'entity', 'metadata', 'metadata', 'SYSTEM', 'properties', 'description');
@@ -99,6 +110,12 @@ export default class OverviewMetaSection extends Component {
             }
             <small>
               {
+                ['datasetinstance', 'stream'].indexOf(this.props.entity.type) !== -1 ?
+                  T.translate('features.Overview.deployedLabel.data')
+                :
+                  T.translate('features.Overview.deployedLabel.app')
+              }
+              {
                 creationTime ?
                   <TimeAgo date={parseInt(creationTime, 10)} />
                 :
@@ -109,7 +126,8 @@ export default class OverviewMetaSection extends Component {
           <FastActions
             className="overview-fast-actions"
             entity={this.props.entity}
-            onUpdate={this.onFastActionsUpdate.bind(this)}
+            onSuccess={this.onFastActionSuccess.bind(this)}
+            onUpdate={this.onFastActionUpdate.bind(this)}
           />
         </div>
         <Description description={description} />
@@ -122,5 +140,7 @@ export default class OverviewMetaSection extends Component {
 }
 
 OverviewMetaSection.propTypes = {
-  entity: PropTypes.object
+  entity: PropTypes.object,
+  onFastActionSuccess: PropTypes.func,
+  onFastActionUpdate: PropTypes.func
 };

--- a/cdap-ui/app/cdap/components/Overview/StreamOverview/index.js
+++ b/cdap-ui/app/cdap/components/Overview/StreamOverview/index.js
@@ -25,7 +25,8 @@ import {MyMetadataApi} from 'api/metadata';
 import {MyStreamApi} from 'api/stream';
 import isNil from 'lodash/isNil';
 import T from 'i18n-react';
-
+import FastActionToMessage from 'services/fast-action-message-helper';
+import capitalize from 'lodash/capitalize';
 
 export default class StreamOverview extends Component {
   constructor(props) {
@@ -34,7 +35,8 @@ export default class StreamOverview extends Component {
     this.state = {
       entity: this.props.entity,
       entityDetail: null,
-      loading: false
+      loading: false,
+      successMessag: null
     };
   }
 
@@ -106,6 +108,22 @@ export default class StreamOverview extends Component {
     }
   }
 
+  onFastActionSuccess(action) {
+    this.props.onCloseAndRefresh(action);
+  }
+
+  onFastActionUpdate(action) {
+    let successMessage;
+    if (action === 'truncate') {
+      successMessage = FastActionToMessage(action, {entityType: capitalize(this.props.entity.type)});
+    } else {
+      successMessage = FastActionToMessage(action);
+    }
+    this.setState({
+      successMessage
+    });
+  }
+
   render() {
     if (this.state.loading) {
       return (
@@ -127,8 +145,13 @@ export default class StreamOverview extends Component {
             }
           }}
           onClose={this.props.onClose}
+          successMessage={this.state.successMessage}
         />
-        <OverviewMetaSection entity={this.state.entity} />
+        <OverviewMetaSection
+          entity={this.state.entity}
+          onFastActionSuccess={this.onFastActionSuccess.bind(this)}
+          onFastActionUpdate={this.onFastActionUpdate.bind(this)}
+        />
         <StreamOverviewTab entity={this.state.entityDetail} />
       </div>
     );
@@ -138,5 +161,6 @@ export default class StreamOverview extends Component {
 StreamOverview.propTypes = {
   toggleOverview: PropTypes.bool,
   entity: PropTypes.object,
-  onClose: PropTypes.func
+  onClose: PropTypes.func,
+  onCloseAndRefresh: PropTypes.func
 };

--- a/cdap-ui/app/cdap/components/Overview/Tabs/DatasetTab/DatasetTab.scss
+++ b/cdap-ui/app/cdap/components/Overview/Tabs/DatasetTab/DatasetTab.scss
@@ -20,5 +20,6 @@
   .message-section {
     margin-left: 5px;
     color: rgba(102, 102, 102, 1);
+    height: 35px;
   }
 }

--- a/cdap-ui/app/cdap/components/Overview/Tabs/OverviewTab.scss
+++ b/cdap-ui/app/cdap/components/Overview/Tabs/OverviewTab.scss
@@ -42,7 +42,7 @@
   .tab-content {
     overflow: auto;
     overflow-x: hidden;
-    height: calc(100% - 33px);
+    height: calc(100% - 15px);
     .tab-pane,
     .row,
     [class*="col-"] {

--- a/cdap-ui/app/cdap/components/Overview/Tabs/ProgramTab/ProgramTab.scss
+++ b/cdap-ui/app/cdap/components/Overview/Tabs/ProgramTab/ProgramTab.scss
@@ -20,5 +20,6 @@
   .message-section {
     margin-left: 5px;
     color: rgba(102, 102, 102, 1);
+    height: 35px;
   }
 }

--- a/cdap-ui/app/cdap/components/Overview/index.js
+++ b/cdap-ui/app/cdap/components/Overview/index.js
@@ -53,12 +53,15 @@ export default class Overview extends Component {
     }
   }
   hideOverview() {
-    this.setState({
-      toggleOverview: false,
-      entity: null
-    });
     if (this.props.onClose) {
       this.props.onClose();
+    }
+  }
+  closeAndRefresh(action) {
+    if (action === 'delete') {
+      if (this.props.onCloseAndRefresh) {
+        this.props.onCloseAndRefresh();
+      }
     }
   }
   render() {
@@ -71,7 +74,8 @@ export default class Overview extends Component {
               Tag,
               {
                 entity: this.state.entity,
-                onClose: this.hideOverview.bind(this)
+                onClose: this.hideOverview.bind(this),
+                onCloseAndRefresh: this.closeAndRefresh.bind(this)
               }
             )
           }
@@ -84,5 +88,6 @@ export default class Overview extends Component {
 Overview.propTypes = {
   toggleOverview: PropTypes.bool,
   entity: PropTypes.object,
-  onClose: PropTypes.func
+  onClose: PropTypes.func,
+  onCloseAndRefresh: PropTypes.func
 };

--- a/cdap-ui/app/cdap/components/ProgramTable/ProgramTable.scss
+++ b/cdap-ui/app/cdap/components/ProgramTable/ProgramTable.scss
@@ -14,7 +14,15 @@
  * the License.
  */
 
+@import '../../styles/variables.scss';
+
 .program-table {
+  table {
+    tr th,
+    tr td {
+      border-color: $custom_table-border-color;
+    }
+  }
   padding-top: 10px;
   .fast-actions-container .btn-link {
     color: #4f5050;

--- a/cdap-ui/app/cdap/services/datasource/index.js
+++ b/cdap-ui/app/cdap/services/datasource/index.js
@@ -53,7 +53,7 @@ export default class Datasource {
   request(resource = {}) {
     let generatedResource = {
       id: uuid.v4(),
-      json: resource.json || true,
+      json: resource.json === false ? false : true,
       method: resource.method || 'GET',
       suppressErrors: resource.suppressErrors || false
     };

--- a/cdap-ui/app/cdap/services/fast-action-message-helper.js
+++ b/cdap-ui/app/cdap/services/fast-action-message-helper.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -13,22 +13,15 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+import T from 'i18n-react';
 
-@import '../../styles/variables.scss';
-
-.dataentity-table {
-  padding-top: 10px;
-  .fast-actions-container .btn-link {
-    color: #4f5050;
-  }
-  .table {
-    [class^="icon-"].fa,
-    [class*=" icon-"].fa {
-      margin-right: 5px;
-    }
-    tr th,
-    tr td {
-      border-color: $custom_table-border-color;
-    }
+export default function FastActionToMessage(action, options) {
+  switch (action) {
+    case 'setPreferences':
+      return T.translate('features.FastAction.setPreferencesSuccess.default', {entityType: options.entityType});
+    case 'truncate':
+      return T.translate('features.FastAction.truncateSuccess');
+    default:
+      return '';
   }
 }

--- a/cdap-ui/app/cdap/styles/variables.scss
+++ b/cdap-ui/app/cdap/styles/variables.scss
@@ -31,7 +31,7 @@ $cdap-gray:             rgb(238, 238, 238); // #eeeeee
 $program-text:          rgb(150, 150, 150); // #969696
 
 // overrides from default bootstrap
-$table-border-color:    $gray;
+$custom_table-border-color: $gray;
 $brand-primary:         rgb(90, 132, 228);  // #5a84e4
 $brand-success:         rgb(74, 182, 60);   // #4ab63c
 $brand-info:            rgb(102, 110, 131); // #666e83

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -83,7 +83,7 @@ features:
   AppDetailedView:
     Title: Application - {appId}
     History:
-      emptyMessage: No Runs
+      emptyMessage: No Runs found.
   ConfirmationModal:
     confirmDefaultText: OK
     cancelDefaultText: Cancel
@@ -135,6 +135,7 @@ features:
     deleteFailed: Failed to delete {entityId}.
     truncateConfirmation: Are you sure you want to truncate *_{entityId}_*?
     truncateLabel: Truncate
+    truncateSuccess: Truncated Successfully
     truncateFailed: Failed to truncate {entityId}.
     sendEventsLabel: Send Events
     setPreferencesModalLabel: Preferences
@@ -154,10 +155,7 @@ features:
     setPreferencesReset: Reset
     setPreferencesFailed: Error - Set Preferences Failed.
     setPreferencesSuccess:
-      default: Preferences Saved
-      system: CDAP Preferences Saved
-      application: Application Preferences Saved
-      program: Program Preferences Saved
+      default: "{entityType} Preferences Saved"
     start: Start
     stop: Stop
     sendEventsButtonLabel: Send
@@ -382,10 +380,10 @@ features:
   Overview:
     ProgramTab:
       emptyMessage: No Programs found.
-      title: "Programs in {appId}:"
+      title: "Programs in \"{appId}\""
       runningProgramLabel: "Number of programs running: {programCount}"
     DatasetTab:
-      title: "Dataset Used by {appId}:"
+      title: "Dataset Used by \"{appId}\""
     SchemaTab:
       emptyMessage: No Schema found.
       title: Schema of each record in the {entityType} "{entityId}"
@@ -393,6 +391,9 @@ features:
     Metadata:
       ttl: "Time To Live (TTL): "
       type: "Type: "
+    deployedLabel:
+      data: Created
+      app: Deployed
   Pagination:
     dropdown-label: Page
   Resource-Center:
@@ -511,8 +512,8 @@ features:
         shorttitle: General Information
         title: General
         description: Provide information about the stream you want to create.
-        ttllabel: Event Life Time
-        ttl-placeholder: Specify time-to-live events in seconds
+        ttllabel: TTL
+        ttl-placeholder: Specify the time-to-live for events in seconds
       Step2:
         shorttitle: Setup Format and Schema
         title: Set Format and Schema


### PR DESCRIPTION
[CDAP-8296](https://issues.cask.co/browse/CDAP-8296)
- Closing the overview pane while switching namespace
- Be consistent in showing app name across all tabs (overview & detailed view)
- Adds 'Deployed' text to the creation time
- Deleting an entity from the detailed view should take the user back to homepage.
- Fast action status should be in context (set preferences, truncate dataset/stream etc.,). These messages should appear within the card.

[CDAP-8247](https://issues.cask.co/browse/CDAP-8247)
- Fix the extra quotes wrapped around each event while ingesting it from UI

[CDAP-7894](https://issues.cask.co/browse/CDAP-7894)
- Fixes the TTL field label in Stream create wizard.
---
- Fixes table border across everywhere (regression caused by styling tables in view switch component)
- Fixes filter dropdown to be closed on click in the home page.

Bamboo build: http://builds.cask.co/browse/CDAP-DRC5534/latest
