### PR TITLE
[CDAP-8550] Fix new UI to handle Authorization to no existing namespaces.

### DIFF
--- a/cdap-ui/app/cdap/components/AuthorizationErrorMessage/AuthorizationMessage.scss
+++ b/cdap-ui/app/cdap/components/AuthorizationErrorMessage/AuthorizationMessage.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2017 Cask Data, Inc.
+ * Copyright © 2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,11 +14,27 @@
  * the License.
  */
 
-export default {
-  APPUPLOAD: 'APPICATION_UPLOAD',
-  STREAMCREATE: 'STREAM_CREATE',
-  PUBLISHPIPELINE: 'PUBLISH_PIPELINE',
-  CREATENAMESPACE: 'CREATE_NAMESPACE',
-  DELETEENTITY: 'DELETE_ENTITY',
-  NONAMESPACE: 'NO_NAMESPACE'
-};
+@import '../../styles/variables.scss';
+
+.auth-error-message {
+  height: 75vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  h3 {
+    border-bottom: 1px solid;
+    padding-bottom: 5px;
+  }
+
+  .cta-section {
+    margin-left: 40px;
+    line-height: 1.8;
+  }
+
+  .link {
+    color: $cdap-orange;
+    cursor: pointer;
+  }
+}

--- a/cdap-ui/app/cdap/components/AuthorizationErrorMessage/index.js
+++ b/cdap-ui/app/cdap/components/AuthorizationErrorMessage/index.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+require('./AuthorizationMessage.scss');
+import NamespaceStore from 'services/NamespaceStore';
+import cookie from 'react-cookie';
+import RedirectToLogin from 'services/redirect-to-login';
+import ee from 'event-emitter';
+import globalEvents from 'services/global-events';
+import T from 'i18n-react';
+
+export default function AuthorizationErrorMessage() {
+  let eventEmitter = ee(ee);
+  const logout = () => {
+    cookie.remove('show-splash-screen-for-session', {path: '/'});
+    RedirectToLogin({statusCode: 401});
+  };
+  const openNamespaceCreateWizard = () => {
+    eventEmitter.emit(globalEvents.CREATENAMESPACE);
+  };
+  let username = NamespaceStore.getState().username;
+  return (
+    <div className="auth-error-message">
+      <h3>
+        <span className="fa fa-exclamation-triangle"></span>
+        <span>{T.translate('features.AuthorizationMessage.mainMessage')}</span>
+      </h3>
+      <div className="cta-section">
+      <ul>
+        <li>
+          <span>{T.translate('features.AuthorizationMessage.callToAction1')}</span>
+        </li>
+        <li>
+          <span>{T.translate('features.AuthorizationMessage.callToAction2.message1', {username})}</span>
+          <span
+            className="link"
+            onClick={logout}
+          >
+            {T.translate('features.AuthorizationMessage.callToAction2.loginLabel')}
+          </span>
+          <span>{T.translate('features.AuthorizationMessage.callToAction2.message2')}</span>
+        </li>
+        <li>
+          <span
+            className="link"
+            onClick={openNamespaceCreateWizard}
+          >
+            {T.translate('features.AuthorizationMessage.callToAction3.message1')}
+          </span>
+          <span>{T.translate('features.AuthorizationMessage.callToAction3.message2')}</span>
+        </li>
+      </ul>
+        </div>
+    </div>
+  );
+}

--- a/cdap-ui/app/cdap/components/Header/index.js
+++ b/cdap-ui/app/cdap/components/Header/index.js
@@ -25,6 +25,8 @@ import CaskMarketButton from 'components/Header/CaskMarketButton';
 import {MyNamespaceApi} from 'api/namespace';
 import NamespaceActions from 'services/NamespaceStore/NamespaceActions';
 import classnames from 'classnames';
+import ee from 'event-emitter';
+import globalEvents from 'services/global-events';
 
 require('./Header.scss');
 
@@ -37,6 +39,7 @@ export default class Header extends Component {
       metadataDropdown: false
     };
     this.namespacesubscription = null;
+    this.eventEmitter = ee(ee);
   }
   componentWillMount() {
     // Polls for namespace data
@@ -51,7 +54,10 @@ export default class Header extends Component {
               }
             });
           } else {
-            // To-Do: No namespaces returned ; throw error / redirect
+            // TL;DR - This is emitted for Authorization in main.js
+            // This means there is no namespace for the user to work on.
+            // which indicates she/he have no authorization for any namesapce in the system.
+            this.eventEmitter.emit(globalEvents.NONAMESPACE);
           }
         }
       );

--- a/cdap-ui/app/cdap/main.js
+++ b/cdap-ui/app/cdap/main.js
@@ -47,15 +47,20 @@ import VersionActions from 'services/VersionStore/VersionActions';
 import StatusFactory from 'services/StatusFactory';
 import LoadingIndicator from 'components/LoadingIndicator';
 import StatusAlertMessage from 'components/StatusAlertMessage';
+import AuthorizationErrorMessage  from 'components/AuthorizationErrorMessage';
 import Page404 from 'components/404';
+import ee from 'event-emitter';
+import globalEvents from 'services/global-events';
 
 class CDAP extends Component {
   constructor(props) {
     super(props);
     this.state = {
       selectedNamespace : NamespaceStore.getState().selectedNamespace,
-      version: ''
+      version: '',
+      authorizationFailed: false
     };
+    this.eventEmitter = ee(ee);
   }
 
   componentWillMount() {
@@ -70,7 +75,11 @@ class CDAP extends Component {
     }
 
     StatusFactory.startPolling();
-
+    this.eventEmitter.on(globalEvents.NONAMESPACE, () => {
+      this.setState({
+        authorizationFailed: true
+      });
+    });
     if (!VersionStore.getState().version) {
       MyCDAPVersionApi.get().subscribe((res) => {
         this.setState({ version : res.version });
@@ -97,18 +106,23 @@ class CDAP extends Component {
           <SplashScreen openVideo={this.openCaskVideo}/>
           <LoadingIndicator />
           <StatusAlertMessage />
-          <div className="container-fluid">
-            <Match exactly pattern="/" component={RouteToNamespace} />
-            <Match exactly pattern="/notfound" component={Page404} />
-            <Match exactly pattern="/administration" component={Administration} />
-            <Match exactly pattern="/ns" component={RouteToNamespace} />
-            <Match pattern="/ns/:namespace" history={history} component={Home} />
-            <Match exactly pattern="/ns/:namespace/dashboard" component={Dashboard} />
-            <Match pattern="/Experimental" component={Experimental} />
-            <Match pattern="/socket-example" component={ConnectionExample} />
-            <Match pattern="/schemaeditor" component={SchemaEditor} />
-            <Miss component={Page404} />
-          </div>
+          {
+            this.state.authorizationFailed ?
+              <AuthorizationErrorMessage />
+            :
+              <div className="container-fluid">
+                <Match exactly pattern="/" component={RouteToNamespace} />
+                <Match exactly pattern="/notfound" component={Page404} />
+                <Match exactly pattern="/administration" component={Administration} />
+                <Match exactly pattern="/ns" component={RouteToNamespace} />
+                <Match pattern="/ns/:namespace" history={history} component={Home} />
+                <Match exactly pattern="/ns/:namespace/dashboard" component={Dashboard} />
+                <Match pattern="/Experimental" component={Experimental} />
+                <Match pattern="/socket-example" component={ConnectionExample} />
+                <Match pattern="/schemaeditor" component={SchemaEditor} />
+                <Miss component={Page404} />
+              </div>
+          }
           <Footer version={this.state.version} />
         </div>
       </Router>

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -114,6 +114,16 @@ features:
       programsLabel: Programs
       datasetsLabel: Datasets
       historyLabel: Runs
+  AuthorizationMessage:
+    mainMessage: " You do not have authorization to access existing namespaces"
+    callToAction1: Please contact your system administrator to request access to a namespace
+    callToAction2:
+      message1: You are logged in as *{username}*.
+      loginLabel: " Login "
+      message2: as another user
+    callToAction3:
+      message1: "Create a new namespace "
+      message2: "(Note: You will require ADMIN privileges on CDAP for creating a namespace)"
   ConfirmationModal:
     confirmDefaultText: OK
     cancelDefaultText: Cancel


### PR DESCRIPTION
- In a auth-enabled cluster the current logged in user might not have access to any of the existing namespaces. In that case we need to show appropriate message and provide actions for the user to take in that scenario.

Bamboo build: http://builds.cask.co/browse/CDAP-DRC5779-1