### PR TITLE
Avoid using the AbstractExecutionThreadService.getServiceName() witho…

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/operations/OperationalStatsService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/operations/OperationalStatsService.java
@@ -134,10 +134,11 @@ public class OperationalStatsService extends AbstractExecutionThreadService {
 
   @Override
   protected Executor executor() {
+    final String name = getClass().getSimpleName();
     return new Executor() {
       @Override
       public void execute(Runnable command) {
-        Thread thread = new Thread(command, getServiceName());
+        Thread thread = new Thread(command, name);
         thread.setDaemon(true);
         thread.start();
       }

--- a/cdap-integration-test/pom.xml
+++ b/cdap-integration-test/pom.xml
@@ -28,14 +28,6 @@
   <name>CDAP Integration Test Framework</name>
 
   <dependencies>
-    <!--
-      Add a direct dependency on guava to make sure it comes before the hive-exec
-      brings in by cdap-standalone as transitive dependency
-    -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-api</artifactId>

--- a/cdap-standalone/src/main/java/co/cask/cdap/UserInterfaceService.java
+++ b/cdap-standalone/src/main/java/co/cask/cdap/UserInterfaceService.java
@@ -127,10 +127,11 @@ final class UserInterfaceService extends AbstractExecutionThreadService {
    */
   @Override
   protected Executor executor() {
+    final String name = getClass().getSimpleName();
     return new Executor() {
       @Override
       public void execute(Runnable command) {
-        Thread thread = new Thread(command, getServiceName());
+        Thread thread = new Thread(command, name);
         thread.setDaemon(true);
         thread.start();
       }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/AggregatedMetricsCollectionService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/collect/AggregatedMetricsCollectionService.java
@@ -146,10 +146,11 @@ public abstract class AggregatedMetricsCollectionService extends AbstractExecuti
 
   @Override
   protected Executor executor() {
+    final String name = getClass().getSimpleName();
     return new Executor() {
       @Override
       public void execute(Runnable command) {
-        Thread thread = new Thread(command, getServiceName());
+        Thread thread = new Thread(command, name);
         thread.setDaemon(true);
         thread.start();
       }


### PR DESCRIPTION
…ut overriding.

- If hive-exec is in the classpath, it throws as that method is only defined since Guava 10 (yes 10, which was release on 9/29/2011)