### PR TITLE
CDAP-8110 Support for dataset creation through cli with owner

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
@@ -20,6 +20,11 @@ package co.cask.cdap.cli;
  * Argument names.
  */
 public enum ArgumentName {
+  /**
+   * Commons
+   */
+  DESCRIPTION("description"),
+
   PROGRAM("app-id.program-id"),
   STREAM("stream-id"),
   WORKER("app-id.worker-id"),
@@ -79,8 +84,6 @@ public enum ArgumentName {
   FREQUENCY("frequency"),
 
   NAMESPACE_NAME("namespace-name"),
-  NAMESPACE_DESCRIPTION("description"),
-  NAMESPACE_PRINCIPAL("principal"),
   NAMESPACE_GROUP_NAME("group-name"),
   NAMESPACE_KEYTAB_PATH("keytab-URI"),
   NAMESPACE_HBASE_NAMESPACE("hbase-namespace"),
@@ -124,7 +127,8 @@ public enum ArgumentName {
    */
   PRINCIPAL_TYPE("principal-type"),
   PRINCIPAL_NAME("principal-name"),
-  ROLE_NAME("role-name");
+  ROLE_NAME("role-name"),
+  PRINCIPAL("principal");
 
   private final String name;
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateNamespaceCommand.java
@@ -46,8 +46,8 @@ public class CreateNamespaceCommand extends AbstractCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     String name = arguments.get(ArgumentName.NAMESPACE_NAME.toString());
 
-    String description = arguments.getOptional(ArgumentName.NAMESPACE_DESCRIPTION.toString(), null);
-    String principal = arguments.getOptional(ArgumentName.NAMESPACE_PRINCIPAL.toString(), null);
+    String description = arguments.getOptional(ArgumentName.DESCRIPTION.toString(), null);
+    String principal = arguments.getOptional(ArgumentName.PRINCIPAL.toString(), null);
     String groupName = arguments.getOptional(ArgumentName.NAMESPACE_GROUP_NAME.toString(), null);
     String keytabPath = arguments.getOptional(ArgumentName.NAMESPACE_KEYTAB_PATH.toString(), null);
     String hbaseNamespace = arguments.getOptional(ArgumentName.NAMESPACE_HBASE_NAMESPACE.toString(), null);
@@ -67,8 +67,8 @@ public class CreateNamespaceCommand extends AbstractCommand {
   public String getPattern() {
     return String.format("create namespace <%s> [%s <%s>] [%s <%s>] [%s <%s>] " +
                            "[%s <%s>] [%s <%s>] [%s <%s>] [%s <%s>] [%s <%s>]", ArgumentName.NAMESPACE_NAME,
-                         ArgumentName.NAMESPACE_DESCRIPTION, ArgumentName.NAMESPACE_DESCRIPTION,
-                         ArgumentName.NAMESPACE_PRINCIPAL, ArgumentName.NAMESPACE_PRINCIPAL,
+                         ArgumentName.DESCRIPTION, ArgumentName.DESCRIPTION,
+                         ArgumentName.PRINCIPAL, ArgumentName.PRINCIPAL,
                          ArgumentName.NAMESPACE_GROUP_NAME, ArgumentName.NAMESPACE_GROUP_NAME,
                          ArgumentName.NAMESPACE_KEYTAB_PATH, ArgumentName.NAMESPACE_KEYTAB_PATH,
                          ArgumentName.NAMESPACE_HBASE_NAMESPACE, ArgumentName.NAMESPACE_HBASE_NAMESPACE,

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeDatasetInstanceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeDatasetInstanceCommand.java
@@ -56,12 +56,12 @@ public class DescribeDatasetInstanceCommand extends AbstractAuthCommand {
     DatasetMeta meta = datasetClient.get(instance);
 
     Table table = Table.builder()
-      .setHeader("hive table", "spec", "type")
+      .setHeader("hive table", "spec", "type", "principal")
       .setRows(ImmutableList.of(meta), new RowMaker<DatasetMeta>() {
         @Override
         public List<?> makeRow(DatasetMeta object) {
           return Lists.newArrayList(object.getHiveTableName(), GSON.toJson(object.getSpec()),
-                                    GSON.toJson(object.getType()));
+                                    GSON.toJson(object.getType()), object.getOwnerPrincipal());
         }
       }).build();
     cliConfig.getTableRenderer().render(cliConfig, output, table);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/DatasetCommands.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/commandset/DatasetCommands.java
@@ -19,6 +19,7 @@ package co.cask.cdap.cli.commandset;
 import co.cask.cdap.cli.Categorized;
 import co.cask.cdap.cli.CommandCategory;
 import co.cask.cdap.cli.command.CreateDatasetInstanceCommand;
+import co.cask.cdap.cli.command.CreateDatasetInstanceCommandV2;
 import co.cask.cdap.cli.command.DeleteDatasetInstanceCommand;
 import co.cask.cdap.cli.command.DeleteDatasetModuleCommand;
 import co.cask.cdap.cli.command.DeployDatasetModuleCommand;
@@ -53,6 +54,7 @@ public class DatasetCommands extends CommandSet<Command> implements Categorized 
         .add(injector.getInstance(GetDatasetInstancePropertiesCommand.class))
         .add(injector.getInstance(SetDatasetInstancePropertiesCommand.class))
         .add(injector.getInstance(CreateDatasetInstanceCommand.class))
+        .add(injector.getInstance(CreateDatasetInstanceCommandV2.class))
         .add(injector.getInstance(DeleteDatasetInstanceCommand.class))
         .add(injector.getInstance(TruncateDatasetInstanceCommand.class))
         .add(injector.getInstance(DescribeDatasetModuleCommand.class))


### PR DESCRIPTION
- Support for Owner in ``create dataset instance``
- Deprecated the old ``create dataset instance`` command and introduced a new one which is more user friendly. 
- Also ``describe dataset instance`` now shows an additional column in the table for owner principal.