### PR TITLE
[CDAP-8118] Create stream if doesn't already exist while uploading datapack

### DIFF
--- a/cdap-ui/app/cdap/components/CaskWizards/PublishPipeline/MetadataStep/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/PublishPipeline/MetadataStep/index.js
@@ -48,7 +48,10 @@ const PipelineName = connect(
 export default function MetadataStep() {
   return (
     <Provider store={PublishPipelineStore}>
-      <Form className="form-horizontal pipeline-publish-metadata-step">
+      <Form
+        className="form-horizontal pipeline-publish-metadata-step"
+        onSubmit={(e) => {e.stopPropagation(); e.preventDefault();}}
+      >
         <FormGroup row>
           <Col xs="3">
             <Label className="control-label">

--- a/cdap-ui/app/cdap/components/CaskWizards/UploadData/SelectDestination/SelectDestination.scss
+++ b/cdap-ui/app/cdap/components/CaskWizards/UploadData/SelectDestination/SelectDestination.scss
@@ -17,4 +17,20 @@
 .select-destination-step {
   height: calc(100% - 32px);
   padding: 10px;
+
+  .destination-input {
+    display: flex;
+    align-items: center;
+    input {
+      margin-right: 10px;
+    }
+    i.fa {
+      font-size: 16px;
+      cursor: pointer;
+      &.btn-link,
+      &.btn-link:hover {
+        text-decoration: none;
+      }
+    }
+  }
 }

--- a/cdap-ui/app/cdap/components/CaskWizards/UploadData/SelectDestination/index.js
+++ b/cdap-ui/app/cdap/components/CaskWizards/UploadData/SelectDestination/index.js
@@ -13,12 +13,13 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-import React from 'react';
+import React, {PropTypes} from 'react';
 import { connect, Provider } from 'react-redux';
 import UploadDataStore from 'services/WizardStores/UploadData/UploadDataStore';
 import UploadDataActions from 'services/WizardStores/UploadData/UploadDataActions';
 import SelectWithOptions from 'components/SelectWithOptions';
 import {Input, Form, FormGroup, Col, Label} from 'reactstrap';
+import {UncontrolledTooltip} from 'components/UncontrolledComponents';
 require('./SelectDestination.scss');
 import T from 'i18n-react';
 
@@ -59,6 +60,30 @@ const mapDispatchToDestinationNameProps = (dispatch) => {
   };
 };
 
+let DestinationInput = ({value, placeholder, onChange}) => (
+  <div className="destination-input">
+    <Input
+      value={value}
+      placeholder={placeholder}
+      onChange={onChange}
+    />
+    <i
+      id="upload-data-destination-tooltip"
+      className="fa fa-exclamation-circle btn-link"
+    />
+    <UncontrolledTooltip
+      target="upload-data-destination-tooltip"
+    >
+      {T.translate('features.Wizard.UploadData.Step2.tooltiptext')}
+    </UncontrolledTooltip>
+  </div>
+);
+DestinationInput.propTypes = {
+  value: PropTypes.string,
+  placeholder: PropTypes.string,
+  onChange: PropTypes.func
+};
+
 let DestinationType = connect(
   mapStateToDestinationTypeProps,
   mapDispatchToDestinationTypeProps
@@ -66,13 +91,14 @@ let DestinationType = connect(
 let DestinationName = connect(
   mapStateToDestinationNameProps,
   mapDispatchToDestinationNameProps
-)(Input);
+)(DestinationInput);
 
 export default function SelectDestination() {
   return (
     <Provider store={UploadDataStore}>
       <Form
         className="form-horizontal select-destination-step"
+         onSubmit={(e) => {e.stopPropagation(); e.preventDefault();}}
       >
       <FormGroup row>
         <Col xs="3">

--- a/cdap-ui/app/cdap/components/UncontrolledComponents/index.js
+++ b/cdap-ui/app/cdap/components/UncontrolledComponents/index.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/*
+  This is a direct copy paste from reactstrap's source. There is only one reason to do this.
+  We can't upgrade reactstrap to 4.* yet as it has upgraded to bootstrap that defaults to flexbox
+  now and we can't make that change at this point in the release. So this artifact stays here until we have
+  upgraded reactstrap.
+*/
+import React, { Component } from 'react';
+import {Tooltip} from 'reactstrap';
+
+const components = {
+  UncontrolledTooltip: Tooltip,
+};
+
+Object.keys(components).forEach(key => {
+  const Tag = components[key];
+  const defaultValue = false;
+
+  class Uncontrolled extends Component {
+    constructor(props) {
+      super(props);
+
+      this.state = { isOpen: defaultValue };
+
+      this.toggle = this.toggle.bind(this);
+    }
+
+    toggle() {
+      this.setState({ isOpen: !this.state.isOpen });
+    }
+
+    render() {
+      return <Tag isOpen={this.state.isOpen} toggle={this.toggle} {...this.props} />;
+    }
+  }
+
+  Uncontrolled.displayName = key;
+
+  components[key] = Uncontrolled;
+});
+
+const UncontrolledTooltip = components.UncontrolledTooltip;
+
+export {
+  UncontrolledTooltip,
+};

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -654,6 +654,7 @@ features:
       Step2:
         shorttitle: Select Destination
         title: Select a Destination
+        tooltiptext: The stream will be created if it does not exist
         description: Select the destination where the data needs to be uploaded.
         dataentitynameplaceholder: Dataset/Stream Name
         destinationtype: Destination Type


### PR DESCRIPTION
- Fixes UploadData wizard to create stream before uploading the datapack if the stream doesn't exist
- Adds a tooltip icon next stream name to indicate to the user that the stream will be created if it doesn't already exist.

Bamboo build: http://builds.cask.co/browse/CDAP-DRC5888-2

#### Note:
There is some code that I have copy-pasted from Reactstrap that would ease up the addition of tooltip component. This will go away when we upgrade reactstrap.