### PR TITLE
ensure tags are fetched before checking out a tag

### DIFF
--- a/cdap-distributions/src/emr/install.sh
+++ b/cdap-distributions/src/emr/install.sh
@@ -109,6 +109,9 @@ git clone --depth 1 --branch ${CDAP_BRANCH} https://github.com/caskdata/cdap.git
 
 # Check out to specific tag if specified
 if [ -n "${CDAP_TAG}" ]; then
+  # Ensure tags are fetched
+  git -C ${__gitdir} fetch --all --tags --prune
+  # Checks out tag to a detached head state
   git -C ${__gitdir} checkout tags/${CDAP_TAG}
 fi
 

--- a/cdap-distributions/src/hdinsight/pkg/install.sh
+++ b/cdap-distributions/src/hdinsight/pkg/install.sh
@@ -58,6 +58,9 @@ git clone --depth 1 --branch ${CDAP_BRANCH} https://github.com/caskdata/cdap.git
 
 # Check out to specific tag if specified
 if [ -n "${CDAP_TAG}" ]; then
+  # Ensure tags are fetched
+  git -C ${__gitdir} fetch --all --tags --prune
+  # Checks out tag to a detached head state
   git -C ${__gitdir} checkout tags/${CDAP_TAG}
 fi
 


### PR DESCRIPTION
prevents the following error in HDInsight install logs, when trying to constrain cdap repo checkout to a tag:

``error: pathspec 'tags/v4.0.1' did not match any file(s) known to git.``

Update: also fixing same code in EMR script