### PR TITLE
CDAP-7255 Add note about the location of "kafka.server.log.dirs"

### DIFF
--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -409,9 +409,14 @@ Port* is used by the CDAP UI to connect to the CDAP Router service.
 
    **Add Service Wizard, Page 4:** Reviewing changes and (initial) configuration.
 
-**Additional CDAP configuration properties** can be added using Cloudera Manager's 
-*Safety Valve Advanced Configuration Snippets.* Documentation of the available CDAP
-properties is in the :ref:`appendix-cdap-site.xml`.
+**Additional CDAP configuration properties** can be added using Cloudera Manager's *Safety
+Valve Advanced Configuration Snippets.* Documentation of the available CDAP properties is
+in the :ref:`appendix-cdap-site.xml`. Note that for certain CDAP properties, the defaults
+values for Cloudera may vary from the above appendix:
+
+- For ``kafka.server.log.dirs``, the default value is ``{$LOCAL_DIR/kafka-logs}`` or
+  ``/var/tmp/cdap/kafka-logs``, instead of ``/tmp/kafka-logs`` as shown in the
+  :ref:`Appendix: Kafka Server <appendix-cdap-default-kafka-server>`.
 
 **Additional environment variables** can be set, as required, using Cloudera Manager's
 *CDAP Service Environment Advanced Configuration Snippet (Safety Valve).* See the example below for


### PR DESCRIPTION
Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB279-1

Build fails, as the guarded file `cdap-default.xml` has changed...

Page of interest: http://builds.cask.co/artifact/CDAP-DQB279/shared/build-1/Docs-HTML/4.1.0-SNAPSHOT/en/admin-manual/installation/cloudera.html#add-service-wizard-reviewing-configuration

Fix for: https://issues.cask.co/browse/CDAP-7255