### PR TITLE
CDAP-8450 Dont do stream cleanup under impersonation

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamFileJanitor.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/StreamFileJanitor.java
@@ -93,16 +93,10 @@ public final class StreamFileJanitor {
         final StreamId streamId = namespace.getNamespaceId().stream(StreamUtils
                                                                       .getStreamNameFromLocation(streamLocation));
         final AtomicLong ttl = new AtomicLong(0);
-        impersonator.doAs(streamId, new Callable<Void>() {
-          @Override
-          public Void call() throws Exception {
-            if (isStreamExists(streamId)) {
-              ttl.set(streamAdmin.getConfig(streamId).getTTL());
-            }
-            clean(streamLocation, ttl.get(), System.currentTimeMillis());
-            return null;
-          }
-        });
+        if (isStreamExists(streamId)) {
+          ttl.set(streamAdmin.getConfig(streamId).getTTL());
+        }
+        clean(streamLocation, ttl.get(), System.currentTimeMillis());
       }
     }
   }


### PR DESCRIPTION
This is just to revert the impersonation added in here https://github.com/caskdata/cdap/pull/7698/files#diff-0a5566e52c51e2b816872293bfa2c954R96

Build: http://builds.cask.co/browse/CDAP-RUT627-1
Issue: https://issues.cask.co/browse/CDAP-8450
ITM: http://builds.cask.co/browse/CDAP-ITM11-5
