### PR TITLE
CDAP-8754: Use the shortname of the user instead of the full principal

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -192,7 +192,7 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
     if (SecurityUtil.isKerberosEnabled(cConf) && !NamespaceId.SYSTEM.equals(namespace)) {
       String namespacePrincipal = metadata.getConfig().getPrincipal();
       if (Strings.isNullOrEmpty(namespacePrincipal)) {
-        executionUserName = SecurityUtil.getMasterPrincipal(cConf);
+        executionUserName = new KerberosName(SecurityUtil.getMasterPrincipal(cConf)).getShortName();
       } else {
         executionUserName = new KerberosName(namespacePrincipal).getShortName();
       }


### PR DESCRIPTION
Currently, we use short name to grant privileges, so instead of passing the principal, extract the short name.