### PR TITLE
(Hydrator-1334) Fix broken preview run due to dataset impersonation

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/preview/PreviewDataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/preview/PreviewDataPipelineTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.datapipeline.preview;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.app.preview.PreviewManager;
+import co.cask.cdap.app.preview.PreviewRunner;
+import co.cask.cdap.app.preview.PreviewStatus;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.utils.Tasks;
+import co.cask.cdap.datapipeline.DataPipelineApp;
+import co.cask.cdap.datapipeline.SmartWorkflow;
+import co.cask.cdap.etl.mock.batch.MockSink;
+import co.cask.cdap.etl.mock.batch.MockSource;
+import co.cask.cdap.etl.mock.test.HydratorTestBase;
+import co.cask.cdap.etl.mock.transform.IdentityTransform;
+import co.cask.cdap.etl.proto.Engine;
+import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
+import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.proto.artifact.preview.PreviewConfig;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.test.DataSetManager;
+import co.cask.cdap.test.TestConfiguration;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.JsonElement;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test for preview for data pipeline app
+ */
+public class PreviewDataPipelineTest extends HydratorTestBase {
+
+  private static final ArtifactId APP_ARTIFACT_ID = NamespaceId.DEFAULT.artifact("app", "1.0.0");
+  private static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("app", "1.0.0");
+  private static int startCount = 0;
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false,
+                                                                       Constants.Security.Store.PROVIDER, "file");
+  private static final String DATA_TRACER_PROPERTY = "records.out";
+
+  @BeforeClass
+  public static void setupTest() throws Exception {
+    if (startCount++ > 0) {
+      return;
+    }
+    setupBatchArtifacts(APP_ARTIFACT_ID, DataPipelineApp.class);
+  }
+
+  @Test
+  public void testDataPipelinePreviewRuns() throws Exception {
+    testDataPipelinePreviewRun(Engine.MAPREDUCE);
+    testDataPipelinePreviewRun(Engine.SPARK);
+  }
+
+  private void testDataPipelinePreviewRun(Engine engine) throws Exception {
+    PreviewManager previewManager = getPreviewManager();
+
+    String sourceTableName = "singleInput";
+    String sinkTableName = "singleOutput";
+    Schema schema = Schema.recordOf(
+      "testRecord",
+      Schema.Field.of("name", Schema.of(Schema.Type.STRING))
+    );
+
+    /*
+     * source --> transform -> sink
+     */
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder("* * * * *")
+      .addStage(new ETLStage("source", MockSource.getPlugin(sourceTableName, schema)))
+      .addStage(new ETLStage("transform", IdentityTransform.getPlugin()))
+      .addStage(new ETLStage("sink", MockSink.getPlugin(sinkTableName)))
+      .addConnection("source", "transform")
+      .addConnection("transform", "sink")
+      .setEngine(engine)
+      .setNumOfRecordsPreview(100)
+      .build();
+
+
+    // Construct the preview config with the program name and program type, also, mark the mock table as a real dataset.
+    // Otherwise, no data will be emitted in the preview run.
+    PreviewConfig previewConfig = new PreviewConfig(SmartWorkflow.NAME, ProgramType.WORKFLOW,
+                                                    ImmutableSet.of(sourceTableName),
+                                                    Collections.<String, String>emptyMap());
+
+    // Create the table for the mock source
+    addDatasetInstance(Table.class.getName(), sourceTableName,
+                       DatasetProperties.of(ImmutableMap.of("schema", schema.toString())));
+    DataSetManager<Table> inputManager = getDataset(NamespaceId.DEFAULT.dataset(sourceTableName));
+    StructuredRecord recordSamuel = StructuredRecord.builder(schema).set("name", "samuel").build();
+    StructuredRecord recordBob = StructuredRecord.builder(schema).set("name", "bob").build();
+    MockSource.writeInput(inputManager, ImmutableList.of(recordSamuel, recordBob));
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig, previewConfig);
+
+    // Start the preview and get the corresponding PreviewRunner.
+    final PreviewRunner previewRunner = previewManager.getRunner(previewManager.start(NamespaceId.DEFAULT, appRequest));
+
+    // Wait for the preview status go into COMPLETED.
+    Tasks.waitFor(PreviewStatus.Status.COMPLETED, new Callable<PreviewStatus.Status>() {
+      @Override
+      public PreviewStatus.Status call() throws Exception {
+        PreviewStatus status = previewRunner.getStatus();
+        return status == null ? null : status.getStatus();
+      }
+    }, 5, TimeUnit.MINUTES);
+
+    // Get the data for stage "source" in the PreviewStore, should contain two records.
+    checkPreviewStore(previewRunner, "source", 2);
+
+    // Get the data for stage "transform" in the PreviewStore, should contain two records.
+    checkPreviewStore(previewRunner, "transform", 2);
+
+    // Get the data for stage "sink" in the PreviewStore, should contain two records.
+    checkPreviewStore(previewRunner, "sink", 2);
+
+    // Check the sink table is not created in the real space.
+    DataSetManager<Table> sinkManager = getDataset(sinkTableName);
+    Assert.assertNull(sinkManager.get());
+    deleteDatasetInstance(NamespaceId.DEFAULT.dataset(sourceTableName));
+  }
+
+  private void checkPreviewStore(PreviewRunner previewRunner, String tracerName, int expectedNumber) {
+    Map<String, List<JsonElement>> result = previewRunner.getData(tracerName);
+    Assert.assertTrue(!result.isEmpty());
+    Assert.assertEquals(expectedNumber, result.get(DATA_TRACER_PROPERTY).size());
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/preview/PreviewDataStreamsTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/preview/PreviewDataStreamsTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.datastreams.preview;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.app.preview.PreviewManager;
+import co.cask.cdap.app.preview.PreviewRunner;
+import co.cask.cdap.app.preview.PreviewStatus;
+import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.utils.Tasks;
+import co.cask.cdap.datastreams.DataStreamsApp;
+import co.cask.cdap.datastreams.DataStreamsSparkLauncher;
+import co.cask.cdap.etl.mock.batch.MockSink;
+import co.cask.cdap.etl.mock.spark.streaming.MockSource;
+import co.cask.cdap.etl.mock.test.HydratorTestBase;
+import co.cask.cdap.etl.mock.transform.IdentityTransform;
+import co.cask.cdap.etl.proto.v2.DataStreamsConfig;
+import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.artifact.ArtifactSummary;
+import co.cask.cdap.proto.artifact.preview.PreviewConfig;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.test.DataSetManager;
+import co.cask.cdap.test.TestConfiguration;
+import com.google.gson.JsonElement;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test for preview for data streams app
+ */
+public class PreviewDataStreamsTest extends HydratorTestBase {
+
+  private static final ArtifactId APP_ARTIFACT_ID = NamespaceId.DEFAULT.artifact("app", "1.0.0");
+  private static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("app", "1.0.0");
+  private static int startCount = 0;
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
+  private static final String DATA_TRACER_PROPERTY = "records.out";
+
+  @BeforeClass
+  public static void setupTest() throws Exception {
+    if (startCount++ > 0) {
+      return;
+    }
+
+    setupStreamingArtifacts(APP_ARTIFACT_ID, DataStreamsApp.class);
+  }
+
+  @Test
+  public void testDataStreamsPreviewRun() throws Exception {
+    PreviewManager previewManager = getPreviewManager();
+
+    String sinkTableName = "singleOutput";
+    Schema schema = Schema.recordOf(
+      "testRecord",
+      Schema.Field.of("name", Schema.of(Schema.Type.STRING))
+    );
+
+    List<StructuredRecord> records = new ArrayList<>();
+    StructuredRecord recordSamuel = StructuredRecord.builder(schema).set("name", "samuel").build();
+    StructuredRecord recordBob = StructuredRecord.builder(schema).set("name", "bob").build();
+    records.add(recordSamuel);
+    records.add(recordBob);
+
+    /*
+     * source --> transform -> sink
+     */
+    DataStreamsConfig etlConfig = DataStreamsConfig.builder()
+      .addStage(new ETLStage("source", MockSource.getPlugin(schema, records)))
+      .addStage(new ETLStage("transform", IdentityTransform.getPlugin()))
+      .addStage(new ETLStage("sink", MockSink.getPlugin(sinkTableName)))
+      .addConnection("source", "transform")
+      .addConnection("transform", "sink")
+      .setNumOfRecordsPreview(100)
+      .setBatchInterval("1s")
+      .build();
+
+    // Construct the preview config with the program name and program type, also, mark the mock table as a real dataset.
+    // Otherwise, no data will be emitted in the preview run.
+    PreviewConfig previewConfig = new PreviewConfig(DataStreamsSparkLauncher.NAME, ProgramType.SPARK,
+                                                    Collections.<String>emptySet(),
+                                                    Collections.<String, String>emptyMap());
+
+    AppRequest<DataStreamsConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig, previewConfig);
+
+    // Start the preview and get the corresponding PreviewRunner.
+    final PreviewRunner previewRunner = previewManager.getRunner(previewManager.start(NamespaceId.DEFAULT, appRequest));
+
+    // Wait for the preview to be running and wait until the records are processed in the sink.
+    Tasks.waitFor(true, new Callable<Boolean>() {
+      @Override
+      public Boolean call() throws Exception {
+        Map<String, List<JsonElement>> data = previewRunner.getData("sink");
+        return data != null && data.get(DATA_TRACER_PROPERTY) != null && data.get(DATA_TRACER_PROPERTY).size() == 2;
+      }
+    }, 1, TimeUnit.MINUTES);
+
+    // check data in source and transform
+    checkPreviewStore(previewRunner, "source", 2);
+    checkPreviewStore(previewRunner, "transform", 2);
+
+    // Stop the preview and wait for status to be KILLED.
+    previewRunner.stopPreview();
+    Tasks.waitFor(PreviewStatus.Status.KILLED, new Callable<PreviewStatus.Status>() {
+      @Override
+      public PreviewStatus.Status call() throws Exception {
+        return previewRunner.getStatus().getStatus();
+      }
+    }, 1, TimeUnit.MINUTES);
+
+    // Check the sink table is not created in the real space.
+    DataSetManager<Table> sinkManager = getDataset(sinkTableName);
+    Assert.assertNull(sinkManager.get());
+  }
+
+  private void checkPreviewStore(PreviewRunner previewRunner, String tracerName, int expectedNumber) {
+    Map<String, List<JsonElement>> result = previewRunner.getData(tracerName);
+    Assert.assertTrue(!result.isEmpty());
+    Assert.assertEquals(expectedNumber, result.get(DATA_TRACER_PROPERTY).size());
+  }
+
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/preview/PreviewDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/preview/PreviewDatasetFramework.java
@@ -152,7 +152,12 @@ public class PreviewDatasetFramework implements DatasetFramework {
   public void addInstance(String datasetTypeName, DatasetId datasetInstanceId,
                           DatasetProperties props,
                           @Nullable KerberosPrincipalId ownerPrincipal) throws DatasetManagementException, IOException {
-    throw new UnsupportedOperationException("Creating dataset instance with owner is not supported");
+    if (ownerPrincipal == null) {
+      addInstance(datasetTypeName, datasetInstanceId, props);
+      return;
+    }
+    throw new UnsupportedOperationException("Creating dataset instance with owner is not supported in preview, " +
+                                              "please try to start the preview without the ownership");
   }
 
   @Override

--- a/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/co/cask/cdap/test/TestBase.java
@@ -33,6 +33,8 @@ import co.cask.cdap.app.guice.AppFabricServiceRuntimeModule;
 import co.cask.cdap.app.guice.AuthorizationModule;
 import co.cask.cdap.app.guice.InMemoryProgramRunnerModule;
 import co.cask.cdap.app.guice.ServiceStoreModules;
+import co.cask.cdap.app.preview.PreviewHttpModule;
+import co.cask.cdap.app.preview.PreviewManager;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.discovery.EndpointStrategy;
@@ -203,6 +205,7 @@ public class TestBase {
   private static AuthorizationBootstrapper authorizationBootstrapper;
   private static MessagingService messagingService;
   private static MessagingContext messagingContext;
+  private static PreviewManager previewManager;
 
   // This list is to record ApplicationManager create inside @Test method
   private static final List<ApplicationManager> applicationManagers = new ArrayList<>();
@@ -273,6 +276,7 @@ public class TestBase {
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getInMemoryModules(),
       new MessagingServerRuntimeModule().getInMemoryModules(),
+      new PreviewHttpModule(),
       new AbstractModule() {
         @Override
         @SuppressWarnings("deprecation")
@@ -348,6 +352,7 @@ public class TestBase {
     secureStoreManager = injector.getInstance(SecureStoreManager.class);
     messagingContext = new MultiThreadMessagingContext(messagingService);
     firstInit = false;
+    previewManager = injector.getInstance(PreviewManager.class);
   }
 
   private static TestManager getTestManager() {
@@ -1199,6 +1204,13 @@ public class TestBase {
   @Beta
   protected static Authorizer getAuthorizer() throws IOException, InvalidAuthorizerException {
     return authorizerInstantiator.get();
+  }
+
+  /**
+   * Returns a {@link PreviewManager} to interact with preview.
+   */
+  protected static PreviewManager getPreviewManager() {
+    return previewManager;
   }
 
   /**


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/HYDRATOR-1334
Build: http://builds.cask.co/browse/CDAP-RUT584-1

Fix the broken preview due to the recent changes to dataset impersonation. Preview needs to deploy the application just like the other application. When we try to create dataset instance for the preview run, the newly added AddInstance() method directly throws an Exception which causes preview to fail. Since currently we do not have plan to support impersonation in preview space, need to make it call the original AddInstance() method to fix the preview.

Also added simple unit tests for preview 