### PR TITLE
Constrain cookbook versions for Docker/VM

### DIFF
--- a/cdap-distributions/src/packer/scripts/cookbook-setup.sh
+++ b/cdap-distributions/src/packer/scripts/cookbook-setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2015-2016 Cask Data, Inc.
+# Copyright © 2015-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -27,6 +27,11 @@ done
 
 ### TODO: remove this hack when chef-cookbooks/ark#181 is solved
 knife cookbook site install ark 2.1.0 || die "Cannot fetch ark cookbook 2.1.0"
+
+# Due to limitations on the Chef version required, pull these manually
+knife cookbook site install build-essential 7.0.3 || die "Cannot fetch build-essential 7.0.3"
+knife cookbook site install yum 4.2.0 || die "Cannot fetch yum 4.2.0"
+knife cookbook site install apt 5.1.0 || die "Cannot fetch apt 5.1.0"
 
 # Do not change HOME for cdap user
 sed -i '/ home /d' /var/chef/cookbooks/cdap/recipes/sdk.rb


### PR DESCRIPTION
Constrain the versions of the following cookbooks to the latest version that supports Chef 12.4:
- apt
- build-essential
- yum