### PR TITLE
CDAP-8509 Enable table if upgrade of coprocessor is not required

### DIFF
--- a/cdap-tms/src/main/java/co/cask/cdap/messaging/store/hbase/HBaseTableFactory.java
+++ b/cdap-tms/src/main/java/co/cask/cdap/messaging/store/hbase/HBaseTableFactory.java
@@ -292,9 +292,11 @@ public final class HBaseTableFactory implements TableFactory {
       ProjectInfo.Version version = HBaseTableUtil.getVersion(tableDescriptor);
 
       if (version.compareTo(ProjectInfo.getVersion()) >= 0) {
-        // If cdap has version has not changed or is greater, no need to update
+        // If cdap has version has not changed or is greater, no need to update. Just enable it, in case
+        // it has been disabled by the upgrade tool, and return
         LOG.info("Table '{}' has not changed and its version '{}' is same or greater than current CDAP version '{}'",
                  tableId, version, ProjectInfo.getVersion());
+        enableTable(ddlExecutor, tableId);
         return;
       }
 


### PR DESCRIPTION
Enable the table even if we determine that upgrading of table coprocessor is not required. This is because, the tables might have been disabled by the upgrade tool.

JIRA : https://issues.cask.co/browse/CDAP-8509
Build : http://builds.cask.co/browse/CDAP-RUT594