### PR TITLE
[CDAP-8831] Switching to pipelines and metadata does not retain the namespace

### DIFF
--- a/cdap-ui/app/cdap/components/Header/MetadataDropdown/index.js
+++ b/cdap-ui/app/cdap/components/Header/MetadataDropdown/index.js
@@ -17,9 +17,9 @@ import React, {Component} from 'react';
 import {Dropdown, DropdownToggle, DropdownItem} from 'reactstrap';
 import CustomDropdownMenu from 'components/CustomDropdownMenu';
 import NamespaceStore from 'services/NamespaceStore';
-import find from 'lodash/find';
 import T from 'i18n-react';
 import classnames from 'classnames';
+import getLastSelectedNamespace from 'services/get-last-selected-namespace';
 
 require('./MetadataDropdown.scss');
 
@@ -39,7 +39,7 @@ export default class MetadataDropdown extends Component {
 
   componentWillMount() {
     this.nsSubscription = NamespaceStore.subscribe(() => {
-      let selectedNamespace = this.getDefaultNamespace();
+      let selectedNamespace = getLastSelectedNamespace();
       if (selectedNamespace !== this.state.currentNamespace) {
         this.setState({
           currentNamespace: selectedNamespace
@@ -49,30 +49,6 @@ export default class MetadataDropdown extends Component {
   }
   componentWillUnmount() {
     this.nsSubscription();
-  }
-  findNamespace(list, name) {
-    return find(list, {name: name});
-  }
-  getDefaultNamespace() {
-    let list = NamespaceStore.getState().namespaces;
-    if (list.length === 0) { return; }
-    let selectedNamespace;
-    let defaultNamespace = localStorage.getItem('DefaultNamespace');
-    let defaultNsFromBackend = list.filter(ns => ns.name === defaultNamespace);
-    if (defaultNsFromBackend.length) {
-      selectedNamespace = defaultNsFromBackend[0];
-    }
-    // Check #2
-    if (!selectedNamespace) {
-      selectedNamespace = this.findNamespace(list, 'default');
-    }
-    // Check #3
-    if (!selectedNamespace) {
-      selectedNamespace = list[0].name;
-    } else {
-      selectedNamespace = selectedNamespace.name;
-    }
-    return selectedNamespace;
   }
   render() {
     let searchHomeUrl = window.getTrackerUrl({

--- a/cdap-ui/app/cdap/components/Header/index.js
+++ b/cdap-ui/app/cdap/components/Header/index.js
@@ -24,10 +24,10 @@ import MetadataDropdown from 'components/Header/MetadataDropdown';
 import CaskMarketButton from 'components/Header/CaskMarketButton';
 import {MyNamespaceApi} from 'api/namespace';
 import NamespaceActions from 'services/NamespaceStore/NamespaceActions';
-import find from 'lodash/find';
 import classnames from 'classnames';
 import ee from 'event-emitter';
 import globalEvents from 'services/global-events';
+import getLastSelectedNamespace from 'services/get-last-selected-namespace';
 
 require('./Header.scss');
 
@@ -63,7 +63,7 @@ export default class Header extends Component {
         }
       );
     this.nsSubscription = NamespaceStore.subscribe(() => {
-      let selectedNamespace = this.getDefaultNamespace();
+      let selectedNamespace = getLastSelectedNamespace();
       if (selectedNamespace !== this.state.currentNamespace) {
         this.setState({
           currentNamespace: selectedNamespace
@@ -76,30 +76,6 @@ export default class Header extends Component {
     if (this.namespacesubscription) {
       this.namespacesubscription.dispose();
     }
-  }
-  findNamespace(list, name) {
-    return find(list, {name: name});
-  }
-  getDefaultNamespace() {
-    let list = NamespaceStore.getState().namespaces;
-    if (list.length === 0) { return; }
-    let selectedNamespace;
-    let defaultNamespace = localStorage.getItem('DefaultNamespace');
-    let defaultNsFromBackend = list.filter(ns => ns.name === defaultNamespace);
-    if (defaultNsFromBackend.length) {
-      selectedNamespace = defaultNsFromBackend[0];
-    }
-    // Check #2
-    if (!selectedNamespace) {
-      selectedNamespace = this.findNamespace(list, 'default');
-    }
-    // Check #3
-    if (!selectedNamespace) {
-      selectedNamespace = list[0].name;
-    } else {
-      selectedNamespace = selectedNamespace.name;
-    }
-    return selectedNamespace;
   }
   toggleNavbar() {
     this.setState({

--- a/cdap-ui/app/cdap/components/NamespaceDropdown/index.js
+++ b/cdap-ui/app/cdap/components/NamespaceDropdown/index.js
@@ -52,6 +52,9 @@ export default class NamespaceDropdown extends Component {
           namespaceList : sortBy(NamespaceStore.getState().namespaces, this.lowerCaseNamespace)
         });
       } else {
+        // have to set this, because the Namespace store gets reset when we visit other apps
+        // e.g. Hydrator or Tracker
+        localStorage.setItem('CurrentNamespace', selectedNamespace);
         this.setState({
           currentNamespace : NamespaceStore.getState().selectedNamespace,
           namespaceList : sortBy(NamespaceStore.getState().namespaces, this.lowerCaseNamespace)

--- a/cdap-ui/app/cdap/services/get-last-selected-namespace.js
+++ b/cdap-ui/app/cdap/services/get-last-selected-namespace.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import find from 'lodash/find';
+import NamespaceStore from 'services/NamespaceStore';
+
+function findNamespace(list, name) {
+  return find(list, {name: name});
+}
+
+/**
+ * 1. Check if localStorage has a 'DefaultNamespace' set by the user, if not,
+ * 2. Check if there is a 'default' namespace from backend, if not,
+ * 3. Take first one from the list of namespaces from backend.
+ **/
+function getDefaultNamespace() {
+  let list = NamespaceStore.getState().namespaces;
+  if (!list || list.length === 0) { return; }
+  let selectedNamespace;
+  let defaultNamespace = localStorage.getItem('DefaultNamespace');
+  let defaultNsFromBackend = list.filter(ns => ns.name === defaultNamespace);
+  if (defaultNsFromBackend.length) {
+    selectedNamespace = defaultNsFromBackend[0];
+  }
+  // Check #2
+  if (!selectedNamespace) {
+    selectedNamespace = findNamespace(list, 'default');
+  }
+  // Check #3
+  if (!selectedNamespace) {
+    selectedNamespace = list[0].name;
+  } else {
+    selectedNamespace = selectedNamespace.name;
+  }
+  return selectedNamespace;
+}
+
+/**
+ * 1. Check if the Namespace store state contains the last selected namespace, if not,
+ * 2. Check if local storage has that info, if not,
+ * 3. Get the 'default' namespace.
+ **/
+export default function getLastSelectedNamespace() {
+  return NamespaceStore.getState().selectedNamespace || localStorage.getItem('CurrentNamespace') || getDefaultNamespace();
+}


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-8831

Originally these components checked for the namespace that the user was in, and then chose the default namespace if the former didn't exist. In a previous PR I improved the algorithm to find the 'default' namespace, but I accidentally removed the first check. This PR reverts that.