### PR TITLE
CDAP-8498 Avoid sending 400 upon IllegalArgumentException.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/metadata/MetadataHttpHandler.java
@@ -877,7 +877,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
       responder.sendJson(HttpResponseStatus.OK, response, MetadataSearchResponse.class, GSON);
     } catch (Exception e) {
       // if MetadataDataset throws an exception, it gets wrapped
-      if (Throwables.getRootCause(e) instanceof IllegalArgumentException) {
+      if (Throwables.getRootCause(e) instanceof BadRequestException) {
         throw new BadRequestException(e.getMessage(), e);
       }
       throw e;

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/MetadataDataset.java
@@ -24,6 +24,7 @@ import co.cask.cdap.api.dataset.table.Put;
 import co.cask.cdap.api.dataset.table.Row;
 import co.cask.cdap.api.dataset.table.Scan;
 import co.cask.cdap.api.dataset.table.Scanner;
+import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.utils.ImmutablePair;
 import co.cask.cdap.data2.dataset2.lib.table.EntityIdKeyHelper;
 import co.cask.cdap.data2.dataset2.lib.table.FuzzyRowFilter;
@@ -563,11 +564,11 @@ public class MetadataDataset extends AbstractDataset {
    *         for subsequent queries to start with, if the specified #sortInfo is not {@link SortInfo#DEFAULT}.
    */
   public SearchResults search(String namespaceId, String searchQuery, Set<EntityTypeSimpleName> types,
-                              SortInfo sortInfo, int offset, int limit, int numCursors,
-                              @Nullable String cursor, boolean showHidden, Set<EntityScope> entityScope) {
+                              SortInfo sortInfo, int offset, int limit, int numCursors, @Nullable String cursor,
+                              boolean showHidden, Set<EntityScope> entityScope) throws BadRequestException {
     if (!SortInfo.DEFAULT.equals(sortInfo)) {
       if (!"*".equals(searchQuery)) {
-        throw new IllegalArgumentException("Cannot search with non-default sort with any query other than '*'");
+        throw new BadRequestException("Cannot search with non-default sort with any query other than '*'");
       }
       return searchByCustomIndex(namespaceId, types, sortInfo, offset, limit, numCursors, cursor, showHidden,
                                  entityScope);

--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
@@ -19,6 +19,7 @@ import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.DatasetAdmin;
 import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.table.Scanner;
+import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.data2.datafabric.dataset.DatasetsUtil;
 import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import co.cask.cdap.data2.metadata.indexer.Indexer;
@@ -1496,14 +1497,14 @@ public class MetadataDatasetTest {
   // should be called inside a transaction. This method does not start a transaction on its own, so that you can
   // have multiple invocations in the same transaction.
   private List<MetadataEntry> searchByDefaultIndex(String namespaceId, String searchQuery,
-                                                   Set<EntityTypeSimpleName> types) {
+                                                   Set<EntityTypeSimpleName> types) throws BadRequestException {
     return searchByDefaultIndex(dataset, namespaceId, searchQuery, types);
   }
 
   // should be called inside a transaction. This method does not start a transaction on its own, so that you can
   // have multiple invocations in the same transaction.
   private List<MetadataEntry> searchByDefaultIndex(MetadataDataset dataset, String namespaceId, String searchQuery,
-                                                   Set<EntityTypeSimpleName> types) {
+                                                   Set<EntityTypeSimpleName> types) throws BadRequestException {
     return dataset.search(namespaceId, searchQuery, types,
                           SortInfo.DEFAULT, 0, Integer.MAX_VALUE, 1, null, false,
                           EnumSet.allOf(EntityScope.class)).getResults();


### PR DESCRIPTION
[CDAP-8498](https://issues.cask.co/browse/CDAP-8498) Without this change, any IllegalArgumentException results in a BadRequestException (400 http response code) to the client. Some IllegalArgumentException may happen for reasons other than a bad request from the client (such as malformed data in the system, which should be an internal server error).

http://builds.cask.co/browse/CDAP-RUT642-6