### PR TITLE
HYDRATOR-1323 introduce error transform

### DIFF
--- a/cdap-app-templates/cdap-data-quality/src/main/java/co/cask/cdap/dq/MapReducePipelineConfigurer.java
+++ b/cdap-app-templates/cdap-data-quality/src/main/java/co/cask/cdap/dq/MapReducePipelineConfigurer.java
@@ -40,7 +40,7 @@ public class MapReducePipelineConfigurer implements PipelineConfigurer {
   public MapReducePipelineConfigurer(MapReduceConfigurer configurer, String stageName) {
     this.mrConfigurer = configurer;
     this.stageName = stageName;
-    this.stageConfigurer = new DefaultStageConfigurer(stageName);
+    this.stageConfigurer = new DefaultStageConfigurer();
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/DataPipelineApp.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/co/cask/cdap/datapipeline/DataPipelineApp.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.app.AbstractApplication;
 import co.cask.cdap.api.dataset.lib.FileSetProperties;
 import co.cask.cdap.api.dataset.lib.TimePartitionedFileSet;
 import co.cask.cdap.api.schedule.Schedules;
+import co.cask.cdap.etl.api.ErrorTransform;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.api.action.Action;
 import co.cask.cdap.etl.api.batch.BatchAggregator;
@@ -48,7 +49,7 @@ public class DataPipelineApp extends AbstractApplication<ETLBatchConfig> {
   private static final Set<String> supportedPluginTypes = ImmutableSet.of(
     BatchSource.PLUGIN_TYPE, BatchSink.PLUGIN_TYPE, Transform.PLUGIN_TYPE, BatchJoiner.PLUGIN_TYPE,
     Constants.CONNECTOR_TYPE, BatchAggregator.PLUGIN_TYPE, SparkCompute.PLUGIN_TYPE, SparkSink.PLUGIN_TYPE,
-    Action.PLUGIN_TYPE);
+    Action.PLUGIN_TYPE, ErrorTransform.PLUGIN_TYPE);
 
   @Override
   public void configure() {

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineDriver.java
@@ -22,6 +22,7 @@ import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.lib.FileSet;
 import co.cask.cdap.api.spark.JavaSparkExecutionContext;
 import co.cask.cdap.api.spark.JavaSparkMain;
+import co.cask.cdap.etl.api.ErrorTransform;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.api.batch.BatchAggregator;
 import co.cask.cdap.etl.api.batch.BatchJoiner;
@@ -57,7 +58,7 @@ public class SparkStreamingPipelineDriver implements JavaSparkMain {
     .create();
   private static final Set<String> SUPPORTED_PLUGIN_TYPES = ImmutableSet.of(
     StreamingSource.PLUGIN_TYPE, BatchSink.PLUGIN_TYPE, Transform.PLUGIN_TYPE, BatchAggregator.PLUGIN_TYPE,
-    BatchJoiner.PLUGIN_TYPE, SparkCompute.PLUGIN_TYPE, Windower.PLUGIN_TYPE);
+    BatchJoiner.PLUGIN_TYPE, SparkCompute.PLUGIN_TYPE, Windower.PLUGIN_TYPE, ErrorTransform.PLUGIN_TYPE);
 
   @Override
   public void run(final JavaSparkExecutionContext sec) throws Exception {
@@ -72,6 +73,7 @@ public class SparkStreamingPipelineDriver implements JavaSparkMain {
                               .addOutputs(stageSpec.getOutputs())
                               .addInputSchemas(stageSpec.getInputSchemas())
                               .setOutputSchema(stageSpec.getOutputSchema())
+                              .setErrorSchema(stageSpec.getErrorSchema())
                               .build());
     }
     final PipelinePhase pipelinePhase = phaseBuilder.build();

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineRunner.java
@@ -31,7 +31,7 @@ import co.cask.cdap.etl.spark.streaming.DStreamCollection;
 import co.cask.cdap.etl.spark.streaming.DefaultStreamingContext;
 import co.cask.cdap.etl.spark.streaming.DynamicDriverContext;
 import co.cask.cdap.etl.spark.streaming.PairDStreamCollection;
-import co.cask.cdap.etl.spark.streaming.function.CountingTranformFunction;
+import co.cask.cdap.etl.spark.streaming.function.CountingTransformFunction;
 import co.cask.cdap.etl.spark.streaming.function.DynamicJoinMerge;
 import co.cask.cdap.etl.spark.streaming.function.DynamicJoinOn;
 import co.cask.cdap.etl.spark.streaming.function.WrapOutputTransformFunction;
@@ -90,7 +90,7 @@ public class SparkStreamingPipelineRunner extends SparkPipelineRunner {
       javaDStream = javaDStream.transform(new LimitingFunction<>(numOfRecordsPreview));
     }
     JavaDStream<Tuple2<Boolean, Object>> outputDStream = javaDStream
-      .transform(new CountingTranformFunction<>(stageInfo.getName(), sec.getMetrics(), "records.out", dataTracer))
+      .transform(new CountingTransformFunction<>(stageInfo.getName(), sec.getMetrics(), "records.out", dataTracer))
       .map(new WrapOutputTransformFunction<>());
     return new DStreamCollection<>(sec, outputDStream);
   }

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/co/cask/cdap/datastreams/SparkStreamingPipelineRunner.java
@@ -34,10 +34,12 @@ import co.cask.cdap.etl.spark.streaming.PairDStreamCollection;
 import co.cask.cdap.etl.spark.streaming.function.CountingTranformFunction;
 import co.cask.cdap.etl.spark.streaming.function.DynamicJoinMerge;
 import co.cask.cdap.etl.spark.streaming.function.DynamicJoinOn;
+import co.cask.cdap.etl.spark.streaming.function.WrapOutputTransformFunction;
 import co.cask.cdap.etl.spark.streaming.function.preview.LimitingFunction;
 import org.apache.spark.streaming.api.java.JavaDStream;
 import org.apache.spark.streaming.api.java.JavaPairDStream;
 import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import scala.Tuple2;
 
 import java.util.List;
 
@@ -60,7 +62,7 @@ public class SparkStreamingPipelineRunner extends SparkPipelineRunner {
   }
 
   @Override
-  protected SparkCollection<Object> getSource(StageInfo stageInfo) throws Exception {
+  protected SparkCollection<Tuple2<Boolean, Object>> getSource(StageInfo stageInfo) throws Exception {
     StreamingSource<Object> source;
     if (checkpointsDisabled) {
       PluginFunctionContext pluginFunctionContext = new PluginFunctionContext(stageInfo, sec);
@@ -87,9 +89,10 @@ public class SparkStreamingPipelineRunner extends SparkPipelineRunner {
       // it will create a new function for each RDD, which would limit each RDD but not the entire DStream.
       javaDStream = javaDStream.transform(new LimitingFunction<>(numOfRecordsPreview));
     }
-    javaDStream = javaDStream.transform(new CountingTranformFunction<>(stageInfo.getName(), sec.getMetrics(),
-                                                                       "records.out", dataTracer));
-    return new DStreamCollection<>(sec, javaDStream);
+    JavaDStream<Tuple2<Boolean, Object>> outputDStream = javaDStream
+      .transform(new CountingTranformFunction<>(stageInfo.getName(), sec.getMetrics(), "records.out", dataTracer))
+      .map(new WrapOutputTransformFunction<>());
+    return new DStreamCollection<>(sec, outputDStream);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/ErrorRecord.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/ErrorRecord.java
@@ -16,8 +16,6 @@
 
 package co.cask.cdap.etl.api;
 
-import javax.annotation.Nullable;
-
 /**
  * Information about a record that was emitted using {@link Emitter#emitError(InvalidEntry)}.
  *
@@ -31,15 +29,13 @@ public interface ErrorRecord<T> {
   T getRecord();
 
   /**
-   * @return the error code if one was give
+   * @return the error code
    */
-  @Nullable
-  Integer getErrorCode();
+  int getErrorCode();
 
   /**
-   * @return the error message if one was given
+   * @return the error message
    */
-  @Nullable
   String getErrorMessage();
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/ErrorRecord.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/ErrorRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,27 +16,34 @@
 
 package co.cask.cdap.etl.api;
 
-import co.cask.cdap.api.annotation.Beta;
+import javax.annotation.Nullable;
 
 /**
- * Used to emit one or more key, value pairs to the next stage.
+ * Information about a record that was emitted using {@link Emitter#emitError(InvalidEntry)}.
  *
- * @param <T> Type of the object to emit
+ * @param <T> the record type
  */
-@Beta
-public interface Emitter<T> {
+public interface ErrorRecord<T> {
 
   /**
-   * Emit an object.
-   * @param value the object to emit
+   * @return the error record
    */
-  void emit(T value);
+  T getRecord();
 
   /**
-   * Emit an Error object. If an {@link ErrorTransform} is placed after this stage, it will be able to consume
-   * the errors. Otherwise the errors are simply dropped.
-   *
-   * @param invalidEntry {@link InvalidEntry InvalidEntry&lt;T&gt;} representing the error.
+   * @return the error code if one was give
    */
-  void emitError(InvalidEntry<T> invalidEntry);
+  @Nullable
+  Integer getErrorCode();
+
+  /**
+   * @return the error message if one was given
+   */
+  @Nullable
+  String getErrorMessage();
+
+  /**
+   * @return the stage the error was emitted from
+   */
+  String getStageName();
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/ErrorTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/ErrorTransform.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.api;
+
+/**
+ * A special type of {@link Transform} that will get as input all errors emitted by the previous stage.
+ * A record is emitted as an error using {@link Emitter#emitError(InvalidEntry)}.
+ *
+ * @param <IN> the type of error record
+ * @param <OUT> the type of output record
+ */
+public abstract class ErrorTransform<IN, OUT> extends Transform<ErrorRecord<IN>, OUT> {
+  public static final String PLUGIN_TYPE = "errortransform";
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/InvalidEntry.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/InvalidEntry.java
@@ -16,12 +16,15 @@
 
 package co.cask.cdap.etl.api;
 
+import java.io.Serializable;
+
 /**
  * Represents a record that fails validation, with provided errorCode and errorMessage
  *
  * @param <T> Type of the object that failed validation.
  */
-public class InvalidEntry<T> {
+public class InvalidEntry<T> implements Serializable {
+  private static final long serialVersionUID = -1232949057204279740L;
   private final int errorCode;
   private final String errorMsg;
   private final T invalidRecord;

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/InvalidEntry.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/InvalidEntry.java
@@ -31,7 +31,8 @@ public class InvalidEntry<T> implements Serializable {
 
   public InvalidEntry(int errorCode, String errorMsg, T invalidRecord) {
     this.errorCode = errorCode;
-    this.errorMsg = errorMsg;
+    // since user code creates this object, just make sure it can't be null
+    this.errorMsg = errorMsg == null ? "" : errorMsg;
     this.invalidRecord = invalidRecord;
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/StageConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/StageConfigurer.java
@@ -18,6 +18,7 @@ package co.cask.cdap.etl.api;
 
 import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.etl.api.batch.BatchSource;
 
 import javax.annotation.Nullable;
 
@@ -37,10 +38,19 @@ public interface StageConfigurer {
   Schema getInputSchema();
 
   /**
-   * set output schema for this stage, or null if its unknown
+   * set the output schema for this stage, or null if its unknown
    *
    * @param outputSchema output schema for this stage
    */
   void setOutputSchema(@Nullable Schema outputSchema);
+
+  /**
+   * set the error schema for this stage, or null if its unknown.
+   * If no error schema is set, it will default to the input schema for the stage. Note that since source
+   * plugins do not have an input schema, it will default to null for sources.
+   *
+   * @param errorSchema error schema for this stage
+   */
+  void setErrorSchema(@Nullable Schema errorSchema);
 
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/PipeTransformDetail.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/PipeTransformDetail.java
@@ -31,13 +31,15 @@ public class PipeTransformDetail implements Destroyable {
   private final Transformation transformation;
   private final PipeEmitter<PipeTransformDetail> emitter;
   private final boolean removeStageName;
+  private final boolean isErrorConsumer;
 
-  public PipeTransformDetail(String stageName, boolean removeStageName,
+  public PipeTransformDetail(String stageName, boolean removeStageName, boolean isErrorConsumer,
                              Transformation transformation, PipeEmitter<PipeTransformDetail> emitter) {
     this.stageName = stageName;
     this.removeStageName = removeStageName;
     this.transformation = transformation;
     this.emitter = emitter;
+    this.isErrorConsumer = isErrorConsumer;
   }
 
   public void process(KeyValue<String, Object> value) {
@@ -54,6 +56,10 @@ public class PipeTransformDetail implements Destroyable {
 
   public void addTransformation(String stageName, PipeTransformDetail pipeTransformDetail) {
     emitter.addTransformDetail(stageName, pipeTransformDetail);
+  }
+
+  public boolean isErrorConsumer() {
+    return isErrorConsumer;
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceTransformExecutorFactory.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceTransformExecutorFactory.java
@@ -251,7 +251,8 @@ public class MapReduceTransformExecutorFactory<T> extends TransformExecutorFacto
                                    String groupKeyClassName,
                                    String groupValClassName) {
       this.aggregator = aggregator;
-      this.groupKeyEmitter = new NoErrorEmitter<>();
+      this.groupKeyEmitter =
+        new NoErrorEmitter<>("Error records cannot be emitted from the groupBy method of an aggregator");
       WritableConversion<GROUP_KEY, OUT_KEY> keyConversion = WritableConversions.getConversion(groupKeyClassName);
       WritableConversion<GROUP_VAL, OUT_VAL> valConversion = WritableConversions.getConversion(groupValClassName);
       // if the conversion is null, it means the user is using a Writable already

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceTransformExecutorFactory.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/co/cask/cdap/etl/batch/mapreduce/MapReduceTransformExecutorFactory.java
@@ -36,9 +36,9 @@ import co.cask.cdap.etl.batch.conversion.WritableConversion;
 import co.cask.cdap.etl.batch.conversion.WritableConversions;
 import co.cask.cdap.etl.batch.join.Join;
 import co.cask.cdap.etl.common.DatasetContextLookupProvider;
-import co.cask.cdap.etl.common.DefaultEmitter;
 import co.cask.cdap.etl.common.DefaultMacroEvaluator;
 import co.cask.cdap.etl.common.DefaultStageMetrics;
+import co.cask.cdap.etl.common.NoErrorEmitter;
 import co.cask.cdap.etl.common.TrackedTransform;
 import co.cask.cdap.etl.common.preview.LimitingTransform;
 import co.cask.cdap.etl.planner.StageInfo;
@@ -243,7 +243,7 @@ public class MapReduceTransformExecutorFactory<T> extends TransformExecutorFacto
   private static class MapperAggregatorTransformation<GROUP_KEY, GROUP_VAL, OUT_KEY extends Writable,
     OUT_VAL extends Writable> implements Transformation<GROUP_VAL, KeyValue<OUT_KEY, OUT_VAL>> {
     private final Aggregator<GROUP_KEY, GROUP_VAL, ?> aggregator;
-    private final DefaultEmitter<GROUP_KEY> groupKeyEmitter;
+    private final NoErrorEmitter<GROUP_KEY> groupKeyEmitter;
     private final WritableConversion<GROUP_KEY, OUT_KEY> keyConversion;
     private final WritableConversion<GROUP_VAL, OUT_VAL> valConversion;
 
@@ -251,7 +251,7 @@ public class MapReduceTransformExecutorFactory<T> extends TransformExecutorFacto
                                    String groupKeyClassName,
                                    String groupValClassName) {
       this.aggregator = aggregator;
-      this.groupKeyEmitter = new DefaultEmitter<>();
+      this.groupKeyEmitter = new NoErrorEmitter<>();
       WritableConversion<GROUP_KEY, OUT_KEY> keyConversion = WritableConversions.getConversion(groupKeyClassName);
       WritableConversion<GROUP_VAL, OUT_VAL> valConversion = WritableConversions.getConversion(groupValClassName);
       // if the conversion is null, it means the user is using a Writable already

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/batch/BatchPhaseSpecTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/co/cask/cdap/etl/batch/BatchPhaseSpecTest.java
@@ -62,7 +62,6 @@ public class BatchPhaseSpecTest {
     BatchPhaseSpec phaseSpec =
       new BatchPhaseSpec("phase-1", builder.build(), new Resources(), new Resources(), new Resources(),
                          false, Collections.<String, String>emptyMap(), 0);
-    String phaseSpecStr = GSON.toJson(phaseSpec);
     Assert.assertEquals("Sources 'source1', 'source2' to sinks 'sink.connector'.", phaseSpec.getDescription());
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/BasicErrorRecord.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/BasicErrorRecord.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.common;
+
+import co.cask.cdap.etl.api.ErrorRecord;
+
+import java.io.Serializable;
+import javax.annotation.Nullable;
+
+/**
+ * Default implementation of {@link ErrorRecord}.
+ *
+ * @param <T> the type of error record
+ */
+public class BasicErrorRecord<T> implements ErrorRecord<T>, Serializable {
+  private static final long serialVersionUID = 3026318232156561080L;
+  private final T record;
+  private final String stageName;
+  private final Integer errorCode;
+  private final String errorMessage;
+
+  public BasicErrorRecord(T record, String stageName, @Nullable Integer errorCode, @Nullable String errorMessage) {
+    this.record = record;
+    this.stageName = stageName;
+    this.errorCode = errorCode;
+    this.errorMessage = errorMessage;
+  }
+
+  @Override
+  public T getRecord() {
+    return record;
+  }
+
+  @Nullable
+  @Override
+  public Integer getErrorCode() {
+    return errorCode;
+  }
+
+  @Nullable
+  @Override
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  @Override
+  public String getStageName() {
+    return stageName;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/BasicErrorRecord.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/BasicErrorRecord.java
@@ -30,10 +30,10 @@ public class BasicErrorRecord<T> implements ErrorRecord<T>, Serializable {
   private static final long serialVersionUID = 3026318232156561080L;
   private final T record;
   private final String stageName;
-  private final Integer errorCode;
+  private final int errorCode;
   private final String errorMessage;
 
-  public BasicErrorRecord(T record, String stageName, @Nullable Integer errorCode, @Nullable String errorMessage) {
+  public BasicErrorRecord(T record, String stageName, int errorCode, String errorMessage) {
     this.record = record;
     this.stageName = stageName;
     this.errorCode = errorCode;
@@ -47,7 +47,7 @@ public class BasicErrorRecord<T> implements ErrorRecord<T>, Serializable {
 
   @Nullable
   @Override
-  public Integer getErrorCode() {
+  public int getErrorCode() {
     return errorCode;
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/DefaultPipelineConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/DefaultPipelineConfigurer.java
@@ -42,7 +42,7 @@ public class DefaultPipelineConfigurer implements PipelineConfigurer, MultiInput
   public DefaultPipelineConfigurer(PluginConfigurer configurer, String stageName) {
     this.configurer = configurer;
     this.stageName = stageName;
-    this.stageConfigurer = new DefaultStageConfigurer(stageName);
+    this.stageConfigurer = new DefaultStageConfigurer();
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/DefaultStageConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/DefaultStageConfigurer.java
@@ -35,12 +35,13 @@ import javax.annotation.Nullable;
  */
 public class DefaultStageConfigurer implements StageConfigurer, MultiInputStageConfigurer {
   private Schema outputSchema;
-  private final String stageName;
-  private Map<String, Schema> inputSchemas;
+  private Schema outputErrorSchema;
+  private boolean errorSchemaSet;
+  protected Map<String, Schema> inputSchemas;
 
-  public DefaultStageConfigurer(String stageName) {
-    this.stageName = stageName;
+  public DefaultStageConfigurer() {
     this.inputSchemas = new HashMap<>();
+    this.errorSchemaSet = false;
   }
 
   @Nullable
@@ -63,6 +64,20 @@ public class DefaultStageConfigurer implements StageConfigurer, MultiInputStageC
   @Override
   public void setOutputSchema(@Nullable Schema outputSchema) {
     this.outputSchema = outputSchema;
+  }
+
+  @Override
+  public void setErrorSchema(@Nullable Schema errorSchema) {
+    this.outputErrorSchema = errorSchema;
+    errorSchemaSet = true;
+  }
+
+  public Schema getErrorSchema() {
+    if (errorSchemaSet) {
+      return outputErrorSchema;
+    }
+    // only joiners can have multiple input schemas, and joiners can't emit errors
+    return inputSchemas.isEmpty() ? null : inputSchemas.values().iterator().next();
   }
 
   public void addInputSchema(String inputStageName, @Nullable Schema inputSchema) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/NoErrorEmitter.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/NoErrorEmitter.java
@@ -32,10 +32,6 @@ public class NoErrorEmitter<T> implements Emitter<T> {
   private final List<T> entryList;
   private final String errorMessage;
 
-  public NoErrorEmitter() {
-    this("Error records cannot be emitted from the groupBy method of an aggregator");
-  }
-
   public NoErrorEmitter(String errorMessage) {
     this.entryList = Lists.newArrayList();
     this.errorMessage = errorMessage;

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/NoErrorEmitter.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/NoErrorEmitter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.common;
+
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.InvalidEntry;
+import com.google.common.collect.Lists;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Default implementation of {@link Emitter}. Has methods to get the values and errors emitted.
+ *
+ * @param <T> the type of object to emit
+ */
+public class NoErrorEmitter<T> implements Emitter<T> {
+  private final List<T> entryList;
+  private final String errorMessage;
+
+  public NoErrorEmitter() {
+    this("Error records cannot be emitted from the groupBy method of an aggregator");
+  }
+
+  public NoErrorEmitter(String errorMessage) {
+    this.entryList = Lists.newArrayList();
+    this.errorMessage = errorMessage;
+  }
+
+  @Override
+  public void emit(T value) {
+    entryList.add(value);
+  }
+
+  @Override
+  public void emitError(InvalidEntry<T> value) {
+    throw new UnsupportedOperationException(errorMessage);
+  }
+
+  public Collection<T> getEntries() {
+    return entryList;
+  }
+
+  public void reset() {
+    entryList.clear();
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/PipelinePlanner.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/PipelinePlanner.java
@@ -204,6 +204,7 @@ public class PipelinePlanner {
         .addInputSchemas(actionStageSpec.getInputSchemas())
         .addOutputs(actionStageSpec.getOutputs())
         .setOutputSchema(actionStageSpec.getOutputSchema())
+        .setErrorSchema(actionStageSpec.getErrorSchema())
         .setErrorDatasetName(actionStageSpec.getErrorDatasetName())
         .build();
       phases.put(node, PipelinePhase.builder(supportedPluginTypes).addStage(actionStageInfo).build());
@@ -274,6 +275,7 @@ public class PipelinePlanner {
                               .addInputSchemas(spec.getInputSchemas())
                               .addOutputs(spec.getOutputs())
                               .setOutputSchema(spec.getOutputSchema())
+                              .setErrorSchema(spec.getErrorSchema())
                               .setErrorDatasetName(spec.getErrorDatasetName())
                               .build());
     }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/StageInfo.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/planner/StageInfo.java
@@ -40,14 +40,17 @@ public class StageInfo implements Serializable {
   private final Map<String, Schema> inputSchemas;
   private final Set<String> outputs;
   private final Schema outputSchema;
+  private final Schema errorSchema;
   private final String errorDatasetName;
 
   private StageInfo(String name, String pluginType, Set<String> inputs, Map<String, Schema> inputSchemas,
-                    Set<String> outputs, @Nullable Schema outputSchema, @Nullable String errorDatasetName) {
+                    Set<String> outputs, @Nullable Schema outputSchema, @Nullable Schema errorSchema,
+                    @Nullable String errorDatasetName) {
     this.name = name;
     this.pluginType = pluginType;
     this.inputSchemas = Collections.unmodifiableMap(inputSchemas);
     this.outputSchema = outputSchema;
+    this.errorSchema = errorSchema;
     this.inputs = ImmutableSet.copyOf(inputs);
     this.outputs = ImmutableSet.copyOf(outputs);
     this.errorDatasetName = errorDatasetName;
@@ -83,6 +86,11 @@ public class StageInfo implements Serializable {
     return errorDatasetName;
   }
 
+  @Nullable
+  public Schema getErrorSchema() {
+    return errorSchema;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -100,24 +108,26 @@ public class StageInfo implements Serializable {
       Objects.equals(inputSchemas, that.inputSchemas) &&
       Objects.equals(outputs, that.outputs) &&
       Objects.equals(outputSchema, that.outputSchema) &&
+      Objects.equals(errorSchema, that.errorSchema) &&
       Objects.equals(errorDatasetName, that.errorDatasetName);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(name, pluginType, inputs, inputSchemas,
-                        outputs, outputSchema, errorDatasetName);
+                        outputs, outputSchema, errorSchema, errorDatasetName);
   }
 
   @Override
   public String toString() {
     return "StageInfo{" +
       "name='" + name + '\'' +
-      "pluginType='" + pluginType + '\'' +
-      "inputs='" + inputs + '\'' +
-      "inputSchemas='" + inputSchemas + '\'' +
-      "outputs='" + outputs + '\'' +
-      "outputSchema='" + outputSchema + '\'' +
+      ", pluginType='" + pluginType + '\'' +
+      ", inputs=" + inputs +
+      ", inputSchemas=" + inputSchemas +
+      ", outputs=" + outputs +
+      ", outputSchema=" + outputSchema +
+      ", errorSchema=" + errorSchema +
       ", errorDatasetName='" + errorDatasetName + '\'' +
       '}';
   }
@@ -136,6 +146,7 @@ public class StageInfo implements Serializable {
     private final Set<String> outputs;
     private final Map<String, Schema> inputSchemas;
     private Schema outputSchema;
+    private Schema errorSchema;
     private String errorDatasetName;
 
     public Builder(String name, String pluginType) {
@@ -181,13 +192,19 @@ public class StageInfo implements Serializable {
       return this;
     }
 
+    public Builder setErrorSchema(Schema schema) {
+      errorSchema = schema;
+      return this;
+    }
+
     public Builder setErrorDatasetName(String errorDatasetName) {
       this.errorDatasetName = errorDatasetName;
       return this;
     }
 
     public StageInfo build() {
-      return new StageInfo(name, pluginType, inputs, inputSchemas, outputs, outputSchema, errorDatasetName);
+      return new StageInfo(name, pluginType, inputs, inputSchemas, outputs,
+                           outputSchema, errorSchema, errorDatasetName);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/StageSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/StageSpec.java
@@ -41,16 +41,19 @@ public class StageSpec {
   private final String errorDatasetName;
   private final Map<String, Schema> inputSchemas;
   private final Schema outputSchema;
+  private final Schema errorSchema;
   private final Set<String> inputs;
   private final Set<String> outputs;
 
   private StageSpec(String name, PluginSpec plugin, String errorDatasetName,
-                    Map<String, Schema> inputSchemas, Schema outputSchema, Set<String> inputs, Set<String> outputs) {
+                    Map<String, Schema> inputSchemas, Schema outputSchema, Schema errorSchema,
+                    Set<String> inputs, Set<String> outputs) {
     this.name = name;
     this.plugin = plugin;
     this.errorDatasetName = errorDatasetName;
     this.inputSchemas = inputSchemas;
     this.outputSchema = outputSchema;
+    this.errorSchema = errorSchema;
     this.inputs = ImmutableSet.copyOf(inputs);
     this.outputs = ImmutableSet.copyOf(outputs);
   }
@@ -73,6 +76,10 @@ public class StageSpec {
 
   public Schema getOutputSchema() {
     return outputSchema;
+  }
+
+  public Schema getErrorSchema() {
+    return errorSchema;
   }
 
   public Set<String> getInputs() {
@@ -99,13 +106,14 @@ public class StageSpec {
       Objects.equals(errorDatasetName, that.errorDatasetName) &&
       Objects.equals(inputSchemas, that.inputSchemas) &&
       Objects.equals(outputSchema, that.outputSchema) &&
+      Objects.equals(errorSchema, that.errorSchema) &&
       Objects.equals(inputs, that.inputs) &&
       Objects.equals(outputs, that.outputs);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, plugin, errorDatasetName, inputSchemas, outputSchema, inputs, outputs);
+    return Objects.hash(name, plugin, errorDatasetName, inputSchemas, outputSchema, errorSchema, inputs, outputs);
   }
 
   @Override
@@ -116,6 +124,7 @@ public class StageSpec {
       ", errorDatasetName='" + errorDatasetName + '\'' +
       ", inputSchemas=" + inputSchemas +
       ", outputSchema=" + outputSchema +
+      ", errorSchema=" + errorSchema +
       ", inputs=" + inputs +
       ", outputs=" + outputs +
       '}';
@@ -134,6 +143,7 @@ public class StageSpec {
     private String errorDatasetName;
     private Map<String, Schema> inputSchemas;
     private Schema outputSchema;
+    private Schema errorSchema;
     private Set<String> inputs;
     private Set<String> outputs;
 
@@ -165,6 +175,11 @@ public class StageSpec {
       return this;
     }
 
+    public Builder setErrorSchema(Schema errorSchema) {
+      this.errorSchema = errorSchema;
+      return this;
+    }
+
     public Builder addInputs(Collection<String> inputs) {
       this.inputs.addAll(inputs);
       return this;
@@ -190,7 +205,7 @@ public class StageSpec {
     }
 
     public StageSpec build() {
-      return new StageSpec(name, plugin, errorDatasetName, inputSchemas, outputSchema, inputs, outputs);
+      return new StageSpec(name, plugin, errorDatasetName, inputSchemas, outputSchema, errorSchema, inputs, outputs);
     }
 
   }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/CombinedEmitter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/CombinedEmitter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark;
+
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.ErrorRecord;
+import co.cask.cdap.etl.api.InvalidEntry;
+import co.cask.cdap.etl.common.BasicErrorRecord;
+import scala.Tuple2;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An emitter used in Spark to collect all output and errors emitted.
+ *
+ * @param <T> the type of object to emit
+ */
+public class CombinedEmitter<T> implements Emitter<T> {
+  private final String stageName;
+  private final List<Tuple2<Boolean, Object>> emitted = new ArrayList<>();
+
+  public CombinedEmitter(String stageName) {
+    this.stageName = stageName;
+  }
+
+  @Override
+  public void emit(T value) {
+    emitted.add(new Tuple2<Boolean, Object>(false, value));
+  }
+
+  @Override
+  public void emitError(InvalidEntry<T> invalidEntry) {
+    ErrorRecord<T> errorRecord = new BasicErrorRecord<>(invalidEntry.getInvalidRecord(), stageName,
+                                                        invalidEntry.getErrorCode(), invalidEntry.getErrorMsg());
+    emitted.add(new Tuple2<Boolean, Object>(true, errorRecord));
+  }
+
+  /**
+   * @return all output and errors emitted. If the first val is true, it is an error. Otherwise it is an output.
+   */
+  public Iterable<Tuple2<Boolean, Object>> getEmitted() {
+    return emitted;
+  }
+
+  public void reset() {
+    emitted.clear();
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/SparkCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/SparkCollection.java
@@ -22,6 +22,7 @@ import co.cask.cdap.etl.api.streaming.Windower;
 import co.cask.cdap.etl.planner.StageInfo;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
+import scala.Tuple2;
 
 import javax.annotation.Nullable;
 
@@ -43,9 +44,11 @@ public interface SparkCollection<T> {
 
   SparkCollection<T> union(SparkCollection<T> other);
 
+  SparkCollection<Tuple2<Boolean, Object>> transform(StageInfo stageInfo);
+
   <U> SparkCollection<U> flatMap(StageInfo stageInfo, FlatMapFunction<T, U> function);
 
-  <U> SparkCollection<U> aggregate(StageInfo stageInfo, @Nullable Integer partitions);
+  SparkCollection<Tuple2<Boolean, Object>> aggregate(StageInfo stageInfo, @Nullable Integer partitions);
 
   <K, V> SparkPairCollection<K, V> flatMapToPair(PairFlatMapFunction<T, K, V> function);
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
@@ -41,6 +41,7 @@ import com.google.common.collect.SetMultimap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.apache.spark.api.java.JavaSparkContext;
+import scala.Tuple2;
 
 import java.io.BufferedReader;
 import java.nio.charset.StandardCharsets;
@@ -71,7 +72,7 @@ public class BatchSparkPipelineDriver extends SparkPipelineRunner
   private transient int numOfRecordsPreview;
 
   @Override
-  protected SparkCollection<Object> getSource(StageInfo stageInfo) {
+  protected SparkCollection<Tuple2<Boolean, Object>> getSource(StageInfo stageInfo) {
     PluginFunctionContext pluginFunctionContext = new PluginFunctionContext(stageInfo, sec);
     return new RDDCollection<>(sec, jsc, datasetContext, sinkFactory,
                                sourceFactory.createRDD(sec, jsc, stageInfo.getName(), Object.class, Object.class)

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/AggregatorGroupByFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/AggregatorGroupByFunction.java
@@ -65,7 +65,8 @@ public class AggregatorGroupByFunction<GROUP_KEY, GROUP_VAL>
 
     GroupByTransform(BatchAggregator<GROUP_KEY, GROUP_VAL, ?> aggregator) {
       this.aggregator = aggregator;
-      this.keyEmitter = new NoErrorEmitter<>();
+      this.keyEmitter =
+        new NoErrorEmitter<>("Error records cannot be emitted from the groupBy method of an aggregator");
     }
 
     @Override

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/AggregatorGroupByFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/AggregatorGroupByFunction.java
@@ -20,6 +20,7 @@ import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.Transformation;
 import co.cask.cdap.etl.api.batch.BatchAggregator;
 import co.cask.cdap.etl.common.DefaultEmitter;
+import co.cask.cdap.etl.common.NoErrorEmitter;
 import co.cask.cdap.etl.common.TrackedTransform;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
 import scala.Tuple2;
@@ -60,11 +61,11 @@ public class AggregatorGroupByFunction<GROUP_KEY, GROUP_VAL>
   private static class GroupByTransform<GROUP_KEY, GROUP_VAL>
     implements Transformation<GROUP_VAL, Tuple2<GROUP_KEY, GROUP_VAL>> {
     private final BatchAggregator<GROUP_KEY, GROUP_VAL, ?> aggregator;
-    private final DefaultEmitter<GROUP_KEY> keyEmitter;
+    private final NoErrorEmitter<GROUP_KEY> keyEmitter;
 
     GroupByTransform(BatchAggregator<GROUP_KEY, GROUP_VAL, ?> aggregator) {
       this.aggregator = aggregator;
-      this.keyEmitter = new DefaultEmitter<>();
+      this.keyEmitter = new NoErrorEmitter<>();
     }
 
     @Override

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/ErrorFilter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/ErrorFilter.java
@@ -19,8 +19,7 @@ package co.cask.cdap.etl.spark.function;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import scala.Tuple2;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collections;
 
 /**
  * Filters a SparkCollection containing both output and errors to one that just contains output.
@@ -31,11 +30,7 @@ public class ErrorFilter<T> implements FlatMapFunction<Tuple2<Boolean, Object>, 
 
   @Override
   public Iterable<T> call(Tuple2<Boolean, Object> input) throws Exception {
-    List<T> output = new ArrayList<>();
-    if (!input._1()) {
-      //noinspection unchecked
-      output.add((T) input._2());
-    }
-    return output;
+    //noinspection unchecked
+    return input._1() ? Collections.<T>emptyList() : Collections.singletonList((T) input._2());
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/ErrorFilter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/ErrorFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark.function;
+
+import org.apache.spark.api.java.function.FlatMapFunction;
+import scala.Tuple2;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Filters a SparkCollection containing both output and errors to one that just contains output.
+ *
+ * @param <T> type of output record
+ */
+public class ErrorFilter<T> implements FlatMapFunction<Tuple2<Boolean, Object>, T> {
+
+  @Override
+  public Iterable<T> call(Tuple2<Boolean, Object> input) throws Exception {
+    List<T> output = new ArrayList<>();
+    if (!input._1()) {
+      //noinspection unchecked
+      output.add((T) input._2());
+    }
+    return output;
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/ErrorTransformFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/ErrorTransformFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,39 +16,40 @@
 
 package co.cask.cdap.etl.spark.function;
 
-import co.cask.cdap.etl.api.Transform;
+import co.cask.cdap.etl.api.ErrorRecord;
+import co.cask.cdap.etl.api.ErrorTransform;
 import co.cask.cdap.etl.common.TrackedTransform;
 import co.cask.cdap.etl.spark.CombinedEmitter;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import scala.Tuple2;
 
 /**
- * Function that uses a Transform to perform a flatmap.
+ * Function that uses an ErrorTransform to perform a flatmap.
  * Non-serializable fields are lazily created since this is used in a Spark closure.
  *
  * @param <T> type of input object
  * @param <U> type of output object
  */
-public class TransformFunction<T, U> implements FlatMapFunction<T, Tuple2<Boolean, Object>> {
+public class ErrorTransformFunction<T, U> implements FlatMapFunction<ErrorRecord<T>, Tuple2<Boolean, Object>> {
   private final PluginFunctionContext pluginFunctionContext;
-  private transient TrackedTransform<T, U> transform;
+  private transient TrackedTransform<ErrorRecord<T>, U> transform;
   private transient CombinedEmitter<U> emitter;
 
-  public TransformFunction(PluginFunctionContext pluginFunctionContext) {
+  public ErrorTransformFunction(PluginFunctionContext pluginFunctionContext) {
     this.pluginFunctionContext = pluginFunctionContext;
   }
 
   @Override
-  public Iterable<Tuple2<Boolean, Object>> call(T input) throws Exception {
+  public Iterable<Tuple2<Boolean, Object>> call(ErrorRecord<T> inputError) throws Exception {
     if (transform == null) {
-      Transform<T, U> plugin = pluginFunctionContext.createPlugin();
+      ErrorTransform<T, U> plugin = pluginFunctionContext.createPlugin();
       plugin.initialize(pluginFunctionContext.createBatchRuntimeContext());
       transform = new TrackedTransform<>(plugin, pluginFunctionContext.createStageMetrics(),
                                          pluginFunctionContext.getDataTracer());
       emitter = new CombinedEmitter<>(pluginFunctionContext.getStageName());
     }
     emitter.reset();
-    transform.transform(input, emitter);
+    transform.transform(inputError, emitter);
     return emitter.getEmitted();
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/OutputFilter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/OutputFilter.java
@@ -20,8 +20,7 @@ import co.cask.cdap.etl.api.ErrorRecord;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import scala.Tuple2;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collections;
 
 /**
  * Filters a SparkCollection containing both output and errors to one that just contains errors.
@@ -32,11 +31,8 @@ public class OutputFilter<T> implements FlatMapFunction<Tuple2<Boolean, Object>,
 
   @Override
   public Iterable<ErrorRecord<T>> call(Tuple2<Boolean, Object> input) throws Exception {
-    List<ErrorRecord<T>> output = new ArrayList<>();
-    if (input._1()) {
-      //noinspection unchecked
-      output.add((ErrorRecord<T>) input._2());
-    }
-    return output;
+    //noinspection unchecked
+    return input._1() ?
+      Collections.singletonList((ErrorRecord<T>) input._2()) : Collections.<ErrorRecord<T>>emptyList();
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/OutputFilter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/function/OutputFilter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark.function;
+
+import co.cask.cdap.etl.api.ErrorRecord;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import scala.Tuple2;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Filters a SparkCollection containing both output and errors to one that just contains errors.
+ *
+ * @param <T> type of error record
+ */
+public class OutputFilter<T> implements FlatMapFunction<Tuple2<Boolean, Object>, ErrorRecord<T>> {
+
+  @Override
+  public Iterable<ErrorRecord<T>> call(Tuple2<Boolean, Object> input) throws Exception {
+    List<ErrorRecord<T>> output = new ArrayList<>();
+    if (input._1()) {
+      //noinspection unchecked
+      output.add((ErrorRecord<T>) input._2());
+    }
+    return output;
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/DStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/DStreamCollection.java
@@ -28,7 +28,7 @@ import co.cask.cdap.etl.spark.SparkCollection;
 import co.cask.cdap.etl.spark.SparkPairCollection;
 import co.cask.cdap.etl.spark.batch.BasicSparkExecutionPluginContext;
 import co.cask.cdap.etl.spark.streaming.function.ComputeTransformFunction;
-import co.cask.cdap.etl.spark.streaming.function.CountingTranformFunction;
+import co.cask.cdap.etl.spark.streaming.function.CountingTransformFunction;
 import co.cask.cdap.etl.spark.streaming.function.DynamicAggregatorAggregate;
 import co.cask.cdap.etl.spark.streaming.function.DynamicAggregatorGroupBy;
 import co.cask.cdap.etl.spark.streaming.function.DynamicSparkCompute;
@@ -133,9 +133,9 @@ public class DStreamCollection<T> implements SparkCollection<T> {
   @Override
   public SparkCollection<T> window(StageInfo stageInfo, Windower windower) {
     String stageName = stageInfo.getName();
-    return wrap(stream.transform(new CountingTranformFunction<T>(stageName, sec.getMetrics(), "records.in", null))
+    return wrap(stream.transform(new CountingTransformFunction<T>(stageName, sec.getMetrics(), "records.in", null))
                   .window(Durations.seconds(windower.getWidth()), Durations.seconds(windower.getSlideInterval()))
-                  .transform(new CountingTranformFunction<T>(stageName, sec.getMetrics(), "records.out",
+                  .transform(new CountingTransformFunction<T>(stageName, sec.getMetrics(), "records.out",
                                                              sec.getDataTracer(stageName))));
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/CountingTransformFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/CountingTransformFunction.java
@@ -29,15 +29,15 @@ import javax.annotation.Nullable;
  *
  * @param <T> type of object in the rdd.
  */
-public class CountingTranformFunction<T> implements Function<JavaRDD<T>, JavaRDD<T>> {
+public class CountingTransformFunction<T> implements Function<JavaRDD<T>, JavaRDD<T>> {
   private final Metrics metrics;
   private final String stageName;
   private final String metricName;
   private final DataTracer dataTracer;
 
   // DataTracer is null for records.in
-  public CountingTranformFunction(String stageName, Metrics metrics, String metricName,
-                                  @Nullable DataTracer dataTracer) {
+  public CountingTransformFunction(String stageName, Metrics metrics, String metricName,
+                                   @Nullable DataTracer dataTracer) {
     this.metrics = metrics;
     this.stageName = stageName;
     this.metricName = metricName;

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/DynamicAggregatorAggregate.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/DynamicAggregatorAggregate.java
@@ -22,6 +22,7 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.streaming.Time;
+import scala.Tuple2;
 
 /**
  * Serializable function that can be used to perform the aggregate part of an Aggregator. Dynamically instantiates
@@ -32,7 +33,7 @@ import org.apache.spark.streaming.Time;
  * @param <OUT> type of output object
  */
 public class DynamicAggregatorAggregate<GROUP_KEY, GROUP_VAL, OUT>
-  implements Function2<JavaPairRDD<GROUP_KEY, Iterable<GROUP_VAL>>, Time, JavaRDD<OUT>> {
+  implements Function2<JavaPairRDD<GROUP_KEY, Iterable<GROUP_VAL>>, Time, JavaRDD<Tuple2<Boolean, Object>>> {
   private final DynamicDriverContext dynamicDriverContext;
   private transient AggregatorAggregateFunction<GROUP_KEY, GROUP_VAL, OUT> function;
 
@@ -41,7 +42,8 @@ public class DynamicAggregatorAggregate<GROUP_KEY, GROUP_VAL, OUT>
   }
 
   @Override
-  public JavaRDD<OUT> call(JavaPairRDD<GROUP_KEY, Iterable<GROUP_VAL>> input, Time batchTime) throws Exception {
+  public JavaRDD<Tuple2<Boolean, Object>> call(JavaPairRDD<GROUP_KEY, Iterable<GROUP_VAL>> input,
+                                               Time batchTime) throws Exception {
     if (function == null) {
       function = new AggregatorAggregateFunction<>(dynamicDriverContext.getPluginFunctionContext());
     }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/DynamicTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/DynamicTransform.java
@@ -21,6 +21,7 @@ import co.cask.cdap.etl.spark.streaming.DynamicDriverContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.streaming.Time;
+import scala.Tuple2;
 
 /**
  * Serializable function that can be used to perform a flat map on a DStream. Dynamically instantiates
@@ -30,7 +31,7 @@ import org.apache.spark.streaming.Time;
  * @param <T> type of input object
  * @param <U> type of output object
  */
-public class DynamicTransform<T, U> implements Function2<JavaRDD<T>, Time, JavaRDD<U>> {
+public class DynamicTransform<T, U> implements Function2<JavaRDD<T>, Time, JavaRDD<Tuple2<Boolean, Object>>> {
   private final DynamicDriverContext dynamicDriverContext;
   private transient TransformFunction<T, U> transformFunction;
 
@@ -39,7 +40,7 @@ public class DynamicTransform<T, U> implements Function2<JavaRDD<T>, Time, JavaR
   }
 
   @Override
-  public JavaRDD<U> call(JavaRDD<T> input, Time batchTime) throws Exception {
+  public JavaRDD<Tuple2<Boolean, Object>> call(JavaRDD<T> input, Time batchTime) throws Exception {
     if (transformFunction == null) {
       transformFunction = new TransformFunction<>(dynamicDriverContext.getPluginFunctionContext());
     }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/WrapOutputTransformFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/WrapOutputTransformFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.spark.streaming.function;
+
+import org.apache.spark.api.java.function.Function;
+import scala.Tuple2;
+
+/**
+ * Simply wraps all elements into a Tuple2 whose first element is false, indicating everything is output and nothing
+ * is an error.
+ *
+ * @param <T> the type of output object
+ */
+public class WrapOutputTransformFunction<T> implements Function<T, Tuple2<Boolean, T>> {
+  @Override
+  public Tuple2<Boolean, T> call(T inputRecord) throws Exception {
+    return new Tuple2<>(false, inputRecord);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/aggregator/GroupFilterAggregator.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/aggregator/GroupFilterAggregator.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.batch.aggregator;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginPropertyField;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.InvalidEntry;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
+import co.cask.cdap.etl.api.batch.BatchAggregator;
+import co.cask.cdap.etl.proto.v2.ETLPlugin;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Aggregator that emits errors for all records that have a specific group key.
+ */
+@Plugin(type = BatchAggregator.PLUGIN_TYPE)
+@Name("GroupFilter")
+public class GroupFilterAggregator extends BatchAggregator<String, StructuredRecord, StructuredRecord> {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
+  private Config config;
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
+    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+    Schema inputSchema = stageConfigurer.getInputSchema();
+    if (inputSchema == null) {
+      return;
+    }
+    Schema.Field groupField = inputSchema.getField(config.field);
+    if (groupField == null) {
+      throw new IllegalArgumentException(config.field + " is not in the input schema");
+    }
+    Schema groupSchema = groupField.getSchema();
+    Schema.Type groupType = groupSchema.isNullable() ? groupSchema.getNonNullable().getType() : groupSchema.getType();
+    if (groupType != Schema.Type.STRING) {
+      throw new IllegalArgumentException(config.field + " is not of type string");
+    }
+    stageConfigurer.setOutputSchema(inputSchema);
+  }
+
+  @Override
+  public void groupBy(StructuredRecord input, Emitter<String> emitter) throws Exception {
+    String val = input.get(config.field);
+    if (val != null) {
+      emitter.emit(val);
+    }
+  }
+
+  @Override
+  public void aggregate(String groupKey, Iterator<StructuredRecord> groupValues,
+                        Emitter<StructuredRecord> emitter) throws Exception {
+    if (config.value.equals(groupKey)) {
+      while (groupValues.hasNext()) {
+        emitter.emitError(new InvalidEntry<>(3, "bad val", groupValues.next()));
+      }
+    } else {
+      while (groupValues.hasNext()) {
+        emitter.emit(groupValues.next());
+      }
+    }
+  }
+
+  /**
+   * The plugin config
+   */
+  public static class Config extends PluginConfig {
+    String field;
+    String value;
+  }
+
+  public static ETLPlugin getPlugin(String field, String val) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("field", field);
+    properties.put("value", val);
+    return new ETLPlugin("GroupFilter", BatchAggregator.PLUGIN_TYPE, properties, null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("field", new PluginPropertyField("field", "", "string", true, false));
+    properties.put("value", new PluginPropertyField("value", "", "string", true, false));
+    return new PluginClass(BatchAggregator.PLUGIN_TYPE, "GroupFilter", "", GroupFilterAggregator.class.getName(),
+                           "config", properties);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/common/MockPipelineConfigurer.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/common/MockPipelineConfigurer.java
@@ -70,6 +70,11 @@ public class MockPipelineConfigurer implements PipelineConfigurer {
       public void setOutputSchema(@Nullable Schema schema) {
         outputSchema = schema;
       }
+
+      @Override
+      public void setErrorSchema(@Nullable Schema errorSchema) {
+
+      }
     };
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/test/HydratorTestBase.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/test/HydratorTestBase.java
@@ -31,6 +31,7 @@ import co.cask.cdap.etl.mock.batch.MockRuntimeDatasetSink;
 import co.cask.cdap.etl.mock.batch.MockRuntimeDatasetSource;
 import co.cask.cdap.etl.mock.batch.NodeStatesAction;
 import co.cask.cdap.etl.mock.batch.aggregator.FieldCountAggregator;
+import co.cask.cdap.etl.mock.batch.aggregator.GroupFilterAggregator;
 import co.cask.cdap.etl.mock.batch.aggregator.IdentityAggregator;
 import co.cask.cdap.etl.mock.batch.joiner.DupeFlagger;
 import co.cask.cdap.etl.mock.batch.joiner.MockJoiner;
@@ -39,9 +40,12 @@ import co.cask.cdap.etl.mock.realtime.MockSink;
 import co.cask.cdap.etl.mock.realtime.MockSource;
 import co.cask.cdap.etl.mock.spark.Window;
 import co.cask.cdap.etl.mock.spark.compute.StringValueFilterCompute;
+import co.cask.cdap.etl.mock.transform.AllErrorTransform;
 import co.cask.cdap.etl.mock.transform.DoubleTransform;
-import co.cask.cdap.etl.mock.transform.ErrorTransform;
+import co.cask.cdap.etl.mock.transform.DropNullTransform;
 import co.cask.cdap.etl.mock.transform.FieldsPrefixTransform;
+import co.cask.cdap.etl.mock.transform.FilterErrorTransform;
+import co.cask.cdap.etl.mock.transform.FlattenErrorTransform;
 import co.cask.cdap.etl.mock.transform.IdentityTransform;
 import co.cask.cdap.etl.mock.transform.IntValueFilterTransform;
 import co.cask.cdap.etl.mock.transform.StringValueFilterTransform;
@@ -63,27 +67,31 @@ public class HydratorTestBase extends TestBase {
   // To work around, we'll just explicitly specify each plugin.
   private static final Set<PluginClass> REALTIME_MOCK_PLUGINS = ImmutableSet.of(
     LookupSource.PLUGIN_CLASS, MockSink.PLUGIN_CLASS, MockSource.PLUGIN_CLASS,
-    DoubleTransform.PLUGIN_CLASS, ErrorTransform.PLUGIN_CLASS, IdentityTransform.PLUGIN_CLASS,
-    IntValueFilterTransform.PLUGIN_CLASS, StringValueFilterTransform.PLUGIN_CLASS
+    DoubleTransform.PLUGIN_CLASS, AllErrorTransform.PLUGIN_CLASS, IdentityTransform.PLUGIN_CLASS,
+    IntValueFilterTransform.PLUGIN_CLASS, StringValueFilterTransform.PLUGIN_CLASS, DropNullTransform.PLUGIN_CLASS,
+    FlattenErrorTransform.PLUGIN_CLASS, FilterErrorTransform.PLUGIN_CLASS
   );
   private static final Set<PluginClass> BATCH_MOCK_PLUGINS = ImmutableSet.of(
-    FieldCountAggregator.PLUGIN_CLASS, IdentityAggregator.PLUGIN_CLASS,
+    FieldCountAggregator.PLUGIN_CLASS, IdentityAggregator.PLUGIN_CLASS, GroupFilterAggregator.PLUGIN_CLASS,
     MockJoiner.PLUGIN_CLASS, DupeFlagger.PLUGIN_CLASS,
     co.cask.cdap.etl.mock.batch.MockSink.PLUGIN_CLASS, co.cask.cdap.etl.mock.batch.MockSource.PLUGIN_CLASS,
     MockRuntimeDatasetSink.PLUGIN_CLASS, MockRuntimeDatasetSource.PLUGIN_CLASS,
     MockExternalSource.PLUGIN_CLASS, MockExternalSink.PLUGIN_CLASS,
-    DoubleTransform.PLUGIN_CLASS, ErrorTransform.PLUGIN_CLASS, IdentityTransform.PLUGIN_CLASS,
-    FieldsPrefixTransform.PLUGIN_CLASS, IntValueFilterTransform.PLUGIN_CLASS, StringValueFilterTransform.PLUGIN_CLASS,
-    MockAction.PLUGIN_CLASS, StringValueFilterCompute.PLUGIN_CLASS
+    DoubleTransform.PLUGIN_CLASS, AllErrorTransform.PLUGIN_CLASS, IdentityTransform.PLUGIN_CLASS,
+    FieldsPrefixTransform.PLUGIN_CLASS, IntValueFilterTransform.PLUGIN_CLASS,
+    StringValueFilterTransform.PLUGIN_CLASS, DropNullTransform.PLUGIN_CLASS,
+    MockAction.PLUGIN_CLASS, StringValueFilterCompute.PLUGIN_CLASS,
+    FlattenErrorTransform.PLUGIN_CLASS, FilterErrorTransform.PLUGIN_CLASS
   );
   private static final Set<PluginClass> STREAMING_MOCK_PLUGINS = ImmutableSet.of(
     co.cask.cdap.etl.mock.spark.streaming.MockSource.PLUGIN_CLASS,
     co.cask.cdap.etl.mock.batch.MockSink.PLUGIN_CLASS,
-    DoubleTransform.PLUGIN_CLASS, ErrorTransform.PLUGIN_CLASS, IdentityTransform.PLUGIN_CLASS,
-    IntValueFilterTransform.PLUGIN_CLASS, StringValueFilterTransform.PLUGIN_CLASS,
-    FieldCountAggregator.PLUGIN_CLASS, IdentityAggregator.PLUGIN_CLASS,
+    DoubleTransform.PLUGIN_CLASS, AllErrorTransform.PLUGIN_CLASS, IdentityTransform.PLUGIN_CLASS,
+    IntValueFilterTransform.PLUGIN_CLASS, StringValueFilterTransform.PLUGIN_CLASS, DropNullTransform.PLUGIN_CLASS,
+    FieldCountAggregator.PLUGIN_CLASS, IdentityAggregator.PLUGIN_CLASS, GroupFilterAggregator.PLUGIN_CLASS,
     MockJoiner.PLUGIN_CLASS, DupeFlagger.PLUGIN_CLASS,
-    StringValueFilterCompute.PLUGIN_CLASS, Window.PLUGIN_CLASS
+    StringValueFilterCompute.PLUGIN_CLASS, Window.PLUGIN_CLASS,
+    FlattenErrorTransform.PLUGIN_CLASS, FilterErrorTransform.PLUGIN_CLASS
   );
 
   public HydratorTestBase() {
@@ -98,7 +106,7 @@ public class HydratorTestBase extends TestBase {
                       artifactId,
                       REALTIME_MOCK_PLUGINS,
                       MockSink.class, MockSource.class, LookupSource.class,
-                      DoubleTransform.class, ErrorTransform.class, IdentityTransform.class,
+                      DoubleTransform.class, AllErrorTransform.class, IdentityTransform.class,
                       IntValueFilterTransform.class, StringValueFilterTransform.class);
   }
 
@@ -117,7 +125,7 @@ public class HydratorTestBase extends TestBase {
                       co.cask.cdap.etl.mock.batch.MockSource.class,
                       co.cask.cdap.etl.mock.batch.MockSink.class,
                       MockExternalSource.class, MockExternalSink.class,
-                      DoubleTransform.class, ErrorTransform.class, IdentityTransform.class,
+                      DoubleTransform.class, AllErrorTransform.class, IdentityTransform.class,
                       IntValueFilterTransform.class, StringValueFilterTransform.class,
                       FieldCountAggregator.class, IdentityAggregator.class, FieldsPrefixTransform.class,
                       StringValueFilterCompute.class,
@@ -139,7 +147,7 @@ public class HydratorTestBase extends TestBase {
                       STREAMING_MOCK_PLUGINS,
                       co.cask.cdap.etl.mock.spark.streaming.MockSource.class,
                       co.cask.cdap.etl.mock.batch.MockSink.class,
-                      DoubleTransform.class, ErrorTransform.class, IdentityTransform.class,
+                      DoubleTransform.class, AllErrorTransform.class, IdentityTransform.class,
                       IntValueFilterTransform.class, StringValueFilterTransform.class,
                       StringValueFilterCompute.class, Window.class);
   }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/AllErrorTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/AllErrorTransform.java
@@ -23,6 +23,8 @@ import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
 import co.cask.cdap.etl.api.InvalidEntry;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 
@@ -30,12 +32,18 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Transform used to test writing to error datasets. Writes all its input as errors.
+ * Transform used to test error emission. Writes all its input as errors.
  */
 @Plugin(type = Transform.PLUGIN_TYPE)
-@Name("Error")
-public class ErrorTransform extends Transform<StructuredRecord, StructuredRecord> {
+@Name("AllError")
+public class AllErrorTransform extends Transform<StructuredRecord, StructuredRecord> {
   public static final PluginClass PLUGIN_CLASS = getPluginClass();
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
+    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+    stageConfigurer.setOutputSchema(stageConfigurer.getInputSchema());
+  }
 
   @Override
   public void transform(StructuredRecord input, Emitter<StructuredRecord> emitter) throws Exception {
@@ -43,11 +51,11 @@ public class ErrorTransform extends Transform<StructuredRecord, StructuredRecord
   }
 
   public static ETLPlugin getPlugin() {
-    return new ETLPlugin("Error", Transform.PLUGIN_TYPE, new HashMap<String, String>(), null);
+    return new ETLPlugin("AllError", Transform.PLUGIN_TYPE, new HashMap<String, String>(), null);
   }
 
   private static PluginClass getPluginClass() {
     Map<String, PluginPropertyField> properties = new HashMap<>();
-    return new PluginClass(Transform.PLUGIN_TYPE, "Error", "", ErrorTransform.class.getName(), null, properties);
+    return new PluginClass(Transform.PLUGIN_TYPE, "AllError", "", AllErrorTransform.class.getName(), null, properties);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/FilterErrorTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/FilterErrorTransform.java
@@ -27,7 +27,6 @@ import co.cask.cdap.etl.api.ErrorRecord;
 import co.cask.cdap.etl.api.ErrorTransform;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
-import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 
 import java.util.HashMap;
@@ -50,7 +49,7 @@ public class FilterErrorTransform extends ErrorTransform<StructuredRecord, Struc
 
   @Override
   public void transform(ErrorRecord<StructuredRecord> input, Emitter<StructuredRecord> emitter) throws Exception {
-    if (input.getErrorCode() != null && input.getErrorCode() != config.code) {
+    if (input.getErrorCode() != config.code) {
       emitter.emit(input.getRecord());
     }
   }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/FilterErrorTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/FilterErrorTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,8 +20,11 @@ import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
 import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.ErrorRecord;
+import co.cask.cdap.etl.api.ErrorTransform;
 import co.cask.cdap.etl.api.PipelineConfigurer;
 import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.Transform;
@@ -31,12 +34,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Transform that doubles every record it receives.
+ * Filters out errors that have a specific error code
  */
-@Plugin(type = Transform.PLUGIN_TYPE)
-@Name("Double")
-public class DoubleTransform extends Transform<StructuredRecord, StructuredRecord> {
+@Plugin(type = ErrorTransform.PLUGIN_TYPE)
+@Name("Filter")
+public class FilterErrorTransform extends ErrorTransform<StructuredRecord, StructuredRecord> {
   public static final PluginClass PLUGIN_CLASS = getPluginClass();
+  private Config config;
 
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
@@ -45,17 +49,29 @@ public class DoubleTransform extends Transform<StructuredRecord, StructuredRecor
   }
 
   @Override
-  public void transform(StructuredRecord input, Emitter<StructuredRecord> emitter) throws Exception {
-    emitter.emit(input);
-    emitter.emit(input);
+  public void transform(ErrorRecord<StructuredRecord> input, Emitter<StructuredRecord> emitter) throws Exception {
+    if (input.getErrorCode() != null && input.getErrorCode() != config.code) {
+      emitter.emit(input.getRecord());
+    }
   }
 
-  public static ETLPlugin getPlugin() {
-    return new ETLPlugin("Double", Transform.PLUGIN_TYPE, new HashMap<String, String>(), null);
+  /**
+   * Config for the error transform.
+   */
+  public static class Config extends PluginConfig {
+    private int code;
+  }
+
+  public static ETLPlugin getPlugin(int code) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("code", String.valueOf(code));
+    return new ETLPlugin("Filter", ErrorTransform.PLUGIN_TYPE, properties, null);
   }
 
   private static PluginClass getPluginClass() {
     Map<String, PluginPropertyField> properties = new HashMap<>();
-    return new PluginClass(Transform.PLUGIN_TYPE, "Double", "", DoubleTransform.class.getName(), null, properties);
+    properties.put("code", new PluginPropertyField("code", "", "int", true, false));
+    return new PluginClass(ErrorTransform.PLUGIN_TYPE, "Filter", "", FilterErrorTransform.class.getName(),
+                           "config", properties);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/FlattenErrorTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/FlattenErrorTransform.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.transform;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginPropertyField;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.ErrorRecord;
+import co.cask.cdap.etl.api.ErrorTransform;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
+import co.cask.cdap.etl.api.TransformContext;
+import co.cask.cdap.etl.proto.v2.ETLPlugin;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Adds the error code and error message to each record, then emits it.
+ */
+@Plugin(type = ErrorTransform.PLUGIN_TYPE)
+@Name("Flatten")
+public class FlattenErrorTransform extends ErrorTransform<StructuredRecord, StructuredRecord> {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
+    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+    Schema inputSchema = stageConfigurer.getInputSchema();
+    if (inputSchema != null) {
+      stageConfigurer.setOutputSchema(getOutputSchema(inputSchema));
+    }
+  }
+
+  @Override
+  public void initialize(TransformContext context) throws Exception {
+    Schema inputSchema = context.getInputSchema();
+    Schema outputSchema = context.getOutputSchema();
+    if (inputSchema != null && !getOutputSchema(inputSchema).equals(outputSchema)) {
+      // should never happen, here for unit tests
+      throw new IllegalStateException("Output schema is not correct.");
+    }
+  }
+
+  @Override
+  public void transform(ErrorRecord<StructuredRecord> input, Emitter<StructuredRecord> emitter) throws Exception {
+    StructuredRecord invalidRecord = input.getRecord();
+    StructuredRecord.Builder output = StructuredRecord.builder(getOutputSchema(invalidRecord.getSchema()));
+    for (Schema.Field field : invalidRecord.getSchema().getFields()) {
+      output.set(field.getName(), invalidRecord.get(field.getName()));
+    }
+    emitter.emit(output.set("errMsg", input.getErrorMessage())
+                   .set("errCode", input.getErrorCode())
+                   .set("errStage", input.getStageName())
+                   .build());
+  }
+
+  private Schema getOutputSchema(Schema inputSchema) {
+    List<Schema.Field> fields = new ArrayList<>();
+    fields.addAll(inputSchema.getFields());
+    fields.add(Schema.Field.of("errMsg", Schema.nullableOf(Schema.of(Schema.Type.STRING))));
+    fields.add(Schema.Field.of("errCode", Schema.nullableOf(Schema.of(Schema.Type.INT))));
+    fields.add(Schema.Field.of("errStage", Schema.nullableOf(Schema.of(Schema.Type.STRING))));
+    return Schema.recordOf("error" + inputSchema.getRecordName(), fields);
+  }
+
+  public static ETLPlugin getPlugin() {
+    return new ETLPlugin("Flatten", ErrorTransform.PLUGIN_TYPE, new HashMap<String, String>(), null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    return new PluginClass(ErrorTransform.PLUGIN_TYPE, "Flatten", "", FlattenErrorTransform.class.getName(),
+                           null, properties);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/StringValueFilterTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/transform/StringValueFilterTransform.java
@@ -24,6 +24,9 @@ import co.cask.cdap.api.plugin.PluginClass;
 import co.cask.cdap.api.plugin.PluginConfig;
 import co.cask.cdap.api.plugin.PluginPropertyField;
 import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.InvalidEntry;
+import co.cask.cdap.etl.api.PipelineConfigurer;
+import co.cask.cdap.etl.api.StageConfigurer;
 import co.cask.cdap.etl.api.Transform;
 import co.cask.cdap.etl.proto.v2.ETLPlugin;
 
@@ -45,10 +48,18 @@ public class StringValueFilterTransform extends Transform<StructuredRecord, Stru
   }
 
   @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) throws IllegalArgumentException {
+    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+    stageConfigurer.setOutputSchema(stageConfigurer.getInputSchema());
+  }
+
+  @Override
   public void transform(StructuredRecord input, Emitter<StructuredRecord> emitter) throws Exception {
     String value = input.get(config.field);
     if (!config.value.equals(value)) {
       emitter.emit(input);
+    } else {
+      emitter.emitError(new InvalidEntry<>(1, "bad string value", input));
     }
   }
 

--- a/cdap-ui/app/services/constants.js
+++ b/cdap-ui/app/services/constants.js
@@ -44,7 +44,8 @@ angular.module(PKG.name + '.services')
         'batchaggregator': 'batchaggregator',
         'sink': 'batchsink',
         'batchjoiner': 'batchjoiner',
-        'windower': 'windower'
+        'windower': 'windower',
+        'errortransform': 'errortransform'
       },
       'cdap-etl-realtime': {
         'source': 'realtimesource',
@@ -59,7 +60,8 @@ angular.module(PKG.name + '.services')
         'sparksink': 'sparksink',
         'sparkcompute': 'sparkcompute',
         'batchjoiner': 'batchjoiner',
-        'action': 'action'
+        'action': 'action',
+        'errortransform': 'errortransform'
       },
       'post-run-actions': {
         'email': 'Send Email',
@@ -79,7 +81,8 @@ angular.module(PKG.name + '.services')
       'batchjoiner': pluginLabels['analytics'],
       'action': 'Action',
       'streamingsource': pluginLabels['source'],
-      'windower': pluginLabels['transform']
+      'windower': pluginLabels['transform'],
+      'errortransform': pluginLabels['transform']
     },
     pluginLabels: pluginLabels,
     // understand what plugin type is what.
@@ -96,7 +99,8 @@ angular.module(PKG.name + '.services')
       'sparksink': 'sink',
       'sparkcompute': 'transform',
       'batchjoiner': 'transform',
-      'action': 'action'
+      'action': 'action',
+      'errortransform': 'transform'
     },
 
     artifactConvert: {


### PR DESCRIPTION
An ErrorTransform can be placed after another stage to consume
the errors emitted by that stage. MapReduce changes boil down to
differentiating between stages that takes output and stages that
take errors. When emit() is called, it will only be sent to stages
that take output. When emitError() is called, it will only be sent
to stages that take errors.

Spark refactoring amounts to making stage return a Tuple2 of
boolean and object. The boolean indicates whether the second
object is an error record or an output record. Each stage that
can emit both is then filtered to make two RDDs, one that only
has outputs and one that only has errors.