### PR TITLE
[CDAP-8381] Handles no logs use case for System services.

### DIFF
--- a/cdap-ui/app/cdap/components/ServiceStatus/index.js
+++ b/cdap-ui/app/cdap/components/ServiceStatus/index.js
@@ -157,7 +157,8 @@ export default class ServiceStatus extends Component {
       _cdapPath : `/system/services/${this.props.name}/logs`
     });
 
-    logUrl = `/downloadLogs?type=raw&backendUrl=${encodeURIComponent(logUrl)}`;
+    let noLogMessage = encodeURIComponent(`service: '${this.props.name}'`);
+    logUrl = `/downloadLogs?type=raw&backendUrl=${encodeURIComponent(logUrl)}&noLogMessage=${noLogMessage}`;
 
     let provisionBtnClasses = classNames('btn btn-primary set-provision-btn', {'provision-btn-with-warning' : this.state.serviceWarning});
 

--- a/cdap-ui/server/express.js
+++ b/cdap-ui/server/express.js
@@ -29,6 +29,7 @@ module.exports = {
 };
 var pkg = require('../package.json');
 var path = require('path');
+var Transform = require('stream').Transform;
 var express = require('express'),
     cookieParser = require('cookie-parser'),
     compression = require('compression'),
@@ -180,6 +181,7 @@ function makeApp (authAddress, cdapConfig, uiSettings) {
 
   app.get('/downloadLogs', function(req, res) {
     var url = decodeURIComponent(req.query.backendUrl);
+    var noLogsMessage = decodeURIComponent(req.query.noLogMessage || '');
     var method = (req.query.method || 'GET');
     log.info('Download Logs Start: ', url);
     var customHeaders;
@@ -206,6 +208,21 @@ function makeApp (authAddress, cdapConfig, uiSettings) {
       'Cache-Control': 'no-cache, no-store'
     };
 
+    var emptyResponseTransformer = new Transform();
+    var datalength = 0;
+    emptyResponseTransformer._transform = function(data, encoding, done) {
+      if (!datalength && data.length) {
+        datalength = data.length;
+      }
+      this.push(data);
+      done();
+    };
+    emptyResponseTransformer._flush = function(cb) {
+      if (!datalength) {
+        this.push(new Buffer('No Logs found for ' + (!noLogsMessage.length ? url : noLogsMessage), 'utf-8'));
+      }
+      cb();
+    };
     try {
       request(requestObject)
         .on('error', function (e) {
@@ -222,16 +239,16 @@ function makeApp (authAddress, cdapConfig, uiSettings) {
               } else {
                 responseHeaders['Content-Type'] = 'text/plain';
               }
-
               res.set(responseHeaders);
             }
           }
         )
+        .pipe(emptyResponseTransformer)
         .pipe(res)
         .on('error', function (e) {
           log.error('Error downloading logs: ', e);
         });
-    } catch(e) {
+    } catch (e) {
       log.error('Downloading logs failed, ', e);
     }
   });


### PR DESCRIPTION
- Fixes ServiceStatus view in Administration to pass in 'noLogsMessage' to be shown when empty logs are shown for system services
- Adds a Transform stream to the response `express.js` to handle empty logs when rendering logs for system services (today we are rendered as plain text which shows an empty page if there are no logs).