### PR TITLE
Documentation tweaks

### DIFF
--- a/cdap-docs/_common/_themes/cdap/downloads.html
+++ b/cdap-docs/_common/_themes/cdap/downloads.html
@@ -6,7 +6,8 @@
 #}
 {%- set zip_archive = "cdap-docs-" ~ release ~ "-web.zip" %}
   <div role="note" aria-label="downloads links">
-    <h3>Downloads</h3>
+    <h3><a href="http://docs.cask.co/cdap/{{ release }}/{{ zip_archive }}"
+            rel="nofollow">Download</a></h3>
     <ul class="this-page-menu">
       <li><a href="http://docs.cask.co/cdap/{{ release }}/{{ zip_archive }}"
             rel="nofollow">Zip Archive of CDAP Documentation</a></li>

--- a/cdap-docs/_common/_themes/cdap/searchbox.html
+++ b/cdap-docs/_common/_themes/cdap/searchbox.html
@@ -13,7 +13,7 @@
     {%- set search_root = '../' %}
   {%- endif %}
 <div id="searchbox" style="display: none" role="search">
-  <h3>Search</h3>
+  <h3><a href="{{ search_root }}{{ pathto('search') }}">Search</a></h3>
     <form class="search" action="{{ search_root }}{{ pathto('search') }}" method="get">
       <input type="text" name="q" />
       <input type="submit" value="{{ _('Go') }}" />

--- a/cdap-docs/_common/common-build.sh
+++ b/cdap-docs/_common/common-build.sh
@@ -84,7 +84,8 @@ function usage() {
   echo "    build-web        Clean build of docs with extras (no Javadocs)"
   echo "    build-docs       Clean build of docs (no extras or Javadocs)"
   echo "    docs             alias for 'build-docs'"
-  echo "    docs-local       Clean build of docs (no extras or Javadocs), using local copies of downloaded files"
+  echo "    build-web-local  Clean build of docs with extras (no Javadocs), using local copies of downloaded files"
+  echo "    build-docs-local Clean build of docs (no extras or Javadocs), using local copies of downloaded files"
   echo
   echo "    check            Runs build without running Sphinx, to check all downloads and includes"
   echo "    license-pdfs     Clean build of License Dependency PDFs"
@@ -135,23 +136,50 @@ function build_docs() {
   fi  
   build_extras
   consolidate_messages
+  add_html_redirect
 }
 
 function build_docs_local() {
-  BELL="${TRUE}"
   LOCAL_INCLUDES="${TRUE}"
   export LOCAL_INCLUDES
   build_docs
 }
 
 function build_web() {
+  echo "common-build.sh build_web"
+  build_docs ${GOOGLE_TAG_MANAGER_CODE}
+}
+
+function build_web_local() {
+  LOCAL_INCLUDES="${TRUE}"
+  export LOCAL_INCLUDES
   build_docs ${GOOGLE_TAG_MANAGER_CODE}
 }
 
 function build_extras() {
   # Over-ride this function in guides where Javadocs or licenses are being built or copied.
-  # Currently performed in reference-manual
   echo "No extras being built or copied."
+}
+
+function add_html_redirect() {
+  local redirect_text=$(cat <<EOF
+<!DOCTYPE HTML>
+<html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="0;url=html/index.html">
+        <script type="text/javascript">
+            window.location.href = "html/index.html"
+        </script>
+        <title></title>
+    </head>
+    <body>
+    </body>
+</html>
+EOF
+)
+  echo_set_message "Adding redirect"
+  echo ${redirect_text} >> ${TARGET}/redirect.html
 }
 
 function check() {
@@ -561,8 +589,9 @@ function rewrite() {
 function run_command() {
   set_version
   case ${1} in
-    build-web|build-docs)  "${1/-/_}";;
-    check|check-includes)  "${1/-/_}";;
+    build-docs|build-web)  "${1/-/_}";;
+    build-docs-local)      "${1//-/_}";;
+    build-web-local)       "${1//-/_}";;
     display-version)       "${1/-/_}";;
     license-pdfs)          "build_license_pdfs";;
     docs)                  "build_docs";;
@@ -570,3 +599,4 @@ function run_command() {
     *)                     usage;;
   esac
 }
+

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -123,7 +123,7 @@ function build_docs_set() {
 function build_docs_set_local() {
   LOCAL_INCLUDES="${TRUE}"
   export LOCAL_INCLUDES
-  _build_docs docs_set "Building Docs Set: docs_set w/ local files"
+  _build_docs docs_set "Building Docs Set: docs_set w/local files"
 }
 
 function build_docs_only() {
@@ -133,7 +133,7 @@ function build_docs_only() {
 function build_docs_only_local() {
   LOCAL_INCLUDES="${TRUE}"
   export LOCAL_INCLUDES
-  _build_docs docs_only "Building Docs Only: docs_only w/ local files"
+  _build_docs docs_only "Building Docs Only: docs_only w/local files"
 }
 
 function build_docs_web_only() {

--- a/cdap-docs/build.sh
+++ b/cdap-docs/build.sh
@@ -41,11 +41,14 @@ function usage() {
   echo 
   echo "  Action (select one)"
   echo
-  echo "    docs-set          Clean build of HTML, CLI, and Javadocs, zipped, ready for deploying"
   echo "    docs-all          alias to \"docs-set\""
+  echo
+  echo "    docs-set          Clean build of HTML, CLI, including Javadocs, zipped"
+  echo "    docs-set-local    Clean build of HTML, CLI, including Javadocs, zipped, but using local copies"
   echo "    docs-web-only     Clean build of HTML, CLI, zipped, skipping Javadocs"
   echo 
   echo "    docs              Dirty build of HTML, skipping CLI, Javadocs, or zipping"
+  echo "    docs-local        Dirty build of HTML, skipping CLI, Javadocs, or zipping, but using local copies"
   echo 
   echo "    clean             Clean up any previous build's target directories"
   echo "    docs-cli          Build CLI input file for documentation"
@@ -65,12 +68,14 @@ function run_command() {
     check )             build_docs_check; warnings=$?;;
     clean )             clean_targets;;
     docs )              build_docs_only; warnings=$?;;
+    docs-local )        build_docs_only_local; warnings=$?;;
     docs-all )          build_docs_set; warnings=$?;;
     docs-cli )          build_docs_cli;;
     docs-first-pass )   build_docs_first_pass;;
     docs-second-pass )  build_docs_second_pass;;
     docs-package )      build_docs_package;;
     docs-set )          build_docs_set; warnings=$?;;
+    docs-set-local )    build_docs_set_local; warnings=$?;;
     docs-web-only )     build_docs_web_only; warnings=$?;;
     javadocs )          build_javadocs docs;;
     javadocs-all )      build_javadocs all;;
@@ -115,8 +120,20 @@ function build_docs_set() {
   _build_docs docs_set "Building Docs Set: docs_set"
 }
 
+function build_docs_set_local() {
+  LOCAL_INCLUDES="${TRUE}"
+  export LOCAL_INCLUDES
+  _build_docs docs_set "Building Docs Set: docs_set w/ local files"
+}
+
 function build_docs_only() {
   _build_docs docs_only "Building Docs Only: docs_only"
+}
+
+function build_docs_only_local() {
+  LOCAL_INCLUDES="${TRUE}"
+  export LOCAL_INCLUDES
+  _build_docs docs_only "Building Docs Only: docs_only w/ local files"
 }
 
 function build_docs_web_only() {
@@ -281,6 +298,10 @@ function build_docs_inner_level() {
   # Change to each manual, and run the local ./build.sh from there.
   # Each manual can (and does) have a customised build script, using the common-build.sh as a base.
   local build_target=${1}
+  if [[ ${LOCAL_INCLUDES} == ${TRUE} ]]; then
+    echo "Using local builds."
+    build_target="${1}-local"
+  fi
   pushd $(pwd) > /dev/null
   for i in ${MANUALS}; do
     echo "========================================================"
@@ -324,6 +345,7 @@ function build_docs_outer_level() {
     ${SPHINX_BUILD} -w ${TARGET}/${SPHINX_MESSAGES} ${google_options} ${TARGET_PATH}/${SOURCE} ${TARGET_PATH}/${HTML}
   fi
   consolidate_messages
+  add_html_redirect
   echo
 }
  


### PR DESCRIPTION
Changes the "Downloads" link in the left sidebar to "Download", as there is only one item to download.
Makes the title itself a link, like the other titles.
Makes the "Search" title a link to the Search page.

Adds to the Doc build "local" building for the entire build process, removing the requirement to download files.

Adds a redirect into the `html` directory of the `target` directory to save clicks when opening the results.