### PR TITLE
Adds Encoded Key-Value Pairs

### DIFF
--- a/cdap-ui/app/directives/widget-container/widget-factory.js
+++ b/cdap-ui/app/directives/widget-container/widget-factory.js
@@ -124,6 +124,13 @@ angular.module(PKG.name + '.commons')
           'data-config': 'myconfig'
         }
       },
+      'keyvalue-encoded': {
+        element: '<my-key-value-encoded></my-key-value-encoded>',
+        attributes: {
+          'ng-model': 'model',
+          'data-config': 'myconfig'
+        }
+      },
       'keyvalue-dropdown': {
         element: '<my-key-value></my-key-value>',
         attributes: {

--- a/cdap-ui/app/directives/widget-container/widget-keyvalue-encoded/widget-keyvalue-encoded.html
+++ b/cdap-ui/app/directives/widget-container/widget-keyvalue-encoded/widget-keyvalue-encoded.html
@@ -1,0 +1,61 @@
+<!--
+  Copyright © 2017 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<div class="keyvalue-container">
+
+  <div class="row" ng-if="showDelimiter">
+    <div class="col-md-6">
+      <div class="form-group">
+        <label class="control-label">Delimiter</label>
+        <input type="text" class="form-control" ng-model="delimiter" />
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="form-group">
+        <label class="control-label">KeyValue Delimiter</label>
+        <input type="text" class="form-control" ng-model="kvdelimiter" />
+      </div>
+    </div>
+  </div>
+
+  <div ng-repeat="property in properties" class="row" ng-keypress="enter($event, $last)">
+    <div class="inputs-container">
+      <input type="text" class="form-control" ng-model="property.key" placeholder="{{ keyPlaceholder }}" my-focus-watch="property.newField" />
+      <input type="text" class="form-control" ng-model="property.value" placeholder="{{ valuePlaceholder }}" ng-if="!isDropdown" />
+      <select class="form-control"
+        ng-model="property.value"
+        ng-if="isDropdown"
+        ng-options="option as option for option in dropdownOptions">
+      </select>
+    </div>
+    <div class="btns-container">
+      <a href="" class="btn btn-danger" ng-click="removeProperty(property)">
+        <span class="fa fa-fw fa-trash"> </span>
+      </a>
+      <a class="btn btn-info btn-transparent" ng-click="addProperty()" ng-if="$last">
+        <span class="fa fa-fw fa-plus"></span>
+      </a>
+    </div>
+  </div>
+
+  <div ng-if="properties.length === 0" class="empty-container">
+    <a class="btn btn-blue" ng-click="addProperty()">
+      <span class="fa fa-fw fa-plus"></span>
+      <span>Add Property</span>
+    </a>
+  </div>
+
+</div>

--- a/cdap-ui/app/directives/widget-container/widget-keyvalue-encoded/widget-keyvalue-encoded.js
+++ b/cdap-ui/app/directives/widget-container/widget-keyvalue-encoded/widget-keyvalue-encoded.js
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name + '.commons')
+  .directive('myKeyValueEncoded', function() {
+    return {
+      restrict: 'E',
+      scope: {
+        model: '=ngModel',
+        config: '=',
+        isDropdown: '='
+      },
+      templateUrl: 'widget-container/widget-keyvalue-encoded/widget-keyvalue-encoded.html',
+      controller: function($scope, myHelpers) {
+        $scope.kvdelimiter = myHelpers.objectQuery($scope.config, 'kv-delimiter') ||
+                             myHelpers.objectQuery($scope.config, 'widget-attributes', 'kv-delimiter') ||
+                             ':';
+        $scope.delimiter = myHelpers.objectQuery($scope.config, 'delimiter') ||
+                           myHelpers.objectQuery($scope.config, 'widget-attributes', 'delimiter') ||
+                           ',';
+
+        $scope.keyPlaceholder = myHelpers.objectQuery($scope.config, 'widget-attributes', 'key-placeholder') || 'key';
+        $scope.valuePlaceholder = myHelpers.objectQuery($scope.config, 'widget-attributes', 'value-placeholder') || 'value';
+
+        $scope.showDelimiter = true;
+        var showDelimiterProperty = myHelpers.objectQuery($scope.config, 'widget-attributes', 'showDelimiter');
+        if (($scope.config.properties && $scope.config.properties.showDelimiter === 'false') || showDelimiterProperty === 'false' ) {
+          $scope.showDelimiter = false;
+        }
+
+        // Changing value field to dropdown based on config
+        if ($scope.isDropdown) {
+          $scope.dropdownOptions = myHelpers.objectQuery($scope.config, 'widget-attributes', 'dropdownOptions');
+        }
+
+        // initializing
+        function initialize() {
+          var str = $scope.model;
+          $scope.properties = [];
+
+          if (!str) {
+            //intialize to one empty property
+            $scope.properties.push({
+              key: '',
+              value: ''
+            });
+
+            return;
+          }
+          var arr = str.split($scope.delimiter);
+
+          angular.forEach(arr, function(a) {
+            var split = a.split($scope.kvdelimiter);
+
+            $scope.properties.push({
+              key: decodeURIComponent(split[0]),
+              value: decodeURIComponent(split[1])
+            });
+          });
+        }
+
+        initialize();
+
+        $scope.$watch('properties', function() {
+
+          var str = '';
+
+          angular.forEach($scope.properties, function(p) {
+            if (p.key.length > 0) {
+              str = str + encodeURIComponent(p.key) + $scope.kvdelimiter + encodeURIComponent(p.value) + $scope.delimiter;
+            }
+          });
+
+          // remove last delimiter
+          if (str.length > 0 && str.charAt(str.length - 1) === $scope.delimiter ) {
+            str = str.substring(0, str.length - 1);
+          }
+
+          $scope.model = str;
+
+        }, true);
+
+
+        $scope.addProperty = function() {
+          $scope.properties.push({
+            key: '',
+            value: '',
+            newField: 'add'
+          });
+        };
+
+        $scope.removeProperty = function(property) {
+          var index = $scope.properties.indexOf(property);
+          $scope.properties.splice(index, 1);
+        };
+
+        $scope.enter = function (event, last) {
+          if (last && event.keyCode === 13) {
+            $scope.addProperty();
+          }
+        };
+      }
+    };
+  });

--- a/cdap-ui/app/directives/widget-container/widget-keyvalue-encoded/widget-keyvalue-encoded.less
+++ b/cdap-ui/app/directives/widget-container/widget-keyvalue-encoded/widget-keyvalue-encoded.less
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+@import "../../../styles/variables.less";
+
+my-key-value-encoded {
+
+  .keyvalue-container {
+    background-color: @body-bg;
+    border: 1px solid #dddddd;
+    border-radius: @border-radius-base;
+    padding: 20px 10px;
+    .empty-container {
+      padding-left: 15px;
+    }
+  }
+  .row {
+    margin-bottom: 2px;
+    display: flex;
+    padding-left: 16px;
+    > div > input.form-control,
+    select.form-control {
+      display: inline-block;
+      width: 48%;
+    }
+    .inputs-container {
+      flex: 0.96;
+      display: flex;
+
+      > input {
+        margin-right: 5px;
+        &:first-child {
+          flex: 0.3;
+        }
+        &:last-child {
+          flex: 0.7;
+        }
+      }
+    }
+  }
+  .labels {
+    [class*="col-"] {
+      margin-bottom: 10px;
+    }
+  }
+
+  .delimiter-label {
+    line-height: 26px;
+    padding-left: 17px;
+
+    > strong {
+      vertical-align: middle;
+    }
+  }
+}


### PR DESCRIPTION
- There is a new requirement for a encoded keyvalue pair widget that can accept the delimiter as part of either key or value in the key value pair.
  For instance if the key-value delimiter is `:`, we need to be able to handle situation if either key or value contains `:` in it. Curreny key-value widget actually creates a newline (new keyvalue pair) instead of having it in the same. 
  
This widget is to encode the key and value pairs so that can it can contain delimiter as par of its value.

This requires a corresponding backend change from @nitinmotgi. Hence the on-hold.