### PR TITLE
[CDAP-8792] fix overflow in market entity action

### DIFF
--- a/cdap-ui/app/cdap/components/MarketActionsContainer/MarketActionsContainer.scss
+++ b/cdap-ui/app/cdap/components/MarketActionsContainer/MarketActionsContainer.scss
@@ -17,6 +17,10 @@
 @import '../../styles/variables.scss';
 
 .market-entity-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+
   .action-container {
     display: inline-flex;
     flex-direction: column;
@@ -52,6 +56,8 @@
       padding: 0;
       font-weight: 500;
       cursor: pointer;
+      height: 100%;
+
       .action-image {
         width: 100px;
         height: 100px;
@@ -61,10 +67,13 @@
         background-color: #dddddd;
       }
       .action-description {
-        height: 40px;
+        min-height: 40px;
         background-color: #eeeeee;
         font-size: 11px;
         padding: 2px 4px;
+        overflow: hidden;
+        word-wrap: break-word;
+        height: calc(100% - 100px);
       }
       .fa {
         &[class*="icon-"],

--- a/cdap-ui/app/cdap/components/MarketActionsContainer/index.js
+++ b/cdap-ui/app/cdap/components/MarketActionsContainer/index.js
@@ -79,6 +79,7 @@ export default class MarketActionsContainer extends Component {
     if (!Array.isArray(this.props.actions)) {
       return null;
     }
+
     return (
       <div className="market-entity-actions">
         {
@@ -104,7 +105,10 @@ export default class MarketActionsContainer extends Component {
                     <div className="action-icon">
                       <div className={classnames("fa", actionIcon)}></div>
                     </div>
-                    <div className="action-description">
+                    <div
+                      className="action-description"
+                      title={action.label}
+                    >
                       {action.label}
                     </div>
                     <button


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-8792


Issue:
Currently this fix do not work in Safari. It won't overflow, but for action label greater than 2 lines, it will just grow and won't align with other actions.

Chrome/Firefox:
![screen shot 2017-02-24 at 8 59 33 pm](https://cloud.githubusercontent.com/assets/4398643/23328584/a06abc30-fad9-11e6-801d-c64d368deb76.png)


Safari:
![screen shot 2017-02-24 at 9 26 34 pm](https://cloud.githubusercontent.com/assets/4398643/23328585/a7d109fc-fad9-11e6-9cee-85af899eaba5.png)

Opening JIRA for 4.2: https://issues.cask.co/browse/CDAP-8794