### PR TITLE
CDAP-8342 Perform add/delete partition as program container user

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramRunnableModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/DistributedProgramRunnableModule.java
@@ -38,7 +38,8 @@ import co.cask.cdap.data.view.ViewAdminModules;
 import co.cask.cdap.data2.audit.AuditModule;
 import co.cask.cdap.data2.metadata.writer.LineageWriter;
 import co.cask.cdap.data2.registry.RuntimeUsageRegistry;
-import co.cask.cdap.explore.guice.ExploreClientModule;
+import co.cask.cdap.explore.client.ExploreClient;
+import co.cask.cdap.explore.client.ProgramDiscoveryExploreClient;
 import co.cask.cdap.internal.app.queue.QueueReaderFactory;
 import co.cask.cdap.internal.app.store.remote.RemoteLineageWriter;
 import co.cask.cdap.internal.app.store.remote.RemoteRuntimeStore;
@@ -47,6 +48,7 @@ import co.cask.cdap.logging.guice.LoggingModules;
 import co.cask.cdap.messaging.guice.MessagingClientModule;
 import co.cask.cdap.metrics.guice.MetricsClientRuntimeModule;
 import co.cask.cdap.notifications.feeds.client.NotificationFeedClientModule;
+import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizationEnforcementModule;
 import co.cask.cdap.security.authorization.RemotePrivilegesManager;
@@ -67,6 +69,7 @@ import org.apache.twill.api.TwillContext;
 import org.apache.twill.common.Cancellable;
 
 import java.net.InetAddress;
+import javax.annotation.Nullable;
 
 /**
  * Defines guice modules for distributed program runnables. For instance, AbstractProgramTwillRunnable, as well as
@@ -83,8 +86,58 @@ public class DistributedProgramRunnableModule {
   }
 
   // usable from any program runtime, such as mapreduce task, spark task, etc
-  public Module createModule() {
-    Module combined = Modules.combine(
+  public Module createModule(final ProgramId programId, @Nullable final String principal) {
+    Module combined = getCombinedModules(programId);
+
+    combined = addAuthenticationModule(principal, combined);
+
+    return Modules.override(combined).with(new AbstractModule() {
+      @Override
+      protected void configure() {
+        bind(LineageWriter.class).to(RemoteLineageWriter.class);
+        bind(RuntimeUsageRegistry.class).to(RemoteRuntimeUsageRegistry.class).in(Scopes.SINGLETON);
+      }
+    });
+  }
+
+  // TODO(terence) make this works for different mode
+  // usable from anywhere a TwillContext is exposed
+  public Module createModule(final TwillContext context, ProgramId programId, @Nullable String principal) {
+    return Modules.combine(createModule(programId, principal),
+                           new AbstractModule() {
+                             @Override
+                             protected void configure() {
+
+                               bind(InetAddress.class).annotatedWith(
+                                 Names.named(Constants.Service.MASTER_SERVICES_BIND_ADDRESS))
+                                 .toInstance(context.getHost());
+
+                               bind(ServiceAnnouncer.class).toInstance(new ServiceAnnouncer() {
+                                 @Override
+                                 public Cancellable announce(String serviceName, int port) {
+                                   return context.announce(serviceName, port);
+                                 }
+
+                                 @Override
+                                 public Cancellable announce(String serviceName, int port, byte[] payload) {
+                                   return context.announce(serviceName, port, payload);
+                                 }
+                               });
+                             }
+                           });
+  }
+
+  private Module addAuthenticationModule(@Nullable String principal, Module combined) {
+    if (principal != null) {
+      return Modules.combine(combined,
+                             new AuthenticationContextModules().getProgramContainerModule(principal));
+    }
+    return Modules.combine(combined,
+                           new AuthenticationContextModules().getProgramContainerModule());
+  }
+
+  private Module getCombinedModules(final ProgramId programId) {
+    return Modules.combine(
       new ConfigModule(cConf, hConf),
       new IOModule(),
       new ZKClientModule(),
@@ -96,14 +149,12 @@ public class DistributedProgramRunnableModule {
       new DiscoveryRuntimeModule().getDistributedModules(),
       new DataFabricModules().getDistributedModules(),
       new DataSetsModules().getDistributedModules(),
-      new ExploreClientModule(),
       new ViewAdminModules().getDistributedModules(),
       new StreamAdminModules().getDistributedModules(),
       new NotificationFeedClientModule(),
       new AuditModule().getDistributedModules(),
       new NamespaceClientRuntimeModule().getDistributedModules(),
       new AuthorizationEnforcementModule().getDistributedModules(),
-      new AuthenticationContextModules().getProgramContainerModule(),
       new SecureStoreModules().getDistributedModules(),
       new AbstractModule() {
         @Override
@@ -126,44 +177,18 @@ public class DistributedProgramRunnableModule {
           bind(PrivilegesManager.class).to(RemotePrivilegesManager.class);
 
           bind(OwnerAdmin.class).to(DefaultOwnerAdmin.class);
+
+          // Bind ProgramId to the passed in instance programId so that we can retrieve it back later when needed.
+          // For example see ProgramDiscoveryExploreClient.
+          // Also binding to instance is fine here as the programId is guaranteed to not change throughout the
+          // lifecycle of this program runnable
+          bind(ProgramId.class).toInstance(programId);
+
+          // bind explore client to ProgramDiscoveryExploreClient which is aware of the programId
+          bind(ExploreClient.class).to(ProgramDiscoveryExploreClient.class).in(Scopes.SINGLETON);
         }
       }
     );
-
-    return Modules.override(combined).with(new AbstractModule() {
-      @Override
-      protected void configure() {
-        bind(LineageWriter.class).to(RemoteLineageWriter.class);
-        bind(RuntimeUsageRegistry.class).to(RemoteRuntimeUsageRegistry.class).in(Scopes.SINGLETON);
-      }
-    });
-  }
-
-  // TODO(terence) make this works for different mode
-  // usable from anywhere a TwillContext is exposed
-  public Module createModule(final TwillContext context) {
-    return Modules.combine(createModule(),
-                           new AbstractModule() {
-                             @Override
-                             protected void configure() {
-
-                               bind(InetAddress.class).annotatedWith(
-                                 Names.named(Constants.Service.MASTER_SERVICES_BIND_ADDRESS))
-                                 .toInstance(context.getHost());
-
-                               bind(ServiceAnnouncer.class).toInstance(new ServiceAnnouncer() {
-                                 @Override
-                                 public Cancellable announce(String serviceName, int port) {
-                                   return context.announce(serviceName, port);
-                                 }
-
-                                 @Override
-                                 public Cancellable announce(String serviceName, int port, byte[] payload) {
-                                   return context.announce(serviceName, port, payload);
-                                 }
-                               });
-                             }
-                           });
   }
 
   private Module createStreamFactoryModule() {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/distributed/DistributedMapReduceTaskContextProvider.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/distributed/DistributedMapReduceTaskContextProvider.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.metrics.MetricsCollectionService;
 import co.cask.cdap.app.guice.DistributedProgramRunnableModule;
 import co.cask.cdap.app.runtime.ProgramOptions;
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.internal.app.runtime.ProgramOptionConstants;
 import co.cask.cdap.internal.app.runtime.SystemArguments;
 import co.cask.cdap.internal.app.runtime.batch.MapReduceClassLoader;
 import co.cask.cdap.internal.app.runtime.batch.MapReduceContextConfig;
@@ -117,6 +118,11 @@ public final class DistributedMapReduceTaskContextProvider extends MapReduceTask
   }
 
   private static Injector createInjector(CConfiguration cConf, Configuration hConf) {
-    return Guice.createInjector(new DistributedProgramRunnableModule(cConf, hConf).createModule());
+    MapReduceContextConfig mapReduceContextConfig = new MapReduceContextConfig(hConf);
+    // principal will be null if running on a kerberos distributed cluster
+    String principal = mapReduceContextConfig.getProgramOptions()
+      .getArguments().getOption(ProgramOptionConstants.PRINCIPAL);
+    return Guice.createInjector(new DistributedProgramRunnableModule(cConf, hConf)
+                                  .createModule(mapReduceContextConfig.getProgramId(), principal));
   }
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
@@ -166,7 +166,15 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
 
       cConf = CConfiguration.create(new File(cmdLine.getOptionValue(RunnableOptions.CDAP_CONF_FILE)));
 
-      Injector injector = Guice.createInjector(createModule(context));
+      programOpts = createProgramOptions(cmdLine, context, context.getSpecification().getConfigs());
+
+      // This impersonation info is added in PropertiesResolver#getSystemProperties
+      // if kerberos is enabled we expect the principal to be provided in the program options as we
+      // need it to be used later in ExploreClient to make request. If kerberos is disabled this will be null
+      String principal = programOpts.getArguments().getOption(ProgramOptionConstants.PRINCIPAL);
+      ProgramId programId = GSON.fromJson(cmdLine.getOptionValue(RunnableOptions.PROGRAM_ID), ProgramId.class);
+
+      Injector injector = Guice.createInjector(createModule(context, programId, principal));
 
       coreServices.add(injector.getInstance(ZKClientService.class));
       coreServices.add(injector.getInstance(KafkaClientService.class));
@@ -174,8 +182,6 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
       coreServices.add(injector.getInstance(MetricsCollectionService.class));
       coreServices.add(injector.getInstance(StreamCoordinatorClient.class));
       coreServices.add(injector.getInstance(AuthorizationEnforcementService.class));
-
-      programOpts = createProgramOptions(cmdLine, context, context.getSpecification().getConfigs());
 
       // Initialize log appender
       logAppenderInitializer = injector.getInstance(LogAppenderInitializer.class);
@@ -186,7 +192,6 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
 
       try {
         Location programJarLocation = Locations.toLocation(new File(cmdLine.getOptionValue(RunnableOptions.JAR)));
-        ProgramId programId = GSON.fromJson(cmdLine.getOptionValue(RunnableOptions.PROGRAM_ID), ProgramId.class);
         ApplicationSpecification appSpec = readAppSpec(new File(cmdLine.getOptionValue(RunnableOptions.APP_SPEC_FILE)));
 
         program = Programs.create(cConf, programRunner, new ProgramDescriptor(programId, appSpec),
@@ -404,8 +409,8 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
     }
   }
 
-  protected Module createModule(TwillContext context) {
-    return new DistributedProgramRunnableModule(cConf, hConf).createModule(context);
+  protected Module createModule(TwillContext context, ProgramId programId, @Nullable String principal) {
+    return new DistributedProgramRunnableModule(cConf, hConf).createModule(context, programId, principal);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WebappTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WebappTwillRunnable.java
@@ -19,11 +19,14 @@ import co.cask.cdap.internal.app.runtime.webapp.ExplodeJarHttpHandler;
 import co.cask.cdap.internal.app.runtime.webapp.JarHttpHandler;
 import co.cask.cdap.internal.app.runtime.webapp.WebappHttpHandlerFactory;
 import co.cask.cdap.internal.app.runtime.webapp.WebappProgramRunner;
+import co.cask.cdap.proto.id.ProgramId;
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.util.Modules;
 import org.apache.twill.api.TwillContext;
+
+import javax.annotation.Nullable;
 
 /**
  * Twill runnable wrapper for webapp.
@@ -35,8 +38,8 @@ final class WebappTwillRunnable extends AbstractProgramTwillRunnable<WebappProgr
   }
 
   @Override
-  protected Module createModule(TwillContext context) {
-    return Modules.combine(super.createModule(context), new AbstractModule() {
+  protected Module createModule(TwillContext context, ProgramId programId, @Nullable String principal) {
+    return Modules.combine(super.createModule(context, programId, principal), new AbstractModule() {
       @Override
       protected void configure() {
         // Create webapp http handler factory.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WorkflowTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/distributed/WorkflowTwillRunnable.java
@@ -23,12 +23,15 @@ import co.cask.cdap.app.runtime.ProgramRuntimeProvider;
 import co.cask.cdap.internal.app.runtime.batch.MapReduceProgramRunner;
 import co.cask.cdap.internal.app.runtime.workflow.WorkflowProgramRunner;
 import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ProgramId;
 import com.google.inject.Module;
 import com.google.inject.PrivateModule;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.MapBinder;
 import com.google.inject.util.Modules;
 import org.apache.twill.api.TwillContext;
+
+import javax.annotation.Nullable;
 
 /**
  *
@@ -40,8 +43,8 @@ final class WorkflowTwillRunnable extends AbstractProgramTwillRunnable<WorkflowP
   }
 
   @Override
-  protected Module createModule(TwillContext context) {
-    Module module = super.createModule(context);
+  protected Module createModule(TwillContext context, ProgramId programId, @Nullable String principal) {
+    Module module = super.createModule(context, programId, principal);
     return Modules.combine(module, new PrivateModule() {
       @Override
       protected void configure() {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/app/guice/DistributedProgramRunnableModuleTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/app/guice/DistributedProgramRunnableModuleTest.java
@@ -17,6 +17,8 @@
 package co.cask.cdap.app.guice;
 
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.ProgramId;
 import com.google.inject.Guice;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.twill.api.ElectionHandler;
@@ -40,7 +42,9 @@ public class DistributedProgramRunnableModuleTest {
   public void createModule() throws Exception {
     DistributedProgramRunnableModule distributedProgramRunnableModule =
       new DistributedProgramRunnableModule(CConfiguration.create(), new Configuration());
-    Guice.createInjector(distributedProgramRunnableModule.createModule());
+    Guice.createInjector(distributedProgramRunnableModule.createModule(new ProgramId("ns", "app",
+                                                                                     ProgramType.MAPREDUCE, "program"),
+                                                                       "user/host@KDC.NET"));
     Guice.createInjector(distributedProgramRunnableModule.createModule(new TwillContext() {
       @Override
       public RunId getRunId() {
@@ -117,6 +121,6 @@ public class DistributedProgramRunnableModuleTest {
       public Cancellable announce(String serviceName, int port, byte[] payload) {
         return null;
       }
-    }));
+    }, new ProgramId("ns", "app", ProgramType.MAPREDUCE, "program"), "user/host@KDC.NET"));
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -875,6 +875,10 @@ public final class Constants {
       public static final String USER_ID = "CDAP-UserId";
       /** User IP header passed from Router to downstream services */
       public static final String USER_IP = "CDAP-UserIP";
+      /** User principal passed from program container to cdap service containers */
+      public static final String USER_PRINCIPAL = "CDAP-User-Principal";
+      /** program id passed from program container to cdap service containers */
+      public static final String PROGRAM_ID = "CDAP-Program-Id";
     }
 
     /**

--- a/cdap-common/src/main/java/co/cask/cdap/common/kerberos/OwnerAdmin.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/kerberos/OwnerAdmin.java
@@ -91,14 +91,9 @@ public interface OwnerAdmin {
    * If a direct owner is not present then the namespace owner information will be returned if
    * one is present else returns null.
    * </p>
-   * <p>
-   * The returned {@link ImpersonationInfo} may have null as the keytab URI, if this owner admin does not
-   * have knowledge about that URI. In this case, it is the caller's responsibility to determine the keytab URI.
-   * </p>
-   *
    * @param entityId the {@link EntityId} whose owner principal information needs to be retrieved
    * @param impersonatedOpType the type of operation which is being impersonated
-   * @return {@link ImpersonationInfo} of the effective owner for the given entity. Its keytab URI may be null.
+   * @return {@link ImpersonationInfo} of the effective owner for the given entity.
    * @throws IOException if  failed to get the store
    * @throws IllegalArgumentException if the given entity is not of supported type.
    */

--- a/cdap-common/src/main/java/co/cask/cdap/common/kerberos/SecurityUtil.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/kerberos/SecurityUtil.java
@@ -229,10 +229,9 @@ public final class SecurityUtil {
   /**
    * This has the logic to construct an impersonation info as follows:
    * <ul>
-   *   <li>If the ownerAdmin has an owner and a keytab URI, return this information</li>
-   *   <li>If the ownerAdmin has an owner, but no keytab, construct a keytab URI as configured in the cConf</li>
-   *   <li>Else the ownerAdmin does not have an owner for this entity.
-   *       Return the master impersonation info as found in the cConf</li>
+   * <li>If the ownerAdmin has an owner and a keytab URI, return this information</li>
+   * <li>Else the ownerAdmin does not have an owner for this entity.
+   * Return the master impersonation info as found in the cConf</li>
    * </ul>
    */
   public static ImpersonationInfo createImpersonationInfo(OwnerAdmin ownerAdmin, CConfiguration cConf,
@@ -241,10 +240,6 @@ public final class SecurityUtil {
     ImpersonationInfo impersonationInfo = ownerAdmin.getImpersonationInfo(entityId, impersonatedOpType);
     if (impersonationInfo == null) {
       return new ImpersonationInfo(getMasterPrincipal(cConf), getMasterKeytabURI(cConf));
-    }
-    if (impersonationInfo.getKeytabURI() == null) {
-      return new ImpersonationInfo(impersonationInfo.getPrincipal(),
-                                   getKeytabURIforPrincipal(impersonationInfo.getPrincipal(), cConf));
     }
     return impersonationInfo;
   }

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/DiscoveryExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/DiscoveryExploreClient.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.explore.client;
 
 import co.cask.cdap.common.ServiceUnavailableException;
+import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.EndpointStrategy;
 import co.cask.cdap.common.discovery.RandomEndpointStrategy;
 import co.cask.cdap.common.http.DefaultHttpRequestConfig;
@@ -26,11 +27,14 @@ import co.cask.common.http.HttpRequestConfig;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import org.apache.twill.discovery.Discoverable;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
 import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static co.cask.cdap.common.conf.Constants.Service;
@@ -95,5 +99,12 @@ public class DiscoveryExploreClient extends AbstractExploreClient {
   @Override
   protected String getUserId() {
     return authenticationContext.getPrincipal().getName();
+  }
+
+  // when run from programs, the user principal will be set in the authentication context
+  @Override
+  protected Map<String, String> addAdditionalSecurityHeaders() {
+    return Collections.singletonMap(Constants.Security.Headers.USER_PRINCIPAL,
+                                    authenticationContext.getPrincipal().getKerberosPrincipal());
   }
 }

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreHttpClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ExploreHttpClient.java
@@ -110,6 +110,12 @@ abstract class ExploreHttpClient implements Explore {
     return null;
   }
 
+  protected Map<String, String> addAdditionalSecurityHeaders () {
+    // by default return null. It is only required to set addition security headers if needed as in case of
+    // ProgramDiscoveryExploreClient
+    return null;
+  }
+
   public void ping() throws UnauthenticatedException, ServiceUnavailableException, ExploreException {
     HttpResponse response = doGet("explore/status");
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
@@ -548,7 +554,9 @@ abstract class ExploreHttpClient implements Explore {
       newHeaders.put("Authorization", "Bearer " + authToken);
     } else {
       newHeaders.put(Constants.Security.Headers.USER_ID, userId);
+      newHeaders.putAll(addAdditionalSecurityHeaders());
     }
+
     return newHeaders;
   }
 

--- a/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ProgramDiscoveryExploreClient.java
+++ b/cdap-explore-client/src/main/java/co/cask/cdap/explore/client/ProgramDiscoveryExploreClient.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.explore.client;
+
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.security.spi.authentication.AuthenticationContext;
+import com.google.inject.Inject;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An Explore Client which extends {@link DiscoveryExploreClient} and is used in program container. This client is
+ * aware of the {@link ProgramId} and add it to the security headers.
+ */
+public class ProgramDiscoveryExploreClient extends DiscoveryExploreClient {
+
+  private final ProgramId programId;
+
+  @Inject
+  public ProgramDiscoveryExploreClient(final DiscoveryServiceClient discoveryClient,
+                                       AuthenticationContext authenticationContext, ProgramId programId) {
+    super(discoveryClient, authenticationContext);
+    this.programId = programId;
+  }
+
+  @Override
+  protected Map<String, String> addAdditionalSecurityHeaders() {
+    Map<String, String> headers = new HashMap<>(super.addAdditionalSecurityHeaders());
+    headers.put(Constants.Security.Headers.PROGRAM_ID, programId.toString());
+    return headers;
+  }
+}

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/security/Principal.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/security/Principal.java
@@ -20,6 +20,7 @@ import co.cask.cdap.api.annotation.Beta;
 import co.cask.cdap.proto.id.EntityId;
 
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
  * Identifies a user, group or role which can be authorized to perform an {@link Action} on a {@link EntityId}.
@@ -38,11 +39,17 @@ public class Principal {
   private final String name;
   private final PrincipalType type;
   private final int hashCode;
+  private final String kerberosPrincipal;
 
   public Principal(String name, PrincipalType type) {
+    this(name, type, null);
+  }
+
+  public Principal(String name, PrincipalType type, @Nullable String kerberosPrincipal) {
     this.name = name;
     this.type = type;
-    this.hashCode = Objects.hash(name, type);
+    this.kerberosPrincipal = kerberosPrincipal;
+    this.hashCode = Objects.hash(name, type, kerberosPrincipal);
   }
 
   public String getName() {
@@ -51,6 +58,11 @@ public class Principal {
 
   public PrincipalType getType() {
     return type;
+  }
+
+  @Nullable
+  public String getKerberosPrincipal() {
+    return kerberosPrincipal;
   }
 
   @Override
@@ -65,7 +77,8 @@ public class Principal {
 
     Principal other = (Principal) o;
 
-    return Objects.equals(name, other.name) && Objects.equals(type, other.type);
+    return Objects.equals(name, other.name) && Objects.equals(type, other.type) &&
+      Objects.equals(kerberosPrincipal, other.kerberosPrincipal);
   }
 
   @Override
@@ -78,6 +91,7 @@ public class Principal {
     return "Principal{" +
       "name='" + name + '\'' +
       ", type=" + type +
+      ", kerberosPrincipal=" + kerberosPrincipal +
       '}';
   }
 }

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/context/AuthenticationContextModules.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/context/AuthenticationContextModules.java
@@ -16,24 +16,28 @@
 
 package co.cask.cdap.security.auth.context;
 
+import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
 import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
+import com.google.common.base.Throwables;
 import com.google.inject.AbstractModule;
+import com.google.inject.Module;
 import org.apache.hadoop.security.UserGroupInformation;
+
+import java.io.IOException;
 
 /**
  * Exposes the right {@link AuthenticationContext} via an {@link AbstractModule} based on the context in which
  * it is being invoked.
  */
 public class AuthenticationContextModules {
-
   /**
    * An {@link AuthenticationContext} for HTTP requests in Master. The authentication details in this context are
    * derived from {@link SecurityRequestContext}.
    *
    * @see SecurityRequestContext
    */
-  public AbstractModule getMasterModule() {
+  public Module getMasterModule() {
     return new AbstractModule() {
       @Override
       protected void configure() {
@@ -44,22 +48,51 @@ public class AuthenticationContextModules {
 
   /**
    * An {@link AuthenticationContext} for use in program containers. The authentication details in this context are
-   * determined based on the {@link UserGroupInformation} of the user running the program.
+   * determined based on the {@link UserGroupInformation} of the user running the program. The provided
+   * kerberos principal information is also included in the {@link Principal}.
    */
-  public AbstractModule getProgramContainerModule() {
+  public Module getProgramContainerModule(final String principal) {
     return new AbstractModule() {
       @Override
       protected void configure() {
-        bind(AuthenticationContext.class).to(ProgramContainerAuthenticationContext.class);
+        String username = getUsername();
+        bind(AuthenticationContext.class)
+          .toInstance(new ProgramContainerAuthenticationContext(new Principal(username,
+                                                                              Principal.PrincipalType.USER,
+                                                                              principal)));
       }
     };
+  }
+
+  /**
+   * An {@link AuthenticationContext} for use in program containers. The authentication details in this context are
+   * determined based on the {@link UserGroupInformation} of the user running the program.
+   */
+  public Module getProgramContainerModule() {
+    return new AbstractModule() {
+      @Override
+      protected void configure() {
+        String username = getUsername();
+        bind(AuthenticationContext.class)
+          .toInstance(new ProgramContainerAuthenticationContext(new Principal(username,
+                                                                              Principal.PrincipalType.USER)));
+      }
+    };
+  }
+
+  private String getUsername() {
+    try {
+      return UserGroupInformation.getCurrentUser().getShortUserName();
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
   }
 
   /**
    * An {@link AuthenticationContext} for use in tests that do not need authentication/authorization. The
    * authentication details in this context are determined based on the {@link System#props user.name} system property.
    */
-  public AbstractModule getNoOpModule() {
+  public Module getNoOpModule() {
     return new AbstractModule() {
       @Override
       protected void configure() {

--- a/cdap-security/src/main/java/co/cask/cdap/security/auth/context/ProgramContainerAuthenticationContext.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/auth/context/ProgramContainerAuthenticationContext.java
@@ -18,23 +18,22 @@ package co.cask.cdap.security.auth.context;
 
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.security.spi.authentication.AuthenticationContext;
-import com.google.common.base.Throwables;
 import org.apache.hadoop.security.UserGroupInformation;
-
-import java.io.IOException;
 
 /**
  * An {@link AuthenticationContext} for use in program containers. The authentication details in this context are
  * determined based on the {@link UserGroupInformation} of the user running the program.
  */
-public class ProgramContainerAuthenticationContext implements AuthenticationContext {
+class ProgramContainerAuthenticationContext implements AuthenticationContext {
+
+  private final Principal principal;
+
+  ProgramContainerAuthenticationContext(Principal principal) {
+    this.principal = principal;
+  }
 
   @Override
   public Principal getPrincipal() {
-    try {
-      return new Principal(UserGroupInformation.getCurrentUser().getShortUserName(), Principal.PrincipalType.USER);
-    } catch (IOException e) {
-      throw Throwables.propagate(e);
-    }
+    return principal;
   }
 }


### PR DESCRIPTION
- Sets the program container principal and keytab in explore query headers
- addParition/deleteParition operations are performed with the given impersonation information.
- If impersonation information for the above operation as it can be in case if kerberos disabled cluster Impersonator gets the current user ugi
- If no impersonation information given for the above call on kerberos enabled cluster then the operation will fail. 

Issue: https://issues.cask.co/browse/CDAP-8342
Build: http://builds.cask.co/browse/CDAP-RUT581-1