### PR TITLE
[docs] add intro describing CSD and Parcels

### DIFF
--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -12,6 +12,24 @@ Installation using Cloudera Manager
 
 .. include:: ../_includes/installation/installation-steps-images.txt
 
+.. rubric:: Notes
+
+This section describes installing CDAP on Hadoop clusters managed by Cloudera Manager.
+
+The CDAP integration with Cloudera Manager is provided in the form of a Custom Service
+Descriptor (CSD), which must be installed into Cloudera Manager prior to installation.  The CSD
+contains service definitions and configurations to make Cloudera Manager "CDAP aware."
+
+After the CDAP CSD has :ref:`been installed <cloudera-installation-download>`, the CDAP service
+can then be installed via the usual CM methods. CDAP parcels will be available from the
+preconfigured CDAP parcel repository, and the CDAP service can be added to a cluster via the
+"Add Service" wizard.
+
+A new CDAP CSD is released with each CDAP minor version, for example 4.0, 4.1, etc, with patch
+releases as needed. The installed CSD version should always match the major.minor version of the
+CDAP Parcel.  For example, the |short-version| CSD can be used with CDAP |short-version-x|.
+
+
 Preparing the Cluster
 =====================
 

--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2016 Cask Data, Inc.
+    :copyright: Copyright © 2016-2017 Cask Data, Inc.
 
 :section-numbering: true
 

--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -17,16 +17,16 @@ Installation using Cloudera Manager
 This section describes installing CDAP on Hadoop clusters managed by Cloudera Manager.
 
 The CDAP integration with Cloudera Manager is provided in the form of a Custom Service
-Descriptor (CSD), which must be installed into Cloudera Manager prior to installation.  The CSD
-contains service definitions and configurations to make Cloudera Manager "CDAP aware."
+Descriptor (CSD), which *must be installed into Cloudera Manager* prior to installing CDAP.  The CSD
+contains service definitions and configurations to make Cloudera Manager "CDAP-aware."
 
-After the CDAP CSD has :ref:`been installed <cloudera-installation-download>`, the CDAP service
-can then be installed via the usual CM methods. CDAP parcels will be available from the
-preconfigured CDAP parcel repository, and the CDAP service can be added to a cluster via the
+After the CDAP CSD has been :ref:`downloaded and installed <cloudera-installation-download>`, the CDAP service
+can then be installed via the usual Cloudera Manager methods. CDAP parcels will be available from the
+preconfigured CDAP parcel repository, and the CDAP service can be added to a cluster using the
 "Add Service" wizard.
 
-A new CDAP CSD is released with each CDAP minor version, for example 4.0, 4.1, etc, with patch
-releases as needed. The installed CSD version should always match the major.minor version of the
+A new CDAP CSD is released with each CDAP minor version (for example: 4.0, 4.1, etc.) with patch
+releases as needed. The installed CSD version should always match the ``major.minor`` version of the
 CDAP Parcel.  For example, the |short-version| CSD can be used with CDAP |short-version-x|.
 
 


### PR DESCRIPTION
Adds a simple intro section to the CM installation docs, to help avoid the case where users overlook the CSD completely.  Fixes [CDAP-7705](https://issues.cask.co/browse/CDAP-7705)

Running as Quick Build: http://builds.cask.co/browse/CDAP-DQB262-1

Page of interest: _to be completed_