### PR TITLE
CDAP-8745 Fix search total

### DIFF
--- a/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/co/cask/cdap/data2/metadata/dataset/MetadataDatasetTest.java
@@ -1137,42 +1137,42 @@ public class MetadataDatasetTest {
         searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 2, 0, null, false,
                                        EnumSet.allOf(EntityScope.class));
         Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry), searchResults.getResults());
-        Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry, appEntry), searchResults.getAllResults());
+        Assert.assertEquals(2, searchResults.getAllResults().size());
         // return 2 with offset 1 in ascending order
         searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 1, 2, 0, null, false,
                                        EnumSet.allOf(EntityScope.class));
         Assert.assertEquals(ImmutableList.of(dsEntry, appEntry), searchResults.getResults());
-        Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry, appEntry), searchResults.getAllResults());
+        Assert.assertEquals(3, searchResults.getAllResults().size());
         // descending sort by name. offset and filter should be respected.
         SortInfo nameDesc = new SortInfo(AbstractSystemMetadataWriter.ENTITY_NAME_KEY, SortInfo.SortOrder.DESC);
         // first 2 in descending order
         searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 0, 2, 0, null, false,
                                        EnumSet.allOf(EntityScope.class));
         Assert.assertEquals(ImmutableList.of(appEntry, dsEntry), searchResults.getResults());
-        Assert.assertEquals(ImmutableList.of(appEntry, dsEntry, flowEntry), searchResults.getAllResults());
+        Assert.assertEquals(2, searchResults.getAllResults().size());
         // last 1 in descending order
         searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 2, 1, 0, null, false,
                                        EnumSet.allOf(EntityScope.class));
         Assert.assertEquals(ImmutableList.of(flowEntry), searchResults.getResults());
-        Assert.assertEquals(ImmutableList.of(appEntry, dsEntry, flowEntry), searchResults.getAllResults());
+        Assert.assertEquals(3, searchResults.getAllResults().size());
         // limit 0 should return empty
         searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 2, 0, 0, null, false,
                                        EnumSet.allOf(EntityScope.class));
         Assert.assertTrue(searchResults.getResults().isEmpty());
-        Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry, appEntry), searchResults.getAllResults());
+        Assert.assertEquals(2, searchResults.getAllResults().size());
         searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 1, 0, 0, null, false,
                                        EnumSet.allOf(EntityScope.class));
         Assert.assertTrue(searchResults.getResults().isEmpty());
-        Assert.assertEquals(ImmutableList.of(appEntry, dsEntry, flowEntry), searchResults.getAllResults());
+        Assert.assertEquals(1, searchResults.getAllResults().size());
         // offset greater than total search results should return empty
         searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 4, 0, 0, null, false,
                                        EnumSet.allOf(EntityScope.class));
         Assert.assertTrue(searchResults.getResults().isEmpty());
-        Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry, appEntry), searchResults.getAllResults());
+        Assert.assertEquals(3, searchResults.getAllResults().size());
         searchResults = dataset.search(namespaceId, "*", targets, nameDesc, 100, 0, 0, null, false,
                                        EnumSet.allOf(EntityScope.class));
         Assert.assertTrue(searchResults.getResults().isEmpty());
-        Assert.assertEquals(ImmutableList.of(appEntry, dsEntry, flowEntry), searchResults.getAllResults());
+        Assert.assertEquals(3, searchResults.getAllResults().size());
 
         // test cursors
         searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 1, 3, null, false,
@@ -1180,6 +1180,7 @@ public class MetadataDatasetTest {
         Assert.assertEquals(ImmutableList.of(flowEntry), searchResults.getResults());
         // only 2 cursors are returned even though we requested 3 because we do not have enough data to return
         Assert.assertEquals(ImmutableList.of(dsName, appName), searchResults.getCursors());
+        Assert.assertEquals(3, searchResults.getAllResults().size());
 
         // use first cursor returned in the previous query. the rest of the parameters stay the same
         searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 1, 3, searchResults.getCursors().get(0),
@@ -1188,6 +1189,7 @@ public class MetadataDatasetTest {
         Assert.assertEquals(ImmutableList.of(dsEntry), searchResults.getResults());
         // only 1 cursor is returned even though we requested 3 because we do not have enough data to return
         Assert.assertEquals(ImmutableList.of(appName), searchResults.getCursors());
+        Assert.assertEquals(2, searchResults.getAllResults().size());
 
         // use first cursor returned in the previous query. the rest of the parameters stay the same
         searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 1, 3, searchResults.getCursors().get(0),
@@ -1196,12 +1198,14 @@ public class MetadataDatasetTest {
         Assert.assertEquals(ImmutableList.of(appEntry), searchResults.getResults());
         // no cursors are returned even though we requested 3 because we do not have enough data
         Assert.assertEquals(ImmutableList.of(), searchResults.getCursors());
+        Assert.assertEquals(1, searchResults.getAllResults().size());
 
         searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 0, 2, 3, null, false,
                                        EnumSet.allOf(EntityScope.class));
         Assert.assertEquals(ImmutableList.of(flowEntry, dsEntry), searchResults.getResults());
         // only 1 cursor is returned even though we requested 3 because we do not have enough data to return
         Assert.assertEquals(ImmutableList.of(appName), searchResults.getCursors());
+        Assert.assertEquals(3, searchResults.getAllResults().size());
 
         searchResults = dataset.search(namespaceId, "*", targets, nameAsc, 3, 1, 2, null, false,
                                        EnumSet.allOf(EntityScope.class));
@@ -1209,6 +1213,7 @@ public class MetadataDatasetTest {
         Assert.assertEquals(ImmutableList.of(), searchResults.getResults());
         // only 1 cursor is returned even though we requested 3 because we do not have enough data to return
         Assert.assertEquals(ImmutableList.of(), searchResults.getCursors());
+        Assert.assertEquals(3, searchResults.getAllResults().size());
       }
     });
   }


### PR DESCRIPTION
This commit fixes the bug where the total returned is incorrect when
doing a sorted metadata search. Prior to this, the total returned was
the actual total. Now, the total returned may be less than the actual
total but the search is more efficient.

JIRA: https://issues.cask.co/browse/CDAP-8745
Bamboo: http://builds.cask.co/browse/CDAP-RUT701