### PR TITLE
CDAP-8355 Support disabling explore queries for impersonated namespace

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/AbstractStorageProviderNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/AbstractStorageProviderNamespaceAdmin.java
@@ -268,12 +268,12 @@ abstract class AbstractStorageProviderNamespaceAdmin implements StorageProviderN
       String groupName = customNamespacedLocation.getGroup();
       String permissions = customNamespacedLocation.getPermissions().substring(3, 6);
       if (!groupName.equals(namespaceMeta.getConfig().getGroupName())) {
-        LOG.warn("The provided home directory '%s' for namespace '%s' has group '%s', which is different from " +
-                   "the configured group '%s' of the namespace.", customNamespacedLocation.toString(),
+        LOG.warn("The provided home directory '{}' for namespace '{}' has group '{}', which is different from " +
+                   "the configured group '{}' of the namespace.", customNamespacedLocation.toString(),
                  namespaceMeta.getNamespaceId(), groupName, namespaceMeta.getConfig().getGroupName());
       }
       if (!"rwx".equals(permissions)) {
-        LOG.warn("The provided home directory '%s' for namespace '%s' has group permissions of '%s'. It is " +
+        LOG.warn("The provided home directory '{}' for namespace '{}' has group permissions of '{}'. It is " +
                    "recommended to set the group permissions to 'rwx'",
                  customNamespacedLocation.toString(), namespaceMeta.getNamespaceId(), permissions);
       }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -160,6 +160,29 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
       validateCustomMapping(metadata);
     }
 
+    // check that the user has configured either both of none of the following configuration: principal and keytab URI
+    boolean hasValidKerberosConf = false;
+    if (metadata.getConfig() != null) {
+      String configuredPrincipal = metadata.getConfig().getPrincipal();
+      String configuredKeytabURI = metadata.getConfig().getKeytabURI();
+      if ((!Strings.isNullOrEmpty(configuredPrincipal) && Strings.isNullOrEmpty(configuredKeytabURI)) ||
+        (Strings.isNullOrEmpty(configuredPrincipal) && !Strings.isNullOrEmpty(configuredKeytabURI))) {
+        throw new BadRequestException(
+          String.format("Either neither or both of the following two configurations must be configured. " +
+                          "Configured principal: %s, Configured keytabURI: %s",
+                        configuredPrincipal, configuredKeytabURI));
+      }
+      hasValidKerberosConf = true;
+    }
+
+    // check that if explore as principal is explicitly set to false then user has kerberos configuration
+    if (!metadata.getConfig().isExploreAsPrincipal() && !hasValidKerberosConf) {
+      throw new BadRequestException(
+        String.format("No kerberos principal or keytab-uri was provided while '%s' was set to true.",
+                      NamespaceConfig.EXPLORE_AS_PRINCIPAL));
+
+    }
+
     // Namespace can be created. Grant all the permissions to the user.
     Principal principal = authenticationContext.getPrincipal();
     privilegesManager.grant(namespace, principal, EnumSet.allOf(Action.class));
@@ -202,7 +225,7 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
       privilegesManager.revoke(namespace);
       throw new NamespaceCannotBeCreatedException(namespace, t);
     }
-    LOG.info("Namespace {} created.", metadata.getNamespaceId());
+    LOG.info("Namespace {} created with meta {}", metadata.getNamespaceId(), metadata);
   }
 
   private void validateCustomMapping(NamespaceMeta metadata) throws Exception {
@@ -358,14 +381,20 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
       builder.setSchedulerQueueName(config.getSchedulerQueueName());
     }
 
+    if (config != null) {
+      builder.setExploreAsPrincipal(config.isExploreAsPrincipal());
+    }
+
     Set<String> difference = existingMeta.getConfig().getDifference(config);
     if (!difference.isEmpty()) {
       throw new BadRequestException(String.format("Mappings %s for namespace %s cannot be updated once the namespace " +
                                                     "is created.", difference, namespaceId));
     }
-    nsStore.update(builder.build());
+    NamespaceMeta updatedMeta = builder.build();
+    nsStore.update(updatedMeta);
     // refresh the cache with new meta
     namespaceMetaCache.refresh(namespaceId);
+    LOG.info("Namespace {} updated with meta {}", namespaceId, updatedMeta);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/PropertiesResolver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/PropertiesResolver.java
@@ -19,6 +19,7 @@ package co.cask.cdap.internal.app.services;
 import co.cask.cdap.app.runtime.scheduler.SchedulerQueueResolver;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.kerberos.ImpersonatedOpType;
 import co.cask.cdap.common.kerberos.ImpersonationInfo;
 import co.cask.cdap.common.kerberos.OwnerAdmin;
 import co.cask.cdap.common.kerberos.SecurityUtil;
@@ -62,7 +63,8 @@ public class PropertiesResolver {
     systemArgs.put(Constants.CLUSTER_NAME, cConf.get(Constants.CLUSTER_NAME, ""));
     systemArgs.put(Constants.AppFabric.APP_SCHEDULER_QUEUE, queueResolver.getQueue(id.getNamespace()));
     if (SecurityUtil.isKerberosEnabled(cConf)) {
-      ImpersonationInfo impersonationInfo = SecurityUtil.createImpersonationInfo(ownerAdmin, cConf, id.toEntityId());
+      ImpersonationInfo impersonationInfo = SecurityUtil.createImpersonationInfo(ownerAdmin, cConf, id.toEntityId(),
+                                                                                 ImpersonatedOpType.OTHER);
       systemArgs.put(ProgramOptionConstants.PRINCIPAL, impersonationInfo.getPrincipal());
       systemArgs.put(ProgramOptionConstants.KEYTAB_URI, impersonationInfo.getKeytabURI());
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/AuthorizationHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/gateway/handlers/AuthorizationHandlerTest.java
@@ -456,7 +456,7 @@ public class AuthorizationHandlerTest {
       caller.call();
     } catch (FeatureDisabledException expected) {
       Assert.assertEquals(expectedDisabledFeature, expected.getFeature());
-      Assert.assertEquals(FeatureDisabledException.CDAP_SITE, expected.getConfigFile());
+      Assert.assertEquals(FeatureDisabledException.CDAP_SITE, expected.getConfigName());
       Assert.assertEquals(expectedEnableConfig, expected.getEnableConfigKey());
       Assert.assertEquals("true", expected.getEnableConfigValue());
     }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
@@ -43,7 +43,6 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import org.apache.http.HttpResponse;
-import org.apache.http.util.EntityUtils;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
 import org.junit.Assert;
@@ -173,25 +172,6 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
     Assert.assertTrue(customLocation.exists());
     // delete it manually
     Assert.assertTrue(customLocation.delete(true));
-  }
-
-  @Test
-  public void testInvalidConfiguration() throws Exception {
-    // test that the namespace create handler doesn't allow configuring only one of the following two:
-    // principal, keytabURI
-    NamespaceMeta namespaceMeta = new NamespaceMeta.Builder().setName("test_ns").setPrincipal("somePrincipal").build();
-    HttpResponse response = createNamespace(GSON.toJson(namespaceMeta), "test_ns");
-    assertResponseCode(400, response);
-    String responseMessage = EntityUtils.toString(response.getEntity());
-    Assert.assertTrue(
-      responseMessage.contains("Either neither or both of the following two configurations must be configured"));
-
-    namespaceMeta = new NamespaceMeta.Builder().setName("test_ns").setKeytabURI("/some/path").build();
-    response = createNamespace(GSON.toJson(namespaceMeta), "test_ns");
-    assertResponseCode(400, response);
-    responseMessage = EntityUtils.toString(response.getEntity());
-    Assert.assertTrue(
-      responseMessage.contains("Either neither or both of the following two configurations must be configured"));
   }
 
   @Test

--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -630,15 +630,16 @@ public class CLIMainTest extends CLITestBase {
 
     // create a namespace
     String command = String.format("create namespace %s description %s principal %s group-name %s keytab-URI %s " +
-                                     "hbase-namespace %s hive-database %s root-directory %s scheduler-queue-name %s",
+                                     "hbase-namespace %s hive-database %s root-directory %s %s %s %s %s",
                                    name, description, principal, group, keytab, hbaseNamespace,
-                                   hiveDatabase, rootDirectory, schedulerQueueName);
+                                   hiveDatabase, rootDirectory, ArgumentName.NAMESPACE_SCHEDULER_QUEUENAME,
+                                   schedulerQueueName, ArgumentName.NAMESPACE_EXPLORE_AS_PRINCIPAL, false);
     testCommandOutputContains(cli, command, String.format("Namespace '%s' created successfully.", name));
 
     NamespaceMeta expected = new NamespaceMeta.Builder()
       .setName(name).setDescription(description).setPrincipal(principal).setGroupName(group).setKeytabURI(keytab)
       .setHBaseNamespace(hbaseNamespace).setSchedulerQueueName(schedulerQueueName)
-      .setHiveDatabase(hiveDatabase).setRootDirectory(rootDirectory).build();
+      .setHiveDatabase(hiveDatabase).setRootDirectory(rootDirectory).setExploreAsPrincipal(false).build();
     expectedNamespaces = Lists.newArrayList(defaultNs, expected);
     // list namespaces and verify
     testNamespacesOutput(cli, "list namespaces", expectedNamespaces);

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
@@ -90,6 +90,7 @@ public enum ArgumentName {
   NAMESPACE_HIVE_DATABASE("hive-database"),
   NAMESPACE_ROOT_DIR("root-directory"),
   NAMESPACE_SCHEDULER_QUEUENAME("scheduler-queue-name"),
+  NAMESPACE_EXPLORE_AS_PRINCIPAL("explore-as-principal"),
 
   INSTANCE("instance-id"),
   COMMAND_CATEGORY("command-category"),

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/CreateNamespaceCommand.java
@@ -54,11 +54,14 @@ public class CreateNamespaceCommand extends AbstractCommand {
     String hiveDatabase = arguments.getOptional(ArgumentName.NAMESPACE_HIVE_DATABASE.toString(), null);
     String schedulerQueueName = arguments.getOptional(ArgumentName.NAMESPACE_SCHEDULER_QUEUENAME.toString(), null);
     String rootDir = arguments.getOptional(ArgumentName.NAMESPACE_ROOT_DIR.toString(), null);
+    String exploreAsPrinc = arguments.getOptional(ArgumentName.NAMESPACE_EXPLORE_AS_PRINCIPAL.toString(), "true");
+    Boolean exploreAsPrincipal = Boolean.valueOf(exploreAsPrinc);
 
     NamespaceMeta.Builder builder = new NamespaceMeta.Builder();
     builder.setName(name).setDescription(description).setPrincipal(principal).setGroupName(groupName)
       .setKeytabURI(keytabPath).setRootDirectory(rootDir).setHBaseNamespace(hbaseNamespace)
-      .setHiveDatabase(hiveDatabase).setSchedulerQueueName(schedulerQueueName);
+      .setHiveDatabase(hiveDatabase).setSchedulerQueueName(schedulerQueueName)
+      .setExploreAsPrincipal(exploreAsPrincipal);
     namespaceClient.create(builder.build());
     output.println(String.format(SUCCESS_MSG, name));
   }
@@ -66,7 +69,7 @@ public class CreateNamespaceCommand extends AbstractCommand {
   @Override
   public String getPattern() {
     return String.format("create namespace <%s> [%s <%s>] [%s <%s>] [%s <%s>] " +
-                           "[%s <%s>] [%s <%s>] [%s <%s>] [%s <%s>] [%s <%s>]", ArgumentName.NAMESPACE_NAME,
+                           "[%s <%s>] [%s <%s>] [%s <%s>] [%s <%s>] [%s <%s>] [%s <%s>]", ArgumentName.NAMESPACE_NAME,
                          ArgumentName.DESCRIPTION, ArgumentName.DESCRIPTION,
                          ArgumentName.PRINCIPAL, ArgumentName.PRINCIPAL,
                          ArgumentName.NAMESPACE_GROUP_NAME, ArgumentName.NAMESPACE_GROUP_NAME,
@@ -74,7 +77,8 @@ public class CreateNamespaceCommand extends AbstractCommand {
                          ArgumentName.NAMESPACE_HBASE_NAMESPACE, ArgumentName.NAMESPACE_HBASE_NAMESPACE,
                          ArgumentName.NAMESPACE_HIVE_DATABASE, ArgumentName.NAMESPACE_HIVE_DATABASE,
                          ArgumentName.NAMESPACE_ROOT_DIR, ArgumentName.NAMESPACE_ROOT_DIR,
-                         ArgumentName.NAMESPACE_SCHEDULER_QUEUENAME, ArgumentName.NAMESPACE_SCHEDULER_QUEUENAME);
+                         ArgumentName.NAMESPACE_SCHEDULER_QUEUENAME, ArgumentName.NAMESPACE_SCHEDULER_QUEUENAME,
+                         ArgumentName.NAMESPACE_EXPLORE_AS_PRINCIPAL, ArgumentName.NAMESPACE_EXPLORE_AS_PRINCIPAL);
   }
 
   @Override

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DescribeNamespaceCommand.java
@@ -25,6 +25,7 @@ import co.cask.cdap.cli.util.AbstractCommand;
 import co.cask.cdap.cli.util.RowMaker;
 import co.cask.cdap.cli.util.table.Table;
 import co.cask.cdap.client.NamespaceClient;
+import co.cask.cdap.proto.NamespaceConfig;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.common.cli.Arguments;
@@ -37,6 +38,8 @@ import java.util.List;
 
 /**
  * {@link Command} to describe a namespace.
+ * Uses {@link NamespaceCommandUtils#prettyPrintNamespaceConfigCLI(NamespaceConfig)} to display the
+ * {@link NamespaceConfig}.
  */
 public class DescribeNamespaceCommand extends AbstractCommand {
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListNamespacesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/ListNamespacesCommand.java
@@ -22,6 +22,7 @@ import co.cask.cdap.cli.util.AbstractCommand;
 import co.cask.cdap.cli.util.RowMaker;
 import co.cask.cdap.cli.util.table.Table;
 import co.cask.cdap.client.NamespaceClient;
+import co.cask.cdap.proto.NamespaceConfig;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.common.cli.Arguments;
 import co.cask.common.cli.Command;
@@ -33,6 +34,8 @@ import java.util.List;
 
 /**
  * {@link Command} to list namespaces.
+ * Uses {@link NamespaceCommandUtils#prettyPrintNamespaceConfigCLI(NamespaceConfig)} to display the
+ * {@link NamespaceConfig}.
  */
 public class ListNamespacesCommand extends AbstractCommand {
 

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/NamespaceCommandUtils.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/NamespaceCommandUtils.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.cli.command;
 
+import co.cask.cdap.cli.ArgumentName;
 import co.cask.cdap.proto.NamespaceConfig;
 
 /**
@@ -34,22 +35,36 @@ public final class NamespaceCommandUtils {
   public static String prettyPrintNamespaceConfigCLI(NamespaceConfig namespaceConfig) {
     StringBuilder builder = new StringBuilder();
     if (!namespaceConfig.getSchedulerQueueName().isEmpty()) {
-      builder.append("scheduler-queue-name='").append(namespaceConfig.getSchedulerQueueName()).append("', ");
+      builder.append(ArgumentName.NAMESPACE_SCHEDULER_QUEUENAME);
+      builder.append("='").append(namespaceConfig.getSchedulerQueueName()).append("', ");
     }
     if (namespaceConfig.getRootDirectory() != null) {
-      builder.append("root-directory='").append(namespaceConfig.getRootDirectory()).append("', ");
+      builder.append(ArgumentName.NAMESPACE_ROOT_DIR);
+      builder.append("='").append(namespaceConfig.getRootDirectory()).append("', ");
     }
     if (namespaceConfig.getHbaseNamespace() != null) {
-      builder.append("hbase-namespace='").append(namespaceConfig.getHbaseNamespace()).append("', ");
+      builder.append(ArgumentName.NAMESPACE_HBASE_NAMESPACE);
+      builder.append("='").append(namespaceConfig.getHbaseNamespace()).append("', ");
     }
     if (namespaceConfig.getHiveDatabase() != null) {
-      builder.append("hive-database='").append(namespaceConfig.getHiveDatabase()).append("', ");
+      builder.append(ArgumentName.NAMESPACE_HIVE_DATABASE);
+      builder.append("='").append(namespaceConfig.getHiveDatabase()).append("', ");
     }
     if (namespaceConfig.getPrincipal() != null) {
-      builder.append("principal='").append(namespaceConfig.getPrincipal()).append("', ");
+      builder.append(ArgumentName.PRINCIPAL);
+      builder.append("='").append(namespaceConfig.getPrincipal()).append("', ");
     }
     if (namespaceConfig.getKeytabURI() != null) {
-      builder.append("keytab-URI='").append(namespaceConfig.getKeytabURI()).append("', ");
+      builder.append(ArgumentName.NAMESPACE_KEYTAB_PATH);
+      builder.append("='").append(namespaceConfig.getKeytabURI()).append("', ");
+    }
+    if (namespaceConfig.getGroupName() != null) {
+      builder.append(ArgumentName.NAMESPACE_GROUP_NAME);
+      builder.append("='").append(namespaceConfig.getGroupName()).append("', ");
+    }
+    if (namespaceConfig.isExploreAsPrincipal() != null) {
+      builder.append(ArgumentName.NAMESPACE_EXPLORE_AS_PRINCIPAL);
+      builder.append("='").append(namespaceConfig.isExploreAsPrincipal()).append("', ");
     }
     // Remove the final ", "
     if (builder.length() > 0) {

--- a/cdap-common/src/main/java/co/cask/cdap/common/FeatureDisabledException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/FeatureDisabledException.java
@@ -28,23 +28,23 @@ public class FeatureDisabledException extends Exception implements HttpErrorStat
    */
   public enum Feature {
     AUTHENTICATION,
-    AUTHORIZATION
+    AUTHORIZATION,
+    EXPLORE
   }
 
   public static final String CDAP_SITE = "cdap-site.xml";
 
   private final Feature feature;
-  private final String configFile;
+  private final String configName;
   private final String enableConfigKey;
   private final String enableConfigValue;
 
-  public FeatureDisabledException(Feature feature, String configFile, String enableConfigKey,
+  public FeatureDisabledException(Feature feature, String configName, String enableConfigKey,
                                   String enableConfigValue) {
-    super(String.format("Feature '%s' is not enabled. Please set '%s' to '%s' in the config file '%s' to " +
-                          "enable this feature.", feature.name().toLowerCase(), enableConfigKey, enableConfigValue,
-                        configFile));
+    super(String.format("Feature '%s' is not enabled. Please set '%s' to '%s' in the '%s' to enable this feature.",
+                        feature.name().toLowerCase(), enableConfigKey, enableConfigValue, configName));
     this.feature = feature;
-    this.configFile = configFile;
+    this.configName = configName;
     this.enableConfigKey = enableConfigKey;
     this.enableConfigValue = enableConfigValue;
   }
@@ -53,8 +53,8 @@ public class FeatureDisabledException extends Exception implements HttpErrorStat
     return feature;
   }
 
-  public String getConfigFile() {
-    return configFile;
+  public String getConfigName() {
+    return configName;
   }
 
   public String getEnableConfigKey() {

--- a/cdap-common/src/main/java/co/cask/cdap/common/kerberos/ImpersonatedOpType.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/kerberos/ImpersonatedOpType.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.kerberos;
+
+import co.cask.cdap.api.annotation.Beta;
+
+/**
+ * A Enum which can represent categorizes different types of operations which are performed with impersonation.
+ * Currently, explore queries running inside a namespace is categorized as {@link #EXPLORE} and all other operations
+ * as {@link #OTHER}.
+ */
+@Beta
+public enum ImpersonatedOpType {
+  EXPLORE,
+  OTHER
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/kerberos/ImpersonationInfo.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/kerberos/ImpersonationInfo.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.common.kerberos;
 
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
  * Encapsulates information necessary to impersonate a user - principal and keytab path.
@@ -28,7 +29,7 @@ public final class ImpersonationInfo {
   /**
    * Creates {@link ImpersonationInfo} using the specified principal and keytab path.
    */
-  public ImpersonationInfo(String principal, String keytabURI) {
+  public ImpersonationInfo(String principal, @Nullable String keytabURI) {
     this.principal = principal;
     this.keytabURI = keytabURI;
   }
@@ -37,6 +38,7 @@ public final class ImpersonationInfo {
     return principal;
   }
 
+  @Nullable
   public String getKeytabURI() {
     return keytabURI;
   }

--- a/cdap-common/src/main/java/co/cask/cdap/common/kerberos/OwnerAdmin.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/kerberos/OwnerAdmin.java
@@ -97,13 +97,14 @@ public interface OwnerAdmin {
    * </p>
    *
    * @param entityId the {@link EntityId} whose owner principal information needs to be retrieved
+   * @param impersonatedOpType the type of operation which is being impersonated
    * @return {@link ImpersonationInfo} of the effective owner for the given entity. Its keytab URI may be null.
-   *
    * @throws IOException if  failed to get the store
    * @throws IllegalArgumentException if the given entity is not of supported type.
    */
   @Nullable
-  ImpersonationInfo getImpersonationInfo(NamespacedEntityId entityId) throws IOException;
+  ImpersonationInfo getImpersonationInfo(NamespacedEntityId entityId,
+                                         ImpersonatedOpType impersonatedOpType) throws IOException;
 
   /**
    * Checks if owner information exists or not

--- a/cdap-common/src/main/java/co/cask/cdap/common/kerberos/SecurityUtil.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/kerberos/SecurityUtil.java
@@ -236,8 +236,9 @@ public final class SecurityUtil {
    * </ul>
    */
   public static ImpersonationInfo createImpersonationInfo(OwnerAdmin ownerAdmin, CConfiguration cConf,
-                                                          NamespacedEntityId entityId) throws IOException {
-    ImpersonationInfo impersonationInfo = ownerAdmin.getImpersonationInfo(entityId);
+                                                          NamespacedEntityId entityId,
+                                                          ImpersonatedOpType impersonatedOpType) throws IOException {
+    ImpersonationInfo impersonationInfo = ownerAdmin.getImpersonationInfo(entityId, impersonatedOpType);
     if (impersonationInfo == null) {
       return new ImpersonationInfo(getMasterPrincipal(cConf), getMasterKeytabURI(cConf));
     }

--- a/cdap-common/src/test/java/co/cask/cdap/common/kerberos/NoOpOwnerAdmin.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/kerberos/NoOpOwnerAdmin.java
@@ -49,7 +49,8 @@ public class NoOpOwnerAdmin implements OwnerAdmin {
 
   @Nullable
   @Override
-  public ImpersonationInfo getImpersonationInfo(NamespacedEntityId entityId) throws IOException {
+  public ImpersonationInfo getImpersonationInfo(NamespacedEntityId entityId,
+                                                ImpersonatedOpType impersonatedOpType) throws IOException {
     return null;
   }
 

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/AbstractExploreQueryExecutorHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/AbstractExploreQueryExecutorHttpHandler.java
@@ -44,8 +44,8 @@ import java.util.Map;
 /**
  * An abstract class that provides common functionality for namespaced and non-namespaced ExploreQuery handlers.
  */
-public class AbstractQueryExecutorHttpHandler extends AbstractHttpHandler {
-  private static final Logger LOG = LoggerFactory.getLogger(AbstractQueryExecutorHttpHandler.class);
+public class AbstractExploreQueryExecutorHttpHandler extends AbstractHttpHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractExploreQueryExecutorHttpHandler.class);
   private static final Gson GSON = new Gson();
   private static final Type STRING_MAP_TYPE = new TypeToken<Map<String, String>>() { }.getType();
 

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorService.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreExecutorService.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Set;
 
 /**
- * Provides various REST endpoints to execute SQL commands via {@link NamespacedQueryExecutorHttpHandler}.
+ * Provides various REST endpoints to execute SQL commands via {@link NamespacedExploreQueryExecutorHttpHandler}.
  * In charge of starting and stopping the {@link co.cask.cdap.explore.service.ExploreService}.
  */
 public class ExploreExecutorService extends AbstractIdleService {

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreQueryExecutorHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/ExploreQueryExecutorHttpHandler.java
@@ -50,13 +50,13 @@ import javax.ws.rs.PathParam;
  *
  */
 @Path(Constants.Gateway.API_VERSION_3)
-public class QueryExecutorHttpHandler extends AbstractQueryExecutorHttpHandler {
-  private static final Logger LOG = LoggerFactory.getLogger(QueryExecutorHttpHandler.class);
+public class ExploreQueryExecutorHttpHandler extends AbstractExploreQueryExecutorHttpHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(ExploreQueryExecutorHttpHandler.class);
 
   private final ExploreService exploreService;
 
   @Inject
-  QueryExecutorHttpHandler(ExploreService exploreService) {
+  ExploreQueryExecutorHttpHandler(ExploreService exploreService) {
     this.exploreService = exploreService;
   }
 

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/NamespacedExploreQueryExecutorHttpHandler.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/NamespacedExploreQueryExecutorHttpHandler.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.explore.executor;
 
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.kerberos.ImpersonatedOpType;
 import co.cask.cdap.common.security.AuditDetail;
 import co.cask.cdap.common.security.AuditPolicy;
 import co.cask.cdap.explore.service.ExploreException;
@@ -49,14 +50,14 @@ import javax.ws.rs.QueryParam;
  * Provides REST endpoints for {@link ExploreService} operations.
  */
 @Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
-public class NamespacedQueryExecutorHttpHandler extends AbstractQueryExecutorHttpHandler {
-  private static final Logger LOG = LoggerFactory.getLogger(NamespacedQueryExecutorHttpHandler.class);
+public class NamespacedExploreQueryExecutorHttpHandler extends AbstractExploreQueryExecutorHttpHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(NamespacedExploreQueryExecutorHttpHandler.class);
 
   private final ExploreService exploreService;
   private final Impersonator impersonator;
 
   @Inject
-  public NamespacedQueryExecutorHttpHandler(ExploreService exploreService, Impersonator impersonator) {
+  public NamespacedExploreQueryExecutorHttpHandler(ExploreService exploreService, Impersonator impersonator) {
     this.exploreService = exploreService;
     this.impersonator = impersonator;
   }
@@ -77,7 +78,7 @@ public class NamespacedQueryExecutorHttpHandler extends AbstractQueryExecutorHtt
         public QueryHandle call() throws Exception {
           return exploreService.execute(new NamespaceId(namespaceId), query, additionalSessionConf);
         }
-      });
+      }, ImpersonatedOpType.EXPLORE);
       responder.sendJson(HttpResponseStatus.OK, queryHandle);
     } catch (IllegalArgumentException e) {
       LOG.debug("Got exception:", e);

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/executor/QueryResultsBodyProducer.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/executor/QueryResultsBodyProducer.java
@@ -79,7 +79,7 @@ final class QueryResultsBodyProducer extends BodyProducer {
     }
     writer.flush();
 
-    results = exploreService.nextResults(handle, AbstractQueryExecutorHttpHandler.DOWNLOAD_FETCH_CHUNK_SIZE);
+    results = exploreService.nextResults(handle, AbstractExploreQueryExecutorHttpHandler.DOWNLOAD_FETCH_CHUNK_SIZE);
     return buffer;
   }
 
@@ -88,7 +88,7 @@ final class QueryResultsBodyProducer extends BodyProducer {
 
     results = exploreService.previewResults(handle);
     if (results.isEmpty()) {
-      results = exploreService.nextResults(handle, AbstractQueryExecutorHttpHandler.DOWNLOAD_FETCH_CHUNK_SIZE);
+      results = exploreService.nextResults(handle, AbstractExploreQueryExecutorHttpHandler.DOWNLOAD_FETCH_CHUNK_SIZE);
     }
   }
 

--- a/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
+++ b/cdap-explore/src/main/java/co/cask/cdap/explore/guice/ExploreRuntimeModule.java
@@ -22,10 +22,10 @@ import co.cask.cdap.common.runtime.RuntimeModule;
 import co.cask.cdap.explore.executor.ExploreExecutorHttpHandler;
 import co.cask.cdap.explore.executor.ExploreExecutorService;
 import co.cask.cdap.explore.executor.ExploreMetadataHttpHandler;
+import co.cask.cdap.explore.executor.ExploreQueryExecutorHttpHandler;
 import co.cask.cdap.explore.executor.ExploreStatusHandler;
 import co.cask.cdap.explore.executor.NamespacedExploreMetadataHttpHandler;
-import co.cask.cdap.explore.executor.NamespacedQueryExecutorHttpHandler;
-import co.cask.cdap.explore.executor.QueryExecutorHttpHandler;
+import co.cask.cdap.explore.executor.NamespacedExploreQueryExecutorHttpHandler;
 import co.cask.cdap.explore.service.ExploreService;
 import co.cask.cdap.explore.service.ExploreServiceUtils;
 import co.cask.cdap.explore.service.hive.Hive14ExploreService;
@@ -88,8 +88,8 @@ public class ExploreRuntimeModule extends RuntimeModule {
       Named exploreSeriveName = Names.named(Constants.Service.EXPLORE_HTTP_USER_SERVICE);
       Multibinder<HttpHandler> handlerBinder =
           Multibinder.newSetBinder(binder(), HttpHandler.class, exploreSeriveName);
-      handlerBinder.addBinding().to(NamespacedQueryExecutorHttpHandler.class);
-      handlerBinder.addBinding().to(QueryExecutorHttpHandler.class);
+      handlerBinder.addBinding().to(NamespacedExploreQueryExecutorHttpHandler.class);
+      handlerBinder.addBinding().to(ExploreQueryExecutorHttpHandler.class);
       handlerBinder.addBinding().to(NamespacedExploreMetadataHttpHandler.class);
       handlerBinder.addBinding().to(ExploreMetadataHttpHandler.class);
       handlerBinder.addBinding().to(ExploreExecutorHttpHandler.class);

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterAuditLookUpTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterAuditLookUpTest.java
@@ -99,7 +99,7 @@ public class RouterAuditLookUpTest {
     // endpoints from NamespacedExploreMetadataHttpHandler
     assertContent("/v3/namespaces/default/data/explore/jdbc/tables",
                   new AuditLogContent(HttpMethod.POST, true, false, EMPTY_HEADERS));
-    // endpoints from NamespacedQueryExecutorHttpHandler
+    // endpoints from NamespacedExploreQueryExecutorHttpHandler
     assertContent("/v3/namespaces/default/data/explore/queries",
                   new AuditLogContent(HttpMethod.POST, true, false, EMPTY_HEADERS));
   }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceConfig.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceConfig.java
@@ -32,6 +32,7 @@ public class NamespaceConfig {
   public static final String ROOT_DIRECTORY = "root.directory";
   public static final String HBASE_NAMESPACE = "hbase.namespace";
   public static final String HIVE_DATABASE = "hive.database";
+  public static final String EXPLORE_AS_PRINCIPAL = "explore.as.principal";
 
   @SerializedName(SCHEDULER_QUEUE_NAME)
   private final String schedulerQueueName;
@@ -45,6 +46,9 @@ public class NamespaceConfig {
   @SerializedName(HIVE_DATABASE)
   private final String hiveDatabase;
 
+  @SerializedName(EXPLORE_AS_PRINCIPAL)
+  private final Boolean exploreAsPrincipal;
+
   private final String principal;
   private final String groupName;
   private final String keytabURI;
@@ -54,6 +58,13 @@ public class NamespaceConfig {
   public NamespaceConfig(String schedulerQueueName, @Nullable String rootDirectory,
                          @Nullable String hbaseNamespace, @Nullable String hiveDatabase,
                          @Nullable String principal, @Nullable String groupName, @Nullable String keytabURI) {
+    this(schedulerQueueName, rootDirectory, hbaseNamespace, hiveDatabase, principal, groupName, keytabURI, true);
+  }
+
+  public NamespaceConfig(String schedulerQueueName, @Nullable String rootDirectory,
+                         @Nullable String hbaseNamespace, @Nullable String hiveDatabase,
+                         @Nullable String principal, @Nullable String groupName, @Nullable String keytabURI,
+                         boolean exploreAsPrincipal) {
     this.schedulerQueueName = schedulerQueueName;
     this.rootDirectory = rootDirectory;
     this.hbaseNamespace = hbaseNamespace;
@@ -61,6 +72,7 @@ public class NamespaceConfig {
     this.principal = principal;
     this.groupName = groupName;
     this.keytabURI = keytabURI;
+    this.exploreAsPrincipal = exploreAsPrincipal;
   }
 
   public String getSchedulerQueueName() {
@@ -94,6 +106,10 @@ public class NamespaceConfig {
   @Nullable
   public String getKeytabURI() {
     return keytabURI;
+  }
+
+  public Boolean isExploreAsPrincipal() {
+    return exploreAsPrincipal == null || exploreAsPrincipal;
   }
 
   public Set<String> getDifference(@Nullable NamespaceConfig other) {
@@ -144,13 +160,15 @@ public class NamespaceConfig {
       Objects.equals(hiveDatabase, other.hiveDatabase) &&
       Objects.equals(principal, other.principal) &&
       Objects.equals(groupName, other.groupName) &&
-      Objects.equals(keytabURI, other.keytabURI);
+      Objects.equals(keytabURI, other.keytabURI) &&
+      Objects.equals(exploreAsPrincipal, other.exploreAsPrincipal);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-      schedulerQueueName, rootDirectory, hbaseNamespace, hiveDatabase, principal, groupName, keytabURI);
+      schedulerQueueName, rootDirectory, hbaseNamespace, hiveDatabase, principal, groupName, keytabURI,
+      exploreAsPrincipal);
   }
 
   @Override
@@ -163,6 +181,7 @@ public class NamespaceConfig {
       ", principal='" + principal + '\'' +
       ", groupName='" + groupName + '\'' +
       ", keytabURI='" + keytabURI + '\'' +
+      ", exploreAsPrincipal='" + exploreAsPrincipal + '\'' +
       '}';
   }
 }

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceMeta.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/NamespaceMeta.java
@@ -63,6 +63,7 @@ public final class NamespaceMeta {
     private String principal;
     private String groupName;
     private String keytabURI;
+    private boolean exploreAsPrincipal = true;
 
     public Builder() {
       // No-Op
@@ -80,6 +81,7 @@ public final class NamespaceMeta {
         this.principal = config.getPrincipal();
         this.groupName = config.getGroupName();
         this.keytabURI = config.getKeytabURI();
+        this.exploreAsPrincipal = config.isExploreAsPrincipal();
       }
     }
 
@@ -138,6 +140,11 @@ public final class NamespaceMeta {
       return this;
     }
 
+    public Builder setExploreAsPrincipal(boolean exploreAsPrincipal) {
+      this.exploreAsPrincipal = exploreAsPrincipal;
+      return this;
+    }
+
     public NamespaceMeta build() {
       if (name == null) {
         throw new IllegalArgumentException("Namespace id cannot be null.");
@@ -154,7 +161,8 @@ public final class NamespaceMeta {
 
       return new NamespaceMeta(name, description, new NamespaceConfig(schedulerQueueName, rootDirectory,
                                                                       hbaseNamespace, hiveDatabase,
-                                                                      principal, groupName, keytabURI));
+                                                                      principal, groupName, keytabURI,
+                                                                      exploreAsPrincipal));
     }
   }
 

--- a/cdap-proto/src/test/java/co/cask/cdap/proto/NamespaceConfigTest.java
+++ b/cdap-proto/src/test/java/co/cask/cdap/proto/NamespaceConfigTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto;
+
+import com.google.gson.Gson;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link NamespaceConfig}
+ */
+public class NamespaceConfigTest {
+
+  private static final Gson GSON = new Gson();
+
+  /**
+   * Test {@link NamespaceConfig} deserialization
+   */
+  @Test
+  public void testNamespaceConfigDeserialize() throws Exception {
+
+    // test that if explore.as.principal is not provided then the default value does get set to true
+    String namespaceConfigWithoutExplore = "{\"scheduler.queue.name\":\"someQueue\",\"root.directory\":\"someRoot\"," +
+      "\"hbase.namespace\":\"someHbase\",\"hive.database\":\"someHive\"}";
+    NamespaceConfig namespaceConfig = GSON.fromJson(namespaceConfigWithoutExplore, NamespaceConfig.class);
+    Assert.assertTrue(namespaceConfig.isExploreAsPrincipal());
+
+    // test that if explore.as.principal is provided as false its retained
+    String namespaceConfigWithExplore = "{\"scheduler.queue.name\":\"somequeue\",\"root.directory\":\"some\"," +
+      "\"explore.as.principal\":false}";
+    namespaceConfig = GSON.fromJson(namespaceConfigWithExplore, NamespaceConfig.class);
+    Assert.assertFalse(namespaceConfig.isExploreAsPrincipal());
+  }
+}

--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/Impersonator.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/Impersonator.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.security.impersonation;
 
 import co.cask.cdap.common.NamespaceNotFoundException;
+import co.cask.cdap.common.kerberos.ImpersonatedOpType;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import com.google.inject.ImplementedBy;
@@ -44,6 +45,20 @@ public interface Impersonator {
    * @throws Exception if the callable throws any exception
    */
   <T> T doAs(NamespacedEntityId entityId, Callable<T> callable) throws Exception;
+
+  /**
+   * Executes a callable as the user, configurable at a namespace level
+   *
+   * @param entityId the entity to use to lookup the user to impersonate
+   * @param callable the callable to execute
+   * @param <T> return type of the callable
+   * @param impersonatedOpType {@link ImpersonatedOpType} representing the type of the operation which is
+   * being impersonated
+   *
+   * @return the return value of the callable
+   * @throws Exception if the callable throws any exception
+   */
+  <T> T doAs(NamespacedEntityId entityId, Callable<T> callable, ImpersonatedOpType impersonatedOpType) throws Exception;
 
   /**
    * Retrieve the {@link UserGroupInformation} for the given {@link NamespaceId}


### PR DESCRIPTION
- Adds a config ``explore.as.principal`` in NamespaceConfig which is used to determine whether the explore queries can run in the namespace impersonating the namespace owner. 
- By default value is true representing that explore queries can run by impersonating the namespace owner.
- User can specify it to be false to disallow running explore queries in the namespace by impersonating namespace owner.
- Support for this in CLI.

Note: This is not yet tested on cluster. I am doing it now.

Issue: https://issues.cask.co/browse/CDAP-8355
Build: http://builds.cask.co/browse/CDAP-RUT530-1
