### PR TITLE
prevent cdap cookbook 2.28.5 from overwriting client config

### DIFF
--- a/cdap-distributions/src/hdinsight/pkg/install.sh
+++ b/cdap-distributions/src/hdinsight/pkg/install.sh
@@ -73,7 +73,7 @@ ${__packerdir}/cookbook-setup.sh || die "Failed to install cookbooks"
 
 # CDAP cli install, ensures package dependencies are present
 # We must specify the cdap version
-echo "{\"cdap\": {\"version\": \"${CDAP_VERSION}\"}}" > ${__tmpdir}/cli-conf.json
+echo "{\"cdap\": {\"version\": \"${CDAP_VERSION}\", \"skip_prerequisites\": \"true\"}}" > ${__tmpdir}/cli-conf.json
 chef-solo -o 'recipe[cdap::cli]' -j ${__tmpdir}/cli-conf.json
 
 # Read zookeeper quorum from hbase-site.xml, using sourced init script function


### PR DESCRIPTION
This fix is already in production... with the refactoring done in 2.28.5, we need to configure the initial chef run that installs the CLI to not include prerequisites, which will wipe out the client configuration.