### PR TITLE
Hydrator-1316 show logs in preview backend

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/preview/PreviewManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/preview/PreviewManager.java
@@ -19,6 +19,7 @@ import co.cask.cdap.common.NotFoundException;
 import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ProgramRunId;
 
 /**
  * Interface used for managing the preview runs.
@@ -29,10 +30,10 @@ public interface PreviewManager {
    * Start the preview of an application config provided as an input in a given namespace.
    * @param namespace the id of the namespace in which preview to be run
    * @param request the {@link AppRequest} with which preview need to be started
-   * @return the {@link ApplicationId} assigned to the preview run
+   * @return the {@link ProgramRunId} assigned to the preview run
    * @throws Exception if there were any error during starting preview
    */
-  ApplicationId start(NamespaceId namespace, AppRequest<?> request) throws Exception;
+  ProgramRunId start(NamespaceId namespace, AppRequest<?> request) throws Exception;
 
   /**
    * Get the {@link PreviewRunner} responsible for managing the given preview.

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/preview/PreviewRunner.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/preview/PreviewRunner.java
@@ -17,6 +17,7 @@
 package co.cask.cdap.app.preview;
 
 import co.cask.cdap.api.metrics.MetricTimeSeries;
+import co.cask.cdap.proto.id.ProgramRunId;
 import com.google.gson.JsonElement;
 import org.apache.twill.api.logging.LogEntry;
 
@@ -33,9 +34,10 @@ public interface PreviewRunner {
   /**
    * Start the preview of an application.
    * @param request the {@link PreviewRequest} with which preview to be started
+   * @return the {@link ProgramRunId} assigned to the preview run
    * @throws Exception if there were any error during starting preview
    */
-  void startPreview(PreviewRequest<?> request) throws Exception;
+  ProgramRunId startPreview(PreviewRequest<?> request) throws Exception;
 
   /**
    * Get the status of the preview represented by this {@link PreviewRunner}.
@@ -67,10 +69,4 @@ public interface PreviewRunner {
    * @return the {@link List} of metrics emitted during the preview run
    */
   List<MetricTimeSeries> getMetrics();
-
-  /**
-   * Get the logs for the preview run represented by this {@link PreviewRunner}.
-   * @return the logs
-   */
-  List<LogEntry> getLogs();
 }

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramController.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/runtime/ProgramController.java
@@ -18,7 +18,6 @@ package co.cask.cdap.app.runtime;
 
 import co.cask.cdap.proto.ProgramRunStatus;
 import co.cask.cdap.proto.ProgramStatus;
-import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.ProgramRunId;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.twill.api.RunId;

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/preview/DefaultPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/preview/DefaultPreviewManager.java
@@ -24,7 +24,6 @@ import co.cask.cdap.app.preview.PreviewRunner;
 import co.cask.cdap.app.preview.PreviewRunnerModule;
 import co.cask.cdap.common.BadRequestException;
 import co.cask.cdap.common.NotFoundException;
-import co.cask.cdap.common.app.RunIds;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.guice.ConfigModule;
@@ -51,6 +50,7 @@ import co.cask.cdap.proto.artifact.AppRequest;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
+import co.cask.cdap.proto.id.ProgramRunId;
 import co.cask.cdap.security.auth.context.AuthenticationContextModules;
 import co.cask.cdap.security.authorization.AuthorizerInstantiator;
 import co.cask.cdap.security.guice.SecurityModules;
@@ -92,6 +92,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public class DefaultPreviewManager implements PreviewManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(DefaultPreviewManager.class);
+  private static final String PREFIX = "preview-";
+
   private final CConfiguration cConf;
   private final Configuration hConf;
   private final DiscoveryService discoveryService;
@@ -165,19 +167,18 @@ public class DefaultPreviewManager implements PreviewManager {
   }
 
   @Override
-  public ApplicationId start(NamespaceId namespace, AppRequest<?> appRequest) throws Exception {
+  public ProgramRunId start(NamespaceId namespace, AppRequest<?> appRequest) throws Exception {
     Set<String> realDatasets = appRequest.getPreview() == null ? new HashSet<String>()
       : appRequest.getPreview().getRealDatasets();
 
-    ApplicationId previewApp = namespace.app(RunIds.generate().getId());
+    ApplicationId previewApp = namespace.app(PREFIX + System.currentTimeMillis());
     Injector injector = createPreviewInjector(previewApp, realDatasets);
     appInjectors.put(previewApp, injector);
     PreviewRunner runner = injector.getInstance(PreviewRunner.class);
     if (runner instanceof Service) {
       ((Service) runner).startAndWait();
     }
-    runner.startPreview(new PreviewRequest<>(getProgramIdFromRequest(previewApp, appRequest), appRequest));
-    return previewApp;
+    return runner.startPreview(new PreviewRequest<>(getProgramIdFromRequest(previewApp, appRequest), appRequest));
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/preview/PreviewDataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/preview/PreviewDataPipelineTest.java
@@ -125,7 +125,8 @@ public class PreviewDataPipelineTest extends HydratorTestBase {
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig, previewConfig);
 
     // Start the preview and get the corresponding PreviewRunner.
-    final PreviewRunner previewRunner = previewManager.getRunner(previewManager.start(NamespaceId.DEFAULT, appRequest));
+    final PreviewRunner previewRunner =
+      previewManager.getRunner(previewManager.start(NamespaceId.DEFAULT, appRequest).getParent().getParent());
 
     // Wait for the preview status go into COMPLETED.
     Tasks.waitFor(PreviewStatus.Status.COMPLETED, new Callable<PreviewStatus.Status>() {

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/preview/PreviewDataStreamsTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/preview/PreviewDataStreamsTest.java
@@ -112,7 +112,8 @@ public class PreviewDataStreamsTest extends HydratorTestBase {
     AppRequest<DataStreamsConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig, previewConfig);
 
     // Start the preview and get the corresponding PreviewRunner.
-    final PreviewRunner previewRunner = previewManager.getRunner(previewManager.start(NamespaceId.DEFAULT, appRequest));
+    final PreviewRunner previewRunner =
+      previewManager.getRunner(previewManager.start(NamespaceId.DEFAULT, appRequest).getParent().getParent());
 
     // Wait for the preview to be running and wait until the records are processed in the sink.
     Tasks.waitFor(true, new Callable<Boolean>() {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/HYDRATOR-1316
Build: http://builds.cask.co/browse/CDAP-DUT5547-1

Preview logs can be fetched same as the regular program run, what we need is just the appId and runId for the preview, then client can use /namespaces/{namespace-id}/apps/{preview-id}/{program-type}/{program-id}/runs/{run-id}/logs to get the preview logs. More details can be found in the JIRA