### PR TITLE
CDAP 8516 Refactor UGIProvider to take NamespacedEntityId

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/store/Store.java
@@ -308,7 +308,7 @@ public interface Store extends RuntimeStore {
    * Deletes data for an application from the WorkflowDataset table
    * @param id id of application to be deleted
    */
-  void deleteWorkflowStats(final ApplicationId id);
+  void deleteWorkflowStats(ApplicationId id);
 
   /**
    * Deletes a schedules from a particular program

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/PropertiesResolver.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/PropertiesResolver.java
@@ -19,7 +19,6 @@ package co.cask.cdap.internal.app.services;
 import co.cask.cdap.app.runtime.scheduler.SchedulerQueueResolver;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.kerberos.ImpersonatedOpType;
 import co.cask.cdap.common.kerberos.ImpersonationInfo;
 import co.cask.cdap.common.kerberos.OwnerAdmin;
 import co.cask.cdap.common.kerberos.SecurityUtil;
@@ -63,10 +62,8 @@ public class PropertiesResolver {
     systemArgs.put(Constants.CLUSTER_NAME, cConf.get(Constants.CLUSTER_NAME, ""));
     systemArgs.put(Constants.AppFabric.APP_SCHEDULER_QUEUE, queueResolver.getQueue(id.getNamespace()));
     if (SecurityUtil.isKerberosEnabled(cConf)) {
-      ImpersonationInfo impersonationInfo = SecurityUtil.createImpersonationInfo(ownerAdmin, cConf, id.toEntityId(),
-                                                                                 ImpersonatedOpType.OTHER);
+      ImpersonationInfo impersonationInfo = SecurityUtil.createImpersonationInfo(ownerAdmin, cConf, id.toEntityId());
       systemArgs.put(ProgramOptionConstants.PRINCIPAL, impersonationInfo.getPrincipal());
-      systemArgs.put(ProgramOptionConstants.KEYTAB_URI, impersonationInfo.getKeytabURI());
     }
     return systemArgs;
   }

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/ConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/deploy/ConfiguratorTest.java
@@ -94,14 +94,14 @@ public class ConfiguratorTest {
     CConfiguration cConf = CConfiguration.create();
     ArtifactRepository artifactRepo = new ArtifactRepository(conf, null, null, authorizer,
                                                              new DummyProgramRunnerFactory(),
-                                                             new DefaultImpersonator(cConf, null, null),
+                                                             new DefaultImpersonator(cConf, null),
                                                              authEnforcer, authenticationContext);
 
     // Create a configurator that is testable. Provide it a application.
     try (CloseableClassLoader artifactClassLoader =
            artifactRepo.createArtifactClassLoader(
              appJar, new EntityImpersonator(artifactId.getNamespace().toEntityId(),
-                                            new DefaultImpersonator(cConf, null, null)))) {
+                                            new DefaultImpersonator(cConf, null)))) {
       Configurator configurator = new InMemoryConfigurator(conf, Id.Namespace.DEFAULT, artifactId,
                                                            WordCountApp.class.getName(), artifactRepo,
                                                            artifactClassLoader, null, "");
@@ -127,7 +127,7 @@ public class ConfiguratorTest {
     CConfiguration cConf = CConfiguration.create();
     ArtifactRepository artifactRepo = new ArtifactRepository(conf, null, null, authorizer,
                                                              new DummyProgramRunnerFactory(),
-                                                             new DefaultImpersonator(cConf, null, null),
+                                                             new DefaultImpersonator(cConf, null),
                                                              authEnforcer, authenticationContext);
 
     ConfigTestApp.ConfigClass config = new ConfigTestApp.ConfigClass("myStream", "myTable");
@@ -135,7 +135,7 @@ public class ConfiguratorTest {
     try (CloseableClassLoader artifactClassLoader =
            artifactRepo.createArtifactClassLoader(
              appJar, new EntityImpersonator(artifactId.getNamespace().toEntityId(),
-                                            new DefaultImpersonator(cConf, null, null)))) {
+                                            new DefaultImpersonator(cConf, null)))) {
       Configurator configuratorWithConfig =
         new InMemoryConfigurator(conf, Id.Namespace.DEFAULT, artifactId, ConfigTestApp.class.getName(),
                                  artifactRepo, artifactClassLoader, null, new Gson().toJson(config));

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
@@ -79,8 +79,7 @@ public class ArtifactInspectorTest {
     try (CloseableClassLoader artifactClassLoader =
            classLoaderFactory.createClassLoader(
              artifactLocation, new EntityImpersonator(artifactId.toEntityId(),
-                                                      new DefaultImpersonator(CConfiguration.create(),
-                                                                                  null, null)))) {
+                                                      new DefaultImpersonator(CConfiguration.create(), null)))) {
       artifactInspector.inspectArtifact(artifactId, appFile, artifactClassLoader);
     }
   }
@@ -97,8 +96,7 @@ public class ArtifactInspectorTest {
     try (CloseableClassLoader artifactClassLoader =
            classLoaderFactory.createClassLoader(
              artifactLocation, new EntityImpersonator(artifactId.toEntityId(),
-                                                      new DefaultImpersonator(CConfiguration.create(),
-                                                                                  null, null)))) {
+                                                      new DefaultImpersonator(CConfiguration.create(), null)))) {
 
       ArtifactClasses classes = artifactInspector.inspectArtifact(artifactId, appFile, artifactClassLoader);
 

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStoreTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStoreTest.java
@@ -1049,6 +1049,6 @@ public class ArtifactStoreTest {
     String contents) throws ArtifactAlreadyExistsException, IOException, WriteConflictException {
     artifactStore.write(artifactId, meta, ByteStreams.newInputStreamSupplier(Bytes.toBytes(contents)),
                         new EntityImpersonator(artifactId.toEntityId(),
-                                               new DefaultImpersonator(CConfiguration.create(), null, null)));
+                                               new DefaultImpersonator(CConfiguration.create(), null)));
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/kerberos/ImpersonationInfo.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/kerberos/ImpersonationInfo.java
@@ -16,8 +16,9 @@
 
 package co.cask.cdap.common.kerberos;
 
+import com.google.common.base.Strings;
+
 import java.util.Objects;
-import javax.annotation.Nullable;
 
 /**
  * Encapsulates information necessary to impersonate a user - principal and keytab path.
@@ -29,7 +30,13 @@ public final class ImpersonationInfo {
   /**
    * Creates {@link ImpersonationInfo} using the specified principal and keytab path.
    */
-  public ImpersonationInfo(String principal, @Nullable String keytabURI) {
+  public ImpersonationInfo(String principal, String keytabURI) {
+    if (Strings.isNullOrEmpty(principal)) {
+      throw new IllegalArgumentException("A principal must be provided");
+    }
+    if (Strings.isNullOrEmpty(keytabURI)) {
+      throw new IllegalArgumentException("A keytabURI must be provided");
+    }
     this.principal = principal;
     this.keytabURI = keytabURI;
   }
@@ -38,7 +45,6 @@ public final class ImpersonationInfo {
     return principal;
   }
 
-  @Nullable
   public String getKeytabURI() {
     return keytabURI;
   }

--- a/cdap-common/src/main/java/co/cask/cdap/common/kerberos/ImpersonationRequest.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/kerberos/ImpersonationRequest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.kerberos;
+
+import co.cask.cdap.proto.id.NamespacedEntityId;
+
+/**
+ * A wrapper which wraps around the {@link co.cask.cdap.proto.id.NamespacedEntityId} on which impersonation needs to
+ * be performed and the type of operation {@link ImpersonatedOpType} which will be performed.
+ */
+public class ImpersonationRequest {
+  private final NamespacedEntityId entityId;
+  private final ImpersonatedOpType impersonatedOpType;
+
+  public ImpersonationRequest(NamespacedEntityId entityId, ImpersonatedOpType impersonatedOpType) {
+    this.entityId = entityId;
+    this.impersonatedOpType = impersonatedOpType;
+  }
+
+  public NamespacedEntityId getEntityId() {
+    return entityId;
+  }
+
+  public ImpersonatedOpType getImpersonatedOpType() {
+    return impersonatedOpType;
+  }
+
+  @Override
+  public String toString() {
+    return "ImpersonationRequest{" +
+      "entityId=" + entityId +
+      ", impersonatedOpType=" + impersonatedOpType +
+      '}';
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/kerberos/OwnerAdmin.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/kerberos/OwnerAdmin.java
@@ -92,14 +92,12 @@ public interface OwnerAdmin {
    * one is present else returns null.
    * </p>
    * @param entityId the {@link EntityId} whose owner principal information needs to be retrieved
-   * @param impersonatedOpType the type of operation which is being impersonated
    * @return {@link ImpersonationInfo} of the effective owner for the given entity.
    * @throws IOException if  failed to get the store
    * @throws IllegalArgumentException if the given entity is not of supported type.
    */
   @Nullable
-  ImpersonationInfo getImpersonationInfo(NamespacedEntityId entityId,
-                                         ImpersonatedOpType impersonatedOpType) throws IOException;
+  ImpersonationInfo getImpersonationInfo(NamespacedEntityId entityId) throws IOException;
 
   /**
    * Checks if owner information exists or not

--- a/cdap-common/src/main/java/co/cask/cdap/common/kerberos/PrincipalCredentials.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/kerberos/PrincipalCredentials.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.kerberos;
+
+/**
+ * A wrapper around kerberos principal and credentials file path of a user to allow creating UGI remotely.
+ */
+public class PrincipalCredentials {
+  private final String principal;
+  private final String credentialsPath;
+
+
+  public PrincipalCredentials(String principal, String credentialsPath) {
+    this.principal = principal;
+    this.credentialsPath = credentialsPath;
+  }
+
+  public String getPrincipal() {
+    return principal;
+  }
+
+  public String getCredentialsPath() {
+    return credentialsPath;
+  }
+
+  @Override
+  public String toString() {
+    return "PrincipalCredentials{" +
+      "principal='" + principal + '\'' +
+      ", credentialsPath=" + credentialsPath +
+      '}';
+  }
+}

--- a/cdap-common/src/main/java/co/cask/cdap/common/kerberos/SecurityUtil.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/kerberos/SecurityUtil.java
@@ -235,9 +235,8 @@ public final class SecurityUtil {
    * </ul>
    */
   public static ImpersonationInfo createImpersonationInfo(OwnerAdmin ownerAdmin, CConfiguration cConf,
-                                                          NamespacedEntityId entityId,
-                                                          ImpersonatedOpType impersonatedOpType) throws IOException {
-    ImpersonationInfo impersonationInfo = ownerAdmin.getImpersonationInfo(entityId, impersonatedOpType);
+                                                          NamespacedEntityId entityId) throws IOException {
+    ImpersonationInfo impersonationInfo = ownerAdmin.getImpersonationInfo(entityId);
     if (impersonationInfo == null) {
       return new ImpersonationInfo(getMasterPrincipal(cConf), getMasterKeytabURI(cConf));
     }

--- a/cdap-common/src/main/java/co/cask/cdap/common/kerberos/UGIWithPrincipal.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/kerberos/UGIWithPrincipal.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.kerberos;
+
+import org.apache.hadoop.security.UserGroupInformation;
+
+/**
+ * A wrapper around kerberos principal of the user and the ugi. This is needed because when remote ugi provider needs
+ * the ugi information (the credentials file location) and also the principal to be able construct the UGI remotely.
+ */
+public class UGIWithPrincipal {
+  private final String principal;
+  private final UserGroupInformation ugi;
+
+  public UGIWithPrincipal(String principal, UserGroupInformation ugi) {
+    this.principal = principal;
+    this.ugi = ugi;
+  }
+
+  public String getPrincipal() {
+    return principal;
+  }
+
+  public UserGroupInformation getUGI() {
+    return ugi;
+  }
+
+  @Override
+  public String toString() {
+    return "UGIWithPrincipal{" +
+      "principal='" + principal + '\'' +
+      ", ugi=" + ugi +
+      '}';
+  }
+}

--- a/cdap-common/src/test/java/co/cask/cdap/common/kerberos/NoOpOwnerAdmin.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/kerberos/NoOpOwnerAdmin.java
@@ -49,8 +49,7 @@ public class NoOpOwnerAdmin implements OwnerAdmin {
 
   @Nullable
   @Override
-  public ImpersonationInfo getImpersonationInfo(NamespacedEntityId entityId,
-                                                ImpersonatedOpType impersonatedOpType) throws IOException {
+  public ImpersonationInfo getImpersonationInfo(NamespacedEntityId entityId) throws IOException {
     return null;
   }
 

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/MultiLiveStreamFileReaderTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/MultiLiveStreamFileReaderTestBase.java
@@ -51,7 +51,7 @@ public abstract class MultiLiveStreamFileReaderTestBase {
 
   protected static CConfiguration cConf = CConfiguration.create();
 
-  private static final Impersonator impersonator = new DefaultImpersonator(cConf, new UnsupportedUGIProvider(), null);
+  private static final Impersonator impersonator = new DefaultImpersonator(cConf, new UnsupportedUGIProvider());
 
   protected abstract LocationFactory getLocationFactory();
 

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamDataFileTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamDataFileTestBase.java
@@ -80,7 +80,7 @@ public abstract class StreamDataFileTestBase {
 
   protected static CConfiguration cConf = CConfiguration.create();
 
-  private static final Impersonator impersonator = new DefaultImpersonator(cConf, new UnsupportedUGIProvider(), null);
+  private static final Impersonator impersonator = new DefaultImpersonator(cConf, new UnsupportedUGIProvider());
 
   @Test
   public void testEmptyFile() throws Exception {

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamFileJanitorTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/StreamFileJanitorTestBase.java
@@ -74,7 +74,7 @@ public abstract class StreamFileJanitorTestBase {
     // Simulate namespace create, since its an inmemory-namespace admin
     getNamespaceAdmin().create(NamespaceMeta.DEFAULT);
     getNamespacedLocationFactory().get(NamespaceId.DEFAULT.toId()).mkdirs();
-    impersonator = new DefaultImpersonator(cConf, new UnsupportedUGIProvider(), null);
+    impersonator = new DefaultImpersonator(cConf, new UnsupportedUGIProvider());
   }
 
   @Test

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/TimePartitionedStreamTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/TimePartitionedStreamTestBase.java
@@ -47,7 +47,7 @@ public abstract class TimePartitionedStreamTestBase {
 
   protected abstract LocationFactory getLocationFactory();
 
-  private static final Impersonator impersonator = new DefaultImpersonator(cConf, new UnsupportedUGIProvider(), null);
+  private static final Impersonator impersonator = new DefaultImpersonator(cConf, new UnsupportedUGIProvider());
 
   @Test
   public void testTimePartition() throws IOException {

--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/ConcurrentStreamWriterTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data/stream/service/ConcurrentStreamWriterTestBase.java
@@ -73,7 +73,7 @@ public abstract class ConcurrentStreamWriterTestBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(ConcurrentStreamWriterTestBase.class);
   private static final CConfiguration cConf = CConfiguration.create();
-  private static final Impersonator impersonator = new DefaultImpersonator(cConf, new UnsupportedUGIProvider(), null);
+  private static final Impersonator impersonator = new DefaultImpersonator(cConf, new UnsupportedUGIProvider());
 
   @ClassRule
   public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/RuntimeUsageRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/RuntimeUsageRegistry.java
@@ -33,7 +33,7 @@ public interface RuntimeUsageRegistry {
    * @param users the users of the stream
    * @param streamId the stream
    */
-  void registerAll(final Iterable<? extends EntityId> users, final StreamId streamId);
+  void registerAll(Iterable<? extends EntityId> users, StreamId streamId);
 
   /**
    * Register usage of a stream by an id.
@@ -49,7 +49,7 @@ public interface RuntimeUsageRegistry {
    * @param users the users of the stream
    * @param datasetId the stream
    */
-  void registerAll(final Iterable<? extends EntityId> users, final DatasetId datasetId);
+  void registerAll(Iterable<? extends EntityId> users, DatasetId datasetId);
 
   /**
    * Registers usage of a dataset by multiple ids.
@@ -65,7 +65,7 @@ public interface RuntimeUsageRegistry {
    * @param programId program
    * @param datasetInstanceId dataset
    */
-  void register(final ProgramId programId, final DatasetId datasetInstanceId);
+  void register(ProgramId programId, DatasetId datasetInstanceId);
 
   /**
    * Registers usage of a stream by a program.
@@ -73,5 +73,5 @@ public interface RuntimeUsageRegistry {
    * @param programId program
    * @param streamId  stream
    */
-  void register(final ProgramId programId, final StreamId streamId);
+  void register(ProgramId programId, StreamId streamId);
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/registry/UsageRegistry.java
@@ -33,17 +33,17 @@ public interface UsageRegistry extends RuntimeUsageRegistry {
    *
    * @param applicationId application
    */
-  void unregister(final ApplicationId applicationId);
+  void unregister(ApplicationId applicationId);
 
-  Set<DatasetId> getDatasets(final ApplicationId id);
+  Set<DatasetId> getDatasets(ApplicationId id);
 
-  Set<StreamId> getStreams(final ApplicationId id);
+  Set<StreamId> getStreams(ApplicationId id);
 
-  Set<DatasetId> getDatasets(final ProgramId id);
+  Set<DatasetId> getDatasets(ProgramId id);
 
-  Set<StreamId> getStreams(final ProgramId id);
+  Set<StreamId> getStreams(ProgramId id);
 
-  Set<ProgramId> getPrograms(final StreamId id);
+  Set<ProgramId> getPrograms(StreamId id);
 
-  Set<ProgramId> getPrograms(final DatasetId id);
+  Set<ProgramId> getPrograms(DatasetId id);
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueClientFactory.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/queue/hbase/HBaseQueueClientFactory.java
@@ -106,7 +106,7 @@ public class HBaseQueueClientFactory implements QueueClientFactory, ProgramConte
     HBaseQueueAdmin admin = ensureTableExists(queueName);
     try {
       final List<ConsumerGroupConfig> groupConfigs = Lists.newArrayList();
-      try (final HBaseConsumerStateStore stateStore = admin.getConsumerStateStore(queueName)) {
+      try (HBaseConsumerStateStore stateStore = admin.getConsumerStateStore(queueName)) {
         Transactions.createTransactionExecutor(txExecutorFactory, stateStore).execute(new Subroutine() {
           @Override
           public void apply() throws Exception {

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -110,7 +110,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
     CConfigurationUtil.copyTxProperties(cConf, txConf);
 
     // ok to pass null, since the impersonator won't actually be called, if kerberos security is not enabled
-    Impersonator impersonator = new DefaultImpersonator(cConf, null, null);
+    Impersonator impersonator = new DefaultImpersonator(cConf, null);
 
     // TODO: Refactor to use injector for everything
     Injector injector = Guice.createInjector(

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -201,7 +201,7 @@ public abstract class DatasetServiceTestBase {
       new SystemDatasetInstantiatorFactory(locationFactory, dsFramework, cConf);
 
     // ok to pass null, since the impersonator won't actually be called, if kerberos security is not enabled
-    Impersonator impersonator = new DefaultImpersonator(cConf, null, null);
+    Impersonator impersonator = new DefaultImpersonator(cConf, null);
     DatasetAdminService datasetAdminService =
       new DatasetAdminService(dsFramework, cConf, locationFactory, datasetInstantiatorFactory, new NoOpMetadataStore(),
                               impersonator);

--- a/cdap-master/src/main/java/co/cask/cdap/master/startup/HBaseCheck.java
+++ b/cdap-master/src/main/java/co/cask/cdap/master/startup/HBaseCheck.java
@@ -20,7 +20,6 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.startup.Check;
 import co.cask.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import co.cask.cdap.data2.util.hbase.HBaseVersion;
-import co.cask.cdap.data2.util.hbase.HTableNameConverter;
 import com.google.inject.Inject;
 import com.google.inject.ProvisionException;
 import org.apache.hadoop.conf.Configuration;
@@ -58,7 +57,7 @@ class HBaseCheck extends Check {
     LOG.info("  HBase version successfully verified.");
 
     LOG.info("Checking HBase availability.");
-    try (final HConnection hbaseConnection = HConnectionManager.createConnection(hConf)) {
+    try (HConnection hbaseConnection = HConnectionManager.createConnection(hConf)) {
       hbaseConnection.listTables();
       LOG.info("  HBase availability successfully verified.");
     } catch (IOException e) {

--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/AbstractCachedUGIProvider.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/AbstractCachedUGIProvider.java
@@ -18,7 +18,8 @@ package co.cask.cdap.security.impersonation;
 
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
-import co.cask.cdap.common.kerberos.ImpersonationInfo;
+import co.cask.cdap.common.kerberos.ImpersonationRequest;
+import co.cask.cdap.common.kerberos.UGIWithPrincipal;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
@@ -31,25 +32,28 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 /**
- * An abstract base class for {@link UGIProvider} that provides caching of {@link UserGroupInformation}.
+ * An abstract base class for {@link UGIProvider} that provides caching of {@link UGIWithPrincipal} containing the
+ * {@link UserGroupInformation}.
  */
 public abstract class AbstractCachedUGIProvider implements UGIProvider {
 
-  private final LoadingCache<ImpersonationInfo, UserGroupInformation> ugiCache;
+  protected final CConfiguration cConf;
+  private final LoadingCache<ImpersonationRequest, UGIWithPrincipal> ugiCache;
 
   protected AbstractCachedUGIProvider(CConfiguration cConf) {
+    this.cConf = cConf;
     this.ugiCache = createUGICache(cConf);
   }
 
   /**
-   * Creates a new {@link UserGroupInformation} based on the given {@link ImpersonationInfo}.
+   * Creates a new {@link UGIWithPrincipal} based on the given {@link ImpersonationRequest}.
    */
-  protected abstract UserGroupInformation createUGI(ImpersonationInfo impersonationInfo) throws IOException;
+  protected abstract UGIWithPrincipal createUGI(ImpersonationRequest impersonationRequest) throws IOException;
 
   @Override
-  public final UserGroupInformation getConfiguredUGI(ImpersonationInfo impersonationInfo) throws IOException {
+  public final UGIWithPrincipal getConfiguredUGI(ImpersonationRequest impersonationRequest) throws IOException {
     try {
-      return ugiCache.get(impersonationInfo);
+      return ugiCache.get(impersonationRequest);
     } catch (ExecutionException e) {
       // Get the root cause of the failure
       Throwable cause = Throwables.getRootCause(e);
@@ -66,14 +70,14 @@ public abstract class AbstractCachedUGIProvider implements UGIProvider {
     ugiCache.cleanUp();
   }
 
-  private LoadingCache<ImpersonationInfo, UserGroupInformation> createUGICache(CConfiguration cConf) {
+  private LoadingCache<ImpersonationRequest, UGIWithPrincipal> createUGICache(CConfiguration cConf) {
     long expirationMillis = cConf.getLong(Constants.Security.UGI_CACHE_EXPIRATION_MS);
     return CacheBuilder.newBuilder()
       .expireAfterWrite(expirationMillis, TimeUnit.MILLISECONDS)
-      .build(new CacheLoader<ImpersonationInfo, UserGroupInformation>() {
+      .build(new CacheLoader<ImpersonationRequest, UGIWithPrincipal>() {
         @Override
-        public UserGroupInformation load(ImpersonationInfo impersonationInfo) throws Exception {
-          return createUGI(impersonationInfo);
+        public UGIWithPrincipal load(ImpersonationRequest impersonationRequest) throws Exception {
+          return createUGI(impersonationRequest);
         }
       });
   }

--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/CurrentUGIProvider.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/CurrentUGIProvider.java
@@ -16,7 +16,10 @@
 
 package co.cask.cdap.security.impersonation;
 
-import co.cask.cdap.common.kerberos.ImpersonationInfo;
+import co.cask.cdap.common.kerberos.ImpersonationRequest;
+import co.cask.cdap.common.kerberos.UGIWithPrincipal;
+import co.cask.cdap.security.spi.authentication.AuthenticationContext;
+import com.google.inject.Inject;
 import org.apache.hadoop.security.UserGroupInformation;
 
 import java.io.IOException;
@@ -26,8 +29,16 @@ import java.io.IOException;
  */
 public class CurrentUGIProvider implements UGIProvider {
 
+  private final AuthenticationContext authenticationContext;
+
+  @Inject
+  public CurrentUGIProvider(AuthenticationContext authenticationContext) {
+    this.authenticationContext = authenticationContext;
+  }
+
   @Override
-  public UserGroupInformation getConfiguredUGI(ImpersonationInfo impersonationInfo) throws IOException {
-    return UserGroupInformation.getCurrentUser();
+  public UGIWithPrincipal getConfiguredUGI(ImpersonationRequest impersonationRequest) throws IOException {
+    return new UGIWithPrincipal(authenticationContext.getPrincipal().getKerberosPrincipal(),
+                                UserGroupInformation.getCurrentUser());
   }
 }

--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/DefaultImpersonator.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/DefaultImpersonator.java
@@ -19,16 +19,13 @@ package co.cask.cdap.security.impersonation;
 import co.cask.cdap.common.NamespaceNotFoundException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.kerberos.ImpersonatedOpType;
-import co.cask.cdap.common.kerberos.ImpersonationInfo;
-import co.cask.cdap.common.kerberos.OwnerAdmin;
+import co.cask.cdap.common.kerberos.ImpersonationRequest;
 import co.cask.cdap.common.kerberos.SecurityUtil;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.NamespacedEntityId;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.security.authentication.util.KerberosName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,18 +38,12 @@ import java.util.concurrent.Callable;
 public class DefaultImpersonator implements Impersonator {
 
   private static final Logger LOG = LoggerFactory.getLogger(DefaultImpersonator.class);
-
-  private final CConfiguration cConf;
-  private final OwnerAdmin ownerAdmin;
-  private final boolean kerberosEnabled;
   private final UGIProvider ugiProvider;
+  private final boolean kerberosEnabled;
 
   @Inject
   @VisibleForTesting
-  public DefaultImpersonator(CConfiguration cConf, UGIProvider ugiProvider,
-                             OwnerAdmin ownerAdmin) {
-    this.cConf = cConf;
-    this.ownerAdmin = ownerAdmin;
+  public DefaultImpersonator(CConfiguration cConf, UGIProvider ugiProvider) {
     this.ugiProvider = ugiProvider;
     this.kerberosEnabled = SecurityUtil.isKerberosEnabled(cConf);
   }
@@ -66,6 +57,8 @@ public class DefaultImpersonator implements Impersonator {
   public <T> T doAs(NamespacedEntityId entityId, Callable<T> callable,
                     ImpersonatedOpType impersonatedOpType) throws Exception {
     UserGroupInformation ugi = getUGI(entityId, impersonatedOpType);
+    LOG.debug("Performing doAs with UGI {} for entity {} and impersonation operation type", ugi, entityId,
+              impersonatedOpType);
     return ImpersonationUtils.doAs(ugi, callable);
   }
 
@@ -74,29 +67,12 @@ public class DefaultImpersonator implements Impersonator {
     return getUGI(entityId, ImpersonatedOpType.OTHER);
   }
 
-  private UserGroupInformation getUGI(NamespacedEntityId entityId, ImpersonatedOpType impersonatedOpType)
-    throws IOException, NamespaceNotFoundException {
+  private UserGroupInformation getUGI(NamespacedEntityId entityId,
+                                      ImpersonatedOpType impersonatedOpType) throws IOException {
     // don't impersonate if kerberos isn't enabled OR if the operation is in the system namespace
     if (!kerberosEnabled || NamespaceId.SYSTEM.equals(entityId.getNamespaceId())) {
       return UserGroupInformation.getCurrentUser();
     }
-    try {
-      ImpersonationInfo info = SecurityUtil.createImpersonationInfo(ownerAdmin, cConf, entityId, impersonatedOpType);
-      LOG.debug("Impersonating principal {} for entity {}, keytab path is {}",
-                info.getPrincipal(), entityId, info.getKeytabURI());
-      return getUGI(info);
-    } catch (Exception e) {
-      Throwables.propagateIfInstanceOf(e, IOException.class);
-      throw Throwables.propagate(e);
-    }
-  }
-
-  private UserGroupInformation getUGI(ImpersonationInfo impersonationInfo) throws IOException {
-    // no need to get a UGI if the current UGI is the one we're requesting; simply return it
-    String configuredPrincipalShortName = new KerberosName(impersonationInfo.getPrincipal()).getShortName();
-    if (UserGroupInformation.getCurrentUser().getShortUserName().equals(configuredPrincipalShortName)) {
-      return UserGroupInformation.getCurrentUser();
-    }
-    return ugiProvider.getConfiguredUGI(impersonationInfo);
+    return ugiProvider.getConfiguredUGI(new ImpersonationRequest(entityId, impersonatedOpType)).getUGI();
   }
 }

--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/DefaultUGIProvider.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/DefaultUGIProvider.java
@@ -16,15 +16,23 @@
 
 package co.cask.cdap.security.impersonation;
 
+import co.cask.cdap.common.FeatureDisabledException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
+import co.cask.cdap.common.kerberos.ImpersonatedOpType;
 import co.cask.cdap.common.kerberos.ImpersonationInfo;
+import co.cask.cdap.common.kerberos.ImpersonationRequest;
+import co.cask.cdap.common.kerberos.OwnerAdmin;
 import co.cask.cdap.common.kerberos.SecurityUtil;
+import co.cask.cdap.common.kerberos.UGIWithPrincipal;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.utils.DirUtils;
 import co.cask.cdap.common.utils.FileUtils;
-import com.google.common.base.Preconditions;
+import co.cask.cdap.proto.NamespaceConfig;
+import co.cask.cdap.proto.element.EntityType;
 import com.google.inject.Inject;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.authentication.util.KerberosName;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
 import org.slf4j.Logger;
@@ -47,13 +55,19 @@ public class DefaultUGIProvider extends AbstractCachedUGIProvider {
 
   private final LocationFactory locationFactory;
   private final File tempDir;
+  private final OwnerAdmin ownerAdmin;
+  private final NamespaceQueryAdmin namespaceQueryAdmin;
+
 
   @Inject
-  DefaultUGIProvider(CConfiguration cConf, LocationFactory locationFactory) {
+  DefaultUGIProvider(CConfiguration cConf, LocationFactory locationFactory, OwnerAdmin ownerAdmin,
+                     NamespaceQueryAdmin namespaceQueryAdmin) {
     super(cConf);
     this.locationFactory = locationFactory;
     this.tempDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
                             cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
+    this.ownerAdmin = ownerAdmin;
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
   }
 
   /**
@@ -63,8 +77,43 @@ public class DefaultUGIProvider extends AbstractCachedUGIProvider {
    * @throws IOException if there was any IOException during localization of the keytab
    */
   @Override
-  protected UserGroupInformation createUGI(ImpersonationInfo impersonationInfo) throws IOException {
-    LOG.debug("Configured impersonation info: {}", impersonationInfo);
+  protected UGIWithPrincipal createUGI(ImpersonationRequest impersonationRequest) throws IOException {
+    if (impersonationRequest.getEntityId().getEntityType().equals(EntityType.NAMESPACE) &&
+      impersonationRequest.getImpersonatedOpType().equals(ImpersonatedOpType.EXPLORE)) {
+      // CDAP-8355 If the operation being impersonated is an explore query then check if the namespace configuration
+      // specifies that it can be impersonated with the namespace owner.
+      // This is done here rather than in the get getConfiguredUGI because the getConfiguredUGI will be called at
+      // remote location as in RemoteUGIProvider. Looking up namespace meta there will make a trip to master followed
+      // by one to get the credentials. Hence do it here in the DefaultUGIProvider which is running in master.
+      // Although, this will cause cache miss for explore implementation if the namespace config doesn't allow
+      // impersonating the namespace owner for explore queries but that a trade-off to avoid multiple remote calls in
+      // more prominent calls.
+      try {
+        NamespaceConfig nsConfig =
+          namespaceQueryAdmin.get(impersonationRequest.getEntityId().getNamespaceId()).getConfig();
+        if (!nsConfig.isExploreAsPrincipal()) {
+          throw new FeatureDisabledException(FeatureDisabledException.Feature.EXPLORE,
+                                             NamespaceConfig.class.getSimpleName() + " of " +
+                                               impersonationRequest.getEntityId(),
+                                             NamespaceConfig.EXPLORE_AS_PRINCIPAL, String.valueOf(true));
+        }
+
+      } catch (IOException e) {
+        throw e;
+      } catch (Exception e) {
+        throw new IOException(e);
+      }
+    }
+
+    ImpersonationInfo impersonationInfo = SecurityUtil.createImpersonationInfo(ownerAdmin, cConf,
+                                                                               impersonationRequest.getEntityId());
+    LOG.debug("Obtained impersonation info: {} for entity {}", impersonationInfo, impersonationRequest.getEntityId());
+
+    // no need to get a UGI if the current UGI is the one we're requesting; simply return it
+    String configuredPrincipalShortName = new KerberosName(impersonationInfo.getPrincipal()).getShortName();
+    if (UserGroupInformation.getCurrentUser().getShortUserName().equals(configuredPrincipalShortName)) {
+      return new UGIWithPrincipal(impersonationInfo.getPrincipal(), UserGroupInformation.getCurrentUser());
+    }
 
     URI keytabURI = URI.create(impersonationInfo.getKeytabURI());
     boolean isKeytabLocal = keytabURI.getScheme() == null || "file".equals(keytabURI.getScheme());
@@ -75,10 +124,17 @@ public class DefaultUGIProvider extends AbstractCachedUGIProvider {
       String expandedPrincipal = SecurityUtil.expandPrincipal(impersonationInfo.getPrincipal());
       LOG.debug("Logging in as: principal={}, keytab={}", expandedPrincipal, localKeytabFile);
 
-      Preconditions.checkArgument(Files.isReadable(localKeytabFile.toPath()),
-                                  "Keytab file is not a readable file: %s", localKeytabFile);
+      // Note: if the keytab file is not local then then localizeKeytab function call above which tries to localize the
+      // keytab from HDFS will throw IOException if the file does not exists or is not readable. Where as if the file
+      // is local then the localizeKeytab function is not called so its important that we throw IOException if the local
+      // keytab file is not readable to ensure that the client gets the same exception in both the modes.
+      if (!Files.isReadable(localKeytabFile.toPath())) {
+        throw new IOException(String.format("Keytab file is not a readable file: %s", localKeytabFile));
+      }
 
-      return UserGroupInformation.loginUserFromKeytabAndReturnUGI(expandedPrincipal, localKeytabFile.getAbsolutePath());
+      UserGroupInformation loggedInUGI =
+        UserGroupInformation.loginUserFromKeytabAndReturnUGI(expandedPrincipal, localKeytabFile.getAbsolutePath());
+      return new UGIWithPrincipal(impersonationInfo.getPrincipal(), loggedInUGI);
     } finally {
       if (!isKeytabLocal && !localKeytabFile.delete()) {
         LOG.warn("Failed to delete file: {}", localKeytabFile);

--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/RemoteUGIProvider.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/RemoteUGIProvider.java
@@ -20,11 +20,16 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.http.DefaultHttpRequestConfig;
 import co.cask.cdap.common.internal.remote.RemoteClient;
-import co.cask.cdap.common.kerberos.ImpersonationInfo;
+import co.cask.cdap.common.kerberos.ImpersonationRequest;
+import co.cask.cdap.common.kerberos.PrincipalCredentials;
+import co.cask.cdap.common.kerberos.UGIWithPrincipal;
+import co.cask.cdap.proto.codec.EntityIdTypeAdapter;
+import co.cask.cdap.proto.id.NamespacedEntityId;
 import co.cask.common.http.HttpMethod;
 import co.cask.common.http.HttpRequest;
 import co.cask.common.http.HttpResponse;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -47,7 +52,9 @@ import java.net.URL;
 public class RemoteUGIProvider extends AbstractCachedUGIProvider {
 
   private static final Logger LOG = LoggerFactory.getLogger(RemoteUGIProvider.class);
-  private static final Gson GSON = new Gson();
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(NamespacedEntityId.class, new EntityIdTypeAdapter())
+    .create();
 
   private final RemoteClient remoteClient;
   private final LocationFactory locationFactory;
@@ -62,15 +69,16 @@ public class RemoteUGIProvider extends AbstractCachedUGIProvider {
   }
 
   @Override
-  protected UserGroupInformation createUGI(ImpersonationInfo impersonationInfo) throws IOException {
-    String credentialsURI = executeRequest(impersonationInfo).getResponseBodyAsString();
-    LOG.debug("Received response: {}", credentialsURI);
+  protected UGIWithPrincipal createUGI(ImpersonationRequest impersonationRequest) throws IOException {
+    PrincipalCredentials principalCredentials =
+      GSON.fromJson(executeRequest(impersonationRequest).getResponseBodyAsString(), PrincipalCredentials.class);
+    LOG.debug("Received response: {}", principalCredentials);
 
-    Location location = locationFactory.create(URI.create(credentialsURI));
+    Location location = locationFactory.create(URI.create(principalCredentials.getCredentialsPath()));
     try {
-      UserGroupInformation impersonatedUGI = UserGroupInformation.createRemoteUser(impersonationInfo.getPrincipal());
+      UserGroupInformation impersonatedUGI = UserGroupInformation.createRemoteUser(principalCredentials.getPrincipal());
       impersonatedUGI.addCredentials(readCredentials(location));
-      return impersonatedUGI;
+      return new UGIWithPrincipal(principalCredentials.getPrincipal(), impersonatedUGI);
     } finally {
       try {
         if (!location.delete()) {
@@ -82,9 +90,9 @@ public class RemoteUGIProvider extends AbstractCachedUGIProvider {
     }
   }
 
-  private HttpResponse executeRequest(ImpersonationInfo impersonationInfo) throws IOException {
+  private HttpResponse executeRequest(ImpersonationRequest impersonationRequest) throws IOException {
     HttpRequest request = remoteClient.requestBuilder(HttpMethod.POST, "impersonation/credentials")
-      .withBody(GSON.toJson(impersonationInfo))
+      .withBody(GSON.toJson(impersonationRequest))
       .build();
     HttpResponse response = remoteClient.execute(request);
     if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {

--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/UGIProvider.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/UGIProvider.java
@@ -17,20 +17,23 @@
 package co.cask.cdap.security.impersonation;
 
 import co.cask.cdap.common.kerberos.ImpersonationInfo;
+import co.cask.cdap.common.kerberos.ImpersonationRequest;
+import co.cask.cdap.common.kerberos.UGIWithPrincipal;
 import org.apache.hadoop.security.UserGroupInformation;
 
 import java.io.IOException;
 
 /**
- * Facilitates getting UserGroupInformation configured for a given user.
+ * Facilitates getting UserGroupInformation configured for a given {@link ImpersonationRequest}.
  */
 public interface UGIProvider {
 
   /**
    * Returns a {@link UserGroupInformation} based on the given {@link ImpersonationInfo}.
    *
-   * @param impersonationInfo information specifying how to create the UGI
-   * @return the {@link UserGroupInformation} for the configured user
+   * @param impersonationRequest information specifying the entity on which the impersonation is being performed and
+   *                            the type of the operation
+   * @return the {@link UGIWithPrincipal} for the configured user
    */
-  UserGroupInformation getConfiguredUGI(ImpersonationInfo impersonationInfo) throws IOException;
+  UGIWithPrincipal getConfiguredUGI(ImpersonationRequest impersonationRequest) throws IOException;
 }

--- a/cdap-security/src/main/java/co/cask/cdap/security/impersonation/UnsupportedUGIProvider.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/impersonation/UnsupportedUGIProvider.java
@@ -16,8 +16,8 @@
 
 package co.cask.cdap.security.impersonation;
 
-import co.cask.cdap.common.kerberos.ImpersonationInfo;
-import org.apache.hadoop.security.UserGroupInformation;
+import co.cask.cdap.common.kerberos.ImpersonationRequest;
+import co.cask.cdap.common.kerberos.UGIWithPrincipal;
 
 import java.io.IOException;
 
@@ -26,7 +26,7 @@ import java.io.IOException;
  */
 public class UnsupportedUGIProvider implements UGIProvider {
   @Override
-  public UserGroupInformation getConfiguredUGI(ImpersonationInfo impersonationInfo) throws IOException {
+  public UGIWithPrincipal getConfiguredUGI(ImpersonationRequest impersonationRequest) throws IOException {
     // If this implementation's method is called, then some guice binding is done improperly.
     // For instance, we don't call this method if Kerberos is not enabled, and we only bind this implementation
     // in-memory and for Standalone, where Kerberos is not enabled.


### PR DESCRIPTION
- Refactor UGIProvider to take NamespacedEntityId
- Removed the call made to OwnerAdmin in DefaultImpersonator which can be at remote location.
- Please ignore the commented out UGIProviderTest for now. I am working on updating it to be in line with the changes. Opening the PR for review of changes
- Tested on cluster.

Issue: https://issues.cask.co/browse/CDAP-8516
Build: http://builds.cask.co/browse/CDAP-RUT597-1
