### PR TITLE
Improvements to build_docs_bucket.sh

### DIFF
--- a/cdap-distributions/bin/build_docs_bucket.sh
+++ b/cdap-distributions/bin/build_docs_bucket.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright © 2016 Cask Data, Inc.
+# Copyright © 2016-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -44,15 +44,43 @@ TARGET_DIR=${DOCS_HOME}/target
 
 S3_BUCKET=${S3_BUCKET:-docs.cask.co}
 S3_REPO_PATH=${S3_REPO_PATH:-cdap} # No leading or trailing slashes
-VERSION=${VERSION:-4.1.0-SNAPSHOT}
+VERSION=${VERSION:-4.2.0-SNAPSHOT}
 
-source ${REPO_HOME}/cdap-common/bin/functions.sh
+function die() { __code=${2:-1}; echo "[ERROR] ${1}" >&2; exit ${__code}; };
+
+function compare_versions() {
+  [[ ${1} == ${2} ]] && return 0
+  local OLDIFS=${IFS}
+  local IFS=.
+  local i ver1=(${1}) ver2=(${2})
+  local IFS=${OLDIFS}
+  # fill empty fields in ver1 with zeros
+  for ((i=${#ver1[@]}; i<${#ver2[@]}; i++)); do
+    ver1[i]=0
+  done
+  for ((i=0; i<${#ver1[@]}; i++)); do
+    if [[ -z ${ver2[i]} ]]; then
+      # fill empty fields in ver2 with zeros
+      ver2[i]=0
+    fi
+    if ((10#${ver1[i]} > 10#${ver2[i]})); then
+      return 1
+    fi
+    if ((10#${ver1[i]} < 10#${ver2[i]})); then
+      return 2
+    fi
+  done
+  return 0
+}
 
 function get_repo_version() {
-  s3cmd get --force s3://${S3_BUCKET}/${S3_REPO_PATH}/version repo_version
+  local __opts="--quiet --force"
+  s3cmd get ${__opts} s3://${S3_BUCKET}/${S3_REPO_PATH}/version repo_version
   __ret=$?
   if [[ ${__ret} -ne 0 ]]; then
-    return ${__ret}
+    echo "ERROR: Failed to fetch version file from S3"
+    # exit rather than return since we're assigning to variable
+    exit ${__ret}
   fi
   echo $(<repo_version)
 }
@@ -66,23 +94,27 @@ function robots_tags() {
   python ${DOCS_HOME}/tools/docs-change.py --robots ${__dir}
 }
 
-__repo_version=$(get_repo_version)
 if [[ ${VERSION} =~ -SNAPSHOT ]]; then
-  # We always tag snapshots
-  robots_tags ${TARGET_DIR}/${VERSION} || die "Failed to add robots tags to ${VERSION}"
+  # SNAPSHOT should be tagged by build
+  echo "SNAPSHOT detected: exiting"
+  exit 0
 else
+  __repo_version=$(get_repo_version)
   compare_versions ${VERSION} ${__repo_version}
   __ret=$?
 
   case ${__ret} in
     1) # Local version is greater
+      echo "Local version is greater: adding robots tags to ${__repo_version}"
       sync_from_s3 || die "Failed to sync ${__repo_version} from S3"
       robots_tags ${TARGET_DIR}/${__repo_version} || die "Failed to add robots tags to ${__repo_version}"
       ;;
     2) # Remote version is greater
+      echo "Remote version is greater: adding robots tags to ${VERSION}"
       robots_tags ${TARGET_DIR}/${VERSION} || die "Failed to add robots tags to ${VERSION}"
       ;;
     0) # Same version
+      echo "Local version is same as remote version: skipping tagging"
       ;;
     *) die "Something went terribly wrong in comparing versions"
   esac


### PR DESCRIPTION
- Import compare_versions to remove external dependency
- Reset IFS after array assignment
- Quiet s3cmd get
- Fail fast in get_repo_version
- Only get_repo_version on non-SNAPSHOT
- Improved output after compare_versions