### PR TITLE
CDAP-8446 throw correct except if tx service unavaible on finish

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/AbstractTransactionContext.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/AbstractTransactionContext.java
@@ -152,9 +152,27 @@ public abstract class AbstractTransactionContext extends TransactionContext {
         }
       }
       if (success) {
-        txClient.abort(currentTx);
+        try {
+          txClient.abort(currentTx);
+        } catch (Throwable t) {
+          if (cause == null) {
+            cause = new TransactionFailureException(String.format(
+              "Error while calling transaction service to abort transaction %d.", currentTx.getTransactionId()));
+          } else {
+            cause.addSuppressed(t);
+          }
+        }
       } else {
-        txClient.invalidate(currentTx.getTransactionId());
+        try {
+          txClient.invalidate(currentTx.getTransactionId());
+        } catch (Throwable t) {
+          if (cause == null) {
+            cause = new TransactionFailureException(String.format(
+              "Error while calling transaction service to invalidate transaction %d.", currentTx.getTransactionId()));
+          } else {
+            cause.addSuppressed(t);
+          }
+        }
       }
       if (cause != null) {
         throw cause;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/AbstractTransactionContext.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/AbstractTransactionContext.java
@@ -151,27 +151,19 @@ public abstract class AbstractTransactionContext extends TransactionContext {
           success = false;
         }
       }
-      if (success) {
-        try {
+      try {
+        if (success) {
           txClient.abort(currentTx);
-        } catch (Throwable t) {
-          if (cause == null) {
-            cause = new TransactionFailureException(String.format(
-              "Error while calling transaction service to abort transaction %d.", currentTx.getTransactionId()));
-          } else {
-            cause.addSuppressed(t);
-          }
-        }
-      } else {
-        try {
+        } else {
           txClient.invalidate(currentTx.getTransactionId());
-        } catch (Throwable t) {
-          if (cause == null) {
-            cause = new TransactionFailureException(String.format(
-              "Error while calling transaction service to invalidate transaction %d.", currentTx.getTransactionId()));
-          } else {
-            cause.addSuppressed(t);
-          }
+        }
+      } catch (Throwable t) {
+        if (cause == null) {
+          cause = new TransactionFailureException(
+            String.format("Error while calling transaction service to %s transaction %d.",
+                          success ? "abort" : "invalidate", currentTx.getTransactionId()));
+        } else {
+          cause.addSuppressed(t);
         }
       }
       if (cause != null) {


### PR DESCRIPTION
Fixes a bug where a RuntimeException was being thrown instead of
a TransactionFailureException if the tx service is unavailable
when a transaction is being finished.