### PR TITLE
CDAP-8632 Added retry strategy for the Metrics table creation.

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/KafkaMetricsProcessorService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/KafkaMetricsProcessorService.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.metrics.process;
 
 import co.cask.cdap.api.metrics.MetricsContext;
+import co.cask.cdap.common.ServiceUnavailableException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.metrics.store.MetricDatasetFactory;
 import com.google.common.util.concurrent.AbstractExecutionThreadService;
@@ -112,6 +113,9 @@ public final class KafkaMetricsProcessorService extends AbstractExecutionThreadS
       }
       try {
         metaTable = metricDatasetFactory.createConsumerMeta();
+      } catch (ServiceUnavailableException e) {
+        // No need to log the exception here since this can only happen when the DatasetService is not running.
+        // try in next iteration
       } catch (Exception e) {
         LOG.warn("Cannot access consumer metaTable, will retry in 1 sec.");
         try {

--- a/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MessagingMetricsProcessorService.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/metrics/process/MessagingMetricsProcessorService.java
@@ -25,6 +25,7 @@ import co.cask.cdap.api.metrics.MetricType;
 import co.cask.cdap.api.metrics.MetricValue;
 import co.cask.cdap.api.metrics.MetricValues;
 import co.cask.cdap.api.metrics.MetricsContext;
+import co.cask.cdap.common.ServiceUnavailableException;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.io.BinaryDecoder;
 import co.cask.cdap.common.logging.LogSamplers;
@@ -154,6 +155,9 @@ public class MessagingMetricsProcessorService extends AbstractExecutionThreadSer
       }
       try {
         metaTable = metricDatasetFactory.createConsumerMeta();
+      } catch (ServiceUnavailableException e) {
+        // No need to log the exception here since this can only happen when the DatasetService is not running.
+        // try in next iteration
       } catch (Exception e) {
         LOG.warn("Cannot access consumer metaTable, will retry in 1 sec.");
         try {


### PR DESCRIPTION
When `OperationalStatsService` is started, it loads `CDAPLoad` extension which requires to access the metrics table. However if the DatasetService is not up yet, we see following exceptions in the log

```java
2017-02-20 18:00:39,081 - WARN  [OperationalStatsService:c.c.c.m.s.DefaultMetricDatasetFactory@128] - Cannot access or create table metrics.v2.table.ts.1, will retry in 1 sec.
2017-02-20 18:00:41,082 - WARN  [OperationalStatsService:c.c.c.m.s.DefaultMetricDatasetFactory@128] - Cannot access or create table metrics.v2.table.ts.1, will retry in 1 sec.
2017-02-20 18:00:43,082 - WARN  [OperationalStatsService:c.c.c.m.s.DefaultMetricDatasetFactory@128] - Cannot access or create table metrics.v2.table.ts.1, will retry 
```

In this PR added fix delay retry strategy for the creation of the metrics table, since `OperationalStatsService` is a system service.