### PR TITLE
[CDAP-8426] Fix rollback of partitions and their files

### DIFF
--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/KeyValueTable.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/lib/KeyValueTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2016 Cask Data, Inc.
+ * Copyright © 2014-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -211,7 +211,7 @@ public class KeyValueTable extends AbstractDataset implements
   * @param stop if non-null, the returned splits will only cover keys that are less
   * @return list of {@link Split}
   */
-  public List<Split> getSplits(int numSplits, byte[] start, byte[] stop) {
+  public List<Split> getSplits(int numSplits, @Nullable byte[] start, @Nullable byte[] stop) {
     return table.getSplits(numSplits, start, stop);
   }
 

--- a/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Table.java
+++ b/cdap-api/src/main/java/co/cask/cdap/api/dataset/table/Table.java
@@ -319,8 +319,7 @@ public interface Table extends BatchReadable<byte[], Row>, BatchWritable<byte[],
    * @param stop if non-null, the returned splits will only cover keys that are less
    * @return list of {@link Split}
    */
-  List<Split> getSplits(int numSplits, byte[] start, byte[] stop);
-
+  List<Split> getSplits(int numSplits, @Nullable byte[] start, @Nullable byte[] stop);
 
   /**
    * Compares-and-swaps (atomically) the value of the specified row and column by looking for
@@ -333,7 +332,6 @@ public interface Table extends BatchReadable<byte[], Row>, BatchWritable<byte[],
    * @return true if compare and swap succeeded, false otherwise (stored value is different from expected)
    */
   boolean compareAndSwap(byte[] key, byte[] keyColumn, byte[] oldValue, byte[] newValue);
-
 
   /**
    * Writes the {key, value} record into a dataset.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -66,6 +66,7 @@ import java.io.File;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -120,7 +121,7 @@ final class BasicMapReduceContext extends AbstractContext implements MapReduceCo
     this.resourcesToLocalize = new HashMap<>();
 
     this.inputs = new HashMap<>();
-    this.outputs = new HashMap<>();
+    this.outputs = new LinkedHashMap<>();
 
     if (spec.getInputDataSet() != null) {
       addInput(Input.ofDataset(spec.getInputDataSet()));
@@ -266,7 +267,8 @@ final class BasicMapReduceContext extends AbstractContext implements MapReduceCo
    * @return a map from output name to provided output for the MapReduce job
    */
   Map<String, ProvidedOutput> getOutputs() {
-    return new HashMap<>(outputs);
+    // LinkedHashMap() will preserve the order of the outputs
+    return new LinkedHashMap<>(outputs);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/MultipleOutputsCommitter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/MultipleOutputsCommitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.internal.app.runtime.batch.dataset.output;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.JobStatus;
 import org.apache.hadoop.mapreduce.OutputCommitter;
@@ -33,7 +32,8 @@ public class MultipleOutputsCommitter extends OutputCommitter {
   private final Map<String, OutputCommitter> committers;
 
   public MultipleOutputsCommitter(Map<String, OutputCommitter> committers) {
-    this.committers = ImmutableMap.copyOf(committers);
+    // do not copy the committers map to preserve its order: committers are called in the order the outputs were added
+    this.committers = committers;
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/MultipleOutputsMainOutputWrapper.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/output/MultipleOutputsMainOutputWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -27,7 +27,7 @@ import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.util.ReflectionUtils;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -97,7 +97,9 @@ public class MultipleOutputsMainOutputWrapper<K, V> extends OutputFormat<K, V> {
     throws IOException, InterruptedException {
     // return a MultipleOutputsCommitter that commits for the root output format as well as all delegate outputformats
     if (committer == null) {
-      Map<String, OutputCommitter> committers = new HashMap<>();
+      // use a linked hash map: it preserves the order of insertion, so the output committers are called in the
+      // same order as outputs were added. This makes multi-output a little more predictable (and testable).
+      Map<String, OutputCommitter> committers = new LinkedHashMap<>();
       for (String name : MultipleOutputs.getNamedOutputsList(context)) {
         Class<? extends OutputFormat> namedOutputFormatClass =
           MultipleOutputs.getNamedOutputFormatClass(context, name);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/DynamicPartitioningOutputCommitter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/dataset/partitioned/DynamicPartitioningOutputCommitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -112,9 +112,8 @@ public class DynamicPartitioningOutputCommitter extends FileOutputCommitter {
         String fileName = relativePath.substring(lastPathSepIdx + 1);
 
         Path finalDir = new Path(FileOutputFormat.getOutputPath(context), relativeDir);
-        Path finalPath = new Path(finalDir, fileName);
-        if (fs.exists(finalPath)) {
-          throw new FileAlreadyExistsException("Final output path " + finalPath + " already exists");
+        if (fs.exists(finalDir)) {
+          throw new FileAlreadyExistsException("Final output path " + finalDir + " already exists");
         }
         PartitionKey partitionKey = getPartitionKey(partitioning, relativeDir);
         partitionsToAdd.add(partitionKey);

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/AddPartitionOperation.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/AddPartitionOperation.java
@@ -19,23 +19,27 @@ package co.cask.cdap.data2.dataset2.lib.partitioned;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 
 /**
- * Represents an operation on a particular path. Must be used in context of a base location, because the path is a
- * relative path.
+ * Represents the creation of a partition.
  */
-class PartitionOperation {
-  private final String relativePath;
-  private final PartitionKey partitionKey;
+class AddPartitionOperation extends PartitionOperation {
 
-  PartitionOperation(PartitionKey partitionKey, String relativePath) {
-    this.partitionKey = partitionKey;
-    this.relativePath = relativePath;
+  private final boolean filesCreated;
+  private boolean explorePartitionCreated = false;
+
+  AddPartitionOperation(PartitionKey partitionKey, String relativePath, boolean filesCreated) {
+    super(partitionKey, relativePath);
+    this.filesCreated = filesCreated;
   }
 
-  String getRelativePath() {
-    return relativePath;
+  void setExplorePartitionCreated() {
+    explorePartitionCreated = true;
   }
 
-  PartitionKey getPartitionKey() {
-    return partitionKey;
+  boolean isFilesCreated() {
+    return filesCreated;
+  }
+
+  boolean isExplorePartitionCreated() {
+    return explorePartitionCreated;
   }
 }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/DropPartitionOperation.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/dataset2/lib/partitioned/DropPartitionOperation.java
@@ -19,23 +19,10 @@ package co.cask.cdap.data2.dataset2.lib.partitioned;
 import co.cask.cdap.api.dataset.lib.PartitionKey;
 
 /**
- * Represents an operation on a particular path. Must be used in context of a base location, because the path is a
- * relative path.
+ * Represents the drop of a partition.
  */
-class PartitionOperation {
-  private final String relativePath;
-  private final PartitionKey partitionKey;
-
-  PartitionOperation(PartitionKey partitionKey, String relativePath) {
-    this.partitionKey = partitionKey;
-    this.relativePath = relativePath;
-  }
-
-  String getRelativePath() {
-    return relativePath;
-  }
-
-  PartitionKey getPartitionKey() {
-    return partitionKey;
+class DropPartitionOperation extends PartitionOperation {
+  DropPartitionOperation(PartitionKey partitionKey, String relativePath) {
+    super(partitionKey, relativePath);
   }
 }

--- a/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceFileSetTestRun.java
+++ b/cdap-explore/src/test/java/co/cask/cdap/explore/service/HiveExploreServiceFileSetTestRun.java
@@ -687,7 +687,7 @@ public class HiveExploreServiceFileSetTestRun extends BaseHiveExploreServiceTest
   }
 
   @Test
-    public void testPartitionedTextFileUpdate() throws Exception {
+  public void testPartitionedTextFileUpdate() throws Exception {
     final DatasetId datasetId = NAMESPACE_ID.dataset("txtupd");
     final String tableName = getDatasetHiveName(datasetId);
 
@@ -1030,8 +1030,8 @@ public class HiveExploreServiceFileSetTestRun extends BaseHiveExploreServiceTest
     });
   }
 
-  private void doTransaction(Dataset tpfs, final Runnable runnable) throws Exception {
-    TransactionExecutor executor = new DefaultTransactionExecutor(transactionSystemClient, (TransactionAware) tpfs);
+  private void doTransaction(Dataset dataset, final Runnable runnable) throws Exception {
+    TransactionExecutor executor = new DefaultTransactionExecutor(transactionSystemClient, (TransactionAware) dataset);
     executor.execute(new TransactionExecutor.Subroutine() {
       @Override
       public void apply() throws Exception {

--- a/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/AppWritingToPartitioned.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/AppWritingToPartitioned.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.partitioned;
+
+import co.cask.cdap.api.ProgramLifecycle;
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.batch.Input;
+import co.cask.cdap.api.data.batch.Output;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.lib.DynamicPartitioner;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetArguments;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSetProperties;
+import co.cask.cdap.api.dataset.lib.Partitioning;
+import co.cask.cdap.api.mapreduce.AbstractMapReduce;
+import co.cask.cdap.api.mapreduce.MapReduceContext;
+import co.cask.cdap.api.mapreduce.MapReduceTaskContext;
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An application used to test MapReduce writing partitions and proper rollback.
+ */
+public class AppWritingToPartitioned extends AbstractApplication {
+
+  static final String INPUT = "input";
+  static final String PFS = "pfs";
+  static final String OTHER = "other";
+  static final String MAPREDUCE = "PFSWriter";
+
+  @Override
+  public void configure() {
+    createDataset(INPUT, KeyValueTable.class.getName(), DatasetProperties.EMPTY);
+    // create two pfs, identical except for their (table) names
+    for (String name : new String[] { PFS, OTHER }) {
+      createDataset(name, PartitionedFileSet.class.getName(), PartitionedFileSetProperties.builder()
+        .setPartitioning(Partitioning.builder().addIntField("number").build())
+        .setOutputFormat(TextOutputFormat.class)
+        .setOutputProperty(TextOutputFormat.SEPERATOR, ",")
+        .setEnableExploreOnCreate(true)
+        .setExploreTableName(name)
+        .setExploreSchema("key STRING, value STRING")
+        .setExploreFormat("csv")
+        .build());
+    }
+    addMapReduce(new PartitionWriterMR());
+  }
+
+  public static class PartitionWriterMR extends AbstractMapReduce {
+
+    @Override
+    public void configure() {
+      setName(MAPREDUCE);
+    }
+
+    @Override
+    public void initialize() throws Exception {
+      MapReduceContext context = getContext();
+      Job job = context.getHadoopJob();
+      job.setMapperClass(TokenMapper.class);
+      job.setNumReduceTasks(0);
+
+      String inputText = getContext().getRuntimeArguments().get("input.text");
+      Preconditions.checkNotNull(inputText);
+      KeyValueTable kvTable = getContext().getDataset(INPUT);
+      kvTable.write("key", inputText);
+      context.addInput(Input.ofDataset(INPUT, kvTable.getSplits(1, null, null)));
+
+      String outputDatasets = getContext().getRuntimeArguments().get("output.datasets");
+      outputDatasets = outputDatasets != null ? outputDatasets : PFS;
+      for (String outputName : outputDatasets.split(",")) {
+        String outputPartition = getContext().getRuntimeArguments().get(outputName + ".output.partition");
+        PartitionKey outputPartitionKey = outputPartition == null ? null :
+          PartitionKey.builder().addField("number", Integer.parseInt(outputPartition)).build();
+        Map<String, String> outputArguments = new HashMap<>();
+        if (outputPartitionKey != null) {
+          PartitionedFileSetArguments.setOutputPartitionKey(outputArguments, outputPartitionKey);
+        } else {
+          PartitionedFileSetArguments.setDynamicPartitioner(outputArguments, KeyPartitioner.class);
+        }
+        context.addOutput(Output.ofDataset(outputName, outputArguments));
+      }
+    }
+
+    public static final class KeyPartitioner extends DynamicPartitioner<String, String> {
+      @Override
+      public PartitionKey getPartitionKey(String key, String value) {
+        return PartitionKey.builder().addIntField("number", Integer.parseInt(key.substring(0, 1))).build();
+      }
+    }
+
+    /**
+     * A mapper that splits each input line and emits each token with a value of 1.
+     */
+    public static class TokenMapper extends Mapper<byte[], byte[], String, String>
+      implements ProgramLifecycle<MapReduceTaskContext<String, String>> {
+
+      MapReduceTaskContext<String, String> taskContext;
+      String[] outputs = null;
+
+      @Override
+      public void initialize(MapReduceTaskContext<String, String> context) throws Exception {
+        taskContext = context;
+        String outputDatasets = context.getRuntimeArguments().get("output.datasets");
+        if (outputDatasets != null) {
+          String[] splitOutputs = outputDatasets.split(",");
+          if (splitOutputs.length > 1) {
+            outputs = splitOutputs;
+          }
+        }
+      }
+
+      @Override
+      public void destroy() {
+      }
+
+      @Override
+      public void map(byte[] key, byte[] data, Context context)
+        throws IOException, InterruptedException {
+        for (String word : Bytes.toString(data).split(" ")) {
+          if (outputs != null) {
+            for (String output : outputs) {
+              taskContext.write(output, word, word);
+            }
+          } else {
+            context.write(word, word);
+          }
+        }
+      }
+    }
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/PartitionRollbackTestRun.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/partitioned/PartitionRollbackTestRun.java
@@ -1,0 +1,426 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.partitioned;
+
+import co.cask.cdap.api.dataset.lib.PartitionDetail;
+import co.cask.cdap.api.dataset.lib.PartitionKey;
+import co.cask.cdap.api.dataset.lib.PartitionOutput;
+import co.cask.cdap.api.dataset.lib.PartitionedFileSet;
+import co.cask.cdap.data2.dataset2.lib.partitioned.PartitionedFileSetDataset;
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.DataSetManager;
+import co.cask.cdap.test.MapReduceManager;
+import co.cask.cdap.test.UnitTestManager;
+import co.cask.cdap.test.XSlowTests;
+import co.cask.cdap.test.base.TestFrameworkTestBase;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
+import org.apache.tephra.TransactionFailureException;
+import org.apache.twill.filesystem.Location;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
+
+@Category(XSlowTests.class)
+public class PartitionRollbackTestRun extends TestFrameworkTestBase {
+
+  private static final String PFS = AppWritingToPartitioned.PFS;
+  private static final String OTHER = AppWritingToPartitioned.OTHER;
+  private static final String BOTH = PFS + "," + OTHER;
+  private static final String PFS_OUT = PFS + ".output.partition";
+  private static final String OTHER_OUT = OTHER + ".output.partition";
+
+  private static final String MAPREDUCE = AppWritingToPartitioned.MAPREDUCE;
+
+  private static final PartitionKey KEY_0 = PartitionKey.builder().addField("number", 0).build();
+  private static final PartitionKey KEY_1 = PartitionKey.builder().addField("number", 1).build();
+  private static final PartitionKey KEY_2 = PartitionKey.builder().addField("number", 2).build();
+  private static final PartitionKey KEY_3 = PartitionKey.builder().addField("number", 3).build();
+  private static final PartitionKey KEY_4 = PartitionKey.builder().addField("number", 4).build();
+  private static final PartitionKey KEY_5 = PartitionKey.builder().addField("number", 5).build();
+
+  class Validator {
+    private final UnitTestManager.UnitTestDatasetManager<PartitionedFileSet> pfsManager;
+    private final String tableName;
+    private final Location location1, location2, location3;
+    private final String path3;
+
+    /*
+     * Set up some partitions in a partitioned file set.
+     * Every time validate() is called it verifies the state is still the same
+     *
+     * KEY_1: partition with data in the standard location
+     * KEY_2: partition with data in a non-standard location
+     * KEY_3: data in standard location, but no partition
+     * KEY_4: partition is only in Hive, with standard location for KEY_3
+     *
+     * This sets us up to predictably produce failure in MR:
+     * - output to KEY_1 or KEY_3 will fail because the location already exists
+     * - output to KEY_2 will fail because the partition already exists
+     * - output to KEY_4 will fail because the Hive partition exists
+     * - output to KEY_0 or KEY_5 will succeed and we can validate they get rolled back after failure
+     *
+     * We will set up two datasets in this way, and can then inject failure into either one by configuring its
+     * output partition.
+     */
+    Validator(String datasetName) throws Exception {
+      this.tableName = datasetName;
+
+      DataSetManager dsManager = getDataset(datasetName);
+      Assert.assertTrue(dsManager instanceof UnitTestManager.UnitTestDatasetManager);
+      // TODO (CDAP-3792): remove this hack when TestBase has better support for transactions
+      //noinspection unchecked
+      pfsManager = (UnitTestManager.UnitTestDatasetManager<PartitionedFileSet>) dsManager;
+      final PartitionedFileSet pfs = pfsManager.get();
+
+      // create a partition n=1 in standard path
+      final PartitionOutput output1 =  pfs.getPartitionOutput(KEY_1);
+      location1 = output1.getLocation();
+      try (Writer writer = new OutputStreamWriter(location1.append("file").getOutputStream())) {
+        writer.write("1,1\n");
+      }
+      output1.addPartition();
+
+      // crete a partition n=2 in different path
+      final String path2 = "path2";
+      location2 = pfs.getEmbeddedFileSet().getLocation(path2);
+      try (Writer writer = new OutputStreamWriter(location2.append("file").getOutputStream())) {
+        writer.write("2,2\n");
+      }
+      pfs.addPartition(KEY_2, path2);
+
+      // create some file in the standard location for n=3 and add it to Hive but not the PFS for n=4
+      final PartitionOutput output3 =  pfs.getPartitionOutput(KEY_3);
+      location3 = output3.getLocation();
+      String basePath = pfs.getEmbeddedFileSet().getBaseLocation().toURI().getPath();
+      String absPath3 = location3.toURI().getPath();
+      Assert.assertTrue(absPath3.startsWith(basePath));
+      path3 = absPath3.substring(basePath.length());
+      try (Writer writer = new OutputStreamWriter(location3.append("file").getOutputStream())) {
+        writer.write("3,3\n");
+      }
+      ((PartitionedFileSetDataset) pfs).addPartitionToExplore(KEY_4, path3);
+      pfsManager.flush();
+      validate();
+    }
+
+    // TODO (CDAP-3792): remove this hack when TestBase has better support for transactions
+    UnitTestManager.UnitTestDatasetManager<PartitionedFileSet> getPfsManager() {
+      return pfsManager;
+    }
+
+    String getRelativePath3() {
+      return path3;
+    }
+
+    private void validate() throws Exception {
+      final PartitionedFileSet pfs = pfsManager.get();
+      pfsManager.execute(new Runnable() {
+        @Override
+        public void run() {
+          try {
+            PartitionDetail detail1 = pfs.getPartition(KEY_1);
+            Assert.assertNotNull(detail1);
+            Assert.assertEquals(location1, detail1.getLocation());
+            Assert.assertTrue(location1.exists());
+            Assert.assertTrue(location1.append("file").exists());
+            PartitionDetail detail2 = pfs.getPartition(KEY_2);
+            Assert.assertNotNull(detail2);
+            Assert.assertEquals(location2, detail2.getLocation());
+            Assert.assertTrue(location2.exists());
+            Assert.assertTrue(location2.append("file").exists());
+            PartitionDetail detail3 = pfs.getPartition(KEY_4);
+            Assert.assertNull(detail3);
+            Assert.assertTrue(location3.exists());
+            Assert.assertTrue(location3.append("file").exists());
+          } catch (Exception e) {
+            throw Throwables.propagate(e);
+          }
+        }
+      });
+
+      // verify that the partitions were added to Hive
+      String[] expectedPartitions = { "number=1", "number=2", "number=4" };
+      SortedMap<String, Integer> expectedRows = ImmutableSortedMap.of("1", 1, "2", 2, "3", 4);
+      try (Connection connection = getQueryClient()) {
+        try (ResultSet results = connection.prepareStatement("show partitions " + tableName).executeQuery()) {
+          for (String expected : expectedPartitions) {
+            Assert.assertTrue(results.next());
+            Assert.assertEquals(expected, results.getString(1));
+          }
+        }
+        try (ResultSet results = connection
+          .prepareStatement("select * from " + tableName + " order by key").executeQuery()) {
+          for (Map.Entry<String, Integer> expected : expectedRows.entrySet()) {
+            Assert.assertTrue(results.next());
+            Assert.assertEquals(expected.getKey(), results.getString(1));
+            Assert.assertEquals(expected.getKey(), results.getString(2));
+            Assert.assertEquals(expected.getValue().intValue(), results.getInt(3));
+          }
+        }
+      }
+    }
+  }
+
+  /*
+   * This tests all the following cases:
+   *
+   *  1. addPartition(location) fails because partition already exists
+   *  2. addPartition(location) fails because Hive partition already exists
+   *  3. addPartition(location) succeeds but transaction fails
+   *  4. partitionOutput.addPartition() fails because partition already exists
+   *  5. partitionOutput.addPartition() fails because Hive partition already exists
+   *  6. partitionOutput.addPartition() succeeds but transaction fails
+   *  7. mapreduce writing partition fails because location already exists
+   *  8. mapreduce writing partition fails because partition already exists
+   *  9. mapreduce writing partition fails because Hive partition already exists
+   *  10. mapreduce writing dynamic partition fails because location already exists
+   *  11. mapreduce writing dynamic partition fails because partition already exists
+   *  12. mapreduce writing dynamic partition fails because Hive partition already exists
+   *  13. multi-output mapreduce writing partition fails because location already exists
+   *  13a. first output fails, other output must rollback 0 and 5
+   *  13b. second output fails, first output must rollback 0 and 5
+   *  14. multi-output mapreduce writing partition fails because partition already exists
+   *  14a. first output fails, other output must rollback partition 5
+   *  14b. second output fails, first output must rollback partition 5
+   *  15. multi-output mapreduce writing partition fails because Hive partition already exists
+   *  15a. first output fails, other output must rollback partitions 0 and 5
+   *  15b. second output fails, first output must rollback partitions 0 and 5
+   *
+   * For all these cases, we validate that existing files and partitions are preserved, and newly
+   * added files and partitions are rolled back.
+   */
+  @Test
+  public void testPFSRollback() throws Exception {
+    ApplicationManager appManager = deployApplication(AppWritingToPartitioned.class);
+    MapReduceManager mrManager = appManager.getMapReduceManager(MAPREDUCE);
+    int numRuns = 0;
+
+    Validator pfsValidator = new Validator(PFS);
+    Validator otherValidator = new Validator(OTHER);
+    final UnitTestManager.UnitTestDatasetManager<PartitionedFileSet> pfsManager = pfsValidator.getPfsManager();
+    final PartitionedFileSet pfs = pfsManager.get();
+    final PartitionedFileSet other = otherValidator.getPfsManager().get();
+    final String path3 = pfsValidator.getRelativePath3();
+
+    // 1. addPartition(location) fails because partition already exists
+    try {
+      pfsManager.execute(new Runnable() {
+        @Override
+        public void run() {
+          pfs.addPartition(KEY_1, path3);
+        }
+      });
+      Assert.fail("Expected tx to fail because partition for number=1 already exists");
+    } catch (TransactionFailureException e) {
+      // expected
+    }
+    pfsValidator.validate();
+
+    // 2. addPartition(location) fails because Hive partition already exists
+    try {
+      pfsManager.execute(new Runnable() {
+        @Override
+        public void run() {
+          pfs.addPartition(KEY_4, path3);
+        }
+      });
+      Assert.fail("Expected tx to fail because hive partition for number=1 already exists");
+    } catch (TransactionFailureException e) {
+      // expected
+    }
+    pfsValidator.validate();
+
+    // 3. addPartition(location) succeeds but transaction fails
+    try {
+      pfsManager.execute(new Runnable() {
+        @Override
+        public void run() {
+          pfs.addPartition(KEY_3, path3);
+          throw new RuntimeException("fail the tx");
+        }
+      });
+      Assert.fail("Expected tx to fail because it threw a runtime exception");
+    } catch (TransactionFailureException e) {
+      // expected
+    }
+    pfsValidator.validate();
+
+    // 4. partitionOutput.addPartition() fails because partition already exists
+    final PartitionOutput output2x =  pfs.getPartitionOutput(KEY_2);
+    final Location location2x = output2x.getLocation();
+    try (Writer writer = new OutputStreamWriter(location2x.append("file").getOutputStream())) {
+      writer.write("2x,2x\n");
+    }
+    try {
+      pfsManager.execute(new Runnable() {
+        @Override
+        public void run() {
+          output2x.addPartition();
+        }
+      });
+      Assert.fail("Expected tx to fail because partition for number=2 already exists");
+    } catch (TransactionFailureException e) {
+      // expected
+    }
+    pfsValidator.validate();
+    Assert.assertFalse(location2x.exists());
+
+    // 5. partitionOutput.addPartition() fails because Hive partition already exists
+    final PartitionOutput output4x =  pfs.getPartitionOutput(KEY_4);
+    final Location location4x = output4x.getLocation();
+    try (Writer writer = new OutputStreamWriter(location4x.append("file").getOutputStream())) {
+      writer.write("4x,4x\n");
+    }
+    try {
+      pfsManager.execute(new Runnable() {
+        @Override
+        public void run() {
+          output4x.addPartition();
+        }
+      });
+      Assert.fail("Expected tx to fail because hive partition for number=4 already exists");
+    } catch (TransactionFailureException e) {
+      // expected
+    }
+    pfsValidator.validate();
+    Assert.assertFalse(location4x.exists());
+
+    // 6. partitionOutput.addPartition() succeeds but transaction fails
+    final PartitionOutput output5x =  pfs.getPartitionOutput(KEY_5);
+    final Location location5x = output5x.getLocation();
+    try (Writer writer = new OutputStreamWriter(location5x.append("file").getOutputStream())) {
+      writer.write("5x,5x\n");
+    }
+    try {
+      pfsManager.execute(new Runnable() {
+        @Override
+        public void run() {
+          output5x.addPartition();
+          throw new RuntimeException("fail the tx");
+        }
+      });
+      Assert.fail("Expected tx to fail because it threw a runtime exception");
+    } catch (TransactionFailureException e) {
+      // expected
+    }
+    pfsValidator.validate();
+    Assert.assertFalse(location5x.exists());
+
+    // 7. mapreduce writing partition fails because location already exists
+    mrManager.start(ImmutableMap.of(PFS_OUT, "1", "input.text", "1x"));
+    mrManager.waitForRuns(ProgramRunStatus.FAILED, ++numRuns, 2, TimeUnit.MINUTES);
+    pfsValidator.validate();
+
+    // 8. mapreduce writing partition fails because partition already exists
+    mrManager.start(ImmutableMap.of(PFS_OUT, "2", "input.text", "2x"));
+    mrManager.waitForRuns(ProgramRunStatus.FAILED, ++numRuns, 2, TimeUnit.MINUTES);
+    pfsValidator.validate();
+    Assert.assertFalse(pfs.getPartitionOutput(KEY_2).getLocation().exists());
+
+    // 9. mapreduce writing partition fails because Hive partition already exists
+    mrManager.start(ImmutableMap.of(PFS_OUT, "4", "input.text", "4x"));
+    mrManager.waitForRuns(ProgramRunStatus.FAILED, ++numRuns, 2, TimeUnit.MINUTES);
+    pfsValidator.validate();
+    Assert.assertFalse(pfs.getPartitionOutput(KEY_4).getLocation().exists());
+
+    // 10. mapreduce writing dynamic partition fails because location already exists
+    mrManager.start(ImmutableMap.of("input.text", "3x 5x"));
+    mrManager.waitForRuns(ProgramRunStatus.FAILED, ++numRuns, 2, TimeUnit.MINUTES);
+    pfsValidator.validate();
+    Assert.assertFalse(pfs.getPartitionOutput(KEY_5).getLocation().exists());
+
+    // 11. mapreduce writing dynamic partition fails because partition already exists
+    mrManager.start(ImmutableMap.of("input.text", "2x 5x"));
+    mrManager.waitForRuns(ProgramRunStatus.FAILED, ++numRuns, 2, TimeUnit.MINUTES);
+    pfsValidator.validate();
+    Assert.assertFalse(pfs.getPartitionOutput(KEY_2).getLocation().exists());
+    Assert.assertFalse(pfs.getPartitionOutput(KEY_5).getLocation().exists());
+
+    // 12. mapreduce writing dynamic partition fails because Hive partition already exists
+    mrManager.start(ImmutableMap.of("input.text", "0x 4x 5x"));
+    mrManager.waitForRuns(ProgramRunStatus.FAILED, ++numRuns, 2, TimeUnit.MINUTES);
+    pfsValidator.validate();
+    Assert.assertFalse(pfs.getPartitionOutput(KEY_0).getLocation().exists());
+    Assert.assertFalse(pfs.getPartitionOutput(KEY_4).getLocation().exists());
+    Assert.assertFalse(pfs.getPartitionOutput(KEY_5).getLocation().exists());
+
+    // 13. multi-output mapreduce writing partition fails because location already exists
+    // 13a. first output fails, other output must rollback 0 and 5
+    mrManager.start(ImmutableMap.of("output.datasets", BOTH, PFS_OUT, "1", "input.text", "0x 5x"));
+    mrManager.waitForRuns(ProgramRunStatus.FAILED, ++numRuns, 2, TimeUnit.MINUTES);
+    pfsValidator.validate();
+    otherValidator.validate();
+    Assert.assertFalse(other.getPartitionOutput(KEY_0).getLocation().exists());
+    Assert.assertFalse(other.getPartitionOutput(KEY_5).getLocation().exists());
+    // 13b. second output fails, first output must rollback 0 and 5
+    mrManager.start(ImmutableMap.of("output.datasets", BOTH, OTHER_OUT, "1", "input.text", "0x 5x"));
+    mrManager.waitForRuns(ProgramRunStatus.FAILED, ++numRuns, 2, TimeUnit.MINUTES);
+    pfsValidator.validate();
+    otherValidator.validate();
+    Assert.assertFalse(pfs.getPartitionOutput(KEY_0).getLocation().exists());
+    Assert.assertFalse(pfs.getPartitionOutput(KEY_5).getLocation().exists());
+
+    // 14. multi-output mapreduce writing partition fails because partition already exists
+    // 14a. first output fails, other output must rollback partition 5
+    // TODO: bring this back when CDAP-8766 is fixed
+    /*
+    mrManager.start(ImmutableMap.of("output.datasets", BOTH, PFS_OUT, "2", OTHER_OUT, "5", "input.text", "2x 5x"));
+    mrManager.waitForRuns(ProgramRunStatus.FAILED, ++numRuns, 2, TimeUnit.MINUTES);
+    pfsValidator.validate();
+    otherValidator.validate();
+    Assert.assertFalse(other.getPartitionOutput(KEY_5).getLocation().exists());
+    */
+    // 14b. second output fails, first output must rollback partition 5
+    mrManager.start(ImmutableMap.of("output.datasets", BOTH, PFS_OUT, "5", OTHER_OUT, "2", "input.text", "2x 5x"));
+    mrManager.waitForRuns(ProgramRunStatus.FAILED, ++numRuns, 2, TimeUnit.MINUTES);
+    pfsValidator.validate();
+    otherValidator.validate();
+    Assert.assertFalse(pfs.getPartitionOutput(KEY_5).getLocation().exists());
+
+    // 15. multi-output mapreduce writing partition fails because Hive partition already exists
+    // 15a. first output fails, other output must rollback partitions 0 and 5
+    // TODO: bring this back when CDAP-8766 is fixed
+    /*
+    mrManager.start(ImmutableMap.of("output.datasets", BOTH, PFS_OUT, "4", "input.text", "0x 5x"));
+    mrManager.waitForRuns(ProgramRunStatus.FAILED, ++numRuns, 2, TimeUnit.MINUTES);
+    pfsValidator.validate();
+    otherValidator.validate();
+    Assert.assertFalse(pfs.getPartitionOutput(KEY_4).getLocation().exists());
+    Assert.assertFalse(other.getPartitionOutput(KEY_0).getLocation().exists());
+    Assert.assertFalse(other.getPartitionOutput(KEY_5).getLocation().exists());
+    // 15b. second output fails, first output must rollback partitions 0 and 5
+    mrManager.start(ImmutableMap.of("output.datasets", BOTH, OTHER_OUT, "4", "input.text", "0x 5x"));
+    mrManager.waitForRuns(ProgramRunStatus.FAILED, ++numRuns, 2, TimeUnit.MINUTES);
+    pfsValidator.validate();
+    otherValidator.validate();
+    Assert.assertFalse(other.getPartitionOutput(KEY_4).getLocation().exists());
+    Assert.assertFalse(pfs.getPartitionOutput(KEY_0).getLocation().exists());
+    Assert.assertFalse(pfs.getPartitionOutput(KEY_5).getLocation().exists());
+    */
+  }
+}

--- a/cdap-unit-test/src/test/java/co/cask/cdap/test/base/TestFrameworkExploreTestSuite.java
+++ b/cdap-unit-test/src/test/java/co/cask/cdap/test/base/TestFrameworkExploreTestSuite.java
@@ -19,6 +19,7 @@ package co.cask.cdap.test.base;
 import co.cask.cdap.common.test.TestSuite;
 import co.cask.cdap.partitioned.PartitionConsumingTestRun;
 import co.cask.cdap.partitioned.PartitionCorrectorTestRun;
+import co.cask.cdap.partitioned.PartitionRollbackTestRun;
 import co.cask.cdap.test.XSlowTests;
 import co.cask.cdap.test.app.DummyBaseCloneTestRun;
 import co.cask.cdap.test.app.DummyBaseTestRun;
@@ -38,6 +39,7 @@ import org.junit.runners.Suite;
   DummyBaseCloneTestRun.class,
   PartitionConsumingTestRun.class,
   PartitionCorrectorTestRun.class,
+  PartitionRollbackTestRun.class,
   TestSQLQueryTestRun.class
 })
 public class TestFrameworkExploreTestSuite extends TestFrameworkTestBase {


### PR DESCRIPTION
The following should be true if a transaction fails:
- partitions added in the transaction should be removed
- pre-existing partitions must be preserved
- partition files should be preserved if they were written independently (that is, not through PartitionOutput.getLocation(), or in other words, added through addPartition(partitionKey, path)). 
- map reduce jobs should always remove the files they have written

See the comments in PartitionRollbackTestRun for all the special cases.

Documentation changes are in the second commit.