### PR TITLE
CDAP-8344 order results so test is deterministic

### DIFF
--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceFileSetTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceFileSetTestRun.java
@@ -219,7 +219,7 @@ public class HiveExploreServiceFileSetTestRun extends BaseHiveExploreServiceTest
                                     props.setTableProperty("avro.schema.literal", K_SCHEMA.toString()).build());
 
     // verify that we can query the key-values in the file with Hive
-    runCommand(NAMESPACE_ID, "SELECT * FROM " + queryTableName, true,
+    runCommand(NAMESPACE_ID, "SELECT * FROM " + queryTableName + " ORDER BY key", true,
                Lists.newArrayList(
                  new ColumnDesc(hiveTableName + ".key", "STRING", 1, null)),
                Lists.newArrayList(


### PR DESCRIPTION
Fix a hive test bug that was asserting an order in query results
for a select * query.