### PR TITLE
Fix custom appender flushing

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/plugins/LocationOutputStream.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/plugins/LocationOutputStream.java
@@ -72,13 +72,21 @@ public class LocationOutputStream extends FilterOutputStream implements Syncable
 
   @Override
   public void flush() throws IOException {
-    out.flush();
+    // output stream on hdfs should be org.apache.hadoop.fs.Syncable
+    if (out instanceof org.apache.hadoop.fs.Syncable) {
+      ((org.apache.hadoop.fs.Syncable) out).hflush();
+    } else {
+      out.flush();
+    }
   }
 
   @Override
   public void sync() throws IOException {
-    if (out instanceof Syncable) {
+    // output stream on hdfs should be org.apache.hadoop.fs.Syncable
+    if (out instanceof org.apache.hadoop.fs.Syncable) {
       ((org.apache.hadoop.fs.Syncable) out).hsync();
+    } else {
+      out.flush();
     }
   }
 


### PR DESCRIPTION
Fixing flush issue introduced due to https://github.com/caskdata/cdap/pull/8053. Use `hflush()` for hdfs files instead of `flush`

Tested on cluster
Build: http://builds.cask.co/browse/CDAP-RUT685-2