### PR TITLE
CDAP-8229 Don't depend on default namespace in UpgradeTool.

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeDatasetServiceManager.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/UpgradeDatasetServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -124,7 +124,7 @@ class UpgradeDatasetServiceManager extends AbstractIdleService {
       @Override
       public Boolean call() throws Exception {
         try {
-          getDSFramework().getInstances(NamespaceId.DEFAULT);
+          getDSFramework().getInstances(NamespaceId.SYSTEM);
           return true;
         } catch (ServiceUnavailableException sue) {
           return false;


### PR DESCRIPTION
[CDAP-8229](https://issues.cask.co/browse/CDAP-8229)  Don't depend on default namespace in UpgradeTool.

Same changes as https://github.com/caskdata/cdap/pull/7870.