### PR TITLE
CDAP-8032 retries for tx service unavailability

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -45,6 +45,7 @@ import co.cask.cdap.common.namespace.NamespacedLocationFactory;
 import co.cask.cdap.common.twill.HadoopClassExcluder;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
+import co.cask.cdap.data2.transaction.RetryingLongTransactionSystemClient;
 import co.cask.cdap.data2.transaction.Transactions;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
 import co.cask.cdap.data2.util.hbase.HBaseDDLExecutorFactory;
@@ -194,7 +195,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
     this.programJarLocation = programJarLocation;
     this.locationFactory = locationFactory;
     this.streamAdmin = streamAdmin;
-    this.txClient = txClient;
+    this.txClient = new RetryingLongTransactionSystemClient(txClient, context.getRetryStrategy());
     this.context = context;
     this.authorizationEnforcer = authorizationEnforcer;
     this.authenticationContext = authenticationContext;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
@@ -64,6 +64,7 @@ import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.tephra.TxConstants;
 import org.apache.twill.api.Command;
 import org.apache.twill.api.TwillContext;
 import org.apache.twill.api.TwillRunnable;
@@ -157,6 +158,9 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
       hConf = new Configuration();
       hConf.clear();
       hConf.addResource(new File(cmdLine.getOptionValue(RunnableOptions.HADOOP_CONF_FILE)).toURI().toURL());
+      // don't have tephra retry in order to give CDAP more control over when to retry and how.
+      hConf.set(TxConstants.Service.CFG_DATA_TX_CLIENT_RETRY_STRATEGY, "n-times");
+      hConf.setInt(TxConstants.Service.CFG_DATA_TX_CLIENT_ATTEMPTS, 0);
 
       UserGroupInformation.setConfiguration(hConf);
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/service/Retries.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/service/Retries.java
@@ -138,7 +138,7 @@ public final class Retries {
       try {
         V v = callable.call();
         if (failures > 0) {
-          LOG.debug("Retry succeeded after {} retries.", failures);
+          LOG.debug("Retry succeeded after {} retries and %d ms.", failures, System.currentTimeMillis() - startTime);
         }
         return v;
       } catch (Throwable t) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/RetryingLongTransactionSystemClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/RetryingLongTransactionSystemClient.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction;
+
+import co.cask.cdap.common.service.Retries;
+import co.cask.cdap.common.service.RetryStrategy;
+import com.google.common.base.Supplier;
+import org.apache.tephra.Transaction;
+import org.apache.tephra.TransactionNotInProgressException;
+import org.apache.tephra.TransactionSystemClient;
+
+import java.util.Collection;
+
+/**
+ * Retries methods used during long transactions.
+ */
+public class RetryingLongTransactionSystemClient extends RetryingTransactionSystemClient {
+
+  public RetryingLongTransactionSystemClient(TransactionSystemClient delegate, RetryStrategy retryStrategy) {
+    super(delegate, retryStrategy);
+  }
+
+  @Override
+  public Transaction startLong() {
+    return supplyWithRetries(new Supplier<Transaction>() {
+      @Override
+      public Transaction get() {
+        return delegate.startLong();
+      }
+    });
+  }
+
+  @Override
+  public boolean canCommit(final Transaction tx,
+                           final Collection<byte[]> changeIds) throws TransactionNotInProgressException {
+    return callWithRetries(new Retries.Callable<Boolean, TransactionNotInProgressException>() {
+      @Override
+      public Boolean call() throws TransactionNotInProgressException {
+        return delegate.canCommit(tx, changeIds);
+      }
+    });
+  }
+
+  @Override
+  public boolean commit(final Transaction tx) throws TransactionNotInProgressException {
+    return callWithRetries(new Retries.Callable<Boolean, TransactionNotInProgressException>() {
+      @Override
+      public Boolean call() throws TransactionNotInProgressException {
+        return delegate.commit(tx);
+      }
+    });
+  }
+
+  @Override
+  public void abort(final Transaction tx) {
+    supplyWithRetries(new Supplier<Void>() {
+      @Override
+      public Void get() {
+        delegate.abort(tx);
+        return null;
+      }
+    });
+  }
+
+  @Override
+  public boolean invalidate(final long tx) {
+    return supplyWithRetries(new Supplier<Boolean>() {
+      @Override
+      public Boolean get() {
+        return delegate.invalidate(tx);
+      }
+    });
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/RetryingShortTransactionSystemClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/RetryingShortTransactionSystemClient.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction;
+
+import co.cask.cdap.common.service.RetryStrategy;
+import com.google.common.base.Supplier;
+import org.apache.tephra.Transaction;
+import org.apache.tephra.TransactionSystemClient;
+
+/**
+ * Retries only the calls to start a transaction.
+ */
+public class RetryingShortTransactionSystemClient extends RetryingTransactionSystemClient {
+
+  public RetryingShortTransactionSystemClient(TransactionSystemClient delegate, RetryStrategy retryStrategy) {
+    super(delegate, retryStrategy);
+  }
+
+  @Override
+  public Transaction startShort() {
+    return supplyWithRetries(new Supplier<Transaction>() {
+      @Override
+      public Transaction get() {
+        return delegate.startShort();
+      }
+    });
+  }
+
+  @Override
+  public Transaction startShort(final int timeout) {
+    return supplyWithRetries(new Supplier<Transaction>() {
+      @Override
+      public Transaction get() {
+        return delegate.startShort(timeout);
+      }
+    });
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/RetryingTransactionSystemClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/RetryingTransactionSystemClient.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction;
+
+import co.cask.cdap.api.Predicate;
+import co.cask.cdap.common.service.Retries;
+import co.cask.cdap.common.service.RetryStrategy;
+import com.google.common.base.Supplier;
+import org.apache.tephra.InvalidTruncateTimeException;
+import org.apache.tephra.Transaction;
+import org.apache.tephra.TransactionCouldNotTakeSnapshotException;
+import org.apache.tephra.TransactionNotInProgressException;
+import org.apache.tephra.TransactionSystemClient;
+import org.apache.thrift.TException;
+
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * Base class that helps in retrying certain calls to the transaction system.
+ * Unfortunately, this class is tightly coupled with the TransactionServiceClient in Tephra,
+ * as it determines a retryable failure by checking if the TransactionSystemClient threw a RuntimeException wrapping
+ * a TException, which is what TransactionServiceClient does. Once Tephra implements better exceptions, this class
+ * can be removed.
+ *
+ * By default, it doesn't retry anything. Subclasses should override the methods that should be retried.
+ */
+public abstract class RetryingTransactionSystemClient implements TransactionSystemClient {
+  private static final Predicate<Throwable> IS_RETRYABLE = new Predicate<Throwable>() {
+    @Override
+    public boolean apply(Throwable input) {
+      return input instanceof RuntimeException && input.getCause() != null && input.getCause() instanceof TException;
+    }
+  };
+  protected final TransactionSystemClient delegate;
+  private final RetryStrategy retryStrategy;
+
+  protected RetryingTransactionSystemClient(TransactionSystemClient delegate, RetryStrategy retryStrategy) {
+    this.delegate = delegate;
+    this.retryStrategy = retryStrategy;
+  }
+
+  @Override
+  public Transaction startShort() {
+    return delegate.startShort();
+  }
+
+  @Override
+  public Transaction startShort(int timeout) {
+    return delegate.startShort(timeout);
+  }
+
+  @Override
+  public Transaction startLong() {
+    return delegate.startLong();
+  }
+
+  @Override
+  public boolean canCommit(Transaction tx, Collection<byte[]> changeIds) throws TransactionNotInProgressException {
+    return delegate.canCommit(tx, changeIds);
+  }
+
+  @Override
+  public boolean commit(Transaction tx) throws TransactionNotInProgressException {
+    return delegate.commit(tx);
+  }
+
+  @Override
+  public void abort(Transaction tx) {
+    delegate.abort(tx);
+  }
+
+  @Override
+  public boolean invalidate(long tx) {
+    return delegate.invalidate(tx);
+  }
+
+  @Override
+  public Transaction checkpoint(Transaction tx) throws TransactionNotInProgressException {
+    return delegate.checkpoint(tx);
+  }
+
+  @Override
+  public InputStream getSnapshotInputStream() throws TransactionCouldNotTakeSnapshotException {
+    return delegate.getSnapshotInputStream();
+  }
+
+  @Override
+  public String status() {
+    return delegate.status();
+  }
+
+  @Override
+  public void resetState() {
+    delegate.resetState();
+  }
+
+  @Override
+  public boolean truncateInvalidTx(Set<Long> invalidTxIds) {
+    return delegate.truncateInvalidTx(invalidTxIds);
+  }
+
+  @Override
+  public boolean truncateInvalidTxBefore(long time) throws InvalidTruncateTimeException {
+    return delegate.truncateInvalidTxBefore(time);
+  }
+
+  @Override
+  public int getInvalidSize() {
+    return delegate.getInvalidSize();
+  }
+
+  protected <V> V supplyWithRetries(Supplier<V> supplier) {
+    return Retries.supplyWithRetries(supplier, retryStrategy, IS_RETRYABLE);
+  }
+
+  protected <V, T extends Throwable> V callWithRetries(Retries.Callable<V, T> callable) throws T {
+    return Retries.callWithRetries(callable, retryStrategy, IS_RETRYABLE);
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/Transactions.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/Transactions.java
@@ -272,7 +272,7 @@ public final class Transactions {
     return result.get();
   }
 
-  /*
+  /**
    * Creates a new {@link Transactional} that will automatically retry upon transaction failure.
    *
    * @param transactional The {@link Transactional} to delegate the transaction execution to

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactional.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkTransactional.java
@@ -22,8 +22,10 @@ import co.cask.cdap.api.data.DatasetContext;
 import co.cask.cdap.api.data.DatasetInstantiationException;
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.spark.SparkExecutionContext;
+import co.cask.cdap.common.service.RetryStrategy;
 import co.cask.cdap.data2.dataset2.DynamicDatasetCache;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
+import co.cask.cdap.data2.transaction.RetryingLongTransactionSystemClient;
 import co.cask.cdap.data2.transaction.Transactions;
 import co.cask.cdap.proto.id.NamespaceId;
 import com.google.common.base.Preconditions;
@@ -112,8 +114,8 @@ final class SparkTransactional implements Transactional {
   private final DynamicDatasetCache datasetCache;
   private final Map<String, TransactionalDatasetContext> transactionInfos;
 
-  SparkTransactional(TransactionSystemClient txClient, DynamicDatasetCache datasetCache) {
-    this.txClient = txClient;
+  SparkTransactional(TransactionSystemClient txClient, DynamicDatasetCache datasetCache, RetryStrategy retryStrategy) {
+    this.txClient = new RetryingLongTransactionSystemClient(txClient, retryStrategy);
     this.datasetCache = datasetCache;
     this.transactionInfos = new ConcurrentHashMap<>();
   }

--- a/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultSparkExecutionContext.scala
+++ b/cdap-spark-core/src/main/scala/co/cask/cdap/app/runtime/spark/DefaultSparkExecutionContext.scala
@@ -75,7 +75,8 @@ class DefaultSparkExecutionContext(runtimeContext: SparkRuntimeContext,
 
   private val taskLocalizationContext = new DefaultTaskLocalizationContext(localizeResources)
   private val transactional = new SparkTransactional(runtimeContext.getTransactionSystemClient,
-                                                     runtimeContext.getDatasetCache)
+                                                     runtimeContext.getDatasetCache,
+                                                     runtimeContext.getRetryStrategy)
   private val workflowInfo = Option(runtimeContext.getWorkflowInfo)
   private val sparkTxService = new SparkTransactionService(runtimeContext.getTransactionSystemClient,
                                                            runtimeContext.getHostname, runtimeContext.getProgramName)


### PR DESCRIPTION
Adding wrappers around Tephra's TransactionSystemClient that will
retry certain operations depending on the context. In programs
where a long transaction is used, each transaction method will
retry according to the retry policy of the program. In programs
where a short transaction is used, only the call to start the
transaction will be retried according to the retry policy of the
program.