### PR TITLE
CDAP-6641 Return 404 when namespace doesn't exist

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -29,12 +29,14 @@ import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.ConflictException;
 import co.cask.cdap.common.MethodNotAllowedException;
+import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.NotImplementedException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.EndpointStrategy;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.common.io.CaseInsensitiveEnumTypeAdapterFactory;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.security.AuditDetail;
 import co.cask.cdap.common.security.AuditPolicy;
 import co.cask.cdap.common.service.ServiceDiscoverable;
@@ -65,6 +67,7 @@ import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.ServiceInstances;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.FlowId;
+import co.cask.cdap.proto.id.Ids;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.ProgramRunId;
@@ -73,6 +76,7 @@ import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.http.HttpResponder;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
@@ -150,6 +154,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   private final PreferencesStore preferencesStore;
   private final MetricStore metricStore;
   private final MRJobInfoFetcher mrJobInfoFetcher;
+  private final NamespaceQueryAdmin namespaceQueryAdmin;
 
   /**
    * Store manages non-runtime lifecycle.
@@ -168,7 +173,8 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                               QueueAdmin queueAdmin,
                               PreferencesStore preferencesStore,
                               MRJobInfoFetcher mrJobInfoFetcher,
-                              MetricStore metricStore) {
+                              MetricStore metricStore,
+                              NamespaceQueryAdmin namespaceQueryAdmin) {
     this.store = store;
     this.runtimeService = runtimeService;
     this.discoveryServiceClient = discoveryServiceClient;
@@ -177,6 +183,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     this.queueAdmin = queueAdmin;
     this.preferencesStore = preferencesStore;
     this.mrJobInfoFetcher = mrJobInfoFetcher;
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
   }
 
   /**
@@ -878,7 +885,8 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/flows")
   public void getAllFlows(HttpRequest request, HttpResponder responder,
                           @PathParam("namespace-id") String namespaceId) throws Exception {
-    responder.sendJson(HttpResponseStatus.OK, lifecycleService.list(new NamespaceId(namespaceId), ProgramType.FLOW));
+    responder.sendJson(HttpResponseStatus.OK,
+                       lifecycleService.list(validateAndGetNamespace(namespaceId), ProgramType.FLOW));
   }
 
   /**
@@ -889,7 +897,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   public void getAllMapReduce(HttpRequest request, HttpResponder responder,
                               @PathParam("namespace-id") String namespaceId) throws Exception {
     responder.sendJson(HttpResponseStatus.OK,
-                       lifecycleService.list(new NamespaceId(namespaceId), ProgramType.MAPREDUCE));
+                       lifecycleService.list(validateAndGetNamespace(namespaceId), ProgramType.MAPREDUCE));
   }
 
   /**
@@ -899,7 +907,8 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/spark")
   public void getAllSpark(HttpRequest request, HttpResponder responder,
                           @PathParam("namespace-id") String namespaceId) throws Exception {
-    responder.sendJson(HttpResponseStatus.OK, lifecycleService.list(new NamespaceId(namespaceId), ProgramType.SPARK));
+    responder.sendJson(HttpResponseStatus.OK,
+                       lifecycleService.list(validateAndGetNamespace(namespaceId), ProgramType.SPARK));
   }
 
   /**
@@ -910,7 +919,8 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   public void getAllWorkflows(HttpRequest request, HttpResponder responder,
                               @PathParam("namespace-id") String namespaceId) throws Exception {
     responder.sendJson(HttpResponseStatus.OK,
-                       lifecycleService.list(new NamespaceId(namespaceId), ProgramType.WORKFLOW));
+                       lifecycleService.list(validateAndGetNamespace(namespaceId),
+                                             ProgramType.WORKFLOW));
   }
 
   /**
@@ -920,14 +930,16 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/services")
   public void getAllServices(HttpRequest request, HttpResponder responder,
                              @PathParam("namespace-id") String namespaceId) throws Exception {
-    responder.sendJson(HttpResponseStatus.OK, lifecycleService.list(new NamespaceId(namespaceId), ProgramType.SERVICE));
+    responder.sendJson(HttpResponseStatus.OK, lifecycleService.list(validateAndGetNamespace(namespaceId),
+                                                                    ProgramType.SERVICE));
   }
 
   @GET
   @Path("/workers")
   public void getAllWorkers(HttpRequest request, HttpResponder responder,
                             @PathParam("namespace-id") String namespaceId) throws Exception {
-    responder.sendJson(HttpResponseStatus.OK, lifecycleService.list(new NamespaceId(namespaceId), ProgramType.WORKER));
+    responder.sendJson(HttpResponseStatus.OK, lifecycleService.list(validateAndGetNamespace(namespaceId),
+                                                                    ProgramType.WORKER));
   }
 
   /**
@@ -938,9 +950,9 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   public void getWorkerInstances(HttpRequest request, HttpResponder responder,
                                  @PathParam("namespace-id") String namespaceId,
                                  @PathParam("app-id") String appId,
-                                 @PathParam("worker-id") String workerId) {
+                                 @PathParam("worker-id") String workerId) throws Exception {
     try {
-      int count = store.getWorkerInstances(new NamespaceId(namespaceId).app(appId).worker(workerId));
+      int count = store.getWorkerInstances(validateAndGetNamespace(namespaceId).app(appId).worker(workerId));
       responder.sendJson(HttpResponseStatus.OK, new Instances(count));
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
@@ -1248,7 +1260,8 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @DELETE
   @Path("/queues")
   public synchronized void deleteQueues(HttpRequest request, HttpResponder responder,
-                                        @PathParam("namespace-id") String namespaceId) {
+                                        @PathParam("namespace-id") String namespaceId)
+    throws NamespaceNotFoundException {
     // synchronized to avoid a potential race condition here:
     // 1. the check for state returns that all flows are STOPPED
     // 2. The API deletes queues because
@@ -1257,9 +1270,9 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     // runtimeService. This should work because the method that is used to start a flow - startStopProgram - is also
     // synchronized on this.
     // This synchronization works in HA mode because even in HA mode there is only one leader at a time.
-    NamespaceId namespace = new NamespaceId(namespaceId);
+    NamespaceId namespace = validateAndGetNamespace(namespaceId);
     try {
-      List<ProgramRecord> flows = lifecycleService.list(new NamespaceId(namespaceId), ProgramType.FLOW);
+      List<ProgramRecord> flows = lifecycleService.list(validateAndGetNamespace(namespaceId), ProgramType.FLOW);
       for (ProgramRecord flow : flows) {
         String appId = flow.getApp();
         String flowId = flow.getName();
@@ -1478,5 +1491,17 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       }
     }
     return result;
+  }
+
+  private NamespaceId validateAndGetNamespace(String namespace) throws NamespaceNotFoundException {
+    NamespaceId namespaceId = Ids.namespace(namespace);
+    try {
+      namespaceQueryAdmin.get(namespaceId);
+    } catch (NamespaceNotFoundException e) {
+      throw e;
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+    return namespaceId;
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -29,7 +29,6 @@ import co.cask.cdap.app.store.Store;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.ConflictException;
 import co.cask.cdap.common.MethodNotAllowedException;
-import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.NotImplementedException;
 import co.cask.cdap.common.conf.Constants;
@@ -67,7 +66,6 @@ import co.cask.cdap.proto.RunRecord;
 import co.cask.cdap.proto.ServiceInstances;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.FlowId;
-import co.cask.cdap.proto.id.Ids;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.ProgramRunId;
@@ -76,7 +74,6 @@ import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import co.cask.http.HttpResponder;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
@@ -1261,7 +1258,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/queues")
   public synchronized void deleteQueues(HttpRequest request, HttpResponder responder,
                                         @PathParam("namespace-id") String namespaceId)
-    throws NamespaceNotFoundException {
+    throws Exception {
     // synchronized to avoid a potential race condition here:
     // 1. the check for state returns that all flows are STOPPED
     // 2. The API deletes queues because
@@ -1493,15 +1490,9 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     return result;
   }
 
-  private NamespaceId validateAndGetNamespace(String namespace) throws NamespaceNotFoundException {
-    NamespaceId namespaceId = Ids.namespace(namespace);
-    try {
-      namespaceQueryAdmin.get(namespaceId);
-    } catch (NamespaceNotFoundException e) {
-      throw e;
-    } catch (Exception e) {
-      throw Throwables.propagate(e);
-    }
+  private NamespaceId validateAndGetNamespace(String namespace) throws Exception {
+    NamespaceId namespaceId = new NamespaceId(namespace);
+    namespaceQueryAdmin.get(namespaceId);
     return namespaceId;
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/WorkflowHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/WorkflowHttpHandler.java
@@ -37,6 +37,7 @@ import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.common.ProgramNotFoundException;
 import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.config.PreferencesStore;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.queue.QueueAdmin;
@@ -114,10 +115,10 @@ public class WorkflowHttpHandler extends ProgramLifecycleHttpHandler {
   WorkflowHttpHandler(Store store, WorkflowClient workflowClient, ProgramRuntimeService runtimeService,
                       QueueAdmin queueAdmin, Scheduler scheduler, PreferencesStore preferencesStore,
                       MRJobInfoFetcher mrJobInfoFetcher, ProgramLifecycleService lifecycleService,
-                      MetricStore metricStore, DatasetFramework datasetFramework,
-                      DiscoveryServiceClient discoveryServiceClient) {
+                      MetricStore metricStore, NamespaceQueryAdmin namespaceQueryAdmin,
+                      DatasetFramework datasetFramework, DiscoveryServiceClient discoveryServiceClient) {
     super(store, runtimeService, discoveryServiceClient, lifecycleService, queueAdmin, preferencesStore,
-          mrJobInfoFetcher, metricStore);
+          mrJobInfoFetcher, metricStore, namespaceQueryAdmin);
     this.workflowClient = workflowClient;
     this.datasetFramework = datasetFramework;
     this.scheduler = scheduler;

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/AppFabricClient.java
@@ -228,7 +228,7 @@ public class AppFabricClient {
     verifyResponse(HttpResponseStatus.OK, responder.getStatus(), "Set worker instances failed");
   }
 
-  public Instances getWorkerInstances(String namespaceId, String appId, String workerId) {
+  public Instances getWorkerInstances(String namespaceId, String appId, String workerId) throws Exception {
     MockResponder responder = new MockResponder();
     String uri = String.format("%s/apps/%s/worker/%s/instances", getNamespacePath(namespaceId), appId, workerId);
     HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
@@ -465,6 +465,20 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
                       historyStatus == 404 && deleteStatus == 200);
   }
 
+  /**
+   * Tests getting a non-existent namespace
+   */
+  @Test
+  public void testNonExistentNamespace() throws Exception {
+    String[] endpoints = {"flows", "spark", "services", "workers", "mapreduce", "workflows"};
+
+    for (String endpoint : endpoints) {
+      HttpResponse response = doGet("/v3/namespaces/default/" + endpoint);
+      Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+      response = doGet("/v3/namespaces/garbage/" + endpoint);
+      Assert.assertEquals(404, response.getStatusLine().getStatusCode());
+    }
+  }
 
   /**
    * Tests history of a workflow.

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultWorkerManager.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/internal/DefaultWorkerManager.java
@@ -48,7 +48,11 @@ public class DefaultWorkerManager extends AbstractProgramManager<WorkerManager> 
 
   @Override
   public int getInstances() {
-    return appFabricClient.getWorkerInstances(programId.getNamespace(), programId.getApplication(),
-                                              programId.getProgram()).getInstances();
+    try {
+      return appFabricClient.getWorkerInstances(programId.getNamespace(), programId.getApplication(),
+                                                programId.getProgram()).getInstances();
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
   }
 }


### PR DESCRIPTION
Prior to this, attempting to get items in a non-existant namespace would
return a 200. This change forces a 404 to be returned instead.

JIRA: https://issues.cask.co/browse/CDAP-6641
Bamboo: http://builds.cask.co/browse/CDAP-DUT5430