### PR TITLE
[CDAP-8262] Deterministic behavior for multi-output dataset permissions

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -263,10 +263,10 @@ final class BasicMapReduceContext extends AbstractContext implements MapReduceCo
   }
 
   /**
-   * @return a map from output name to provied output for the MapReduce job
+   * @return a map from output name to provided output for the MapReduce job
    */
   Map<String, ProvidedOutput> getOutputs() {
-    return ImmutableMap.copyOf(outputs);
+    return new HashMap<>(outputs);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -85,6 +85,7 @@ import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import com.google.inject.Injector;
 import com.google.inject.ProvisionException;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.MRJobConfig;
@@ -123,6 +124,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -147,6 +149,7 @@ import javax.annotation.Nullable;
 final class MapReduceRuntimeService extends AbstractExecutionThreadService {
 
   private static final Logger LOG = LoggerFactory.getLogger(MapReduceRuntimeService.class);
+  private static final String HADOOP_UMASK_PROPERTY = FsPermission.UMASK_LABEL; // fs.permissions.umask-mode
 
   /**
    * Do not remove: we need this variable for loading MRClientSecurityInfo class required for communicating with
@@ -154,10 +157,6 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
    */
   @SuppressWarnings("unused")
   private org.apache.hadoop.mapreduce.v2.app.MRClientSecurityInfo mrClientSecurityInfo;
-
-  // Regex pattern for configuration source if it is set programmatically. This constant is not defined in Hadoop
-  // Hadoop 2.3.0 and before has a typo as 'programatically', while it is fixed later as 'programmatically'.
-  private static final Pattern PROGRAMATIC_SOURCE_PATTERN = Pattern.compile("program{1,2}atically");
 
   private final Injector injector;
   private final CConfiguration cConf;
@@ -809,6 +808,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
    */
   private void setOutputsIfNeeded(Job job) {
     Map<String, ProvidedOutput> outputsMap = context.getOutputs();
+    fixOutputPermissions(job, outputsMap);
     LOG.debug("Using as output for MapReduce Job: {}", outputsMap.keySet());
     Collection<ProvidedOutput> outputs = outputsMap.values();
     if (outputs.isEmpty()) {
@@ -836,6 +836,58 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
 
     }
   }
+
+  private void fixOutputPermissions(Job job, Map<String, ProvidedOutput> outputs) {
+    Configuration jobconf = job.getConfiguration();
+    Set<String> outputsWithUmask = new HashSet<>();
+    Set<String> outputUmasks = new HashSet<>();
+    for (Map.Entry<String, ProvidedOutput> entry : outputs.entrySet()) {
+      String umask = entry.getValue().getOutputFormatConfiguration().get(HADOOP_UMASK_PROPERTY);
+      if (umask != null) {
+        outputsWithUmask.add(entry.getKey());
+        outputUmasks.add(umask);
+      }
+    }
+    boolean allOutputsHaveUmask = outputsWithUmask.size() == outputs.size();
+    boolean allOutputsAgree = outputUmasks.size() == 1;
+    boolean jobConfHasUmask = isProgrammaticConfig(jobconf, HADOOP_UMASK_PROPERTY);
+    String jobConfUmask = jobconf.get(HADOOP_UMASK_PROPERTY);
+
+    boolean mustFixUmasks = false;
+    if (jobConfHasUmask) {
+      // case 1: job conf has a programmatic umask. It prevails.
+      mustFixUmasks = !outputsWithUmask.isEmpty();
+      if (mustFixUmasks) {
+        LOG.info("Overriding permissions of outputs {} because a umask of {} was set programmatically in the job " +
+                   "configuration.", outputsWithUmask, jobConfUmask);
+      }
+    } else if (allOutputsHaveUmask && allOutputsAgree) {
+      // case 2: no programmatic umask in job conf, all outputs want the same umask: set it in job conf
+      String umaskToUse = outputUmasks.iterator().next();
+      jobconf.set(HADOOP_UMASK_PROPERTY, umaskToUse);
+      LOG.debug("Setting umask of {} in job configuration because all outputs {} agree on it.",
+                umaskToUse, outputsWithUmask);
+    } else {
+      // case 3: some outputs configure a umask, but not all of them, or not all the same: use job conf default
+      mustFixUmasks = !outputsWithUmask.isEmpty();
+      if (mustFixUmasks) {
+        LOG.warn("Overriding permissions of outputs {} because they configure different permissions. Falling back " +
+                   "to default umask of {} in job configuration.", outputsWithUmask, jobConfUmask);
+      }
+    }
+
+    // fix all output configurations that have a umask by removing that property from their configs
+    if (mustFixUmasks) {
+      for (String outputName : outputsWithUmask) {
+        ProvidedOutput output = outputs.get(outputName);
+        Map<String, String> outputConfig = new HashMap<>(output.getOutputFormatConfiguration());
+        outputConfig.remove(HADOOP_UMASK_PROPERTY);
+        outputs.put(outputName, new ProvidedOutput(output.getAlias(), output.getOutputFormatProvider(),
+                                                   output.getOutputFormatClassName(), outputConfig));
+      }
+    }
+  }
+
 
   /**
    * Returns the input value type of the MR job based on the job Mapper/Reducer type.
@@ -1099,11 +1151,26 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
     }
   }
 
+  // Regex pattern for configuration source if it is set programmatically. This constant is not defined in Hadoop
+  // Hadoop 2.3.0 and before has a typo as 'programatically', while it is fixed later as 'programmatically'.
+  private static final Pattern PROGRAMATIC_SOURCE_PATTERN = Pattern.compile("program{1,2}atically");
+
+  /**
+   * Returns, based on the sources of a configuration property, whether this property was set programmatically.
+   * This is the case if the first (that is, oldest) source is "programatic" or "programmatic" (depending on the
+   * Hadoop version).
+   *
+   * Note: the "program(m)atic" will always be the first source. If the configuration is written to a file and
+   * then loaded again, then the file name will become the second source, etc. This is the case, for example,
+   * in a mapper or reducer task.
+   *
+   * See {@link Configuration#getPropertySources(String)}.
+   */
   private boolean isProgrammaticConfig(Configuration conf, String name) {
     String[] sources = conf.getPropertySources(name);
-    return sources != null && sources.length > 0 &&
-      PROGRAMATIC_SOURCE_PATTERN.matcher(sources[sources.length - 1]).matches();
+    return sources != null && sources.length > 0 && PROGRAMATIC_SOURCE_PATTERN.matcher(sources[0]).matches();
   }
+
 
   /**
    * Copies a plugin archive jar to the target location.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/ProvidedOutput.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/ProvidedOutput.java
@@ -42,6 +42,16 @@ public class ProvidedOutput {
     }
   }
 
+  public ProvidedOutput(String alias,
+                        OutputFormatProvider outputFormatProvider,
+                        String outputFormatClassName,
+                        Map<String, String> outputFormatConfiguration) {
+    this.alias = alias;
+    this.outputFormatProvider = outputFormatProvider;
+    this.outputFormatClassName = outputFormatClassName;
+    this.outputFormatConfiguration = outputFormatConfiguration;
+  }
+
   public String getAlias() {
     return alias;
   }

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Configuration.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Configuration.java
@@ -1097,7 +1097,7 @@ public class Configuration implements Iterable<Map.Entry<String, String>> {
   /**
    * Gets information about why a property was set.  Typically this is the
    * path to the resource objects (file, URL, etc.) the property came from, but
-   * it can also indicate that it was set programatically, or because of the
+   * it can also indicate that it was set programmatically, or because of the
    * command line.
    *
    * @param name - The property name to get the source of.

--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/ConfigurationUtil.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/ConfigurationUtil.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 /**
@@ -106,7 +107,7 @@ public final class ConfigurationUtil {
   /**
    * Retrieves all configurations that are prefixed with a particular prefix.
    *
-   * @see {@link #setNamedConfigurations(Configuration, String, Map)}.
+   * @see #setNamedConfigurations(Configuration, String, Map)
    *
    * @param conf the Configuration from which to get the configurations
    * @param confKeyPrefix the prefix to search for in the keys

--- a/cdap-common/src/test/java/co/cask/cdap/common/test/AppJarHelper.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/test/AppJarHelper.java
@@ -102,7 +102,7 @@ public final class AppJarHelper {
           }
 
           // TODO: this is due to manifest possibly already existing in the jar, but we also
-          // create a manifest programatically so it's possible to have a duplicate entry here
+          // create a manifest programmatically so it's possible to have a duplicate entry here
           if ("META-INF/MANIFEST.MF".equalsIgnoreCase(jarEntry.getName())) {
             jarEntry = jarInput.getNextJarEntry();
             continue;

--- a/cdap-common/src/test/java/co/cask/cdap/common/test/PluginJarHelper.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/test/PluginJarHelper.java
@@ -89,7 +89,7 @@ public final class PluginJarHelper {
           }
 
           // TODO: this is due to manifest possibly already existing in the jar, but we also
-          // create a manifest programatically so it's possible to have a duplicate entry here
+          // create a manifest programmatically so it's possible to have a duplicate entry here
           if ("META-INF/MANIFEST.MF".equalsIgnoreCase(jarEntry.getName())) {
             jarEntry = jarInput.getNextJarEntry();
             continue;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/file/FileSetDataset.java
@@ -35,6 +35,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.twill.filesystem.ForwardingLocationFactory;
@@ -60,10 +61,11 @@ import javax.annotation.Nullable;
  */
 public final class FileSetDataset implements FileSet, DatasetOutputCommitter {
 
-  private static final Logger LOG = LoggerFactory.getLogger(FileSetDataset.class);
-
   public static final String FILESET_VERSION_PROPERTY = "fileset.version";
   static final String FILESET_VERSION = "2";
+
+  private static final Logger LOG = LoggerFactory.getLogger(FileSetDataset.class);
+  private static final String HADOOP_UMASK_PROPERTY = FsPermission.UMASK_LABEL; // fs.permissions.umask-mode
 
   private final DatasetSpecification spec;
   private final Map<String, String> runtimeArguments;
@@ -267,7 +269,7 @@ public final class FileSetDataset implements FileSet, DatasetOutputCommitter {
       outputPermissions = this.permissions;
     }
     if (outputPermissions != null) {
-      config.put("fs.permissions.umask-mode", FileUtils.permissionsToUmask(outputPermissions));
+      config.put(HADOOP_UMASK_PROPERTY, FileUtils.permissionsToUmask(outputPermissions));
     }
     config.putAll(outputArguments);
     return config;


### PR DESCRIPTION
see https://issues.cask.co/browse/CDAP-8262 for design. 

Note: unit tests are not possible because the umask is not applied by the local MR runner.  I have tested this manually on a secure cluster.