### PR TITLE
Stop PrunWriter thread in MessageTable and HBaseQueue coprocessors

### DIFF
--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase96/MessageTableRegionObserver.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase96/MessageTableRegionObserver.java
@@ -108,6 +108,10 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     if (e instanceof RegionCoprocessorEnvironment) {
       getTopicMetadataCache((RegionCoprocessorEnvironment) e).stop();
     }
+
+    if (compactionState != null) {
+      compactionState.stop();
+    }
   }
 
   @Override

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase96/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase96/HBaseQueueRegionObserver.java
@@ -125,6 +125,13 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   }
 
   @Override
+  public void stop(CoprocessorEnvironment e) throws IOException {
+    if (compactionState != null) {
+      compactionState.stop();
+    }
+  }
+
+  @Override
   public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e,
                                   Store store, InternalScanner scanner) throws IOException {
     if (!e.getEnvironment().getRegion().isAvailable()) {

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase98/MessageTableRegionObserver.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase98/MessageTableRegionObserver.java
@@ -108,6 +108,10 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     if (e instanceof RegionCoprocessorEnvironment) {
       getTopicMetadataCache((RegionCoprocessorEnvironment) e).stop();
     }
+
+    if (compactionState != null) {
+      compactionState.stop();
+    }
   }
 
   @Override

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase98/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase98/HBaseQueueRegionObserver.java
@@ -123,6 +123,13 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       configCache = createConfigCache(env);
     }
   }
+  
+  @Override
+  public void stop(CoprocessorEnvironment e) throws IOException {
+    if (compactionState != null) {
+      compactionState.stop();
+    }
+  }
 
   @Override
   public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e,

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase10cdh/MessageTableRegionObserver.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase10cdh/MessageTableRegionObserver.java
@@ -108,6 +108,10 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     if (e instanceof RegionCoprocessorEnvironment) {
       getTopicMetadataCache((RegionCoprocessorEnvironment) e).stop();
     }
+
+    if (compactionState != null) {
+      compactionState.stop();
+    }
   }
 
   @Override

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10cdh/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10cdh/HBaseQueueRegionObserver.java
@@ -125,6 +125,13 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   }
 
   @Override
+  public void stop(CoprocessorEnvironment e) throws IOException {
+    if (compactionState != null) {
+      compactionState.stop();
+    }
+  }
+
+  @Override
   public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e,
                                   Store store, InternalScanner scanner) throws IOException {
     if (!e.getEnvironment().getRegion().isAvailable()) {

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase10cdh550/MessageTableRegionObserver.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase10cdh550/MessageTableRegionObserver.java
@@ -109,6 +109,10 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     if (e instanceof RegionCoprocessorEnvironment) {
       getTopicMetadataCache((RegionCoprocessorEnvironment) e).stop();
     }
+
+    if (compactionState != null) {
+      compactionState.stop();
+    }
   }
 
   @Override

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10cdh550/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10cdh550/HBaseQueueRegionObserver.java
@@ -126,6 +126,13 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   }
 
   @Override
+  public void stop(CoprocessorEnvironment e) throws IOException {
+    if (compactionState != null) {
+      compactionState.stop();
+    }
+  }
+
+  @Override
   public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e,
                                   Store store, InternalScanner scanner) throws IOException {
     if (!e.getEnvironment().getRegion().isAvailable()) {

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase10/MessageTableRegionObserver.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase10/MessageTableRegionObserver.java
@@ -108,6 +108,10 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     if (e instanceof RegionCoprocessorEnvironment) {
       getTopicMetadataCache((RegionCoprocessorEnvironment) e).stop();
     }
+
+    if (compactionState != null) {
+      compactionState.stop();
+    }
   }
 
   @Override

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10/HBaseQueueRegionObserver.java
@@ -123,6 +123,13 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       configCache = createConfigCache(env);
     }
   }
+  
+  @Override
+  public void stop(CoprocessorEnvironment e) throws IOException {
+    if (compactionState != null) {
+      compactionState.stop();
+    }
+  }
 
   @Override
   public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e,

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase11/MessageTableRegionObserver.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase11/MessageTableRegionObserver.java
@@ -109,6 +109,10 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     if (e instanceof RegionCoprocessorEnvironment) {
       getTopicMetadataCache((RegionCoprocessorEnvironment) e).stop();
     }
+
+    if (compactionState != null) {
+      compactionState.stop();
+    }
   }
 
   @Override

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase11/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase11/HBaseQueueRegionObserver.java
@@ -126,6 +126,13 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   }
 
   @Override
+  public void stop(CoprocessorEnvironment e) throws IOException {
+    if (compactionState != null) {
+      compactionState.stop();
+    }
+  }
+
+  @Override
   public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e,
                                   Store store, InternalScanner scanner) throws IOException {
     if (!e.getEnvironment().getRegion().isAvailable()) {

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase12cdh570/MessageTableRegionObserver.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase12cdh570/MessageTableRegionObserver.java
@@ -109,6 +109,10 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     if (e instanceof RegionCoprocessorEnvironment) {
       getTopicMetadataCache((RegionCoprocessorEnvironment) e).stop();
     }
+
+    if (compactionState != null) {
+      compactionState.stop();
+    }
   }
 
   @Override

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase12cdh570/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase12cdh570/HBaseQueueRegionObserver.java
@@ -126,6 +126,13 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
   }
 
   @Override
+  public void stop(CoprocessorEnvironment e) throws IOException {
+    if (compactionState != null) {
+      compactionState.stop();
+    }
+  }
+
+  @Override
   public InternalScanner preFlush(ObserverContext<RegionCoprocessorEnvironment> e,
                                   Store store, InternalScanner scanner) throws IOException {
     if (!e.getEnvironment().getRegion().isAvailable()) {


### PR DESCRIPTION
Fixes the recent hung builds - stop the PruneUpperBoundWriter thread in coprocessors.