### PR TITLE
Improve output message of delete namespace command.

### DIFF
--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteNamespaceCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/DeleteNamespaceCommand.java
@@ -68,7 +68,7 @@ public class DeleteNamespaceCommand extends AbstractCommand {
       String userConfirm = consoleReader.readLine(prompt);
       if ("y".equalsIgnoreCase(userConfirm)) {
         namespaceClient.delete(namespaceId);
-        out.println(String.format(SUCCESS_MSG, namespaceId));
+        out.println(String.format(SUCCESS_MSG, namespaceId.getNamespace()));
         if (cliConfig.getCurrentNamespace().equals(namespaceId)) {
           cliConfig.setNamespace(NamespaceId.DEFAULT);
           out.printf("Now using namespace '%s'", NamespaceId.DEFAULT.getNamespace());


### PR DESCRIPTION
Otherwise, deleting a namespace returns this message:
`Namespace 'namespace:ali' deleted successfully.`
Instead, it should say:
`Namespace 'ali' deleted successfully.`

http://builds.cask.co/browse/CDAP-RUT589-1