### PR TITLE
[CDAP-8441] Improve exception logging in startup check

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/master/startup/ConfigurationCheck.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/startup/ConfigurationCheck.java
@@ -136,7 +136,7 @@ class ConfigurationCheck extends AbstractMasterCheck {
   }
 
   private void checkLogPartitionKey(Set<String> problemKeys) {
-    if (!isValidPartitionKey(cConf.get(Constants.Logging.LOG_PUBLISH_PARTITION_KEY).toUpperCase())) {
+    if (!isValidPartitionKey(cConf.get(Constants.Logging.LOG_PUBLISH_PARTITION_KEY))) {
       problemKeys.add(Constants.Logging.LOG_PUBLISH_PARTITION_KEY);
     }
   }
@@ -191,8 +191,8 @@ class ConfigurationCheck extends AbstractMasterCheck {
 
   private boolean isValidPartitionKey(String key) {
     try {
-      LogPartitionType.valueOf(key);
-    } catch (IllegalArgumentException e) {
+      LogPartitionType.valueOf(key.toUpperCase());
+    } catch (IllegalArgumentException | NullPointerException e) {
       LOG.error("Invalid log partition type: {}. Only program/application types are allowed", key, e.getMessage());
       return false;
     }

--- a/cdap-master/src/main/java/co/cask/cdap/master/startup/MasterStartupTool.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/startup/MasterStartupTool.java
@@ -100,7 +100,9 @@ public class MasterStartupTool {
     List<CheckRunner.Failure> failures = checkRunner.runChecks();
     if (!failures.isEmpty()) {
       for (CheckRunner.Failure failure : failures) {
-        LOG.error("{} failed: {}", failure.getName(), failure.getException().getMessage());
+        LOG.error("{} failed with {}: {}", failure.getName(),
+                  failure.getException().getClass().getSimpleName(),
+                  failure.getException().getMessage());
         if (failure.getException().getCause() != null) {
           LOG.error("  Root cause: {}", ExceptionUtils.getRootCauseMessage(failure.getException().getCause()));
         }


### PR DESCRIPTION
- Avoid logging null when a property is missing 
- log the exception class name in addition to the exception message (which may be null)
