### PR TITLE
CDAP-8194 Document specifying Spark driver properties in CDAP Spark program

### DIFF
--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright © 2014-2016 Cask Data, Inc.
+# Copyright © 2014-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -76,6 +76,18 @@ def print_sdk_version():
         print "Version tuple: %s" % (version_tuple)
     else:
         print "Could not get version (%s), full version (%s) from grep" % (version, full_version)
+
+def get_spark_version():
+    spark_version = None
+    try:
+        p1 = subprocess.Popen(['grep' , '<spark.version>', '../../../pom.xml' ], stdout=subprocess.PIPE)
+        p2 = subprocess.Popen(['awk', 'NR==1;START{print $1}'], stdin=p1.stdout, stdout=subprocess.PIPE)
+        version = p2.communicate()[0]
+        version = version.strip().replace('<spark.version>', '').replace('</spark.version>', '')
+    except:
+        print "Unexpected error: %s" % sys.exc_info()[0]
+        pass
+    return version
 
 def get_git_hash_timestamp():
     # Gets the Git commit information
@@ -198,6 +210,7 @@ locale_dirs = ['_locale/', '../../_common/_locale']
 # The X.Y short-version
 # The "full" version, which includes any alpha/beta/rc/SNAPSHOT tags, also called the "release" version.
 version, short_version, release, version_tuple = get_sdk_version()
+spark_version = get_spark_version()
 
 # The GIT info and GIT environment variables for the build
 git_hash, git_timestamp = get_git_hash_timestamp()
@@ -245,6 +258,7 @@ extlinks = {
     'cask-issue': ('https://issues.cask.co/browse/%s', ''),
     'cask-repository-parcels-cdap': ("http://repository.cask.co/parcels/cdap/%s/%%s" % short_version, None),
     'cdap-guides': (cdap_guides_github_pattern, None),
+    'spark-docs': ("https://spark.apache.org/docs/%s/%%s" % spark_version, None),
 }
 
 # A string of reStructuredText that will be included at the end of every source file that

--- a/cdap-docs/developers-manual/source/building-blocks/spark-programs.rst
+++ b/cdap-docs/developers-manual/source/building-blocks/spark-programs.rst
@@ -37,6 +37,8 @@ You can extend from the abstract class ``AbstractSpark`` to simplify the impleme
         .setMainClassName("com.example.WordCounter")
         .build();
     }
+    ...
+  }
 
 The configure method is similar to the one found in flows and MapReduce programs. It
 defines the name, description, and the class containing the Spark program to be executed
@@ -46,6 +48,17 @@ The ``initialize()`` method is invoked at runtime, before the
 Spark program is executed. Because many Spark programs do not
 need this method, the ``AbstractSpark`` class provides a default
 implementation that does nothing.
+
+However, if your program requires it, you can override this method to obtain access to the
+``SparkConf`` configuration and use it to set the :spark-docs:`Spark properties
+<configuration.html>` for the program::
+
+    import org.apache.spark.SparkConf;
+    . . .
+    @Override
+    protected void initialize() throws Exception {
+      getContext().setSparkConf(new SparkConf().set("spark.driver.extraJavaOptions", "-XX:MaxDirectMemorySize=1024m"));
+    }
 
 The ``destroy()`` method is invoked after the Spark program has
 finished. You could perform cleanup or send a notification of program
@@ -224,7 +237,7 @@ In Scala, custom object conversion is done through an implicit conversion functi
 .. highlight:: java
 
 In Java, you can read custom objects from a stream by providing a ``decoderType`` extended from
-`StreamEventDecoder <../../reference-manual/javadocs/co/cask/cdap/api/stream/StreamEventDecoder.html>`__::
+:javadoc:`StreamEventDecoder <co/cask/cdap/api/stream/StreamEventDecoder>`::
 
     sec.fromStream(streamName, startTime, endTime, decoderType, keyType, valueType);
 
@@ -302,8 +315,8 @@ Transactions and Spark
 ======================
 When a Spark program interacts with datasets, CDAP will automatically create a
 long-running transaction that covers the Spark job execution. A Spark job refers to a
-Spark action and any tasks that need to be executed to evaluate the action (see `Spark Job
-Scheduling <http://spark.apache.org/docs/1.6.1/job-scheduling.html#scheduling-within-an-application>`__
+Spark action and any tasks that need to be executed to evaluate the action (see
+:spark-docs:`Spark Job Scheduling <job-scheduling.html#scheduling-within-an-application>`
 for details). 
 
 You can also control the transaction scope yourself explicitly. It's useful when you want
@@ -383,12 +396,12 @@ Here is an example of using an explicit transaction in Spark:
 
 Spark Program Examples
 ======================
-- For examples of **Spark programs,** see the :ref:`Spam Classifier
-  <examples-spam-classifier>`, :ref:`Spark K-Means <examples-spark-k-means>`, and
-  :ref:`Spark Page Rank <examples-spark-page-rank>` examples.
+- For examples of **Spark programs,** see the :ref:`Log Analysis <examples-log-analysis>`,
+  :ref:`Spam Classifier <examples-spam-classifier>`, :ref:`Spark K-Means <examples-spark-k-means>`,
+  :ref:`Spark Page Rank <examples-spark-page-rank>`, and :ref:`Wikipedia Pipeline
+  <examples-wikipedia-data-pipeline>` examples.
 
 - For a longer example, the how-to guide :ref:`cdap-spark-guide` gives another demonstration.
 
 - If you have problems with resolving methods when developing Spark problems in an IDE 
   or running Spark programs, see :ref:`these hints <development-troubleshooting-spark>`.
-  


### PR DESCRIPTION
Add a link to the CDAP Spark version documentation, replace all hard-coded
links with it, add more example links at the page end, add example of using SparkConf.

Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB257-1

Page of interest: http://builds.cask.co/artifact/CDAP-DQB257/shared/build-1/Docs-HTML/4.1.0-SNAPSHOT/en/developers-manual/building-blocks/spark-programs.html