### PR TITLE
Propagate 400x errors

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
@@ -473,7 +473,7 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
         throw new NotFoundException(e.getCause());
       } else if (e.getCause() instanceof javax.ws.rs.BadRequestException) {
         throw new BadRequestException(e.getCause());
-      } else if (e.getCause() instanceof IllegalArgumentException) {
+      } else if (e.getCause() instanceof IllegalArgumentException && e.getCause() != null) {
         responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getCause().getMessage());
       } else {
         responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error while invoking plugin method");

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/gateway/handlers/ArtifactHttpHandler.java
@@ -473,6 +473,8 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
         throw new NotFoundException(e.getCause());
       } else if (e.getCause() instanceof javax.ws.rs.BadRequestException) {
         throw new BadRequestException(e.getCause());
+      } else if (e.getCause() instanceof IllegalArgumentException) {
+        responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getCause().getMessage());
       } else {
         responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error while invoking plugin method");
       }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/HYDRATOR-1397
Handle IlegalArgumentException and return a 400 with meaningful error instead of throwing an internal server error.

Created a follow up JIRA to cover negative scenarios for the end point: https://issues.cask.co/browse/HYDRATOR-1399