### PR TITLE
[CDAP-6690] Pretty-print get dataset properties output in CLI

### DIFF
--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -349,7 +349,7 @@ public class CLIMainTest extends CLITestBase {
     testCommandOutputContains(cli, "create dataset instance " + datasetType.getName() + " " + datasetName + " \"a=1\"",
                               "Successfully created dataset");
     testCommandOutputContains(cli, "list dataset instances", FakeDataset.class.getSimpleName());
-    testCommandOutputContains(cli, "get dataset instance properties " + datasetName, "\"a\":\"1\"");
+    testCommandOutputContains(cli, "get dataset instance properties " + datasetName, "a,1");
 
     NamespaceClient namespaceClient = new NamespaceClient(cliConfig.getClientConfig());
     NamespaceId barspace = new NamespaceId("bar");

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetDatasetInstancePropertiesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/GetDatasetInstancePropertiesCommand.java
@@ -22,21 +22,25 @@ import co.cask.cdap.cli.ElementType;
 import co.cask.cdap.cli.english.Article;
 import co.cask.cdap.cli.english.Fragment;
 import co.cask.cdap.cli.util.AbstractCommand;
+import co.cask.cdap.cli.util.table.Table;
 import co.cask.cdap.client.DatasetClient;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.common.cli.Arguments;
-import com.google.gson.Gson;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 
 import java.io.PrintStream;
+import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Sets properties for a dataset instance.
  */
 public class GetDatasetInstancePropertiesCommand extends AbstractCommand {
 
-  private static final Gson GSON = new Gson();
   private final DatasetClient datasetClient;
 
   @Inject
@@ -51,7 +55,17 @@ public class GetDatasetInstancePropertiesCommand extends AbstractCommand {
       arguments.get(ArgumentName.DATASET.toString()));
 
     Map<String, String> properties = datasetClient.getProperties(instance);
-    output.printf(GSON.toJson(properties));
+    Table table = Table.builder()
+      .setHeader("property", "value")
+      .setRows(Iterables.transform(properties.entrySet(), new Function<Map.Entry<String, String>, List<String>>() {
+        @Nullable
+        @Override
+        public List<String> apply(Map.Entry<String, String> entry) {
+          return ImmutableList.of(entry.getKey(), entry.getValue());
+        }
+      }))
+      .build();
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
   }
 
   @Override


### PR DESCRIPTION
Output now looks like this:
```
cdap (http://MacBook-Pro-2.local:11015/namespace:default)> get dataset instance properties mytable
+=========================================+
| property                       | value  |
+=========================================+
| table.colum.family             | xx     |
| table.conflict.detection.level | COLUMN |
| table.ttl                      | 100    |
+=========================================+
```