### PR TITLE
CDAP-3255 Return the current page as a link instead of the index page.

### DIFF
--- a/cdap-docs/_common/_themes/cdap/static/version-menu.js
+++ b/cdap-docs/_common/_themes/cdap/static/version-menu.js
@@ -48,7 +48,12 @@
   var versionsURL = 'http://docs.cask.co/cdap/';
   var versionID = 'select-version';
   var buildURL = (function(dir){
-    return versionsURL + dir + '/en/' + location.pathname.substr(location.pathname.lastIndexOf('/en/')+4);
+    var en = location.pathname.indexOf('/en/');
+    if (en != -1) {
+      return versionsURL + dir + location.pathname.substr(en);
+    } else {
+      return versionsURL + dir + '/en/';
+    }    
   });
   var writeLink = (function(dir, label){
     document.write('<option value="' + buildURL(dir) + '">' + label + '</option>');

--- a/cdap-docs/_common/_themes/cdap/static/version-menu.js
+++ b/cdap-docs/_common/_themes/cdap/static/version-menu.js
@@ -40,7 +40,7 @@
  * 
  * list of development versions; one current version; list of additional versions; dict of Google Custom Search Engines (gcse)
  *
- * version 0.4
+ * version 0.5
  * 
  */
 
@@ -48,7 +48,7 @@
   var versionsURL = 'http://docs.cask.co/cdap/';
   var versionID = 'select-version';
   var buildURL = (function(dir){
-    return versionsURL + dir + '/en/';
+    return versionsURL + dir + '/en/' + location.pathname.substr(location.pathname.lastIndexOf('/en/')+4);
   });
   var writeLink = (function(dir, label){
     document.write('<option value="' + buildURL(dir) + '">' + label + '</option>');


### PR DESCRIPTION
This is an often-requested feature. With the pop-up menu in the upper-left of the docs, instead of going to the top-page when you change versions, it goes to the same page as the one you are on, which is often the case from version to version.

Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB281-1

Page of interest: _to be completed_