### PR TITLE
CDAP-8339:Packaging operational stats jar with standalone

### DIFF
--- a/cdap-operational-stats-core/pom.xml
+++ b/cdap-operational-stats-core/pom.xml
@@ -143,6 +143,22 @@
                   <goal>jar</goal>
                 </goals>
               </execution>
+              <execution>
+                <id>jar-sdk</id>
+                <phase>prepare-package</phase>
+                <configuration combine.self="override">
+                  <outputDirectory>${project.build.directory}</outputDirectory>
+                  <finalName>${project.groupId}.${project.build.finalName}.sdk</finalName>
+                  <excludes>
+                    <exclude>**/hbase/*.class</exclude>
+                    <exclude>**/hdfs/*.class</exclude>
+                    <exclude>**/yarn/*.class</exclude>
+                  </excludes>
+                </configuration>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
             </executions>
           </plugin>
         </plugins>

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -220,6 +220,13 @@
           <version>${project.version}</version>
           <scope>provided</scope>
         </dependency>
+        <!-- Add dependencies on cdap-operational-stats to make sure it is built before standalone -->
+        <dependency>
+          <groupId>co.cask.cdap</groupId>
+          <artifactId>cdap-operational-stats-core</artifactId>
+          <version>${project.version}</version>
+          <scope>provided</scope>
+        </dependency>
       </dependencies>
 
       <build>
@@ -390,6 +397,14 @@
                       <targetPath>ext/runtimes/spark</targetPath>
                       <includes>
                         <include>*.jar</include>
+                      </includes>
+                    </resource>
+                    <!-- copy operational stats extensions -->
+                    <resource>
+                      <directory>${project.parent.basedir}/cdap-operational-stats-core/target</directory>
+                      <targetPath>ext/operations/core</targetPath>
+                      <includes>
+                        <include>*.sdk.jar</include>
                       </includes>
                     </resource>
                   </resources>


### PR DESCRIPTION
Built the SDK locally and verified that `cdap-standalone/target/sdk/cdap-sdk-4.1.0-SNAPSHOT/ext/operations/core/co.cask.cdap.cdap-operational-stats-core-4.1.0-SNAPSHOT.sdk.jar` exists.