### PR TITLE
CDAP-8032 retry when connect fails after service discovery

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteLineageWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteLineageWriter.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.internal.app.store.remote;
 
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.internal.remote.RemoteOpsClient;
 import co.cask.cdap.data2.metadata.lineage.AccessType;
@@ -42,8 +41,8 @@ public class RemoteLineageWriter extends RemoteOpsClient implements LineageWrite
   private final ConcurrentMap<BasicLineageWriter.DataAccessKey, Boolean> registered = new ConcurrentHashMap<>();
 
   @Inject
-  RemoteLineageWriter(CConfiguration cConf, DiscoveryServiceClient discoveryClient) {
-    super(cConf, discoveryClient, Constants.Service.REMOTE_SYSTEM_OPERATION);
+  RemoteLineageWriter(DiscoveryServiceClient discoveryClient) {
+    super(discoveryClient, Constants.Service.REMOTE_SYSTEM_OPERATION);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeStore.java
@@ -18,7 +18,6 @@ package co.cask.cdap.internal.app.store.remote;
 
 import co.cask.cdap.api.workflow.WorkflowToken;
 import co.cask.cdap.app.store.RuntimeStore;
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.internal.remote.RemoteOpsClient;
 import co.cask.cdap.proto.BasicThrowable;
@@ -39,8 +38,8 @@ import javax.annotation.Nullable;
 public class RemoteRuntimeStore extends RemoteOpsClient implements RuntimeStore {
 
   @Inject
-  RemoteRuntimeStore(CConfiguration cConf, DiscoveryServiceClient discoveryClient) {
-    super(cConf, discoveryClient, Constants.Service.REMOTE_SYSTEM_OPERATION);
+  RemoteRuntimeStore(DiscoveryServiceClient discoveryClient) {
+    super(discoveryClient, Constants.Service.REMOTE_SYSTEM_OPERATION);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeUsageRegistry.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/remote/RemoteRuntimeUsageRegistry.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.internal.app.store.remote;
 
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.internal.remote.RemoteOpsClient;
 import co.cask.cdap.data2.registry.DatasetUsageKey;
@@ -40,8 +39,8 @@ public class RemoteRuntimeUsageRegistry extends RemoteOpsClient implements Runti
   private final ConcurrentMap<DatasetUsageKey, Boolean> registered = new ConcurrentHashMap<>();
 
   @Inject
-  RemoteRuntimeUsageRegistry(CConfiguration cConf, DiscoveryServiceClient discoveryClient) {
-    super(cConf, discoveryClient, Constants.Service.REMOTE_SYSTEM_OPERATION);
+  RemoteRuntimeUsageRegistry(DiscoveryServiceClient discoveryClient) {
+    super(discoveryClient, Constants.Service.REMOTE_SYSTEM_OPERATION);
   }
 
   @Override

--- a/cdap-common/src/main/java/co/cask/cdap/common/ServiceUnavailableException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/ServiceUnavailableException.java
@@ -27,12 +27,20 @@ public class ServiceUnavailableException extends RetryableException implements H
   private final String serviceName;
 
   public ServiceUnavailableException(String serviceName) {
-    super("Service '" + serviceName + "' is not available. Please wait until it is up and running.");
+    this(serviceName, "Service '" + serviceName + "' is not available. Please wait until it is up and running.");
+  }
+
+  public ServiceUnavailableException(String serviceName, String message) {
+    super(message);
     this.serviceName = serviceName;
   }
 
   public ServiceUnavailableException(String serviceName, Throwable cause) {
-    super("Service '" + serviceName + "' is not available. Please wait until it is up and running.", cause);
+    this(serviceName, "Service '" + serviceName + "' is not available. Please wait until it is up and running.", cause);
+  }
+
+  public ServiceUnavailableException(String serviceName, String message, Throwable cause) {
+    super(message, cause);
     this.serviceName = serviceName;
   }
 

--- a/cdap-common/src/main/java/co/cask/cdap/common/internal/remote/RemoteClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/internal/remote/RemoteClient.java
@@ -50,8 +50,7 @@ public class RemoteClient {
   private final String discoverableServiceName;
   private final String basePath;
 
-  public RemoteClient(final DiscoveryServiceClient discoveryClient,
-                      final String discoverableServiceName,
+  public RemoteClient(final DiscoveryServiceClient discoveryClient, final String discoverableServiceName,
                       HttpRequestConfig httpRequestConfig, String basePath) {
     this.discoverableServiceName = discoverableServiceName;
     this.httpRequestConfig = httpRequestConfig;
@@ -67,12 +66,12 @@ public class RemoteClient {
   }
 
   /**
-   * Discover the service address and use it and the base path and specified resource to generate the URL
-   * to use when making a request to the service.
+   * Create a {@link HttpRequest.Builder} using the specified http method and resource. This client will
+   * discover the service address and combine the specified resource in order to set a URL for the builder.
    *
    * @param method the request method
    * @param resource the request resource
-   * @return a builder to create the http request
+   * @return a builder to create the http request, with method and URL already set
    */
   public HttpRequest.Builder requestBuilder(HttpMethod method, String resource) {
     return HttpRequest.builder(method, resolve(resource));

--- a/cdap-common/src/main/java/co/cask/cdap/common/internal/remote/RemoteClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/internal/remote/RemoteClient.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.internal.remote;
+
+import co.cask.cdap.common.ServiceUnavailableException;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.discovery.EndpointStrategy;
+import co.cask.cdap.common.discovery.RandomEndpointStrategy;
+import co.cask.common.http.HttpMethod;
+import co.cask.common.http.HttpRequest;
+import co.cask.common.http.HttpRequestConfig;
+import co.cask.common.http.HttpRequests;
+import co.cask.common.http.HttpResponse;
+import com.google.common.base.Joiner;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import org.apache.twill.discovery.Discoverable;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Discovers a remote service and resolves URLs to that service.
+ */
+public class RemoteClient {
+  private final Supplier<EndpointStrategy> endpointStrategySupplier;
+  private final HttpRequestConfig httpRequestConfig;
+  private final String discoverableServiceName;
+  private final String basePath;
+
+  public RemoteClient(final DiscoveryServiceClient discoveryClient,
+                      final String discoverableServiceName,
+                      HttpRequestConfig httpRequestConfig, String basePath) {
+    this.discoverableServiceName = discoverableServiceName;
+    this.httpRequestConfig = httpRequestConfig;
+    // Use a supplier to delay the discovery until the first time it is being used.
+    this.endpointStrategySupplier = Suppliers.memoize(new Supplier<EndpointStrategy>() {
+      @Override
+      public EndpointStrategy get() {
+        return new RandomEndpointStrategy(discoveryClient.discover(discoverableServiceName));
+      }
+    });
+    String cleanBasePath = basePath.startsWith("/") ? basePath : "/" + basePath;
+    this.basePath = cleanBasePath.endsWith("/") ? cleanBasePath : cleanBasePath + "/";
+  }
+
+  /**
+   * Discover the service address and use it and the base path and specified resource to generate the URL
+   * to use when making a request to the service.
+   *
+   * @param method the request method
+   * @param resource the request resource
+   * @return a builder to create the http request
+   */
+  public HttpRequest.Builder requestBuilder(HttpMethod method, String resource) {
+    return HttpRequest.builder(method, resolve(resource));
+  }
+
+  /**
+   * Perform the request, returning the response. If there was a ConnectException while making the request,
+   * a ServiceUnavailableException is thrown.
+   *
+   * @param request the request to perform
+   * @return the response
+   * @throws IOException if there was an IOException while performing the request
+   * @throws ServiceUnavailableException if there was a ConnectException while making the request, or if the response
+   *                                     was a 503
+   */
+  public HttpResponse execute(HttpRequest request) throws IOException {
+    try {
+      HttpResponse response = HttpRequests.execute(request, httpRequestConfig);
+      if (response.getResponseCode() == HttpURLConnection.HTTP_UNAVAILABLE) {
+        throw new ServiceUnavailableException(discoverableServiceName, response.getResponseBodyAsString());
+      }
+      return response;
+    } catch (ConnectException e) {
+      throw new ServiceUnavailableException(discoverableServiceName, e);
+    }
+  }
+
+  /**
+   * Discover the service address, then append the base path and specified resource to get the URL.
+   *
+   * @param resource the resource to use
+   * @return the resolved URL
+   * @throws ServiceUnavailableException if the service could not be discovered
+   */
+  public URL resolve(String resource) {
+    Discoverable discoverable = endpointStrategySupplier.get().pick(1L, TimeUnit.SECONDS);
+    if (discoverable == null) {
+      throw new ServiceUnavailableException(discoverableServiceName);
+    }
+    InetSocketAddress address = discoverable.getSocketAddress();
+    String scheme = Arrays.equals(Constants.Security.SSL_URI_SCHEME.getBytes(), discoverable.getPayload()) ?
+      Constants.Security.SSL_URI_SCHEME : Constants.Security.URI_SCHEME;
+    String urlStr = String.format("%s%s:%d%s%s", scheme, address.getHostName(), address.getPort(), basePath, resource);
+    try {
+      return new URL(urlStr);
+    } catch (MalformedURLException e) {
+      // shouldn't happen. If it does, it means there is some bug in the service announcer
+      throw new IllegalStateException(String.format("Discovered service %s, but it announced malformed URL %s",
+                                                    discoverableServiceName, urlStr), e);
+    }
+  }
+
+  /**
+   * Create a generic error message about a failure to make a specified request.
+   *
+   * @param request the request made
+   * @param body the request body if it should be in the error message
+   * @return a generic error message about the failure
+   */
+  public String createErrorMessage(HttpRequest request, @Nullable String body) {
+    String headers = request.getHeaders() == null ?
+      "null" : Joiner.on(",").withKeyValueSeparator("=").join(request.getHeaders().entries());
+    return String.format("Error making request to %s service at %s while doing %s with headers %s%s.",
+                         discoverableServiceName, request.getURL(), request.getMethod(),
+                         headers, body == null ? "" : " and body " + body);
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/internal/remote/RemoteOpsClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/internal/remote/RemoteOpsClient.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.common.internal.remote;
 
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.http.DefaultHttpRequestConfig;
 import co.cask.cdap.proto.BasicThrowable;
 import co.cask.cdap.proto.WorkflowTokenDetail;
@@ -50,7 +49,7 @@ public class RemoteOpsClient {
 
   private final RemoteClient remoteClient;
 
-  protected RemoteOpsClient(CConfiguration cConf, final DiscoveryServiceClient discoveryClient,
+  protected RemoteOpsClient(final DiscoveryServiceClient discoveryClient,
                             final String discoverableServiceName) {
     this.remoteClient = new RemoteClient(discoveryClient, discoverableServiceName,
                                          new DefaultHttpRequestConfig(false), "/v1/execute/");

--- a/cdap-common/src/main/java/co/cask/cdap/common/internal/remote/RemoteOpsClient.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/internal/remote/RemoteOpsClient.java
@@ -16,11 +16,7 @@
 
 package co.cask.cdap.common.internal.remote;
 
-import co.cask.cdap.common.ServiceUnavailableException;
 import co.cask.cdap.common.conf.CConfiguration;
-import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.discovery.EndpointStrategy;
-import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.common.http.DefaultHttpRequestConfig;
 import co.cask.cdap.proto.BasicThrowable;
 import co.cask.cdap.proto.WorkflowTokenDetail;
@@ -30,28 +26,17 @@ import co.cask.cdap.proto.codec.WorkflowTokenDetailCodec;
 import co.cask.cdap.proto.codec.WorkflowTokenNodeDetailCodec;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
-import co.cask.common.http.HttpRequestConfig;
-import co.cask.common.http.HttpRequests;
 import co.cask.common.http.HttpResponse;
-import com.google.common.base.Joiner;
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import org.apache.twill.discovery.Discoverable;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.InetSocketAddress;
-import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
 
 /**
  * Common HTTP client functionality for remote operations from programs.
@@ -63,21 +48,12 @@ public class RemoteOpsClient {
     .registerTypeAdapter(WorkflowTokenNodeDetail.class, new WorkflowTokenNodeDetailCodec())
     .create();
 
-  private final Supplier<EndpointStrategy> endpointStrategySupplier;
-  private final HttpRequestConfig httpRequestConfig;
-  private final String discoverableServiceName;
+  private final RemoteClient remoteClient;
 
   protected RemoteOpsClient(CConfiguration cConf, final DiscoveryServiceClient discoveryClient,
                             final String discoverableServiceName) {
-    this.endpointStrategySupplier = Suppliers.memoize(new Supplier<EndpointStrategy>() {
-      @Override
-      public EndpointStrategy get() {
-        return new RandomEndpointStrategy(discoveryClient.discover(discoverableServiceName));
-      }
-    });
-
-    this.httpRequestConfig = new DefaultHttpRequestConfig(false);
-    this.discoverableServiceName = discoverableServiceName;
+    this.remoteClient = new RemoteClient(discoveryClient, discoverableServiceName,
+                                         new DefaultHttpRequestConfig(false), "/v1/execute/");
   }
 
   protected HttpResponse executeRequest(String methodName, Object... arguments) {
@@ -85,21 +61,26 @@ public class RemoteOpsClient {
   }
 
   protected HttpResponse executeRequest(String methodName, Map<String, String> headers, Object... arguments) {
-    return doRequest("execute/" + methodName, HttpMethod.POST, headers, GSON.toJson(createArguments(arguments)));
-  }
-
-  private String resolve(String resource) {
-    Discoverable discoverable = endpointStrategySupplier.get().pick(1L, TimeUnit.SECONDS);
-    if (discoverable == null) {
-      throw new ServiceUnavailableException(discoverableServiceName);
+    String body = GSON.toJson(createBody(arguments));
+    HttpRequest.Builder builder = remoteClient.requestBuilder(HttpMethod.POST, methodName).addHeaders(headers);
+    if (body != null) {
+      builder.withBody(body);
     }
-    InetSocketAddress address = discoverable.getSocketAddress();
-    String scheme = Arrays.equals(Constants.Security.SSL_URI_SCHEME.getBytes(), discoverable.getPayload()) ?
-      Constants.Security.SSL_URI_SCHEME : Constants.Security.URI_SCHEME;
-    return String.format("%s%s:%s%s/%s", scheme, address.getHostName(), address.getPort(), "/v1", resource);
+    HttpRequest request = builder.build();
+    try {
+      HttpResponse response = remoteClient.execute(request);
+      if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
+        return response;
+      }
+      throw new RuntimeException(String.format("%s Response: %s.",
+                                               remoteClient.createErrorMessage(request, body),
+                                               response));
+    } catch (IOException e) {
+      throw new RuntimeException(remoteClient.createErrorMessage(request, body), e);
+    }
   }
 
-  private static List<MethodArgument> createArguments(Object... arguments) {
+  private static List<MethodArgument> createBody(Object... arguments) {
     List<MethodArgument> methodArguments = new ArrayList<>();
     for (Object arg : arguments) {
       if (arg == null) {
@@ -112,33 +93,4 @@ public class RemoteOpsClient {
     return methodArguments;
   }
 
-  private HttpResponse doRequest(String resource, HttpMethod requestMethod,
-                                 @Nullable Map<String, String> headers, @Nullable String body) {
-    String resolvedUrl = resolve(resource);
-    try {
-      URL url = new URL(resolvedUrl);
-      HttpRequest.Builder builder = HttpRequest.builder(requestMethod, url).addHeaders(headers);
-      if (body != null) {
-        builder.withBody(body);
-      }
-      HttpResponse response = HttpRequests.execute(builder.build(), httpRequestConfig);
-      if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
-        return response;
-      }
-      throw new RuntimeException(String.format("%s Response: %s.",
-                                               createErrorMessage(resolvedUrl, requestMethod, headers, body),
-                                               response));
-    } catch (IOException e) {
-      throw new RuntimeException(createErrorMessage(resolvedUrl, requestMethod, headers, body), e);
-    }
-  }
-
-  // creates error message, encoding details about the request
-  private String createErrorMessage(String resolvedUrl, HttpMethod requestMethod,
-                                    @Nullable Map<String, String> headers, @Nullable String body) {
-    return String.format("Error making request to %s service at %s while doing %s with headers %s and body %s.",
-                         discoverableServiceName, resolvedUrl, requestMethod,
-                         headers == null ? "null" : Joiner.on(",").withKeyValueSeparator("=").join(headers),
-                         body == null ? "null" : body);
-  }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/service/Retries.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/service/Retries.java
@@ -138,7 +138,7 @@ public final class Retries {
       try {
         V v = callable.call();
         if (failures > 0) {
-          LOG.debug("Retry succeeded after {} retries and %d ms.", failures, System.currentTimeMillis() - startTime);
+          LOG.debug("Retry succeeded after {} retries and {} ms.", failures, System.currentTimeMillis() - startTime);
         }
         return v;
       } catch (Throwable t) {

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/DistributedStreamService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/DistributedStreamService.java
@@ -18,6 +18,7 @@ package co.cask.cdap.data.stream.service;
 
 import co.cask.cdap.api.data.stream.StreamSpecification;
 import co.cask.cdap.api.metrics.MetricStore;
+import co.cask.cdap.api.retry.RetryableException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.stream.notification.StreamSizeNotification;
@@ -395,7 +396,7 @@ public class DistributedStreamService extends AbstractStreamService {
         feedManager.createFeed(streamHeartbeatsFeed);
         LOG.info("Stream HeartbeatsFeed created.");
         return;
-      } catch (NotificationFeedException e) {
+      } catch (NotificationFeedException | RetryableException e) {
         if (!isRetry) {
           LOG.warn("Could not ensure existence of HeartbeatsFeed. Will retry until successful. " +
                      "Retry failures will be logged at debug level.", e);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -282,7 +282,7 @@ class DatasetServiceClient {
     try {
       return remoteClient.execute(request);
     } catch (IOException e) {
-      throw new DatasetManagementException(remoteClient.createErrorMessage(request, body));
+      throw new DatasetManagementException(remoteClient.createErrorMessage(request, body), e);
     }
   }
 
@@ -301,7 +301,7 @@ class DatasetServiceClient {
     } catch (ConnectException e) {
       throw new ServiceUnavailableException(Constants.Service.DATASET_MANAGER, e);
     } catch (IOException e) {
-      throw new DatasetManagementException(remoteClient.createErrorMessage(request, null));
+      throw new DatasetManagementException(remoteClient.createErrorMessage(request, null), e);
     }
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -23,15 +23,13 @@ import co.cask.cdap.api.dataset.InstanceNotFoundException;
 import co.cask.cdap.common.ServiceUnavailableException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.discovery.EndpointStrategy;
-import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.common.http.DefaultHttpRequestConfig;
+import co.cask.cdap.common.internal.remote.RemoteClient;
 import co.cask.cdap.common.io.Locations;
 import co.cask.cdap.common.kerberos.SecurityUtil;
 import co.cask.cdap.data2.dataset2.ModuleConflictException;
 import co.cask.cdap.proto.DatasetInstanceConfiguration;
 import co.cask.cdap.proto.DatasetMeta;
-import co.cask.cdap.proto.DatasetModuleMeta;
 import co.cask.cdap.proto.DatasetSpecificationSummary;
 import co.cask.cdap.proto.DatasetTypeMeta;
 import co.cask.cdap.proto.id.EntityId;
@@ -40,22 +38,14 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
-import co.cask.common.http.HttpRequestConfig;
-import co.cask.common.http.HttpRequests;
 import co.cask.common.http.HttpResponse;
 import com.google.common.base.Joiner;
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
-import com.google.common.io.InputSupplier;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authentication.util.KerberosName;
-import org.apache.twill.discovery.Discoverable;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.filesystem.Location;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
@@ -63,15 +53,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.lang.reflect.Type;
-import java.net.InetSocketAddress;
-import java.net.URL;
-import java.util.Arrays;
+import java.net.ConnectException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
@@ -82,12 +68,10 @@ class DatasetServiceClient {
   private static final Logger LOG = LoggerFactory.getLogger(DatasetServiceClient.class);
   private static final Gson GSON = new Gson();
   private static final Type SUMMARY_LIST_TYPE = new TypeToken<List<DatasetSpecificationSummary>>() { }.getType();
-  private static final Type MODULE_META_LIST_TYPE = new TypeToken<List<DatasetModuleMeta>>() { }.getType();
   private static final Type DATASET_NAME_TYPE = new TypeToken<Set<String>>() { }.getType();
 
-  private final Supplier<EndpointStrategy> endpointStrategySupplier;
+  private final RemoteClient remoteClient;
   private final NamespaceId namespaceId;
-  private final HttpRequestConfig httpRequestConfig;
   private final boolean securityEnabled;
   private final boolean kerberosEnabled;
   private final boolean authorizationEnabled;
@@ -96,14 +80,10 @@ class DatasetServiceClient {
 
   DatasetServiceClient(final DiscoveryServiceClient discoveryClient, NamespaceId namespaceId,
                        CConfiguration cConf, AuthenticationContext authenticationContext) {
-    this.endpointStrategySupplier = Suppliers.memoize(new Supplier<EndpointStrategy>() {
-      @Override
-      public EndpointStrategy get() {
-        return new RandomEndpointStrategy(discoveryClient.discover(Constants.Service.DATASET_MANAGER));
-      }
-    });
+    this.remoteClient = new RemoteClient(
+      discoveryClient, Constants.Service.DATASET_MANAGER, new DefaultHttpRequestConfig(false),
+      String.format("%s/namespaces/%s/data", Constants.Gateway.API_VERSION_3, namespaceId.getNamespace()));
     this.namespaceId = namespaceId;
-    this.httpRequestConfig = new DefaultHttpRequestConfig(false);
     this.securityEnabled = cConf.getBoolean(Constants.Security.ENABLED);
     this.kerberosEnabled = SecurityUtil.isKerberosEnabled(cConf);
     this.authorizationEnabled = cConf.getBoolean(Constants.Security.Authorization.ENABLED);
@@ -158,16 +138,6 @@ class DatasetServiceClient {
     }
 
     return GSON.fromJson(response.getResponseBodyAsString(), SUMMARY_LIST_TYPE);
-  }
-
-  public Collection<DatasetModuleMeta> getAllModules() throws DatasetManagementException {
-    HttpResponse response = doGet("modules");
-    if (HttpResponseStatus.OK.getCode() != response.getResponseCode()) {
-      throw new DatasetManagementException(String.format("Cannot retrieve all dataset instances, details: %s",
-                                                         response));
-    }
-
-    return GSON.fromJson(response.getResponseBodyAsString(), MODULE_META_LIST_TYPE);
   }
 
   @Nullable
@@ -265,9 +235,10 @@ class DatasetServiceClient {
 
   public void addModule(String moduleName, String className, Location jarLocation) throws DatasetManagementException {
 
-    HttpResponse response = doRequest(HttpMethod.PUT, "modules/" + moduleName,
-                                      ImmutableMultimap.of("X-Class-Name", className),
-                                      Locations.newInputSupplier(jarLocation));
+    HttpRequest.Builder requestBuilder = remoteClient.requestBuilder(HttpMethod.PUT, "modules/" + moduleName)
+      .addHeader("X-Class-Name", className)
+      .withBody(Locations.newInputSupplier(jarLocation));
+    HttpResponse response = doRequest(requestBuilder);
 
     if (HttpResponseStatus.CONFLICT.getCode() == response.getResponseCode()) {
       throw new ModuleConflictException(String.format("Failed to add module %s due to conflict, details: %s",
@@ -301,61 +272,40 @@ class DatasetServiceClient {
   }
 
   private HttpResponse doGet(String resource) throws DatasetManagementException {
-    return doRequest(HttpMethod.GET, resource);
+    return doRequest(remoteClient.requestBuilder(HttpMethod.GET, resource));
   }
 
   private HttpResponse doPut(String resource, String body) throws DatasetManagementException {
-    return doRequest(HttpMethod.PUT, resource, null, body);
+    HttpRequest request = addUserIdHeader(remoteClient.requestBuilder(HttpMethod.PUT, resource)
+      .withBody(body))
+      .build();
+    try {
+      return remoteClient.execute(request);
+    } catch (IOException e) {
+      throw new DatasetManagementException(remoteClient.createErrorMessage(request, body));
+    }
   }
 
   private HttpResponse doPost(String resource) throws DatasetManagementException {
-    return doRequest(HttpMethod.POST, resource);
+    return doRequest(remoteClient.requestBuilder(HttpMethod.POST, resource));
   }
 
   private HttpResponse doDelete(String resource) throws DatasetManagementException {
-    return doRequest(HttpMethod.DELETE, resource);
+    return doRequest(remoteClient.requestBuilder(HttpMethod.DELETE, resource));
   }
 
-  private HttpResponse doRequest(HttpMethod method, String resource, @Nullable Multimap<String, String> headers,
-                                 String body) throws DatasetManagementException {
-    String url = resolve(resource);
+  private HttpResponse doRequest(HttpRequest.Builder requestBuilder) throws DatasetManagementException {
+    HttpRequest request = addUserIdHeader(requestBuilder).build();
     try {
-      return HttpRequests.execute(addUserIdHeader(
-        HttpRequest.builder(method, new URL(url))
-          .addHeaders(headers)
-          .withBody(body)
-      ).build(), httpRequestConfig);
+      return remoteClient.execute(request);
+    } catch (ConnectException e) {
+      throw new ServiceUnavailableException(Constants.Service.DATASET_MANAGER, e);
     } catch (IOException e) {
-      throw new DatasetManagementException(
-        String.format("Error during talking to Dataset Service at %s while doing %s with headers %s and body %s",
-                      url, method,
-                      headers == null ? "null" : Joiner.on(",").withKeyValueSeparator("=").join(headers.entries()),
-                      body == null ? "null" : body), e);
+      throw new DatasetManagementException(remoteClient.createErrorMessage(request, null));
     }
   }
 
-  private HttpResponse doRequest(HttpMethod method, String resource,
-                                 @Nullable Multimap<String, String> headers,
-                                 @Nullable InputSupplier<? extends InputStream> body)
-    throws DatasetManagementException {
-
-    String url = resolve(resource);
-    try {
-      return HttpRequests.execute(addUserIdHeader(
-        HttpRequest.builder(method, new URL(url))
-          .addHeaders(headers)
-          .withBody(body)
-      ).build(), httpRequestConfig);
-    } catch (IOException e) {
-      throw new DatasetManagementException(
-        String.format("Error during talking to Dataset Service at %s while doing %s with headers %s and body %s",
-                      url, method,
-                      headers == null ? "null" : Joiner.on(",").withKeyValueSeparator("=").join(headers.entries()),
-                      body == null ? "null" : body), e);
-    }
-  }
-
-  private HttpRequest.Builder addUserIdHeader(HttpRequest.Builder builder) throws IOException {
+  private HttpRequest.Builder addUserIdHeader(HttpRequest.Builder builder) throws DatasetManagementException {
     if (!securityEnabled || !authorizationEnabled) {
       return builder;
     }
@@ -364,7 +314,7 @@ class DatasetServiceClient {
     try {
       currUserShortName = UserGroupInformation.getCurrentUser().getShortUserName();
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new DatasetManagementException("Unable to get the current user", e);
     }
 
     // If the request originated from the router and was forwarded to any service other than dataset service, before
@@ -386,26 +336,10 @@ class DatasetServiceClient {
       if (!kerberosEnabled || currUserShortName.equals(masterShortUserName)) {
         LOG.trace("Accessing dataset in system namespace using the system principal because the current user " +
                     "{} is the same as the CDAP master user {}.",
-                  UserGroupInformation.getCurrentUser().getUserName(), masterShortUserName);
+                  currUserShortName, masterShortUserName);
         userId = currUserShortName;
       }
     }
     return builder.addHeader(Constants.Security.Headers.USER_ID, userId);
-  }
-
-  private HttpResponse doRequest(HttpMethod method, String url) throws DatasetManagementException {
-    return doRequest(method, url, null, (InputSupplier<? extends InputStream>) null);
-  }
-
-  private String resolve(String resource) throws DatasetManagementException {
-    Discoverable discoverable = endpointStrategySupplier.get().pick(1L, TimeUnit.SECONDS);
-    if (discoverable == null) {
-      throw new ServiceUnavailableException("DatasetService");
-    }
-    InetSocketAddress address = discoverable.getSocketAddress();
-    String scheme = Arrays.equals(Constants.Security.SSL_URI_SCHEME.getBytes(), discoverable.getPayload()) ?
-      Constants.Security.SSL_URI_SCHEME : Constants.Security.URI_SCHEME;
-    return String.format("%s%s:%s%s/namespaces/%s/data/%s", scheme, address.getHostName(), address.getPort(),
-                         Constants.Gateway.API_VERSION_3, namespaceId.getNamespace(), resource);
   }
 }

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/DiscoveryExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/DiscoveryExploreClient.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.explore.client;
 
+import co.cask.cdap.common.ServiceUnavailableException;
 import co.cask.cdap.common.discovery.EndpointStrategy;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.common.http.DefaultHttpRequestConfig;
@@ -69,7 +70,7 @@ public class DiscoveryExploreClient extends AbstractExploreClient {
     if (discoverable != null) {
       return discoverable.getSocketAddress();
     }
-    throw new RuntimeException(String.format("Cannot discover service %s", Service.EXPLORE_HTTP_USER_SERVICE));
+    throw new ServiceUnavailableException(Service.EXPLORE_HTTP_USER_SERVICE);
   }
 
   // This class is only used internally.

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreDisabledTest.java
@@ -19,6 +19,7 @@ package co.cask.cdap.explore.service;
 import co.cask.cdap.api.common.Bytes;
 import co.cask.cdap.api.dataset.DatasetDefinition;
 import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.common.ServiceUnavailableException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
@@ -103,9 +104,8 @@ public class ExploreDisabledTest {
     try {
       exploreClient.ping();
       Assert.fail("Expected not to be able to ping explore client.");
-    } catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Cannot discover service " +
-                                                  Constants.Service.EXPLORE_HTTP_USER_SERVICE));
+    } catch (ServiceUnavailableException e) {
+      // expected
     }
 
     datasetFramework = injector.getInstance(DatasetFramework.class);

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/RemotePrivilegesFetcher.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/RemotePrivilegesFetcher.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.security.authorization;
 
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.internal.remote.RemoteOpsClient;
 import co.cask.cdap.internal.guava.reflect.TypeToken;
@@ -50,8 +49,8 @@ class RemotePrivilegesFetcher extends RemoteOpsClient implements PrivilegesFetch
   private static final Type SET_PRIVILEGES_TYPE = new TypeToken<Set<Privilege>>() { }.getType();
 
   @Inject
-  RemotePrivilegesFetcher(CConfiguration cConf, DiscoveryServiceClient discoveryClient) {
-    super(cConf, discoveryClient, Constants.Service.APP_FABRIC_HTTP);
+  RemotePrivilegesFetcher(DiscoveryServiceClient discoveryClient) {
+    super(discoveryClient, Constants.Service.APP_FABRIC_HTTP);
   }
 
   @Override

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/RemotePrivilegesManager.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/RemotePrivilegesManager.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.security.authorization;
 
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.internal.remote.RemoteOpsClient;
 import co.cask.cdap.proto.id.EntityId;
@@ -39,8 +38,8 @@ public class RemotePrivilegesManager extends RemoteOpsClient implements Privileg
   private static final Logger LOG = LoggerFactory.getLogger(RemotePrivilegesManager.class);
 
   @Inject
-  RemotePrivilegesManager(CConfiguration cConf, DiscoveryServiceClient discoveryClient) {
-    super(cConf, discoveryClient, Constants.Service.APP_FABRIC_HTTP);
+  RemotePrivilegesManager(DiscoveryServiceClient discoveryClient) {
+    super(discoveryClient, Constants.Service.APP_FABRIC_HTTP);
   }
 
   @Override

--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/RemoteUGIProvider.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/RemoteUGIProvider.java
@@ -18,21 +18,16 @@ package co.cask.cdap.security.impersonation;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.discovery.EndpointStrategy;
-import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.common.http.DefaultHttpRequestConfig;
+import co.cask.cdap.common.internal.remote.RemoteClient;
 import co.cask.cdap.common.kerberos.ImpersonationInfo;
+import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
-import co.cask.common.http.HttpRequestConfig;
-import co.cask.common.http.HttpRequests;
 import co.cask.common.http.HttpResponse;
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.twill.discovery.Discoverable;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
@@ -43,11 +38,8 @@ import java.io.BufferedInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URL;
-import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Makes requests to ImpersonationHandler to request credentials.
@@ -57,22 +49,16 @@ public class RemoteUGIProvider extends AbstractCachedUGIProvider {
   private static final Logger LOG = LoggerFactory.getLogger(RemoteUGIProvider.class);
   private static final Gson GSON = new Gson();
 
-  private final Supplier<EndpointStrategy> endpointStrategySupplier;
+  private final RemoteClient remoteClient;
   private final LocationFactory locationFactory;
-  private final HttpRequestConfig httpRequestConfig;
 
   @Inject
   RemoteUGIProvider(CConfiguration cConf, final DiscoveryServiceClient discoveryClient,
                     LocationFactory locationFactory) {
     super(cConf);
-    this.endpointStrategySupplier = Suppliers.memoize(new Supplier<EndpointStrategy>() {
-      @Override
-      public EndpointStrategy get() {
-        return new RandomEndpointStrategy(discoveryClient.discover(Constants.Service.APP_FABRIC_HTTP));
-      }
-    });
+    this.remoteClient = new RemoteClient(discoveryClient, Constants.Service.APP_FABRIC_HTTP,
+                                         new DefaultHttpRequestConfig(false), "/v1/");
     this.locationFactory = locationFactory;
-    this.httpRequestConfig = new DefaultHttpRequestConfig(false);
   }
 
   @Override
@@ -96,26 +82,15 @@ public class RemoteUGIProvider extends AbstractCachedUGIProvider {
     }
   }
 
-  private URL resolve(String resource) throws IOException {
-    Discoverable discoverable = endpointStrategySupplier.get().pick(3L, TimeUnit.SECONDS);
-    if (discoverable == null) {
-      throw new IOException(String.format("Cannot discover service %s", Constants.Service.APP_FABRIC_HTTP));
-    }
-    InetSocketAddress address = discoverable.getSocketAddress();
-    String scheme = Arrays.equals(Constants.Security.SSL_URI_SCHEME.getBytes(), discoverable.getPayload()) ?
-      Constants.Security.SSL_URI_SCHEME : Constants.Security.URI_SCHEME;
-    URI baseURI = URI.create(String.format("%s%s:%d", scheme, address.getHostName(), address.getPort()));
-    return baseURI.resolve("/v1/" + resource).toURL();
-  }
-
   private HttpResponse executeRequest(ImpersonationInfo impersonationInfo) throws IOException {
-    URL url = resolve("impersonation/credentials");
-    HttpRequest.Builder builder = HttpRequest.post(url).withBody(GSON.toJson(impersonationInfo));
-    HttpResponse response = HttpRequests.execute(builder.build(), httpRequestConfig);
+    HttpRequest request = remoteClient.requestBuilder(HttpMethod.POST, "impersonation/credentials")
+      .withBody(GSON.toJson(impersonationInfo))
+      .build();
+    HttpResponse response = remoteClient.execute(request);
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
       return response;
     }
-    throw new IOException(String.format("%s Response: %s.", createErrorMessage(url), response));
+    throw new IOException(String.format("%s Response: %s.", createErrorMessage(request.getURL()), response));
   }
 
   // creates error message, encoding details about the request


### PR DESCRIPTION
Refactoring several clients that perform service discovery
then http requests so that they use a single common class. This
client will throw ServiceUnavailableException if the service
cannot be discovered, if discovery succeeded but a ConnectException
was thrown while making the request, or if the response itself
was a 503 service unavailable.