### PR TITLE
CDAP-8367 Fix hive on spark

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ExploreServiceTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ExploreServiceTwillRunnable.java
@@ -67,12 +67,10 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.MRJobConfig;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.twill.api.TwillContext;
@@ -340,11 +338,6 @@ public class ExploreServiceTwillRunnable extends AbstractMasterTwillRunnable {
       // YARN_APPLICATION_CLASSPATH before job.jar for container's classpath.
       conf.setBoolean(Job.MAPREDUCE_JOB_USER_CLASSPATH_FIRST, false);
       conf.setBoolean(MRJobConfig.MAPREDUCE_JOB_CLASSLOADER, false);
-
-      // We override this param due to the change in HIVE-14383. Otherwise, the hive job will be launched as the
-      // 'hive' user (or fail to even launch, if on ClouderaManager). See CDAP-8367 for more details.
-      conf.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION,
-               UserGroupInformation.AuthenticationMethod.SIMPLE.name());
 
       String sparkHome = System.getenv(Constants.SPARK_HOME);
       if (sparkHome != null) {


### PR DESCRIPTION
First commit reverts the old fix, which brought about a regression in the MapReduce engine for Explore.
Second commit brings in a better fix, which works also for the MapReduce engine.
Third commit makes it so that the user doesn't need to manually add all the parameters that Explore service modifies (via sessionConf) into their `hive.security.authorization.sqlstd.confwhitelist.append` of their hive-site.xml.

https://issues.cask.co/browse/CDAP-8367
http://builds.cask.co/browse/CDAP-RUT547-2

Integration tests: http://builds.cask.co/browse/CDAP-ITM6-15