### PR TITLE
[CDAP-8673] Fixes explore fast action to show right query

### DIFF
--- a/cdap-ui/app/cdap/components/DatasetDetailedView/index.js
+++ b/cdap-ui/app/cdap/components/DatasetDetailedView/index.js
@@ -52,7 +52,8 @@ export default class DatasetDetailedView extends Component {
       isInvalid: false,
       routeToHome: false,
       successMessage: null,
-      notFound: false
+      notFound: false,
+      modalToOpen: objectQuery(this.props, 'location', 'query', 'modalToOpen') || ''
     };
   }
 
@@ -260,6 +261,7 @@ export default class DatasetDetailedView extends Component {
           entity={this.state.entityMetadata}
           onFastActionSuccess={this.goToHome.bind(this)}
           onFastActionUpdate={this.goToHome.bind(this)}
+          fastActionToOpen={this.state.modalToOpen}
           showFullCreationTime={true}
         />
         <DatasetDetaildViewTab

--- a/cdap-ui/app/cdap/components/FastAction/ExploreAction/ExploreModal.js
+++ b/cdap-ui/app/cdap/components/FastAction/ExploreAction/ExploreModal.js
@@ -46,6 +46,15 @@ export default class ExploreModal extends Component {
     this._mounted = false;
     this.subscriptions.map(subscriber => subscriber.dispose());
   }
+  componentWillReceiveProps(nextProps) {
+    let {databaseName:existingDatabaseName, tableName:existingTableName} = this.props.entity;
+    let {databaseName:newDatabaseName, tableName:newTablename} = nextProps.entity;
+    if (existingDatabaseName !== newDatabaseName || existingTableName !== newTablename) {
+      this.setState({
+        queryString: `SELECT * FROM ${nextProps.entity.databaseName}.${nextProps.entity.tableName} LIMIT 500`,
+      });
+    }
+  }
   updateState() {
     if (!this._mounted) {
       return;


### PR DESCRIPTION
### Existing issue:
where the user directly goes to explore view on streams/datasets detailed view with explore modal opened. We right now show incorrect query as the database and table name is not available for UI yet. 
### Fix:
The fix is to update the query on database and tablenames gets updated from backend.


Putting on hold to see if I can fix: https://issues.cask.co/browse/TRACKER-292 in the same PR