### PR TITLE
fix deprecation warning on hdinsights

### DIFF
--- a/cdap-distributions/src/hdinsight/cdap-conf.json
+++ b/cdap-distributions/src/hdinsight/cdap-conf.json
@@ -7,7 +7,7 @@
       "explore.executor.container.memory.mb": "2304",
       "http.client.read.timeout.ms": "120000",
       "kafka.server.log.dirs": "/var/cdap/kafka-logs",
-      "log.saver.run.memory.megs": "1536",
+      "log.saver.container.memory.mb": "1536",
       "master.service.memory.mb": "1536",
       "metrics.memory.mb": "1536",
       "metrics.processor.memory.mb": "1536",


### PR DESCRIPTION
fixes the following deprecation warning when using CLI on hdinsights:

```
2017-02-25 00:50:25,022 - WARN  [main:c.c.c.c.c.Configuration@624] - log.saver.run.memory.megs is deprecated. Instead, use log.saver.container.memory.mb
```