### PR TITLE
[CDAP-7597] Fix getTableInfo with custom database name in HttpExploreClient

### DIFF
--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/NamespacedExploreMetadataHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/NamespacedExploreMetadataHttpHandler.java
@@ -43,6 +43,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 
 /**
  * Handler that implements namespaced explore metadata APIs.
@@ -83,13 +84,14 @@ public class NamespacedExploreMetadataHttpHandler extends AbstractExploreMetadat
   @Path("tables/{table}/info")
   public void getTableSchema(HttpRequest request, final HttpResponder responder,
                              @PathParam("namespace-id") final String namespaceId,
-                             @PathParam("table") final String table) {
+                             @PathParam("table") final String table,
+                             @QueryParam("database") final String database) {
     LOG.trace("Received get table info for table {}", table);
     try {
       impersonator.doAs(new NamespaceId(namespaceId), new Callable<Void>() {
         @Override
         public Void call() throws Exception {
-          responder.sendJson(HttpResponseStatus.OK, exploreService.getTableInfo(namespaceId, table));
+          responder.sendJson(HttpResponseStatus.OK, exploreService.getTableInfo(namespaceId, database, table));
           return null;
         }
       });

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/BaseHiveExploreServiceTest.java
@@ -46,6 +46,7 @@ import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutor;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.transaction.stream.StreamAdmin;
+import co.cask.cdap.explore.client.DiscoveryExploreClient;
 import co.cask.cdap.explore.client.ExploreClient;
 import co.cask.cdap.explore.client.ExploreExecutionResult;
 import co.cask.cdap.explore.executor.ExploreExecutorService;
@@ -155,7 +156,7 @@ public class BaseHiveExploreServiceTest {
   protected static NotificationService notificationService;
   protected static StreamHttpService streamHttpService;
   protected static StreamService streamService;
-  protected static ExploreClient exploreClient;
+  protected static DiscoveryExploreClient exploreClient;
   protected static ExploreTableManager exploreTableManager;
   protected static NamespaceAdmin namespaceAdmin;
   private static StreamAdmin streamAdmin;
@@ -212,7 +213,7 @@ public class BaseHiveExploreServiceTest {
     exploreExecutorService.startAndWait();
 
     datasetFramework = injector.getInstance(DatasetFramework.class);
-    exploreClient = injector.getInstance(ExploreClient.class);
+    exploreClient = injector.getInstance(DiscoveryExploreClient.class);
     exploreService = injector.getInstance(ExploreService.class);
     exploreClient.ping();
 


### PR DESCRIPTION
This is the endpoint .../namespaces/<namespace>/data/explore/table/<name>/info[?database=<dbname>]

The client was already adding the ?database parameter but the handler did not honor that. Added a fix and a unit test. 

This endpoint is used by UI to determine wether a dataset is explorable. 