### PR TITLE
CDAP-8744 fix coprocessor upgrade

### DIFF
--- a/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableDescriptorUtil.java
+++ b/cdap-hbase-compat-0.96/src/main/java/co/cask/cdap/data2/util/hbase/HBase96TableDescriptorUtil.java
@@ -74,8 +74,6 @@ public class HBase96TableDescriptorUtil {
     }
 
     for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
-      // TODO: should not add coprocessor related properties since those were already be added
-      // using addCoprocessor call.
       htd.setValue(property.getKey(), property.getValue());
     }
     return htd;
@@ -90,11 +88,7 @@ public class HBase96TableDescriptorUtil {
     Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
     coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
 
-    Map<String, String> properties = new HashMap<>();
-    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
-      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
-                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
-    }
+    Map<String, String> properties = CoprocessorUtil.getNonCoprocessorProperties(descriptor);
 
     // TODO: should add configurations as well
     return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),

--- a/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableDescriptorUtil.java
+++ b/cdap-hbase-compat-0.98/src/main/java/co/cask/cdap/data2/util/hbase/HBase98TableDescriptorUtil.java
@@ -74,8 +74,6 @@ public class HBase98TableDescriptorUtil {
     }
 
     for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
-      // TODO: should not add coprocessor related properties since those were already be added
-      // using addCoprocessor call.
       htd.setValue(property.getKey(), property.getValue());
     }
     return htd;
@@ -90,11 +88,7 @@ public class HBase98TableDescriptorUtil {
     Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
     coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
 
-    Map<String, String> properties = new HashMap<>();
-    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
-      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
-                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
-    }
+    Map<String, String> properties = CoprocessorUtil.getNonCoprocessorProperties(descriptor);
 
     // TODO: should add configurations as well
     return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),

--- a/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableDescriptorUtil.java
+++ b/cdap-hbase-compat-1.0-cdh/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDHTableDescriptorUtil.java
@@ -74,8 +74,6 @@ public class HBase10CDHTableDescriptorUtil {
     }
 
     for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
-      // TODO: should not add coprocessor related properties since those were already be added
-      // using addCoprocessor call.
       htd.setValue(property.getKey(), property.getValue());
     }
     return htd;
@@ -90,11 +88,7 @@ public class HBase10CDHTableDescriptorUtil {
     Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
     coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
 
-    Map<String, String> properties = new HashMap<>();
-    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
-      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
-                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
-    }
+    Map<String, String> properties = CoprocessorUtil.getNonCoprocessorProperties(descriptor);
 
     // TODO: should add configurations as well
     return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),

--- a/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDH550TableDescriptorUtil.java
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10CDH550TableDescriptorUtil.java
@@ -74,8 +74,6 @@ public class HBase10CDH550TableDescriptorUtil {
     }
 
     for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
-      // TODO: should not add coprocessor related properties since those were already be added
-      // using addCoprocessor call.
       htd.setValue(property.getKey(), property.getValue());
     }
     return htd;
@@ -90,11 +88,7 @@ public class HBase10CDH550TableDescriptorUtil {
     Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
     coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
 
-    Map<String, String> properties = new HashMap<>();
-    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
-      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
-                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
-    }
+    Map<String, String> properties = CoprocessorUtil.getNonCoprocessorProperties(descriptor);
 
     // TODO: should add configurations as well
     return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),

--- a/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableDescriptorUtil.java
+++ b/cdap-hbase-compat-1.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase10TableDescriptorUtil.java
@@ -74,8 +74,6 @@ public class HBase10TableDescriptorUtil {
     }
 
     for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
-      // TODO: should not add coprocessor related properties since those were already be added
-      // using addCoprocessor call.
       htd.setValue(property.getKey(), property.getValue());
     }
     return htd;
@@ -90,11 +88,7 @@ public class HBase10TableDescriptorUtil {
     Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
     coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
 
-    Map<String, String> properties = new HashMap<>();
-    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
-      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
-                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
-    }
+    Map<String, String> properties = CoprocessorUtil.getNonCoprocessorProperties(descriptor);
 
     // TODO: should add configurations as well
     return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),

--- a/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/HBase11TableDescriptorUtil.java
+++ b/cdap-hbase-compat-1.1/src/main/java/co/cask/cdap/data2/util/hbase/HBase11TableDescriptorUtil.java
@@ -21,6 +21,7 @@ import co.cask.cdap.spi.hbase.CoprocessorDescriptor;
 import co.cask.cdap.spi.hbase.TableDescriptor;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
@@ -74,8 +75,6 @@ public class HBase11TableDescriptorUtil {
     }
 
     for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
-      // TODO: should not add coprocessor related properties since those were already be added
-      // using addCoprocessor call.
       htd.setValue(property.getKey(), property.getValue());
     }
     return htd;
@@ -90,11 +89,7 @@ public class HBase11TableDescriptorUtil {
     Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
     coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
 
-    Map<String, String> properties = new HashMap<>();
-    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
-      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
-                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
-    }
+    Map<String, String> properties = CoprocessorUtil.getNonCoprocessorProperties(descriptor);
 
     // TODO: should add configurations as well
     return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),

--- a/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570TableDescriptorUtil.java
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/src/main/java/co/cask/cdap/data2/util/hbase/HBase12CDH570TableDescriptorUtil.java
@@ -74,8 +74,6 @@ public class HBase12CDH570TableDescriptorUtil {
     }
 
     for (Map.Entry<String, String> property : descriptor.getProperties().entrySet()) {
-      // TODO: should not add coprocessor related properties since those were already be added
-      // using addCoprocessor call.
       htd.setValue(property.getKey(), property.getValue());
     }
     return htd;
@@ -90,11 +88,7 @@ public class HBase12CDH570TableDescriptorUtil {
     Set<CoprocessorDescriptor> coprocessors = new HashSet<>();
     coprocessors.addAll(CoprocessorUtil.getCoprocessors(descriptor).values());
 
-    Map<String, String> properties = new HashMap<>();
-    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> value : descriptor.getValues().entrySet()) {
-      properties.put(org.apache.hadoop.hbase.util.Bytes.toString(value.getKey().get()),
-                     org.apache.hadoop.hbase.util.Bytes.toString(value.getValue().get()));
-    }
+    Map<String, String> properties = CoprocessorUtil.getNonCoprocessorProperties(descriptor);
 
     // TODO: should add configurations as well
     return new TableDescriptor(descriptor.getTableName().getNamespaceAsString(),

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/CoprocessorManager.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/CoprocessorManager.java
@@ -75,7 +75,7 @@ public class CoprocessorManager {
   /**
    * Get the descriptor for a single coprocessor that uses the pre-built coprocessor jar.
    */
-  public CoprocessorDescriptor getCoprocessorDescriptor(Class<? extends  Coprocessor> coprocessor,
+  public CoprocessorDescriptor getCoprocessorDescriptor(Class<? extends Coprocessor> coprocessor,
                                                         @Nullable Integer priority) throws IOException {
     if (priority == null) {
       priority = Coprocessor.PRIORITY_USER;

--- a/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/CoprocessorUtil.java
+++ b/cdap-hbase-compat-base/src/main/java/co/cask/cdap/data2/util/hbase/CoprocessorUtil.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 
@@ -37,6 +38,23 @@ public final class CoprocessorUtil {
   private static final Logger LOG = LoggerFactory.getLogger(CoprocessorUtil.class);
   private CoprocessorUtil() {
 
+  }
+
+  /**
+   * @return all non-coprocessor properties.
+   */
+  public static Map<String, String> getNonCoprocessorProperties(HTableDescriptor tableDescriptor) {
+    Map<String, String> properties = new HashMap<>();
+    for (Map.Entry<ImmutableBytesWritable, ImmutableBytesWritable> entry : tableDescriptor.getValues().entrySet()) {
+      String key = Bytes.toString(entry.getKey().get()).trim();
+      String val = Bytes.toString(entry.getValue().get()).trim();
+
+      if (HConstants.CP_HTD_ATTR_KEY_PATTERN.matcher(key).matches()) {
+        continue;
+      }
+      properties.put(key, val);
+    }
+    return properties;
   }
 
   /**


### PR DESCRIPTION
Fix the conversion from HTableDescriptor into a TableDescriptor
so that it does not copy properties that represent coprocessors,
since the TableDescriptor has its own coprocessor fields.
This fixes a bug in the upgrade tool where tables with more than
one coprocessor would end up with a copy of each coprocessor.