### PR TITLE
HYDRATOR-602 Implement table lookup

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/lookup/TableLookup.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/co/cask/cdap/etl/api/lookup/TableLookup.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.api.lookup;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.etl.api.Lookup;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * {@link Lookup} implementation for {@link Table}.
+ */
+public class TableLookup implements Lookup<Row> {
+
+  private final Table table;
+
+  public TableLookup(Table table) {
+    this.table = table;
+  }
+
+  @Override
+  public Row lookup(String key) {
+    return table.get(Bytes.toBytes(key));
+  }
+
+  @Override
+  public Map<String, Row> lookup(String... keys) {
+    return lookup(ImmutableSet.copyOf(keys));
+  }
+
+  @Override
+  public Map<String, Row> lookup(Set<String> keys) {
+    Map<String, Row> results = new HashMap<>();
+    for (String key : keys) {
+      results.put(key, lookup(key));
+    }
+    return results;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/AbstractLookupProvider.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/common/AbstractLookupProvider.java
@@ -13,13 +13,16 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package co.cask.cdap.etl.common;
 
 import co.cask.cdap.api.dataset.Dataset;
 import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.dataset.table.Table;
 import co.cask.cdap.etl.api.Lookup;
 import co.cask.cdap.etl.api.LookupProvider;
 import co.cask.cdap.etl.api.lookup.KeyValueTableLookup;
+import co.cask.cdap.etl.api.lookup.TableLookup;
 
 import javax.annotation.Nullable;
 
@@ -36,6 +39,8 @@ public abstract class AbstractLookupProvider implements LookupProvider {
 
     if (dataset instanceof KeyValueTable) {
       return (Lookup<T>) new KeyValueTableLookup((KeyValueTable) dataset);
+    } else if (dataset instanceof Table) {
+      return (Lookup<T>) new TableLookup((Table) dataset);
     } else {
       throw new RuntimeException(String.format("Dataset %s does not support lookup", table));
     }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/LookupTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/batch/LookupTransform.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.etl.mock.batch;
+
+import co.cask.cdap.api.annotation.Name;
+import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.plugin.PluginClass;
+import co.cask.cdap.api.plugin.PluginConfig;
+import co.cask.cdap.api.plugin.PluginPropertyField;
+import co.cask.cdap.etl.api.Emitter;
+import co.cask.cdap.etl.api.Lookup;
+import co.cask.cdap.etl.api.Transform;
+import co.cask.cdap.etl.api.TransformContext;
+import co.cask.cdap.etl.proto.v2.ETLPlugin;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Transform used to test lookup functionality. Takes a field name whose value will be used as the key in a lookup.
+ * If the lookup is from a Table, the value of the lookup will be a Row, and the columns of the Row will be added as
+ * individual fields of the output StructuredRecord.
+ * If the lookup is from a KeyValueTable, the value of the lookup will be a String, and the 'destinationField' will
+ * be used to determine where in the output StructuredRecord to place the value.
+ *
+ * @param <T> The type of object that will be returned for the lookup.
+ */
+@Plugin(type = Transform.PLUGIN_TYPE)
+@Name("Lookup")
+public class LookupTransform<T> extends Transform<StructuredRecord, StructuredRecord> {
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
+  private final Config config;
+  private Lookup<T> lookup;
+
+  public LookupTransform(Config config) {
+    this.config = config;
+  }
+
+  @Override
+  public void initialize(TransformContext context) throws Exception {
+    super.initialize(context);
+    lookup = context.provide(config.lookupName, new HashMap<String, String>());
+  }
+
+  @Override
+  public void transform(StructuredRecord input, Emitter<StructuredRecord> emitter) throws Exception {
+    T lookedUpValue = lookup.lookup((String) input.get(config.lookupKey));
+    // for the output schema, copy all the input fields, and add the 'destinationField'
+    List<Schema.Field> outFields = new ArrayList<>();
+    for (Schema.Field field : input.getSchema().getFields()) {
+      outFields.add(field);
+    }
+    if (lookedUpValue instanceof String) {
+      outFields.add(Schema.Field.of(config.destinationField, Schema.of(Schema.Type.STRING)));
+    } else if (lookedUpValue instanceof Row) {
+      Row lookedupRow = (Row) lookedUpValue;
+      for (byte[] column : lookedupRow.getColumns().keySet()) {
+        outFields.add(Schema.Field.of(Bytes.toString(column), Schema.of(Schema.Type.STRING)));
+      }
+    } else {
+      throw new IllegalArgumentException("Unexpected value type: " + lookedUpValue.getClass());
+    }
+    Schema outSchema = Schema.recordOf(input.getSchema().getRecordName(), outFields);
+
+    // copy all the values
+    StructuredRecord.Builder outputBuilder = StructuredRecord.builder(outSchema);
+    for (Schema.Field inField : input.getSchema().getFields()) {
+      if (inField.getName().equals(config.lookupKey)) {
+        if (lookedUpValue instanceof String) {
+          outputBuilder.set(config.destinationField, lookedUpValue);
+        } else {
+          // due to the check above, we know its a Row
+          Row lookedupRow = (Row) lookedUpValue;
+          for (Map.Entry<byte[], byte[]> entry : lookedupRow.getColumns().entrySet()) {
+            outputBuilder.set(Bytes.toString(entry.getKey()), Bytes.toString(entry.getValue()));
+          }
+        }
+      }
+      // what if the destinationField already exists?
+      outputBuilder.set(inField.getName(), input.get(inField.getName()));
+    }
+    emitter.emit(outputBuilder.build());
+  }
+
+  /**
+   * Config for the source.
+   */
+  public static class Config extends PluginConfig {
+    private String lookupKey;
+    private String destinationField;
+    private String lookupName;
+  }
+
+  // note that destination is only used if the lookup table is a KeyValueTable
+  public static ETLPlugin getPlugin(String lookupKey, String destinationField, String lookupName) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("lookupKey", lookupKey);
+    properties.put("destinationField", destinationField);
+    properties.put("lookupName", lookupName);
+    return new ETLPlugin("Lookup", Transform.PLUGIN_TYPE, properties, null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("lookupKey", new PluginPropertyField("fields", "", "string", true, false));
+    properties.put("destinationField", new PluginPropertyField("destinationField", "", "string", true, false));
+    properties.put("lookupName", new PluginPropertyField("lookupName", "", "string", true, false));
+    return new PluginClass(Transform.PLUGIN_TYPE, "Lookup", "", LookupTransform.class.getName(),
+                           "config", properties);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/test/HydratorTestBase.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/co/cask/cdap/etl/mock/test/HydratorTestBase.java
@@ -25,6 +25,7 @@ import co.cask.cdap.etl.api.batch.SparkCompute;
 import co.cask.cdap.etl.api.realtime.RealtimeSource;
 import co.cask.cdap.etl.api.streaming.StreamingSource;
 import co.cask.cdap.etl.mock.action.MockAction;
+import co.cask.cdap.etl.mock.batch.LookupTransform;
 import co.cask.cdap.etl.mock.batch.MockExternalSink;
 import co.cask.cdap.etl.mock.batch.MockExternalSource;
 import co.cask.cdap.etl.mock.batch.MockRuntimeDatasetSink;
@@ -129,7 +130,7 @@ public class HydratorTestBase extends TestBase {
                       IntValueFilterTransform.class, StringValueFilterTransform.class,
                       FieldCountAggregator.class, IdentityAggregator.class, FieldsPrefixTransform.class,
                       StringValueFilterCompute.class,
-                      NodeStatesAction.class);
+                      NodeStatesAction.class, LookupTransform.class);
   }
 
   protected static void setupStreamingArtifacts(ArtifactId artifactId, Class<?> appClass) throws Exception {


### PR DESCRIPTION
https://issues.cask.co/browse/HYDRATOR-602
https://issues.cask.co/browse/HYDRATOR-1398
Motivation for this is to surface Table lookup in Cask Wrangler, but this also will allow users to use the Table Lookup in their Transforms.
Previously, only KeyValueTable was permitted.

http://builds.cask.co/browse/CDAP-RUT735-1