### PR TITLE
CDAP-8458 Add ability to filter system entities

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/DefaultMetadataAdmin.java
@@ -25,6 +25,7 @@ import co.cask.cdap.common.entity.EntityExistenceVerifier;
 import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.proto.EntityScope;
 import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
@@ -166,9 +167,11 @@ public class DefaultMetadataAdmin implements MetadataAdmin {
   public MetadataSearchResponse search(String namespaceId, String searchQuery,
                                        Set<EntityTypeSimpleName> types,
                                        SortInfo sortInfo, int offset, int limit,
-                                       int numCursors, String cursor, boolean showHidden) throws Exception {
+                                       int numCursors, String cursor, boolean showHidden,
+                                       Set<EntityScope> entityScope) throws Exception {
     return filterAuthorizedSearchResult(
-      metadataStore.search(namespaceId, searchQuery, types, sortInfo, offset, limit, numCursors, cursor, showHidden)
+      metadataStore.search(namespaceId, searchQuery, types, sortInfo, offset, limit, numCursors, cursor, showHidden,
+                           entityScope)
     );
   }
 
@@ -192,7 +195,7 @@ public class DefaultMetadataAdmin implements MetadataAdmin {
           }
         })
       ),
-      results.getCursors(), results.isShowHidden());
+      results.getCursors(), results.isShowHidden(), results.getEntityScope());
   }
 
   // Helper methods to validate the metadata entries.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataAdmin.java
@@ -19,6 +19,7 @@ package co.cask.cdap.metadata;
 import co.cask.cdap.common.InvalidMetadataException;
 import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
+import co.cask.cdap.proto.EntityScope;
 import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
@@ -170,9 +171,10 @@ public interface MetadataAdmin {
    *               the cursor. If {@code null}, the first row is used as the cursor
    * @param showHidden boolean which specifies whether to display hidden entities (entity whose name start with "_")
    *                    or not.
+   * @param entityScope a set which specifies which scope of entities to display.
    * @return the {@link MetadataSearchResponse} containing search results for the specified search query and filters
    */
   MetadataSearchResponse search(String namespaceId, String searchQuery, Set<EntityTypeSimpleName> types,
                                 SortInfo sortInfo, int offset, int limit, int numCursors,
-                                String cursor, boolean showHidden) throws Exception;
+                                String cursor, boolean showHidden, Set<EntityScope> entityScope) throws Exception;
 }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/metadata/MetadataAdminAuthorizationTest.java
@@ -23,6 +23,7 @@ import co.cask.cdap.common.test.AppJarHelper;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.internal.AppFabricTestHelper;
 import co.cask.cdap.internal.app.services.AppFabricServer;
+import co.cask.cdap.proto.EntityScope;
 import co.cask.cdap.proto.Id;
 import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -80,11 +81,13 @@ public class MetadataAdminAuthorizationTest {
     EnumSet<EntityTypeSimpleName> types = EnumSet.allOf(EntityTypeSimpleName.class);
     Assert.assertFalse(
       metadataAdmin.search(NamespaceId.DEFAULT.getNamespace(), "*", types,
-                           SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 0, null, false).getResults().isEmpty());
+                           SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 0, null, false,
+                           EnumSet.allOf(EntityScope.class)).getResults().isEmpty());
     SecurityRequestContext.setUserId("bob");
     Assert.assertTrue(
       metadataAdmin.search(NamespaceId.DEFAULT.getNamespace(), "*", types,
-                           SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 0, null, false).getResults().isEmpty());
+                           SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 0, null, false,
+                           EnumSet.allOf(EntityScope.class)).getResults().isEmpty());
   }
 
   @AfterClass

--- a/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataHttpHandlerTestRun.java
+++ b/cdap-client-tests/src/test/java/co/cask/cdap/client/MetadataHttpHandlerTestRun.java
@@ -38,6 +38,7 @@ import co.cask.cdap.data2.metadata.system.AbstractSystemMetadataWriter;
 import co.cask.cdap.data2.metadata.system.DatasetSystemMetadataWriter;
 import co.cask.cdap.metadata.MetadataHttpHandler;
 import co.cask.cdap.proto.DatasetInstanceConfiguration;
+import co.cask.cdap.proto.EntityScope;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.StreamProperties;
@@ -1822,7 +1823,8 @@ public class MetadataHttpHandlerTestRun extends MetadataTestBase {
     }
     return new MetadataSearchResponse(searchResponse.getSort(), searchResponse.getOffset(), searchResponse.getLimit(),
                                       searchResponse.getNumCursors(), searchResponse.getTotal(), transformed,
-                                      searchResponse.getCursors(), searchResponse.isShowHidden());
+                                      searchResponse.getCursors(), searchResponse.isShowHidden(),
+                                      searchResponse.getEntityScope());
   }
 
   private MetadataSearchResponse searchMetadata(NamespaceId namespaceId, String query,

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/MetadataStore.java
@@ -19,6 +19,7 @@ package co.cask.cdap.data2.metadata.store;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.data2.metadata.dataset.MetadataDataset;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
+import co.cask.cdap.proto.EntityScope;
 import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
@@ -177,12 +178,14 @@ public interface MetadataStore {
    *               the cursor. If {@code null}, the first row is used as the cursor
    * @param showHidden boolean which specifies whether to display hidden entities (entity whose name start with "_")
    *                    or not.
+   * @param entityScope a set which specifies which scope of entities to display.
    * @return the {@link MetadataSearchResponse} containing search results for the specified search query and filters
    */
   MetadataSearchResponse search(String namespaceId, String searchQuery,
                                 Set<EntityTypeSimpleName> types,
                                 SortInfo sortInfo, int offset, int limit,
-                                int numCursors, String cursor, boolean showHidden) throws BadRequestException;
+                                int numCursors, String cursor, boolean showHidden,
+                                Set<EntityScope> entityScope) throws BadRequestException;
 
   /**
    * Returns the snapshot of the metadata for entities on or before the given time in both {@link MetadataScope#USER}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/store/NoOpMetadataStore.java
@@ -16,6 +16,7 @@
 package co.cask.cdap.data2.metadata.store;
 
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
+import co.cask.cdap.proto.EntityScope;
 import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.cdap.proto.metadata.MetadataRecord;
@@ -119,10 +120,10 @@ public class NoOpMetadataStore implements MetadataStore {
   public MetadataSearchResponse search(String namespaceId, String searchQuery,
                                        Set<EntityTypeSimpleName> types,
                                        SortInfo sort, int offset, int limit, int numCursors, String cursor,
-                                       boolean showHidden) {
+                                       boolean showHidden, Set<EntityScope> entityScope) {
     return new MetadataSearchResponse(sort.toString(), offset, limit, numCursors, 0,
                                       Collections.<MetadataSearchResultRecord>emptySet(),
-                                      Collections.<String>emptyList(), showHidden);
+                                      Collections.<String>emptyList(), showHidden, entityScope);
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
@@ -24,6 +24,7 @@ import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import co.cask.cdap.data2.metadata.indexer.Indexer;
 import co.cask.cdap.data2.metadata.indexer.InvertedValueIndexer;
 import co.cask.cdap.data2.metadata.system.AbstractSystemMetadataWriter;
+import co.cask.cdap.proto.EntityScope;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.ApplicationId;
@@ -677,6 +678,55 @@ public class MetadataDatasetTest {
   }
 
   @Test
+  public void testSearchDifferentEntityScope() throws InterruptedException, TransactionFailureException {
+    final ArtifactId sysArtifact = NamespaceId.SYSTEM.artifact("artifact", "1.0");
+    final ArtifactId nsArtifact = new ArtifactId("ns1", "artifact", "1.0");
+    final String multiWordKey = "multiword";
+    final String multiWordValue = "aV1 av2 ,  -  ,  av3 - av4_av5 av6";
+
+    txnl.execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        dataset.setProperty(nsArtifact, multiWordKey, multiWordValue);
+        dataset.setProperty(sysArtifact, multiWordKey, multiWordValue);
+      }
+    });
+
+    final MetadataEntry systemArtifactEntry = new MetadataEntry(sysArtifact, multiWordKey, multiWordValue);
+    final MetadataEntry nsArtifactEntry = new MetadataEntry(nsArtifact, multiWordKey, multiWordValue);
+
+    txnl.execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        List<MetadataEntry> results = dataset.search("ns1", "aV5", ImmutableSet.of(EntityTypeSimpleName.ALL),
+                                                     SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 1, null,
+                                                     false, EnumSet.of(EntityScope.USER)).getResults();
+        // the result should not contain system entities
+        Assert.assertEquals(Sets.newHashSet(nsArtifactEntry), Sets.newHashSet(results));
+        results = dataset.search("ns1", "aV5", ImmutableSet.of(EntityTypeSimpleName.ALL),
+                                 SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 1, null,
+                                 false, EnumSet.of(EntityScope.SYSTEM)).getResults();
+        // the result should not contain user entities
+        Assert.assertEquals(Sets.newHashSet(systemArtifactEntry), Sets.newHashSet(results));
+        results = dataset.search("ns1", "aV5", ImmutableSet.of(EntityTypeSimpleName.ALL),
+                                 SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 1, null,
+                                 false, EnumSet.allOf(EntityScope.class)).getResults();
+        // the result should contain both entity scopes
+        Assert.assertEquals(Sets.newHashSet(nsArtifactEntry, systemArtifactEntry), Sets.newHashSet(results));
+      }
+    });
+
+    // clean up
+    txnl.execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        dataset.removeProperties(nsArtifact);
+        dataset.removeProperties(sysArtifact);
+      }
+    });
+  }
+
+  @Test
   public void testUpdateSearch() throws Exception {
     txnl.execute(new TransactionExecutor.Subroutine() {
       @Override
@@ -1071,7 +1121,7 @@ public class MetadataDatasetTest {
       public void apply() throws Exception {
         // since no sort is to be performed by the dataset, we return all (ignore limit and offset)
         SearchResults searchResults = dataset.search(namespaceId, "name*", targets, SortInfo.DEFAULT, 0, 3, 1, null,
-                                                     false);
+                                                     false, EnumSet.allOf(EntityScope.class));
         Assert.assertEquals(
           // since default indexer is used:
           // 1 index for flow: 'name11'
@@ -1083,64 +1133,77 @@ public class MetadataDatasetTest {
         // ascending sort by name. offset and limit should be respected.
         SortInfo nameAsc = new SortInfo(AbstractSystemMetadataWriter.ENTITY_NAME_KEY, SortInfo.SortOrder.ASC);
         // first 2 in ascending order
-        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 2, 0, null, false);
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 2, 0, null, false,
+                                       EnumSet.allOf(EntityScope.class));
         Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry), searchResults.getResults());
         Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry, appEntry), searchResults.getAllResults());
         // return 2 with offset 1 in ascending order
-        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 1, 2, 0, null, false);
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 1, 2, 0, null, false,
+                                       EnumSet.allOf(EntityScope.class));
         Assert.assertEquals(ImmutableList.of(dsEntry, appEntry), searchResults.getResults());
         Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry, appEntry), searchResults.getAllResults());
         // descending sort by name. offset and filter should be respected.
         SortInfo nameDesc = new SortInfo(AbstractSystemMetadataWriter.ENTITY_NAME_KEY, SortInfo.SortOrder.DESC);
         // first 2 in descending order
-        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 0, 2, 0, null, false);
+        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 0, 2, 0, null, false,
+                                       EnumSet.allOf(EntityScope.class));
         Assert.assertEquals(ImmutableList.of(appEntry, dsEntry), searchResults.getResults());
         Assert.assertEquals(ImmutableList.of(appEntry, dsEntry, flowEntry), searchResults.getAllResults());
         // last 1 in descending order
-        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 2, 1, 0, null, false);
+        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 2, 1, 0, null, false,
+                                       EnumSet.allOf(EntityScope.class));
         Assert.assertEquals(ImmutableList.of(flowEntry), searchResults.getResults());
         Assert.assertEquals(ImmutableList.of(appEntry, dsEntry, flowEntry), searchResults.getAllResults());
         // limit 0 should return empty
-        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 2, 0, 0, null, false);
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 2, 0, 0, null, false,
+                                       EnumSet.allOf(EntityScope.class));
         Assert.assertTrue(searchResults.getResults().isEmpty());
         Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry, appEntry), searchResults.getAllResults());
-        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 1, 0, 0, null, false);
+        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 1, 0, 0, null, false,
+                                       EnumSet.allOf(EntityScope.class));
         Assert.assertTrue(searchResults.getResults().isEmpty());
         Assert.assertEquals(ImmutableList.of(appEntry, dsEntry, flowEntry), searchResults.getAllResults());
         // offset greater than total search results should return empty
-        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 4, 0, 0, null, false);
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 4, 0, 0, null, false,
+                                       EnumSet.allOf(EntityScope.class));
         Assert.assertTrue(searchResults.getResults().isEmpty());
         Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry, appEntry), searchResults.getAllResults());
-        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 100, 0, 0, null, false);
+        searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 100, 0, 0, null, false,
+                                       EnumSet.allOf(EntityScope.class));
         Assert.assertTrue(searchResults.getResults().isEmpty());
         Assert.assertEquals(ImmutableList.of(appEntry, dsEntry, flowEntry), searchResults.getAllResults());
 
         // test cursors
-        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 1, 3, null, false);
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 1, 3, null, false,
+                                       EnumSet.allOf(EntityScope.class));
         Assert.assertEquals(ImmutableList.of(flowEntry), searchResults.getResults());
         // only 2 cursors are returned even though we requested 3 because we do not have enough data to return
         Assert.assertEquals(ImmutableList.of(dsName, appName), searchResults.getCursors());
 
         // use first cursor returned in the previous query. the rest of the parameters stay the same
         searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 1, 3, searchResults.getCursors().get(0),
-                                       false);
+                                       false,
+                                       EnumSet.allOf(EntityScope.class));
         Assert.assertEquals(ImmutableList.of(dsEntry), searchResults.getResults());
         // only 1 cursor is returned even though we requested 3 because we do not have enough data to return
         Assert.assertEquals(ImmutableList.of(appName), searchResults.getCursors());
 
         // use first cursor returned in the previous query. the rest of the parameters stay the same
         searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 1, 3, searchResults.getCursors().get(0),
-                                       false);
+                                       false,
+                                       EnumSet.allOf(EntityScope.class));
         Assert.assertEquals(ImmutableList.of(appEntry), searchResults.getResults());
         // no cursors are returned even though we requested 3 because we do not have enough data
         Assert.assertEquals(ImmutableList.of(), searchResults.getCursors());
 
-        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 2, 3, null, false);
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 2, 3, null, false,
+                                       EnumSet.allOf(EntityScope.class));
         Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry), searchResults.getResults());
         // only 1 cursor is returned even though we requested 3 because we do not have enough data to return
         Assert.assertEquals(ImmutableList.of(appName), searchResults.getCursors());
 
-        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 3, 1, 2, null, false);
+        searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 3, 1, 2, null, false,
+                                       EnumSet.allOf(EntityScope.class));
         // limit is 1, we return 0 because offset is too high
         Assert.assertEquals(ImmutableList.of(), searchResults.getResults());
         // only 1 cursor is returned even though we requested 3 because we do not have enough data to return
@@ -1442,7 +1505,8 @@ public class MetadataDatasetTest {
   private List<MetadataEntry> searchByDefaultIndex(MetadataDataset dataset, String namespaceId, String searchQuery,
                                                    Set<EntityTypeSimpleName> types) {
     return dataset.search(namespaceId, searchQuery, types,
-                          SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 1, null, false).getResults();
+                          SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 1, null, false,
+                          EnumSet.allOf(EntityScope.class)).getResults();
   }
 
   private static MetadataDataset getDataset(DatasetId instance) throws Exception {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/MetadataStoreTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/store/MetadataStoreTest.java
@@ -27,6 +27,7 @@ import co.cask.cdap.data.runtime.SystemDatasetRuntimeModule;
 import co.cask.cdap.data2.audit.AuditModule;
 import co.cask.cdap.data2.audit.InMemoryAuditPublisher;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
+import co.cask.cdap.proto.EntityScope;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.audit.AuditMessage;
 import co.cask.cdap.proto.audit.AuditType;
@@ -435,7 +436,7 @@ public class MetadataStoreTest {
     throws BadRequestException {
     return store.search(
       ns, searchQuery, EnumSet.allOf(EntityTypeSimpleName.class),
-      sortInfo, offset, limit, numCursors, "", showHidden);
+      sortInfo, offset, limit, numCursors, "", showHidden, EnumSet.allOf(EntityScope.class));
   }
 
   private void generateMetadataUpdates() {

--- a/cdap-docs/reference-manual/source/http-restful-api/metadata.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/metadata.rst
@@ -539,6 +539,9 @@ metadata property or metadata tag, submit an HTTP GET request::
           * - ``showHidden``
             - By default, metadata search hides entities whose name starts with an ``_`` (underscore) from the search
               results. Set this to ``true`` to include these hidden entities in search results. Default is ``false``.
+          * - ``entityScope``
+            - The scope of entities for the metadata search. By default, all entities will be returned. Set this to
+              ``USER`` to include only user entities; set this to ``SYSTEM`` to include only system entities.
 
        Format for an option: ``&<option-name>=<option-value>``
 
@@ -552,6 +555,7 @@ Entities that match the specified query and entity type are returned in the body
     "showHidden": false,
     "sort": "creation-time DESC",
     "total": 2,
+    "entityScope": [ "SYSTEM" ]
     "results": [
         {
             "entityId": {

--- a/cdap-master/src/main/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemover.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/tools/DeletedDatasetMetadataRemover.java
@@ -21,6 +21,7 @@ import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.metadata.dataset.SortInfo;
 import co.cask.cdap.data2.metadata.store.MetadataStore;
+import co.cask.cdap.proto.EntityScope;
 import co.cask.cdap.proto.NamespaceMeta;
 import co.cask.cdap.proto.element.EntityTypeSimpleName;
 import co.cask.cdap.proto.id.DatasetId;
@@ -56,7 +57,8 @@ final class DeletedDatasetMetadataRemover {
     for (NamespaceMeta namespaceMeta : nsStore.list()) {
       Set<MetadataSearchResultRecord> searchResults =
         metadataStore.search(namespaceMeta.getName(), "*", EnumSet.of(EntityTypeSimpleName.DATASET),
-                             SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 0, null, false).getResults();
+                             SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 0, null, false,
+                             EnumSet.allOf(EntityScope.class)).getResults();
       for (MetadataSearchResultRecord searchResult : searchResults) {
         NamespacedEntityId entityId = searchResult.getEntityId();
         Preconditions.checkState(entityId instanceof DatasetId,

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/EntityScope.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/EntityScope.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto;
+
+/**
+ * Represents the scope for an entity.
+ */
+public enum EntityScope {
+  USER,
+  SYSTEM
+}

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataSearchResponse.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/metadata/MetadataSearchResponse.java
@@ -16,6 +16,8 @@
 
 package co.cask.cdap.proto.metadata;
 
+import co.cask.cdap.proto.EntityScope;
+
 import java.util.List;
 import java.util.Set;
 
@@ -31,9 +33,11 @@ public class MetadataSearchResponse {
   private final Set<MetadataSearchResultRecord> results;
   private final List<String> cursors;
   private final boolean showHidden;
+  private final Set<EntityScope> entityScope;
 
   public MetadataSearchResponse(String sort, int offset, int limit, int numCursors, int total,
-                                Set<MetadataSearchResultRecord> results, List<String> cursors, boolean showHidden) {
+                                Set<MetadataSearchResultRecord> results, List<String> cursors, boolean showHidden,
+                                Set<EntityScope> entityScope) {
     this.sort = sort;
     this.offset = offset;
     this.limit = limit;
@@ -42,6 +46,7 @@ public class MetadataSearchResponse {
     this.results = results;
     this.cursors = cursors;
     this.showHidden = showHidden;
+    this.entityScope = entityScope;
   }
 
   public String getSort() {
@@ -74,5 +79,9 @@ public class MetadataSearchResponse {
 
   public boolean isShowHidden() {
     return showHidden;
+  }
+
+  public Set<EntityScope> getEntityScope() {
+    return entityScope;
   }
 }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-8458
Builds: http://builds.cask.co/browse/CDAP-RUT577-2

Added the ability to filter system entities in the search API so that UI can pass in a query param to indicate whether system entities need to show up.