### PR TITLE
Initial DataPrep setup for Namespace Integration

### DIFF
--- a/cdap-ui/app/cdap/api/dataprep.js
+++ b/cdap-ui/app/cdap/api/dataprep.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import DataSourceConfigurer from 'services/datasource/DataSourceConfigurer';
+import {apiCreator} from 'services/resource-helper';
+
+let dataSrc = DataSourceConfigurer.getInstance();
+
+const appPath = '/namespaces/:namespace/apps/wrangler';
+const baseServicePath = `${appPath}/services/service`;
+const basepath = `${baseServicePath}/methods/workspaces/:workspaceId`;
+
+const MyDataPrepApi = {
+  create: apiCreator(dataSrc, 'PUT', 'REQUEST', basepath),
+  delete: apiCreator(dataSrc, 'DELETE', 'REQUEST', basepath),
+  upload: apiCreator(dataSrc, 'POST', 'REQUEST', `${basepath}/upload`),
+  execute: apiCreator(dataSrc, 'GET', 'REQUEST', `${basepath}/execute`),
+  summary: apiCreator(dataSrc, 'GET', 'REQUEST', `${basepath}/summary`),
+  getSchema: apiCreator(dataSrc, 'GET', 'REQUEST', `${basepath}/schema`),
+  getUsage: apiCreator(dataSrc, 'GET', 'REQUEST', `${baseServicePath}/methods/usage`),
+
+  // WRANGLER SERVICE MANAGEMENT
+  getApp: apiCreator(dataSrc, 'GET', 'REQUEST', `${appPath}`),
+  startService: apiCreator(dataSrc, 'POST', 'REQUEST', `${baseServicePath}/start`),
+  pollServiceStatus: apiCreator(dataSrc, 'GET', 'POLL', `${baseServicePath}/status`),
+  createApp: apiCreator(dataSrc, 'PUT', 'REQUEST', `${appPath}`)
+};
+
+export default MyDataPrepApi;

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepServiceControl/index.js
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { Component } from 'react';
+import MyDataPrepApi from 'api/dataprep';
+import {MyArtifactApi} from 'api/artifact';
+import find from 'lodash/find';
+import NamespaceStore from 'services/NamespaceStore';
+
+export default class DataPrepServiceControl extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      loading: false,
+      error: null,
+      extendedMessage: null
+    };
+
+    this.enableService = this.enableService.bind(this);
+  }
+
+  componentWillUnmount() {
+    if (this.servicePoll && this.servicePoll.dispose) {
+      this.servicePoll.dispose();
+    }
+  }
+
+  enableService() {
+    this.setState({loading: true});
+
+    /**
+     *  1. Get Wrangler Service App
+     *  2. If not found, create app
+     *  3. Start Wrangler Service
+     *  4. Poll until service starts, then reload page
+     **/
+
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    MyDataPrepApi.getApp({ namespace })
+      .subscribe(() => {
+        // Wrangler app already exist
+        // Just start service
+        this.startService();
+      }, () => {
+        // App does not exist
+        // Go to create app
+        this.createApp();
+      });
+  }
+
+  createApp() {
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    MyArtifactApi.list({ namespace })
+      .subscribe((res) => {
+        let artifact = find(res, { 'name': 'wrangler-service' });
+
+        MyDataPrepApi.createApp({ namespace }, { artifact })
+          .subscribe(() => {
+            this.startService();
+          }, (err) => {
+            this.setState({
+              error: 'Failed to start service',
+              extendedMessage: err.data || err,
+              loading: false
+            });
+          });
+      });
+  }
+
+  startService() {
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    MyDataPrepApi.startService({ namespace })
+      .subscribe(() => {
+        this.pollServiceStatus();
+      }, (err) => {
+        this.setState({
+          error: 'Failed to start service',
+          extendedMessage: err.data || err,
+          loading: false
+        });
+      });
+  }
+
+  pollServiceStatus() {
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    this.servicePoll = MyDataPrepApi.pollServiceStatus({ namespace })
+      .subscribe((res) => {
+        if (res.status === 'RUNNING') {
+          window.onbeforeunload = null;
+          window.location.reload();
+        }
+      }, (err) => {
+        this.setState({
+          error: 'Failed to get service status',
+          extendedMessage: err.data || err,
+          loading: false
+        });
+      });
+  }
+
+  renderError() {
+    if (!this.state.error) { return null; }
+
+    return (
+      <div>
+        <h5 className="text-danger text-xs-center">
+          {this.state.error}
+        </h5>
+        <p className="text-dangertext-xs-center">
+          {this.state.extendedMessage}
+        </p>
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <div className="wrangler-container error">
+        <h4 className="text-xs-center">
+          Data Preparation (Beta) is not enabled. Please enable it.
+        </h4>
+        <br/>
+        <div className="text-xs-center">
+          <button
+            className="btn btn-primary"
+            onClick={this.enableService}
+            disabled={this.state.loading}
+          >
+            {
+              !this.state.loading ? 'Enable Data Preparation Service' : (
+                <span>
+                  <span className="fa fa-spin fa-spinner" /> Enabling...
+                </span>
+              )
+            }
+          </button>
+        </div>
+
+        <br/>
+
+        {this.renderError()}
+      </div>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepServiceControl/index.js
@@ -75,7 +75,7 @@ export default class DataPrepServiceControl extends Component {
             this.startService();
           }, (err) => {
             this.setState({
-              error: 'Failed to start service',
+              error: 'Failed to enable data preparation',
               extendedMessage: err.data || err,
               loading: false
             });
@@ -91,7 +91,7 @@ export default class DataPrepServiceControl extends Component {
         this.pollServiceStatus();
       }, (err) => {
         this.setState({
-          error: 'Failed to start service',
+          error: 'Failed to enable data preparation',
           extendedMessage: err.data || err,
           loading: false
         });
@@ -104,12 +104,11 @@ export default class DataPrepServiceControl extends Component {
     this.servicePoll = MyDataPrepApi.pollServiceStatus({ namespace })
       .subscribe((res) => {
         if (res.status === 'RUNNING') {
-          window.onbeforeunload = null;
           window.location.reload();
         }
       }, (err) => {
         this.setState({
-          error: 'Failed to get service status',
+          error: 'Failed to enable data preparation',
           extendedMessage: err.data || err,
           loading: false
         });

--- a/cdap-ui/app/cdap/components/DataPrep/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/index.js
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { Component } from 'react';
+// import DataPrepTopPanel from 'components/DataPrep/TopPanel';
+// import DataPrepTable from 'components/DataPrep/DataPrepTable';
+// import DataPrepSidePanel from 'components/DataPrep/DataPrepSidePanel';
+// import DataPrepCLI from 'components/DataPrep/DataPrepCLI';
+import MyDataPrepApi from 'api/dataprep';
+import cookie from 'react-cookie';
+import DataPrepStore from 'components/DataPrep/store';
+import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
+import DataPrepServiceControl from 'components/DataPrep/DataPrepServiceControl';
+import ee from 'event-emitter';
+import NamespaceStore from 'services/NamespaceStore';
+
+/**
+ *  Data Prep requires a container component (DataPrepHome) that will handle routing within React.
+ *  This is beacause DataPrep component will be included in Pipelines,
+ **/
+export default class DataPrep extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      backendDown: false
+    };
+
+    this.toggleBackendDown = this.toggleBackendDown.bind(this);
+    this.eventEmitter = ee(ee);
+
+    this.eventEmitter.on('DATAPREP_BACKEND_DOWN', this.toggleBackendDown);
+
+  }
+
+  componentWillMount() {
+    let workspaceId = cookie.load('DATAPREP_WORKSPACE');
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    let params = {
+      namespace,
+      workspaceId: workspaceId,
+      limit: 100
+    };
+
+    MyDataPrepApi.execute(params)
+      .subscribe((res) => {
+        DataPrepStore.dispatch({
+          type: DataPrepActions.setWorkspace,
+          payload: {
+            data: res.value,
+            headers: res.header,
+            workspaceId
+          }
+        });
+      }, (err) => {
+        if (err.statusCode === 503) {
+          console.log('backend not started');
+          this.eventEmitter.emit('DATAPREP_BACKEND_DOWN');
+          return;
+        }
+
+        console.log('Init Error', err);
+        cookie.remove('DATAPREP_WORKSPACE');
+
+        DataPrepStore.dispatch({
+          type: DataPrepActions.setInitialized
+        });
+        this.eventEmitter.emit('DATAPREP_NO_WORKSPACE_ID');
+      });
+  }
+
+  componentWillUnmount() {
+    DataPrepStore.dispatch({
+      type: DataPrepActions.reset
+    });
+    this.eventEmitter.off('DATAPREP_BACKEND_DOWN', this.toggleBackendDown);
+  }
+
+  toggleBackendDown() {
+    this.setState({backendDown: true});
+  }
+
+  renderBackendDown() {
+    if (!this.state.backendDown) { return null; }
+
+    return (
+      <DataPrepServiceControl />
+    );
+  }
+
+  render() {
+    if (this.state.backendDown) { return this.renderBackendDown(); }
+
+    return (
+      <div className="dataprep-container">
+        <h4>DataPrep</h4>
+      </div>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/index.js
@@ -73,7 +73,6 @@ export default class DataPrep extends Component {
           return;
         }
 
-        console.log('Init Error', err);
         cookie.remove('DATAPREP_WORKSPACE');
 
         DataPrepStore.dispatch({

--- a/cdap-ui/app/cdap/components/DataPrep/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/index.js
@@ -29,7 +29,7 @@ import NamespaceStore from 'services/NamespaceStore';
 
 /**
  *  Data Prep requires a container component (DataPrepHome) that will handle routing within React.
- *  This is beacause DataPrep component will be included in Pipelines,
+ *  This is beacause DataPrep component will be included in Pipelines.
  **/
 export default class DataPrep extends Component {
   constructor(props) {
@@ -94,8 +94,6 @@ export default class DataPrep extends Component {
   }
 
   renderBackendDown() {
-    if (!this.state.backendDown) { return null; }
-
     return (
       <DataPrepServiceControl />
     );

--- a/cdap-ui/app/cdap/components/DataPrep/store/DataPrepActions.js
+++ b/cdap-ui/app/cdap/components/DataPrep/store/DataPrepActions.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+const DataPrepActions = {
+  setData: 'DATAPREP_SET_DATA',
+  setDirectives: 'DATAPREP_SET_DIRECTIVES',
+  setWorkspace: 'DATAPREP_SET_WORKSPACE',
+  setInitialized: 'DATAPREP_SET_INITIALIZED',
+  reset: 'DATAPREP_RESET'
+};
+
+export default DataPrepActions;

--- a/cdap-ui/app/cdap/components/DataPrep/store/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/store/index.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import {combineReducers, createStore} from 'redux';
+import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
+
+const defaultAction = {
+  action : '',
+  payload : {}
+};
+
+const defaultInitialState = {
+  initialized: false,
+  workspaceId: '',
+  data: [],
+  headers: [],
+  directives: []
+};
+
+const dataprep = (state = defaultInitialState, action = defaultAction) => {
+  let stateCopy;
+
+  switch (action.type) {
+    case DataPrepActions.setData:
+      stateCopy = Object.assign({}, state, {
+        data: action.payload.data,
+        headers: action.payload.headers
+      });
+      break;
+    case DataPrepActions.setDirectives:
+      stateCopy = Object.assign({}, state, {
+        data: action.payload.data,
+        headers: action.payload.headers,
+        directives: action.payload.directives
+      });
+      break;
+    case DataPrepActions.setWorkspace:
+      stateCopy = Object.assign({}, state, {
+        workspaceId: action.payload.workspaceId,
+        headers: action.payload.headers || [],
+        directives: [],
+        data: action.payload.data || [],
+        initialized: true
+      });
+      break;
+    case DataPrepActions.setInitialized:
+      stateCopy = Object.assign({}, state, { initialized: true });
+      break;
+    case DataPrepActions.reset:
+      return defaultInitialState;
+    default:
+      return state;
+  }
+
+  return Object.assign({}, state, stateCopy);
+};
+
+const DataPrepStore = createStore(
+  combineReducers({
+    dataprep
+  }),
+  defaultInitialState,
+  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+);
+
+export default DataPrepStore;

--- a/cdap-ui/app/cdap/components/DataPrepHome/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepHome/index.js
@@ -15,7 +15,6 @@
  */
 
 import React, { Component } from 'react';
-import NavigationPrompt from 'react-router/NavigationPrompt';
 import DataPrep from 'components/DataPrep';
 
 /**
@@ -25,13 +24,6 @@ export default class DataPrepHome extends Component {
   constructor(props) {
     super(props);
 
-    window.onbeforeunload = function() {
-      return "Are you sure you want to leave this page?";
-    };
-  }
-
-  componentWillUnmount() {
-    window.onbeforeunload = null;
   }
 
   render() {
@@ -39,10 +31,6 @@ export default class DataPrepHome extends Component {
       <div>
         <DataPrep />
 
-        <NavigationPrompt
-          when={true}
-          message="Are you sure you want to leave this page?"
-        />
       </div>
     );
   }

--- a/cdap-ui/app/cdap/components/DataPrepHome/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepHome/index.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { Component } from 'react';
+import NavigationPrompt from 'react-router/NavigationPrompt';
+import DataPrep from 'components/DataPrep';
+
+/**
+ *  Routing container for DataPrep for React
+ **/
+export default class DataPrepHome extends Component {
+  constructor(props) {
+    super(props);
+
+    window.onbeforeunload = function() {
+      return "Are you sure you want to leave this page?";
+    };
+  }
+
+  componentWillUnmount() {
+    window.onbeforeunload = null;
+  }
+
+  render() {
+    return (
+      <div>
+        <DataPrep />
+
+        <NavigationPrompt
+          when={true}
+          message="Are you sure you want to leave this page?"
+        />
+      </div>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/Home/index.js
+++ b/cdap-ui/app/cdap/components/Home/index.js
@@ -23,6 +23,7 @@ import DatasetDetailedView from 'components/DatasetDetailedView';
 import StreamDetailedView from 'components/StreamDetailedView';
 import NamespaceStore from 'services/NamespaceStore';
 import NamespaceActions from 'services/NamespaceStore/NamespaceActions';
+import DataPrepHome from 'components/DataPrepHome';
 
 export default class Home extends Component {
   componentWillMount() {
@@ -40,6 +41,7 @@ export default class Home extends Component {
         <Match pattern="/ns/:namespace/apps/:appId" component={AppDetailedView} />
         <Match pattern="/ns/:namespace/datasets/:datasetId" component={DatasetDetailedView} />
         <Match pattern="/ns/:namespace/streams/:streamId" component={StreamDetailedView} />
+        <Match pattern="/ns/:namespace/dataprep" component={DataPrepHome} />
         <Miss component={Page404} />
       </div>
     );

--- a/cdap-ui/app/cdap/components/Wrangler/TopPanel/AddToPipelineModal.js
+++ b/cdap-ui/app/cdap/components/Wrangler/TopPanel/AddToPipelineModal.js
@@ -20,6 +20,7 @@ import {MyArtifactApi} from 'api/artifact';
 import find from 'lodash/find';
 import MyWranglerApi from 'api/wrangler';
 import WranglerStore from 'components/Wrangler/store';
+import NamespaceStore from 'services/NamespaceStore';
 
 export default class AddToHydratorModal extends Component {
   constructor(props) {
@@ -45,11 +46,13 @@ export default class AddToHydratorModal extends Component {
   }
 
   generateLinks() {
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
     let state = WranglerStore.getState().wrangler;
     let workspaceId = state.workspaceId;
 
     let requestObj = {
-      namespace: 'default',
+      namespace,
       workspaceId
     };
 
@@ -58,7 +61,7 @@ export default class AddToHydratorModal extends Component {
       requestObj.directive = directives;
     }
 
-    MyArtifactApi.list({namespace: 'default'})
+    MyArtifactApi.list({ namespace })
       .combineLatest(MyWranglerApi.getSchema(requestObj))
       .subscribe((res) => {
         let batchArtifact = find(res[0], { 'name': 'cdap-data-pipeline' });
@@ -101,7 +104,7 @@ export default class AddToHydratorModal extends Component {
         let realtimeUrl = window.getHydratorUrl({
           stateName: 'hydrator.create',
           stateParams: {
-            namespace: 'default',
+            namespace,
             configParams: realtimeConfig
           }
         });
@@ -109,7 +112,7 @@ export default class AddToHydratorModal extends Component {
         let batchUrl = window.getHydratorUrl({
           stateName: 'hydrator.create',
           stateParams: {
-            namespace: 'default',
+            namespace,
             configParams: batchConfig
           }
         });

--- a/cdap-ui/app/cdap/components/Wrangler/TopPanel/AddToPipelineModal.js
+++ b/cdap-ui/app/cdap/components/Wrangler/TopPanel/AddToPipelineModal.js
@@ -20,7 +20,7 @@ import {MyArtifactApi} from 'api/artifact';
 import find from 'lodash/find';
 import MyWranglerApi from 'api/wrangler';
 import WranglerStore from 'components/Wrangler/store';
-import NamespaceStore from 'services/NamespaceStore';
+// import NamespaceStore from 'services/NamespaceStore';
 
 export default class AddToHydratorModal extends Component {
   constructor(props) {
@@ -46,7 +46,7 @@ export default class AddToHydratorModal extends Component {
   }
 
   generateLinks() {
-    let namespace = NamespaceStore.getState().selectedNamespace;
+    let namespace = 'default';
 
     let state = WranglerStore.getState().wrangler;
     let workspaceId = state.workspaceId;

--- a/cdap-ui/app/cdap/components/Wrangler/TopPanel/SchemaModal.js
+++ b/cdap-ui/app/cdap/components/Wrangler/TopPanel/SchemaModal.js
@@ -22,7 +22,7 @@ import {getParsedSchema} from 'components/SchemaEditor/SchemaHelpers';
 import MyWranglerApi from 'api/wrangler';
 import WranglerStore from 'components/Wrangler/store';
 import fileDownload from 'react-file-download';
-import NamespaceStore from 'services/NamespaceStore';
+// import NamespaceStore from 'services/NamespaceStore';
 
 export default class SchemaModal extends Component {
   constructor(props) {
@@ -47,7 +47,7 @@ export default class SchemaModal extends Component {
     let state = WranglerStore.getState().wrangler;
     let workspaceId = state.workspaceId;
 
-    let namespace = NamespaceStore.getState().selectedNamespace;
+    let namespace = 'default';
 
     let requestObj = {
       namespace,

--- a/cdap-ui/app/cdap/components/Wrangler/TopPanel/SchemaModal.js
+++ b/cdap-ui/app/cdap/components/Wrangler/TopPanel/SchemaModal.js
@@ -22,6 +22,7 @@ import {getParsedSchema} from 'components/SchemaEditor/SchemaHelpers';
 import MyWranglerApi from 'api/wrangler';
 import WranglerStore from 'components/Wrangler/store';
 import fileDownload from 'react-file-download';
+import NamespaceStore from 'services/NamespaceStore';
 
 export default class SchemaModal extends Component {
   constructor(props) {
@@ -46,8 +47,10 @@ export default class SchemaModal extends Component {
     let state = WranglerStore.getState().wrangler;
     let workspaceId = state.workspaceId;
 
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
     let requestObj = {
-      namespace: 'default',
+      namespace,
       workspaceId
     };
 

--- a/cdap-ui/app/cdap/components/Wrangler/TopPanel/WorkspaceModal.js
+++ b/cdap-ui/app/cdap/components/Wrangler/TopPanel/WorkspaceModal.js
@@ -23,7 +23,7 @@ import WranglerActions from 'components/Wrangler/store/WranglerActions';
 import CardActionFeedback from 'components/CardActionFeedback';
 import cookie from 'react-cookie';
 import isNil from 'lodash/isNil';
-import NamespaceStore from 'services/NamespaceStore';
+// import NamespaceStore from 'services/NamespaceStore';
 
 export default class WorkspaceModal extends Component {
   constructor(props) {
@@ -71,7 +71,7 @@ export default class WorkspaceModal extends Component {
   setWorkspace() {
     if (!this.state.workspaceId) { return; }
     let workspaceId = this.state.workspaceId;
-    let namespace = NamespaceStore.getState().selectedNamespace;
+    let namespace = 'default';
 
     let params = {
       namespace,
@@ -103,7 +103,7 @@ export default class WorkspaceModal extends Component {
   createWorkspace() {
     if (!this.state.workspaceId) { return; }
     let workspaceId = this.state.workspaceId;
-    let namespace = NamespaceStore.getState().selectedNamespace;
+    let namespace = 'default';
 
     MyWranglerApi.create({
       namespace,
@@ -134,7 +134,7 @@ export default class WorkspaceModal extends Component {
   deleteWorkspace() {
     if (!this.state.workspaceId) { return; }
     let workspaceId = this.state.workspaceId;
-    let namespace = NamespaceStore.getState().selectedNamespace;
+    let namespace = 'default';
 
     MyWranglerApi.delete({
       namespace,
@@ -179,7 +179,7 @@ export default class WorkspaceModal extends Component {
     if (!this.state.file) { return; }
 
     let delimiter = this.state.recordDelimiter;
-    let namespace = NamespaceStore.getState().selectedNamespace;
+    let namespace = 'default';
 
     let url = `/namespaces/${namespace}/apps/wrangler/services/service/methods/workspaces/${this.state.activeWorkspace}/upload`;
 

--- a/cdap-ui/app/cdap/components/Wrangler/TopPanel/WorkspaceModal.js
+++ b/cdap-ui/app/cdap/components/Wrangler/TopPanel/WorkspaceModal.js
@@ -22,6 +22,7 @@ import WranglerStore from 'components/Wrangler/store';
 import WranglerActions from 'components/Wrangler/store/WranglerActions';
 import CardActionFeedback from 'components/CardActionFeedback';
 import cookie from 'react-cookie';
+import isNil from 'lodash/isNil';
 
 export default class WorkspaceModal extends Component {
   constructor(props) {
@@ -176,10 +177,19 @@ export default class WorkspaceModal extends Component {
     let delimiter = this.state.recordDelimiter;
 
     let url = `/namespaces/default/apps/wrangler/services/service/methods/workspaces/${this.state.activeWorkspace}/upload`;
+
     let headers = {
       'Content-Type': 'application/octet-stream',
       'X-Archive-Name': name
     };
+
+    // add authorization headers!!!
+    if (window.CDAP_CONFIG.securityEnabled) {
+      let token = cookie.load('CDAP_Auth_Token');
+      if (!isNil(token)) {
+        headers.Authorization = `Bearer ${token}`;
+      }
+    }
 
     if (delimiter) {
       headers['recorddelimiter'] = delimiter;

--- a/cdap-ui/app/cdap/components/Wrangler/TopPanel/WorkspaceModal.js
+++ b/cdap-ui/app/cdap/components/Wrangler/TopPanel/WorkspaceModal.js
@@ -23,6 +23,7 @@ import WranglerActions from 'components/Wrangler/store/WranglerActions';
 import CardActionFeedback from 'components/CardActionFeedback';
 import cookie from 'react-cookie';
 import isNil from 'lodash/isNil';
+import NamespaceStore from 'services/NamespaceStore';
 
 export default class WorkspaceModal extends Component {
   constructor(props) {
@@ -70,9 +71,10 @@ export default class WorkspaceModal extends Component {
   setWorkspace() {
     if (!this.state.workspaceId) { return; }
     let workspaceId = this.state.workspaceId;
+    let namespace = NamespaceStore.getState().selectedNamespace;
 
     let params = {
-      namespace: 'default',
+      namespace,
       workspaceId: workspaceId,
       limit: 100
     };
@@ -101,9 +103,10 @@ export default class WorkspaceModal extends Component {
   createWorkspace() {
     if (!this.state.workspaceId) { return; }
     let workspaceId = this.state.workspaceId;
+    let namespace = NamespaceStore.getState().selectedNamespace;
 
     MyWranglerApi.create({
-      namespace: 'default',
+      namespace,
       workspaceId
     }).subscribe((res) => {
       this.setState({
@@ -131,9 +134,10 @@ export default class WorkspaceModal extends Component {
   deleteWorkspace() {
     if (!this.state.workspaceId) { return; }
     let workspaceId = this.state.workspaceId;
+    let namespace = NamespaceStore.getState().selectedNamespace;
 
     MyWranglerApi.delete({
-      namespace: 'default',
+      namespace,
       workspaceId
     }).subscribe((res) => {
       console.log(res);
@@ -175,8 +179,9 @@ export default class WorkspaceModal extends Component {
     if (!this.state.file) { return; }
 
     let delimiter = this.state.recordDelimiter;
+    let namespace = NamespaceStore.getState().selectedNamespace;
 
-    let url = `/namespaces/default/apps/wrangler/services/service/methods/workspaces/${this.state.activeWorkspace}/upload`;
+    let url = `/namespaces/${namespace}/apps/wrangler/services/service/methods/workspaces/${this.state.activeWorkspace}/upload`;
 
     let headers = {
       'Content-Type': 'application/octet-stream',
@@ -200,7 +205,7 @@ export default class WorkspaceModal extends Component {
         console.log(res);
 
         let params = {
-          namespace: 'default',
+          namespace,
           workspaceId: this.state.activeWorkspace,
           limit: 100
         };

--- a/cdap-ui/app/cdap/components/Wrangler/WranglerCLI/index.js
+++ b/cdap-ui/app/cdap/components/Wrangler/WranglerCLI/index.js
@@ -19,7 +19,7 @@ import WranglerStore from 'components/Wrangler/store';
 import WranglerActions from 'components/Wrangler/store/WranglerActions';
 import MyWranglerApi from 'api/wrangler';
 import WranglerAutoComplete from 'components/Wrangler/AutoComplete';
-import NamespaceStore from 'services/NamespaceStore';
+// import NamespaceStore from 'services/NamespaceStore';
 require('./WranglerCLI.scss');
 
 export default class WranglerCLI extends Component {
@@ -63,7 +63,7 @@ export default class WranglerCLI extends Component {
     let updatedDirectives = store.directives.concat(addDirective);
 
     let workspaceId = store.workspaceId;
-    let namespace = NamespaceStore.getState().selectedNamespace;
+    let namespace = 'default';
 
     let params = {
       namespace,

--- a/cdap-ui/app/cdap/components/Wrangler/WranglerCLI/index.js
+++ b/cdap-ui/app/cdap/components/Wrangler/WranglerCLI/index.js
@@ -19,6 +19,7 @@ import WranglerStore from 'components/Wrangler/store';
 import WranglerActions from 'components/Wrangler/store/WranglerActions';
 import MyWranglerApi from 'api/wrangler';
 import WranglerAutoComplete from 'components/Wrangler/AutoComplete';
+import NamespaceStore from 'services/NamespaceStore';
 require('./WranglerCLI.scss');
 
 export default class WranglerCLI extends Component {
@@ -62,9 +63,10 @@ export default class WranglerCLI extends Component {
     let updatedDirectives = store.directives.concat(addDirective);
 
     let workspaceId = store.workspaceId;
+    let namespace = NamespaceStore.getState().selectedNamespace;
 
     let params = {
-      namespace: 'default',
+      namespace,
       workspaceId: workspaceId,
       limit: 100,
       directive: updatedDirectives

--- a/cdap-ui/app/cdap/components/Wrangler/WranglerServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/Wrangler/WranglerServiceControl/index.js
@@ -18,6 +18,7 @@ import React, { Component } from 'react';
 import MyWranglerApi from 'api/wrangler';
 import {MyArtifactApi} from 'api/artifact';
 import find from 'lodash/find';
+import NamespaceStore from 'services/NamespaceStore';
 
 export default class WranglerServiceControl extends Component {
   constructor(props) {
@@ -48,7 +49,9 @@ export default class WranglerServiceControl extends Component {
      *  4. Poll until service starts, then reload page
      **/
 
-    MyWranglerApi.getWranglerApp({ namespace: 'default' })
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    MyWranglerApi.getWranglerApp({ namespace })
       .subscribe(() => {
         // Wrangler app already exist
         // Just start service
@@ -63,12 +66,14 @@ export default class WranglerServiceControl extends Component {
   }
 
   createApp() {
-    MyArtifactApi.list({ namespace: 'default' })
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    MyArtifactApi.list({ namespace })
       .subscribe((res) => {
         console.log('Finding wrangler artifact');
         let artifact = find(res, { 'name': 'wrangler-service' });
 
-        MyWranglerApi.createApp({ namespace: 'default' }, { artifact })
+        MyWranglerApi.createApp({ namespace }, { artifact })
           .subscribe(() => {
             console.log('Wrangler app created. Starting service');
             this.startService();
@@ -82,7 +87,9 @@ export default class WranglerServiceControl extends Component {
   }
 
   startService() {
-    MyWranglerApi.startService({ namespace: 'default' })
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    MyWranglerApi.startService({ namespace })
       .subscribe(() => {
         console.log('Service started. Polling for service status');
         this.pollServiceStatus();
@@ -95,7 +102,9 @@ export default class WranglerServiceControl extends Component {
   }
 
   pollServiceStatus() {
-    this.servicePoll = MyWranglerApi.pollServiceStatus({ namespace: 'default' })
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    this.servicePoll = MyWranglerApi.pollServiceStatus({ namespace })
       .subscribe((res) => {
         if (res.status === 'RUNNING') {
           console.log('Service is RUNNING. Going into wrangler');

--- a/cdap-ui/app/cdap/components/Wrangler/WranglerServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/Wrangler/WranglerServiceControl/index.js
@@ -18,7 +18,7 @@ import React, { Component } from 'react';
 import MyWranglerApi from 'api/wrangler';
 import {MyArtifactApi} from 'api/artifact';
 import find from 'lodash/find';
-import NamespaceStore from 'services/NamespaceStore';
+// import NamespaceStore from 'services/NamespaceStore';
 
 export default class WranglerServiceControl extends Component {
   constructor(props) {
@@ -49,7 +49,7 @@ export default class WranglerServiceControl extends Component {
      *  4. Poll until service starts, then reload page
      **/
 
-    let namespace = NamespaceStore.getState().selectedNamespace;
+    let namespace = 'default';
 
     MyWranglerApi.getWranglerApp({ namespace })
       .subscribe(() => {
@@ -66,7 +66,7 @@ export default class WranglerServiceControl extends Component {
   }
 
   createApp() {
-    let namespace = NamespaceStore.getState().selectedNamespace;
+    let namespace = 'default';
 
     MyArtifactApi.list({ namespace })
       .subscribe((res) => {
@@ -87,7 +87,7 @@ export default class WranglerServiceControl extends Component {
   }
 
   startService() {
-    let namespace = NamespaceStore.getState().selectedNamespace;
+    let namespace = 'default';
 
     MyWranglerApi.startService({ namespace })
       .subscribe(() => {
@@ -102,7 +102,7 @@ export default class WranglerServiceControl extends Component {
   }
 
   pollServiceStatus() {
-    let namespace = NamespaceStore.getState().selectedNamespace;
+    let namespace = 'default';
 
     this.servicePoll = MyWranglerApi.pollServiceStatus({ namespace })
       .subscribe((res) => {

--- a/cdap-ui/app/cdap/components/Wrangler/WranglerSidePanel/ColumnsTab.js
+++ b/cdap-ui/app/cdap/components/Wrangler/WranglerSidePanel/ColumnsTab.js
@@ -20,6 +20,7 @@ import MyWranglerApi from 'api/wrangler';
 import shortid from 'shortid';
 import ColumnsTabRow from 'components/Wrangler/WranglerSidePanel/ColumnsTabRow';
 import {objectQuery} from 'services/helpers';
+import NamespaceStore from 'services/NamespaceStore';
 
 export default class ColumnsTab extends Component {
   constructor(props) {
@@ -48,9 +49,10 @@ export default class ColumnsTab extends Component {
   getSummary() {
     let state = WranglerStore.getState().wrangler;
     if (!state.workspaceId) { return; }
+    let namespace = NamespaceStore.getState().selectedNamespace;
 
     let params = {
-      namespace: 'default',
+      namespace,
       workspaceId: state.workspaceId,
       limit: 100,
       directive: state.directives

--- a/cdap-ui/app/cdap/components/Wrangler/WranglerSidePanel/ColumnsTab.js
+++ b/cdap-ui/app/cdap/components/Wrangler/WranglerSidePanel/ColumnsTab.js
@@ -20,7 +20,7 @@ import MyWranglerApi from 'api/wrangler';
 import shortid from 'shortid';
 import ColumnsTabRow from 'components/Wrangler/WranglerSidePanel/ColumnsTabRow';
 import {objectQuery} from 'services/helpers';
-import NamespaceStore from 'services/NamespaceStore';
+// import NamespaceStore from 'services/NamespaceStore';
 
 export default class ColumnsTab extends Component {
   constructor(props) {
@@ -49,7 +49,7 @@ export default class ColumnsTab extends Component {
   getSummary() {
     let state = WranglerStore.getState().wrangler;
     if (!state.workspaceId) { return; }
-    let namespace = NamespaceStore.getState().selectedNamespace;
+    let namespace = 'default';
 
     let params = {
       namespace,

--- a/cdap-ui/app/cdap/components/Wrangler/WranglerSidePanel/DirectivesTab.js
+++ b/cdap-ui/app/cdap/components/Wrangler/WranglerSidePanel/DirectivesTab.js
@@ -21,7 +21,7 @@ import shortid from 'shortid';
 import MyWranglerApi from 'api/wrangler';
 import DirectivesTabRow from 'components/Wrangler/WranglerSidePanel/DirectivesTabRow';
 import fileDownload from 'react-file-download';
-import NamespaceStore from 'services/NamespaceStore';
+// import NamespaceStore from 'services/NamespaceStore';
 
 export default class DirectivesTab extends Component {
   constructor(props) {
@@ -75,7 +75,7 @@ export default class DirectivesTab extends Component {
 
     let newDirectives = directives.slice(0, index);
 
-    let namespace = NamespaceStore.getState().selectedNamespace;
+    let namespace = 'default';
 
     let params = {
       namespace,

--- a/cdap-ui/app/cdap/components/Wrangler/WranglerSidePanel/DirectivesTab.js
+++ b/cdap-ui/app/cdap/components/Wrangler/WranglerSidePanel/DirectivesTab.js
@@ -21,6 +21,7 @@ import shortid from 'shortid';
 import MyWranglerApi from 'api/wrangler';
 import DirectivesTabRow from 'components/Wrangler/WranglerSidePanel/DirectivesTabRow';
 import fileDownload from 'react-file-download';
+import NamespaceStore from 'services/NamespaceStore';
 
 export default class DirectivesTab extends Component {
   constructor(props) {
@@ -74,8 +75,10 @@ export default class DirectivesTab extends Component {
 
     let newDirectives = directives.slice(0, index);
 
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
     let params = {
-      namespace: 'default',
+      namespace,
       workspaceId: state.workspaceId,
       limit: 100,
       directive: newDirectives

--- a/cdap-ui/app/cdap/components/Wrangler/index.js
+++ b/cdap-ui/app/cdap/components/Wrangler/index.js
@@ -25,6 +25,7 @@ import WranglerStore from 'components/Wrangler/store';
 import WranglerActions from 'components/Wrangler/store/WranglerActions';
 import WranglerServiceControl from 'components/Wrangler/WranglerServiceControl';
 import ee from 'event-emitter';
+import NamespaceStore from 'services/NamespaceStore';
 
 require('./Wrangler.scss');
 
@@ -44,8 +45,10 @@ export default class Wrangler extends Component {
 
   componentWillMount() {
     let workspaceId = cookie.load('WRANGLER_WORKSPACE');
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
     let params = {
-      namespace: 'default',
+      namespace,
       workspaceId: workspaceId,
       limit: 100
     };

--- a/cdap-ui/app/cdap/components/Wrangler/index.js
+++ b/cdap-ui/app/cdap/components/Wrangler/index.js
@@ -25,7 +25,7 @@ import WranglerStore from 'components/Wrangler/store';
 import WranglerActions from 'components/Wrangler/store/WranglerActions';
 import WranglerServiceControl from 'components/Wrangler/WranglerServiceControl';
 import ee from 'event-emitter';
-import NamespaceStore from 'services/NamespaceStore';
+// import NamespaceStore from 'services/NamespaceStore';
 
 require('./Wrangler.scss');
 
@@ -45,7 +45,7 @@ export default class Wrangler extends Component {
 
   componentWillMount() {
     let workspaceId = cookie.load('WRANGLER_WORKSPACE');
-    let namespace = NamespaceStore.getState().selectedNamespace;
+    let namespace = 'default';
 
     let params = {
       namespace,


### PR DESCRIPTION
You can ignore the changes under `cdap-ui/app/cdap/components/Wrangler`

The new components will go under `components/DataPrep`


To access: `ns/:namespace/dataprep`