### PR TITLE
CDAP-7772 reduce log level of ignore explore jar message

### DIFF
--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ExploreServiceTwillRunnable.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/ExploreServiceTwillRunnable.java
@@ -235,7 +235,7 @@ public class ExploreServiceTwillRunnable extends AbstractMasterTwillRunnable {
       if (!hiveExtraJars.containsKey(fileName)) {
         hiveExtraJars.put(fileName, url);
       } else {
-        LOG.info("Ignore jar with name {} that was added previously with {}", fileName, url);
+        LOG.debug("Ignore jar with name {} that was added previously with {}", fileName, url);
       }
     }
 


### PR DESCRIPTION
This message is really only useful if there are classpath issues
on explore and we see that some jars are missing. To the majority
of users, they are excessive.