### PR TITLE
CDAP-8110 Support owner in dataset cli

### DIFF
--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -342,6 +342,7 @@ public class CLIMainTest extends CLITestBase {
   @Test
   public void testDataset() throws Exception {
     String datasetName = PREFIX + "sdf123lkj";
+    String ownedDatasetName = PREFIX + "owned";
 
     DatasetTypeClient datasetTypeClient = new DatasetTypeClient(cliConfig.getClientConfig());
     DatasetTypeMeta datasetType = datasetTypeClient.list(NamespaceId.DEFAULT).get(0);
@@ -349,6 +350,16 @@ public class CLIMainTest extends CLITestBase {
                               "Successfully created dataset");
     testCommandOutputContains(cli, "list dataset instances", FakeDataset.class.getSimpleName());
     testCommandOutputContains(cli, "get dataset instance properties " + datasetName, "\"a\":\"1\"");
+
+    // test dataset creation with owner
+    String commandOutput = getCommandOutput(cli, "create dataset instance " + datasetType.getName() + " " +
+      ownedDatasetName + " \"a=1\"" + " " + "someDescription " + ArgumentName.PRINCIPAL +
+      " alice/somehost.net@somekdc.net");
+    Assert.assertTrue(commandOutput.contains("Successfully created dataset"));
+    Assert.assertTrue(commandOutput.contains("alice/somehost.net@somekdc.net"));
+
+    // test describing the table returns the given owner information
+    testCommandOutputContains(cli, "describe dataset instance " + ownedDatasetName, "alice/somehost.net@somekdc.net");
 
     NamespaceClient namespaceClient = new NamespaceClient(cliConfig.getClientConfig());
     NamespaceId barspace = new NamespaceId("bar");
@@ -376,6 +387,7 @@ public class CLIMainTest extends CLITestBase {
                               "Successfully created dataset");
     testCommandOutputContains(cli, "list dataset instances", description);
     testCommandOutputContains(cli, "delete dataset instance " + datasetName2, "Successfully deleted");
+    testCommandOutputContains(cli, "delete dataset instance " + ownedDatasetName, "Successfully deleted");
   }
 
   @Test

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
@@ -20,6 +20,11 @@ package co.cask.cdap.cli;
  * Argument names.
  */
 public enum ArgumentName {
+  /**
+   * Commons
+   */
+  DESCRIPTION("description"),
+
   PROGRAM("app-id.program-id"),
   STREAM("stream-id"),
   WORKER("app-id.worker-id"),
@@ -79,8 +84,6 @@ public enum ArgumentName {
   FREQUENCY("frequency"),
 
   NAMESPACE_NAME("namespace-name"),
-  NAMESPACE_DESCRIPTION("description"),
-  NAMESPACE_PRINCIPAL("principal"),
   NAMESPACE_GROUP_NAME("group-name"),
   NAMESPACE_KEYTAB_PATH("keytab-URI"),
   NAMESPACE_HBASE_NAMESPACE("hbase-namespace"),
@@ -124,7 +127,8 @@ public enum ArgumentName {
    */
   PRINCIPAL_TYPE("principal-type"),
   PRINCIPAL_NAME("principal-name"),
-  ROLE_NAME("role-name");
+  ROLE_NAME("role-name"),
+  PRINCIPAL("principal");
 
   private final String name;
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateDatasetInstanceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateDatasetInstanceCommand.java
@@ -54,28 +54,41 @@ public class CreateDatasetInstanceCommand extends AbstractAuthCommand {
     String datasetDescription = arguments.getOptional(ArgumentName.DATASET_DESCRIPTON.toString(), null);
     Map<String, String> datasetProperties = ArgumentParser.parseMap(datasetPropertiesString,
                                                                     ArgumentName.DATASET_PROPERTIES.toString());
+    String datasetOwner = arguments.getOptional(ArgumentName.PRINCIPAL.toString(), null);
+
     // TODO: CDAP-8110 (Rohit) Support owner principal in CLI by deprecating this command and introducing a more user
     // friendly create dataset instance command
     DatasetInstanceConfiguration datasetConfig =
-      new DatasetInstanceConfiguration(datasetType, datasetProperties, datasetDescription, null);
+      new DatasetInstanceConfiguration(datasetType, datasetProperties, datasetDescription, datasetOwner);
 
     datasetClient.create(cliConfig.getCurrentNamespace().dataset(datasetName), datasetConfig);
-    output.printf("Successfully created dataset named '%s' with type '%s' and properties '%s'",
-                  datasetName, datasetType, GSON.toJson(datasetProperties));
+
+    StringBuilder builder = new StringBuilder(String.format("Successfully created dataset named '%s' with type " +
+                                                              "'%s', properties '%s'", datasetName, datasetType,
+                                                            GSON.toJson(datasetProperties)));
+    if (datasetDescription != null) {
+      builder.append(String.format(", description '%s'", datasetDescription));
+    }
+    if (datasetOwner != null) {
+      builder.append(String.format(", owner principal '%s'", datasetOwner));
+    }
+    output.printf(builder.toString());
     output.println();
   }
 
   @Override
   public String getPattern() {
-    return String.format("create dataset instance <%s> <%s> [<%s>] [<%s>]",
+    return String.format("create dataset instance <%s> <%s> [<%s>] [<%s>] [%s <%s>]",
                          ArgumentName.DATASET_TYPE, ArgumentName.NEW_DATASET, ArgumentName.DATASET_PROPERTIES,
-                         ArgumentName.DATASET_DESCRIPTON);
+                         ArgumentName.DATASET_DESCRIPTON, ArgumentName.PRINCIPAL, ArgumentName.PRINCIPAL);
   }
 
   @Override
   public String getDescription() {
-    return String.format("Creates %s. '<%s>' is in the format 'key1=val1 key2=val2'.",
-                         Fragment.of(Article.A, ElementType.DATASET.getName()),
-                         ArgumentName.DATASET_PROPERTIES);
+    return String.format("Creates %s instance of the specified %s. Can optionally take %s, %s, or %s where '<%s>' " +
+                           "is in the format 'key1=val1 key2=val2' and '<%s>' is the Kerberos principal of the owner " +
+                           "of the dataset.", Fragment.of(Article.A, ElementType.DATASET.getName()),
+                         ArgumentName.DATASET_TYPE, ArgumentName.DATASET_PROPERTIES, ArgumentName.DATASET_DESCRIPTON,
+                         ArgumentName.PRINCIPAL, ArgumentName.DATASET_PROPERTIES, ArgumentName.PRINCIPAL);
   }
 }

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateNamespaceCommand.java
@@ -46,8 +46,8 @@ public class CreateNamespaceCommand extends AbstractCommand {
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     String name = arguments.get(ArgumentName.NAMESPACE_NAME.toString());
 
-    String description = arguments.getOptional(ArgumentName.NAMESPACE_DESCRIPTION.toString(), null);
-    String principal = arguments.getOptional(ArgumentName.NAMESPACE_PRINCIPAL.toString(), null);
+    String description = arguments.getOptional(ArgumentName.DESCRIPTION.toString(), null);
+    String principal = arguments.getOptional(ArgumentName.PRINCIPAL.toString(), null);
     String groupName = arguments.getOptional(ArgumentName.NAMESPACE_GROUP_NAME.toString(), null);
     String keytabPath = arguments.getOptional(ArgumentName.NAMESPACE_KEYTAB_PATH.toString(), null);
     String hbaseNamespace = arguments.getOptional(ArgumentName.NAMESPACE_HBASE_NAMESPACE.toString(), null);
@@ -67,8 +67,8 @@ public class CreateNamespaceCommand extends AbstractCommand {
   public String getPattern() {
     return String.format("create namespace <%s> [%s <%s>] [%s <%s>] [%s <%s>] " +
                            "[%s <%s>] [%s <%s>] [%s <%s>] [%s <%s>] [%s <%s>]", ArgumentName.NAMESPACE_NAME,
-                         ArgumentName.NAMESPACE_DESCRIPTION, ArgumentName.NAMESPACE_DESCRIPTION,
-                         ArgumentName.NAMESPACE_PRINCIPAL, ArgumentName.NAMESPACE_PRINCIPAL,
+                         ArgumentName.DESCRIPTION, ArgumentName.DESCRIPTION,
+                         ArgumentName.PRINCIPAL, ArgumentName.PRINCIPAL,
                          ArgumentName.NAMESPACE_GROUP_NAME, ArgumentName.NAMESPACE_GROUP_NAME,
                          ArgumentName.NAMESPACE_KEYTAB_PATH, ArgumentName.NAMESPACE_KEYTAB_PATH,
                          ArgumentName.NAMESPACE_HBASE_NAMESPACE, ArgumentName.NAMESPACE_HBASE_NAMESPACE,

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeDatasetInstanceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeDatasetInstanceCommand.java
@@ -56,12 +56,12 @@ public class DescribeDatasetInstanceCommand extends AbstractAuthCommand {
     DatasetMeta meta = datasetClient.get(instance);
 
     Table table = Table.builder()
-      .setHeader("hive table", "spec", "type")
+      .setHeader("hive table", "spec", "type", "principal")
       .setRows(ImmutableList.of(meta), new RowMaker<DatasetMeta>() {
         @Override
         public List<?> makeRow(DatasetMeta object) {
           return Lists.newArrayList(object.getHiveTableName(), GSON.toJson(object.getSpec()),
-                                    GSON.toJson(object.getType()));
+                                    GSON.toJson(object.getType()), object.getOwnerPrincipal());
         }
       }).build();
     cliConfig.getTableRenderer().render(cliConfig, output, table);


### PR DESCRIPTION
- Support for owner in ``create dataset instance`` command
- Support for owner in ``describe dataset`` command

Note: We had some discussion past  about deprecating this CLI command and introducing a new one which is more user friendly but we decided not to do it in this release. See issue: https://issues.cask.co/browse/CDAP-8388

Build: http://builds.cask.co/browse/CDAP-RUT520-1