### PR TITLE
CDAP-8406 Add a method which accepts String for deletes

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/KeyValueTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/KeyValueTable.java
@@ -167,6 +167,16 @@ public class KeyValueTable extends AbstractDataset implements
    * @param key the key to delete
    */
   @WriteOnly
+  public void delete(String key) {
+    delete(Bytes.toBytes(key));
+  }
+
+  /**
+   * Delete a key.
+   *
+   * @param key the key to delete
+   */
+  @WriteOnly
   public void delete(byte[] key) {
     this.table.delete(key, KEY_COLUMN);
   }


### PR DESCRIPTION
Prior to this, read/write had overloaded methods which accepted String,
but delete did not. This commit will introduce this functionality.

JIRA: https://issues.cask.co/browse/CDAP-8406
Bamboo: http://builds.cask.co/browse/CDAP-DUT5449