### PR TITLE
CDAP-8445 return 503 for enqueue endpoint is dataset unavailable

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/DefaultStreamBatchWriter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/stream/DefaultStreamBatchWriter.java
@@ -18,7 +18,7 @@ package co.cask.cdap.app.stream;
 
 import co.cask.cdap.api.data.stream.StreamBatchWriter;
 import co.cask.cdap.common.io.ByteBuffers;
-import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.id.StreamId;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
 import java.io.IOException;
@@ -33,10 +33,10 @@ public class DefaultStreamBatchWriter implements StreamBatchWriter {
 
   private final HttpURLConnection connection;
   private final OutputStream outputStream;
-  private final Id.Stream stream;
+  private final StreamId stream;
   private boolean open;
 
-  public DefaultStreamBatchWriter(HttpURLConnection connection, Id.Stream stream) throws IOException {
+  public DefaultStreamBatchWriter(HttpURLConnection connection, StreamId stream) throws IOException {
     this.connection = connection;
     this.outputStream = connection.getOutputStream();
     this.stream = stream;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
@@ -383,13 +383,14 @@ public final class StreamHandler extends AbstractHttpHandler {
       properties = GSON.fromJson(reader, StreamProperties.class);
     } catch (Exception e) {
       throw new BadRequestException("Invalid stream configuration. Please check that the " +
-                                      "configuration is a valid JSON Object with a valid schema.");
+                                      "configuration is a valid JSON Object with a valid schema. Cause: " +
+                                      e.getMessage());
     }
 
     // Validate ttl
     Long ttl = properties.getTTL();
     if (ttl != null && ttl < 0) {
-      throw new BadRequestException("TTL value should be positive.");
+      throw new BadRequestException("Invalid TTL " + ttl + ". TTL value should be positive.");
     }
 
     // Validate format
@@ -417,7 +418,8 @@ public final class StreamHandler extends AbstractHttpHandler {
     // Validate notification threshold
     Integer threshold = properties.getNotificationThresholdMB();
     if (threshold != null && threshold <= 0) {
-      throw new BadRequestException("Threshold value should be greater than zero.");
+      throw new BadRequestException(
+        "Invalid threshold " + threshold + ". Threshold value should be greater than zero.");
     }
 
     // validate owner principal if one is provided


### PR DESCRIPTION
Fixes the stream service endpoint for enqueuing messages to a
stream so that it returns a 503 if some dependent service
(dataset service in this case) is not available.

Also changing the DefaultStreamWriter so that it retries
if it gets a 503 back from the stream service.