### PR TITLE
Fix Documentation highlighting of source code

### DIFF
--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -855,7 +855,7 @@ def source_read_handler(app, docname, source):
         if app.env.config.rst_prolog:
             app.env.config.rst_prolog_cache = app.env.config.rst_prolog
             app.env.config.rst_prolog = None
-        if app.env.config.highlight_language:
+        if app.env.config.highlight_language and not app.env.config.highlight_language == 'none':
             app.env.config.highlight_language_cache = app.env.config.highlight_language
             app.env.config.highlight_language = 'none'
     else:
@@ -865,10 +865,13 @@ def source_read_handler(app, docname, source):
         if (not app.env.config.rst_prolog and hasattr(app.env.config, 'rst_prolog_cache') and 
                 app.env.config.rst_prolog_cache):
             app.env.config.rst_prolog = app.env.config.rst_prolog_cache
-        if (app.env.config.highlight_language == 'none' and 
-                hasattr(app.env.config, 'highlight_language_cache') and 
-                app.env.config.highlight_language_cache):
-            app.env.config.highlight_language = app.env.config.highlight_language_cache
+        if (not app.env.config.highlight_language or app.env.config.highlight_language == 'none'):
+            if (hasattr(app.env.config, 'highlight_language_cache') and 
+                app.env.config.highlight_language_cache and 
+                not app.env.config.highlight_language == 'none'):
+                app.env.config.highlight_language = app.env.config.highlight_language_cache
+            else:
+                app.env.config.highlight_language = 'java'
             
 
 # -- Configure Application --------------------------------------------------

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -855,7 +855,7 @@ def source_read_handler(app, docname, source):
         if app.env.config.rst_prolog:
             app.env.config.rst_prolog_cache = app.env.config.rst_prolog
             app.env.config.rst_prolog = None
-        if app.env.config.highlight_language and not app.env.config.highlight_language == 'none':
+        if app.env.config.highlight_language and app.env.config.highlight_language != 'none':
             app.env.config.highlight_language_cache = app.env.config.highlight_language
             app.env.config.highlight_language = 'none'
     else:
@@ -868,7 +868,7 @@ def source_read_handler(app, docname, source):
         if (not app.env.config.highlight_language or app.env.config.highlight_language == 'none'):
             if (hasattr(app.env.config, 'highlight_language_cache') and 
                 app.env.config.highlight_language_cache and 
-                not app.env.config.highlight_language == 'none'):
+                app.env.config.highlight_language_cache != 'none'):
                 app.env.config.highlight_language = app.env.config.highlight_language_cache
             else:
                 app.env.config.highlight_language = 'java'


### PR DESCRIPTION
When a Markdown file is read, the current source code highlighting value (by default ``'java'``) is cached, then  the current source code highlighting is set to ``'none'``, and then restored for the next file. There was a bug if more than one Markdown file was read, it would cache the next ``'none'`` value, rather than preserving it for the next non-Markdown file it reads.

It's complicated because the current source code highlighting cannot be the Python `None` but instead must be a string `'none'`.

Only cache the highlight language if the value being cached is not 'none'
or only restore it if the value being restored is not 'none'.
Only restore it for non-Markdown files, and if there is no value, use 'java'.

Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB274-1

Example of the problem: http://docs.cask.co/cdap/4.1.0-SNAPSHOT/en/developers-manual/building-blocks/streams.html#reading-from-a-stream (Code sample is not colored)

Example of the corrected page: http://builds.cask.co/artifact/CDAP-DQB274/shared/build-1/Docs-HTML/4.1.0-SNAPSHOT/en/developers-manual/building-blocks/streams.html#reading-from-a-stream