### PR TITLE
CDAP-8672 don't log errors in router for 503

### DIFF
--- a/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterServiceLookup.java
+++ b/cdap-gateway/src/main/java/co/cask/cdap/gateway/router/RouterServiceLookup.java
@@ -160,7 +160,7 @@ public class RouterServiceLookup {
 
     if (endpointStrategy.pick() == null) {
       String message = String.format("No discoverable endpoints found for service %s", cacheKey);
-      LOG.error(message);
+      LOG.debug(message);
       throw new Exception(message);
     }
 


### PR DESCRIPTION
Fixes a bug where 503 responses due to an undiscoverable service
would result in an error log and a stack trace. A 503 is normal
behavior for the router and does not indicate an error in the
router. As such, logging these as debug instead of error. Only
internal router errors should be logged as error.