### PR TITLE
[CDAP-8486] Fixes header in Logs view in UI

### DIFF
--- a/cdap-ui/app/cdap/components/AppDetailedView/Tabs/HistoryTab.js
+++ b/cdap-ui/app/cdap/components/AppDetailedView/Tabs/HistoryTab.js
@@ -19,6 +19,7 @@ import {MyProgramApi} from 'api/program';
 import {convertProgramToApi} from 'services/program-api-converter';
 import NamespaceStore from 'services/NamespaceStore';
 import {humanReadableDate} from 'services/helpers';
+import LogAction from 'components/FastAction/LogAction';
 import T from 'i18n-react';
 import orderBy from 'lodash/orderBy';
 
@@ -64,9 +65,12 @@ export default class HistoryTab extends Component {
                 runRecord.end = runRecord.end !== runFromBackend.end ? runFromBackend.end : runRecord.end;
                 return runRecord;
               });
-              newRuns.map( r => {
-                r.programName = programId;
-                return r;
+              newRuns = newRuns.map( r => {
+                return Object.assign({}, r, {
+                  programName: programId,
+                  programType,
+                  appId
+                });
               });
               res = orderBy([
                 ...newRuns,
@@ -99,6 +103,7 @@ export default class HistoryTab extends Component {
                     <th>Start Time</th>
                     <th>Run ID</th>
                     <th>Status</th>
+                    <th>Logs</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -112,6 +117,16 @@ export default class HistoryTab extends Component {
                             <td>{humanReadableDate(history.start)}</td>
                             <td>{history.runid}</td>
                             <td>{history.status}</td>
+                            <td>
+                              <LogAction
+                                entity={{
+                                  id: history.programName,
+                                  uniqueId: history.runid,
+                                  applicationId: history.appId,
+                                  programType: history.programType
+                                }}
+                              />
+                            </td>
                           </tr>
                         );
                       })

--- a/cdap-ui/app/cdap/components/AppDetailedView/Tabs/HistoryTab.scss
+++ b/cdap-ui/app/cdap/components/AppDetailedView/Tabs/HistoryTab.scss
@@ -32,5 +32,8 @@
     tr td {
       border-color: $custom_table-border-color;
     }
+    a.btn.btn-link {
+      color: #4f5050;
+    }
   }
 }

--- a/cdap-ui/app/cdap/components/AppDetailedView/Tabs/index.js
+++ b/cdap-ui/app/cdap/components/AppDetailedView/Tabs/index.js
@@ -22,6 +22,7 @@ import HistoryTab from 'components/AppDetailedView/Tabs/HistoryTab';
 import isNil from 'lodash/isNil';
 import Match from 'react-router/Match';
 import Link from 'react-router/Link';
+import T from 'i18n-react';
 
 export default class AppDetailedViewTab extends Component {
   constructor(props) {
@@ -51,7 +52,7 @@ export default class AppDetailedViewTab extends Component {
                    return location.pathname.match(basepath);
                 }}
               >
-                Programs ({this.state.entity.programs.length})
+                {T.translate('features.AppDetailedView.Tabs.programsLabel')} ({this.state.entity.programs.length})
               </Link>
             </NavLink>
           </NavItem>
@@ -60,7 +61,9 @@ export default class AppDetailedViewTab extends Component {
               <Link
                 to={`/ns/${this.props.params.namespace}/apps/${this.props.params.appId}/datasets`}
                 activeClassName="active"
-              >Datasets ({this.state.entity.datasets.length})</Link>
+              >
+                {T.translate('features.AppDetailedView.Tabs.datasetsLabel')} ({this.state.entity.datasets.length})
+              </Link>
             </NavLink>
           </NavItem>
           <NavItem>
@@ -68,7 +71,9 @@ export default class AppDetailedViewTab extends Component {
               <Link
                 to={`/ns/${this.props.params.namespace}/apps/${this.props.params.appId}/history`}
                 activeClassName="active"
-              >History</Link>
+              >
+                {T.translate('features.AppDetailedView.Tabs.historyLabel')}
+              </Link>
             </NavLink>
           </NavItem>
         </Nav>

--- a/cdap-ui/app/cdap/components/NamespaceDropdown/index.js
+++ b/cdap-ui/app/cdap/components/NamespaceDropdown/index.js
@@ -173,7 +173,12 @@ export default class NamespaceDropdown extends Component {
     let baseurl = '';
     if (this.props.tag) {
       let basename = document.querySelector('base');
-      basename = basename.getAttribute('href') ? basename.getAttribute('href') : null;
+      let baseurlname = basename.getAttribute('href');
+      // FIXME: This is a one of thing (an interim solution) and that should go away in subsequent releases.
+      if (baseurlname.indexOf('logviewer') !== -1) {
+        baseurlname = '/cdap/';
+      }
+      basename = baseurlname ? baseurlname : null;
       LinkEl = this.props.tag;
       baseurl = `${basename}`;
     }
@@ -311,7 +316,7 @@ export default class NamespaceDropdown extends Component {
                         key={shortid.generate()}
                       >
                         <LinkEl
-                          href={baseurl + `/ns/${item.name}`}
+                          href={baseurl + `ns/${item.name}`}
                           to={baseurl + `/ns/${item.name}`}
                           className="namespace-link"
                         >

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -110,6 +110,10 @@ features:
     Title: CDAP | Applications | {appId}
     History:
       emptyMessage: No Runs found.
+    Tabs:
+      programsLabel: Programs
+      datasetsLabel: Datasets
+      historyLabel: Runs
   ConfirmationModal:
     confirmDefaultText: OK
     cancelDefaultText: Cancel

--- a/cdap-ui/app/logviewer/controllers/home-ctrl.js
+++ b/cdap-ui/app/logviewer/controllers/home-ctrl.js
@@ -15,10 +15,11 @@
  */
 
 class LogsAppHomeController {
-  constructor($state, LogViewerStore, $scope) {
+  constructor($state, LogViewerStore, $scope, moment) {
     'ngInject';
 
     this.LogViewerStore = LogViewerStore;
+    this.moment = moment;
 
     let {
       namespace,
@@ -47,6 +48,9 @@ class LogsAppHomeController {
     this.startTime = statusInfo.startTime;
     this.endTime = statusInfo.endTime;
     this.status = statusInfo.status;
+    if (document.title.indexOf('started at') === -1 && this.startTime) {
+      document.title = document.title + ' (started at ' + this.moment.utc(this.startTime * 1000).format('MM/DD/YYYY HH:mm:ss')+ ' )';
+    }
   }
 
   checkValidQueryParams() {

--- a/cdap-ui/app/logviewer/logviewer.html
+++ b/cdap-ui/app/logviewer/logviewer.html
@@ -17,7 +17,7 @@
 <!DOCTYPE html>
 <html lang="en" ng-app="cdap-ui">
 <head>
-    <title>CDAP - Log Viewer</title>
+    <title>CDAP | Logs </title>
 
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -29,9 +29,7 @@
     <link rel="stylesheet" type="text/css" href="/assets/bundle/app.css" />
 </head>
 <body ng-class="bodyClass" ng-controller="BodyCtrl">
-  <header>
-    <img src="/cdap_assets/img/company_logo.png" />
-  </header>
+  <my-global-navbar></my-global-navbar>
 
   <main class="container"
         id="app-container">

--- a/cdap-ui/app/logviewer/routes.js
+++ b/cdap-ui/app/logviewer/routes.js
@@ -21,6 +21,9 @@ angular.module(PKG.name + '.feature.logviewer')
       .state('logviewerhome', {
         url: '/view?namespace&appId&programType&programId&runId',
         templateUrl: '/assets/features/logviewer/templates/home.html',
+        onEnter: function($stateParams) {
+          document.title = 'CDAP | Logs | ' + $stateParams.programId;
+        },
         controller: 'LogsAppHomeController',
         controllerAs: 'Home'
       });


### PR DESCRIPTION
- [CDAP-8574](https://issues.cask.co/browse/CDAP-8574) - Fixes Header to be consistent in logs view
- Fixes Namespace dropdown to handle `logviewer` separately as there is no `/logviewer/ns/default` . This right now defaults to `/cdap/ns/<currentnamespace>`
- [CDAP-8519](https://issues.cask.co/browse/CDAP-8519) - Adds logs fast action to app detailed view (Runs tab).
- Renames `History` to `Runs` tab in app detailed view.

Bamboo build: http://builds.cask.co/browse/CDAP-DRC5786/latest