### PR TITLE
CDAP-8367 Rewrite the hive-site.xml that explore container uses

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ExploreServiceTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ExploreServiceTwillRunnable.java
@@ -69,10 +69,12 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.MRJobConfig;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.twill.api.TwillContext;
@@ -340,6 +342,11 @@ public class ExploreServiceTwillRunnable extends AbstractMasterTwillRunnable {
       // YARN_APPLICATION_CLASSPATH before job.jar for container's classpath.
       conf.setBoolean(Job.MAPREDUCE_JOB_USER_CLASSPATH_FIRST, false);
       conf.setBoolean(MRJobConfig.MAPREDUCE_JOB_CLASSLOADER, false);
+
+      // We override this param due to the change in HIVE-14383. Otherwise, the hive job will be launched as the
+      // 'hive' user (or fail to even launch, if on ClouderaManager). See CDAP-8367 for more details.
+      conf.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION,
+               UserGroupInformation.AuthenticationMethod.SIMPLE.name());
 
       String sparkHome = System.getenv(Constants.SPARK_HOME);
       if (sparkHome != null) {


### PR DESCRIPTION
[CDAP-8367](https://issues.cask.co/browse/CDAP-8367) Rewrite the hive-site.xml that explore container uses that hive-on-spark is not impacted by the changes in [HIVE-14383](https://issues.apache.org/jira/browse/HIVE-14383). See the patch in that JIRA, if you're curious.
Otherwise, the hive jobs are launched as the 'hive' user on later versions of hive.
Even worse, on a CM cluster, the hive jobs fail to even launch.

http://builds.cask.co/browse/CDAP-RUT528