### PR TITLE
Let AbstractProgramManager call getHistory with ProgramId

### DIFF
--- a/cdap-test/src/main/java/co/cask/cdap/test/AbstractProgramManager.java
+++ b/cdap-test/src/main/java/co/cask/cdap/test/AbstractProgramManager.java
@@ -140,7 +140,7 @@ public abstract class AbstractProgramManager<T extends ProgramManager> implement
 
   @Override
   public List<RunRecord> getHistory(ProgramRunStatus status) {
-    return applicationManager.getHistory(programId.toId(), status);
+    return applicationManager.getHistory(programId, status);
   }
 
   @Override


### PR DESCRIPTION
`waitForRun` calls `getHistory(ProgramRunStatus status)`. `waitForRun` need to work for programs in versioned apps too, so we need `ProgramId` to support this.