### PR TITLE
sleep between retries, to avoid busy cpu usage

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/pipeline/kafka/KafkaLogProcessorPipeline.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/pipeline/kafka/KafkaLogProcessorPipeline.java
@@ -165,6 +165,8 @@ public final class KafkaLogProcessorPipeline extends AbstractExecutionThreadServ
           } catch (IOException e) {
             OUTAGE_LOG.warn("Failed to fetch or process messages from {}:{}. Will be retried in next iteration.",
                             topic, partition, e);
+            // to avoid busy wait during kafka server outage
+            TimeUnit.SECONDS.sleep(1);
           }
         }
 


### PR DESCRIPTION
when kafka server is down while log.saver is running, we repeatedly retry for it to be up. this overloads cpu usage. we should sleep between retries to avoid excess cpu usage.