### PR TITLE
(CDAP-8565) Improve master stop experience

### DIFF
--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -87,7 +87,7 @@ case ${1} in
     echo
     if [[ $(cdap_context) == 'distributed' ]]; then
     # No indent to make lining up easier
-    echo "    auth-server  - Sends the arguments (start/stop/etc.) to the appropriate CDAP service on this host"
+    echo "    auth-server  - Sends the arguments (start/stop/kill/etc.) to the appropriate CDAP service on this host"
     echo "    kafka-server"
     echo "    master"
     echo "    router"

--- a/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/election/LeaderElectionInfoService.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/zookeeper/election/LeaderElectionInfoService.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.zookeeper.election;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.SettableFuture;
+import org.apache.twill.common.Cancellable;
+import org.apache.twill.zookeeper.NodeChildren;
+import org.apache.twill.zookeeper.NodeData;
+import org.apache.twill.zookeeper.ZKClient;
+import org.apache.twill.zookeeper.ZKOperations;
+import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.SortedMap;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.annotation.Nullable;
+
+/**
+ * A service for watching changes in the leader-election participants.
+ */
+public class LeaderElectionInfoService extends AbstractIdleService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LeaderElectionInfoService.class);
+
+  private final ZKClient zkClient;
+  private final String leaderElectionPath;
+  private final SettableFuture<CountDownLatch> readyFuture;
+  private final ConcurrentNavigableMap<Integer, Participant> participants;
+  private Cancellable cancellable;
+
+  public LeaderElectionInfoService(ZKClient zkClient, String leaderElectionPath) {
+    this.zkClient = zkClient;
+    this.leaderElectionPath = leaderElectionPath.startsWith("/") ? leaderElectionPath : "/" + leaderElectionPath;
+    this.readyFuture = SettableFuture.create();
+    this.participants = new ConcurrentSkipListMap<>();
+  }
+
+  /**
+   * Gets the map of participants. This method will block until the participants information is fetched
+   * for the first time from ZK or timeout happened.
+   *
+   * @return An immutable {@link SortedMap} ordered by the participant ID with the smallest key in the map
+   *         as the current leader. The returned map is thread-safe and will be updated asynchronously
+   * @throws InterruptedException if the caller thread is interrupted while waiting for the participants information
+   *                              to be available
+   * @throws TimeoutException if the wait timed out
+   */
+  public SortedMap<Integer, Participant> getParticipants(long timeout,
+                                                         TimeUnit unit) throws InterruptedException, TimeoutException {
+    try {
+      Stopwatch stopwatch = new Stopwatch().start();
+      CountDownLatch readyLatch = readyFuture.get(timeout, unit);
+      long latchTimeout = Math.max(0, stopwatch.elapsedTime(unit) - timeout);
+      readyLatch.await(latchTimeout, unit);
+    } catch (ExecutionException e) {
+      // The ready future never throw on get. If this happen, just return an empty map
+      return ImmutableSortedMap.of();
+    }
+    return Collections.unmodifiableSortedMap(participants);
+  }
+
+  /**
+   * Fetches the latest participants from ZK. This method will block until it fetched all participants information.
+   * Note that the map returned is only a snapshot of the leader election information in ZK, which only reflects
+   * the states in ZK at the time when the snapshot was taken.
+   *
+   * @return An immutable {@link SortedMap} ordered by the participant ID with the smallest key in the map
+   *         as the current leader
+   * @throws InterruptedException if the caller thread is interrupted while waiting for the participants information
+   *                              to be available
+   * @throws Exception if failed to fetch information from ZK
+   */
+  public SortedMap<Integer, Participant> fetchCurrentParticipants() throws Exception {
+    try {
+      NodeChildren nodeChildren = zkClient.getChildren(leaderElectionPath).get();
+
+      ConcurrentNavigableMap<Integer, Participant> result = new ConcurrentSkipListMap<>();
+      SettableFuture<CountDownLatch> completion = SettableFuture.create();
+      childrenUpdated(nodeChildren, result, completion);
+
+      completion.get().await();
+      return Collections.unmodifiableSortedMap(result);
+
+    } catch (ExecutionException e) {
+      // If the election path doesn't exists, that means there is no participant
+      Throwable cause = e.getCause();
+      if (cause instanceof KeeperException.NoNodeException) {
+        return ImmutableSortedMap.of();
+      }
+      Throwables.propagateIfPossible(cause, Exception.class);
+      // Shouldn't reach here as we propagate any Exception/RuntimeException/Error already
+      return ImmutableSortedMap.of();
+    }
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    cancellable = ZKOperations.watchChildren(zkClient, leaderElectionPath, new ZKOperations.ChildrenCallback() {
+      @Override
+      public void updated(NodeChildren nodeChildren) {
+        childrenUpdated(nodeChildren, participants, readyFuture);
+      }
+    });
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    if (cancellable != null) {
+      cancellable.cancel();
+    }
+  }
+
+  private void childrenUpdated(NodeChildren nodeChildren,
+                               ConcurrentNavigableMap<Integer, Participant> participants,
+                               SettableFuture<CountDownLatch> readyFuture) {
+    if (!isRunning()) {
+      return;
+    }
+
+    Map<Integer, String> childIdNodes = new HashMap<>();
+
+    for (String child : nodeChildren.getChildren()) {
+      int idx = child.lastIndexOf("-");
+      if (idx < 0) {
+        // This is not expected as ZK nodes created by LeaderElection always has "-" to separate the node seq no.
+        LOG.warn("Ignoring child node {} due to un-recognized format. Expected to be [guid]-[integer]", child);
+        continue;
+      }
+
+      int id;
+      try {
+        id = Integer.parseInt(child.substring(idx + 1));
+        childIdNodes.put(id, child);
+        participants.putIfAbsent(id, new Participant(leaderElectionPath + "/" + child, null));
+      } catch (NumberFormatException e) {
+        LOG.warn("Ignoring child node {} due to un-recognized format. Expected to be [guid]-[integer]", child);
+      }
+    }
+
+    // If no participants, just clear the participants map and return
+    if (childIdNodes.isEmpty()) {
+      participants.clear();
+      readyFuture.set(new CountDownLatch(0));
+      return;
+    }
+
+    // Prepare the ready latch and set it to ready future if it wasn't set before
+    CountDownLatch readyLatch = null;
+    if (!readyFuture.isDone()) {
+      readyLatch = new CountDownLatch(childIdNodes.size());
+      readyFuture.set(readyLatch);
+    }
+
+    // Remove participants that are gone
+    Iterator<Integer> iterator = participants.keySet().iterator();
+    while (iterator.hasNext()) {
+      if (!childIdNodes.containsKey(iterator.next())) {
+        iterator.remove();
+      }
+    }
+
+    // Fetch each child node
+    for (Map.Entry<Integer, String> entry : childIdNodes.entrySet()) {
+      fetchParticipant(entry.getValue(), entry.getKey(), participants, readyLatch);
+    }
+  }
+
+  private void fetchParticipant(String participantNode, final int participantId,
+                                final ConcurrentNavigableMap<Integer, Participant> participants,
+                                @Nullable final CountDownLatch readyLatch) {
+    final String path = leaderElectionPath + "/" + participantNode;
+    final Participant oldInfo = participants.get(participantId);
+
+    Futures.addCallback(zkClient.getData(path), new FutureCallback<NodeData>() {
+      @Override
+      public void onSuccess(NodeData result) {
+        byte[] data = result.getData();
+        String hostname = (data == null) ? null : new String(data, StandardCharsets.UTF_8);
+        Participant newInfo = new Participant(path, hostname);
+        participants.replace(participantId, oldInfo, newInfo);
+        if (readyLatch != null) {
+          readyLatch.countDown();
+        }
+      }
+
+      @Override
+      public void onFailure(Throwable t) {
+        if (t instanceof KeeperException.NoNodeException) {
+          // It's possible the node is gone
+          participants.remove(participantId, oldInfo);
+        } else {
+          // Just log info and replace the participant info with the UNKNOWN_INFO
+          LOG.info("Failed in fetching participant information from {}", path);
+          participants.replace(participantId, oldInfo, new Participant(path, null));
+        }
+
+        if (readyLatch != null) {
+          readyLatch.countDown();
+        }
+      }
+    });
+  }
+
+  /**
+   * Class representing a participant in leader-election.
+   */
+  public static final class Participant {
+
+    private final String zkPath;
+    private final String hostname;
+
+    Participant(String zkPath, @Nullable String hostname) {
+      this.zkPath = zkPath;
+      this.hostname = hostname;
+    }
+
+    public String getZkPath() {
+      return zkPath;
+    }
+
+    @Nullable
+    public String getHostname() {
+      return hostname;
+    }
+
+    @Override
+    public String toString() {
+      return "ParticipantInfo{" +
+        "zkPath='" + zkPath + '\'' +
+        ", hostname='" + hostname + '\'' +
+        '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Participant that = (Participant) o;
+      return Objects.equals(zkPath, that.zkPath) && Objects.equals(hostname, that.hostname);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(zkPath, hostname);
+    }
+  }
+}

--- a/cdap-common/src/test/java/co/cask/cdap/common/zookeeper/election/LeaderElectionInfoServiceTest.java
+++ b/cdap-common/src/test/java/co/cask/cdap/common/zookeeper/election/LeaderElectionInfoServiceTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common.zookeeper.election;
+
+import co.cask.cdap.common.utils.Tasks;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import org.apache.twill.api.ElectionHandler;
+import org.apache.twill.internal.zookeeper.DefaultZKClientService;
+import org.apache.twill.internal.zookeeper.InMemoryZKServer;
+import org.apache.twill.internal.zookeeper.LeaderElection;
+import org.apache.twill.zookeeper.ZKClientService;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ *
+ */
+public class LeaderElectionInfoServiceTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LeaderElectionInfoServiceTest.class);
+
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+  private static InMemoryZKServer zkServer;
+
+  @BeforeClass
+  public static void init() throws IOException {
+    zkServer = InMemoryZKServer.builder().setDataDir(TEMP_FOLDER.newFolder()).build();
+    zkServer.startAndWait();
+  }
+
+  @AfterClass
+  public static void finish() {
+    zkServer.stopAndWait();
+  }
+
+  @Test
+  public void testParticipants() throws Exception {
+    final int size = 5;
+    String prefix = "/election";
+
+    List<ZKClientService> zkClients = new ArrayList<>();
+
+    ZKClientService infoZKClient = DefaultZKClientService.Builder.of(zkServer.getConnectionStr()).build();
+    infoZKClient.startAndWait();
+    zkClients.add(infoZKClient);
+
+    // Start the LeaderElectionInfoService
+    LeaderElectionInfoService infoService = new LeaderElectionInfoService(infoZKClient, prefix);
+    infoService.startAndWait();
+
+    // This will timeout as there is no leader election node created yet
+    try {
+      infoService.getParticipants(1, TimeUnit.SECONDS);
+      Assert.fail("Expected timeout");
+    } catch (TimeoutException e) {
+      // Expected
+    }
+
+    // Starts multiple leader elections
+    List<LeaderElection> leaderElections = new ArrayList<>();
+    for (int i = 0; i < size; i++) {
+      ZKClientService zkClient = DefaultZKClientService.Builder.of(zkServer.getConnectionStr()).build();
+      zkClient.startAndWait();
+      zkClients.add(zkClient);
+
+      final int participantId = i;
+      LeaderElection leaderElection = new LeaderElection(zkClient, prefix, new ElectionHandler() {
+        @Override
+        public void leader() {
+          LOG.info("Leader: {}", participantId);
+        }
+
+        @Override
+        public void follower() {
+          LOG.info("Follow: {}", participantId);
+        }
+      });
+      leaderElection.start();
+      leaderElections.add(leaderElection);
+    }
+
+    // Get the dynamic participants map
+    final SortedMap<Integer, LeaderElectionInfoService.Participant> participants =
+      infoService.getParticipants(5, TimeUnit.SECONDS);
+
+    // Expects to set all participants with hostname information
+    Tasks.waitFor(true, new Callable<Boolean>() {
+      @Override
+      public Boolean call() throws Exception {
+        if (participants.size() != size) {
+          return false;
+        }
+        return Iterables.all(participants.values(), new Predicate<LeaderElectionInfoService.Participant>() {
+          @Override
+          public boolean apply(LeaderElectionInfoService.Participant input) {
+            return input.getHostname() != null;
+          }
+        });
+      }
+    }, 5, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+
+    // Fetch the static snapshot. It should be the same as the dynamic participants.
+    SortedMap<Integer, LeaderElectionInfoService.Participant> snapshot = infoService.fetchCurrentParticipants();
+    Assert.assertEquals(size, snapshot.size());
+    Assert.assertEquals(participants, snapshot);
+
+    int expectedSize = size;
+    for (LeaderElection leaderElection : leaderElections) {
+      leaderElection.stopAndWait();
+      Tasks.waitFor(--expectedSize, new Callable<Integer>() {
+        @Override
+        public Integer call() throws Exception {
+          return participants.size();
+        }
+      }, 5, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
+    }
+
+    // Fetch the static snapshot again. It should be empty and the same as the dynamic one.
+    snapshot = infoService.fetchCurrentParticipants();
+    Assert.assertTrue(snapshot.isEmpty());
+    Assert.assertEquals(participants, snapshot);
+
+    infoService.stopAndWait();
+
+    for (ZKClientService zkClient : zkClients) {
+      zkClient.stopAndWait();
+    }
+  }
+}

--- a/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/co/cask/cdap/data/runtime/main/MasterServiceMain.java
@@ -542,7 +542,8 @@ public class MasterServiceMain extends DaemonMain {
    */
   @VisibleForTesting
   static Injector createLeaderInjector(CConfiguration cConf, Configuration hConf,
-                                       final ZKClientService zkClientService) {
+                                       final ZKClientService zkClientService,
+                                       final LeaderElectionInfoService electionInfoService) {
     return Guice.createInjector(
       new ConfigModule(cConf, hConf),
       new AbstractModule() {
@@ -552,6 +553,7 @@ public class MasterServiceMain extends DaemonMain {
           // binding to reuse the same ZKClient used for leader election
           bind(ZKClient.class).toInstance(zkClientService);
           bind(ZKClientService.class).toInstance(zkClientService);
+          bind(LeaderElectionInfoService.class).toInstance(electionInfoService);
         }
       },
       new LoggingModules().getDistributedModules(),
@@ -619,7 +621,7 @@ public class MasterServiceMain extends DaemonMain {
 
       // We need to create a new injector each time becoming leader so that new instances of singleton Services
       // will be created
-      injector = createLeaderInjector(cConf, hConf, zkClient);
+      injector = createLeaderInjector(cConf, hConf, zkClient, electionInfoService);
 
       if (cConf.getBoolean(Constants.Explore.EXPLORE_ENABLED)) {
         exploreClient = injector.getInstance(ExploreClient.class);

--- a/cdap-master/src/test/java/co/cask/cdap/data/runtime/main/MasterServiceMainTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/data/runtime/main/MasterServiceMainTest.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.data.runtime.main;
 
 import co.cask.cdap.common.conf.CConfiguration;
+import co.cask.cdap.common.zookeeper.election.LeaderElectionInfoService;
 import co.cask.cdap.data2.datafabric.dataset.service.DatasetService;
 import co.cask.cdap.internal.app.services.AppFabricServer;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;
@@ -38,9 +39,12 @@ public class MasterServiceMainTest {
   @Test
   public void testInjector() {
     Injector baseInjector = MasterServiceMain.createProcessInjector(CConfiguration.create(), new Configuration());
-    Injector injector = MasterServiceMain.createLeaderInjector(baseInjector.getInstance(CConfiguration.class),
-                                                               baseInjector.getInstance(Configuration.class),
-                                                               baseInjector.getInstance(ZKClientService.class));
+    Injector injector = MasterServiceMain.createLeaderInjector(
+      baseInjector.getInstance(CConfiguration.class),
+      baseInjector.getInstance(Configuration.class),
+      baseInjector.getInstance(ZKClientService.class),
+      new LeaderElectionInfoService(baseInjector.getInstance(ZKClientService.class), "/election")
+    );
 
     Assert.assertNotNull(injector.getInstance(AuthorizerInstantiator.class));
     Assert.assertNotNull(injector.getInstance(DatasetService.class));

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/Containers.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/Containers.java
@@ -55,7 +55,7 @@ public interface Containers {
     private final Integer debugPort;
 
     public ContainerInfo(ContainerType type, String name,
-                         @Nullable Integer instance, @Nullable String container, String host,
+                         @Nullable Integer instance, @Nullable String container, @Nullable String host,
                          @Nullable Integer memory, @Nullable Integer virtualCores, @Nullable Integer debugPort) {
       this.type = type.name().toLowerCase();
       this.name = name;
@@ -100,6 +100,7 @@ public interface Containers {
       return container;
     }
 
+    @Nullable
     public String getHost() {
       return host;
     }


### PR DESCRIPTION
Changes are already grouped into different commits

- Added a `LeaderElectionInfoService` to provide information about leader-election participants based on info in ZK
- Enhanced shutdown logic in `MasterServiceMain` to keep the master twill app running in YARN when appropriate
- Added leader election participants information to the live-info endpoint
- Added a `kill` command to cdap script to `kill -9` processes