### PR TITLE
CDAP-7090 Add a 'stopped' flag to RetryOnStartFailureService

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/service/RetryOnStartFailureService.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/service/RetryOnStartFailureService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,7 +17,6 @@
 package co.cask.cdap.common.service;
 
 import com.google.common.base.Supplier;
-import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.AbstractService;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -40,6 +39,7 @@ public class RetryOnStartFailureService extends AbstractService {
   private final Thread startupThread;
   private final String delegateServiceName;
   private volatile Service currentDelegate;
+  private volatile boolean stopped = false;
 
   /**
    * Creates a new instance.
@@ -58,7 +58,7 @@ public class RetryOnStartFailureService extends AbstractService {
         long delay = 0L;
         Service delegateService = service;
 
-        while (delay >= 0 && !isInterrupted()) {
+        while (delay >= 0 && !isInterrupted() && !stopped) {
           try {
             currentDelegate = delegateService;
             delegateService.start().get();
@@ -103,6 +103,7 @@ public class RetryOnStartFailureService extends AbstractService {
 
   @Override
   protected void doStop() {
+    stopped = true;
     startupThread.interrupt();
     Uninterruptibles.joinUninterruptibly(startupThread);
 


### PR DESCRIPTION
[CDAP-7090](https://issues.cask.co/browse/CDAP-7090) Add a 'stopped' flag to RetryOnStartFailureService, in case the interrupted flag is inappropriately reset by called code.
This fixes an issue where this class otherwise prevents cdap from shutting down (it hangs instead and continuously retries).

http://builds.cask.co/browse/CDAP-RUT487-5

Running integration tests on this branch, just to be safe: http://builds.cask.co/browse/CDAP-ITM0-50