### PR TITLE
[CDAP-8743] Wait for namespace list to load before getting default namespace

### DIFF
--- a/cdap-ui/app/cdap/components/Header/MetadataDropdown/index.js
+++ b/cdap-ui/app/cdap/components/Header/MetadataDropdown/index.js
@@ -17,6 +17,7 @@ import React, {Component} from 'react';
 import {Dropdown, DropdownToggle, DropdownItem} from 'reactstrap';
 import CustomDropdownMenu from 'components/CustomDropdownMenu';
 import NamespaceStore from 'services/NamespaceStore';
+import find from 'lodash/find';
 import T from 'i18n-react';
 import classnames from 'classnames';
 
@@ -54,10 +55,9 @@ export default class MetadataDropdown extends Component {
   }
   getDefaultNamespace() {
     let list = NamespaceStore.getState().namespaces;
+    if (list.length === 0) { return; }
     let selectedNamespace;
-    let defaultNamespace;
-
-    defaultNamespace = localStorage.getItem('DefaultNamespace');
+    let defaultNamespace = localStorage.getItem('DefaultNamespace');
     let defaultNsFromBackend = list.filter(ns => ns.name === defaultNamespace);
     if (defaultNsFromBackend.length) {
       selectedNamespace = defaultNsFromBackend[0];

--- a/cdap-ui/app/cdap/components/Header/index.js
+++ b/cdap-ui/app/cdap/components/Header/index.js
@@ -24,6 +24,7 @@ import MetadataDropdown from 'components/Header/MetadataDropdown';
 import CaskMarketButton from 'components/Header/CaskMarketButton';
 import {MyNamespaceApi} from 'api/namespace';
 import NamespaceActions from 'services/NamespaceStore/NamespaceActions';
+import find from 'lodash/find';
 import classnames from 'classnames';
 import ee from 'event-emitter';
 import globalEvents from 'services/global-events';
@@ -81,10 +82,9 @@ export default class Header extends Component {
   }
   getDefaultNamespace() {
     let list = NamespaceStore.getState().namespaces;
+    if (list.length === 0) { return; }
     let selectedNamespace;
-    let defaultNamespace;
-
-    defaultNamespace = localStorage.getItem('DefaultNamespace');
+    let defaultNamespace = localStorage.getItem('DefaultNamespace');
     let defaultNsFromBackend = list.filter(ns => ns.name === defaultNamespace);
     if (defaultNsFromBackend.length) {
       selectedNamespace = defaultNsFromBackend[0];


### PR DESCRIPTION
Relevant JIRA: https://issues.cask.co/browse/CDAP-8743.

This PR is to fix a bug not caught in the previous PR for this JIRA. An error was being thrown when we tried to get the default namespace, when the list of namespaces had not been returned from the backend yet. This PR fixes this issue.