### PR TITLE
utility to merge parcel repo manifests, and updating parcel repo buil…

### DIFF
--- a/cdap-distributions/bin/merge_manifests.rb
+++ b/cdap-distributions/bin/merge_manifests.rb
@@ -1,0 +1,115 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+#
+# Copyright © 2017 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This program merges two Parcel Repository Manifests into a single manifest.json
+# See https://github.com/cloudera/cm_ext/wiki/The-parcel-repository-format for
+# more information on Parcel Repository Manifests
+
+# This script simply merges the manifests as follows:
+#   lastUpdated: the most recent timestamp is used
+#   parcels: the arrays are concatenated. An error will be thrown if duplicate parcel
+#     names are found in both manifests. It will not try to deep merge.
+
+require 'json'
+require 'optparse'
+
+# Parse command line options.
+options = {}
+begin
+  op = OptionParser.new do |opts|
+    opts.banner = "Usage: #{$PROGRAM_NAME} [options] [file1] [file2]"
+    opts.on('-m', '--manifest FILE', 'manifest file to merge. Can be specified twice, or once as a comma-separated list') do |m|
+      options[:manifest] = [] unless options[:manifest]
+      options[:manifest] += m.split(',')
+    end
+    opts.on('-o', '--output FILE', 'Output manifest file to create. Will overwrite any existing file') do |o|
+      options[:output] = o
+    end
+
+    opts.separator ''
+    opts.separator 'Required Arguments: must specify two input manifest files, via two -m arguments or two positional parameters'
+    opts.separator ''
+    opts.separator 'Examples:'
+    opts.separator '  # Merges two manifests and writes output to a file:'
+    opts.separator "  #{$PROGRAM_NAME} -m /path/to/manifest1 -m /path/to/manifest2 -o /path/to/output"
+    opts.separator '  # Equivalent to above:'
+    opts.separator "  #{$PROGRAM_NAME} -m /path/to/manifest1,/path/to/manifest2 -o /path/to/output"
+    opts.separator '  # Writes to stdout only:'
+    opts.separator "  #{$PROGRAM_NAME} /path/to/manifest1 /path/to/manifest2"
+    opts.separator ''
+  end
+  op.parse!(ARGV)
+rescue OptionParser::InvalidArgument, OptionParser::InvalidOption
+  puts "Invalid Argument/Options: #{$ERROR_INFO}"
+  puts op # prints usage
+  exit 1
+end
+
+# Validate args
+# If no -m supplied, but 2 positional parameters, use them
+options[:manifest] = ARGV if !options.key?(:manifest) && ARGV.length == 2
+
+# Ensure we have 2 inputs
+raise 'Must supply two input manifest.json files using the -m option' unless options.key?(:manifest) && options[:manifest].length == 2
+
+# Convert json file to hash obj
+def deserialize_manifest(path)
+  JSON.parse(File.read(path))
+end
+
+# Convert hash obj to json string
+def serialize_manifest(obj)
+  JSON.pretty_generate(obj, indent: '    ')
+end
+
+# Check for unmergable input and fail
+def check_for_duplicates(m1, m2)
+  m1_parcels = m1['parcels'].map { |h| h['parcelName'] }
+  m2_parcels = m2['parcels'].map { |h| h['parcelName'] }
+
+  duplicates = m1_parcels & m2_parcels
+  raise "Cannot merge, duplicate parcels across manifests: #{duplicates}" unless duplicates.empty?
+end
+
+# Given two manifest hashes, merge into one
+def merge_manifests(m1, m2)
+  # Fail on invalid input
+  check_for_duplicates(m1, m2)
+
+  output = {}
+  # Set lastUpdated to most recent of the inputs
+  output['lastUpdated'] = m1['lastUpdated'] > m2['lastUpdated'] ? m1['lastUpdated'] : m2['lastUpdated']
+  # Set parcels to union of inputs
+  output['parcels'] = m1['parcels'] | m2['parcels']
+
+  output
+end
+
+# Begin main logic
+m1 = deserialize_manifest(options[:manifest][0])
+m2 = deserialize_manifest(options[:manifest][1])
+
+merged = merge_manifests(m1, m2)
+
+if options.key?(:output)
+  # Write to specified output file
+  File.write(options[:output], serialize_manifest(merged))
+else
+  # Write to STDOUT only
+  puts serialize_manifest(merged)
+end


### PR DESCRIPTION
…d to use it

- [x] ``merge_manifests.rb`` which will take 2 input manifests and merge them to an output
   - [x] checks that parcels are not duplicated in both inputs, otherwise fails. (enforces simple merges)
- [x] update ``build_parcel_repo.sh`` to build cumulative repo using only the remote manifest.