### PR TITLE
CDAP-8508 Rollback namespace create, if there is a failure in getting UGI

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -205,13 +205,13 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
     // store the meta first in the namespace store because namespacedLocationFactory needs to look up location
     // mapping from namespace config
     nsStore.create(metadata);
-    UserGroupInformation ugi;
-    if (NamespaceId.DEFAULT.equals(namespace)) {
-      ugi = UserGroupInformation.getCurrentUser();
-    } else {
-      ugi = impersonator.getUGI(namespace);
-    }
     try {
+      UserGroupInformation ugi;
+      if (NamespaceId.DEFAULT.equals(namespace)) {
+        ugi = UserGroupInformation.getCurrentUser();
+      } else {
+        ugi = impersonator.getUGI(namespace);
+      }
       ImpersonationUtils.doAs(ugi, new Callable<Void>() {
         @Override
         public Void call() throws Exception {


### PR DESCRIPTION
[CDAP-8508](https://issues.cask.co/browse/CDAP-8508) Rollback namespace create, if there is a failure in getting the UGI configured for that namespace.

Manually validated the change and filed a JIRA to write an integration test: https://issues.cask.co/browse/CDAP-8675

http://builds.cask.co/browse/CDAP-RUT665-3