### PR TITLE
CDAP-8313 throw invalid artifact if it is not a valid zip

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspector.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspector.java
@@ -59,6 +59,7 @@ import org.objectweb.asm.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -136,6 +137,8 @@ final class ArtifactInspector {
         }
         return builder.build();
       }
+    } catch (EOFException | ZipException e) {
+      throw new InvalidArtifactException("Artifact " + artifactId + " is not a valid zip file.", e);
     } finally {
       try {
         DirUtils.deleteDirectoryContents(stageDir.toFile());


### PR DESCRIPTION
If an artifact is not a valid zip file, then throw an
InvalidArtifactException to indicate it is a user error.
This also fixes a bug where such an invalid jar would cause the
master to repeatedly load system artifacts on startup.