### PR TITLE
ensure tags are fetched before checking out a tag

### DIFF
--- a/cdap-distributions/src/hdinsight/pkg/install.sh
+++ b/cdap-distributions/src/hdinsight/pkg/install.sh
@@ -58,6 +58,9 @@ git clone --depth 1 --branch ${CDAP_BRANCH} https://github.com/caskdata/cdap.git
 
 # Check out to specific tag if specified
 if [ -n "${CDAP_TAG}" ]; then
+  # Ensure tags are fetched
+  git -C ${__gitdir} fetch --all --tags --prune
+  # Checks out tag to a detached head state
   git -C ${__gitdir} checkout tags/${CDAP_TAG}
 fi
 


### PR DESCRIPTION
Conflicts:
	cdap-distributions/src/emr/install.sh

backport #7975.  Only the HDInsight install script.  Conflict was in the EMR script, for which the backport is not applicable.