### PR TITLE
Fix broken Doc build: update MD5 hash.

### DIFF
--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="6231fc3012d3e4e55ec2632585654040"
+DEFAULT_XML_MD5_HASH="b0cf675c26ec5b4080fff7f143bf1af3"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
After checking guarded file, no changes required.

Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB280-1