### PR TITLE
CDAP-8583 - update the market url in place

### DIFF
--- a/cdap-distributions/src/hdinsight/pkg/install.sh
+++ b/cdap-distributions/src/hdinsight/pkg/install.sh
@@ -98,6 +98,9 @@ chef-solo -o 'recipe[ulimit::default],recipe[cdap::fullstack],recipe[cdap::init]
 # Temporary Hack to workaround CDAP-4089
 rm -f /opt/cdap/kafka/lib/log4j.log4j-1.2.14.jar
 
+# Temporary Hack to workaround CDAP-8583
+sed -i 's/market.cask.co/market.cask.co\/4.0.1/' /opt/cdap/ui/server/config/cdap-ui-config.json
+
 # Start CDAP Services
 for i in /etc/init.d/cdap-*
 do


### PR DESCRIPTION
fixes [CDAP-8583](https://issues.cask.co/browse/CDAP-8583) via temporary hack to set the right market url in the HDInsight install script.