### PR TITLE
[CDAP-8407] Read keytab for namespace principal from namespace config

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ImpersonationHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ImpersonationHandler.java
@@ -17,8 +17,8 @@
 package co.cask.cdap.gateway.handlers;
 
 import co.cask.cdap.common.BadRequestException;
+import co.cask.cdap.common.kerberos.ImpersonationInfo;
 import co.cask.cdap.security.TokenSecureStoreUpdater;
-import co.cask.cdap.security.impersonation.ImpersonationInfo;
 import co.cask.cdap.security.impersonation.ImpersonationUtils;
 import co.cask.cdap.security.impersonation.UGIProvider;
 import co.cask.http.AbstractHttpHandler;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -40,7 +40,6 @@ import co.cask.cdap.proto.id.InstanceId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
-import co.cask.cdap.security.impersonation.ImpersonationInfo;
 import co.cask.cdap.security.impersonation.ImpersonationUtils;
 import co.cask.cdap.security.impersonation.Impersonator;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
@@ -170,7 +169,7 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
     if (SecurityUtil.isKerberosEnabled(cConf) && !NamespaceId.SYSTEM.equals(namespace)) {
       String namespacePrincipal = metadata.getConfig().getPrincipal();
       if (Strings.isNullOrEmpty(namespacePrincipal)) {
-        executionUserName = ImpersonationInfo.getMasterImpersonationInfo(cConf).getPrincipal();
+        executionUserName = SecurityUtil.getMasterPrincipal(cConf);
       } else {
         executionUserName = new KerberosName(namespacePrincipal).getShortName();
       }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/PropertiesResolver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/PropertiesResolver.java
@@ -19,13 +19,12 @@ package co.cask.cdap.internal.app.services;
 import co.cask.cdap.app.runtime.scheduler.SchedulerQueueResolver;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.kerberos.ImpersonationInfo;
 import co.cask.cdap.common.kerberos.OwnerAdmin;
 import co.cask.cdap.common.kerberos.SecurityUtil;
 import co.cask.cdap.config.PreferencesStore;
 import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.proto.Id;
-import co.cask.cdap.proto.id.KerberosPrincipalId;
-import co.cask.cdap.security.impersonation.ImpersonationInfo;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 
@@ -63,13 +62,7 @@ public class PropertiesResolver {
     systemArgs.put(Constants.CLUSTER_NAME, cConf.get(Constants.CLUSTER_NAME, ""));
     systemArgs.put(Constants.AppFabric.APP_SCHEDULER_QUEUE, queueResolver.getQueue(id.getNamespace()));
     if (SecurityUtil.isKerberosEnabled(cConf)) {
-      ImpersonationInfo impersonationInfo;
-      KerberosPrincipalId principalId = ownerAdmin.getEffectiveOwner(id.toEntityId());
-      if (principalId == null) {
-        impersonationInfo = ImpersonationInfo.getMasterImpersonationInfo(cConf);
-      } else {
-        impersonationInfo = new ImpersonationInfo(principalId.getPrincipal(), cConf);
-      }
+      ImpersonationInfo impersonationInfo = SecurityUtil.createImpersonationInfo(ownerAdmin, cConf, id.toEntityId());
       systemArgs.put(ProgramOptionConstants.PRINCIPAL, impersonationInfo.getPrincipal());
       systemArgs.put(ProgramOptionConstants.KEYTAB_URI, impersonationInfo.getKeytabURI());
     }

--- a/cdap-common/src/main/java/co/cask/cdap/common/kerberos/ImpersonationInfo.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/kerberos/ImpersonationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2017 Cask Data, Inc.
+ * Copyright © 2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,13 +14,8 @@
  * the License.
  */
 
-package co.cask.cdap.security.impersonation;
+package co.cask.cdap.common.kerberos;
 
-import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.kerberos.SecurityUtil;
-
-import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -33,22 +28,9 @@ public final class ImpersonationInfo {
   /**
    * Creates {@link ImpersonationInfo} using the specified principal and keytab path.
    */
-  public ImpersonationInfo(String principal, CConfiguration cConf) throws IOException {
-    this.principal = principal;
-    this.keytabURI = SecurityUtil.getKeytabURIforPrincipal(principal, cConf);
-  }
-
-  /**
-   * Creates {@link ImpersonationInfo} using the specified principal and keytab path.
-   */
   public ImpersonationInfo(String principal, String keytabURI) {
     this.principal = principal;
     this.keytabURI = keytabURI;
-  }
-
-  public static ImpersonationInfo getMasterImpersonationInfo(CConfiguration cConf) {
-    return new ImpersonationInfo(cConf.get(Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL),
-                                 cConf.get(Constants.Security.CFG_CDAP_MASTER_KRB_KEYTAB_PATH));
   }
 
   public String getPrincipal() {

--- a/cdap-common/src/main/java/co/cask/cdap/common/kerberos/OwnerAdmin.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/kerberos/OwnerAdmin.java
@@ -84,21 +84,26 @@ public interface OwnerAdmin {
 
   /**
    * <p>
-   * Retrieves the owner information for the given {@link EntityId} by tracing the entity hierarchy.
+   * Retrieves the impersonation information for the given {@link EntityId} by tracing the entity hierarchy.
    * </p>
    * <p>
-   * If an owner is present for this entity id then returns the {@link KerberosPrincipalId} of that immediate owner.
-   * If a direct owner is not present then the namespace owner {@link KerberosPrincipalId} will be returned if
+   * If an owner is present for this entity id then returns the information of that immediate owner.
+   * If a direct owner is not present then the namespace owner information will be returned if
    * one is present else returns null.
+   * </p>
    * <p>
+   * The returned {@link ImpersonationInfo} may have null as the keytab URI, if this owner admin does not
+   * have knowledge about that URI. In this case, it is the caller's responsibility to determine the keytab URI.
+   * </p>
    *
    * @param entityId the {@link EntityId} whose owner principal information needs to be retrieved
-   * @return {@link KerberosPrincipalId} of the effective owner for the given entity
+   * @return {@link ImpersonationInfo} of the effective owner for the given entity. Its keytab URI may be null.
+   *
    * @throws IOException if  failed to get the store
    * @throws IllegalArgumentException if the given entity is not of supported type.
    */
   @Nullable
-  KerberosPrincipalId getEffectiveOwner(NamespacedEntityId entityId) throws IOException;
+  ImpersonationInfo getImpersonationInfo(NamespacedEntityId entityId) throws IOException;
 
   /**
    * Checks if owner information exists or not

--- a/cdap-common/src/test/java/co/cask/cdap/common/kerberos/NoOpOwnerAdmin.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/kerberos/NoOpOwnerAdmin.java
@@ -49,7 +49,7 @@ public class NoOpOwnerAdmin implements OwnerAdmin {
 
   @Nullable
   @Override
-  public KerberosPrincipalId getEffectiveOwner(NamespacedEntityId entityId) throws IOException {
+  public ImpersonationInfo getImpersonationInfo(NamespacedEntityId entityId) throws IOException {
     return null;
   }
 

--- a/cdap-common/src/test/java/co/cask/cdap/common/kerberos/SecurityUtilTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/kerberos/SecurityUtilTest.java
@@ -24,8 +24,6 @@ import org.junit.Test;
 import java.io.IOException;
 import java.net.InetAddress;
 
-import static co.cask.cdap.common.kerberos.SecurityUtil.getKeytabURIforPrincipal;
-
 /**
  * Tests for {@link SecurityUtil}
  */
@@ -72,7 +70,7 @@ public class SecurityUtilTest {
     cConf.set(Constants.Security.KEYTAB_PATH, confPath);
     cConf.set("user", "blah blah");
 
-    String path = getKeytabURIforPrincipal(user, cConf);
+    String path = SecurityUtil.getKeytabURIforPrincipal(user, cConf);
     Assert.assertEquals(expectedPath, path);
   }
 }

--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/AbstractCachedUGIProvider.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/AbstractCachedUGIProvider.java
@@ -18,6 +18,7 @@ package co.cask.cdap.security.impersonation;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.kerberos.ImpersonationInfo;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;

--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/CurrentUGIProvider.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/CurrentUGIProvider.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.security.impersonation;
 
+import co.cask.cdap.common.kerberos.ImpersonationInfo;
 import org.apache.hadoop.security.UserGroupInformation;
 
 import java.io.IOException;

--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/DefaultImpersonator.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/DefaultImpersonator.java
@@ -18,10 +18,9 @@ package co.cask.cdap.security.impersonation;
 
 import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.kerberos.ImpersonationInfo;
 import co.cask.cdap.common.kerberos.OwnerAdmin;
 import co.cask.cdap.common.kerberos.SecurityUtil;
-import co.cask.cdap.proto.id.KerberosPrincipalId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import com.google.common.annotations.VisibleForTesting;
@@ -69,17 +68,11 @@ public class DefaultImpersonator implements Impersonator {
     if (!kerberosEnabled || NamespaceId.SYSTEM.equals(entityId.getNamespaceId())) {
       return UserGroupInformation.getCurrentUser();
     }
-    String principal = cConf.get(Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL);
-    String keytabURI = cConf.get(Constants.Security.CFG_CDAP_MASTER_KRB_KEYTAB_PATH);
     try {
-      KerberosPrincipalId principalId = ownerAdmin.getEffectiveOwner(entityId);
-      // If an effective owner was not found then the operation will be performed as the configured master user
-      if (principalId != null) {
-        principal = principalId.getPrincipal();
-        keytabURI = SecurityUtil.getKeytabURIforPrincipal(principal, cConf);
-      }
-      LOG.debug("Impersonating principal {} for entity {}, keytab path is {}", principal, entityId, keytabURI);
-      return getUGI(new ImpersonationInfo(principal, keytabURI));
+      ImpersonationInfo info = SecurityUtil.createImpersonationInfo(ownerAdmin, cConf, entityId);
+      LOG.debug("Impersonating principal {} for entity {}, keytab path is {}",
+                info.getPrincipal(), entityId, info.getKeytabURI());
+      return getUGI(info);
     } catch (Exception e) {
       Throwables.propagateIfInstanceOf(e, IOException.class);
       throw Throwables.propagate(e);

--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/DefaultUGIProvider.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/DefaultUGIProvider.java
@@ -18,6 +18,7 @@ package co.cask.cdap.security.impersonation;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.kerberos.ImpersonationInfo;
 import co.cask.cdap.common.kerberos.SecurityUtil;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.common.utils.FileUtils;

--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/RemoteUGIProvider.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/RemoteUGIProvider.java
@@ -21,6 +21,7 @@ import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.EndpointStrategy;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.common.http.DefaultHttpRequestConfig;
+import co.cask.cdap.common.kerberos.ImpersonationInfo;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpRequestConfig;
 import co.cask.common.http.HttpRequests;

--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/UGIProvider.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/UGIProvider.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.security.impersonation;
 
+import co.cask.cdap.common.kerberos.ImpersonationInfo;
 import org.apache.hadoop.security.UserGroupInformation;
 
 import java.io.IOException;

--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/UnsupportedUGIProvider.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/UnsupportedUGIProvider.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.security.impersonation;
 
+import co.cask.cdap.common.kerberos.ImpersonationInfo;
 import org.apache.hadoop.security.UserGroupInformation;
 
 import java.io.IOException;

--- a/cdap-security/src/test/java/co/cask/cdap/security/impersonation/UGIProviderTest.java
+++ b/cdap-security/src/test/java/co/cask/cdap/security/impersonation/UGIProviderTest.java
@@ -19,6 +19,7 @@ package co.cask.cdap.security.impersonation;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.Locations;
+import co.cask.cdap.common.kerberos.ImpersonationInfo;
 import co.cask.http.AbstractHttpHandler;
 import co.cask.http.HttpResponder;
 import co.cask.http.NettyHttpService;


### PR DESCRIPTION
- Make sure a namespace principal's keytab path is read from the namespace config.
- This is for backward compatibility with existing namespace impersonation
- Also some refactoring of duplicate code.