### PR TITLE
CDAP-8206 adding documentation on program retry policies

### DIFF
--- a/cdap-docs/_common/_source/index.rst
+++ b/cdap-docs/_common/_source/index.rst
@@ -102,7 +102,7 @@ CDAP capabilities include *CDAP Pipelines* and *Metadata Management*.
   - |dev-man-tad-black|_ Test framework plus tools and practices for debugging your applications
   - |dev-man-id-black|_ Different techniques for ingesting data into CDAP
   - |dev-man-at-black|_ Adding a custom logback, best practices for CDAP development,
-    class loading in CDAP, configuring program resources
+    class loading in CDAP, configuring program resources and retry policies
 
 
 .. |admin-manual| replace:: **Administration Manual:**

--- a/cdap-docs/developers-manual/source/advanced/index.rst
+++ b/cdap-docs/developers-manual/source/advanced/index.rst
@@ -15,6 +15,7 @@ Advanced Topics
     Best Practices <best-practices>
     Class Loading <class-loading>
     Configuring Program Resources <configuring-resources>
+    Program Retry Policies <program-retry-policies>
 
 
 This section of the documentation includes articles that cover advanced topics on CDAP that
@@ -42,8 +43,9 @@ will be of interest to developers who want a deeper dive into CDAP:
 
 - |configuring-resources|_ Setting the YARN resources used by the programs of a CDAP application.
 
-.. |retry-policies| replace:: **Program Retry Policies:**
-.. _retry-policies: retry-policies.html
 
-- |retry-policies|_ Configuring the Retry Policy used by the programs of a CDAP application.
+.. |program-retry-policies| replace:: **Program Retry Policies:**
+.. _program-retry-policies: program-retry-policies.html
+
+- |program-retry-policies|_ Configuring the retry policies used by the programs of a CDAP application.
 

--- a/cdap-docs/developers-manual/source/advanced/index.rst
+++ b/cdap-docs/developers-manual/source/advanced/index.rst
@@ -41,3 +41,9 @@ will be of interest to developers who want a deeper dive into CDAP:
 .. _configuring-resources: configuring-resources.html
 
 - |configuring-resources|_ Setting the YARN resources used by the programs of a CDAP application.
+
+.. |retry-policies| replace:: **Program Retry Policies:**
+.. _retry-policies: retry-policies.html
+
+- |retry-policies|_ Configuring the Retry Policy used by the programs of a CDAP application.
+

--- a/cdap-docs/developers-manual/source/advanced/program-retry-policies.rst
+++ b/cdap-docs/developers-manual/source/advanced/program-retry-policies.rst
@@ -2,6 +2,10 @@
     :author: Cask Data, Inc.
     :copyright: Copyright © 2017 Cask Data, Inc.
 
+.. _program-retry-policies:
+
+.. highlight:: java
+
 ======================
 Program Retry Policies
 ======================
@@ -16,7 +20,7 @@ Retry policies discussed here pertain to retrying individual API calls.
 If a program run has failed, it will not be retried. 
 
 
-.. _retry-policies-operations
+.. _program-retry-policies-operations:
 
 Retryable Operations
 ====================
@@ -31,7 +35,7 @@ dataset service that actually creates the dataset.
 
 Methods in the ``Admin``, ``Transactional``, ``StreamWriter``, and ``DatasetContext`` interface
 will be retried by CDAP if they fail due to unavailability of a required CDAP system service. 
-For example, consider a ``Worker`` that uses ``Transactional`` to write to a Table:: 
+For example, consider a ``Worker`` that uses ``Transactional`` to write to a ``Table``:: 
 
   @Override
   public void run() {
@@ -51,7 +55,7 @@ The developer does not need to worry about what will happen when this code is ru
 transaction service is unavailable. The program will retry the relevant transaction calls until
 the configured timeout is reached or the transaction service recovers.
 
-.. _retry-policies-config
+.. _program-retry-policies-config:
 
 Configuring Default Retry Policy 
 ================================
@@ -59,35 +63,36 @@ Each program type is configured with its own default retry policy. For example, 
 a different default retry policy than a Service. The default retry policy for each program type
 can be set by specifying these properties in the ``cdap-site.xml`` file: 
 
-  - <program-type>.retry.policy.type
-  - <program-type>.retry.policy.max.time.secs
-  - <program-type>.retry.policy.max.retries
-  - <program-type>.retry.policy.base.delay.ms
-  - <program-type>.retry.policy.max.delay.ms
+  - ``<program-type>.retry.policy.type``
+  - ``<program-type>.retry.policy.max.time.secs``
+  - ``<program-type>.retry.policy.max.retries``
+  - ``<program-type>.retry.policy.base.delay.ms``
+  - ``<program-type>.retry.policy.max.delay.ms``
 
-where program type is one of ``mapreduce``, ``spark``, ``workflow``, ``custom.action``, ``worker``, 
-``service``, or ``flow``.
+where ``<program-type>`` is one of ``custom.action``, ``flow``, ``mapreduce``,
+``service``, ``spark``, ``worker``, or ``workflow``.
 
-- The ``retry.policy.type`` property must be set to one of ``none``, ``fixed.delay``, or ``exponential.backoff``.
+The **retry.policy.type** property must be set to one of ``none``, ``fixed.delay``, or ``exponential.backoff``:
+
 - The ``none`` type means there will be no retry attempt.
 - The ``fixed.delay`` type will retry the call at a fixed interval.
 - The ``exponential.backoff`` type will retry at exponentially greater intervals after each failure.
 
-The ``retry.policy.max.time.secs`` property specifies a limit to the total amount of time CDAP will 
+The **retry.policy.max.time.secs** property specifies a limit to the total amount of time CDAP will 
 wait before aborting the operation. For example, when set to 60, CDAP will abort the operation
 if more than 60 seconds have passed since the original call was made.
 
-The ``retry.policy.max.retries`` property specifies a limit to the number of retries CDAP will
+The **retry.policy.max.retries** property specifies a limit to the number of retries CDAP will
 attempt before aborting the operation. The original call does not count as a retry attempt.
 For example, when set to five, CDAP will abort the operation after the sixth call has failed.
 
-The ``retry.policy.base.delay.ms`` property applies to the ``fixed.delay`` and ``exponential.backoff``
+The **retry.policy.base.delay.ms** property applies to the ``fixed.delay`` and ``exponential.backoff``
 retry policy types. When using ``fixed.delay``, it is the amount of time in milliseconds between
 retry attempts. For example, when set to 500, CDAP will retry the operation 500 milliseconds
 after the previous attempt failed. When using ``exponential.backoff``, it is the amount of time
 in milliseconds between the original failure and the first retry attempt. 
 
-The ``retry.policy.max.delay.ms`` property only applies to the ``exponential.backoff`` retry policy type.
+The **retry.policy.max.delay.ms** property only applies to the ``exponential.backoff`` retry policy type.
 It is the maximum amount of time in milliseconds between retry attempts. For example, when
 ``retry.policy.base.delay.ms`` is 1000 and ``retry.policy.max.delay.ms`` is 4000, CDAP will wait for
 one second after the original failure to attempt the first retry. If that fails, CDAP will wait
@@ -96,18 +101,18 @@ before attempting the third retry. For every failure after that, CDAP will wait 
 ``retry.policy.max.delay.ms`` has been reached.
 Once an attempt succeeds, the time between retries will be reset to the base delay.
 
-.. _retry-policies-override
+.. _program-retry-policies-override:
 
 Overriding Retry Policy
 =======================
 Retry policies can be overridden using preferences and runtime arguments. Each of the five
 properties can be overriden by setting that preference or runtime argument prefixed with ``system``:
 
-  - system.retry.policy.type
-  - system.retry.policy.max.time.secs
-  - system.retry.policy.max.retries
-  - system.retry.policy.delay.base.ms
-  - system.retry.policy.delay.max.ms
+  - ``system.retry.policy.type``
+  - ``system.retry.policy.max.time.secs``
+  - ``system.retry.policy.max.retries``
+  - ``system.retry.policy.delay.base.ms``
+  - ``system.retry.policy.delay.max.ms``
 
 In this way, you can set different retry policies for different programs. For example, if one MapReduce
 program normally takes days to finish, you may want to use a longer retry policy for it than for a

--- a/cdap-docs/developers-manual/source/advanced/retry-policies.rst
+++ b/cdap-docs/developers-manual/source/advanced/retry-policies.rst
@@ -1,0 +1,115 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2017 Cask Data, Inc.
+
+======================
+Program Retry Policies
+======================
+
+Like many distributed systems, CDAP needs to deal with node failures across the cluster.
+If any of the CDAP system services that are running in your cluster is unavailable for any
+reason, CDAP programs can be configured to retry API calls that rely on these services.
+For example, the leader transaction service was running on a node that has suddendly died,
+programs can retry their transactional calls until the follower transaction service comes online.
+
+Retry policies discussed here pertain to retrying individual API calls.
+If a program run has failed, it will not be retried. 
+
+
+.. _retry-policies-operations
+
+Retryable Operations
+====================
+
+In general, developers can assume that CDAP will attempt to retry every operation that 
+can be safely retried. As a rule of thumb, any operation that is idempotent can be retried.
+Some non-idempotent operations can also be retried depending on the type of failure.
+For example, developers can use the `Admin` interface to create a new dataset.
+This is not an idempotent operation, as attempting to create a dataset that already
+exists will result in a failure. However, the call to create a dataset will be retried
+by CDAP if it failed because the program could not discover or connect to the CDAP
+dataset service that actually creates the dataset.
+
+Methods in the `Admin`, `Transactional`, `StreamWriter`, and `DatasetContext` interface
+will be retried by CDAP if they fail due to unavailability of a required CDAP system service. 
+For example, consider a `Worker` that uses `Transactional` to write to a Table:: 
+
+  @Override
+  public void run() {
+    ...
+    getContext().execute(new TxRunnable() {
+      @Override
+      public void run(DatasetContext datasetContext) throws Exception {
+        Table table = datasetContext.getDataset("mytable");
+        Put put = new Put(row);
+        put.add(col, val);
+        table.write(row, put);
+      }
+    });
+  }
+
+The developer does not need to worry about what will happen when this code is run and the CDAP
+transaction service is unavailable. The program will retry the relevant transaction calls until
+the configured timeout is reached or the transaction service recovers.
+
+.. _retry-policies-config
+
+Configuring Default Retry Policy 
+================================
+
+Each program type is configured with its own default retry policy. For example, MapReduce has
+a different default retry policy than a Service. The default retry policy for each program type
+can be changed by modifying properties in cdap-site.xml: 
+
+  - <program-type>.retry.policy.type
+  - <program-type>.retry.policy.max.time.secs
+  - <program-type>.retry.policy.max.retries
+  - <program-type>.retry.policy.base.delay.ms
+  - <program-type>.retry.policy.max.delay.ms
+
+program type is `mapreduce`, `spark`, `workflow`, `custom.action`, `worker`, `service`, or `flow`.
+The `retry.policy.type` property must be set to `none`, `fixed.delay`, or `exponential.backoff`.
+The `none` type means there will be no retry attempt.
+The `fixed.delay` type will retry the call at a fixed interval.
+The `exponential.backoff` type will retry at exponentially greater intervals after each failure.
+
+The `retry.policy.max.time.secs` property specifies a limit to the total amount of time CDAP will 
+wait before aborting the operation. For example, when set to 60, CDAP will abort the operation
+if more than 60 seconds have passed since the original call was made.
+
+The `retry.policy.max.retries` property specifies a limit to the number of retries CDAP will
+attempt before aborting the operation. The original call does not count as a retry attempt.
+For example, when set to five, CDAP will abort the operation after the sixth call has failed.
+
+The `retry.policy.base.delay.ms` property applies to the `fixed.delay` and `exponential.backoff`
+retry policy types. When using `fixed.delay`, it is the amount of time in milliseconds between
+retry attempts. For example, when set to 500, CDAP will retry the operation 500 milliseconds
+after the previous attempt failed. When using `exponential.backoff`, it is the amount of time
+in milliseconds between the original failure and the first retry attempt. 
+
+The `retry.policy.max.delay.ms` property only applies to the `exponential.backoff` retry policy type.
+It is the maximum amount of time in milliseconds between retry attempts. For example, when
+`retry.policy.base.delay.ms` is 1000 and `retry.policy.max.delay.ms` is 4000, CDAP will wait for
+one second after the original failure to attempt the first retry. If that fails, CDAP will wait
+for two seconds before attempting the second retry. If that fails, CDAP will wait for four seconds
+before attempting the third retry. For every failure after that, CDAP will wait for four seconds.
+Once an attempt succeeds, the time between retries will be reset to the base delay.
+
+.. _retry-policies-override
+
+Overriding Retry Policy
+=======================
+
+Retry policies can be overridden using preferences and runtime arguments. Each of the five
+properties can be overriden by setting that preference or runtime argument prefixed with 'system':
+
+  - system.retry.policy.type
+  - system.retry.policy.max.time.secs
+  - system.retry.policy.max.retries
+  - system.retry.policy.delay.base.ms
+  - system.retry.policy.delay.max.ms
+
+In this way, you can set different retry policies for different programs. For example, if one mapreduce
+program normally takes days to finish, you may want to use a longer retry policy for it than for a
+mapreduce that normally takes ten minutes to finish. 
+

--- a/cdap-docs/developers-manual/source/advanced/retry-policies.rst
+++ b/cdap-docs/developers-manual/source/advanced/retry-policies.rst
@@ -7,9 +7,9 @@ Program Retry Policies
 ======================
 
 Like many distributed systems, CDAP needs to deal with node failures across the cluster.
-If any of the CDAP system services that are running in your cluster is unavailable for any
+If any of the CDAP system services that are running in your cluster are unavailable for any
 reason, CDAP programs can be configured to retry API calls that rely on these services.
-For example, the leader transaction service was running on a node that has suddendly died,
+For example, if the leader transaction service that was running on a node has suddendly died,
 programs can retry their transactional calls until the follower transaction service comes online.
 
 Retry policies discussed here pertain to retrying individual API calls.
@@ -20,19 +20,18 @@ If a program run has failed, it will not be retried.
 
 Retryable Operations
 ====================
-
 In general, developers can assume that CDAP will attempt to retry every operation that 
 can be safely retried. As a rule of thumb, any operation that is idempotent can be retried.
-Some non-idempotent operations can also be retried depending on the type of failure.
-For example, developers can use the `Admin` interface to create a new dataset.
+Some non-idempotent operations can also be retried, depending on the type of failure.
+For example, developers can use the ``Admin`` interface to create a new dataset.
 This is not an idempotent operation, as attempting to create a dataset that already
 exists will result in a failure. However, the call to create a dataset will be retried
 by CDAP if it failed because the program could not discover or connect to the CDAP
 dataset service that actually creates the dataset.
 
-Methods in the `Admin`, `Transactional`, `StreamWriter`, and `DatasetContext` interface
+Methods in the ``Admin``, ``Transactional``, ``StreamWriter``, and ``DatasetContext`` interface
 will be retried by CDAP if they fail due to unavailability of a required CDAP system service. 
-For example, consider a `Worker` that uses `Transactional` to write to a Table:: 
+For example, consider a ``Worker`` that uses ``Transactional`` to write to a Table:: 
 
   @Override
   public void run() {
@@ -56,10 +55,9 @@ the configured timeout is reached or the transaction service recovers.
 
 Configuring Default Retry Policy 
 ================================
-
-Each program type is configured with its own default retry policy. For example, MapReduce has
+Each program type is configured with its own default retry policy. For example, a MapReduce program has
 a different default retry policy than a Service. The default retry policy for each program type
-can be changed by modifying properties in cdap-site.xml: 
+can be set by specifying these properties in the ``cdap-site.xml`` file: 
 
   - <program-type>.retry.policy.type
   - <program-type>.retry.policy.max.time.secs
@@ -67,41 +65,43 @@ can be changed by modifying properties in cdap-site.xml:
   - <program-type>.retry.policy.base.delay.ms
   - <program-type>.retry.policy.max.delay.ms
 
-program type is `mapreduce`, `spark`, `workflow`, `custom.action`, `worker`, `service`, or `flow`.
-The `retry.policy.type` property must be set to `none`, `fixed.delay`, or `exponential.backoff`.
-The `none` type means there will be no retry attempt.
-The `fixed.delay` type will retry the call at a fixed interval.
-The `exponential.backoff` type will retry at exponentially greater intervals after each failure.
+where program type is one of ``mapreduce``, ``spark``, ``workflow``, ``custom.action``, ``worker``, 
+``service``, or ``flow``.
 
-The `retry.policy.max.time.secs` property specifies a limit to the total amount of time CDAP will 
+- The ``retry.policy.type`` property must be set to one of ``none``, ``fixed.delay``, or ``exponential.backoff``.
+- The ``none`` type means there will be no retry attempt.
+- The ``fixed.delay`` type will retry the call at a fixed interval.
+- The ``exponential.backoff`` type will retry at exponentially greater intervals after each failure.
+
+The ``retry.policy.max.time.secs`` property specifies a limit to the total amount of time CDAP will 
 wait before aborting the operation. For example, when set to 60, CDAP will abort the operation
 if more than 60 seconds have passed since the original call was made.
 
-The `retry.policy.max.retries` property specifies a limit to the number of retries CDAP will
+The ``retry.policy.max.retries`` property specifies a limit to the number of retries CDAP will
 attempt before aborting the operation. The original call does not count as a retry attempt.
 For example, when set to five, CDAP will abort the operation after the sixth call has failed.
 
-The `retry.policy.base.delay.ms` property applies to the `fixed.delay` and `exponential.backoff`
-retry policy types. When using `fixed.delay`, it is the amount of time in milliseconds between
+The ``retry.policy.base.delay.ms`` property applies to the ``fixed.delay`` and ``exponential.backoff``
+retry policy types. When using ``fixed.delay``, it is the amount of time in milliseconds between
 retry attempts. For example, when set to 500, CDAP will retry the operation 500 milliseconds
-after the previous attempt failed. When using `exponential.backoff`, it is the amount of time
+after the previous attempt failed. When using ``exponential.backoff``, it is the amount of time
 in milliseconds between the original failure and the first retry attempt. 
 
-The `retry.policy.max.delay.ms` property only applies to the `exponential.backoff` retry policy type.
+The ``retry.policy.max.delay.ms`` property only applies to the ``exponential.backoff`` retry policy type.
 It is the maximum amount of time in milliseconds between retry attempts. For example, when
-`retry.policy.base.delay.ms` is 1000 and `retry.policy.max.delay.ms` is 4000, CDAP will wait for
+``retry.policy.base.delay.ms`` is 1000 and ``retry.policy.max.delay.ms`` is 4000, CDAP will wait for
 one second after the original failure to attempt the first retry. If that fails, CDAP will wait
 for two seconds before attempting the second retry. If that fails, CDAP will wait for four seconds
-before attempting the third retry. For every failure after that, CDAP will wait for four seconds.
+before attempting the third retry. For every failure after that, CDAP will wait for four seconds, as
+``retry.policy.max.delay.ms`` has been reached.
 Once an attempt succeeds, the time between retries will be reset to the base delay.
 
 .. _retry-policies-override
 
 Overriding Retry Policy
 =======================
-
 Retry policies can be overridden using preferences and runtime arguments. Each of the five
-properties can be overriden by setting that preference or runtime argument prefixed with 'system':
+properties can be overriden by setting that preference or runtime argument prefixed with ``system``:
 
   - system.retry.policy.type
   - system.retry.policy.max.time.secs
@@ -109,7 +109,6 @@ properties can be overriden by setting that preference or runtime argument prefi
   - system.retry.policy.delay.base.ms
   - system.retry.policy.delay.max.ms
 
-In this way, you can set different retry policies for different programs. For example, if one mapreduce
+In this way, you can set different retry policies for different programs. For example, if one MapReduce
 program normally takes days to finish, you may want to use a longer retry policy for it than for a
-mapreduce that normally takes ten minutes to finish. 
-
+MapReduce that normally takes ten minutes to finish.

--- a/cdap-docs/developers-manual/source/index.rst
+++ b/cdap-docs/developers-manual/source/index.rst
@@ -86,4 +86,4 @@ CDAP Developers’ Manual
 - |advanced|_ Covers **advanced topics on CDAP** that will be of interest to
   developers who want a deeper dive into CDAP, including **adding a custom logback** to a
   CDAP application, suggested **best practices for CDAP development**, **class loading in
-  CDAP**, and on **configuring program resources** of a CDAP application.
+  CDAP**, and on **configuring program resources** and **program retry policies** of a CDAP application.


### PR DESCRIPTION
Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB277-2

Page of interest: http://builds.cask.co/artifact/CDAP-DQB277/shared/build-2/Docs-HTML/4.1.0-SNAPSHOT/en/developers-manual/advanced/program-retry-policies.html