### PR TITLE
Feature release/cdap 8725 fix preview in windows and flaky preview data pipeline test

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/preview/DefaultPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/preview/DefaultPreviewManager.java
@@ -202,7 +202,6 @@ public class DefaultPreviewManager implements PreviewManager {
     java.nio.file.Path previewDir = Files.createDirectories(Paths.get(previewDirPath.toAbsolutePath().toString(),
                                                                       applicationId.getApplication()));
     previewcConf.set(Constants.CFG_LOCAL_DATA_DIR, previewDir.toString());
-    previewcConf.set(Constants.Dataset.DATA_DIR, previewDir.toString());
     Configuration previewhConf = new Configuration(hConf);
     previewhConf.set(Constants.CFG_LOCAL_DATA_DIR, previewDir.toString());
     previewcConf.setIfUnset(Constants.CFG_DATA_LEVELDB_DIR, previewDir.toString());


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-8725
Build: http://builds.cask.co/browse/CDAP-RUT695-1

Prevent creating dataset in preview space with duplicated path. In Windows, the path will have c:/ which will cause mkdir to fail.

For flaky test, gson is not thread safe and PreviewStore is a singleton, so we have to create gson for each put and get operation.

Still need test on Windows, sent out for review first.