### PR TITLE
constrain ohai to last chef 12.4.3 compatible version

### DIFF
--- a/cdap-distributions/src/packer/scripts/cookbook-setup.sh
+++ b/cdap-distributions/src/packer/scripts/cookbook-setup.sh
@@ -32,6 +32,7 @@ knife cookbook site install ark 2.1.0 || die "Cannot fetch ark cookbook 2.1.0"
 knife cookbook site install build-essential 7.0.3 || die "Cannot fetch build-essential 7.0.3"
 knife cookbook site install yum 4.2.0 || die "Cannot fetch yum 4.2.0"
 knife cookbook site install apt 5.1.0 || die "Cannot fetch apt 5.1.0"
+knife cookbook site install ohai 4.2.3 || die "Cannot fetch ohai 4.2.3"
 
 # Do not change HOME for cdap user
 sed -i '/ home /d' /var/chef/cookbooks/cdap/recipes/sdk.rb


### PR DESCRIPTION
ohai 5.0 release not compatible with our version of Chef: https://github.com/chef-cookbooks/ohai/blob/master/CHANGELOG.md

