### PR TITLE
CDAP-8694 Properly detect distributed CDAP_HOME outside /opt/cdap

### DIFF
--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -47,10 +47,15 @@ __comp_home=${COMPONENT_HOME:-$(cd "${__target%/*/*}" >&- 2>/dev/null; pwd -P)}
 
 # Determine if we're in Distributed from packages or SDK/Parcel
 if [[ ${__comp_home%/*} == /opt/cdap ]] && [[ ${__comp_home} != /opt/cdap/sdk* ]]; then
+  # We're distributed from packages
   __app_home=${__comp_home}
   __cdap_home=${CDAP_HOME:-/opt/cdap}
+elif [[ ${__comp_home##*/} == cli ]]; then
+  # We're distributed in a non-standard location, such as Parcel, or CLI
+  __app_home=${__comp_home}
+  __cdap_home=${CDAP_HOME:-${__comp_home%/*}}
 else
-  # We're in the SDK, __app_home and __cdap_home are identical, but honor CDAP_HOME if it's set (for Parcel)
+  # We're in the SDK, __app_home and __cdap_home are identical
   __cdap_home=${CDAP_HOME:-${__app_home}}
 fi
 

--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -142,6 +142,9 @@ cdap_home() {
   if [[ ${__comp_home%/*} == /opt/cdap ]] && [[ ${__comp_home} != /opt/cdap/sdk* ]]; then
     __app_home=${__comp_home}
     __cdap_home=/opt/cdap
+  elif [[ ${__comp_home##*/} == cli ]]; then
+    __app_home=${__comp_home}
+    __cdap_home=${__comp_home%/*}
   else
     __app_home=$(dirname "${__script_bin}")
     __cdap_home=${__app_home}


### PR DESCRIPTION
This allows CDAP to properly detect itself, even when its canonical on-disk location is not `/opt/cdap`, provided the script is being executed from the CLI, which will be the `cdap` in the PATH for both Parcel and non-standard distributed installations.

Before:
```
[chris@csd19144-1000 ~]$ cdap classpath
[ERROR] Unable to determine HBase version! Aborting.
```

After:
```
[chris@csd19144-1000 ~]$ cdap classpath
/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/hbase-compat-1.2-cdh5.7.0/lib/*:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/antlr.antlr-2.7.7.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/aopalliance.aopalliance-1.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/c3p0.c3p0-0.9.1.1.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/ch.qos.logback.logback-classic-1.0.9.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/ch.qos.logback.logback-core-1.0.9.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.cdap.cdap-api-4.1.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.cdap.cdap-api-common-4.1.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.cdap.cdap-app-fabric-4.1.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.cdap.cdap-common-4.1.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.cdap.cdap-data-fabric-4.1.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.cdap.cdap-explore-4.1.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.cdap.cdap-explore-client-4.1.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.cdap.cdap-formats-4.1.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.cdap.cdap-hbase-compat-base-4.1.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.cdap.cdap-hbase-spi-4.1.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.cdap.cdap-kms-4.1.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.cdap.cdap-master-4.1.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.cdap.cdap-notifications-4.1.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.cdap.cdap-notifications-api-4.1.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.cdap.cdap-proto-4.1.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.cdap.cdap-security-4.1.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.cdap.cdap-security-spi-4.1.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.cdap.cdap-spi-4.1.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.cdap.cdap-tms-4.1.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.cdap.cdap-watchdog-4.1.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.cdap.cdap-watchdog-api-4.1.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.common.common-http-0.7.1.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.common.common-io-0.7.1.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.common.common-lang-0.7.1.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/co.cask.http.netty-http-0.16.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/com.101tec.zkclient-0.3.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/com.github.tony19.named-regexp-0.2.3.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/com.google.code.findbugs.jsr305-2.0.1.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/com.google.code.gson.gson-2.2.4.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/com.google.guava.guava-13.0.1.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/com.google.inject.extensions.guice-assistedinject-3.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/com.google.inject.extensions.guice-multibindings-3.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/com.google.inject.extensions.guice-servlet-3.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/com.google.inject.guice-3.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/com.jamesmurty.utils.java-xmlbuilder-0.4.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/com.jcraft.jsch-0.1.42.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/com.jolbox.bonecp-0.8.0.RELEASE.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/commons-beanutils.commons-beanutils-1.7.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/commons-beanutils.commons-beanutils-core-1.8.3.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/commons-cli.commons-cli-1.2.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/commons-codec.commons-codec-1.6.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/commons-collections.commons-collections-3.2.1.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/commons-configuration.commons-configuration-1.6.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/commons-dbcp.commons-dbcp-1.4.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/commons-digester.commons-digester-1.8.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/commons-el.commons-el-1.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/commons-httpclient.commons-httpclient-3.1.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/commons-io.commons-io-2.4.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/commons-lang.commons-lang-2.6.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/commons-net.commons-net-3.1.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/commons-pool.commons-pool-1.5.4.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/com.ning.async-http-client-1.7.18.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/com.thoughtworks.paranamer.paranamer-2.3.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/com.yammer.metrics.metrics-core-2.2.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/io.dropwizard.metrics.metrics-core-3.1.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/io.netty.netty-3.6.6.Final.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/io.thekraken.grok-0.1.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/it.unimi.dsi.fastutil-6.5.6.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/javax.activation.activation-1.1.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/javax.annotation.jsr250-api-1.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/javax.inject.javax.inject-1.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/javax.jdo.jdo-api-3.0.1.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/javax.servlet.javax.servlet-api-3.0.1.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/javax.transaction.jta-1.1.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/javax.ws.rs.javax.ws.rs-api-2.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/jline.jline-2.12.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/joda-time.joda-time-2.1.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/log4j.apache-log4j-extras-1.2.17.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/log4j.log4j-1.2.17.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/net.hydromatic.eigenbase-properties-1.1.5.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/net.java.dev.jets3t.jets3t-0.9.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/net.jcip.jcip-annotations-1.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/net.jpountz.lz4.lz4-1.3.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/net.sf.jopt-simple.jopt-simple-3.2.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/net.sf.jpam.jpam-1.1.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/net.sf.opencsv.opencsv-2.3.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.antlr.antlr-runtime-3.4.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.antlr.ST4-4.0.4.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.antlr.stringtemplate-3.2.1.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.ant.ant-1.9.1.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.ant.ant-launcher-1.9.1.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.avro.avro-1.6.2.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.avro.avro-ipc-1.6.2.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.avro.avro-mapred-1.6.2.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.calcite.calcite-avatica-1.2.0-incubating.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.calcite.calcite-core-1.2.0-incubating.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.calcite.calcite-linq4j-1.2.0-incubating.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.commons.commons-compress-1.9.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.commons.commons-lang3-3.3.2.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.commons.commons-math3-3.1.1.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.curator.apache-curator-2.6.0.pom:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.curator.curator-client-2.6.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.curator.curator-framework-2.6.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.curator.curator-recipes-2.6.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.derby.derby-10.10.2.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.flume.flume-ng-configuration-1.2.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.flume.flume-ng-core-1.2.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.flume.flume-ng-sdk-1.2.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.geronimo.components.geronimo-jaspi-2.0.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.geronimo.specs.geronimo-jaspic_1.0_spec-1.1.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.ivy.ivy-2.4.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.kafka.kafka_2.10-0.8.2.2.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.kafka.kafka-clients-0.8.2.2.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.tephra.tephra-api-0.11.0-incubating-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.tephra.tephra-core-0.11.0-incubating-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.thrift.libfb303-0.9.2.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.thrift.libthrift-0.9.3.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.twill.twill-api-0.10.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.twill.twill-common-0.10.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.twill.twill-core-0.10.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.twill.twill-discovery-api-0.10.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.twill.twill-discovery-core-0.10.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.twill.twill-yarn-0.10.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.twill.twill-zookeeper-0.10.0-SNAPSHOT.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.velocity.velocity-1.5.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.apache.xbean.xbean-reflect-3.6.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.codehaus.janino.commons-compiler-2.7.6.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.codehaus.janino.janino-2.7.6.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.datanucleus.datanucleus-api-jdo-3.2.6.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.datanucleus.datanucleus-core-3.2.10.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.datanucleus.datanucleus-rdbms-3.2.9.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.eclipse.jetty.jetty-continuation-8.1.15.v20140411.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.eclipse.jetty.jetty-http-8.1.15.v20140411.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.eclipse.jetty.jetty-io-8.1.15.v20140411.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.eclipse.jetty.jetty-jaspi-8.1.15.v20140411.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.eclipse.jetty.jetty-jndi-8.1.15.v20140411.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.eclipse.jetty.jetty-plus-8.1.15.v20140411.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.eclipse.jetty.jetty-security-8.1.15.v20140411.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.eclipse.jetty.jetty-server-8.1.15.v20140411.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.eclipse.jetty.jetty-servlet-8.1.15.v20140411.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.eclipse.jetty.jetty-util-8.1.15.v20140411.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.eclipse.jetty.jetty-webapp-8.1.15.v20140411.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.eclipse.jetty.jetty-xml-8.1.15.v20140411.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.eclipse.jetty.orbit.javax.activation-1.1.0.v201105071233.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.eclipse.jetty.orbit.javax.mail.glassfish-1.4.1.v201005082020.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.eclipse.jetty.orbit.javax.security.auth.message-1.0.0.v201108011116.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.eclipse.jetty.orbit.javax.servlet-3.0.0.v201112011016.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.eclipse.jetty.orbit.javax.transaction-1.1.1.v201105210645.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.iq80.leveldb.leveldb-0.6.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.iq80.leveldb.leveldb-api-0.6.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.jboss.resteasy.async-http-servlet-3.0-3.0.8.Final.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.jboss.resteasy.jaxrs-api-3.0.8.Final.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.jboss.resteasy.resteasy-guice-3.0.8.Final.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.jboss.resteasy.resteasy-jaxrs-3.0.8.Final.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.jboss.resteasy.resteasy-servlet-initializer-3.0.8.Final.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.jboss.spec.javax.annotation.jboss-annotations-api_1.1_spec-1.0.1.Final.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.json.json-20090211.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.ow2.asm.asm-all-5.0.3.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.pentaho.pentaho-aggdesigner-algorithm-5.1.5-jhyde.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.quartz-scheduler.quartz-2.2.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.quartz-scheduler.quartz-jobs-2.2.0.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.scala-lang.scala-library-2.10.4.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.slf4j.jcl-over-slf4j-1.7.5.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.slf4j.slf4j-api-1.7.5.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/org.xerial.snappy.snappy-java-1.1.1.7.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/oro.oro-2.0.8.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/stax.stax-api-1.0.1.jar:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/lib/xmlenc.xmlenc-0.52.jar::/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../conf:/usr/lib/jvm/java/lib/tools.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/..:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/activation-1.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/apacheds-i18n-2.0.0-M15.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/apacheds-kerberos-codec-2.0.0-M15.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/api-asn1-api-1.0.0-M20.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/api-util-1.0.0-M20.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/asm-3.2.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/avro.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/aws-java-sdk-core-1.10.6.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/aws-java-sdk-kms-1.10.6.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/aws-java-sdk-s3-1.10.6.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/aws-java-sdk-sts-1.10.6.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/commons-beanutils-1.9.2.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/commons-beanutils-core-1.8.0.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/commons-cli-1.2.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/commons-codec-1.9.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/commons-collections-3.2.2.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/commons-compress-1.4.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/commons-configuration-1.6.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/commons-daemon-1.0.3.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/commons-digester-1.8.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/commons-el-1.0.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/commons-httpclient-3.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/commons-io-2.4.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/commons-lang-2.6.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/commons-logging-1.2.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/commons-math-2.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/commons-math3-3.1.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/commons-net-3.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/core-3.1.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/curator-client-2.7.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/curator-framework-2.7.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/curator-recipes-2.7.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/disruptor-3.3.0.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/findbugs-annotations-1.3.9-1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/gson-2.2.4.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/guava-12.0.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hamcrest-core-1.3.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-annotations-1.2.0-cdh5.9.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-annotations-1.2.0-cdh5.9.1-tests.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-client-1.2.0-cdh5.9.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-common-1.2.0-cdh5.9.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-common-1.2.0-cdh5.9.1-tests.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-examples-1.2.0-cdh5.9.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-external-blockcache-1.2.0-cdh5.9.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-hadoop2-compat-1.2.0-cdh5.9.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-hadoop2-compat-1.2.0-cdh5.9.1-tests.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-hadoop-compat-1.2.0-cdh5.9.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-hadoop-compat-1.2.0-cdh5.9.1-tests.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-it-1.2.0-cdh5.9.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-it-1.2.0-cdh5.9.1-tests.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-prefix-tree-1.2.0-cdh5.9.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-procedure-1.2.0-cdh5.9.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-protocol-1.2.0-cdh5.9.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-resource-bundle-1.2.0-cdh5.9.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-rest-1.2.0-cdh5.9.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-server-1.2.0-cdh5.9.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-server-1.2.0-cdh5.9.1-tests.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-shell-1.2.0-cdh5.9.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-spark-1.2.0-cdh5.9.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hbase-thrift-1.2.0-cdh5.9.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/high-scale-lib-1.1.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/hsqldb-1.8.0.10.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/htrace-core-3.2.0-incubating.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/htrace-core4-4.0.1-incubating.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/htrace-core.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/httpclient-4.2.5.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/httpcore-4.2.5.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jackson-annotations-2.2.3.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jackson-core-2.2.3.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jackson-core-asl-1.8.8.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jackson-databind-2.2.3.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jackson-jaxrs-1.8.8.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jackson-mapper-asl-1.8.8.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jackson-xc-1.8.8.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jamon-runtime-2.4.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jasper-compiler-5.5.23.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jasper-runtime-5.5.23.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/java-xmlbuilder-0.4.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jaxb-api-2.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jaxb-impl-2.2.3-1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jcodings-1.0.8.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jersey-client-1.9.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jersey-core-1.9.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jersey-json-1.9.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jersey-server-1.9.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jets3t-0.9.0.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jettison-1.3.3.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jetty-6.1.26.cloudera.4.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jetty-sslengine-6.1.26.cloudera.4.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jetty-util-6.1.26.cloudera.4.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/joni-2.1.2.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jruby-cloudera-1.0.0.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jsch-0.1.42.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jsp-2.1-6.1.14.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jsp-api-2.1-6.1.14.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/jsp-api-2.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/junit-4.12.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/leveldbjni-all-1.8.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/libthrift-0.9.3.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/log4j-1.2.17.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/metrics-core-2.2.0.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/netty-all-4.0.23.Final.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/paranamer-2.3.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/protobuf-java-2.5.0.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/servlet-api-2.5-6.1.14.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/servlet-api-2.5.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/slf4j-api-1.7.5.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/slf4j-log4j12.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/snappy-java-1.0.4.1.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/spymemcached-2.11.6.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/xmlenc-0.52.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/xz-1.0.jar:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hbase/bin/../lib/zookeeper.jar:/etc/hadoop/conf:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hadoop/libexec/../../hadoop/lib/*:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hadoop/libexec/../../hadoop/.//*:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hadoop/libexec/../../hadoop-hdfs/./:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hadoop/libexec/../../hadoop-hdfs/lib/*:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hadoop/libexec/../../hadoop-hdfs/.//*:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hadoop/libexec/../../hadoop-yarn/lib/*:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/lib/hadoop/libexec/../../hadoop-yarn/.//*:/data/cloudera/parcels/CDH/lib/hadoop-mapreduce/lib/*:/data/cloudera/parcels/CDH/lib/hadoop-mapreduce/.//*:/etc/hadoop/conf/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/bin/../lib/hadoop/*:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/bin/../lib/hadoop/lib/*:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/bin/../lib/zookeeper/*:/data/cloudera/parcels/CDH-5.9.1-1.cdh5.9.1.p0.4/bin/../lib/zookeeper/lib/*::/etc/cdap/conf/:/data/cloudera/parcels/CDAP-4.1.0.1487632328472-1/master/conf/:
```

Fixes CDAP-8694