### PR TITLE
Fix full Doc Build by caching the results of the CLI command build

### DIFF
--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -132,11 +132,15 @@ function _build_docs() {
   clear_messages_file
   if [[ ${type} == "docs_set" ]] || [[ ${type} == "docs_web_only" ]]; then
     clean_targets
+    # Build CLI and its rst file before the first doc build so that its refs can be included
     build_docs_cli
     build_docs_first_pass
     clear_messages_file
     if [[ ${type} == "docs_set" ]]; then
+      cache_docs_cli
       build_javadocs docs
+      # As build_javadocs wipes out the results of the build_docs_cli
+      restore_cached_docs_cli
     fi
   fi
   build_docs_second_pass
@@ -216,7 +220,7 @@ function build_docs_cli() {
   if [[ -n ${NO_CLI_DOCS} ]]; then
     echo_red_bold "Building CLI input file disabled. '${NO_CLI_DOCS}'"
   else
-    local target_txt=${SCRIPT_PATH}/../cdap-docs-gen/${TARGET}/cdap-docs-cli.txt
+    local target_txt=${SCRIPT_PATH}/../cdap-docs-gen/target/cdap-docs-cli.txt
     set_version
     check_build_rst
     set_environment
@@ -241,6 +245,18 @@ function build_docs_cli() {
   fi
   display_end_title ${title}
   return ${warnings}
+}
+
+function cache_docs_cli() {
+  local target_txt=${SCRIPT_PATH}/../cdap-docs-gen/target/cdap-docs-cli.txt
+  local cache_txt=${SCRIPT_PATH}/target/cdap-docs-cli.txt
+  cp target_txt cache_txt
+}
+
+function restore_cached_docs_cli() {
+  local target_txt=${SCRIPT_PATH}/../cdap-docs-gen/target/cdap-docs-cli.txt
+  local cache_txt=${SCRIPT_PATH}/target/cdap-docs-cli.txt
+  cp cache_txt target_txt
 }
 
 function build_docs_inner_level() {

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -132,16 +132,14 @@ function _build_docs() {
   clear_messages_file
   if [[ ${type} == "docs_set" ]] || [[ ${type} == "docs_web_only" ]]; then
     clean_targets
+    if [[ ${type} == "docs_set" ]]; then
+      # As build_javadocs wipes out the results of the build_docs_cli, need to build it first
+      build_javadocs docs
+    fi
     # Build CLI and its rst file before the first doc build so that its refs can be included
     build_docs_cli
     build_docs_first_pass
     clear_messages_file
-    if [[ ${type} == "docs_set" ]]; then
-      cache_docs_cli
-      build_javadocs docs
-      # As build_javadocs wipes out the results of the build_docs_cli
-      restore_cached_docs_cli
-    fi
   fi
   build_docs_second_pass
   
@@ -245,18 +243,6 @@ function build_docs_cli() {
   fi
   display_end_title ${title}
   return ${warnings}
-}
-
-function cache_docs_cli() {
-  local target_txt=${SCRIPT_PATH}/../cdap-docs-gen/target/cdap-docs-cli.txt
-  local cache_txt=${SCRIPT_PATH}/target/cdap-docs-cli.txt
-  cp target_txt cache_txt
-}
-
-function restore_cached_docs_cli() {
-  local target_txt=${SCRIPT_PATH}/../cdap-docs-gen/target/cdap-docs-cli.txt
-  local cache_txt=${SCRIPT_PATH}/target/cdap-docs-cli.txt
-  cp cache_txt target_txt
 }
 
 function build_docs_inner_level() {


### PR DESCRIPTION
The Javadocs build wipes out the CLI build results, so need to always build them first, if they are being built. This error happened as the CLI build was moved (by an earlier commit) to before the Javadocs build so that references could be created in the first doc build.