### PR TITLE
CDAP-8152 expose cdap context in spark streaming plugins

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/co/cask/cdap/etl/api/streaming/StreamingContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/co/cask/cdap/etl/api/streaming/StreamingContext.java
@@ -18,6 +18,7 @@ package co.cask.cdap.etl.api.streaming;
 
 import co.cask.cdap.api.Transactional;
 import co.cask.cdap.api.annotation.Beta;
+import co.cask.cdap.api.spark.JavaSparkExecutionContext;
 import co.cask.cdap.etl.api.StageContext;
 import org.apache.spark.streaming.api.java.JavaStreamingContext;
 
@@ -32,4 +33,8 @@ public interface StreamingContext extends StageContext, Transactional {
    */
   JavaStreamingContext getSparkStreamingContext();
 
+  /**
+   * @return CDAP JavaSparkExecutionContext for the pipeline.
+   */
+  JavaSparkExecutionContext getSparkExecutionContext();
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/DefaultStreamingContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/DefaultStreamingContext.java
@@ -42,6 +42,11 @@ public class DefaultStreamingContext extends AbstractStageContext implements Str
   }
 
   @Override
+  public JavaSparkExecutionContext getSparkExecutionContext() {
+    return sec;
+  }
+
+  @Override
   public void execute(TxRunnable runnable) throws TransactionFailureException {
     sec.execute(runnable);
   }


### PR DESCRIPTION
This allows users to get RDDs from CDAP datasets and streams in
their StreamingContext plugin.