### PR TITLE
Update Chef client to 12.19.36

### DIFF
--- a/cdap-distributions/src/Dockerfile
+++ b/cdap-distributions/src/Dockerfile
@@ -45,7 +45,7 @@ COPY packer/scripts /tmp/scripts
 COPY packer/files /tmp/files
 
 # Install Chef, setup APT, run Chef cdap::sdk recipe, then clean up
-RUN curl -vL http://chef.io/chef/install.sh | bash -s -- -v 12.4.3 && \
+RUN curl -vL http://chef.io/chef/install.sh | bash -s -- -v 12.19.36 && \
     for i in apt-setup.sh cookbook-dir.sh cookbook-setup.sh ; do /tmp/scripts/$i ; done && \
     chef-solo -o cdap::sdk -j /tmp/files/cdap-sdk.json && \
     for i in remove-chef.sh sdk-cleanup.sh apt-cleanup.sh ; do /tmp/scripts/$i ; done && \

--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu12-with-uri.json
@@ -70,7 +70,7 @@
     },
     {
       "type": "chef-solo",
-      "install_command": "curl -L https://www.chef.io/chef/install.sh | {{if .Sudo}}sudo{{end}} bash -s -- -v 12.4.3",
+      "install_command": "curl -L https://www.chef.io/chef/install.sh | {{if .Sudo}}sudo{{end}} bash -s -- -v 12.19.36",
       "remote_cookbook_paths": "/var/chef/cookbooks",
       "pause_before": "10s"
     },

--- a/cdap-distributions/src/packer/scripts/cookbook-setup.sh
+++ b/cdap-distributions/src/packer/scripts/cookbook-setup.sh
@@ -25,16 +25,6 @@ for cb in cdap idea maven openssh; do
   knife cookbook site install $cb || die "Cannot fetch cookbook $cb"
 done
 
-### TODO: remove this hack when chef-cookbooks/ark#181 is solved
-knife cookbook site install ark 2.1.0 || die "Cannot fetch ark cookbook 2.1.0"
-
-# Due to limitations on the Chef version required, pull these manually
-knife cookbook site install build-essential 7.0.3 || die "Cannot fetch build-essential 7.0.3"
-knife cookbook site install yum 4.2.0 || die "Cannot fetch yum 4.2.0"
-knife cookbook site install apt 5.1.0 || die "Cannot fetch apt 5.1.0"
-knife cookbook site install ohai 4.2.3 || die "Cannot fetch ohai 4.2.3"
-knife cookbook site install selinux 0.9.0 || die "Cannot fetch selinux 0.9.0"
-
 # Do not change HOME for cdap user
 sed -i '/ home /d' /var/chef/cookbooks/cdap/recipes/sdk.rb
 


### PR DESCRIPTION
Tested by building a Docker image with no cache.

```
Step 11 : CMD cdap sdk start --foreground
 ---> Running in c1173aea2329
 ---> 6022bc55fb37
Removing intermediate container c1173aea2329
Successfully built 6022bc55fb37
```