### PR TITLE
Set ALICE as the user in SecurityRequestContext before each test.

### DIFF
--- a/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/security/AuthorizationTest.java
@@ -171,12 +171,12 @@ public class AuthorizationTest extends TestBase {
   public static void setup() {
     instance = new InstanceId(getConfiguration().get(Constants.INSTANCE_NAME));
     oldUser = SecurityRequestContext.getUserId();
-    SecurityRequestContext.setUserId(ALICE.getName());
   }
 
   @Before
   public void setupTest() throws Exception {
     Assert.assertEquals(ImmutableSet.<Privilege>of(), getAuthorizer().listPrivileges(ALICE));
+    SecurityRequestContext.setUserId(ALICE.getName());
   }
 
   @Test


### PR DESCRIPTION
Because this showed up in BUT

`co.cask.cdap.security.spi.authorization.UnauthorizedException: Principal 'Principal{name='bob', type=USER}' is not authorized to perform actions '[ADMIN]' on entity 'instance:cdap'
	at co.cask.cdap.security.authorization.DefaultAuthorizationEnforcementService.doEnforce(DefaultAuthorizationEnforcementService.java:109)
	at co.cask.cdap.security.authorization.DefaultAuthorizationEnforcementService.enforce(DefaultAuthorizationEnforcementService.java:70)
	at co.cask.cdap.common.security.AuthEnforceUtil.enforce(AuthEnforceUtil.java:51)
	at co.cask.cdap.internal.app.namespace.DefaultNamespaceAdmin.create(DefaultNamespaceAdmin.java)
	at co.cask.cdap.security.AuthorizationTest.createAuthNamespace(AuthorizationTest.java:1279)
	at co.cask.cdap.security.AuthorizationTest.testCrossNSSpark(AuthorizationTest.java:1001)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)`