### PR TITLE
CDAP-8524, CDAP-5801 CDAP Staging Directories

### DIFF
--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -53,7 +53,7 @@ function download_includes() {
   local source_rst="${target_includes_dir}/../../source/_includes/installation"
   local pattern="\|distribution\|"
   local distributions="cloudera ambari mapr packages"
-  local types="installation configuration starting"
+  local types="configuration hdfs-permissions installation starting"
   local dist
   local type
   for dist in ${distributions}; do

--- a/cdap-docs/admin-manual/source/_includes/installation/configuration.txt
+++ b/cdap-docs/admin-manual/source/_includes/installation/configuration.txt
@@ -96,7 +96,7 @@ for CDAP to run successfully.
         .. parsed-literal::
         
           |$| su hdfs
-          |$| hdfs dfs -mkdir -p /user/|hdfs-user| && hadoop fs -chown |hdfs-user| /user/|hdfs-user| && hadoop fs -chgrp |hdfs-user| /user/|hdfs-user|
+          |$| hadoop fs -mkdir -p /user/|hdfs-user| && hadoop fs -chown |hdfs-user| /user/|hdfs-user| && hadoop fs -chgrp |hdfs-user| /user/|hdfs-user|
 
    #. If you want to use **an HDFS directory** with a name other than ``/cdap``:
 
@@ -131,7 +131,7 @@ for CDAP to run successfully.
            .. parsed-literal::
          
              |$| su hdfs
-             |$| hdfs dfs -mkdir -p /user/|my_username| && hadoop fs -chown |my_username| /user/|my_username| && hadoop fs -chgrp |my_username| /user/|my_username|
+             |$| hadoop fs -mkdir -p /user/|my_username| && hadoop fs -chown |my_username| /user/|my_username| && hadoop fs -chgrp |my_username| /user/|my_username|
       
       #. If you use an HDFS user other than |hdfs-user|, you must use either a secure
          cluster or use the `LinuxContainerExecutor

--- a/cdap-docs/admin-manual/source/_includes/installation/configuration.txt
+++ b/cdap-docs/admin-manual/source/_includes/installation/configuration.txt
@@ -96,7 +96,7 @@ for CDAP to run successfully.
         .. parsed-literal::
         
           |$| su hdfs
-          |$| hadoop fs -mkdir -p /user/|hdfs-user| && hadoop fs -chown |hdfs-user| /user/|hdfs-user| && hadoop fs -chgrp |hdfs-user| /user/|hdfs-user|
+          |$| hadoop fs -mkdir -p /user/|hdfs-user| && hadoop fs -chown |hdfs-user|:|hdfs-user| /user/|hdfs-user|
 
    #. If you want to use **an HDFS directory** with a name other than ``/cdap``:
 
@@ -131,7 +131,7 @@ for CDAP to run successfully.
            .. parsed-literal::
          
              |$| su hdfs
-             |$| hadoop fs -mkdir -p /user/|my_username| && hadoop fs -chown |my_username| /user/|my_username| && hadoop fs -chgrp |my_username| /user/|my_username|
+             |$| hadoop fs -mkdir -p /user/|my_username| && hadoop fs -chown |my_username|:|my_username| /user/|my_username|
       
       #. If you use an HDFS user other than |hdfs-user|, you must use either a secure
          cluster or use the `LinuxContainerExecutor

--- a/cdap-docs/admin-manual/source/_includes/installation/hdfs-permissions.txt
+++ b/cdap-docs/admin-manual/source/_includes/installation/hdfs-permissions.txt
@@ -9,5 +9,5 @@ ensuring that the HDFS ``/user/yarn`` and ``/user/cdap`` directories exist with 
 permissions::
    
   # su hdfs
-  $ hadoop fs -mkdir -p /user/yarn && hadoop fs -chown yarn /user/yarn && hadoop fs -chgrp yarn /user/yarn
-  $ hadoop fs -mkdir -p /user/cdap && hadoop fs -chown cdap /user/cdap && hadoop fs -chgrp cdap /user/cdap
+  $ hadoop fs -mkdir -p /user/yarn && hadoop fs -chown yarn:yarn /user/yarn
+  $ hadoop fs -mkdir -p /user/cdap && hadoop fs -chown cdap:cdap /user/cdap

--- a/cdap-docs/admin-manual/source/_includes/installation/hdfs-permissions.txt
+++ b/cdap-docs/admin-manual/source/_includes/installation/hdfs-permissions.txt
@@ -1,9 +1,13 @@
 .. highlight:: console
 
+.. _|distribution|-hdfs-permissions:
+
 HDFS Permissions
 ----------------
 Ensure YARN is configured properly to run MapReduce programs.  Often, this includes
-ensuring that the HDFS ``/user/yarn`` directory exists with proper permissions::
+ensuring that the HDFS ``/user/yarn`` and ``/user/cdap`` directories exist with proper
+permissions::
    
   # su hdfs
-  $ hdfs dfs -mkdir -p /user/yarn && hadoop fs -chown yarn /user/yarn && hadoop fs -chgrp yarn /user/yarn
+  $ hadoop fs -mkdir -p /user/yarn && hadoop fs -chown yarn /user/yarn && hadoop fs -chgrp yarn /user/yarn
+  $ hadoop fs -mkdir -p /user/cdap && hadoop fs -chown cdap /user/cdap && hadoop fs -chgrp cdap /user/cdap

--- a/cdap-docs/admin-manual/source/installation/ambari.rst
+++ b/cdap-docs/admin-manual/source/installation/ambari.rst
@@ -38,7 +38,7 @@ You can make these changes during the configuration of your cluster `using Ambar
 
 .. HDFS Permissions
 .. ----------------
-.. include:: ../_includes/installation/hdfs-permissions.txt
+.. include:: /../target/_includes/ambari-hdfs-permissions.rst
 
 
 Downloading and Distributing Packages

--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -119,7 +119,7 @@ changes.
 
 .. HDFS Permissions
 .. ----------------
-.. include:: ../_includes/installation/hdfs-permissions.txt
+.. include:: /../target/_includes/cloudera-hdfs-permissions.rst
 
 
 Downloading and Distributing Packages

--- a/cdap-docs/admin-manual/source/installation/mapr.rst
+++ b/cdap-docs/admin-manual/source/installation/mapr.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2016 Cask Data, Inc.
+    :copyright: Copyright © 2016-2017 Cask Data, Inc.
 
 :section-numbering: true
 
@@ -42,7 +42,7 @@ packages installed, and can be configured using the MapR `configure.sh
 
 .. HDFS Permissions
 .. ----------------
-.. include:: ../_includes/installation/hdfs-permissions.txt
+.. include:: /../target/_includes/mapr-hdfs-permissions.rst
       
 
 Downloading and Distributing Packages

--- a/cdap-docs/admin-manual/source/installation/packages.rst
+++ b/cdap-docs/admin-manual/source/installation/packages.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2014-2016 Cask Data, Inc.
+    :copyright: Copyright © 2014-2017 Cask Data, Inc.
 
 :section-numbering: true
 
@@ -53,7 +53,7 @@ node(s) where CDAP will run.
 
 .. HDFS Permissions
 .. ----------------
-.. include:: ../_includes/installation/hdfs-permissions.txt
+.. include:: /../target/_includes/packages-hdfs-permissions.rst
 
   
 Downloading and Distributing Packages

--- a/cdap-docs/admin-manual/source/security/impersonation.rst
+++ b/cdap-docs/admin-manual/source/security/impersonation.rst
@@ -40,6 +40,14 @@ Because of this, it is simplest to specify a custom mapping for ``root.directory
 ``hbase.namespace`` when using impersonation so that the privileges granted to the
 configured principal can be kept to a minimum.
 
+HDFS Permissions
+----------------
+In the case of impersonation, *every user who can be impersonated* will need access to
+their corresponding HDFS ``/user/<username>`` directory. The commands for this are
+described in the installation section for each distribution (:ref:`Cloudera Manager
+<cloudera-hdfs-permissions>`, :ref:`Ambari <ambari-hdfs-permissions>`, 
+:ref:`MapR <mapr-hdfs-permissions>`, and :ref:`packages <packages-hdfs-permissions>`).
+
 
 Limitations
 ===========


### PR DESCRIPTION
Add notes about setting directories and permissions for users, especially when using impersonation, links, and replace usage of `hdfs fs` with `hadoop fs`.

Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB284-1 (fails, because release was broken at time of branching)

Fix for:
- https://issues.cask.co/browse/CDAP-5801
- https://issues.cask.co/browse/CDAP-8524

Pages of interest:
- Cloudera: http://builds.cask.co/artifact/CDAP-DQB284/shared/build-1/Docs-HTML/4.1.0-SNAPSHOT/en/admin-manual/installation/cloudera.html#hdfs-permissions
- Ambari: http://builds.cask.co/artifact/CDAP-DQB284/shared/build-1/Docs-HTML/4.1.0-SNAPSHOT/en/admin-manual/installation/ambari.html#hdfs-permissions
- MapR: http://builds.cask.co/artifact/CDAP-DQB284/shared/build-1/Docs-HTML/4.1.0-SNAPSHOT/en/admin-manual/installation/mapr.html#hdfs-permissions
- Packages: http://builds.cask.co/artifact/CDAP-DQB284/shared/build-1/Docs-HTML/4.1.0-SNAPSHOT/en/admin-manual/installation/packages.html#hdfs-permissions
- Impersonation: http://builds.cask.co/artifact/CDAP-DQB284/shared/build-1/Docs-HTML/4.1.0-SNAPSHOT/en/admin-manual/security/impersonation.html#hdfs-permissions
- Configuration change (common)
  - MapR: http://builds.cask.co/artifact/CDAP-DQB284/shared/build-1/Docs-HTML/4.1.0-SNAPSHOT/en/admin-manual/installation/mapr.html#cdap-configuration
  - Packages: http://builds.cask.co/artifact/CDAP-DQB284/shared/build-1/Docs-HTML/4.1.0-SNAPSHOT/en/admin-manual/installation/packages.html#cdap-configuration
