### PR TITLE
[CDAP-8341] Create namespace tmp/ streams/[.deleted/ dirs with same group and permissions as data/

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamUtils.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamUtils.java
@@ -51,7 +51,7 @@ public final class StreamUtils {
 
   // The directory name for storing stream files that are pending for deletion
   // StreamId cannot have "." there, so it's safe that it won't clash with any stream name
-  private static final String DELETED = ".deleted";
+  public static final String DELETED = ".deleted";
 
   /**
    * Decode a map.


### PR DESCRIPTION
This is because otherwise, with per-app impersonation, the first program that runs (or the first stream that is created) will create them, and depending on the permissions:
- that will fail because the app user has no permissions
- that will succeed but then the next app will fail because it has no permissions

Therefore we must create these directories ahead of time, with group write for the group that is configured for the namespace. 

Logic is exactly the same as the existing logic for the data/ directory. Hence refactoring a little to avoid code duplication.  