### PR TITLE
CDAP-7648 Package apache http libs in Standalone.

### DIFF
--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -151,6 +151,25 @@
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
     </dependency>
+    <!-- Need to have a compile dependency in Standalone, as these dependences are provided only on cluster -->
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${http.component.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>${http.component.version}</version>
+      <scope>compile</scope>
+    </dependency>
     <dependency>
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-ui</artifactId>


### PR DESCRIPTION
In https://github.com/caskdata/cdap/pull/7260, we removed the dependency on apache http libs, because its already available on hadoop clusters. However, in our standalone, its missing, so this is packaging it back for standalone. Otherwise, failures like [HYDRATOR-1377](https://issues.cask.co/browse/HYDRATOR-1377) occur in standalone CDAP.

https://issues.cask.co/browse/CDAP-7648
http://builds.cask.co/browse/CDAP-RUT622-1