### PR TITLE
[CDAP-6704] Improve CLI dataset properties help text and error messag…

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateDatasetInstanceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateDatasetInstanceCommand.java
@@ -52,7 +52,8 @@ public class CreateDatasetInstanceCommand extends AbstractAuthCommand {
     String datasetName = arguments.get(ArgumentName.NEW_DATASET.toString());
     String datasetPropertiesString = arguments.getOptional(ArgumentName.DATASET_PROPERTIES.toString(), "");
     String datasetDescription = arguments.getOptional(ArgumentName.DATASET_DESCRIPTON.toString(), null);
-    Map<String, String> datasetProperties = ArgumentParser.parseMap(datasetPropertiesString);
+    Map<String, String> datasetProperties = ArgumentParser.parseMap(datasetPropertiesString,
+                                                                    ArgumentName.DATASET_PROPERTIES.toString());
     // TODO: CDAP-8110 (Rohit) Support owner principal in CLI by deprecating this command and introducing a more user
     // friendly create dataset instance command
     DatasetInstanceConfiguration datasetConfig =

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetDatasetInstancePropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetDatasetInstancePropertiesCommand.java
@@ -49,9 +49,8 @@ public class SetDatasetInstancePropertiesCommand extends AbstractCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     DatasetId instance = cliConfig.getCurrentNamespace().dataset(arguments.get(ArgumentName.DATASET.toString()));
-    Map<String, String> properties = ArgumentParser.parseMap(
-      arguments.get(ArgumentName.DATASET_PROPERTIES.toString()));
-
+    Map<String, String> properties = ArgumentParser.parseMap(arguments.get(ArgumentName.DATASET_PROPERTIES.toString()),
+                                                             ArgumentName.DATASET_PROPERTIES.toString());
     datasetClient.updateExisting(instance, properties);
     output.printf("Successfully updated properties for dataset instance '%s' to %s",
                   instance.getEntityName(), GSON.toJson(properties));
@@ -65,7 +64,8 @@ public class SetDatasetInstancePropertiesCommand extends AbstractCommand {
 
   @Override
   public String getDescription() {
-    return String.format("Sets properties for %s.",
-                         Fragment.of(Article.A, ElementType.DATASET.getName()));
+    return String.format("Sets properties for %s. '<%s>' is in the format 'key1=val1 key2=val2'.",
+                         Fragment.of(Article.A, ElementType.DATASET.getName()),
+                         ArgumentName.DATASET_PROPERTIES);
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetPreferencesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetPreferencesCommand.java
@@ -48,7 +48,7 @@ public class SetPreferencesCommand extends AbstractSetPreferencesCommand {
   @Override
   public void perform(Arguments arguments, PrintStream printStream) throws Exception {
     String runtimeArgs = arguments.get(ArgumentName.RUNTIME_ARGS.toString());
-    Map<String, String> args = ArgumentParser.parseMap(runtimeArgs);
+    Map<String, String> args = ArgumentParser.parseMap(runtimeArgs, ArgumentName.RUNTIME_ARGS.toString());
     setPreferences(arguments, printStream, args);
   }
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetProgramRuntimeArgsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetProgramRuntimeArgsCommand.java
@@ -26,7 +26,6 @@ import co.cask.cdap.cli.util.ArgumentParser;
 import co.cask.cdap.client.ProgramClient;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.common.cli.Arguments;
-import com.google.gson.Gson;
 
 import java.io.PrintStream;
 import java.util.Map;
@@ -52,7 +51,7 @@ public class SetProgramRuntimeArgsCommand extends AbstractAuthCommand {
     String appVersion = programId.getVersion();
     String programName = programId.getProgram();
     String runtimeArgsString = arguments.get(ArgumentName.RUNTIME_ARGS.toString());
-    Map<String, String> runtimeArgs = ArgumentParser.parseMap(runtimeArgsString);
+    Map<String, String> runtimeArgs = ArgumentParser.parseMap(runtimeArgsString, ArgumentName.RUNTIME_ARGS.toString());
     programClient.setRuntimeArgs(programId, runtimeArgs);
     output.printf("Successfully set runtime args of %s '%s' of application '%s.%s' to '%s'\n",
                   elementType.getName(), programName, appName, appVersion, runtimeArgsString);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetRouteConfigCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetRouteConfigCommand.java
@@ -29,7 +29,6 @@ import co.cask.common.cli.Arguments;
 import com.google.inject.Inject;
 
 import java.io.PrintStream;
-import java.util.Map;
 
 /**
  * Sets RouteConfig for a service.
@@ -47,7 +46,8 @@ public class SetRouteConfigCommand extends AbstractAuthCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     ServiceId serviceId = new ServiceId(parseProgramId(arguments, ElementType.SERVICE));
     String routeConfig = arguments.get(ArgumentName.ROUTE_CONFIG.getName());
-    serviceClient.storeRouteConfig(serviceId, ArgumentParser.parseStringIntegerMap(routeConfig));
+    serviceClient.storeRouteConfig(serviceId, ArgumentParser.parseStringIntegerMap(
+      routeConfig, ArgumentName.ROUTE_CONFIG.toString()));
     output.printf("Successfully set route configuration of %s '%s' of application '%s' to '%s'\n",
                   ElementType.SERVICE.getName(), serviceId.getProgram(), serviceId.getApplication(), routeConfig);
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamFormatCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/SetStreamFormatCommand.java
@@ -63,7 +63,8 @@ public class SetStreamFormatCommand extends AbstractAuthCommand {
     Schema schema = getSchema(arguments);
     Map<String, String> settings = Collections.emptyMap();
     if (arguments.hasArgument(ArgumentName.SETTINGS.toString())) {
-      settings = ArgumentParser.parseMap(arguments.get(ArgumentName.SETTINGS.toString()));
+      settings = ArgumentParser.parseMap(arguments.get(ArgumentName.SETTINGS.toString()),
+                                         ArgumentName.SETTINGS.toString());
     }
     FormatSpecification formatSpecification = new FormatSpecification(formatName, schema, settings);
     StreamProperties streamProperties = new StreamProperties(currentProperties.getTTL(),

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/StartProgramCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/StartProgramCommand.java
@@ -70,7 +70,8 @@ public class StartProgramCommand extends AbstractAuthCommand {
                     elementType.getName(), programName, appName, appVersion, runtimeArgsString);
     } else {
       // run with user-provided runtime args
-      Map<String, String> runtimeArgs = ArgumentParser.parseMap(runtimeArgsString);
+      Map<String, String> runtimeArgs = ArgumentParser.parseMap(runtimeArgsString,
+                                                                ArgumentName.RUNTIME_ARGS.toString());
       programClient.start(programId, isDebug, runtimeArgs);
       output.printf("Successfully started %s '%s' of application '%s.%s' with provided runtime arguments '%s'\n",
                     elementType.getName(), programName, appName, appVersion, runtimeArgsString);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/AddMetadataPropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metadata/AddMetadataPropertiesCommand.java
@@ -43,7 +43,7 @@ public class AddMetadataPropertiesCommand extends AbstractCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     EntityId entity = EntityId.fromString(arguments.get(ArgumentName.ENTITY.toString()));
-    Map<String, String> properties = parseMap(arguments.get("properties"));
+    Map<String, String> properties = parseMap(arguments.get("properties"), "<properties>");
     client.addProperties(entity.toId(), properties);
     output.println("Successfully added metadata properties");
   }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metrics/GetMetricCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metrics/GetMetricCommand.java
@@ -49,7 +49,7 @@ public class GetMetricCommand extends AbstractAuthCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     String metric = arguments.get("metric-name");
-    Map<String, String> tags = ArgumentParser.parseMap(arguments.getOptional("tags", ""));
+    Map<String, String> tags = ArgumentParser.parseMap(arguments.getOptional("tags", ""), "<tags>");
     String start = arguments.getOptional("start", "");
     String end = arguments.getOptional("end", "");
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metrics/SearchMetricNamesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metrics/SearchMetricNamesCommand.java
@@ -42,7 +42,7 @@ public class SearchMetricNamesCommand extends AbstractAuthCommand {
 
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
-    Map<String, String> tags = ArgumentParser.parseMap(arguments.getOptional("tags", ""));
+    Map<String, String> tags = ArgumentParser.parseMap(arguments.getOptional("tags", ""), "<tags>");
     List<String> results = client.searchMetrics(tags);
     for (String result : results) {
       output.println(result);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/metrics/SearchMetricTagsCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/metrics/SearchMetricTagsCommand.java
@@ -43,7 +43,7 @@ public class SearchMetricTagsCommand extends AbstractAuthCommand {
 
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
-    Map<String, String> tags = ArgumentParser.parseMap(arguments.getOptional("tags", ""));
+    Map<String, String> tags = ArgumentParser.parseMap(arguments.getOptional("tags", ""), "<tags>");
     List<MetricTagValue> results = client.searchTags(tags);
     for (MetricTagValue result : results) {
       output.printf("%s=%s\n", result.getName(), result.getValue());

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/stream/view/CreateOrUpdateStreamViewCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/stream/view/CreateOrUpdateStreamViewCommand.java
@@ -59,7 +59,8 @@ public class CreateOrUpdateStreamViewCommand extends AbstractAuthCommand {
 
     Map<String, String> settings = Collections.emptyMap();
     if (arguments.hasArgument(ArgumentName.SETTINGS.toString())) {
-      settings = ArgumentParser.parseMap(arguments.get(ArgumentName.SETTINGS.toString()));
+      settings = ArgumentParser.parseMap(arguments.get(ArgumentName.SETTINGS.toString()),
+                                         ArgumentName.SETTINGS.toString());
     }
     FormatSpecification formatSpecification = new FormatSpecification(formatName, schema, settings);
     ViewSpecification viewSpecification = new ViewSpecification(formatSpecification);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/util/AbstractCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/util/AbstractCommand.java
@@ -19,9 +19,6 @@ package co.cask.cdap.cli.util;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.cli.CLIConfig;
 import co.cask.cdap.cli.exception.CommandInputError;
-import co.cask.cdap.proto.ProgramType;
-import co.cask.cdap.proto.id.ApplicationId;
-import co.cask.cdap.proto.id.ProgramId;
 import co.cask.common.cli.util.Parser;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -45,8 +42,8 @@ public abstract class AbstractCommand extends AbstractAuthCommand {
     super(cliConfig);
   }
 
-  protected Map<String, String> parseMap(@Nullable String value) {
-    return ArgumentParser.parseMap(value);
+  protected Map<String, String> parseMap(@Nullable String value, String description) {
+    return ArgumentParser.parseMap(value, description);
   }
 
   protected List<String> parseList(@Nullable String value) {

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/util/ArgumentParser.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/util/ArgumentParser.java
@@ -43,7 +43,7 @@ public class ArgumentParser {
    * @param mapString {@link String} representation of the map
    * @return a {@link Map} with {@link String} keys and {@link String} values
    */
-  public static Map<String, String> parseMap(String mapString) {
+  public static Map<String, String> parseMap(String mapString, String description) {
     if (mapString == null || mapString.isEmpty()) {
       return ImmutableMap.of();
     }
@@ -56,6 +56,8 @@ public class ArgumentParser {
         String key = token.substring(0, firstEquals);
         String value = token.substring(firstEquals + 1, token.length());
         result.put(extractValue(key), extractValue(value));
+      } else {
+        throw new IllegalArgumentException(description + " must be of the form 'key1=val1 key2=val2'");
       }
     }
     return result.build();
@@ -67,8 +69,8 @@ public class ArgumentParser {
    * @param mapString {@link String} representation of the map
    * @return a {@link Map} with {@link String} keys and {@link Integer} values
    */
-  public static Map<String, Integer> parseStringIntegerMap(String mapString) {
-    return Maps.transformValues(parseMap(mapString), new Function<String, Integer>() {
+  public static Map<String, Integer> parseStringIntegerMap(String mapString, String description) {
+    return Maps.transformValues(parseMap(mapString, description), new Function<String, Integer>() {
       @Override
       public Integer apply(String input) {
         return Integer.valueOf(input);

--- a/cdap-cli/src/test/java/co/cask/cdap/cli/util/ArgumentParserTest.java
+++ b/cdap-cli/src/test/java/co/cask/cdap/cli/util/ArgumentParserTest.java
@@ -77,8 +77,13 @@ public class ArgumentParserTest {
     String argValue = "^\\[(?<timestamp>%{DAY} \\s+ %{MONTHDAY} %{TIME} %{YEAR})\\]";
     String mapString = "\"test\"='OXF' arg='" + argValue + "'";
 
-    Map<String, String> actual = ArgumentParser.parseMap(mapString);
+    Map<String, String> actual = ArgumentParser.parseMap(mapString, "<arguments>");
     Assert.assertEquals("OXF", actual.get("test"));
     Assert.assertEquals(argValue, actual.get("arg"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testParseInvalidMap() {
+    Map<String, String> actual = ArgumentParser.parseMap("key1=value key2", "<arguments>");
   }
 }


### PR DESCRIPTION
and error messages for map-typed arguments.

New CLI output for such commands:
```
cdap (http://MacBook-Pro-2.local:11015/namespace:default)> set dataset instance properties myds "tttl=100 key"
Error: dataset-properties must be of the form 'key1=val1 key2=val2'

cdap (http://MacBook-Pro-2.local:11015/namespace:default)> create dataset instance table mytable "ttl"
Error: dataset-properties must be of the form 'key1=val1 key2=val2'

cdap (http://MacBook-Pro-2.local:11015/namespace:default)> start mapreduce myApp.myMR "arg1=1000 arg2"
Error: runtime-args must be of the form 'key1=val1 key2=val2'
```