### PR TITLE
Force get version from S3 and store as repo_version

### DIFF
--- a/cdap-distributions/bin/build_docs_bucket.sh
+++ b/cdap-distributions/bin/build_docs_bucket.sh
@@ -49,12 +49,12 @@ VERSION=${VERSION:-4.1.0-SNAPSHOT}
 source ${REPO_HOME}/cdap-common/bin/functions.sh
 
 function get_repo_version() {
-  s3cmd get s3://${S3_BUCKET}/${S3_REPO_PATH}/version
+  s3cmd get --force s3://${S3_BUCKET}/${S3_REPO_PATH}/version repo_version
   __ret=$?
   if [[ ${__ret} -ne 0 ]]; then
     return ${__ret}
   fi
-  echo $(<version)
+  echo $(<repo_version)
 }
 
 function sync_from_s3() {


### PR DESCRIPTION
This prevents failures if the `version` file already exists locally.