### PR TITLE
(CDAP-8537) Fix RSS memory leak in explore container

### DIFF
--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreServiceUtilsTest.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/ExploreServiceUtilsTest.java
@@ -57,8 +57,8 @@ public class ExploreServiceUtilsTest {
     String hiveJarFilePath = hiveAuthURL.getPath();
     File hiveJarFile = new File(URI.create(hiveJarFilePath.substring(0, hiveJarFilePath.indexOf("!/"))));
 
-    File targetJar = ExploreServiceUtils.rewriteHiveAuthFactory(hiveJarFile,
-                                                                new File(tmpFolder.newFolder(), "hive.jar"));
+    File targetJar = ExploreServiceUtils.patchHiveClasses(hiveJarFile,
+                                                          new File(tmpFolder.newFolder(), "hive.jar"));
 
     try (
       TestHiveAuthFactoryClassLoader cl = new TestHiveAuthFactoryClassLoader(targetJar, classLoader)
@@ -73,7 +73,7 @@ public class ExploreServiceUtilsTest {
     // Try to rewrite a jar file without the hive auth factory class, it should just return the original jar
     String functionClassPath = classLoader.getResource(Function.class.getName().replace('.', '/') + ".class").getPath();
     File guavaJarFile = new File(URI.create(functionClassPath.substring(0, functionClassPath.indexOf("!/"))));
-    targetJar = ExploreServiceUtils.rewriteHiveAuthFactory(guavaJarFile, new File(tmpFolder.newFolder(), "guava.jar"));
+    targetJar = ExploreServiceUtils.patchHiveClasses(guavaJarFile, new File(tmpFolder.newFolder(), "guava.jar"));
 
     Assert.assertSame(guavaJarFile, targetJar);
   }

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterTwillApplication.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterTwillApplication.java
@@ -387,7 +387,7 @@ public class MasterTwillApplication implements TwillApplication {
         extraClassPath.add(file.getName() + "/lib/*");
       } else {
         File targetFile = tempDir.resolve(System.currentTimeMillis() + "-" + file.getName()).toFile();
-        File resultFile = ExploreServiceUtils.rewriteHiveAuthFactory(file, targetFile);
+        File resultFile = ExploreServiceUtils.patchHiveClasses(file, targetFile);
         if (resultFile == targetFile) {
           LOG.info("Rewritten HiveAuthFactory from jar file {} to jar file {}", file, resultFile);
         }


### PR DESCRIPTION
- Rewrite the SessionState.loadAuxJars method to no-op as we don’t need
  aux jars loaded for the session that runs in the explore container
  as it already contains all necessary CDAP jars in the container
  classpath. We only use the aux jars config to have Hive localizing
  CDAP jars to task containers.
  This is effectively reverting the changes introduced in HIVE-14229
  that get included in Hive in CDH 5.9