### PR TITLE
CDAP-8229 Don't depend on default namespace in UpgradeTool.

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeDatasetServiceManager.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeDatasetServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -50,7 +50,7 @@ import co.cask.cdap.metrics.store.DefaultMetricStore;
 import co.cask.cdap.metrics.store.MetricDatasetFactory;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
 import co.cask.cdap.notifications.guice.NotificationServiceRuntimeModule;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementService;
@@ -116,7 +116,7 @@ class UpgradeDatasetServiceManager extends AbstractIdleService {
       @Override
       public Boolean call() throws Exception {
         try {
-          getDSFramework().getInstances(Id.Namespace.DEFAULT);
+          getDSFramework().getInstances(NamespaceId.SYSTEM.toId());
           return true;
         } catch (ServiceUnavailableException sue) {
           return false;


### PR DESCRIPTION
[CDAP-8229](https://issues.cask.co/browse/CDAP-8229) Don't depend on default namespace in UpgradeTool.

http://builds.cask.co/browse/CDAP-RUT514-1