### PR TITLE
CDAP-8676, CDAP-8667 Reduce log level to DEBUG for the TokenSecureStoreUpdater.

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ImpersonationHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ImpersonationHandler.java
@@ -81,7 +81,7 @@ public class ImpersonationHandler extends AbstractHttpHandler {
       throw new BadRequestException("Request body is empty.");
     }
     ImpersonationRequest impersonationRequest = GSON.fromJson(requestContent, ImpersonationRequest.class);
-    LOG.info("Fetching credentials for {}", impersonationRequest);
+    LOG.debug("Fetching credentials for {}", impersonationRequest);
     UGIWithPrincipal ugiWithPrincipal = ugiProvider.getConfiguredUGI(impersonationRequest);
     Credentials credentials = ImpersonationUtils.doAs(ugiWithPrincipal.getUGI(), new Callable<Credentials>() {
       @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/security/TokenSecureStoreUpdater.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/security/TokenSecureStoreUpdater.java
@@ -134,7 +134,7 @@ public final class TokenSecureStoreUpdater implements SecureStoreUpdater {
     String renewer = YarnUtils.getYarnTokenRenewer(config);
 
     Token<?>[] tokens = fileSystem.addDelegationTokens(renewer, credentials);
-    LOG.info("Added HDFS DelegationTokens: {}", Arrays.toString(tokens));
+    LOG.debug("Added HDFS DelegationTokens: {}", Arrays.toString(tokens));
 
     return tokens == null ? ImmutableList.<Token<?>>of() : ImmutableList.copyOf(tokens);
   }
@@ -244,7 +244,7 @@ public final class TokenSecureStoreUpdater implements SecureStoreUpdater {
    */
   public SecureStore update() {
     Credentials credentials = refreshCredentials();
-    LOG.info("Updated credentials {}", credentials.getAllTokens());
+    LOG.debug("Updated credentials {}", credentials.getAllTokens());
     try {
       return YarnSecureStore.create(credentials, UserGroupInformation.getCurrentUser());
     } catch (IOException e) {

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/security/hive/HiveTokenUtils.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/security/hive/HiveTokenUtils.java
@@ -41,7 +41,6 @@ public final class HiveTokenUtils {
     Thread.currentThread().setContextClassLoader(hiveClassloader);
 
     try {
-      LOG.info("Obtaining delegation token for Hive");
       Class hiveConfClass = hiveClassloader.loadClass("org.apache.hadoop.hive.conf.HiveConf");
       Object hiveConf = hiveConfClass.newInstance();
 
@@ -58,12 +57,11 @@ public final class HiveTokenUtils {
       Token<DelegationTokenIdentifier> delegationToken = new Token<>();
       delegationToken.decodeFromUrlString(tokenStr);
       delegationToken.setService(new Text(HiveAuthFactory.HS2_CLIENT_TOKEN));
-      LOG.info("Adding delegation token {} from MetaStore for service {} for user {}",
-               delegationToken, delegationToken.getService(), user);
+      LOG.debug("Adding delegation token {} from MetaStore for service {} for user {}",
+                delegationToken, delegationToken.getService(), user);
       credentials.addToken(delegationToken.getService(), delegationToken);
       return credentials;
     } catch (Exception e) {
-      LOG.error("Exception when fetching delegation token from Hive MetaStore", e);
       throw Throwables.propagate(e);
     } finally {
       Thread.currentThread().setContextClassLoader(contextClassloader);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/security/hive/JobHistoryServerTokenUtils.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/security/hive/JobHistoryServerTokenUtils.java
@@ -58,8 +58,6 @@ public final class JobHistoryServerTokenUtils {
     String historyServerAddress = configuration.get("mapreduce.jobhistory.address");
     HostAndPort hostAndPort = HostAndPort.fromString(historyServerAddress);
     try {
-      LOG.info("Obtaining delegation token for JHS");
-
       ResourceMgrDelegate resourceMgrDelegate = new ResourceMgrDelegate(new YarnConfiguration(configuration));
       MRClientCache clientCache = new MRClientCache(configuration, resourceMgrDelegate);
       MRClientProtocol hsProxy = clientCache.getInitializedHSProxy();
@@ -71,9 +69,9 @@ public final class JobHistoryServerTokenUtils {
         ConverterUtils.convertFromYarn(hsProxy.getDelegationToken(request).getDelegationToken(), address);
 
       credentials.addToken(new Text(token.getService()), token);
+      LOG.debug("Adding JobHistoryServer delegation token {}.", token);
       return credentials;
     } catch (Exception e) {
-      LOG.error("Failed to get secure token for JHS at {}.", hostAndPort, e);
       throw Throwables.propagate(e);
     }
   }

--- a/cdap-common/src/main/java/co/cask/cdap/common/security/YarnTokenUtils.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/security/YarnTokenUtils.java
@@ -80,12 +80,12 @@ public final class YarnTokenUtils {
           services.add(SecurityUtil.buildTokenService(YarnUtils.getRMAddress(configuration)).toString());
         }
 
-        Token<TokenIdentifier> token = ConverterUtils.convertFromYarn(rmDelegationToken, (InetSocketAddress) null);
+        Token<TokenIdentifier> token = ConverterUtils.convertFromYarn(rmDelegationToken, null);
         token.setService(new Text(Joiner.on(',').join(services)));
         credentials.addToken(new Text(token.getService()), token);
 
         // OK to log, it won't log the credential, only information about the token.
-        LOG.info("Added RM delegation token: {}", token);
+        LOG.debug("Added RM delegation token: {}", token);
 
       } finally {
         yarnClient.stop();
@@ -93,7 +93,6 @@ public final class YarnTokenUtils {
 
       return credentials;
     } catch (Exception e) {
-      LOG.error("Failed to get secure token for Yarn.", e);
       throw Throwables.propagate(e);
     }
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/security/HBaseTokenUtils.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/security/HBaseTokenUtils.java
@@ -22,8 +22,6 @@ import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 
@@ -31,8 +29,6 @@ import java.lang.reflect.Method;
  * Helper class for getting HBase security delegation token.
  */
 public final class HBaseTokenUtils {
-
-  private static final Logger LOG = LoggerFactory.getLogger(HBaseTokenUtils.class);
 
   /**
    * Gets a HBase delegation token and stores it in the given Credentials.
@@ -54,7 +50,6 @@ public final class HBaseTokenUtils {
       return credentials;
 
     } catch (Exception e) {
-      LOG.error("Failed to get secure token for HBase.", e);
       throw Throwables.propagate(e);
     }
   }


### PR DESCRIPTION
1. Reduce the log level to `DEBUG`
2. No need to catch Exception just to log it. Logging will be handled by the caller.