### PR TITLE
Fix cdap-default.xml and documetation build

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -672,16 +672,20 @@
   </property>
 
   <property>
+    <name>data.tx.prune.state.table</name>
+    <value>${dataset.table.prefix}_system:tephra.state</value>
+    <description>
+      Table used to store intermediate state when invalid transaction list pruning is
+      enabled
+    </description>
+  </property>
+
+  <property>
     <name>data.tx.pruning.plugin.class</name>
     <value>co.cask.data2.txprune.DefaultHBaseTransactionPruningPlugin</value>
     <description>
       Class name for the default transaction pruning plugin
     </description>
-  </property>
-
-  <property>
-    <name>data.tx.prune.state.table</name>
-    <value>${dataset.table.prefix}_system:tephra.state</value>
   </property>
 
   <property>

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="274486b983a68498c86f7bf02c1fc9a5"
+DEFAULT_XML_MD5_HASH="5c65540c9e10d70df2fc9905a39a831e"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
Re-order and add a description for a property. Fixes MD5 hash.

Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB268-1