### PR TITLE
[HYDRATOR-1269] - export should not put _copy in the pipeline name, in the JSON

### DIFF
--- a/cdap-ui/app/hydrator/services/detail/stores/pipeline-detail-nonruns-store.js
+++ b/cdap-ui/app/hydrator/services/detail/stores/pipeline-detail-nonruns-store.js
@@ -174,7 +174,7 @@ angular.module(PKG.name + '.feature.hydrator')
       // One of the worst cases of 2way binding where right now the app is super big that I have no f***ing clue where which one is modified.
       let appConfigClone = angular.copy(appConfig);
       appConfig.cloneConfig = {
-        name: app.name + '_copy',
+        name: app.name,
         artifact: app.artifact,
         description: appConfigClone.configJson.description,
         __ui__: appConfigClone.DAGConfig,


### PR DESCRIPTION
https://issues.cask.co/browse/HYDRATOR-1269