### PR TITLE
Fix broken doc build.

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -287,7 +287,7 @@
     <name>app.bind.port</name>
     <value>0</value>
     <description>
-      App Fabric service bind port; if 0 binds to a random port
+      App Fabric service bind port; if 0, binds to a random port
     </description>
   </property>
 
@@ -486,7 +486,7 @@
     <name>data.tx.bind.port</name>
     <value>0</value>
     <description>
-      Transaction service bind port; if 0 binds to a random port
+      Transaction service bind port; if 0, binds to a random port
     </description>
   </property>
 
@@ -732,7 +732,7 @@
     <name>dataset.executor.bind.port</name>
     <value>0</value>
     <description>
-      Dataset executor bind port; if 0 binds to a random port
+      Dataset executor bind port; if 0, binds to a random port
     </description>
   </property>
 
@@ -748,7 +748,7 @@
     <name>dataset.service.bind.port</name>
     <value>0</value>
     <description>
-      Dataset service bind port; if 0 binds to a random port
+      Dataset service bind port; if 0, binds to a random port
     </description>
   </property>
 
@@ -853,7 +853,7 @@
     <name>explore.service.bind.port</name>
     <value>0</value>
     <description>
-      CDAP Explore service bind port; if 0 binds to a random port
+      CDAP Explore service bind port; if 0, binds to a random port
     </description>
   </property>
 
@@ -1098,7 +1098,7 @@
     <name>log.pipeline.cdap.file.retention.duration.days</name>
     <value>7</value>
     <description>
-      Maximum time in days a file is kept before it could be deleted by log cleanup. Default is 7 days.
+      Maximum time in days a file is kept before it can be deleted by log cleanup.
     </description>
   </property>
 
@@ -1106,8 +1106,8 @@
     <name>log.pipeline.cdap.file.cleanup.transaction.timeout</name>
     <value>60</value>
     <description>
-      Transaction timeout for running file cleanup tasks, default is 60 seconds,
-      this should not be larger than max transaction timeout
+      Transaction timeout in seconds for running file cleanup tasks.
+      This should not be larger than ${data.tx.max.timeout}.
     </description>
   </property>
 
@@ -1115,7 +1115,7 @@
     <name>log.pipeline.cdap.file.cleanup.interval.mins</name>
     <value>1440</value>
     <description>
-      interval period for the log cleanup thread to run.
+      Time in minutes for each interval of the log cleanup thread to run
     </description>
   </property>
 
@@ -1256,6 +1256,7 @@
     </description>
   </property>
 
+
   <!-- Market Configuration -->
 
   <property>
@@ -1266,6 +1267,7 @@
       The default value shown is that of the public Cask Market.
     </description>
   </property>
+
 
   <!-- Master Configuration -->
 
@@ -1571,6 +1573,7 @@
     </description>
   </property>
 
+
   <!-- Metadata Configuration -->
 
   <property>
@@ -1593,7 +1596,7 @@
     <name>metadata.service.bind.port</name>
     <value>0</value>
     <description>
-      Metadata HTTP service bind port; if 0 binds to a random port
+      Metadata HTTP service bind port; if 0, binds to a random port
     </description>
   </property>
 
@@ -2322,7 +2325,7 @@
     <name>router.audit.path.check.enabled</name>
     <value>true</value>
     <description>
-      The boolean which indicates whether we need to check the number of paths for audit logging.
+      Determines if to check the number of paths for audit logging
     </description>
   </property>
 
@@ -2434,6 +2437,7 @@
       any service and will return "service not found".
     </description>
   </property>
+
 
   <!-- Security Configuration -->
 
@@ -2634,8 +2638,9 @@
     <name>security.keytab.path</name>
     <value></value>
     <description>
-      The location of kerberos keytabs used for impersonation. The location can contain ${name}
-      which will be replaced by the short user name of the principal being impersonated.
+      The location of Kerberos keytabs used for impersonation. The location can contain
+      ${name} which will be replaced by the short user name of the principal being
+      impersonated.
     </description>
   </property>
 
@@ -2797,7 +2802,7 @@
     <name>stream.bind.port</name>
     <value>0</value>
     <description>
-      Stream HTTP service bind port; if 0 binds to a random port
+      Stream HTTP service bind port; if 0, binds to a random port
     </description>
   </property>
 
@@ -2981,4 +2986,5 @@
       Read timeout in milliseconds for internal HTTP requests
     </description>
   </property>
+
 </configuration>

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2639,7 +2639,7 @@
     <value></value>
     <description>
       The location of Kerberos keytabs used for impersonation. The location can contain
-      ${name} which will be replaced by the short user name of the principal being
+      ${name}, which will be replaced by the short user name of the principal being
       impersonated.
     </description>
   </property>

--- a/cdap-docs/_common/common_conf.py
+++ b/cdap-docs/_common/common_conf.py
@@ -307,7 +307,7 @@ git_vars = {
     'GIT_CASK_MARKET_VERSION': 'cask-market-version',
     'GIT_PLUGINS_SPEC_VERSION': 'plugins-spec-version',
     'GIT_NODE_JS_MIN_VERSION': 'node-js-min-version',
-    'GIT_NODE_JS_MAX_VERSION': 'node-js-max-version',
+#     'GIT_NODE_JS_MAX_VERSION': 'node-js-max-version',
     }
 
 for h_key in git_vars.keys():

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="2113ce4f556f49cdca22e1aa02b3a84c"
+DEFAULT_XML_MD5_HASH="1be21881515a83b55fce71bcf09f5a95"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="9216e372e92a4797efcb9765372473cb"
+DEFAULT_XML_MD5_HASH="2113ce4f556f49cdca22e1aa02b3a84c"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-docs/vars
+++ b/cdap-docs/vars
@@ -62,8 +62,7 @@ GIT_BRANCH_HYDRATOR_PLUGINS="release/1.2"
 GIT_PLUGINS_SPEC_VERSION="1.3"
 
 # Used by examples manual
-GIT_BRANCH_CDAP_GUIDES="release/cdap-4.0-compatible"
-# GIT_BRANCH_CDAP_GUIDES="release/cdap-4.1-compatible"
+GIT_BRANCH_CDAP_GUIDES="release/cdap-4.1-compatible"
 
 # Used by integrations-manual
 GIT_BRANCH_CDAP_PACKS="release/cdap-4.1-compatible"


### PR DESCRIPTION
Update descriptions in "cdap-default.xml"; update MD5 hash.
Remove the "GIT_NODE_JS_MAX_VERSION" from being loaded, as it is not
being used currently and attempting to load it gives a warning.
Set the "GIT_BRANCH_CDAP_GUIDES" to "release/cdap-4.1-compatible" as
those branches have been created.

Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB288-1