### PR TITLE
bump version, set tag, and correct branch for HDInsight release

### DIFF
--- a/cdap-distributions/src/hdinsight/pkg/install.sh
+++ b/cdap-distributions/src/hdinsight/pkg/install.sh
@@ -20,11 +20,11 @@
 
 # CDAP config
 # The git branch to clone
-CDAP_BRANCH='develop'
+CDAP_BRANCH='release/4.1'
 # Optional tag to checkout - All released versions of this script should set this
-CDAP_TAG=''
+CDAP_TAG='v4.1.0'
 # The CDAP package version passed to Chef
-CDAP_VERSION='4.1.0-1'
+CDAP_VERSION='4.1.0-2'
 # The version of Chef to install
 CHEF_VERSION='12.10.24'
 # cdap-site.xml configuration parameters


### PR DESCRIPTION
updating cdap version, tag, and branch in installer script, for 4.1 HDInsight package.