### PR TITLE
CDAP-8708 Don't show impersonating principal in properties

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -222,7 +222,7 @@ ApplicationLifecycleService extends AbstractIdleService {
       ArtifactSummary artifactSummary = artifactId == null ?
         new ArtifactSummary(appSpec.getName(), null) : ArtifactSummary.from(artifactId);
       ApplicationRecord record = new ApplicationRecord(artifactSummary, appId, appSpec.getDescription(),
-                                                       ownerAdmin.getImpersonationPrincipal(appId));
+                                                       ownerAdmin.getOwnerPrincipal(appId));
       if (predicate.apply(record)) {
         appRecords.add(record);
       }
@@ -251,7 +251,7 @@ ApplicationLifecycleService extends AbstractIdleService {
       throw new ApplicationNotFoundException(appId);
     }
     ensureAccess(appId);
-    String ownerPrincipal = ownerAdmin.getImpersonationPrincipal(appId);
+    String ownerPrincipal = ownerAdmin.getOwnerPrincipal(appId);
     return ApplicationDetail.fromSpec(appSpec, ownerPrincipal);
   }
 

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/datafabric/dataset/service/DatasetInstanceService.java
@@ -197,7 +197,7 @@ public class DatasetInstanceService {
     // (causing its own lookup) as the SystemDatasetInitiator.getDataset is called when CDAP starts
     String ownerPrincipal = null;
     if (!NamespaceId.SYSTEM.equals(instance.getNamespaceId())) {
-      ownerPrincipal = ownerAdmin.getImpersonationPrincipal(instance);
+      ownerPrincipal = ownerAdmin.getOwnerPrincipal(instance);
     }
     return new DatasetMeta(spec, typeMeta, null, ownerPrincipal);
   }

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data2/transaction/stream/FileStreamAdmin.java
@@ -334,7 +334,7 @@ public class FileStreamAdmin implements StreamAdmin {
     // User should have any access on the stream to read its properties
     ensureAccess(streamId);
     // get the principal which will be used for impersonation to display as owner
-    String ownerPrincipal = ownerAdmin.getImpersonationPrincipal(streamId);
+    String ownerPrincipal = ownerAdmin.getOwnerPrincipal(streamId);
     StreamConfig config = getConfig(streamId);
     StreamSpecification spec = streamMetaStore.getStream(streamId);
     return new StreamProperties(config.getTTL(), config.getFormat(), config.getNotificationThresholdMB(),


### PR DESCRIPTION
Showing impersonating principal was added in this PR: https://github.com/caskdata/cdap/pull/8175
in which we check for impersonating principal for update/redeployment. 
We are not including it properties too even though its impersonated ns to keep it backward compatible. 
Build: http://builds.cask.co/browse/CDAP-RUT699-9