### PR TITLE
Backport build_docs_bucket.sh to release/3.6

### DIFF
--- a/cdap-distributions/bin/build_docs_bucket.sh
+++ b/cdap-distributions/bin/build_docs_bucket.sh
@@ -44,12 +44,16 @@ TARGET_DIR=${DOCS_HOME}/target
 
 S3_BUCKET=${S3_BUCKET:-docs.cask.co}
 S3_REPO_PATH=${S3_REPO_PATH:-cdap} # No leading or trailing slashes
-VERSION=${VERSION:-4.0.1}
+VERSION=${VERSION:-3.6.0-SNAPSHOT}
+
+function die() { __code=${2:-1}; echo "[ERROR] ${1}" >&2; exit ${__code}; };
 
 function compare_versions() {
   [[ ${1} == ${2} ]] && return 0
+  local OLDIFS=${IFS}
   local IFS=.
   local i ver1=(${1}) ver2=(${2})
+  local IFS=${OLDIFS}
   # fill empty fields in ver1 with zeros
   for ((i=${#ver1[@]}; i<${#ver2[@]}; i++)); do
     ver1[i]=0
@@ -70,10 +74,13 @@ function compare_versions() {
 }
 
 function get_repo_version() {
-  s3cmd get --force s3://${S3_BUCKET}/${S3_REPO_PATH}/version repo_version
+  local __opts="--quiet --force"
+  s3cmd get ${__opts} s3://${S3_BUCKET}/${S3_REPO_PATH}/version repo_version
   __ret=$?
   if [[ ${__ret} -ne 0 ]]; then
-    return ${__ret}
+    echo "ERROR: Failed to fetch version file from S3"
+    # exit rather than return since we're assigning to variable
+    exit ${__ret}
   fi
   echo $(<repo_version)
 }
@@ -87,23 +94,27 @@ function robots_tags() {
   python ${DOCS_HOME}/tools/docs-change.py --robots ${__dir}
 }
 
-__repo_version=$(get_repo_version)
 if [[ ${VERSION} =~ -SNAPSHOT ]]; then
-  # We always tag snapshots
-  robots_tags ${TARGET_DIR}/${VERSION} || die "Failed to add robots tags to ${VERSION}"
+  # SNAPSHOT should be tagged by build
+  echo "SNAPSHOT detected: exiting"
+  exit 0
 else
+  __repo_version=$(get_repo_version)
   compare_versions ${VERSION} ${__repo_version}
   __ret=$?
 
   case ${__ret} in
     1) # Local version is greater
+      echo "Local version is greater: adding robots tags to ${__repo_version}"
       sync_from_s3 || die "Failed to sync ${__repo_version} from S3"
       robots_tags ${TARGET_DIR}/${__repo_version} || die "Failed to add robots tags to ${__repo_version}"
       ;;
     2) # Remote version is greater
+      echo "Remote version is greater: adding robots tags to ${VERSION}"
       robots_tags ${TARGET_DIR}/${VERSION} || die "Failed to add robots tags to ${VERSION}"
       ;;
     0) # Same version
+      echo "Local version is same as remote version: skipping tagging"
       ;;
     *) die "Something went terribly wrong in comparing versions"
   esac


### PR DESCRIPTION
This backports the changes from #7846 to release/3.6