### PR TITLE
[CDAP-8402][CDAP-8573][CDAP-8674] Program/App/Dataset list view visual updates

### DIFF
--- a/cdap-ui/app/cdap/components/AppDetailedView/Tabs/HistoryTab.js
+++ b/cdap-ui/app/cdap/components/AppDetailedView/Tabs/HistoryTab.js
@@ -20,6 +20,7 @@ import {convertProgramToApi} from 'services/program-api-converter';
 import NamespaceStore from 'services/NamespaceStore';
 import {humanReadableDate} from 'services/helpers';
 import LogAction from 'components/FastAction/LogAction';
+import SortableTable from 'components/SortableTable';
 import T from 'i18n-react';
 import orderBy from 'lodash/orderBy';
 
@@ -33,6 +34,26 @@ export default class HistoryTab extends Component {
       entity: props.entity
     };
     this.pollSubscriptions = [];
+    this.tableHeaders = [
+      {
+        property: 'programName',
+        label: T.translate('features.AppDetailedView.History.nameLabel')
+      },
+      {
+        property: 'start',
+        label: T.translate('features.AppDetailedView.History.startLabel')
+      },
+      {
+        label: T.translate('features.AppDetailedView.History.runIDLabel')
+      },
+      {
+        property: 'status',
+        label: T.translate('features.AppDetailedView.History.statusLabel')
+      },
+      {
+        label: T.translate('features.FastAction.logLabel')
+      }
+    ];
   }
   componentWillMount() {
     this.state
@@ -84,55 +105,57 @@ export default class HistoryTab extends Component {
           );
         });
   }
+
   componentWillUnmount() {
     this.pollSubscriptions
-        .forEach(subscription => {
-          subscription.dispose();
-        });
+      .forEach(subscription => {
+        subscription.dispose();
+      });
   }
+
+  renderTableBody(history) {
+    let historyState = history || this.state.history;
+    return (
+      <tbody>
+        {
+          historyState
+            .map( history => {
+              return (
+                <tr key={history.runid}>
+                  <td>{history.programName}</td>
+                  <td>{humanReadableDate(history.start)}</td>
+                  <td>{history.runid}</td>
+                  <td>{history.status}</td>
+                  <td>
+                    <LogAction
+                      entity={{
+                        id: history.programName,
+                        uniqueId: history.runid,
+                        runId: history.runid,
+                        applicationId: history.appId,
+                        programType: history.programType
+                      }}
+                    />
+                  </td>
+                </tr>
+              );
+            })
+        }
+      </tbody>
+    );
+  }
+
   render() {
     const renderHistoryRows = () => {
       if (Array.isArray(this.state.history)) {
         if (this.state.history.length) {
           return (
             <div className="history-tab">
-              <table className="table table-bordered">
-                <thead>
-                  <tr>
-                    <th>Program Name </th>
-                    <th>Start Time</th>
-                    <th>Run ID</th>
-                    <th>Status</th>
-                    <th>Logs</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {
-                    this.state
-                      .history
-                      .map( history => {
-                        return (
-                          <tr key={history.runid}>
-                            <td>{history.programName}</td>
-                            <td>{humanReadableDate(history.start)}</td>
-                            <td>{history.runid}</td>
-                            <td>{history.status}</td>
-                            <td>
-                              <LogAction
-                                entity={{
-                                  id: history.programName,
-                                  uniqueId: history.runid,
-                                  applicationId: history.appId,
-                                  programType: history.programType
-                                }}
-                              />
-                            </td>
-                          </tr>
-                        );
-                      })
-                  }
-                </tbody>
-              </table>
+              <SortableTable
+                entities={this.state.history}
+                tableHeaders={this.tableHeaders}
+                renderTableBody={this.renderTableBody}
+              />
             </div>
           );
         } else {

--- a/cdap-ui/app/cdap/components/AppDetailedView/Tabs/HistoryTab.scss
+++ b/cdap-ui/app/cdap/components/AppDetailedView/Tabs/HistoryTab.scss
@@ -16,24 +16,39 @@
 
 @import '../../../styles/variables.scss';
 
+$border-color: #bbbbbb;
+
 .history-tab {
   padding: 10px 20px;
-  overflow-y: hidden;
   height: 100%;
   overflow-y: auto;
 
-  &.table-bordered {
-    width: calc(100% - 20px);
-    margin: 10px;
-  }
-
   table {
-    tr th,
-    tr td {
-      border-color: $custom_table-border-color;
-    }
-    a.btn.btn-link {
-      color: #4f5050;
+    border: 1px solid $border-color;
+
+    tr {
+      th,
+      td {
+        border-left: 0;
+        border-right: 0;
+        border-top: 0;
+        border-bottom: 1px solid $border-color;
+        padding-top: 0;
+        padding-bottom: 0;
+        vertical-align: middle;
+      }
+
+      th {
+        line-height: 30px;
+      }
+
+      td {
+        line-height: 40px;
+
+        a.btn.btn-link {
+          color: #4f5050;
+        }
+      }
     }
   }
 }

--- a/cdap-ui/app/cdap/components/DatasetStreamTable/DatasetStreamTable.scss
+++ b/cdap-ui/app/cdap/components/DatasetStreamTable/DatasetStreamTable.scss
@@ -16,19 +16,98 @@
 
 @import '../../styles/variables.scss';
 
+$border-color: #bbbbbb;
+
 .dataentity-table {
   padding-top: 10px;
-  .fast-actions-container .btn-link {
-    color: #4f5050;
-  }
   .table {
-    [class^="icon-"].fa,
-    [class*=" icon-"].fa {
-      margin-right: 5px;
+    border: 1px solid $border-color;
+
+    tr {
+      th,
+      td {
+        border-left: 0;
+        border-right: 0;
+        border-top: 0;
+        border-bottom: 1px solid $border-color;
+        padding-top: 0;
+        padding-bottom: 0;
+        vertical-align: middle;
+
+        &:first-child {
+          padding-left: 0.75rem;
+        }
+
+        &:last-child {
+          padding-left: 5%;
+        }
+
+        &:nth-child(3),
+        &:nth-child(4),
+        &:nth-child(5),
+        &:nth-child(6) {
+          text-align: right;
+        }
+      }
+
+      th {
+        line-height: 30px;
+      }
+
+      td {
+        line-height: 40px;
+      }
     }
-    tr th,
-    tr td {
-      border-color: $custom_table-border-color;
+
+    tbody {
+      font-size: 12px;
+
+      tr {
+        &:hover {
+          background-color: white;
+          cursor: pointer;
+        }
+
+        a {
+          color: inherit;
+          display: block;
+
+          &:hover {
+            text-decoration: none;
+          }
+        }
+
+        td {
+          &:first-child {
+            max-width: 110px;
+
+            a {
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+          }
+
+          &:last-child {
+            .fast-actions-container {
+              min-width: 175px;
+              max-width: 400px;
+            }
+          }
+
+          [class^="icon-"].fa,
+          [class*=" icon-"].fa {
+            margin-right: 5px;
+          }
+
+          .fast-actions-container .btn-link {
+            color: #4f5050;
+            padding-left: 5%;
+            padding-right: 5%;
+            max-width: 40px;
+          }
+        }
+      }
     }
   }
 }

--- a/cdap-ui/app/cdap/components/FastAction/LogAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/LogAction/index.js
@@ -27,15 +27,14 @@ export default class LogAction extends Component {
 
     this.state = {
       isDisabled: false,
-      runId: null,
-      startTime: null,
-      endTime: null,
+      runId: props.entity.runId,
       tooltipOpen: false
     };
     this.toggleTooltip = this.toggleTooltip.bind(this);
   }
 
   componentWillMount() {
+    if (this.state.runId) { return; }
     let namespace = NamespaceStore.getState().selectedNamespace;
 
     this.pollRuns$ = MyProgramApi.pollRuns({
@@ -46,16 +45,16 @@ export default class LogAction extends Component {
     }).subscribe((res) => {
       if (res.length > 0) {
         this.setState({
-          runId: res[0].runid,
-          startTime: res[0].start,
-          endTime: res[0].end
+          runId: res[0].runid
         });
       }
     });
   }
 
   componentWillUnmount() {
-    this.pollRuns$.dispose();
+    if (this.pollRuns$) {
+      this.pollRuns$.dispose();
+    }
   }
 
   generateLink() {
@@ -76,7 +75,8 @@ export default class LogAction extends Component {
   }
 
   render() {
-    const tooltipID = `${this.props.entity.uniqueId}-logs`;
+    // have to do this because ID cannot start with a number
+    const tooltipID = `logs-${this.props.entity.uniqueId}`;
     const renderDisabled = (
       <button
         className="btn btn-link"
@@ -124,6 +124,7 @@ LogAction.propTypes = {
     id: PropTypes.string.isRequired,
     uniqueId: PropTypes.string,
     applicationId: PropTypes.string.isRequired,
-    programType: PropTypes.string.isRequired
-  })
+    programType: PropTypes.string.isRequired,
+    runId: PropTypes.string
+  }),
 };

--- a/cdap-ui/app/cdap/components/FastAction/StartStopAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/StartStopAction/index.js
@@ -123,6 +123,7 @@ export default class StartStopAction extends Component {
     let confirmBtnText;
     let headerText;
     let confirmationText;
+    let icon;
 
     if (this.startStop === 'start') {
       confirmBtnText = 'startConfirmLabel';
@@ -134,7 +135,11 @@ export default class StartStopAction extends Component {
       confirmationText = T.translate('features.FastAction.stopConfirmation', {entityId: this.props.entity.id});
     }
     // icon can change in the background, so using state instead of this.startStop
-    let icon = this.state.programStatus === 'STOPPED' ? 'fa fa-play text-success' : 'fa fa-stop text-danger';
+    if (this.state.programStatus === '') {
+      icon = 'fa fa-spinner fa-spin';
+    } else {
+      icon = this.state.programStatus === 'STOPPED' ? 'fa fa-play text-success' : 'fa fa-stop text-danger';
+    }
     let tooltipID = `${this.props.entity.uniqueId}-${this.startStop}`;
 
     return (

--- a/cdap-ui/app/cdap/components/ProgramTable/ProgramTable.scss
+++ b/cdap-ui/app/cdap/components/ProgramTable/ProgramTable.scss
@@ -16,15 +16,67 @@
 
 @import '../../styles/variables.scss';
 
+$border-color: #bbbbbb;
+
 .program-table {
-  table {
-    tr th,
-    tr td {
-      border-color: $custom_table-border-color;
-    }
-  }
+  overflow-x: auto;
   padding-top: 10px;
-  .fast-actions-container .btn-link {
-    color: #4f5050;
+
+  table {
+    border: 1px solid $border-color;
+
+    tbody {
+      font-size: 12px;
+    }
+
+    tr {
+      th,
+      td {
+        border-left: 0;
+        border-right: 0;
+        border-top: 0;
+        border-bottom: 1px solid $border-color;
+        padding-top: 0;
+        padding-bottom: 0;
+        vertical-align: middle;
+      }
+
+      th {
+        line-height: 30px;
+
+        span {
+          &:last-child {
+            text-align: center;
+          }
+        }
+      }
+
+      td {
+        line-height: 40px;
+
+        i.fa {
+          margin-right: 5px;
+        }
+
+        &:first-child {
+          max-width: 150px;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        &:last-child {
+          min-width: 103px;
+          padding-left: 0;
+          padding-right: 0;
+        }
+
+        .fast-actions-container .btn-link {
+          color: #4f5050;
+          padding-left: 5%;
+          padding-right: 5%;
+        }
+      }
+    }
   }
 }

--- a/cdap-ui/app/cdap/components/SortableTable/SortableTable.scss
+++ b/cdap-ui/app/cdap/components/SortableTable/SortableTable.scss
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+.table {
+  th span {
+    cursor: pointer;
+
+    .text-underline {
+      text-decoration: underline;
+    }
+
+    i {
+      margin-left: 3px;
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/SortableTable/index.js
+++ b/cdap-ui/app/cdap/components/SortableTable/index.js
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, {Component, PropTypes} from 'react';
+import orderBy from 'lodash/orderBy';
+import classnames from 'classnames';
+require('./SortableTable.scss');
+
+export default class SortableTable extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      entities: props.entities,
+      sortByHeader: '',
+      sortOrder: 'asc'
+    };
+
+    this.renderTableBody = this.props.renderTableBody.bind(this);
+  }
+
+  componentWillMount() {
+    let entities = this.props.entities;
+    let sortByHeader = this.getDefaultSortedHeader();
+    entities = orderBy(entities, [sortByHeader], [this.state.sortOrder]);
+    this.setState({
+      entities,
+      sortByHeader
+    });
+  }
+
+  getDefaultSortedHeader() {
+    let defaultHeader = '';
+    for (let i = 0; i < this.props.tableHeaders.length; i++) {
+      if (this.props.tableHeaders[i].property) {
+        defaultHeader = this.props.tableHeaders[i].property;
+        break;
+      }
+    }
+    return defaultHeader;
+  }
+
+  sortBy(header) {
+    let headerProp = header.property;
+    let entities = this.state.entities;
+    let sortOrder = this.state.sortOrder;
+    let sortByHeader = this.state.sortByHeader;
+    if (sortByHeader === headerProp) {
+      if (sortOrder === 'asc') { // already sorting in this column, sort the other way
+        sortOrder = 'desc';
+      } else {
+        sortOrder = 'asc';
+      }
+    } else { // a new sort, so start with ascending sort
+      sortByHeader = headerProp;
+      sortOrder = 'asc';
+    }
+    if (header.sortFunc) {
+      entities = orderBy(entities, [header.sortFunc], [sortOrder]);
+    } else {
+      entities = orderBy(entities, [sortByHeader], [sortOrder]);
+    }
+    this.setState({
+      entities,
+      sortOrder,
+      sortByHeader
+    });
+  }
+
+  renderSortableTableHeader(header) {
+    if (this.state.sortByHeader !== header.property) {
+      return (
+        <span onClick={this.sortBy.bind(this, header)}>
+          {header.label}
+        </span>
+      );
+    }
+    return (
+      <span onClick={this.sortBy.bind(this, header)}>
+        <span className="text-underline">{header.label}</span>
+        {
+          this.state.sortOrder === 'asc' ?
+            <i className="fa fa-caret-down fa-lg"></i>
+          :
+            <i className="fa fa-caret-up fa-lg"></i>
+        }
+      </span>
+    );
+  }
+
+  render() {
+    let tableClasses = classnames('table', this.props.className);
+    return (
+      <table className={tableClasses}>
+        <thead>
+          <tr>
+            {
+              this.props.tableHeaders.map(tableHeader => {
+                return (
+                  <th>
+                    {
+                      tableHeader.property ?
+                        this.renderSortableTableHeader(tableHeader)
+                      :
+                        tableHeader.label
+                    }
+                  </th>
+                );
+              })
+            }
+          </tr>
+        </thead>
+        {this.renderTableBody(this.state.entities)}
+      </table>
+    );
+  }
+}
+SortableTable.propTypes = {
+  tableHeaders: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string,
+      property: PropTypes.string
+    })
+  ),
+  renderTableBody: PropTypes.func,
+  entities: PropTypes.arrayOf(PropTypes.object),
+  className: PropTypes.string
+};

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -110,10 +110,14 @@ features:
     Title: CDAP | Applications | {appId}
     History:
       emptyMessage: No Runs found.
+      nameLabel: Program Name
+      startLabel: Start Time
+      runIDLabel: Run ID
+      statusLabel: Status
     Tabs:
       programsLabel: Programs
       datasetsLabel: Datasets
-      historyLabel: Runs
+      historyLabel: Program Runs
       propertiesLabel: Properties
 
   AuthorizationMessage:
@@ -863,7 +867,7 @@ features:
       readsLabel: Reads
       writesLabel: Writes
       eventsLabel: Events
-      sizeLabel: Size
+      sizeLabel: Size(MB)
     ProgramTable:
       lastStartedLabel: Last Started
       statusLabel: Status


### PR DESCRIPTION
[CDAP-8402] https://issues.cask.co/browse/CDAP-8402
- Added hover state for rows in the datasets and stream table. Clicking on them takes the user to the detail view of that entity. 
- Added sortable feature for App, Dataset and History tables (by creating a new generic component SortableTable)

[CDAP-8573] https://issues.cask.co/browse/CDAP-8573
- Adjusted width of Actions column to show all fast actions.
- Adjusted width of columns to show all information on one line for all entities.

[CDAP-8674] https://issues.cask.co/browse/CDAP-8674
- Fixed bug where programs with the same name were only appearing as one program in the list view.