### PR TITLE
[HYDRATOR-1364] Fixes pipeline studio to remove __ui__ property while exporting pipeline

### DIFF
--- a/cdap-ui/app/hydrator/controllers/create/leftpanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/leftpanel-ctrl.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -173,7 +173,7 @@ class HydratorPlusPlusLeftPanelCtrl {
       let isScopeExists = [];
       let isNameExists = this.artifacts.filter( artifact => artifact.name === importArtifact.name );
       isVersionExists = isNameExists.filter( artifact => artifact.version === importArtifact.version );
-      isScopeExists = isNameExists.filter( artifact => artifact.scope === importArtifact.scope );
+      isScopeExists = isNameExists.filter( artifact => artifact.scope.toUpperCase() === importArtifact.scope.toUpperCase() );
       return {
         name: isNameExists.length > 0,
         version: isVersionExists.length > 0,

--- a/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -133,6 +133,7 @@ class HydratorPlusPlusTopPanelCtrl {
     this.DAGPlusPlusNodesActionsFactory.resetSelectedNode();
     let config = angular.copy(this.HydratorPlusPlusConfigStore.getDisplayConfig());
     let exportConfig = this.HydratorPlusPlusConfigStore.getConfigForExport();
+    delete exportConfig.__ui__;
     this.myPipelineExportModalService.show(config, exportConfig);
   }
   onSaveDraft() {

--- a/cdap-ui/app/hydrator/controllers/detail/top-panel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/detail/top-panel-ctrl.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -255,6 +255,7 @@ class HydratorDetailTopPanelController {
       plugin: stage.plugin
     }));
     let exportConfig = this.HydratorPlusPlusDetailNonRunsStore.getCloneConfig();
+    delete exportConfig.__ui__;
     this.myPipelineExportModalService.show(config, exportConfig);
   }
   do(action) {


### PR DESCRIPTION
- Remove `__ui__` from pipeline config while exporting a pipeline
- Fixes scope comparison to be case insensitive while importing pipeline (artifact check before importing a pipeline).


JIRA link: https://issues.cask.co/browse/HYDRATOR-1364