### PR TITLE
CDAP-8108 rotate file after max file size in bytes

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Configuration.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Configuration.java
@@ -259,6 +259,8 @@ public class Configuration implements Iterable<Map.Entry<String, String>> {
       // The following keys are log appender specific keys and they are not defined in Constants.
       put("log.file.sync.interval.bytes",
           new DeprecatedKeyInfo("log.pipeline.cdap.file.sync.interval.bytes"));
+      put("log.max.file.size.bytes",
+          new DeprecatedKeyInfo("log.pipeline.cdap.file.max.size.bytes"));
       put("log.saver.max.file.lifetime.ms",
           new DeprecatedKeyInfo("log.pipeline.cdap.file.max.lifetime.ms"));
     }
@@ -285,6 +287,7 @@ public class Configuration implements Iterable<Map.Entry<String, String>> {
       put(Constants.Security.SSL.EXTERNAL_ENABLED, new String[] { Constants.Security.SSL_ENABLED_DEPRECATED });
       put(Constants.Logging.PIPELINE_CHECKPOINT_INTERVAL_MS, new String[] { "log.saver.checkpoint.interval.ms" });
       put("log.pipeline.cdap.file.sync.interval.bytes", new String[] { "log.file.sync.interval.bytes" });
+      put("log.pipeline.cdap.file.max.size.bytes", new String[] { "log.max.file.size.bytes" });
       put("log.pipeline.cdap.file.max.lifetime.ms", new String[] { "log.saver.max.file.lifetime.ms" });
     }
   };

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1078,6 +1078,14 @@
   </property>
 
   <property>
+    <name>log.pipeline.cdap.file.max.size.bytes</name>
+    <value>104857600</value>
+    <description>
+      Maximum size in bytes a file is kept opened by the system log appender
+    </description>
+  </property>
+
+  <property>
     <name>log.pipeline.cdap.file.permissions</name>
     <value>600</value>
     <description>

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/framework/CDAPLogAppender.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/framework/CDAPLogAppender.java
@@ -55,6 +55,7 @@ public class CDAPLogAppender extends AppenderBase<ILoggingEvent> implements Flus
   private String filePermissions;
   private int syncIntervalBytes;
   private long maxFileLifetimeMs;
+  private long maxFileSizeInBytes;
 
   /**
    * TODO: start a separate cleanup thread to remove files that has passed the TTL
@@ -91,6 +92,13 @@ public class CDAPLogAppender extends AppenderBase<ILoggingEvent> implements Flus
     this.maxFileLifetimeMs = maxFileLifetimeMs;
   }
 
+  /**
+   * Sets the maximum size of a file. This is called by the logback framework.
+   */
+  public void setMaxFileSizeInBytes(long maxFileSizeInBytes) {
+    this.maxFileSizeInBytes = maxFileSizeInBytes;
+  }
+
   @Override
   public void start() {
     // These should all passed. The settings are from the cdap-log-pipeline.xml and the context must be AppenderContext
@@ -98,11 +106,12 @@ public class CDAPLogAppender extends AppenderBase<ILoggingEvent> implements Flus
     Preconditions.checkState(filePermissions != null, "Property filePermissions cannot be null");
     Preconditions.checkState(syncIntervalBytes > 0, "Property syncIntervalBytes must be > 0.");
     Preconditions.checkState(maxFileLifetimeMs > 0, "Property maxFileLifetimeMs must be > 0");
+    Preconditions.checkState(maxFileSizeInBytes > 0, "Property maxFileSizeInBytes must be > 0");
 
     if (context instanceof AppenderContext) {
       AppenderContext context = (AppenderContext) this.context;
-      logFileManager = new LogFileManager(dirPermissions, filePermissions, maxFileLifetimeMs, syncIntervalBytes,
-                                          LogSchema.LoggingEvent.SCHEMA,
+      logFileManager = new LogFileManager(dirPermissions, filePermissions, maxFileLifetimeMs, maxFileSizeInBytes,
+                                          syncIntervalBytes, LogSchema.LoggingEvent.SCHEMA,
                                           new FileMetaDataWriter(context.getDatasetManager(), context),
                                           context.getLocationFactory());
     } else if (!Boolean.TRUE.equals(context.getObject(Constants.Logging.PIPELINE_VALIDATION))) {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/framework/LogFileManager.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/framework/LogFileManager.java
@@ -48,17 +48,19 @@ final class LogFileManager implements Flushable, Syncable {
   private final String filePermissions;
   private final int syncIntervalBytes;
   private final long maxLifetimeMillis;
+  private final long maxFileSizeInBytes;
   private final Map<LogPathIdentifier, LogFileOutputStream> outputStreamMap;
   private final Location logsDirectoryLocation;
   private final FileMetaDataWriter fileMetaDataWriter;
   private final Schema schema;
 
   LogFileManager(String dirPermissions, String filePermissions,
-                 long maxFileLifetimeMs, int syncIntervalBytes,
+                 long maxFileLifetimeMs, long maxFileSizeInBytes, int syncIntervalBytes,
                  Schema schema, FileMetaDataWriter fileMetaDataWriter, LocationFactory locationFactory) {
     this.dirPermissions = dirPermissions;
     this.filePermissions = filePermissions;
     this.maxLifetimeMillis = maxFileLifetimeMs;
+    this.maxFileSizeInBytes = maxFileSizeInBytes;
     this.syncIntervalBytes = syncIntervalBytes;
     this.schema = schema;
     this.fileMetaDataWriter = fileMetaDataWriter;
@@ -138,7 +140,7 @@ final class LogFileManager implements Flushable, Syncable {
                                                  LogPathIdentifier identifier, long timestamp) throws IOException {
     long currentTs = System.currentTimeMillis();
     long timeSinceFileCreate = currentTs - logFileOutputStream.getCreateTime();
-    if (timeSinceFileCreate > maxLifetimeMillis) {
+    if (timeSinceFileCreate > maxLifetimeMillis || logFileOutputStream.getSize() > maxFileSizeInBytes) {
       logFileOutputStream.close();
       return createOutputStream(identifier, timestamp);
     }

--- a/cdap-watchdog/src/main/resources/cdap-log-pipeline.xml
+++ b/cdap-watchdog/src/main/resources/cdap-log-pipeline.xml
@@ -29,6 +29,7 @@
     <filePermissions>${file.permissions}</filePermissions>
     <syncIntervalBytes>${file.sync.interval.bytes}</syncIntervalBytes>
     <maxFileLifetimeMs>${file.max.lifetime.ms}</maxFileLifetimeMs>
+    <maxFileSizeInBytes>${file.max.size.bytes}</maxFileSizeInBytes>
   </appender>
 
   <appender name="METRICS" class="co.cask.cdap.logging.framework.MetricsLogAppender"/>

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/framework/CDAPLogAppenderTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/framework/CDAPLogAppenderTest.java
@@ -201,7 +201,7 @@ public class CDAPLogAppenderTest {
     cdapLogAppender.start();
 
     Map<String, String> properties = new HashMap<>();
-    properties.put(NamespaceLoggingContext.TAG_NAMESPACE_ID, "testRotation");
+    properties.put(NamespaceLoggingContext.TAG_NAMESPACE_ID, "testTimeRotation");
     properties.put(ApplicationLoggingContext.TAG_APPLICATION_ID, "testApp");
     properties.put(FlowletLoggingContext.TAG_FLOW_ID, "testFlow");
     properties.put(FlowletLoggingContext.TAG_FLOWLET_ID, "testFlowlet");
@@ -235,8 +235,8 @@ public class CDAPLogAppenderTest {
       Assert.assertEquals(2, files.size());
       assertLogEventDetails(event1, files.get(0));
       assertLogEventDetails(event2, files.get(1));
-      Assert.assertEquals(files.get(0).getEventTimeMs(), currentTimeMillisEvent1);
-      Assert.assertEquals(files.get(1).getEventTimeMs(), currentTimeMillisEvent1 + 1000);
+      Assert.assertEquals(currentTimeMillisEvent1, files.get(0).getEventTimeMs());
+      Assert.assertEquals(currentTimeMillisEvent1 + 1000, files.get(1).getEventTimeMs());
       Assert.assertTrue(files.get(0).getFileCreationTimeMs() >= currentTimeMillisEvent1);
       Assert.assertTrue(files.get(1).getFileCreationTimeMs() >= currentTimeMillisEvent2);
 
@@ -246,6 +246,68 @@ public class CDAPLogAppenderTest {
         Location location = file.getLocation();
         Assert.assertEquals(expectedPermissions, location.getPermissions());
       }
+    } catch (Exception e) {
+      Assert.fail();
+    }
+  }
+
+  @Test
+  public void testCDAPLogAppenderSizeBasedRotation() throws Exception {
+    int syncInterval = 1024 * 1024;
+    FileMetaDataReader fileMetaDataReader = injector.getInstance(FileMetaDataReader.class);
+    CDAPLogAppender cdapLogAppender = new CDAPLogAppender();
+    AppenderContext context = new LocalAppenderContext(injector.getInstance(DatasetFramework.class),
+                                                       injector.getInstance(TransactionSystemClient.class),
+                                                       injector.getInstance(LocationFactory.class),
+                                                       new NoOpMetricsCollectionService());
+    context.start();
+
+    cdapLogAppender.setSyncIntervalBytes(syncInterval);
+    cdapLogAppender.setMaxFileLifetimeMs(TimeUnit.DAYS.toMillis(1));
+    cdapLogAppender.setMaxFileSizeInBytes(500);
+    cdapLogAppender.setDirPermissions("750");
+    cdapLogAppender.setFilePermissions("640");
+    cdapLogAppender.setContext(context);
+    cdapLogAppender.start();
+
+    Map<String, String> properties = new HashMap<>();
+    properties.put(NamespaceLoggingContext.TAG_NAMESPACE_ID, "testSizeRotation");
+    properties.put(ApplicationLoggingContext.TAG_APPLICATION_ID, "testApp");
+    properties.put(FlowletLoggingContext.TAG_FLOW_ID, "testFlow");
+    properties.put(FlowletLoggingContext.TAG_FLOWLET_ID, "testFlowlet");
+
+    long currentTimeMillisEvent1 = System.currentTimeMillis();
+
+    LoggingEvent event1 =
+      getLoggingEvent("co.cask.Test1",
+                      (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME),
+                      Level.ERROR , "test message 1", properties);
+
+    event1.setTimeStamp(currentTimeMillisEvent1);
+    cdapLogAppender.doAppend(event1);
+    // sync updates the file size
+    cdapLogAppender.sync();
+
+    long currentTimeMillisEvent2 = System.currentTimeMillis();
+    LoggingEvent event2 = getLoggingEvent("co.cask.Test2",
+                                          (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(
+                                            Logger.ROOT_LOGGER_NAME), Level.ERROR , "test message 2", properties);
+    event2.setTimeStamp(currentTimeMillisEvent2);
+    // one new append, we will rotate to new file as the file size limit is very low and last append exceeded that.
+    cdapLogAppender.doAppend(event2);
+    cdapLogAppender.stop();
+    context.stop();
+
+    try {
+      List<LogLocation> files = fileMetaDataReader.listFiles(cdapLogAppender.getLoggingPath(properties),
+                                                             0, Long.MAX_VALUE);
+      Assert.assertEquals(2, files.size());
+      assertLogEventDetails(event1, files.get(0));
+      assertLogEventDetails(event2, files.get(1));
+      Assert.assertEquals(currentTimeMillisEvent1, files.get(0).getEventTimeMs());
+      Assert.assertEquals(currentTimeMillisEvent2, files.get(1).getEventTimeMs());
+      Assert.assertTrue(files.get(0).getFileCreationTimeMs() >= currentTimeMillisEvent1);
+      Assert.assertTrue(files.get(1).getFileCreationTimeMs() >= currentTimeMillisEvent2);
     } catch (Exception e) {
       Assert.fail();
     }

--- a/cdap-watchdog/src/test/java/co/cask/cdap/logging/framework/CDAPLogAppenderTest.java
+++ b/cdap-watchdog/src/test/java/co/cask/cdap/logging/framework/CDAPLogAppenderTest.java
@@ -124,6 +124,7 @@ public class CDAPLogAppenderTest {
 
     cdapLogAppender.setSyncIntervalBytes(syncInterval);
     cdapLogAppender.setMaxFileLifetimeMs(TimeUnit.DAYS.toMillis(1));
+    cdapLogAppender.setMaxFileSizeInBytes(104857600);
     cdapLogAppender.setDirPermissions("700");
     cdapLogAppender.setFilePermissions("600");
     AppenderContext context = new LocalAppenderContext(injector.getInstance(DatasetFramework.class),
@@ -193,6 +194,7 @@ public class CDAPLogAppenderTest {
 
     cdapLogAppender.setSyncIntervalBytes(syncInterval);
     cdapLogAppender.setMaxFileLifetimeMs(500);
+    cdapLogAppender.setMaxFileSizeInBytes(104857600);
     cdapLogAppender.setDirPermissions("750");
     cdapLogAppender.setFilePermissions("640");
     cdapLogAppender.setContext(context);


### PR DESCRIPTION
rotate file after max file size. depreciating the old key and using the new parameter.
