### PR TITLE
Added startup check to fail the router when paths with audit policy is …

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/conf/Constants.java
@@ -479,6 +479,7 @@ public final class Constants {
     public static final String CLIENT_WORKER_THREADS = "router.client.worker.threads";
     public static final String CONNECTION_TIMEOUT_SECS = "router.connection.idle.timeout.secs";
     public static final String ROUTER_USERSERVICE_FALLBACK_STRAGEY = "router.userservice.fallback.strategy";
+    public static final String ROUTER_AUDIT_PATH_CHECK_ENABLED = "router.audit.path.check.enabled";
 
     /**
      * Defaults.

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2319,6 +2319,14 @@
   <!-- Router Configuration -->
 
   <property>
+    <name>router.audit.path.check.enabled</name>
+    <value>true</value>
+    <description>
+      The boolean which indicates whether we need to check the number of paths for audit logging.
+    </description>
+  </property>
+
+  <property>
     <name>router.bind.address</name>
     <value>0.0.0.0</value>
     <description>
@@ -2426,7 +2434,6 @@
       any service and will return "service not found".
     </description>
   </property>
-
 
   <!-- Security Configuration -->
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="8133eadcf3f6628d0c1c0a425996e2eb"
+DEFAULT_XML_MD5_HASH="11b5967551587eb8d76d8f678fab534b"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/ExceptedNumberOfAuditPolicyPaths.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/ExceptedNumberOfAuditPolicyPaths.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package co.cask.cdap.gateway.router;
+
+/**
+ * Expected number of paths annotated with {@link co.cask.cdap.common.security.AuditPolicy}
+ */
+public final class ExceptedNumberOfAuditPolicyPaths {
+  public static final int EXPECTED_PATH_NUMBER = 86;
+}

--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterMain.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterMain.java
@@ -73,6 +73,13 @@ public class RouterMain extends DaemonMain {
       cConf = CConfiguration.create();
 
       if (cConf.getBoolean(Constants.Security.ENABLED)) {
+        int foundPaths = RouterAuditLookUp.getAuditLookUp().getNumberOfPaths();
+        if (cConf.getBoolean(Constants.Router.ROUTER_AUDIT_PATH_CHECK_ENABLED) &&
+          foundPaths != ExceptedNumberOfAuditPolicyPaths.EXPECTED_PATH_NUMBER) {
+          LOG.error("Failed to start the router due to the incorrect number of paths with AuditPolicy. " +
+                      "Expected: {}, found: {}", ExceptedNumberOfAuditPolicyPaths.EXPECTED_PATH_NUMBER, foundPaths);
+          System.exit(1);
+        }
         // Enable Kerberos login
         SecurityUtil.enableKerberosLogin(cConf);
       }

--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterAuditLookUpTest.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/router/RouterAuditLookUpTest.java
@@ -35,6 +35,11 @@ public class RouterAuditLookUpTest {
   private static final AuditLogContent DEFAULT_AUDIT = new AuditLogContent(HttpMethod.PUT, true, false, EMPTY_HEADERS);
 
   @Test
+  public void testCorrectNumberInClassPath() throws Exception {
+    Assert.assertEquals(ExceptedNumberOfAuditPolicyPaths.EXPECTED_PATH_NUMBER, AUDIT_LOOK_UP.getNumberOfPaths());
+  }
+
+  @Test
   public void testDataFabricEndpoints() throws Exception {
     // endpoints from DatasetInstanceHandler
     assertContent("/v3/namespaces/default/data/datasets/myDataset", DEFAULT_AUDIT);


### PR DESCRIPTION
Added a check before we start the router to make sure all the paths are getting scanned for audit logging. 

Builds: http://builds.cask.co/browse/CDAP-RUT609-JOB1-2