### PR TITLE
[CDAP-8370] Add links on entity cards to their overview/detail pages

### DIFF
--- a/cdap-ui/app/cdap/components/DatasetStreamCards/index.js
+++ b/cdap-ui/app/cdap/components/DatasetStreamCards/index.js
@@ -15,11 +15,15 @@
  */
 import React, {PropTypes} from 'react';
 import EntityCard from 'components/EntityCard';
+import NamespaceStore from 'services/NamespaceStore';
 import {parseMetadata} from 'services/metadata-parser';
+import {convertEntityTypeToApi} from 'services/entity-type-api-converter';
+import {Link} from 'react-router';
 import shortid from 'shortid';
 require('./DataStreamCards.scss');
 
 export default function DatasetStreamCards({dataEntities}) {
+  let currentNamespace = NamespaceStore.getState().selectedNamespace;
   let data = dataEntities.map( dataEntity => {
     let entity = {
       entityId: dataEntity.entityId,
@@ -35,11 +39,13 @@ export default function DatasetStreamCards({dataEntities}) {
     <div className="dataentity-cards">
       {
         data.map(dataEntity => (
-          <EntityCard
-            className="entity-card-container"
-            entity={dataEntity}
-            key={dataEntity.uniqueId}
-          />
+          <Link to={`/ns/${currentNamespace}/${convertEntityTypeToApi(dataEntity.type)}/${dataEntity.id}`}>
+            <EntityCard
+              className="entity-card-container"
+              entity={dataEntity}
+              key={dataEntity.uniqueId}
+            />
+          </Link>
         ))
       }
     </div>

--- a/cdap-ui/app/cdap/components/EntityCard/EntityCard.scss
+++ b/cdap-ui/app/cdap/components/EntityCard/EntityCard.scss
@@ -74,7 +74,7 @@ $jump-button-container-size: 80px;
   &.datasetinstance,
   &.stream {
     .cask-card {
-      .card-header { cursor: pointer; }
+      cursor: pointer;
     }
   }
   .cask-card {

--- a/cdap-ui/app/cdap/components/EntityCard/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/index.js
@@ -103,7 +103,6 @@ export default class EntityCard extends Component {
     }
     const header = (
       <EntityCardHeader
-        onClick={this.onClick.bind(this)}
         className={this.props.entity.isHydrator ? 'datapipeline' : this.props.entity.type}
         entity={this.props.entity}
         systemTags={this.props.entity.metadata.metadata.SYSTEM.tags}
@@ -129,6 +128,7 @@ export default class EntityCard extends Component {
               `entity-cards-${this.props.entity.type}`
             )
           }
+          onClick={this.onClick.bind(this)}
         >
           <div className="entity-information clearfix">
             <div className={classnames("entity-id-container", {'with-version': this.props.entity.version})}>

--- a/cdap-ui/app/cdap/components/FastAction/FastActionButton/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/FastActionButton/index.js
@@ -18,15 +18,32 @@ import React, {PropTypes} from 'react';
 
 export default function FastActionButton({icon, action, disabled, id}) {
 
+  let preventPropagation = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    event.nativeEvent.stopImmediatePropagation();
+  };
+
+  let onButtonClick = (event) => {
+    preventPropagation(event);
+    action();
+  };
+
   return (
-    <button
-      className="btn btn-link"
-      onClick={action}
-      disabled={disabled}
+    // have to create a wrapper, because disabled elements don't fire mouse events in Firefox
+    // also set tooltip ID on this wrapper, so that the tooltip shows up even on a disabled button
+    <span
+      onClick={preventPropagation.bind(this)}
       id={id}
     >
-      <span className={icon}></span>
-    </button>
+      <button
+        className="btn btn-link"
+        disabled={disabled}
+        onClick={onButtonClick.bind(this)}
+      >
+        <span className={icon}></span>
+      </button>
+    </span>
   );
 }
 

--- a/cdap-ui/app/cdap/services/entity-type-api-converter/index.js
+++ b/cdap-ui/app/cdap/services/entity-type-api-converter/index.js
@@ -14,12 +14,13 @@
  * the License.
  */
 
-$card-title-text-color: #373a5c;
+const apiEntityTypeConvert = {
+  application: 'apps',
+  dataset: 'datasets',
+  datasetinstance: 'datasets',
+  stream: 'streams'
+};
 
-.dataentity-cards {
-  padding-top: 10px;
-
-  .entity-information {
-    color: $card-title-text-color;
-  }
+export function convertEntityTypeToApi(entityType) {
+  return apiEntityTypeConvert[entityType.toLowerCase()];
 }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-8370

- Clicking on dataset and stream cards inside the Dataset tab will lead to their detail pages.
- Clicking anywhere on an app/dataset/stream card on the home page will open up their overview.