### PR TITLE
CDAP-8448 return 503 when tx service is down

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/config/DefaultConfigStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/config/DefaultConfigStore.java
@@ -30,6 +30,7 @@ import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
+import co.cask.cdap.data2.transaction.TransactionSystemClientAdapter;
 import co.cask.cdap.data2.transaction.Transactions;
 import co.cask.cdap.data2.transaction.TxCallable;
 import co.cask.cdap.proto.id.DatasetId;
@@ -67,7 +68,7 @@ public class DefaultConfigStore implements ConfigStore {
     this.datasetFramework = datasetFramework;
     this.transactional = Transactions.createTransactionalWithRetry(
       Transactions.createTransactional(new MultiThreadDatasetCache(
-        new SystemDatasetInstantiator(datasetFramework), txClient,
+        new SystemDatasetInstantiator(datasetFramework), new TransactionSystemClientAdapter(txClient),
         NamespaceId.SYSTEM, ImmutableMap.<String, String>of(), null, null)),
       RetryStrategies.retryOnConflict(20, 100)
     );

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/TransactionHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/TransactionHttpHandler.java
@@ -20,6 +20,7 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.security.AuditDetail;
 import co.cask.cdap.common.security.AuditPolicy;
+import co.cask.cdap.data2.transaction.TransactionSystemClientAdapter;
 import co.cask.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
 import co.cask.http.ChunkResponder;
 import co.cask.http.HttpResponder;
@@ -72,7 +73,7 @@ public class TransactionHttpHandler extends AbstractAppFabricHttpHandler {
 
   @Inject
   public TransactionHttpHandler(CConfiguration cConf, TransactionSystemClient txClient) {
-    this.txClient = txClient;
+    this.txClient = new TransactionSystemClientAdapter(txClient);
     try {
       this.debugClazz = getClass().getClassLoader()
         .loadClass("org.apache.tephra.hbase.txprune.InvalidListPruningDebug");

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactStore.java
@@ -40,6 +40,7 @@ import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
+import co.cask.cdap.data2.transaction.TransactionSystemClientAdapter;
 import co.cask.cdap.data2.transaction.Transactions;
 import co.cask.cdap.data2.transaction.TxCallable;
 import co.cask.cdap.internal.app.runtime.plugin.PluginNotExistsException;
@@ -174,7 +175,8 @@ public class ArtifactStore {
     this.datasetFramework = datasetFramework;
     this.transactional = Transactions.createTransactionalWithRetry(
       Transactions.createTransactional(new MultiThreadDatasetCache(new SystemDatasetInstantiator(datasetFramework),
-                                                                   txClient, META_ID.getParent(),
+                                                                   new TransactionSystemClientAdapter(txClient),
+                                                                   META_ID.getParent(),
                                                                    Collections.<String, String>emptyMap(), null, null)),
       RetryStrategies.retryOnConflict(20, 100)
     );

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/store/DefaultStore.java
@@ -45,6 +45,7 @@ import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
+import co.cask.cdap.data2.transaction.TransactionSystemClientAdapter;
 import co.cask.cdap.data2.transaction.Transactions;
 import co.cask.cdap.data2.transaction.TxCallable;
 import co.cask.cdap.internal.app.ForwardingApplicationSpecification;
@@ -112,7 +113,7 @@ public class DefaultStore implements Store {
     this.dsFramework = framework;
     this.transactional = Transactions.createTransactionalWithRetry(
       Transactions.createTransactional(new MultiThreadDatasetCache(
-        new SystemDatasetInstantiator(framework), txClient,
+        new SystemDatasetInstantiator(framework), new TransactionSystemClientAdapter(txClient),
         NamespaceId.SYSTEM, ImmutableMap.<String, String>of(), null, null)),
       RetryStrategies.retryOnConflict(20, 100)
     );

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/MDSStreamMetaStore.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/MDSStreamMetaStore.java
@@ -29,6 +29,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
 import co.cask.cdap.data2.dataset2.lib.table.MDSKey;
 import co.cask.cdap.data2.dataset2.lib.table.MetadataStoreDataset;
+import co.cask.cdap.data2.transaction.TransactionSystemClientAdapter;
 import co.cask.cdap.data2.transaction.Transactions;
 import co.cask.cdap.data2.transaction.TxCallable;
 import co.cask.cdap.proto.id.DatasetId;
@@ -65,7 +66,7 @@ public final class MDSStreamMetaStore implements StreamMetaStore {
     this.datasetFramework = dsFramework;
     this.transactional = Transactions.createTransactionalWithRetry(
       Transactions.createTransactional(new MultiThreadDatasetCache(
-        new SystemDatasetInstantiator(datasetFramework), txClient,
+        new SystemDatasetInstantiator(datasetFramework), new TransactionSystemClientAdapter(txClient),
         NamespaceId.SYSTEM, ImmutableMap.<String, String>of(), null, null)),
       RetryStrategies.retryOnConflict(20, 100)
     );

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/instance/DatasetInstanceManager.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/instance/DatasetInstanceManager.java
@@ -24,6 +24,7 @@ import co.cask.cdap.data2.dataset2.DatasetFramework;
 import co.cask.cdap.data2.dataset2.DynamicDatasetCache;
 import co.cask.cdap.data2.dataset2.MultiThreadDatasetCache;
 import co.cask.cdap.data2.transaction.TransactionExecutorFactory;
+import co.cask.cdap.data2.transaction.TransactionSystemClientAdapter;
 import co.cask.cdap.data2.transaction.TransactionSystemClientService;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.NamespaceId;
@@ -54,7 +55,8 @@ public class DatasetInstanceManager {
 
     Map<String, String> emptyArgs = Collections.emptyMap();
     this.datasetCache = new MultiThreadDatasetCache(new SystemDatasetInstantiator(datasetFramework),
-                                                    txClientService, NamespaceId.SYSTEM, emptyArgs, null,
+                                                    new TransactionSystemClientAdapter(txClientService),
+                                                    NamespaceId.SYSTEM, emptyArgs, null,
                                                     ImmutableMap.of(
                                                       DatasetMetaTableUtil.INSTANCE_TABLE_NAME, emptyArgs
                                                     ));

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/TransactionSystemClientAdapter.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/TransactionSystemClientAdapter.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.data2.transaction;
+
+import co.cask.cdap.common.ServiceUnavailableException;
+import co.cask.cdap.common.conf.Constants;
+import org.apache.tephra.InvalidTruncateTimeException;
+import org.apache.tephra.Transaction;
+import org.apache.tephra.TransactionCouldNotTakeSnapshotException;
+import org.apache.tephra.TransactionNotInProgressException;
+import org.apache.tephra.TransactionSystemClient;
+import org.apache.thrift.TException;
+
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * Translates exceptions thrown by Tephra's TransactionServiceClient when the tx service is unavailable into
+ * CDAP's ServiceUnavailableException.
+ */
+public class TransactionSystemClientAdapter implements TransactionSystemClient {
+
+  private final TransactionSystemClient delegate;
+
+  public TransactionSystemClientAdapter(TransactionSystemClient delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public Transaction startShort() {
+    try {
+      return delegate.startShort();
+    } catch (RuntimeException e) {
+      throw handleException(e);
+    }
+  }
+
+  @Override
+  public Transaction startShort(int timeout) {
+    try {
+      return delegate.startShort(timeout);
+    } catch (RuntimeException e) {
+      throw handleException(e);
+    }
+  }
+
+  @Override
+  public Transaction startLong() {
+    try {
+      return delegate.startLong();
+    } catch (RuntimeException e) {
+      throw handleException(e);
+    }
+  }
+
+  @Override
+  public boolean canCommit(Transaction tx, Collection<byte[]> changeIds) throws TransactionNotInProgressException {
+    try {
+      return delegate.canCommit(tx, changeIds);
+    } catch (RuntimeException e) {
+      throw handleException(e);
+    }
+  }
+
+  @Override
+  public boolean commit(Transaction tx) throws TransactionNotInProgressException {
+    try {
+      return delegate.commit(tx);
+    } catch (RuntimeException e) {
+      throw handleException(e);
+    }
+  }
+
+  @Override
+  public void abort(Transaction tx) {
+    try {
+      delegate.abort(tx);
+    } catch (RuntimeException e) {
+      throw handleException(e);
+    }
+  }
+
+  @Override
+  public boolean invalidate(long tx) {
+    try {
+      return delegate.invalidate(tx);
+    } catch (RuntimeException e) {
+      throw handleException(e);
+    }
+  }
+
+  @Override
+  public Transaction checkpoint(Transaction tx) throws TransactionNotInProgressException {
+    try {
+      return delegate.checkpoint(tx);
+    } catch (RuntimeException e) {
+      throw handleException(e);
+    }
+  }
+
+  @Override
+  public InputStream getSnapshotInputStream() throws TransactionCouldNotTakeSnapshotException {
+    try {
+      return delegate.getSnapshotInputStream();
+    } catch (RuntimeException e) {
+      throw handleException(e);
+    }
+  }
+
+  @Override
+  public String status() {
+    try {
+      return delegate.status();
+    } catch (RuntimeException e) {
+      throw handleException(e);
+    }
+  }
+
+  @Override
+  public void resetState() {
+    try {
+      delegate.resetState();
+    } catch (RuntimeException e) {
+      throw handleException(e);
+    }
+  }
+
+  @Override
+  public boolean truncateInvalidTx(Set<Long> invalidTxIds) {
+    try {
+      return delegate.truncateInvalidTx(invalidTxIds);
+    } catch (RuntimeException e) {
+      throw handleException(e);
+    }
+  }
+
+  @Override
+  public boolean truncateInvalidTxBefore(long time) throws InvalidTruncateTimeException {
+    try {
+      return delegate.truncateInvalidTxBefore(time);
+    } catch (RuntimeException e) {
+      throw handleException(e);
+    }
+  }
+
+  @Override
+  public int getInvalidSize() {
+    try {
+      return delegate.getInvalidSize();
+    } catch (RuntimeException e) {
+      throw handleException(e);
+    }
+  }
+
+  private RuntimeException handleException(RuntimeException e) {
+    Throwable cause = e.getCause();
+    if (cause != null && cause instanceof TException) {
+      throw new ServiceUnavailableException(Constants.Service.TRANSACTION, cause);
+    }
+    throw e;
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/Transactions.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/Transactions.java
@@ -21,8 +21,6 @@ import co.cask.cdap.api.TxRunnable;
 import co.cask.cdap.api.annotation.TransactionControl;
 import co.cask.cdap.api.annotation.TransactionPolicy;
 import co.cask.cdap.api.data.DatasetContext;
-import co.cask.cdap.common.ServiceUnavailableException;
-import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.data2.dataset2.DynamicDatasetCache;
 import com.google.common.base.Functions;
 import com.google.common.base.Objects;
@@ -37,7 +35,6 @@ import org.apache.tephra.TransactionContext;
 import org.apache.tephra.TransactionExecutor;
 import org.apache.tephra.TransactionFailureException;
 import org.apache.tephra.TransactionSystemClient;
-import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -431,34 +428,30 @@ public final class Transactions {
   }
 
   /**
-   * Executes the given callable with a transaction.
+   * Executes the given callable with a transaction. Think twice before you call this. Usages of this method
+   * likely indicate poor exception handling.
+   *
    * @param transactional the {@link Transactional} used to submit the task
    * @param callable the task
    * @param <V> type of result
    * @return value returned by the given {@link TxCallable}.
-   * @throws ServiceUnavailableException when the transaction service is not running
-   * @throws RuntimeException for any other errors that occurs
+   * @throws RuntimeException for any errors that occur
    */
   public static <V> V executeUnchecked(Transactional transactional, final TxCallable<V> callable) {
     try {
       return execute(transactional, callable);
     } catch (TransactionFailureException e) {
       throw propagate(e);
-    } catch (RuntimeException e) {
-      Throwable t = e.getCause();
-      if (t != null && t instanceof TException) {
-        throw new ServiceUnavailableException(Constants.Service.TRANSACTION, e);
-      }
-      throw e;
     }
   }
 
   /**
-   * Executes the given runnable with a transaction.
+   * Executes the given runnable with a transaction. Think twice before you call this. Usages of this method
+   * likely indicate poor exception handling.
+   *
    * @param transactional the {@link Transactional} used to submit the task
    * @param runnable task
-   * @throws ServiceUnavailableException when the transaction service is not running
-   * @throws RuntimeException for any other errors that occurs
+   * @throws RuntimeException for errors that occur
    */
   public static void executeUnchecked(Transactional transactional, final TxRunnable runnable) {
     executeUnchecked(transactional, new TxCallable<Void>() {


### PR DESCRIPTION
Changes so that CDAP RESTful APIs return 503 instead of 500 when
the transaction service is down.