### PR TITLE
Fix maven warnings by removing deprecated use of artifactId

### DIFF
--- a/cdap-hbase-compat-0.96/pom.xml
+++ b/cdap-hbase-compat-0.96/pom.xml
@@ -182,7 +182,7 @@
                 </goals>
                 <configuration>
                   <excludeArtifactIds>*</excludeArtifactIds>
-                  <includeArtifactIds>${artifactId}</includeArtifactIds>
+                  <includeArtifactIds>${project.artifactId}</includeArtifactIds>
                   <silent>true</silent>
                   <includeScope>compile</includeScope>
                 </configuration>

--- a/cdap-hbase-compat-0.98/pom.xml
+++ b/cdap-hbase-compat-0.98/pom.xml
@@ -182,7 +182,7 @@
                 </goals>
                 <configuration>
                   <excludeArtifactIds>*</excludeArtifactIds>
-                  <includeArtifactIds>${artifactId}</includeArtifactIds>
+                  <includeArtifactIds>${project.artifactId}</includeArtifactIds>
                   <silent>true</silent>
                   <includeScope>compile</includeScope>
                 </configuration>

--- a/cdap-hbase-compat-1.0-cdh/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh/pom.xml
@@ -203,7 +203,7 @@
                 </goals>
                 <configuration>
                   <excludeArtifactIds>*</excludeArtifactIds>
-                  <includeArtifactIds>${artifactId}</includeArtifactIds>
+                  <includeArtifactIds>${project.artifactId}</includeArtifactIds>
                   <silent>true</silent>
                   <includeScope>compile</includeScope>
                 </configuration>

--- a/cdap-hbase-compat-1.0-cdh5.5.0/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/pom.xml
@@ -203,7 +203,7 @@
                 </goals>
                 <configuration>
                   <excludeArtifactIds>*</excludeArtifactIds>
-                  <includeArtifactIds>${artifactId}</includeArtifactIds>
+                  <includeArtifactIds>${project.artifactId}</includeArtifactIds>
                   <silent>true</silent>
                   <includeScope>compile</includeScope>
                 </configuration>

--- a/cdap-hbase-compat-1.0/pom.xml
+++ b/cdap-hbase-compat-1.0/pom.xml
@@ -189,7 +189,7 @@
                 </goals>
                 <configuration>
                   <excludeArtifactIds>*</excludeArtifactIds>
-                  <includeArtifactIds>${artifactId}</includeArtifactIds>
+                  <includeArtifactIds>${project.artifactId}</includeArtifactIds>
                   <silent>true</silent>
                   <includeScope>compile</includeScope>
                 </configuration>

--- a/cdap-hbase-compat-1.1/pom.xml
+++ b/cdap-hbase-compat-1.1/pom.xml
@@ -189,7 +189,7 @@
                 </goals>
                 <configuration>
                   <excludeArtifactIds>*</excludeArtifactIds>
-                  <includeArtifactIds>${artifactId}</includeArtifactIds>
+                  <includeArtifactIds>${project.artifactId}</includeArtifactIds>
                   <silent>true</silent>
                   <includeScope>compile</includeScope>
                 </configuration>

--- a/cdap-hbase-compat-1.2-cdh5.7.0/pom.xml
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/pom.xml
@@ -192,7 +192,7 @@
                 </goals>
                 <configuration>
                   <excludeArtifactIds>*</excludeArtifactIds>
-                  <includeArtifactIds>${artifactId}</includeArtifactIds>
+                  <includeArtifactIds>${project.artifactId}</includeArtifactIds>
                   <silent>true</silent>
                   <includeScope>compile</includeScope>
                 </configuration>


### PR DESCRIPTION
Otherwise we get the following warnings during maven build : 

[WARNING] Some problems were encountered while building the effective model for co.cask.cdap:cdap-hbase-compat-0.98:jar:4.1.0-SNAPSHOT
[WARNING] The expression ${artifactId} is deprecated. Please use ${project.artifactId} instead.

Build : 