### PR TITLE
CDAP-8622 Suppress redundant output

### DIFF
--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -209,11 +209,10 @@ cdap_stop_pidfile() {
 cdap_check_pidfile() {
   local readonly __pidfile=${1} __label=${2:-Process}
   local readonly __ret
-  cdap_status_pidfile ${__pidfile} ${__label}
+  cdap_status_pidfile ${__pidfile} ${__label} > /dev/null
   __ret=$?
   case ${__ret} in
-    3) echo "Please delete ${__pidfile} and try again" ;;
-    0) echo "Please stop ${__label}, first" ;;
+    0) echo "$(date) Please stop ${__label} running at $(<${__pidfile}), first, or use the restart function" ;;
     *) return 0 ;;
   esac
   return 1


### PR DESCRIPTION
Suppress output from `cdap_status_pidfile` in favor of `cdap_check_pidfile` output only.

Fixes CDAP-8622