### PR TITLE
CDAP-8759 Improve metadata search efficiency

### DIFF
--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/SearchResults.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/metadata/dataset/SearchResults.java
@@ -23,26 +23,20 @@ import java.util.List;
  * list of cursors to start subsequent searches from.
  */
 public class SearchResults {
-  private final List<MetadataEntry> resultsFromOffset;
+  private final List<MetadataEntry> results;
   private final List<String> cursors;
-  private final List<MetadataEntry> resultsFromBeginning;
 
 
-  SearchResults(List<MetadataEntry> results, List<String> cursors, List<MetadataEntry> allResults) {
-    this.resultsFromOffset = results;
+  SearchResults(List<MetadataEntry> results, List<String> cursors) {
+    this.results = results;
     this.cursors = cursors;
-    this.resultsFromBeginning = allResults;
   }
 
-  public List<MetadataEntry> getResultsFromOffset() {
-    return resultsFromOffset;
+  public List<MetadataEntry> getResults() {
+    return results;
   }
 
   public List<String> getCursors() {
     return cursors;
-  }
-
-  public List<MetadataEntry> getResultsFromBeginning() {
-    return resultsFromBeginning;
   }
 }


### PR DESCRIPTION
This commit fixes the issue where MetadataSet creates two Lists with
duplicate content. Instead, only one List is created and it is truncated
before being sent.

Note that the publicly exposed behaviour is essentially the same as before.

JIRA: https://issues.cask.co/browse/CDAP-8759
Bamboo: http://builds.cask.co/browse/CDAP-DUT5620