### PR TITLE
CDAP-8701 Avoid logging from LogFileManager in SDK, to avoid deadlock

### DIFF
--- a/cdap-standalone/src/main/resources/logback.xml
+++ b/cdap-standalone/src/main/resources/logback.xml
@@ -39,6 +39,8 @@
   <logger name="org.quartz.core" level="WARN"/>
   <logger name="org.eclipse.jetty" level="WARN"/>
   <logger name="io.netty.util.internal" level="WARN"/>
+  <!-- Avoid logging from LogFileManager in SDK, to avoid deadlock. See CDAP-8701 -->
+  <logger name="co.cask.cdap.logging.framework.LogFileManager" level="ERROR"/>
   <logger name="co.cask.cdap.operations.OperationalStats" level="ERROR"/>
   <logger name="co.cask.cdap.extension.AbstractExtensionLoader" level="ERROR"/>
 


### PR DESCRIPTION
[CDAP-8701](https://issues.cask.co/browse/CDAP-8701) Avoid logging from LogFileManager in SDK, to avoid deadlock in logging framework.