### PR TITLE
[CDAP-8173] Disable Finish button in wizards when required fields are empty

### DIFF
--- a/cdap-ui/app/cdap/components/CaskWizards/AddNamespace/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/AddNamespace/index.js
@@ -62,7 +62,6 @@ export default class AddNamespaceWizard extends Component {
               isOpen={this.state.showWizard}
               toggle={this.props.onClose}
               className="add-namespace-wizard"
-              backdrop={this.props.backdrop}
             >
               <Wizard
                 wizardConfig={AddNamespaceWizardConfig}
@@ -82,6 +81,5 @@ export default class AddNamespaceWizard extends Component {
 AddNamespaceWizard.propTypes = {
   isOpen: PropTypes.bool,
   context: PropTypes.string,
-  onClose: PropTypes.func,
-  backdrop: PropTypes.bool
+  onClose: PropTypes.func
 };

--- a/cdap-ui/app/cdap/components/CaskWizards/HydratorPipeline/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/HydratorPipeline/index.js
@@ -70,6 +70,7 @@ export default class HydratorPipeline extends Component {
         toggle={this.closeHandler.bind(this)}
         className="wizard-modal create-stream-wizard hydrator-pipeline-wizard-modal"
         size="lg"
+        backdrop='static'
       >
         <ModalHeader>
           <span className="float-xs-left">

--- a/cdap-ui/app/cdap/components/CaskWizards/PublishPipeline/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/PublishPipeline/index.js
@@ -34,34 +34,22 @@ export default class PublishPipelineWizard extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      showWizard: this.props.isOpen,
-      pipelineNameIsEmpty: false
+      showWizard: this.props.isOpen
     };
 
     this.successInfo = {};
     this.setDefaultConfig();
 
-    PublishPipelineWizardStore.subscribe(() => {
-      let pipelineName = PublishPipelineWizardStore.getState().pipelinemetadata.name;
-      if (pipelineName === "") {
-        this.setState({pipelineNameIsEmpty: true});
-      } else {
-        if (this.state.pipelineNameIsEmpty) {
-          this.setState({pipelineNameIsEmpty: false});
-        }
-      }
-    });
     this.eventEmitter = ee(ee);
   }
   componentWillMount() {
     let action = this.props.input.action;
     let filename = head(action.arguments.filter(arg => arg.name === 'config')).value;
-    PublishPipelineActionCreator
-      .fetchPipelineConfig({
-        entityName: this.props.input.package.name,
-        entityVersion: this.props.input.package.version,
-        filename
-      });
+    PublishPipelineActionCreator.fetchPipelineConfig({
+      entityName: this.props.input.package.name,
+      entityVersion: this.props.input.package.version,
+      filename
+    });
   }
   componentWillReceiveProps({isOpen}) {
     this.setState({
@@ -174,7 +162,6 @@ export default class PublishPipelineWizard extends Component {
                 successInfo={this.successInfo}
                 onClose={this.toggleWizard.bind(this)}
                 store={PublishPipelineWizardStore}
-                finishButtonDisabled={this.state.pipelineNameIsEmpty}
               />
             </WizardModal>
           :

--- a/cdap-ui/app/cdap/components/ConfirmationModal/index.js
+++ b/cdap-ui/app/cdap/components/ConfirmationModal/index.js
@@ -107,6 +107,7 @@ export default class ConfirmationModal extends Component {
         isOpen={this.props.isOpen}
         toggle={this.props.toggleModal}
         className="confirmation-modal"
+        backdrop='static'
       >
         <ModalHeader>
           {this.props.headerTitle}

--- a/cdap-ui/app/cdap/components/FastAction/ExploreAction/ExploreModal.js
+++ b/cdap-ui/app/cdap/components/FastAction/ExploreAction/ExploreModal.js
@@ -305,6 +305,7 @@ export default class ExploreModal extends Component {
         className="explore-modal confirmation-modal"
         toggle={this.props.onClose}
         isOpen={this.props.isOpen}
+        backdrop='static'
       >
         <ModalHeader>
           Explore Dataset

--- a/cdap-ui/app/cdap/components/FastAction/SendEventAction/SendEventModal.js
+++ b/cdap-ui/app/cdap/components/FastAction/SendEventAction/SendEventModal.js
@@ -162,6 +162,7 @@ export default class SendEventModal extends Component {
         toggle={this.props.onClose}
         className="confirmation-modal stream-send-events"
         size="lg"
+        backdrop='static'
       >
         <ModalHeader>
           <div className="float-xs-left">

--- a/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceModal.js
+++ b/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceModal.js
@@ -428,6 +428,7 @@ export default class SetPreferenceModal extends Component {
         toggle={this.props.toggleModal}
         className="confirmation-modal set-preference-modal"
         size="lg"
+        backdrop='static'
       >
         <ModalHeader
           className="modal-header"

--- a/cdap-ui/app/cdap/components/Management/index.js
+++ b/cdap-ui/app/cdap/components/Management/index.js
@@ -310,7 +310,6 @@ class Management extends Component {
           isOpen={this.state.wizard.actionIndex !== null && this.state.wizard.actionType !== null}
           onClose={this.closeWizard.bind(this)}
           wizardType={this.state.wizard.actionType}
-          backdrop={true}
         />
         <SetPreferenceModal
           isOpen={this.state.preferenceModal}

--- a/cdap-ui/app/cdap/components/NamespaceDropdown/index.js
+++ b/cdap-ui/app/cdap/components/NamespaceDropdown/index.js
@@ -344,7 +344,6 @@ export default class NamespaceDropdown extends Component {
           isOpen={this.state.openWizard}
           onClose={this.hideNamespaceWizard}
           wizardType='add_namespace'
-          backdrop={true}
         />
     </div>
     );

--- a/cdap-ui/app/cdap/components/PlusButtonModal/index.js
+++ b/cdap-ui/app/cdap/components/PlusButtonModal/index.js
@@ -70,6 +70,7 @@ export default class PlusButtonModal extends Component {
         toggle={this.closeHandler.bind(this)}
         className="plus-button-modal"
         size="lg"
+        backdrop='static'
       >
         <ModalHeader>
           <span className="float-xs-left">

--- a/cdap-ui/app/cdap/components/Wizard/index.js
+++ b/cdap-ui/app/cdap/components/Wizard/index.js
@@ -49,7 +49,31 @@ export default class Wizard extends Component {
       successInfo: {},
       loading: false,
       error: '',
+      requiredStepsCompleted: false
     };
+  }
+  componentWillMount() {
+    this.checkRequiredSteps();
+    this.storeSubscription = this.props.store.subscribe(() => {
+      this.checkRequiredSteps();
+    });
+  }
+  componentWillUnmount() {
+    this.storeSubscription();
+  }
+  checkRequiredSteps() {
+    let state = this.props.store.getState();
+    let steps = Object.keys(state);
+
+    // non-required steps are marked as complete by default
+    let requiredStepsCompleted = steps.every(key => {
+      return state[key].__complete;
+    });
+    if (this.state.requiredStepsCompleted != requiredStepsCompleted) {
+      this.setState({
+        requiredStepsCompleted
+      });
+    }
   }
   getChildContext() {
     return {
@@ -127,7 +151,7 @@ export default class Wizard extends Component {
         <button
           className="btn btn-primary"
           onClick={this.submitForm.bind(this)}
-          disabled={this.props.finishButtonDisabled ? 'disabled' : null}
+          disabled={(!this.state.requiredStepsCompleted || this.state.loading) ? 'disabled' : null}
         >
           Finish
         </button>
@@ -351,5 +375,4 @@ Wizard.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   successInfo: PropTypes.object,
   onClose: PropTypes.func.isRequired,
-  finishButtonDisabled: PropTypes.bool
 };

--- a/cdap-ui/app/cdap/components/WizardModal/index.js
+++ b/cdap-ui/app/cdap/components/WizardModal/index.js
@@ -27,6 +27,7 @@ export default function WizardModal({children, title, isOpen, toggle, className}
       toggle={toggle}
       className={classnames("wizard-modal", className)}
       size="lg"
+      backdrop='static'
     >
       <ModalHeader>
         <span className="float-xs-left">
@@ -58,8 +59,7 @@ export default function WizardModal({children, title, isOpen, toggle, className}
 WizardModal.defaultProps = {
   title: 'Wizard',
   isOpen: false,
-  closeHandler: () => {},
-  backdrop: false
+  closeHandler: () => {}
 };
 
 WizardModal.propTypes = {

--- a/cdap-ui/app/cdap/services/WizardStores/ArtifactUpload/ArtifactUploadStore.js
+++ b/cdap-ui/app/cdap/services/WizardStores/ArtifactUpload/ArtifactUploadStore.js
@@ -15,6 +15,8 @@
  */
 import {combineReducers, createStore} from 'redux';
 import ArtifactUploadActions from 'services/WizardStores/ArtifactUpload/ArtifactUploadActions';
+import ArtifactUploadWizardConfig from 'services/WizardConfigs/ArtifactUploadWizardConfig';
+import head from 'lodash/head';
 
 const defaultAction = {
   type: '',
@@ -46,6 +48,15 @@ const defaultInitialState = {
   configure: defaultConfigureState
 };
 
+const isNil = (value) => value === null || typeof value === 'undefined' || value === '';
+const isComplete = (state, requiredFields) => {
+  let emptyFieldsInState = Object.keys(state)
+    .filter(fieldName => {
+      return isNil(state[fieldName]) && requiredFields.indexOf(fieldName) !== -1;
+    });
+  return !emptyFieldsInState.length ? true : false;
+};
+
 const upload = (state = defaultUploadState, action = defaultAction) => {
   let stateCopy;
 
@@ -68,7 +79,14 @@ const upload = (state = defaultUploadState, action = defaultAction) => {
 
 const configure = (state = defaultConfigureState, action = defaultAction) => {
   let stateCopy;
-
+  let configurationStepRequiredFields = [];
+  if (ArtifactUploadWizardConfig) {
+    configurationStepRequiredFields = head(
+      ArtifactUploadWizardConfig
+        .steps
+        .filter(step => step.id === 'configuration')
+      ).requiredFields;
+  }
   switch (action.type) {
     case ArtifactUploadActions.setName:
       stateCopy = Object.assign({}, state, {
@@ -101,7 +119,7 @@ const configure = (state = defaultConfigureState, action = defaultAction) => {
       return state;
   }
   return Object.assign({}, stateCopy, {
-    __complete: true
+    __complete: isComplete(stateCopy, configurationStepRequiredFields)
   });
 };
 


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-8173
Build: http://builds.cask.co/browse/CDAP-DRC5616

- Disable Finish button in wizards when required fields are empty or waiting for backend response
- Disable behavior where clicking outside any modal closes that modal