### PR TITLE
(CDAP-8623) Load the tx prune properties dynamically

### DIFF
--- a/cdap-hbase-compat-0.96/pom.xml
+++ b/cdap-hbase-compat-0.96/pom.xml
@@ -68,10 +68,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.tephra</groupId>
-      <artifactId>tephra-hbase-compat-0.96</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
     </dependency>
@@ -186,7 +182,7 @@
                 </goals>
                 <configuration>
                   <excludeArtifactIds>*</excludeArtifactIds>
-                  <includeArtifactIds>tephra-hbase-compat-0.96</includeArtifactIds>
+                  <includeArtifactIds>${artifactId}</includeArtifactIds>
                   <silent>true</silent>
                   <includeScope>compile</includeScope>
                 </configuration>

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase96/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase96/DefaultTransactionProcessor.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.data2.transaction.coprocessor.hbase96;
 
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTable;
 import co.cask.cdap.data2.increment.hbase96.IncrementTxFilter;
@@ -32,9 +31,14 @@ import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.OperationWithAttributes;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.KeyValueScanner;
 import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.regionserver.Store;
+import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TxConstants;
@@ -44,7 +48,7 @@ import org.apache.tephra.hbase.coprocessor.TransactionProcessor;
 import org.apache.tephra.util.TxUtils;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -68,7 +72,9 @@ public class DefaultTransactionProcessor extends TransactionProcessor {
       String hbaseNamespacePrefix = tableDesc.getValue(Constants.Dataset.TABLE_PREFIX);
 
       this.sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(hbaseNamespacePrefix);
-      this.cConfCacheSupplier = new CConfigurationCacheSupplier(env.getConfiguration(), sysConfigTablePrefix);
+      this.cConfCacheSupplier = new CConfigurationCacheSupplier(env.getConfiguration(), sysConfigTablePrefix,
+                                                                TxConstants.Manager.CFG_TX_MAX_LIFETIME,
+                                                                TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME);
       this.cConfCache = cConfCacheSupplier.get();
     }
     // Need to create the cConf cache before calling start on the parent, since it is required for
@@ -83,55 +89,94 @@ public class DefaultTransactionProcessor extends TransactionProcessor {
   }
 
   @Override
+  public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+    reloadPruneState(e.getEnvironment());
+    super.postFlush(e);
+  }
+
+  @Override
+  public InternalScanner preCompactScannerOpen(ObserverContext<RegionCoprocessorEnvironment> c, Store store,
+                                               List<? extends KeyValueScanner> scanners, ScanType scanType,
+                                               long earliestPutTs, InternalScanner s,
+                                               CompactionRequest request) throws IOException {
+    reloadPruneState(c.getEnvironment());
+    return super.preCompactScannerOpen(c, store, scanners, scanType, earliestPutTs, s, request);
+  }
+
+  @Override
   protected void ensureValidTxLifetime(RegionCoprocessorEnvironment env, OperationWithAttributes op,
                                        @Nullable Transaction tx) throws IOException {
     if (tx == null) {
       return;
     }
 
-    long maxLifetimeMillis;
-    if (txMaxLifetimeMillis == null) {
-      Configuration conf = getConfiguration(env);
-      if (conf != null) {
-        this.txMaxLifetimeMillis = TimeUnit.SECONDS.toMillis(conf.getInt(TxConstants.Manager.CFG_TX_MAX_LIFETIME,
-                                                                         TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME));
-        maxLifetimeMillis = this.txMaxLifetimeMillis;
-      } else {
-        // Get maxLifetimeMillis from transaction attributes
-        byte[] maxLifetimeBytes = op.getAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY);
-        if (maxLifetimeBytes != null) {
-          maxLifetimeMillis = Bytes.toLong(maxLifetimeBytes);
-        } else {
-          LOG.warn("txMaxLifetimeMillis is not available in client's operation attributes. " +
-                     "Defaulting to default tx_max_lifetime");
-          maxLifetimeMillis = TimeUnit.SECONDS.toMillis(TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME);
-        }
-      }
-    } else {
-      maxLifetimeMillis = txMaxLifetimeMillis;
-    }
-
+    long currMaxLifetimeinMillis = getCurrMaxLifetime(env, op, cConfCache.getTxMaxLifetimeMillis());
+    // Since we don't always set the txMaxLifetimeMillis variable (in case when we get the info from the client)
+    // we need to compute whether the transaction is within the validLifetime boundary here instead of
+    // relying on the parent
     boolean validLifetime =
-      TxUtils.getTimestamp(tx.getTransactionId()) + maxLifetimeMillis > System.currentTimeMillis();
+      (TxUtils.getTimestamp(tx.getTransactionId()) + currMaxLifetimeinMillis) > System.currentTimeMillis();
     if (!validLifetime) {
       throw new DoNotRetryIOException(String.format("Transaction %s has exceeded max lifetime %s ms",
-                                                    tx.getTransactionId(), maxLifetimeMillis));
+                                                    tx.getTransactionId(), currMaxLifetimeinMillis));
+    }
+  }
+
+  private long getCurrMaxLifetime(RegionCoprocessorEnvironment env, OperationWithAttributes op,
+                                  @Nullable Long maxLifetimeFromConf) {
+    // If conf has the value, update the txMaxLifetimeMillis and return it
+    if (maxLifetimeFromConf != null) {
+      txMaxLifetimeMillis = maxLifetimeFromConf;
+      return maxLifetimeFromConf;
+    }
+
+    // This case shouldn't happen but in case current value from conf is null but it was set earlier, return that
+    if (txMaxLifetimeMillis != null) {
+      return txMaxLifetimeMillis;
+    }
+
+    // If value from conf is null, derive it from the attribute set by the client
+    byte[] maxLifetimeBytes = op.getAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY);
+    if (maxLifetimeBytes != null) {
+      return Bytes.toLong(maxLifetimeBytes);
+    }
+
+    // If maxLifetimeMillis could not be found in the client request as well, just use the default value
+    long defaultMaxLifeTimeInSecs = TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME;
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(String.format("txMaxLifetimeMillis is not available in client's operation attributes. " +
+                                "Defaulting to the default value of %d seconds for region %s.",
+                              defaultMaxLifeTimeInSecs, env.getRegion().getRegionInfo().getRegionNameAsString()));
+    }
+    return TimeUnit.SECONDS.toMillis(defaultMaxLifeTimeInSecs);
+  }
+
+  private void reloadPruneState(RegionCoprocessorEnvironment env) {
+    if (pruneEnable == null) {
+      // If prune enable has never been initialized, try to do so now
+      initializePruneState(env);
+    } else {
+      Configuration conf = getConfiguration(env);
+      if (conf != null) {
+        boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                                 TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+        if (newPruneEnable != pruneEnable) {
+          // pruning enable has been changed, resetting prune state
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Transaction Invalid List pruning feature is set to %s now for region %s.",
+                                    newPruneEnable, env.getRegion().getRegionInfo().getRegionNameAsString()));
+          }
+          resetPruneState();
+          initializePruneState(env);
+        }
+      }
     }
   }
 
   @Override
   @Nullable
   protected Configuration getConfiguration(CoprocessorEnvironment env) {
-    CConfiguration cConf = cConfCache.getCConf();
-    if (cConf == null) {
-      return null;
-    }
-
-    Configuration hConf = new Configuration();
-    for (Map.Entry<String, String> entry : cConf) {
-      hConf.set(entry.getKey(), entry.getValue());
-    }
-    return hConf;
+    return cConfCache.getConf();
   }
 
   @Override

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase96/MessageTableRegionObserver.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase96/MessageTableRegionObserver.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.filter.FilterBase;
+import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.InternalScanner;
 import org.apache.hadoop.hbase.regionserver.KeyValueScanner;
 import org.apache.hadoop.hbase.regionserver.ScanType;
@@ -129,6 +130,23 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
   }
 
   @Override
+  public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+    // Record whether the region is empty after a flush
+    HRegion region = e.getEnvironment().getRegion();
+    // After a flush, if the memstore size is zero and there are no store files for any stores in the region
+    // then the region must be empty
+    long numStoreFiles = numStoreFilesForRegion(e);
+    long memstoreSize = region.getMemstoreSize().get();
+    LOG.debug(String.format("Region %s: memstore size = %s, num store files = %s",
+                            region.getRegionInfo().getRegionNameAsString(), memstoreSize, numStoreFiles));
+    if (memstoreSize == 0 && numStoreFiles == 0) {
+      if (compactionState != null) {
+        compactionState.persistRegionEmpty(System.currentTimeMillis());
+      }
+    }
+  }
+
+  @Override
   public InternalScanner preCompactScannerOpen(ObserverContext<RegionCoprocessorEnvironment> c, Store store,
                                                List<? extends KeyValueScanner> scanners, ScanType scanType,
                                                long earliestPutTs, InternalScanner s,
@@ -136,25 +154,8 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     LOG.info("preCompact, filter using MessageDataFilter");
     TransactionVisibilityState txVisibilityState = txStateCache.getLatestState();
 
-    if (pruneEnable == null) {
-      CConfiguration cConf = topicMetadataCache.getCConfiguration();
-      if (cConf != null) {
-        pruneEnable = cConf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
-                                       TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
-        if (Boolean.TRUE.equals(pruneEnable)) {
-          String pruneTable = cConf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
-                                        TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
-          long pruneFlushInterval = TimeUnit.SECONDS.toMillis(
-            cConf.getLong(TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
-                          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
-          compactionState = new CompactionState(c.getEnvironment(), TableName.valueOf(pruneTable), pruneFlushInterval);
-          LOG.debug("Automatic invalid list pruning is enabled. Compaction state will be recorded in table " +
-                      pruneTable);
-        }
-      }
-    }
-
-    if (Boolean.TRUE.equals(pruneEnable)) {
+    reloadPruneState(c.getEnvironment());
+    if (compactionState != null) {
       // Record tx state before the compaction
       compactionState.record(request, txVisibilityState);
     }
@@ -173,6 +174,60 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     // Persist the compaction state after a successful compaction
     if (compactionState != null) {
       compactionState.persist();
+    }
+  }
+
+  private void reloadPruneState(RegionCoprocessorEnvironment env) {
+    if (pruneEnable == null) {
+      // If prune enable has never been initialized, try to do so now
+      initializePruneState(env);
+    } else {
+      CConfiguration conf = topicMetadataCache.getCConfiguration();
+      if (conf != null) {
+        boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                                 TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+        if (newPruneEnable != pruneEnable) {
+          // pruning enable has been changed, resetting prune state
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Transaction Invalid List pruning feature is set to %s now for region %s.",
+                                    newPruneEnable, env.getRegion().getRegionInfo().getRegionNameAsString()));
+          }
+          resetPruneState();
+          initializePruneState(env);
+        }
+      }
+    }
+  }
+
+  private void initializePruneState(RegionCoprocessorEnvironment env) {
+    CConfiguration conf = topicMetadataCache.getCConfiguration();
+    if (conf != null) {
+      pruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                    TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+
+      if (Boolean.TRUE.equals(pruneEnable)) {
+        String pruneTable = conf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
+                                     TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
+        long pruneFlushInterval = TimeUnit.SECONDS.toMillis(conf.getLong(
+          TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
+          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
+
+        compactionState = new CompactionState(env, TableName.valueOf(pruneTable), pruneFlushInterval);
+        if (LOG.isDebugEnabled()) {
+          TableName tableName = env.getRegion().getRegionInfo().getTable();
+          LOG.debug(String.format("Automatic invalid list pruning is enabled for table %s:%s. Compaction state " +
+                                    "will be recorded in table %s", tableName.getNamespaceAsString(),
+                                  tableName.getNameAsString(), pruneTable));
+        }
+      }
+    }
+  }
+
+  private void resetPruneState() {
+    pruneEnable = false;
+    if (compactionState != null) {
+      compactionState.stop();
+      compactionState = null;
     }
   }
 
@@ -215,6 +270,14 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
       }
       delegate.close();
     }
+  }
+
+  private long numStoreFilesForRegion(ObserverContext<RegionCoprocessorEnvironment> c) {
+    long numStoreFiles = 0;
+    for (Store store : c.getEnvironment().getRegion().getStores().values()) {
+      numStoreFiles += store.getStorefiles().size();
+    }
+    return numStoreFiles;
   }
 
   private static final class MessageDataFilter extends FilterBase {

--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase96/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase96/HBaseQueueRegionObserver.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.InternalScanner;
 import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.regionserver.Store;
@@ -151,28 +152,10 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
     }
 
     LOG.info("preCompact, creates EvictionInternalScanner");
-    ConsumerConfigCache consumerConfigCache = getConfigCache(e.getEnvironment());
     TransactionVisibilityState txVisibilityState = txStateCache.getLatestState();
 
-    if (pruneEnable == null) {
-      CConfiguration cConf = consumerConfigCache.getCConf();
-      if (cConf != null) {
-        pruneEnable = cConf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
-                                       TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
-        if (Boolean.TRUE.equals(pruneEnable)) {
-          String pruneTable = cConf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
-                                        TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
-          long pruneFlushInterval = TimeUnit.SECONDS.toMillis(
-            cConf.getLong(TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
-                          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
-          compactionState = new CompactionState(e.getEnvironment(), TableName.valueOf(pruneTable), pruneFlushInterval);
-          LOG.debug("Automatic invalid list pruning is enabled. Compaction state will be recorded in table " +
-                      pruneTable);
-        }
-      }
-    }
-
-    if (Boolean.TRUE.equals(pruneEnable)) {
+    reloadPruneState(e.getEnvironment());
+    if (compactionState != null) {
       // Record tx state before the compaction
       compactionState.record(request, txVisibilityState);
     }
@@ -186,6 +169,85 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
     // Persist the compaction state after a successful compaction
     if (this.compactionState != null) {
       this.compactionState.persist();
+    }
+  }
+
+  @Override
+  public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+    // Record whether the region is empty after a flush
+    HRegion region = e.getEnvironment().getRegion();
+    // After a flush, if the memstore size is zero and there are no store files for any stores in the region
+    // then the region must be empty
+    long numStoreFiles = numStoreFilesForRegion(e);
+    long memstoreSize = region.getMemstoreSize().get();
+    LOG.debug(String.format("Region %s: memstore size = %s, num store files = %s",
+                            region.getRegionInfo().getRegionNameAsString(), memstoreSize, numStoreFiles));
+    if (memstoreSize == 0 && numStoreFiles == 0) {
+      if (compactionState != null) {
+        compactionState.persistRegionEmpty(System.currentTimeMillis());
+      }
+    }
+  }
+
+  private long numStoreFilesForRegion(ObserverContext<RegionCoprocessorEnvironment> c) {
+    long numStoreFiles = 0;
+    for (Store store : c.getEnvironment().getRegion().getStores().values()) {
+      numStoreFiles += store.getStorefiles().size();
+    }
+    return numStoreFiles;
+  }
+
+  private void reloadPruneState(RegionCoprocessorEnvironment env) {
+    if (pruneEnable == null) {
+      // If prune enable has never been initialized, try to do so now
+      initializePruneState(env);
+    } else {
+      CConfiguration conf = getConfigCache(env).getCConf();
+      if (conf != null) {
+        boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                                 TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+        if (newPruneEnable != pruneEnable) {
+          // pruning enable has been changed, resetting prune state
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Transaction Invalid List pruning feature is set to %s now for region %s.",
+                                    newPruneEnable, env.getRegion().getRegionInfo().getRegionNameAsString()));
+          }
+          resetPruneState();
+          initializePruneState(env);
+        }
+      }
+    }
+  }
+
+  private void initializePruneState(RegionCoprocessorEnvironment env) {
+    CConfiguration conf = getConfigCache(env).getCConf();
+    if (conf != null) {
+      pruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                    TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+
+      if (Boolean.TRUE.equals(pruneEnable)) {
+        String pruneTable = conf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
+                                     TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
+        long pruneFlushInterval = TimeUnit.SECONDS.toMillis(conf.getLong(
+          TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
+          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
+
+        compactionState = new CompactionState(env, TableName.valueOf(pruneTable), pruneFlushInterval);
+        if (LOG.isDebugEnabled()) {
+          TableName tableName = env.getRegion().getRegionInfo().getTable();
+          LOG.debug(String.format("Automatic invalid list pruning is enabled for table %s:%s. Compaction state " +
+                                    "will be recorded in table %s", tableName.getNamespaceAsString(),
+                                  tableName.getNameAsString(), pruneTable));
+        }
+      }
+    }
+  }
+
+  private void resetPruneState() {
+    pruneEnable = false;
+    if (compactionState != null) {
+      compactionState.stop();
+      compactionState = null;
     }
   }
 

--- a/cdap-hbase-compat-0.98/pom.xml
+++ b/cdap-hbase-compat-0.98/pom.xml
@@ -68,10 +68,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.tephra</groupId>
-      <artifactId>tephra-hbase-compat-0.98</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
     </dependency>
@@ -186,7 +182,7 @@
                 </goals>
                 <configuration>
                   <excludeArtifactIds>*</excludeArtifactIds>
-                  <includeArtifactIds>tephra-hbase-compat-0.98</includeArtifactIds>
+                  <includeArtifactIds>${artifactId}</includeArtifactIds>
                   <silent>true</silent>
                   <includeScope>compile</includeScope>
                 </configuration>

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase98/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase98/DefaultTransactionProcessor.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.data2.transaction.coprocessor.hbase98;
 
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTable;
 import co.cask.cdap.data2.increment.hbase98.IncrementTxFilter;
@@ -32,9 +31,14 @@ import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.OperationWithAttributes;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.KeyValueScanner;
 import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.regionserver.Store;
+import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TxConstants;
@@ -44,7 +48,7 @@ import org.apache.tephra.hbase.coprocessor.TransactionProcessor;
 import org.apache.tephra.util.TxUtils;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -68,7 +72,9 @@ public class DefaultTransactionProcessor extends TransactionProcessor {
       String hbaseNamespacePrefix = tableDesc.getValue(Constants.Dataset.TABLE_PREFIX);
 
       this.sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(hbaseNamespacePrefix);
-      this.cConfCacheSupplier = new CConfigurationCacheSupplier(env.getConfiguration(), sysConfigTablePrefix);
+      this.cConfCacheSupplier = new CConfigurationCacheSupplier(env.getConfiguration(), sysConfigTablePrefix,
+                                                                TxConstants.Manager.CFG_TX_MAX_LIFETIME,
+                                                                TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME);
       this.cConfCache = cConfCacheSupplier.get();
     }
     // Need to create the cConf cache before calling start on the parent, since it is required for
@@ -83,55 +89,94 @@ public class DefaultTransactionProcessor extends TransactionProcessor {
   }
 
   @Override
+  public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+    reloadPruneState(e.getEnvironment());
+    super.postFlush(e);
+  }
+
+  @Override
+  public InternalScanner preCompactScannerOpen(ObserverContext<RegionCoprocessorEnvironment> c, Store store,
+                                               List<? extends KeyValueScanner> scanners, ScanType scanType,
+                                               long earliestPutTs, InternalScanner s,
+                                               CompactionRequest request) throws IOException {
+    reloadPruneState(c.getEnvironment());
+    return super.preCompactScannerOpen(c, store, scanners, scanType, earliestPutTs, s, request);
+  }
+
+  @Override
   protected void ensureValidTxLifetime(RegionCoprocessorEnvironment env, OperationWithAttributes op,
                                        @Nullable Transaction tx) throws IOException {
     if (tx == null) {
       return;
     }
 
-    long maxLifetimeMillis;
-    if (txMaxLifetimeMillis == null) {
-      Configuration conf = getConfiguration(env);
-      if (conf != null) {
-        this.txMaxLifetimeMillis = TimeUnit.SECONDS.toMillis(conf.getInt(TxConstants.Manager.CFG_TX_MAX_LIFETIME,
-                                                                         TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME));
-        maxLifetimeMillis = this.txMaxLifetimeMillis;
-      } else {
-        // Get maxLifetimeMillis from transaction attributes
-        byte[] maxLifetimeBytes = op.getAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY);
-        if (maxLifetimeBytes != null) {
-          maxLifetimeMillis = Bytes.toLong(maxLifetimeBytes);
-        } else {
-          LOG.warn("txMaxLifetimeMillis is not available in client's operation attributes. " +
-                     "Defaulting to default tx_max_lifetime");
-          maxLifetimeMillis = TimeUnit.SECONDS.toMillis(TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME);
-        }
-      }
-    } else {
-      maxLifetimeMillis = txMaxLifetimeMillis;
-    }
-
+    long currMaxLifetimeinMillis = getCurrMaxLifetime(env, op, cConfCache.getTxMaxLifetimeMillis());
+    // Since we don't always set the txMaxLifetimeMillis variable (in case when we get the info from the client)
+    // we need to compute whether the transaction is within the validLifetime boundary here instead of
+    // relying on the parent
     boolean validLifetime =
-      TxUtils.getTimestamp(tx.getTransactionId()) + maxLifetimeMillis > System.currentTimeMillis();
+      (TxUtils.getTimestamp(tx.getTransactionId()) + currMaxLifetimeinMillis) > System.currentTimeMillis();
     if (!validLifetime) {
       throw new DoNotRetryIOException(String.format("Transaction %s has exceeded max lifetime %s ms",
-                                                    tx.getTransactionId(), maxLifetimeMillis));
+                                                    tx.getTransactionId(), currMaxLifetimeinMillis));
+    }
+  }
+
+  private long getCurrMaxLifetime(RegionCoprocessorEnvironment env, OperationWithAttributes op,
+                                  @Nullable Long maxLifetimeFromConf) {
+    // If conf has the value, update the txMaxLifetimeMillis and return it
+    if (maxLifetimeFromConf != null) {
+      txMaxLifetimeMillis = maxLifetimeFromConf;
+      return maxLifetimeFromConf;
+    }
+
+    // This case shouldn't happen but in case current value from conf is null but it was set earlier, return that
+    if (txMaxLifetimeMillis != null) {
+      return txMaxLifetimeMillis;
+    }
+
+    // If value from conf is null, derive it from the attribute set by the client
+    byte[] maxLifetimeBytes = op.getAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY);
+    if (maxLifetimeBytes != null) {
+      return Bytes.toLong(maxLifetimeBytes);
+    }
+
+    // If maxLifetimeMillis could not be found in the client request as well, just use the default value
+    long defaultMaxLifeTimeInSecs = TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME;
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(String.format("txMaxLifetimeMillis is not available in client's operation attributes. " +
+                                "Defaulting to the default value of %d seconds for region %s.",
+                              defaultMaxLifeTimeInSecs, env.getRegion().getRegionInfo().getRegionNameAsString()));
+    }
+    return TimeUnit.SECONDS.toMillis(defaultMaxLifeTimeInSecs);
+  }
+
+  private void reloadPruneState(RegionCoprocessorEnvironment env) {
+    if (pruneEnable == null) {
+      // If prune enable has never been initialized, try to do so now
+      initializePruneState(env);
+    } else {
+      Configuration conf = getConfiguration(env);
+      if (conf != null) {
+        boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                                 TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+        if (newPruneEnable != pruneEnable) {
+          // pruning enable has been changed, resetting prune state
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Transaction Invalid List pruning feature is set to %s now for region %s.",
+                                    newPruneEnable, env.getRegion().getRegionInfo().getRegionNameAsString()));
+          }
+          resetPruneState();
+          initializePruneState(env);
+        }
+      }
     }
   }
 
   @Override
   @Nullable
   protected Configuration getConfiguration(CoprocessorEnvironment env) {
-    CConfiguration cConf = cConfCache.getCConf();
-    if (cConf == null) {
-      return null;
-    }
-
-    Configuration hConf = new Configuration();
-    for (Map.Entry<String, String> entry : cConf) {
-      hConf.set(entry.getKey(), entry.getValue());
-    }
-    return hConf;
+    return cConfCache.getConf();
   }
 
   @Override

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase98/MessageTableRegionObserver.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase98/MessageTableRegionObserver.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.filter.FilterBase;
+import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.InternalScanner;
 import org.apache.hadoop.hbase.regionserver.KeyValueScanner;
 import org.apache.hadoop.hbase.regionserver.ScanType;
@@ -129,6 +130,23 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
   }
 
   @Override
+  public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+    // Record whether the region is empty after a flush
+    HRegion region = e.getEnvironment().getRegion();
+    // After a flush, if the memstore size is zero and there are no store files for any stores in the region
+    // then the region must be empty
+    long numStoreFiles = numStoreFilesForRegion(e);
+    long memstoreSize = region.getMemstoreSize().get();
+    LOG.debug(String.format("Region %s: memstore size = %s, num store files = %s",
+                            region.getRegionInfo().getRegionNameAsString(), memstoreSize, numStoreFiles));
+    if (memstoreSize == 0 && numStoreFiles == 0) {
+      if (compactionState != null) {
+        compactionState.persistRegionEmpty(System.currentTimeMillis());
+      }
+    }
+  }
+
+  @Override
   public InternalScanner preCompactScannerOpen(ObserverContext<RegionCoprocessorEnvironment> c, Store store,
                                                List<? extends KeyValueScanner> scanners, ScanType scanType,
                                                long earliestPutTs, InternalScanner s,
@@ -136,25 +154,8 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     LOG.info("preCompact, filter using MessageDataFilter");
     TransactionVisibilityState txVisibilityState = txStateCache.getLatestState();
 
-    if (pruneEnable == null) {
-      CConfiguration cConf = topicMetadataCache.getCConfiguration();
-      if (cConf != null) {
-        pruneEnable = cConf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
-                                       TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
-        if (Boolean.TRUE.equals(pruneEnable)) {
-          String pruneTable = cConf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
-                                        TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
-          long pruneFlushInterval = TimeUnit.SECONDS.toMillis(
-            cConf.getLong(TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
-                          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
-          compactionState = new CompactionState(c.getEnvironment(), TableName.valueOf(pruneTable), pruneFlushInterval);
-          LOG.debug("Automatic invalid list pruning is enabled. Compaction state will be recorded in table " +
-                      pruneTable);
-        }
-      }
-    }
-
-    if (Boolean.TRUE.equals(pruneEnable)) {
+    reloadPruneState(c.getEnvironment());
+    if (compactionState != null) {
       // Record tx state before the compaction
       compactionState.record(request, txVisibilityState);
     }
@@ -173,6 +174,60 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     // Persist the compaction state after a successful compaction
     if (compactionState != null) {
       compactionState.persist();
+    }
+  }
+
+  private void reloadPruneState(RegionCoprocessorEnvironment env) {
+    if (pruneEnable == null) {
+      // If prune enable has never been initialized, try to do so now
+      initializePruneState(env);
+    } else {
+      CConfiguration conf = topicMetadataCache.getCConfiguration();
+      if (conf != null) {
+        boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                                 TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+        if (newPruneEnable != pruneEnable) {
+          // pruning enable has been changed, resetting prune state
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Transaction Invalid List pruning feature is set to %s now for region %s.",
+                                    newPruneEnable, env.getRegion().getRegionInfo().getRegionNameAsString()));
+          }
+          resetPruneState();
+          initializePruneState(env);
+        }
+      }
+    }
+  }
+
+  private void initializePruneState(RegionCoprocessorEnvironment env) {
+    CConfiguration conf = topicMetadataCache.getCConfiguration();
+    if (conf != null) {
+      pruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                    TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+
+      if (Boolean.TRUE.equals(pruneEnable)) {
+        String pruneTable = conf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
+                                     TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
+        long pruneFlushInterval = TimeUnit.SECONDS.toMillis(conf.getLong(
+          TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
+          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
+
+        compactionState = new CompactionState(env, TableName.valueOf(pruneTable), pruneFlushInterval);
+        if (LOG.isDebugEnabled()) {
+          TableName tableName = env.getRegion().getRegionInfo().getTable();
+          LOG.debug(String.format("Automatic invalid list pruning is enabled for table %s:%s. Compaction state " +
+                                    "will be recorded in table %s", tableName.getNamespaceAsString(),
+                                  tableName.getNameAsString(), pruneTable));
+        }
+      }
+    }
+  }
+
+  private void resetPruneState() {
+    pruneEnable = false;
+    if (compactionState != null) {
+      compactionState.stop();
+      compactionState = null;
     }
   }
 
@@ -215,6 +270,14 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
       }
       delegate.close();
     }
+  }
+
+  private long numStoreFilesForRegion(ObserverContext<RegionCoprocessorEnvironment> c) {
+    long numStoreFiles = 0;
+    for (Store store : c.getEnvironment().getRegion().getStores().values()) {
+      numStoreFiles += store.getStorefiles().size();
+    }
+    return numStoreFiles;
   }
 
   private static final class MessageDataFilter extends FilterBase {

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase98/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase98/HBaseQueueRegionObserver.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.InternalScanner;
 import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.regionserver.Store;
@@ -123,7 +124,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       configCache = createConfigCache(env);
     }
   }
-  
+
   @Override
   public void stop(CoprocessorEnvironment e) {
     if (compactionState != null) {
@@ -151,28 +152,10 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
     }
 
     LOG.info("preCompact, creates EvictionInternalScanner");
-    ConsumerConfigCache consumerConfigCache = getConfigCache(e.getEnvironment());
     TransactionVisibilityState txVisibilityState = txStateCache.getLatestState();
 
-    if (pruneEnable == null) {
-      CConfiguration cConf = consumerConfigCache.getCConf();
-      if (cConf != null) {
-        pruneEnable = cConf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
-                                       TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
-        if (Boolean.TRUE.equals(pruneEnable)) {
-          String pruneTable = cConf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
-                                        TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
-          long pruneFlushInterval = TimeUnit.SECONDS.toMillis(
-            cConf.getLong(TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
-                          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
-          compactionState = new CompactionState(e.getEnvironment(), TableName.valueOf(pruneTable), pruneFlushInterval);
-          LOG.debug("Automatic invalid list pruning is enabled. Compaction state will be recorded in table " +
-                      pruneTable);
-        }
-      }
-    }
-
-    if (Boolean.TRUE.equals(pruneEnable)) {
+    reloadPruneState(e.getEnvironment());
+    if (compactionState != null) {
       // Record tx state before the compaction
       compactionState.record(request, txVisibilityState);
     }
@@ -186,6 +169,85 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
     // Persist the compaction state after a successful compaction
     if (this.compactionState != null) {
       this.compactionState.persist();
+    }
+  }
+
+  @Override
+  public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+    // Record whether the region is empty after a flush
+    HRegion region = e.getEnvironment().getRegion();
+    // After a flush, if the memstore size is zero and there are no store files for any stores in the region
+    // then the region must be empty
+    long numStoreFiles = numStoreFilesForRegion(e);
+    long memstoreSize = region.getMemstoreSize().get();
+    LOG.debug(String.format("Region %s: memstore size = %s, num store files = %s",
+                            region.getRegionInfo().getRegionNameAsString(), memstoreSize, numStoreFiles));
+    if (memstoreSize == 0 && numStoreFiles == 0) {
+      if (compactionState != null) {
+        compactionState.persistRegionEmpty(System.currentTimeMillis());
+      }
+    }
+  }
+
+  private long numStoreFilesForRegion(ObserverContext<RegionCoprocessorEnvironment> c) {
+    long numStoreFiles = 0;
+    for (Store store : c.getEnvironment().getRegion().getStores().values()) {
+      numStoreFiles += store.getStorefiles().size();
+    }
+    return numStoreFiles;
+  }
+
+  private void reloadPruneState(RegionCoprocessorEnvironment env) {
+    if (pruneEnable == null) {
+      // If prune enable has never been initialized, try to do so now
+      initializePruneState(env);
+    } else {
+      CConfiguration conf = getConfigCache(env).getCConf();
+      if (conf != null) {
+        boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                                 TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+        if (newPruneEnable != pruneEnable) {
+          // pruning enable has been changed, resetting prune state
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Transaction Invalid List pruning feature is set to %s now for region %s.",
+                                    newPruneEnable, env.getRegion().getRegionInfo().getRegionNameAsString()));
+          }
+          resetPruneState();
+          initializePruneState(env);
+        }
+      }
+    }
+  }
+
+  private void initializePruneState(RegionCoprocessorEnvironment env) {
+    CConfiguration conf = getConfigCache(env).getCConf();
+    if (conf != null) {
+      pruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                    TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+
+      if (Boolean.TRUE.equals(pruneEnable)) {
+        String pruneTable = conf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
+                                     TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
+        long pruneFlushInterval = TimeUnit.SECONDS.toMillis(conf.getLong(
+          TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
+          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
+
+        compactionState = new CompactionState(env, TableName.valueOf(pruneTable), pruneFlushInterval);
+        if (LOG.isDebugEnabled()) {
+          TableName tableName = env.getRegion().getRegionInfo().getTable();
+          LOG.debug(String.format("Automatic invalid list pruning is enabled for table %s:%s. Compaction state " +
+                                    "will be recorded in table %s", tableName.getNamespaceAsString(),
+                                  tableName.getNameAsString(), pruneTable));
+        }
+      }
+    }
+  }
+
+  private void resetPruneState() {
+    pruneEnable = false;
+    if (compactionState != null) {
+      compactionState.stop();
+      compactionState = null;
     }
   }
 

--- a/cdap-hbase-compat-1.0-cdh/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh/pom.xml
@@ -69,10 +69,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.tephra</groupId>
-      <artifactId>tephra-hbase-compat-1.0-cdh</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
     </dependency>
@@ -207,7 +203,7 @@
                 </goals>
                 <configuration>
                   <excludeArtifactIds>*</excludeArtifactIds>
-                  <includeArtifactIds>tephra-hbase-compat-1.0-cdh</includeArtifactIds>
+                  <includeArtifactIds>${artifactId}</includeArtifactIds>
                   <silent>true</silent>
                   <includeScope>compile</includeScope>
                 </configuration>

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase10cdh/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase10cdh/DefaultTransactionProcessor.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.data2.transaction.coprocessor.hbase10cdh;
 
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTable;
 import co.cask.cdap.data2.increment.hbase10cdh.IncrementTxFilter;
@@ -32,9 +31,14 @@ import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.OperationWithAttributes;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.KeyValueScanner;
 import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.regionserver.Store;
+import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TxConstants;
@@ -44,7 +48,7 @@ import org.apache.tephra.hbase.coprocessor.TransactionProcessor;
 import org.apache.tephra.util.TxUtils;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -68,7 +72,9 @@ public class DefaultTransactionProcessor extends TransactionProcessor {
       String hbaseNamespacePrefix = tableDesc.getValue(Constants.Dataset.TABLE_PREFIX);
 
       this.sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(hbaseNamespacePrefix);
-      this.cConfCacheSupplier = new CConfigurationCacheSupplier(env.getConfiguration(), sysConfigTablePrefix);
+      this.cConfCacheSupplier = new CConfigurationCacheSupplier(env.getConfiguration(), sysConfigTablePrefix,
+                                                                TxConstants.Manager.CFG_TX_MAX_LIFETIME,
+                                                                TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME);
       this.cConfCache = cConfCacheSupplier.get();
     }
     // Need to create the cConf cache before calling start on the parent, since it is required for
@@ -83,55 +89,94 @@ public class DefaultTransactionProcessor extends TransactionProcessor {
   }
 
   @Override
+  public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+    reloadPruneState(e.getEnvironment());
+    super.postFlush(e);
+  }
+
+  @Override
+  public InternalScanner preCompactScannerOpen(ObserverContext<RegionCoprocessorEnvironment> c, Store store,
+                                               List<? extends KeyValueScanner> scanners, ScanType scanType,
+                                               long earliestPutTs, InternalScanner s,
+                                               CompactionRequest request) throws IOException {
+    reloadPruneState(c.getEnvironment());
+    return super.preCompactScannerOpen(c, store, scanners, scanType, earliestPutTs, s, request);
+  }
+
+  @Override
   protected void ensureValidTxLifetime(RegionCoprocessorEnvironment env, OperationWithAttributes op,
                                        @Nullable Transaction tx) throws IOException {
     if (tx == null) {
       return;
     }
 
-    long maxLifetimeMillis;
-    if (txMaxLifetimeMillis == null) {
-      Configuration conf = getConfiguration(env);
-      if (conf != null) {
-        this.txMaxLifetimeMillis = TimeUnit.SECONDS.toMillis(conf.getInt(TxConstants.Manager.CFG_TX_MAX_LIFETIME,
-                                                                         TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME));
-        maxLifetimeMillis = this.txMaxLifetimeMillis;
-      } else {
-        // Get maxLifetimeMillis from transaction attributes
-        byte[] maxLifetimeBytes = op.getAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY);
-        if (maxLifetimeBytes != null) {
-          maxLifetimeMillis = Bytes.toLong(maxLifetimeBytes);
-        } else {
-          LOG.warn("txMaxLifetimeMillis is not available in client's operation attributes. " +
-                     "Defaulting to default tx_max_lifetime");
-          maxLifetimeMillis = TimeUnit.SECONDS.toMillis(TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME);
-        }
-      }
-    } else {
-      maxLifetimeMillis = txMaxLifetimeMillis;
-    }
-
+    long currMaxLifetimeinMillis = getCurrMaxLifetime(env, op, cConfCache.getTxMaxLifetimeMillis());
+    // Since we don't always set the txMaxLifetimeMillis variable (in case when we get the info from the client)
+    // we need to compute whether the transaction is within the validLifetime boundary here instead of
+    // relying on the parent
     boolean validLifetime =
-      TxUtils.getTimestamp(tx.getTransactionId()) + maxLifetimeMillis > System.currentTimeMillis();
+      (TxUtils.getTimestamp(tx.getTransactionId()) + currMaxLifetimeinMillis) > System.currentTimeMillis();
     if (!validLifetime) {
       throw new DoNotRetryIOException(String.format("Transaction %s has exceeded max lifetime %s ms",
-                                                    tx.getTransactionId(), maxLifetimeMillis));
+                                                    tx.getTransactionId(), currMaxLifetimeinMillis));
+    }
+  }
+
+  private long getCurrMaxLifetime(RegionCoprocessorEnvironment env, OperationWithAttributes op,
+                                  @Nullable Long maxLifetimeFromConf) {
+    // If conf has the value, update the txMaxLifetimeMillis and return it
+    if (maxLifetimeFromConf != null) {
+      txMaxLifetimeMillis = maxLifetimeFromConf;
+      return maxLifetimeFromConf;
+    }
+
+    // This case shouldn't happen but in case current value from conf is null but it was set earlier, return that
+    if (txMaxLifetimeMillis != null) {
+      return txMaxLifetimeMillis;
+    }
+
+    // If value from conf is null, derive it from the attribute set by the client
+    byte[] maxLifetimeBytes = op.getAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY);
+    if (maxLifetimeBytes != null) {
+      return Bytes.toLong(maxLifetimeBytes);
+    }
+
+    // If maxLifetimeMillis could not be found in the client request as well, just use the default value
+    long defaultMaxLifeTimeInSecs = TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME;
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(String.format("txMaxLifetimeMillis is not available in client's operation attributes. " +
+                                "Defaulting to the default value of %d seconds for region %s.",
+                              defaultMaxLifeTimeInSecs, env.getRegionInfo().getRegionNameAsString()));
+    }
+    return TimeUnit.SECONDS.toMillis(defaultMaxLifeTimeInSecs);
+  }
+
+  private void reloadPruneState(RegionCoprocessorEnvironment env) {
+    if (pruneEnable == null) {
+      // If prune enable has never been initialized, try to do so now
+      initializePruneState(env);
+    } else {
+      Configuration conf = getConfiguration(env);
+      if (conf != null) {
+        boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                                 TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+        if (newPruneEnable != pruneEnable) {
+          // pruning enable has been changed, resetting prune state
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Transaction Invalid List pruning feature is set to %s now for region %s.",
+                                    newPruneEnable, env.getRegionInfo().getRegionNameAsString()));
+          }
+          resetPruneState();
+          initializePruneState(env);
+        }
+      }
     }
   }
 
   @Override
   @Nullable
   protected Configuration getConfiguration(CoprocessorEnvironment env) {
-    CConfiguration cConf = cConfCache.getCConf();
-    if (cConf == null) {
-      return null;
-    }
-
-    Configuration hConf = new Configuration();
-    for (Map.Entry<String, String> entry : cConf) {
-      hConf.set(entry.getKey(), entry.getValue());
-    }
-    return hConf;
+    return cConfCache.getConf();
   }
 
   @Override

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10cdh/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10cdh/HBaseQueueRegionObserver.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.InternalScanner;
 import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.regionserver.Store;
@@ -151,28 +152,10 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
     }
 
     LOG.info("preCompact, creates EvictionInternalScanner");
-    ConsumerConfigCache consumerConfigCache = getConfigCache(e.getEnvironment());
     TransactionVisibilityState txVisibilityState = txStateCache.getLatestState();
 
-    if (pruneEnable == null) {
-      CConfiguration cConf = consumerConfigCache.getCConf();
-      if (cConf != null) {
-        pruneEnable = cConf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
-                                       TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
-        if (Boolean.TRUE.equals(pruneEnable)) {
-          String pruneTable = cConf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
-                                        TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
-          long pruneFlushInterval = TimeUnit.SECONDS.toMillis(
-            cConf.getLong(TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
-                          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
-          compactionState = new CompactionState(e.getEnvironment(), TableName.valueOf(pruneTable), pruneFlushInterval);
-          LOG.debug("Automatic invalid list pruning is enabled. Compaction state will be recorded in table " +
-                      pruneTable);
-        }
-      }
-    }
-
-    if (Boolean.TRUE.equals(pruneEnable)) {
+    reloadPruneState(e.getEnvironment());
+    if (compactionState != null) {
       // Record tx state before the compaction
       compactionState.record(request, txVisibilityState);
     }
@@ -186,6 +169,85 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
     // Persist the compaction state after a successful compaction
     if (this.compactionState != null) {
       this.compactionState.persist();
+    }
+  }
+
+  @Override
+  public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+    // Record whether the region is empty after a flush
+    HRegion region = e.getEnvironment().getRegion();
+    // After a flush, if the memstore size is zero and there are no store files for any stores in the region
+    // then the region must be empty
+    long numStoreFiles = numStoreFilesForRegion(e);
+    long memstoreSize = region.getMemstoreSize().get();
+    LOG.debug(String.format("Region %s: memstore size = %s, num store files = %s",
+                            region.getRegionInfo().getRegionNameAsString(), memstoreSize, numStoreFiles));
+    if (memstoreSize == 0 && numStoreFiles == 0) {
+      if (compactionState != null) {
+        compactionState.persistRegionEmpty(System.currentTimeMillis());
+      }
+    }
+  }
+
+  private long numStoreFilesForRegion(ObserverContext<RegionCoprocessorEnvironment> c) {
+    long numStoreFiles = 0;
+    for (Store store : c.getEnvironment().getRegion().getStores().values()) {
+      numStoreFiles += store.getStorefiles().size();
+    }
+    return numStoreFiles;
+  }
+
+  private void reloadPruneState(RegionCoprocessorEnvironment env) {
+    if (pruneEnable == null) {
+      // If prune enable has never been initialized, try to do so now
+      initializePruneState(env);
+    } else {
+      CConfiguration conf = getConfigCache(env).getCConf();
+      if (conf != null) {
+        boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                                 TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+        if (newPruneEnable != pruneEnable) {
+          // pruning enable has been changed, resetting prune state
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Transaction Invalid List pruning feature is set to %s now for region %s.",
+                                    newPruneEnable, env.getRegionInfo().getRegionNameAsString()));
+          }
+          resetPruneState();
+          initializePruneState(env);
+        }
+      }
+    }
+  }
+
+  private void initializePruneState(RegionCoprocessorEnvironment env) {
+    CConfiguration conf = getConfigCache(env).getCConf();
+    if (conf != null) {
+      pruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                    TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+
+      if (Boolean.TRUE.equals(pruneEnable)) {
+        String pruneTable = conf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
+                                     TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
+        long pruneFlushInterval = TimeUnit.SECONDS.toMillis(conf.getLong(
+          TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
+          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
+
+        compactionState = new CompactionState(env, TableName.valueOf(pruneTable), pruneFlushInterval);
+        if (LOG.isDebugEnabled()) {
+          TableName tableName = env.getRegionInfo().getTable();
+          LOG.debug(String.format("Automatic invalid list pruning is enabled for table %s:%s. Compaction state " +
+                                    "will be recorded in table %s", tableName.getNamespaceAsString(),
+                                  tableName.getNameAsString(), pruneTable));
+        }
+      }
+    }
+  }
+
+  private void resetPruneState() {
+    pruneEnable = false;
+    if (compactionState != null) {
+      compactionState.stop();
+      compactionState = null;
     }
   }
 

--- a/cdap-hbase-compat-1.0-cdh5.5.0/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/pom.xml
@@ -69,10 +69,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.tephra</groupId>
-      <artifactId>tephra-hbase-compat-1.0-cdh</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
     </dependency>
@@ -207,7 +203,7 @@
                 </goals>
                 <configuration>
                   <excludeArtifactIds>*</excludeArtifactIds>
-                  <includeArtifactIds>tephra-hbase-compat-1.0-cdh</includeArtifactIds>
+                  <includeArtifactIds>${artifactId}</includeArtifactIds>
                   <silent>true</silent>
                   <includeScope>compile</includeScope>
                 </configuration>

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase10cdh550/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase10cdh550/DefaultTransactionProcessor.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.data2.transaction.coprocessor.hbase10cdh550;
 
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTable;
 import co.cask.cdap.data2.increment.hbase10cdh550.IncrementTxFilter;
@@ -32,9 +31,14 @@ import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.OperationWithAttributes;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.KeyValueScanner;
 import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.regionserver.Store;
+import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TxConstants;
@@ -44,7 +48,7 @@ import org.apache.tephra.hbase.coprocessor.TransactionProcessor;
 import org.apache.tephra.util.TxUtils;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -68,7 +72,9 @@ public class DefaultTransactionProcessor extends TransactionProcessor {
       String hbaseNamespacePrefix = tableDesc.getValue(Constants.Dataset.TABLE_PREFIX);
 
       this.sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(hbaseNamespacePrefix);
-      this.cConfCacheSupplier = new CConfigurationCacheSupplier(env.getConfiguration(), sysConfigTablePrefix);
+      this.cConfCacheSupplier = new CConfigurationCacheSupplier(env.getConfiguration(), sysConfigTablePrefix,
+                                                                TxConstants.Manager.CFG_TX_MAX_LIFETIME,
+                                                                TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME);
       this.cConfCache = cConfCacheSupplier.get();
     }
     // Need to create the cConf cache before calling start on the parent, since it is required for
@@ -83,55 +89,94 @@ public class DefaultTransactionProcessor extends TransactionProcessor {
   }
 
   @Override
+  public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+    reloadPruneState(e.getEnvironment());
+    super.postFlush(e);
+  }
+
+  @Override
+  public InternalScanner preCompactScannerOpen(ObserverContext<RegionCoprocessorEnvironment> c, Store store,
+                                               List<? extends KeyValueScanner> scanners, ScanType scanType,
+                                               long earliestPutTs, InternalScanner s,
+                                               CompactionRequest request) throws IOException {
+    reloadPruneState(c.getEnvironment());
+    return super.preCompactScannerOpen(c, store, scanners, scanType, earliestPutTs, s, request);
+  }
+
+  @Override
   protected void ensureValidTxLifetime(RegionCoprocessorEnvironment env, OperationWithAttributes op,
                                        @Nullable Transaction tx) throws IOException {
     if (tx == null) {
       return;
     }
 
-    long maxLifetimeMillis;
-    if (txMaxLifetimeMillis == null) {
-      Configuration conf = getConfiguration(env);
-      if (conf != null) {
-        this.txMaxLifetimeMillis = TimeUnit.SECONDS.toMillis(conf.getInt(TxConstants.Manager.CFG_TX_MAX_LIFETIME,
-                                                                         TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME));
-        maxLifetimeMillis = this.txMaxLifetimeMillis;
-      } else {
-        // Get maxLifetimeMillis from transaction attributes
-        byte[] maxLifetimeBytes = op.getAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY);
-        if (maxLifetimeBytes != null) {
-          maxLifetimeMillis = Bytes.toLong(maxLifetimeBytes);
-        } else {
-          LOG.warn("txMaxLifetimeMillis is not available in client's operation attributes. " +
-                     "Defaulting to default tx_max_lifetime");
-          maxLifetimeMillis = TimeUnit.SECONDS.toMillis(TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME);
-        }
-      }
-    } else {
-      maxLifetimeMillis = txMaxLifetimeMillis;
-    }
-
+    long currMaxLifetimeinMillis = getCurrMaxLifetime(env, op, cConfCache.getTxMaxLifetimeMillis());
+    // Since we don't always set the txMaxLifetimeMillis variable (in case when we get the info from the client)
+    // we need to compute whether the transaction is within the validLifetime boundary here instead of
+    // relying on the parent
     boolean validLifetime =
-      TxUtils.getTimestamp(tx.getTransactionId()) + maxLifetimeMillis > System.currentTimeMillis();
+      (TxUtils.getTimestamp(tx.getTransactionId()) + currMaxLifetimeinMillis) > System.currentTimeMillis();
     if (!validLifetime) {
       throw new DoNotRetryIOException(String.format("Transaction %s has exceeded max lifetime %s ms",
-                                                    tx.getTransactionId(), maxLifetimeMillis));
+                                                    tx.getTransactionId(), currMaxLifetimeinMillis));
+    }
+  }
+
+  private long getCurrMaxLifetime(RegionCoprocessorEnvironment env, OperationWithAttributes op,
+                                  @Nullable Long maxLifetimeFromConf) {
+    // If conf has the value, update the txMaxLifetimeMillis and return it
+    if (maxLifetimeFromConf != null) {
+      txMaxLifetimeMillis = maxLifetimeFromConf;
+      return maxLifetimeFromConf;
+    }
+
+    // This case shouldn't happen but in case current value from conf is null but it was set earlier, return that
+    if (txMaxLifetimeMillis != null) {
+      return txMaxLifetimeMillis;
+    }
+
+    // If value from conf is null, derive it from the attribute set by the client
+    byte[] maxLifetimeBytes = op.getAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY);
+    if (maxLifetimeBytes != null) {
+      return Bytes.toLong(maxLifetimeBytes);
+    }
+
+    // If maxLifetimeMillis could not be found in the client request as well, just use the default value
+    long defaultMaxLifeTimeInSecs = TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME;
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(String.format("txMaxLifetimeMillis is not available in client's operation attributes. " +
+                                "Defaulting to the default value of %d seconds for region %s.",
+                              defaultMaxLifeTimeInSecs, env.getRegionInfo().getRegionNameAsString()));
+    }
+    return TimeUnit.SECONDS.toMillis(defaultMaxLifeTimeInSecs);
+  }
+
+  private void reloadPruneState(RegionCoprocessorEnvironment env) {
+    if (pruneEnable == null) {
+      // If prune enable has never been initialized, try to do so now
+      initializePruneState(env);
+    } else {
+      Configuration conf = getConfiguration(env);
+      if (conf != null) {
+        boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                                 TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+        if (newPruneEnable != pruneEnable) {
+          // pruning enable has been changed, resetting prune state
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Transaction Invalid List pruning feature is set to %s now for region %s.",
+                                    newPruneEnable, env.getRegionInfo().getRegionNameAsString()));
+          }
+          resetPruneState();
+          initializePruneState(env);
+        }
+      }
     }
   }
 
   @Override
   @Nullable
   protected Configuration getConfiguration(CoprocessorEnvironment env) {
-    CConfiguration cConf = cConfCache.getCConf();
-    if (cConf == null) {
-      return null;
-    }
-
-    Configuration hConf = new Configuration();
-    for (Map.Entry<String, String> entry : cConf) {
-      hConf.set(entry.getKey(), entry.getValue());
-    }
-    return hConf;
+    return cConfCache.getConf();
   }
 
   @Override

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase10cdh550/MessageTableRegionObserver.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase10cdh550/MessageTableRegionObserver.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.filter.FilterBase;
+import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.InternalScanner;
 import org.apache.hadoop.hbase.regionserver.KeyValueScanner;
 import org.apache.hadoop.hbase.regionserver.ScanType;
@@ -130,6 +131,23 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
   }
 
   @Override
+  public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+    // Record whether the region is empty after a flush
+    HRegion region = e.getEnvironment().getRegion();
+    // After a flush, if the memstore size is zero and there are no store files for any stores in the region
+    // then the region must be empty
+    long numStoreFiles = numStoreFilesForRegion(e);
+    long memstoreSize = region.getMemstoreSize().get();
+    LOG.debug(String.format("Region %s: memstore size = %s, num store files = %s",
+                            region.getRegionInfo().getRegionNameAsString(), memstoreSize, numStoreFiles));
+    if (memstoreSize == 0 && numStoreFiles == 0) {
+      if (compactionState != null) {
+        compactionState.persistRegionEmpty(System.currentTimeMillis());
+      }
+    }
+  }
+
+  @Override
   public InternalScanner preCompactScannerOpen(ObserverContext<RegionCoprocessorEnvironment> c, Store store,
                                                List<? extends KeyValueScanner> scanners, ScanType scanType,
                                                long earliestPutTs, InternalScanner s,
@@ -137,25 +155,8 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     LOG.info("preCompact, filter using MessageDataFilter");
     TransactionVisibilityState txVisibilityState = txStateCache.getLatestState();
 
-    if (pruneEnable == null) {
-      CConfiguration cConf = topicMetadataCache.getCConfiguration();
-      if (cConf != null) {
-        pruneEnable = cConf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
-                                       TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
-        if (Boolean.TRUE.equals(pruneEnable)) {
-          String pruneTable = cConf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
-                                        TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
-          long pruneFlushInterval = TimeUnit.SECONDS.toMillis(
-            cConf.getLong(TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
-                          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
-          compactionState = new CompactionState(c.getEnvironment(), TableName.valueOf(pruneTable), pruneFlushInterval);
-          LOG.debug("Automatic invalid list pruning is enabled. Compaction state will be recorded in table " +
-                      pruneTable);
-        }
-      }
-    }
-
-    if (Boolean.TRUE.equals(pruneEnable)) {
+    reloadPruneState(c.getEnvironment());
+    if (compactionState != null) {
       // Record tx state before the compaction
       compactionState.record(request, txVisibilityState);
     }
@@ -174,6 +175,59 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     // Persist the compaction state after a successful compaction
     if (compactionState != null) {
       compactionState.persist();
+    }
+  }
+
+  private void reloadPruneState(RegionCoprocessorEnvironment env) {
+    if (pruneEnable == null) {
+      // If prune enable has never been initialized, try to do so now
+      initializePruneState(env);
+    } else {
+      CConfiguration conf = topicMetadataCache.getCConfiguration();
+      if (conf != null) {
+        boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                                 TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+        if (newPruneEnable != pruneEnable) {
+          // pruning enable has been changed, resetting prune state
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Transaction Invalid List pruning feature is set to %s now for region %s.",
+                                    newPruneEnable, env.getRegionInfo().getRegionNameAsString()));
+          }
+          resetPruneState();
+          initializePruneState(env);
+        }
+      }
+    }
+  }
+
+  private void initializePruneState(RegionCoprocessorEnvironment env) {
+    CConfiguration conf = topicMetadataCache.getCConfiguration();
+    if (conf != null) {
+      pruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                    TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+
+      if (Boolean.TRUE.equals(pruneEnable)) {
+        String pruneTable = conf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
+                                     TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
+        long pruneFlushInterval = TimeUnit.SECONDS.toMillis(conf.getLong(
+          TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
+          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
+
+        compactionState = new CompactionState(env, TableName.valueOf(pruneTable), pruneFlushInterval);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug(String.format("Automatic invalid list pruning is enabled for table %s. Compaction state " +
+                                    "will be recorded in table %s",
+                                  env.getRegionInfo().getTable().getNameWithNamespaceInclAsString(), pruneTable));
+        }
+      }
+    }
+  }
+
+  private void resetPruneState() {
+    pruneEnable = false;
+    if (compactionState != null) {
+      compactionState.stop();
+      compactionState = null;
     }
   }
 
@@ -216,6 +270,14 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
       }
       delegate.close();
     }
+  }
+
+  private long numStoreFilesForRegion(ObserverContext<RegionCoprocessorEnvironment> c) {
+    long numStoreFiles = 0;
+    for (Store store : c.getEnvironment().getRegion().getStores().values()) {
+      numStoreFiles += store.getStorefiles().size();
+    }
+    return numStoreFiles;
   }
 
   private static final class MessageDataFilter extends FilterBase {

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10cdh550/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10cdh550/HBaseQueueRegionObserver.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.InternalScanner;
 import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.regionserver.ScannerContext;
@@ -152,28 +153,10 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
     }
 
     LOG.info("preCompact, creates EvictionInternalScanner");
-    ConsumerConfigCache consumerConfigCache = getConfigCache(e.getEnvironment());
     TransactionVisibilityState txVisibilityState = txStateCache.getLatestState();
 
-    if (pruneEnable == null) {
-      CConfiguration cConf = consumerConfigCache.getCConf();
-      if (cConf != null) {
-        pruneEnable = cConf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
-                                       TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
-        if (Boolean.TRUE.equals(pruneEnable)) {
-          String pruneTable = cConf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
-                                        TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
-          long pruneFlushInterval = TimeUnit.SECONDS.toMillis(
-            cConf.getLong(TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
-                          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
-          compactionState = new CompactionState(e.getEnvironment(), TableName.valueOf(pruneTable), pruneFlushInterval);
-          LOG.debug("Automatic invalid list pruning is enabled. Compaction state will be recorded in table " +
-                      pruneTable);
-        }
-      }
-    }
-
-    if (Boolean.TRUE.equals(pruneEnable)) {
+    reloadPruneState(e.getEnvironment());
+    if (compactionState != null) {
       // Record tx state before the compaction
       compactionState.record(request, txVisibilityState);
     }
@@ -187,6 +170,84 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
     // Persist the compaction state after a successful compaction
     if (this.compactionState != null) {
       this.compactionState.persist();
+    }
+  }
+
+  @Override
+  public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+    // Record whether the region is empty after a flush
+    HRegion region = e.getEnvironment().getRegion();
+    // After a flush, if the memstore size is zero and there are no store files for any stores in the region
+    // then the region must be empty
+    long numStoreFiles = numStoreFilesForRegion(e);
+    long memstoreSize = region.getMemstoreSize().get();
+    LOG.debug(String.format("Region %s: memstore size = %s, num store files = %s",
+                            region.getRegionInfo().getRegionNameAsString(), memstoreSize, numStoreFiles));
+    if (memstoreSize == 0 && numStoreFiles == 0) {
+      if (compactionState != null) {
+        compactionState.persistRegionEmpty(System.currentTimeMillis());
+      }
+    }
+  }
+
+  private long numStoreFilesForRegion(ObserverContext<RegionCoprocessorEnvironment> c) {
+    long numStoreFiles = 0;
+    for (Store store : c.getEnvironment().getRegion().getStores().values()) {
+      numStoreFiles += store.getStorefiles().size();
+    }
+    return numStoreFiles;
+  }
+
+  private void reloadPruneState(RegionCoprocessorEnvironment env) {
+    if (pruneEnable == null) {
+      // If prune enable has never been initialized, try to do so now
+      initializePruneState(env);
+    } else {
+      CConfiguration conf = getConfigCache(env).getCConf();
+      if (conf != null) {
+        boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                                 TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+        if (newPruneEnable != pruneEnable) {
+          // pruning enable has been changed, resetting prune state
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Transaction Invalid List pruning feature is set to %s now for region %s.",
+                                    newPruneEnable, env.getRegionInfo().getRegionNameAsString()));
+          }
+          resetPruneState();
+          initializePruneState(env);
+        }
+      }
+    }
+  }
+
+  private void initializePruneState(RegionCoprocessorEnvironment env) {
+    CConfiguration conf = getConfigCache(env).getCConf();
+    if (conf != null) {
+      pruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                    TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+
+      if (Boolean.TRUE.equals(pruneEnable)) {
+        String pruneTable = conf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
+                                     TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
+        long pruneFlushInterval = TimeUnit.SECONDS.toMillis(conf.getLong(
+          TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
+          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
+
+        compactionState = new CompactionState(env, TableName.valueOf(pruneTable), pruneFlushInterval);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug(String.format("Automatic invalid list pruning is enabled for table %s. Compaction state " +
+                                    "will be recorded in table %s",
+                                  env.getRegionInfo().getTable().getNameWithNamespaceInclAsString(), pruneTable));
+        }
+      }
+    }
+  }
+
+  private void resetPruneState() {
+    pruneEnable = false;
+    if (compactionState != null) {
+      compactionState.stop();
+      compactionState = null;
     }
   }
 

--- a/cdap-hbase-compat-1.0/pom.xml
+++ b/cdap-hbase-compat-1.0/pom.xml
@@ -62,10 +62,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.tephra</groupId>
-      <artifactId>tephra-hbase-compat-1.0</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
     </dependency>
@@ -193,7 +189,7 @@
                 </goals>
                 <configuration>
                   <excludeArtifactIds>*</excludeArtifactIds>
-                  <includeArtifactIds>tephra-hbase-compat-1.0</includeArtifactIds>
+                  <includeArtifactIds>${artifactId}</includeArtifactIds>
                   <silent>true</silent>
                   <includeScope>compile</includeScope>
                 </configuration>

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase10/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase10/DefaultTransactionProcessor.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.data2.transaction.coprocessor.hbase10;
 
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTable;
 import co.cask.cdap.data2.increment.hbase10.IncrementTxFilter;
@@ -32,9 +31,14 @@ import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.OperationWithAttributes;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.KeyValueScanner;
 import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.regionserver.Store;
+import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TxConstants;
@@ -44,7 +48,7 @@ import org.apache.tephra.hbase.coprocessor.TransactionProcessor;
 import org.apache.tephra.util.TxUtils;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -68,7 +72,9 @@ public class DefaultTransactionProcessor extends TransactionProcessor {
       String hbaseNamespacePrefix = tableDesc.getValue(Constants.Dataset.TABLE_PREFIX);
 
       this.sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(hbaseNamespacePrefix);
-      this.cConfCacheSupplier = new CConfigurationCacheSupplier(env.getConfiguration(), sysConfigTablePrefix);
+      this.cConfCacheSupplier = new CConfigurationCacheSupplier(env.getConfiguration(), sysConfigTablePrefix,
+                                                                TxConstants.Manager.CFG_TX_MAX_LIFETIME,
+                                                                TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME);
       this.cConfCache = cConfCacheSupplier.get();
     }
     // Need to create the cConf cache before calling start on the parent, since it is required for
@@ -83,55 +89,94 @@ public class DefaultTransactionProcessor extends TransactionProcessor {
   }
 
   @Override
+  public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+    reloadPruneState(e.getEnvironment());
+    super.postFlush(e);
+  }
+
+  @Override
+  public InternalScanner preCompactScannerOpen(ObserverContext<RegionCoprocessorEnvironment> c, Store store,
+                                               List<? extends KeyValueScanner> scanners, ScanType scanType,
+                                               long earliestPutTs, InternalScanner s,
+                                               CompactionRequest request) throws IOException {
+    reloadPruneState(c.getEnvironment());
+    return super.preCompactScannerOpen(c, store, scanners, scanType, earliestPutTs, s, request);
+  }
+
+  @Override
   protected void ensureValidTxLifetime(RegionCoprocessorEnvironment env, OperationWithAttributes op,
                                        @Nullable Transaction tx) throws IOException {
     if (tx == null) {
       return;
     }
 
-    long maxLifetimeMillis;
-    if (txMaxLifetimeMillis == null) {
-      Configuration conf = getConfiguration(env);
-      if (conf != null) {
-        this.txMaxLifetimeMillis = TimeUnit.SECONDS.toMillis(conf.getInt(TxConstants.Manager.CFG_TX_MAX_LIFETIME,
-                                                                         TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME));
-        maxLifetimeMillis = this.txMaxLifetimeMillis;
-      } else {
-        // Get maxLifetimeMillis from transaction attributes
-        byte[] maxLifetimeBytes = op.getAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY);
-        if (maxLifetimeBytes != null) {
-          maxLifetimeMillis = Bytes.toLong(maxLifetimeBytes);
-        } else {
-          LOG.warn("txMaxLifetimeMillis is not available in client's operation attributes. " +
-                     "Defaulting to default tx_max_lifetime");
-          maxLifetimeMillis = TimeUnit.SECONDS.toMillis(TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME);
-        }
-      }
-    } else {
-      maxLifetimeMillis = txMaxLifetimeMillis;
-    }
-
+    long currMaxLifetimeinMillis = getCurrMaxLifetime(env, op, cConfCache.getTxMaxLifetimeMillis());
+    // Since we don't always set the txMaxLifetimeMillis variable (in case when we get the info from the client)
+    // we need to compute whether the transaction is within the validLifetime boundary here instead of
+    // relying on the parent
     boolean validLifetime =
-      TxUtils.getTimestamp(tx.getTransactionId()) + maxLifetimeMillis > System.currentTimeMillis();
+      (TxUtils.getTimestamp(tx.getTransactionId()) + currMaxLifetimeinMillis) > System.currentTimeMillis();
     if (!validLifetime) {
       throw new DoNotRetryIOException(String.format("Transaction %s has exceeded max lifetime %s ms",
-                                                    tx.getTransactionId(), maxLifetimeMillis));
+                                                    tx.getTransactionId(), currMaxLifetimeinMillis));
+    }
+  }
+
+  private long getCurrMaxLifetime(RegionCoprocessorEnvironment env, OperationWithAttributes op,
+                                  @Nullable Long maxLifetimeFromConf) {
+    // If conf has the value, update the txMaxLifetimeMillis and return it
+    if (maxLifetimeFromConf != null) {
+      txMaxLifetimeMillis = maxLifetimeFromConf;
+      return maxLifetimeFromConf;
+    }
+
+    // This case shouldn't happen but in case current value from conf is null but it was set earlier, return that
+    if (txMaxLifetimeMillis != null) {
+      return txMaxLifetimeMillis;
+    }
+
+    // If value from conf is null, derive it from the attribute set by the client
+    byte[] maxLifetimeBytes = op.getAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY);
+    if (maxLifetimeBytes != null) {
+      return Bytes.toLong(maxLifetimeBytes);
+    }
+
+    // If maxLifetimeMillis could not be found in the client request as well, just use the default value
+    long defaultMaxLifeTimeInSecs = TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME;
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(String.format("txMaxLifetimeMillis is not available in client's operation attributes. " +
+                                "Defaulting to the default value of %d seconds for region %s.",
+                              defaultMaxLifeTimeInSecs, env.getRegionInfo().getRegionNameAsString()));
+    }
+    return TimeUnit.SECONDS.toMillis(defaultMaxLifeTimeInSecs);
+  }
+
+  private void reloadPruneState(RegionCoprocessorEnvironment env) {
+    if (pruneEnable == null) {
+      // If prune enable has never been initialized, try to do so now
+      initializePruneState(env);
+    } else {
+      Configuration conf = getConfiguration(env);
+      if (conf != null) {
+        boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                                 TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+        if (newPruneEnable != pruneEnable) {
+          // pruning enable has been changed, resetting prune state
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Transaction Invalid List pruning feature is set to %s now for region %s.",
+                                    newPruneEnable, env.getRegionInfo().getRegionNameAsString()));
+          }
+          resetPruneState();
+          initializePruneState(env);
+        }
+      }
     }
   }
 
   @Override
   @Nullable
   protected Configuration getConfiguration(CoprocessorEnvironment env) {
-    CConfiguration cConf = cConfCache.getCConf();
-    if (cConf == null) {
-      return null;
-    }
-
-    Configuration hConf = new Configuration();
-    for (Map.Entry<String, String> entry : cConf) {
-      hConf.set(entry.getKey(), entry.getValue());
-    }
-    return hConf;
+    return cConfCache.getConf();
   }
 
   @Override

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase10/HBaseQueueRegionObserver.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.InternalScanner;
 import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.regionserver.Store;
@@ -123,7 +124,7 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
       configCache = createConfigCache(env);
     }
   }
-  
+
   @Override
   public void stop(CoprocessorEnvironment e) {
     if (compactionState != null) {
@@ -151,28 +152,10 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
     }
 
     LOG.info("preCompact, creates EvictionInternalScanner");
-    ConsumerConfigCache consumerConfigCache = getConfigCache(e.getEnvironment());
     TransactionVisibilityState txVisibilityState = txStateCache.getLatestState();
 
-    if (pruneEnable == null) {
-      CConfiguration cConf = consumerConfigCache.getCConf();
-      if (cConf != null) {
-        pruneEnable = cConf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
-                                       TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
-        if (Boolean.TRUE.equals(pruneEnable)) {
-          String pruneTable = cConf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
-                                        TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
-          long pruneFlushInterval = TimeUnit.SECONDS.toMillis(
-            cConf.getLong(TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
-                          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
-          compactionState = new CompactionState(e.getEnvironment(), TableName.valueOf(pruneTable), pruneFlushInterval);
-          LOG.debug("Automatic invalid list pruning is enabled. Compaction state will be recorded in table " +
-                      pruneTable);
-        }
-      }
-    }
-
-    if (Boolean.TRUE.equals(pruneEnable)) {
+    reloadPruneState(e.getEnvironment());
+    if (compactionState != null) {
       // Record tx state before the compaction
       compactionState.record(request, txVisibilityState);
     }
@@ -186,6 +169,85 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
     // Persist the compaction state after a successful compaction
     if (this.compactionState != null) {
       this.compactionState.persist();
+    }
+  }
+
+  @Override
+  public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+    // Record whether the region is empty after a flush
+    HRegion region = e.getEnvironment().getRegion();
+    // After a flush, if the memstore size is zero and there are no store files for any stores in the region
+    // then the region must be empty
+    long numStoreFiles = numStoreFilesForRegion(e);
+    long memstoreSize = region.getMemstoreSize().get();
+    LOG.debug(String.format("Region %s: memstore size = %s, num store files = %s",
+                            region.getRegionInfo().getRegionNameAsString(), memstoreSize, numStoreFiles));
+    if (memstoreSize == 0 && numStoreFiles == 0) {
+      if (compactionState != null) {
+        compactionState.persistRegionEmpty(System.currentTimeMillis());
+      }
+    }
+  }
+
+  private long numStoreFilesForRegion(ObserverContext<RegionCoprocessorEnvironment> c) {
+    long numStoreFiles = 0;
+    for (Store store : c.getEnvironment().getRegion().getStores().values()) {
+      numStoreFiles += store.getStorefiles().size();
+    }
+    return numStoreFiles;
+  }
+
+  private void reloadPruneState(RegionCoprocessorEnvironment env) {
+    if (pruneEnable == null) {
+      // If prune enable has never been initialized, try to do so now
+      initializePruneState(env);
+    } else {
+      CConfiguration conf = getConfigCache(env).getCConf();
+      if (conf != null) {
+        boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                                 TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+        if (newPruneEnable != pruneEnable) {
+          // pruning enable has been changed, resetting prune state
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Transaction Invalid List pruning feature is set to %s now for region %s.",
+                                    newPruneEnable, env.getRegionInfo().getRegionNameAsString()));
+          }
+          resetPruneState();
+          initializePruneState(env);
+        }
+      }
+    }
+  }
+
+  private void initializePruneState(RegionCoprocessorEnvironment env) {
+    CConfiguration conf = getConfigCache(env).getCConf();
+    if (conf != null) {
+      pruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                    TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+
+      if (Boolean.TRUE.equals(pruneEnable)) {
+        String pruneTable = conf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
+                                     TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
+        long pruneFlushInterval = TimeUnit.SECONDS.toMillis(conf.getLong(
+          TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
+          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
+
+        compactionState = new CompactionState(env, TableName.valueOf(pruneTable), pruneFlushInterval);
+        if (LOG.isDebugEnabled()) {
+          TableName tableName = env.getRegionInfo().getTable();
+          LOG.debug(String.format("Automatic invalid list pruning is enabled for table %s:%s. Compaction state " +
+                                    "will be recorded in table %s", tableName.getNamespaceAsString(),
+                                  tableName.getNameAsString(), pruneTable));
+        }
+      }
+    }
+  }
+
+  private void resetPruneState() {
+    pruneEnable = false;
+    if (compactionState != null) {
+      compactionState.stop();
+      compactionState = null;
     }
   }
 

--- a/cdap-hbase-compat-1.1/pom.xml
+++ b/cdap-hbase-compat-1.1/pom.xml
@@ -62,10 +62,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.tephra</groupId>
-      <artifactId>tephra-hbase-compat-1.1</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
     </dependency>
@@ -193,7 +189,7 @@
                 </goals>
                 <configuration>
                   <excludeArtifactIds>*</excludeArtifactIds>
-                  <includeArtifactIds>tephra-hbase-compat-1.1</includeArtifactIds>
+                  <includeArtifactIds>${artifactId}</includeArtifactIds>
                   <silent>true</silent>
                   <includeScope>compile</includeScope>
                 </configuration>

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase11/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase11/DefaultTransactionProcessor.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.data2.transaction.coprocessor.hbase11;
 
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTable;
 import co.cask.cdap.data2.increment.hbase11.IncrementTxFilter;
@@ -32,9 +31,14 @@ import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.OperationWithAttributes;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.KeyValueScanner;
 import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.regionserver.Store;
+import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TxConstants;
@@ -44,7 +48,7 @@ import org.apache.tephra.hbase.coprocessor.TransactionProcessor;
 import org.apache.tephra.util.TxUtils;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -68,7 +72,9 @@ public class DefaultTransactionProcessor extends TransactionProcessor {
       String hbaseNamespacePrefix = tableDesc.getValue(Constants.Dataset.TABLE_PREFIX);
 
       this.sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(hbaseNamespacePrefix);
-      this.cConfCacheSupplier = new CConfigurationCacheSupplier(env.getConfiguration(), sysConfigTablePrefix);
+      this.cConfCacheSupplier = new CConfigurationCacheSupplier(env.getConfiguration(), sysConfigTablePrefix,
+                                                                TxConstants.Manager.CFG_TX_MAX_LIFETIME,
+                                                                TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME);
       this.cConfCache = cConfCacheSupplier.get();
     }
     // Need to create the cConf cache before calling start on the parent, since it is required for
@@ -83,55 +89,94 @@ public class DefaultTransactionProcessor extends TransactionProcessor {
   }
 
   @Override
+  public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+    reloadPruneState(e.getEnvironment());
+    super.postFlush(e);
+  }
+
+  @Override
+  public InternalScanner preCompactScannerOpen(ObserverContext<RegionCoprocessorEnvironment> c, Store store,
+                                               List<? extends KeyValueScanner> scanners, ScanType scanType,
+                                               long earliestPutTs, InternalScanner s,
+                                               CompactionRequest request) throws IOException {
+    reloadPruneState(c.getEnvironment());
+    return super.preCompactScannerOpen(c, store, scanners, scanType, earliestPutTs, s, request);
+  }
+
+  @Override
   protected void ensureValidTxLifetime(RegionCoprocessorEnvironment env, OperationWithAttributes op,
                                        @Nullable Transaction tx) throws IOException {
     if (tx == null) {
       return;
     }
 
-    long maxLifetimeMillis;
-    if (txMaxLifetimeMillis == null) {
-      Configuration conf = getConfiguration(env);
-      if (conf != null) {
-        this.txMaxLifetimeMillis = TimeUnit.SECONDS.toMillis(conf.getInt(TxConstants.Manager.CFG_TX_MAX_LIFETIME,
-                                                                         TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME));
-        maxLifetimeMillis = this.txMaxLifetimeMillis;
-      } else {
-        // Get maxLifetimeMillis from transaction attributes
-        byte[] maxLifetimeBytes = op.getAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY);
-        if (maxLifetimeBytes != null) {
-          maxLifetimeMillis = Bytes.toLong(maxLifetimeBytes);
-        } else {
-          LOG.warn("txMaxLifetimeMillis is not available in client's operation attributes. " +
-                     "Defaulting to default tx_max_lifetime");
-          maxLifetimeMillis = TimeUnit.SECONDS.toMillis(TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME);
-        }
-      }
-    } else {
-      maxLifetimeMillis = txMaxLifetimeMillis;
-    }
-
+    long currMaxLifetimeinMillis = getCurrMaxLifetime(env, op, cConfCache.getTxMaxLifetimeMillis());
+    // Since we don't always set the txMaxLifetimeMillis variable (in case when we get the info from the client)
+    // we need to compute whether the transaction is within the validLifetime boundary here instead of
+    // relying on the parent
     boolean validLifetime =
-      TxUtils.getTimestamp(tx.getTransactionId()) + maxLifetimeMillis > System.currentTimeMillis();
+      (TxUtils.getTimestamp(tx.getTransactionId()) + currMaxLifetimeinMillis) > System.currentTimeMillis();
     if (!validLifetime) {
       throw new DoNotRetryIOException(String.format("Transaction %s has exceeded max lifetime %s ms",
-                                                    tx.getTransactionId(), maxLifetimeMillis));
+                                                    tx.getTransactionId(), currMaxLifetimeinMillis));
+    }
+  }
+
+  private long getCurrMaxLifetime(RegionCoprocessorEnvironment env, OperationWithAttributes op,
+                                  @Nullable Long maxLifetimeFromConf) {
+    // If conf has the value, update the txMaxLifetimeMillis and return it
+    if (maxLifetimeFromConf != null) {
+      txMaxLifetimeMillis = maxLifetimeFromConf;
+      return maxLifetimeFromConf;
+    }
+
+    // This case shouldn't happen but in case current value from conf is null but it was set earlier, return that
+    if (txMaxLifetimeMillis != null) {
+      return txMaxLifetimeMillis;
+    }
+
+    // If value from conf is null, derive it from the attribute set by the client
+    byte[] maxLifetimeBytes = op.getAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY);
+    if (maxLifetimeBytes != null) {
+      return Bytes.toLong(maxLifetimeBytes);
+    }
+
+    // If maxLifetimeMillis could not be found in the client request as well, just use the default value
+    long defaultMaxLifeTimeInSecs = TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME;
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(String.format("txMaxLifetimeMillis is not available in client's operation attributes. " +
+                                "Defaulting to the default value of %d seconds for region %s.",
+                              defaultMaxLifeTimeInSecs, env.getRegionInfo().getRegionNameAsString()));
+    }
+    return TimeUnit.SECONDS.toMillis(defaultMaxLifeTimeInSecs);
+  }
+
+  private void reloadPruneState(RegionCoprocessorEnvironment env) {
+    if (pruneEnable == null) {
+      // If prune enable has never been initialized, try to do so now
+      initializePruneState(env);
+    } else {
+      Configuration conf = getConfiguration(env);
+      if (conf != null) {
+        boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                                 TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+        if (newPruneEnable != pruneEnable) {
+          // pruning enable has been changed, resetting prune state
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Transaction Invalid List pruning feature is set to %s now for region %s.",
+                                    newPruneEnable, env.getRegionInfo().getRegionNameAsString()));
+          }
+          resetPruneState();
+          initializePruneState(env);
+        }
+      }
     }
   }
 
   @Override
   @Nullable
   protected Configuration getConfiguration(CoprocessorEnvironment env) {
-    CConfiguration cConf = cConfCache.getCConf();
-    if (cConf == null) {
-      return null;
-    }
-
-    Configuration hConf = new Configuration();
-    for (Map.Entry<String, String> entry : cConf) {
-      hConf.set(entry.getKey(), entry.getValue());
-    }
-    return hConf;
+    return cConfCache.getConf();
   }
 
   @Override

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase11/MessageTableRegionObserver.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase11/MessageTableRegionObserver.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.filter.FilterBase;
 import org.apache.hadoop.hbase.regionserver.InternalScanner;
 import org.apache.hadoop.hbase.regionserver.KeyValueScanner;
+import org.apache.hadoop.hbase.regionserver.Region;
 import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.regionserver.ScannerContext;
 import org.apache.hadoop.hbase.regionserver.Store;
@@ -130,6 +131,23 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
   }
 
   @Override
+  public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+    // Record whether the region is empty after a flush
+    Region region = e.getEnvironment().getRegion();
+    // After a flush, if the memstore size is zero and there are no store files for any stores in the region
+    // then the region must be empty
+    long numStoreFiles = numStoreFilesForRegion(e);
+    long memstoreSize = region.getMemstoreSize();
+    LOG.debug(String.format("Region %s: memstore size = %s, num store files = %s",
+                            region.getRegionInfo().getRegionNameAsString(), memstoreSize, numStoreFiles));
+    if (memstoreSize == 0 && numStoreFiles == 0) {
+      if (compactionState != null) {
+        compactionState.persistRegionEmpty(System.currentTimeMillis());
+      }
+    }
+  }
+
+  @Override
   public InternalScanner preCompactScannerOpen(ObserverContext<RegionCoprocessorEnvironment> c, Store store,
                                                List<? extends KeyValueScanner> scanners, ScanType scanType,
                                                long earliestPutTs, InternalScanner s,
@@ -137,25 +155,8 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     LOG.info("preCompact, filter using MessageDataFilter");
     TransactionVisibilityState txVisibilityState = txStateCache.getLatestState();
 
-    if (pruneEnable == null) {
-      CConfiguration cConf = topicMetadataCache.getCConfiguration();
-      if (cConf != null) {
-        pruneEnable = cConf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
-                                       TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
-        if (Boolean.TRUE.equals(pruneEnable)) {
-          String pruneTable = cConf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
-                                        TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
-          long pruneFlushInterval = TimeUnit.SECONDS.toMillis(
-            cConf.getLong(TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
-                          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
-          compactionState = new CompactionState(c.getEnvironment(), TableName.valueOf(pruneTable), pruneFlushInterval);
-          LOG.debug("Automatic invalid list pruning is enabled. Compaction state will be recorded in table " +
-                      pruneTable);
-        }
-      }
-    }
-
-    if (Boolean.TRUE.equals(pruneEnable)) {
+    reloadPruneState(c.getEnvironment());
+    if (compactionState != null) {
       // Record tx state before the compaction
       compactionState.record(request, txVisibilityState);
     }
@@ -174,6 +175,59 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     // Persist the compaction state after a successful compaction
     if (compactionState != null) {
       compactionState.persist();
+    }
+  }
+
+  private void reloadPruneState(RegionCoprocessorEnvironment env) {
+    if (pruneEnable == null) {
+      // If prune enable has never been initialized, try to do so now
+      initializePruneState(env);
+    } else {
+      CConfiguration conf = topicMetadataCache.getCConfiguration();
+      if (conf != null) {
+        boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                                 TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+        if (newPruneEnable != pruneEnable) {
+          // pruning enable has been changed, resetting prune state
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Transaction Invalid List pruning feature is set to %s now for region %s.",
+                                    newPruneEnable, env.getRegionInfo().getRegionNameAsString()));
+          }
+          resetPruneState();
+          initializePruneState(env);
+        }
+      }
+    }
+  }
+
+  private void initializePruneState(RegionCoprocessorEnvironment env) {
+    CConfiguration conf = topicMetadataCache.getCConfiguration();
+    if (conf != null) {
+      pruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                    TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+
+      if (Boolean.TRUE.equals(pruneEnable)) {
+        String pruneTable = conf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
+                                     TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
+        long pruneFlushInterval = TimeUnit.SECONDS.toMillis(conf.getLong(
+          TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
+          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
+
+        compactionState = new CompactionState(env, TableName.valueOf(pruneTable), pruneFlushInterval);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug(String.format("Automatic invalid list pruning is enabled for table %s. Compaction state " +
+                                    "will be recorded in table %s",
+                                  env.getRegionInfo().getTable().getNameWithNamespaceInclAsString(), pruneTable));
+        }
+      }
+    }
+  }
+
+  private void resetPruneState() {
+    pruneEnable = false;
+    if (compactionState != null) {
+      compactionState.stop();
+      compactionState = null;
     }
   }
 
@@ -216,6 +270,14 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
       }
       delegate.close();
     }
+  }
+
+  private long numStoreFilesForRegion(ObserverContext<RegionCoprocessorEnvironment> c) {
+    long numStoreFiles = 0;
+    for (Store store : c.getEnvironment().getRegion().getStores()) {
+      numStoreFiles += store.getStorefiles().size();
+    }
+    return numStoreFiles;
   }
 
   private static final class MessageDataFilter extends FilterBase {

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase11/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase11/HBaseQueueRegionObserver.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.Region;
 import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.regionserver.ScannerContext;
 import org.apache.hadoop.hbase.regionserver.Store;
@@ -152,28 +153,10 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
     }
 
     LOG.info("preCompact, creates EvictionInternalScanner");
-    ConsumerConfigCache consumerConfigCache = getConfigCache(e.getEnvironment());
     TransactionVisibilityState txVisibilityState = txStateCache.getLatestState();
 
-    if (pruneEnable == null) {
-      CConfiguration cConf = consumerConfigCache.getCConf();
-      if (cConf != null) {
-        pruneEnable = cConf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
-                                       TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
-        if (Boolean.TRUE.equals(pruneEnable)) {
-          String pruneTable = cConf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
-                                        TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
-          long pruneFlushInterval = TimeUnit.SECONDS.toMillis(
-            cConf.getLong(TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
-                          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
-          compactionState = new CompactionState(e.getEnvironment(), TableName.valueOf(pruneTable), pruneFlushInterval);
-          LOG.debug("Automatic invalid list pruning is enabled. Compaction state will be recorded in table " +
-                      pruneTable);
-        }
-      }
-    }
-
-    if (Boolean.TRUE.equals(pruneEnable)) {
+    reloadPruneState(e.getEnvironment());
+    if (compactionState != null) {
       // Record tx state before the compaction
       compactionState.record(request, txVisibilityState);
     }
@@ -187,6 +170,84 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
     // Persist the compaction state after a successful compaction
     if (this.compactionState != null) {
       this.compactionState.persist();
+    }
+  }
+
+  @Override
+  public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+    // Record whether the region is empty after a flush
+    Region region = e.getEnvironment().getRegion();
+    // After a flush, if the memstore size is zero and there are no store files for any stores in the region
+    // then the region must be empty
+    long numStoreFiles = numStoreFilesForRegion(e);
+    long memstoreSize = region.getMemstoreSize();
+    LOG.debug(String.format("Region %s: memstore size = %s, num store files = %s",
+                            region.getRegionInfo().getRegionNameAsString(), memstoreSize, numStoreFiles));
+    if (memstoreSize == 0 && numStoreFiles == 0) {
+      if (compactionState != null) {
+        compactionState.persistRegionEmpty(System.currentTimeMillis());
+      }
+    }
+  }
+
+  private long numStoreFilesForRegion(ObserverContext<RegionCoprocessorEnvironment> c) {
+    long numStoreFiles = 0;
+    for (Store store : c.getEnvironment().getRegion().getStores()) {
+      numStoreFiles += store.getStorefiles().size();
+    }
+    return numStoreFiles;
+  }
+
+  private void reloadPruneState(RegionCoprocessorEnvironment env) {
+    if (pruneEnable == null) {
+      // If prune enable has never been initialized, try to do so now
+      initializePruneState(env);
+    } else {
+      CConfiguration conf = getConfigCache(env).getCConf();
+      if (conf != null) {
+        boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                                 TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+        if (newPruneEnable != pruneEnable) {
+          // pruning enable has been changed, resetting prune state
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Transaction Invalid List pruning feature is set to %s now for region %s.",
+                                    newPruneEnable, env.getRegionInfo().getRegionNameAsString()));
+          }
+          resetPruneState();
+          initializePruneState(env);
+        }
+      }
+    }
+  }
+
+  private void initializePruneState(RegionCoprocessorEnvironment env) {
+    CConfiguration conf = getConfigCache(env).getCConf();
+    if (conf != null) {
+      pruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                    TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+
+      if (Boolean.TRUE.equals(pruneEnable)) {
+        String pruneTable = conf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
+                                     TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
+        long pruneFlushInterval = TimeUnit.SECONDS.toMillis(conf.getLong(
+          TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
+          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
+
+        compactionState = new CompactionState(env, TableName.valueOf(pruneTable), pruneFlushInterval);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug(String.format("Automatic invalid list pruning is enabled for table %s. Compaction state " +
+                                    "will be recorded in table %s",
+                                  env.getRegionInfo().getTable().getNameWithNamespaceInclAsString(), pruneTable));
+        }
+      }
+    }
+  }
+
+  private void resetPruneState() {
+    pruneEnable = false;
+    if (compactionState != null) {
+      compactionState.stop();
+      compactionState = null;
     }
   }
 

--- a/cdap-hbase-compat-1.2-cdh5.7.0/pom.xml
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/pom.xml
@@ -66,10 +66,6 @@
     <version>${project.version}</version>
   </dependency>
   <dependency>
-    <groupId>org.apache.tephra</groupId>
-    <artifactId>tephra-hbase-compat-1.1</artifactId>
-  </dependency>
-  <dependency>
     <groupId>org.apache.hadoop</groupId>
     <artifactId>hadoop-common</artifactId>
   </dependency>
@@ -196,7 +192,7 @@
                 </goals>
                 <configuration>
                   <excludeArtifactIds>*</excludeArtifactIds>
-                  <includeArtifactIds>tephra-hbase-compat-1.1</includeArtifactIds>
+                  <includeArtifactIds>${artifactId}</includeArtifactIds>
                   <silent>true</silent>
                   <includeScope>compile</includeScope>
                 </configuration>

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase12cdh570/DefaultTransactionProcessor.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/coprocessor/hbase12cdh570/DefaultTransactionProcessor.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.data2.transaction.coprocessor.hbase12cdh570;
 
-import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.lib.table.hbase.HBaseTable;
 import co.cask.cdap.data2.increment.hbase12cdh570.IncrementTxFilter;
@@ -32,9 +31,14 @@ import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.OperationWithAttributes;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.KeyValueScanner;
 import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.regionserver.Store;
+import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TxConstants;
@@ -44,12 +48,12 @@ import org.apache.tephra.hbase.coprocessor.TransactionProcessor;
 import org.apache.tephra.util.TxUtils;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
- * Implementation of the {@link TransactionProcessor}
+ * Implementation of the {@link org.apache.tephra.hbase.coprocessor.TransactionProcessor}
  * coprocessor that uses {@link co.cask.cdap.data2.transaction.coprocessor.DefaultTransactionStateCache}
  * to automatically refresh transaction state.
  */
@@ -68,7 +72,9 @@ public class DefaultTransactionProcessor extends TransactionProcessor {
       String hbaseNamespacePrefix = tableDesc.getValue(Constants.Dataset.TABLE_PREFIX);
 
       this.sysConfigTablePrefix = HTableNameConverter.getSysConfigTablePrefix(hbaseNamespacePrefix);
-      this.cConfCacheSupplier = new CConfigurationCacheSupplier(env.getConfiguration(), sysConfigTablePrefix);
+      this.cConfCacheSupplier = new CConfigurationCacheSupplier(env.getConfiguration(), sysConfigTablePrefix,
+                                                                TxConstants.Manager.CFG_TX_MAX_LIFETIME,
+                                                                TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME);
       this.cConfCache = cConfCacheSupplier.get();
     }
     // Need to create the cConf cache before calling start on the parent, since it is required for
@@ -83,55 +89,94 @@ public class DefaultTransactionProcessor extends TransactionProcessor {
   }
 
   @Override
+  public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+    reloadPruneState(e.getEnvironment());
+    super.postFlush(e);
+  }
+
+  @Override
+  public InternalScanner preCompactScannerOpen(ObserverContext<RegionCoprocessorEnvironment> c, Store store,
+                                               List<? extends KeyValueScanner> scanners, ScanType scanType,
+                                               long earliestPutTs, InternalScanner s,
+                                               CompactionRequest request) throws IOException {
+    reloadPruneState(c.getEnvironment());
+    return super.preCompactScannerOpen(c, store, scanners, scanType, earliestPutTs, s, request);
+  }
+
+  @Override
   protected void ensureValidTxLifetime(RegionCoprocessorEnvironment env, OperationWithAttributes op,
                                        @Nullable Transaction tx) throws IOException {
     if (tx == null) {
       return;
     }
 
-    long maxLifetimeMillis;
-    if (txMaxLifetimeMillis == null) {
-      Configuration conf = getConfiguration(env);
-      if (conf != null) {
-        this.txMaxLifetimeMillis = TimeUnit.SECONDS.toMillis(conf.getInt(TxConstants.Manager.CFG_TX_MAX_LIFETIME,
-                                                                         TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME));
-        maxLifetimeMillis = this.txMaxLifetimeMillis;
-      } else {
-        // Get maxLifetimeMillis from transaction attributes
-        byte[] maxLifetimeBytes = op.getAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY);
-        if (maxLifetimeBytes != null) {
-          maxLifetimeMillis = Bytes.toLong(maxLifetimeBytes);
-        } else {
-          LOG.warn("txMaxLifetimeMillis is not available in client's operation attributes. " +
-                     "Defaulting to default tx_max_lifetime");
-          maxLifetimeMillis = TimeUnit.SECONDS.toMillis(TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME);
-        }
-      }
-    } else {
-      maxLifetimeMillis = txMaxLifetimeMillis;
-    }
-
+    long currMaxLifetimeinMillis = getCurrMaxLifetime(env, op, cConfCache.getTxMaxLifetimeMillis());
+    // Since we don't always set the txMaxLifetimeMillis variable (in case when we get the info from the client)
+    // we need to compute whether the transaction is within the validLifetime boundary here instead of
+    // relying on the parent
     boolean validLifetime =
-      TxUtils.getTimestamp(tx.getTransactionId()) + maxLifetimeMillis > System.currentTimeMillis();
+      (TxUtils.getTimestamp(tx.getTransactionId()) + currMaxLifetimeinMillis) > System.currentTimeMillis();
     if (!validLifetime) {
       throw new DoNotRetryIOException(String.format("Transaction %s has exceeded max lifetime %s ms",
-                                                    tx.getTransactionId(), maxLifetimeMillis));
+                                                    tx.getTransactionId(), currMaxLifetimeinMillis));
+    }
+  }
+
+  private long getCurrMaxLifetime(RegionCoprocessorEnvironment env, OperationWithAttributes op,
+                                  @Nullable Long maxLifetimeFromConf) {
+    // If conf has the value, update the txMaxLifetimeMillis and return it
+    if (maxLifetimeFromConf != null) {
+      txMaxLifetimeMillis = maxLifetimeFromConf;
+      return maxLifetimeFromConf;
+    }
+
+    // This case shouldn't happen but in case current value from conf is null but it was set earlier, return that
+    if (txMaxLifetimeMillis != null) {
+      return txMaxLifetimeMillis;
+    }
+
+    // If value from conf is null, derive it from the attribute set by the client
+    byte[] maxLifetimeBytes = op.getAttribute(HBaseTable.TX_MAX_LIFETIME_MILLIS_KEY);
+    if (maxLifetimeBytes != null) {
+      return Bytes.toLong(maxLifetimeBytes);
+    }
+
+    // If maxLifetimeMillis could not be found in the client request as well, just use the default value
+    long defaultMaxLifeTimeInSecs = TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME;
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(String.format("txMaxLifetimeMillis is not available in client's operation attributes. " +
+                                "Defaulting to the default value of %d seconds for region %s.",
+                              defaultMaxLifeTimeInSecs, env.getRegionInfo().getRegionNameAsString()));
+    }
+    return TimeUnit.SECONDS.toMillis(defaultMaxLifeTimeInSecs);
+  }
+
+  private void reloadPruneState(RegionCoprocessorEnvironment env) {
+    if (pruneEnable == null) {
+      // If prune enable has never been initialized, try to do so now
+      initializePruneState(env);
+    } else {
+      Configuration conf = getConfiguration(env);
+      if (conf != null) {
+        boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                                 TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+        if (newPruneEnable != pruneEnable) {
+          // pruning enable has been changed, resetting prune state
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Transaction Invalid List pruning feature is set to %s now for region %s.",
+                                    newPruneEnable, env.getRegionInfo().getRegionNameAsString()));
+          }
+          resetPruneState();
+          initializePruneState(env);
+        }
+      }
     }
   }
 
   @Override
   @Nullable
   protected Configuration getConfiguration(CoprocessorEnvironment env) {
-    CConfiguration cConf = cConfCache.getCConf();
-    if (cConf == null) {
-      return null;
-    }
-
-    Configuration hConf = new Configuration();
-    for (Map.Entry<String, String> entry : cConf) {
-      hConf.set(entry.getKey(), entry.getValue());
-    }
-    return hConf;
+    return cConfCache.getConf();
   }
 
   @Override

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase12cdh570/MessageTableRegionObserver.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/messaging/coprocessor/hbase12cdh570/MessageTableRegionObserver.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.filter.FilterBase;
 import org.apache.hadoop.hbase.regionserver.InternalScanner;
 import org.apache.hadoop.hbase.regionserver.KeyValueScanner;
+import org.apache.hadoop.hbase.regionserver.Region;
 import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.regionserver.ScannerContext;
 import org.apache.hadoop.hbase.regionserver.Store;
@@ -130,6 +131,23 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
   }
 
   @Override
+  public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+    // Record whether the region is empty after a flush
+    Region region = e.getEnvironment().getRegion();
+    // After a flush, if the memstore size is zero and there are no store files for any stores in the region
+    // then the region must be empty
+    long numStoreFiles = numStoreFilesForRegion(e);
+    long memstoreSize = region.getMemstoreSize();
+    LOG.debug(String.format("Region %s: memstore size = %s, num store files = %s",
+                            region.getRegionInfo().getRegionNameAsString(), memstoreSize, numStoreFiles));
+    if (memstoreSize == 0 && numStoreFiles == 0) {
+      if (compactionState != null) {
+        compactionState.persistRegionEmpty(System.currentTimeMillis());
+      }
+    }
+  }
+
+  @Override
   public InternalScanner preCompactScannerOpen(ObserverContext<RegionCoprocessorEnvironment> c, Store store,
                                                List<? extends KeyValueScanner> scanners, ScanType scanType,
                                                long earliestPutTs, InternalScanner s,
@@ -137,25 +155,8 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     LOG.info("preCompact, filter using MessageDataFilter");
     TransactionVisibilityState txVisibilityState = txStateCache.getLatestState();
 
-    if (pruneEnable == null) {
-      CConfiguration cConf = topicMetadataCache.getCConfiguration();
-      if (cConf != null) {
-        pruneEnable = cConf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
-                                       TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
-        if (Boolean.TRUE.equals(pruneEnable)) {
-          String pruneTable = cConf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
-                                        TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
-          long pruneFlushInterval = TimeUnit.SECONDS.toMillis(
-            cConf.getLong(TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
-                          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
-          compactionState = new CompactionState(c.getEnvironment(), TableName.valueOf(pruneTable), pruneFlushInterval);
-          LOG.debug("Automatic invalid list pruning is enabled. Compaction state will be recorded in table " +
-                      pruneTable);
-        }
-      }
-    }
-
-    if (Boolean.TRUE.equals(pruneEnable)) {
+    reloadPruneState(c.getEnvironment());
+    if (compactionState != null) {
       // Record tx state before the compaction
       compactionState.record(request, txVisibilityState);
     }
@@ -174,6 +175,59 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
     // Persist the compaction state after a successful compaction
     if (compactionState != null) {
       compactionState.persist();
+    }
+  }
+
+  private void reloadPruneState(RegionCoprocessorEnvironment env) {
+    if (pruneEnable == null) {
+      // If prune enable has never been initialized, try to do so now
+      initializePruneState(env);
+    } else {
+      CConfiguration conf = topicMetadataCache.getCConfiguration();
+      if (conf != null) {
+        boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                                 TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+        if (newPruneEnable != pruneEnable) {
+          // pruning enable has been changed, resetting prune state
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Transaction Invalid List pruning feature is set to %s now for region %s.",
+                                    newPruneEnable, env.getRegionInfo().getRegionNameAsString()));
+          }
+          resetPruneState();
+          initializePruneState(env);
+        }
+      }
+    }
+  }
+
+  private void initializePruneState(RegionCoprocessorEnvironment env) {
+    CConfiguration conf = topicMetadataCache.getCConfiguration();
+    if (conf != null) {
+      pruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                    TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+
+      if (Boolean.TRUE.equals(pruneEnable)) {
+        String pruneTable = conf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
+                                     TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
+        long pruneFlushInterval = TimeUnit.SECONDS.toMillis(conf.getLong(
+          TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
+          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
+
+        compactionState = new CompactionState(env, TableName.valueOf(pruneTable), pruneFlushInterval);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug(String.format("Automatic invalid list pruning is enabled for table %s. Compaction state " +
+                                    "will be recorded in table %s",
+                                  env.getRegionInfo().getTable().getNameWithNamespaceInclAsString(), pruneTable));
+        }
+      }
+    }
+  }
+
+  private void resetPruneState() {
+    pruneEnable = false;
+    if (compactionState != null) {
+      compactionState.stop();
+      compactionState = null;
     }
   }
 
@@ -216,6 +270,14 @@ public class MessageTableRegionObserver extends BaseRegionObserver {
       }
       delegate.close();
     }
+  }
+
+  private long numStoreFilesForRegion(ObserverContext<RegionCoprocessorEnvironment> c) {
+    long numStoreFiles = 0;
+    for (Store store : c.getEnvironment().getRegion().getStores()) {
+      numStoreFiles += store.getStorefiles().size();
+    }
+    return numStoreFiles;
   }
 
   private static final class MessageDataFilter extends FilterBase {

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase12cdh570/HBaseQueueRegionObserver.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/transaction/queue/coprocessor/hbase12cdh570/HBaseQueueRegionObserver.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.Region;
 import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.regionserver.ScannerContext;
 import org.apache.hadoop.hbase.regionserver.Store;
@@ -152,28 +153,10 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
     }
 
     LOG.info("preCompact, creates EvictionInternalScanner");
-    ConsumerConfigCache consumerConfigCache = getConfigCache(e.getEnvironment());
     TransactionVisibilityState txVisibilityState = txStateCache.getLatestState();
 
-    if (pruneEnable == null) {
-      CConfiguration cConf = consumerConfigCache.getCConf();
-      if (cConf != null) {
-        pruneEnable = cConf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
-                                       TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
-        if (Boolean.TRUE.equals(pruneEnable)) {
-          String pruneTable = cConf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
-                                        TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
-          long pruneFlushInterval = TimeUnit.SECONDS.toMillis(
-            cConf.getLong(TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
-                          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
-          compactionState = new CompactionState(e.getEnvironment(), TableName.valueOf(pruneTable), pruneFlushInterval);
-          LOG.debug("Automatic invalid list pruning is enabled. Compaction state will be recorded in table " +
-                      pruneTable);
-        }
-      }
-    }
-
-    if (Boolean.TRUE.equals(pruneEnable)) {
+    reloadPruneState(e.getEnvironment());
+    if (compactionState != null) {
       // Record tx state before the compaction
       compactionState.record(request, txVisibilityState);
     }
@@ -187,6 +170,84 @@ public final class HBaseQueueRegionObserver extends BaseRegionObserver {
     // Persist the compaction state after a successful compaction
     if (this.compactionState != null) {
       this.compactionState.persist();
+    }
+  }
+
+  @Override
+  public void postFlush(ObserverContext<RegionCoprocessorEnvironment> e) throws IOException {
+    // Record whether the region is empty after a flush
+    Region region = e.getEnvironment().getRegion();
+    // After a flush, if the memstore size is zero and there are no store files for any stores in the region
+    // then the region must be empty
+    long numStoreFiles = numStoreFilesForRegion(e);
+    long memstoreSize = region.getMemstoreSize();
+    LOG.debug(String.format("Region %s: memstore size = %s, num store files = %s",
+                            region.getRegionInfo().getRegionNameAsString(), memstoreSize, numStoreFiles));
+    if (memstoreSize == 0 && numStoreFiles == 0) {
+      if (compactionState != null) {
+        compactionState.persistRegionEmpty(System.currentTimeMillis());
+      }
+    }
+  }
+
+  private long numStoreFilesForRegion(ObserverContext<RegionCoprocessorEnvironment> c) {
+    long numStoreFiles = 0;
+    for (Store store : c.getEnvironment().getRegion().getStores()) {
+      numStoreFiles += store.getStorefiles().size();
+    }
+    return numStoreFiles;
+  }
+
+  private void reloadPruneState(RegionCoprocessorEnvironment env) {
+    if (pruneEnable == null) {
+      // If prune enable has never been initialized, try to do so now
+      initializePruneState(env);
+    } else {
+      CConfiguration conf = getConfigCache(env).getCConf();
+      if (conf != null) {
+        boolean newPruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                                 TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+        if (newPruneEnable != pruneEnable) {
+          // pruning enable has been changed, resetting prune state
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Transaction Invalid List pruning feature is set to %s now for region %s.",
+                                    newPruneEnable, env.getRegionInfo().getRegionNameAsString()));
+          }
+          resetPruneState();
+          initializePruneState(env);
+        }
+      }
+    }
+  }
+
+  private void initializePruneState(RegionCoprocessorEnvironment env) {
+    CConfiguration conf = getConfigCache(env).getCConf();
+    if (conf != null) {
+      pruneEnable = conf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
+                                    TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
+
+      if (Boolean.TRUE.equals(pruneEnable)) {
+        String pruneTable = conf.get(TxConstants.TransactionPruning.PRUNE_STATE_TABLE,
+                                     TxConstants.TransactionPruning.DEFAULT_PRUNE_STATE_TABLE);
+        long pruneFlushInterval = TimeUnit.SECONDS.toMillis(conf.getLong(
+          TxConstants.TransactionPruning.PRUNE_FLUSH_INTERVAL,
+          TxConstants.TransactionPruning.DEFAULT_PRUNE_FLUSH_INTERVAL));
+
+        compactionState = new CompactionState(env, TableName.valueOf(pruneTable), pruneFlushInterval);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug(String.format("Automatic invalid list pruning is enabled for table %s. Compaction state " +
+                                    "will be recorded in table %s",
+                                  env.getRegionInfo().getTable().getNameWithNamespaceInclAsString(), pruneTable));
+        }
+      }
+    }
+  }
+
+  private void resetPruneState() {
+    pruneEnable = false;
+    if (compactionState != null) {
+      compactionState.stop();
+      compactionState = null;
     }
   }
 

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/transaction/coprocessor/CConfigurationCacheSupplier.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/transaction/coprocessor/CConfigurationCacheSupplier.java
@@ -29,11 +29,12 @@ public class CConfigurationCacheSupplier implements CacheSupplier<CConfiguration
 
   private final Supplier<CConfigurationCache> supplier;
 
-  public CConfigurationCacheSupplier(final Configuration hConf, final String sysConfTablePrefix) {
+  public CConfigurationCacheSupplier(final Configuration hConf, final String sysConfTablePrefix,
+                                     final String maxLifetimeProperty, final int defaultMaxLifetime) {
     this.supplier = new Supplier<CConfigurationCache>() {
       @Override
       public CConfigurationCache get() {
-        return new CConfigurationCache(hConf, sysConfTablePrefix);
+        return new CConfigurationCache(hConf, sysConfTablePrefix, maxLifetimeProperty, defaultMaxLifetime);
       }
     };
   }

--- a/cdap-hbase-compat-base/src/test/java/co/cask/cdap/data2/util/ReferenceCountedSupplierTests.java
+++ b/cdap-hbase-compat-base/src/test/java/co/cask/cdap/data2/util/ReferenceCountedSupplierTests.java
@@ -42,12 +42,13 @@ public class ReferenceCountedSupplierTests {
   private static final Log LOG = LogFactory.getLog(ReferenceCountedSupplierTests.class);
   private static final int NUM_OPS = 100;
   private static final int NUM_THREADS = 5;
+  private static final String DUMMY_PROPERTY = "dummyProperty";
 
   @Test
   public void testSupplier() throws Exception {
     // ReferenceCountSupplier is created only once per CacheSupplier class. Thus it is fine to create separate
     // CacheSupplier objects
-    CacheSupplier cConfSupplier = new CConfigurationCacheSupplier(null, null);
+    CacheSupplier cConfSupplier = new CConfigurationCacheSupplier(null, null, DUMMY_PROPERTY, Integer.MAX_VALUE);
     testGetSupplier(Lists.newArrayList(cConfSupplier));
     testReleaseSupplier(Lists.newArrayList(cConfSupplier));
 
@@ -57,8 +58,10 @@ public class ReferenceCountedSupplierTests {
     }
 
     // Test increase and decrease of counts for cConf supplier
-    testGetSupplier(Lists.<CacheSupplier>newArrayList(new CConfigurationCacheSupplier(null, null)));
-    testReleaseSupplier(Lists.<CacheSupplier>newArrayList(new CConfigurationCacheSupplier(null, null)));
+    testGetSupplier(Lists.<CacheSupplier>newArrayList(new CConfigurationCacheSupplier(null, null, DUMMY_PROPERTY,
+                                                                                      Integer.MAX_VALUE)));
+    testReleaseSupplier(Lists.<CacheSupplier>newArrayList(new CConfigurationCacheSupplier(null, null, DUMMY_PROPERTY,
+                                                                                          Integer.MAX_VALUE)));
 
     // Repeat the tests for TopicMetadata CacheSupplier
     testGetSupplier(Lists.<CacheSupplier>newArrayList(new TopicMetadataCacheSupplier(null, null, null, null, null)));
@@ -70,7 +73,7 @@ public class ReferenceCountedSupplierTests {
 
     // Tests multiple suppliers at the same time
     List<CacheSupplier> cacheSupplierList = new ArrayList<>();
-    cacheSupplierList.add(new CConfigurationCacheSupplier(null, null));
+    cacheSupplierList.add(new CConfigurationCacheSupplier(null, null, DUMMY_PROPERTY, Integer.MAX_VALUE));
     cacheSupplierList.add(new TopicMetadataCacheSupplier(null, null, null, null, null));
     testGetSupplier(cacheSupplierList);
     testReleaseSupplier(cacheSupplierList);


### PR DESCRIPTION
We want to support turning of pruning without restarting HBase. This PR will try to load the property every time before compaction so that if there is a change in the prune enable value, we can stop or start the compactionState as required.

Also, we want to read the txMaxLifetimeMillis everytime we want to ensure that the operation within the valid lifetime. Since we don't want to convert CConfiguration -> Configuration every time we make this call, moving that conversion to CConfigurationCache thread.

We can also rename the CConfigurationCache and use the getConf method in all modules instead of getCConf.

JIRA : https://issues.cask.co/browse/CDAP-8623
Build : http://builds.cask.co/browse/CDAP-RUT602