### PR TITLE
Correct spelling from 'time stamp' to 'timestamp'

### DIFF
--- a/cdap-docs/developers-manual/source/testing/debugging.rst
+++ b/cdap-docs/developers-manual/source/testing/debugging.rst
@@ -47,7 +47,7 @@ to debug a container, you need to start the component with debugging enabled by 
 an HTTP request to the component’s URL. For example, the following will start a flow for debugging::
 
   POST /v3/namespaces/default/apps/WordCount/flows/WordCounter/debug
-  
+
 Using ``curl``:
 
 .. tabbed-parsed-literal::
@@ -55,7 +55,7 @@ Using ``curl``:
   $ curl -w"\n" -X POST "http://<hostname>:11015/v3/namespaces/default/apps/WordCount/flows/WordCounter/debug"
 
 Note that this URL differs from the URL for starting the flow only by the last path
-component (``debug`` instead of ``start``; see the :ref:`http-restful-api-lifecycle`). 
+component (``debug`` instead of ``start``; see the :ref:`http-restful-api-lifecycle`).
 You can pass in runtime arguments in the exact same way as you normally would start a flow.
 
 Once the flow is running, each flowlet will detect an available port in its container
@@ -64,7 +64,7 @@ To find out the address of a container’s host and the container’s debug port
 the CDAP for a flow or service’s live info via HTTP::
 
   GET /v3/namespaces/default/apps/WordCount/flows/WordCounter/live-info
-  
+
 or, using the CDAP CLI:
 
 .. tabbed-parsed-literal::
@@ -167,7 +167,7 @@ You may need to adjust them for your installation or version.
 
 #. Enter the host name, for example, ``localhost`` or ``node-1003.my.cluster.net``
    in the Host field.
-   
+
 #. Enter the debugging port, for example, ``5005`` in the Port field.
 
 #. In your project, click ``Debug`` to start the debugger.
@@ -188,7 +188,7 @@ Debugging the Transaction Manager (Advanced Use)
 In this advanced use section, we will explain in depth how transactions work internally.
 Transactions are introduced in the :ref:`Transaction System <transaction-system>`.
 
-A transaction is defined by an identifier, which contains the time stamp, in milliseconds,
+A transaction is defined by an identifier, which contains the timestamp, in milliseconds,
 of its creation. This identifier—also called the `write pointer`—represents the version
 that this transaction will use for all of its writes. It is also used to determine
 the order between transactions. A transaction with a smaller write pointer than
@@ -295,11 +295,11 @@ To download a snapshot of the state of the TM of the CDAP, use the command:
 .. tabbed-parsed-literal::
 
   .. Linux
-  
+
   $ cdap debug transactions view --host <name> [--save <filename>]
 
   .. Windows
-  
+
   > tx-debugger.bat view --host <name> [--save <filename>]
 
 where `name` is the host name of your CDAP instance, and the optional `filename`
@@ -312,11 +312,11 @@ with the command:
 .. tabbed-parsed-literal::
 
   .. Linux
-  
+
   $ cdap debug transactions view --filename <filename>
 
   .. Windows
-  
+
   > tx-debugger.bat view --filename <filename>
 
 where `filename` specifies the location where the snapshot has been saved.
@@ -343,11 +343,11 @@ use this command to invalidate it:
 .. tabbed-parsed-literal::
 
   .. Linux
-  
+
   $ cdap debug transactions invalidate --host <name> --transaction <writePtr>
 
   .. Windows
-  
+
   > tx-debugger.bat invalidate --host <name> --transaction <writePtr>
 
 Invalidating a transaction when we know for sure that its writes should

--- a/cdap-docs/examples-manual/source/examples/stream-conversion.rst
+++ b/cdap-docs/examples-manual/source/examples/stream-conversion.rst
@@ -39,7 +39,7 @@ of the application are tied together by the class ``StreamConversionApp``:
 The interesting part is the creation of the dataset *converted*:
 
 - It is a ``TimePartitionedFileSet``. This dataset manages the files in a ``FileSet`` by
-  associating each file with a time stamp.
+  associating each file with a timestamp.
 - The properties are divided in two sections:
 
   - The first set of properties configures the underlying FileSet, as documented in the
@@ -60,7 +60,7 @@ and it configures the *events* stream as its input and the *converted* dataset a
      :language: java
      :lines: 65-70
      :dedent: 4
-     
+
 - Based on the logical start time, the MapReduce determines the range of events to read from the stream:
 
   .. literalinclude:: /../../../cdap-examples/StreamConversion/src/main/java/co/cask/cdap/examples/streamconversion/StreamConversionMapReduce.java
@@ -121,11 +121,11 @@ to send 10000 events at a rate of roughly two per second (one per second in the 
 .. tabbed-parsed-literal::
 
   .. Linux
-  
+
   $ examples/StreamConversion/bin/send-events.sh --events 10000 --delay 0.5
 
   .. Windows
-  
+
   > examples\StreamConversion\bin\send-events.bat 10000 1
 
 You can now wait for the workflow to run, after which you can query the partitions in the
@@ -134,7 +134,7 @@ You can now wait for the workflow to run, after which you can query the partitio
 .. tabbed-parsed-literal::
 
   $ cdap cli execute "\"show partitions dataset_converted\""
-  
+
   +============================================+
   | partition: STRING                          |
   +============================================+
@@ -151,7 +151,7 @@ You can also query the data in the dataset. For example, to find the five most f
 .. tabbed-parsed-literal::
 
   $ cdap cli execute "\"select count(*) as count, body from dataset_converted group by body order by count desc limit 5\""
-  
+
   +==============================+
   | count: BIGINT | body: STRING |
   +==============================+


### PR DESCRIPTION
@awholegunch, overheard part your conversation so I decided to make the change while waiting for my cluster to spin up.