### PR TITLE
Fix Doc Build

### DIFF
--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -249,14 +249,32 @@ function build_docs_cli() {
 
 function cache_docs_cli() {
   local target_txt=${SCRIPT_PATH}/../cdap-docs-gen/target/cdap-docs-cli.txt
-  local cache_txt=${SCRIPT_PATH}/target/cdap-docs-cli.txt
-  cp target_txt cache_txt
+  local cache=${SCRIPT_PATH}/target
+  cp ${target_txt} ${cache}
+  warnings=$?
+  if [[ ${warnings} -eq 0 ]]; then
+    echo "Caching CLI output file from '${target_txt}'"
+  else
+    echo "Error caching CLI output file: ${warnings}"
+    echo "From: ${target_txt}"
+    echo "To: ${cache}"
+  fi
+  return ${warnings}
 }
 
 function restore_cached_docs_cli() {
-  local target_txt=${SCRIPT_PATH}/../cdap-docs-gen/target/cdap-docs-cli.txt
+  local target=${SCRIPT_PATH}/../cdap-docs-gen/target
   local cache_txt=${SCRIPT_PATH}/target/cdap-docs-cli.txt
-  cp cache_txt target_txt
+  cp ${cache_txt} ${target}
+  warnings=$?
+  if [[ ${warnings} -eq 0 ]]; then
+    echo "Restored CLI output file from '${cache_txt}'"
+  else
+    echo "Error restoring CLI output file: ${warnings}"
+    echo "From: ${cache_txt}"
+    echo "To: ${target}"
+  fi
+  return ${warnings}
 }
 
 function build_docs_inner_level() {

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -132,11 +132,15 @@ function _build_docs() {
   clear_messages_file
   if [[ ${type} == "docs_set" ]] || [[ ${type} == "docs_web_only" ]]; then
     clean_targets
+    # Build CLI and its rst file before the first doc build so that its refs can be included
     build_docs_cli
     build_docs_first_pass
     clear_messages_file
     if [[ ${type} == "docs_set" ]]; then
+      cache_docs_cli
       build_javadocs docs
+      # As build_javadocs wipes out the results of the build_docs_cli
+      restore_cached_docs_cli
     fi
   fi
   build_docs_second_pass
@@ -216,7 +220,7 @@ function build_docs_cli() {
   if [[ -n ${NO_CLI_DOCS} ]]; then
     echo_red_bold "Building CLI input file disabled. '${NO_CLI_DOCS}'"
   else
-    local target_txt=${SCRIPT_PATH}/../cdap-docs-gen/${TARGET}/cdap-docs-cli.txt
+    local target_txt=${SCRIPT_PATH}/../cdap-docs-gen/target/cdap-docs-cli.txt
     set_version
     check_build_rst
     set_environment
@@ -241,6 +245,18 @@ function build_docs_cli() {
   fi
   display_end_title ${title}
   return ${warnings}
+}
+
+function cache_docs_cli() {
+  local target_txt=${SCRIPT_PATH}/../cdap-docs-gen/target/cdap-docs-cli.txt
+  local cache_txt=${SCRIPT_PATH}/target/cdap-docs-cli.txt
+  cp target_txt cache_txt
+}
+
+function restore_cached_docs_cli() {
+  local target_txt=${SCRIPT_PATH}/../cdap-docs-gen/target/cdap-docs-cli.txt
+  local cache_txt=${SCRIPT_PATH}/target/cdap-docs-cli.txt
+  cp cache_txt target_txt
 }
 
 function build_docs_inner_level() {


### PR DESCRIPTION
Cache the results of the CLI build as they are wiped out by the Javadoc build.

Running as http://builds.cask.co/browse/CDAP-DBT7-2 (passes)

Pages of interest: 
- http://builds.cask.co/artifact/CDAP-DBT7/shared/build-2/Current-Docs-HTML/4.1.0-SNAPSHOT/en/reference-manual/javadocs/index.html
- http://builds.cask.co/artifact/CDAP-DBT7/shared/build-2/Current-Docs-HTML/4.1.0-SNAPSHOT/en/reference-manual/cli-api.html#available-commands
- http://builds.cask.co/artifact/CDAP-DBT7/shared/build-2/Current-Docs-HTML/4.1.0-SNAPSHOT/en/admin-manual/security/authorization.html#bootstrapping-authorization

This was caused by an earlier merge that moved the CLI build to before the first doc build and the Javadoc build so that the first doc build could create references used in the second doc build. As the Javadoc build then wipes out the CLI build results, making them unavailable to the second doc build. We don't want to run the Javadoc build first, as then we would loose any messages from its build, as all messages are wiped out after the first doc build.