### PR TITLE
Re-built cdap-default.xml

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -20,6 +20,19 @@
   <!-- General Configuration -->
 
   <property>
+    <name>cluster.name</name>
+    <value></value>
+    <description>
+      A cluster-based name for CDAP. It is used for scope resolution of
+      preferences and runtime arguments. For example: the preference key
+      "cluster.[cluster.name].my.key" would be resolved to "my.key" at
+      runtime; a program can then retrieve the preference value by using
+      just "my.key". The administrator can use this property to set
+      different preferences for each cluster.
+    </description>
+  </property>
+
+  <property>
     <name>hdfs.lib.dir</name>
     <value>${hdfs.namespace}/lib</value>
     <description>
@@ -52,18 +65,6 @@
       alphanumeric, and should not be changed after CDAP has been started.
       If it is changed, there is a risk of losing data (for example,
       authorization policies).
-    </description>
-  </property>
-
-  <property>
-    <name>cluster.name</name>
-    <value></value>
-    <description>
-      A cluster-based name for CDAP. It is used for scope resolution of preferences and
-      runtime arguments. For example: the preference key "cluster.[cluster.name].my.key"
-      would be resolved to "my.key" at runtime; a program can then retrieve the preference
-      value by using just "my.key". The administrator can use this property to set
-      different preferences for each cluster.
     </description>
   </property>
 
@@ -178,16 +179,6 @@
   </property>
 
   <property>
-    <name>twill.location.cache.dir</name>
-    <value>.cache</value>
-    <description>
-      The relative directory name on the distributed file system for Apache Twill to cache
-      generated files, to speed up launching applications. This directory is relative to
-      ${root.namespace}/twill on the file system.
-    </description>
-  </property>
-
-  <property>
     <name>twill.jvm.gc.opts</name>
     <value>-verbose:gc -Xloggc:&lt;LOG_DIR&gt;/gc.log -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M</value>
     <description>
@@ -199,10 +190,22 @@
   </property>
 
   <property>
+    <name>twill.location.cache.dir</name>
+    <value>.cache</value>
+    <description>
+      The relative directory name on the distributed file system for Apache
+      Twill to cache generated files, to speed up launching applications.
+      This directory is relative to ${root.namespace}/twill on the file
+      system.
+    </description>
+  </property>
+
+  <property>
     <name>twill.no.container.timeout</name>
     <value>120000</value>
     <description>
-      Duration in milliseconds to wait for at least one container for Apache Twill runnable
+      Duration in milliseconds to wait for at least one container for Apache
+      Twill runnable
     </description>
   </property>
 
@@ -218,8 +221,8 @@
     <name>zookeeper.client.startup.timeout.millis</name>
     <value>60000</value>
     <description>
-      Duration in milliseconds to wait for a successful connection to a server in the
-      ZooKeeper quorum
+      Duration in milliseconds to wait for a successful connection to a
+      server in the ZooKeeper quorum
     </description>
   </property>
 
@@ -247,9 +250,9 @@
     <name>dataset.unchecked.upgrade</name>
     <value>false</value>
     <description>
-      If false, any changes made to existing datasets are not deployed
-      when an app is redeployed; setting this value to true allows the
-      dataset changes to be deployed upon app redeployment
+      If false, any changes made to existing datasets are not deployed when
+      an app is redeployed; setting this value to true allows the dataset
+      changes to be deployed upon app redeployment
     </description>
   </property>
 
@@ -276,26 +279,18 @@
   </property>
 
   <property>
-    <name>app.meta.upgrade.timeout.secs</name>
-    <value>60</value>
-    <description>
-      Timeout value in seconds while upgrading application versions
-    </description>
-  </property>
-
-  <property>
-    <name>master.services.bind.address</name>
-    <value>0.0.0.0</value>
-    <description>
-      Bind address for app fabric service and dataset service
-    </description>
-  </property>
-
-  <property>
     <name>app.bind.port</name>
     <value>0</value>
     <description>
       App Fabric service bind port; if 0, binds to a random port
+    </description>
+  </property>
+
+  <property>
+    <name>app.meta.upgrade.timeout.secs</name>
+    <value>60</value>
+    <description>
+      Timeout value in seconds while upgrading application versions
     </description>
   </property>
 
@@ -311,9 +306,9 @@
     <name>app.program.extra.classpath</name>
     <value></value>
     <description>
-      Additional Java classpath for CDAP programs. These extra classpaths must
-      be present on all nodes in the cluster. Supports wildcard suffix "*"
-      to include all JAR files under a directory.
+      Additional Java classpath for CDAP programs. These extra classpaths
+      must be present on all nodes in the cluster. Supports wildcard suffix
+      "*" to include all JAR files under a directory.
     </description>
   </property>
 
@@ -329,7 +324,8 @@
     <name>app.program.max.start.seconds</name>
     <value>300</value>
     <description>
-      Maximum number of seconds to wait for a program to start before killing it
+      Maximum number of seconds to wait for a program to start before
+      killing it
     </description>
   </property>
 
@@ -337,7 +333,8 @@
     <name>app.program.max.stop.seconds</name>
     <value>300</value>
     <description>
-      Maximum number of seconds to wait for a program to stop before killing it
+      Maximum number of seconds to wait for a program to stop before killing
+      it
     </description>
   </property>
 
@@ -345,8 +342,8 @@
     <name>app.program.runid.corrector.interval</name>
     <value>180</value>
     <description>
-      Interval in seconds of how often the run id corrector thread will run; this value
-      should be greater than 0
+      Interval in seconds of how often the run id corrector thread will run;
+      this value should be greater than 0
     </description>
   </property>
 
@@ -363,15 +360,9 @@
     <name>app.program.spark.yarn.client.rewrite.enabled</name>
     <value>true</value>
     <description>
-      Specify whether to rewrite the YARN 'Client.scala' class in Spark to work
-      around issue SPARK-13441 in CDH clusters
+      Specify whether to rewrite the YARN 'Client.scala' class in Spark to
+      work around issue SPARK-13441 in CDH clusters
     </description>
-  </property>
-
-  <property>
-    <name>apps.scheduler.queue</name>
-    <value></value>
-    <description>Scheduler queue for CDAP programs and CDAP Explore queries</description>
   </property>
 
   <property>
@@ -391,13 +382,29 @@
   </property>
 
   <property>
+    <name>apps.scheduler.queue</name>
+    <value></value>
+    <description>
+      Scheduler queue for CDAP programs and CDAP Explore queries
+    </description>
+  </property>
+
+  <property>
+    <name>master.services.bind.address</name>
+    <value>0.0.0.0</value>
+    <description>
+      Bind address for app fabric service and dataset service
+    </description>
+  </property>
+
+  <property>
     <name>program.container.dist.jars</name>
     <value></value>
     <description>
       Additional jars to be localized to every program container and to be
-      added to classpaths of CDAP programs. They can be local file paths
-      on the CDAP Master or URIs of remote files. Multiple JAR files
-      are comma-separated.
+      added to classpaths of CDAP programs. They can be local file paths on
+      the CDAP Master or URIs of remote files. Multiple JAR files are comma-
+      separated.
     </description>
   </property>
 
@@ -422,8 +429,8 @@
     <name>workflow.token.max.size.mb</name>
     <value>30</value>
     <description>
-      Maximum allowed size in megabytes of a workflow token; if the
-      workflow token exceeds this size, no further updates are allowed
+      Maximum allowed size in megabytes of a workflow token; if the workflow
+      token exceeds this size, no further updates are allowed
     </description>
   </property>
 
@@ -450,7 +457,8 @@
     <name>audit.topic</name>
     <value>audit</value>
     <description>
-      Topic name in the messaging system to which audit messages are published
+      Topic name in the messaging system to which audit messages are
+      published
     </description>
   </property>
 
@@ -550,6 +558,15 @@
   </property>
 
   <property>
+    <name>data.tx.max.timeout</name>
+    <value>600</value>
+    <description>
+      The limit for the allowed transaction timeout, in seconds. Attempts to
+      start a transaction with a longer timeout will fail.
+    </description>
+  </property>
+
+  <property>
     <name>data.tx.memory.mb</name>
     <value>${master.service.memory.mb}</value>
     <description>
@@ -570,6 +587,40 @@
     <value>1</value>
     <description>
       Requested number of transaction service instances
+    </description>
+  </property>
+
+  <property>
+    <name>data.tx.prune.enable</name>
+    <value>false</value>
+    <description>
+      Enable invalid transaction list pruning
+    </description>
+  </property>
+
+  <property>
+    <name>data.tx.prune.plugins</name>
+    <value>data.tx.pruning.plugin</value>
+    <description>
+      List of transaction pruning plugins; for CDAP HBase tables that use
+      transaction functionality to skip or clean invalid data
+    </description>
+  </property>
+
+  <property>
+    <name>data.tx.prune.state.table</name>
+    <value>${dataset.table.prefix}_system:tephra.state</value>
+    <description>
+      Table used to store intermediate state when invalid transaction list
+      pruning is enabled
+    </description>
+  </property>
+
+  <property>
+    <name>data.tx.pruning.plugin.class</name>
+    <value>co.cask.data2.txprune.DefaultHBaseTransactionPruningPlugin</value>
+    <description>
+      Class name for the default transaction pruning plugin
     </description>
   </property>
 
@@ -638,9 +689,9 @@
     <name>data.tx.thrift.max.read.buffer</name>
     <value>${thrift.max.read.buffer}</value>
     <description>
-      Maximum read buffer size in bytes used by the transaction service;
-      the value should be set to something greater than the maximum frame
-      sent on the RPC channel
+      Maximum read buffer size in bytes used by the transaction service; the
+      value should be set to something greater than the maximum frame sent
+      on the RPC channel
     </description>
   </property>
 
@@ -654,53 +705,18 @@
   </property>
 
   <property>
-    <name>data.tx.max.timeout</name>
-    <value>600</value>
-    <description>
-      The limit for the allowed transaction timeout, in seconds. Attempts to
-      start a transaction with a longer timeout will fail.
-    </description>
-  </property>
-
-  <property>
-    <name>data.tx.prune.enable</name>
-    <value>false</value>
-    <description>
-      Enable invalid transaction list pruning
-    </description>
-  </property>
-
-  <property>
-    <name>data.tx.prune.plugins</name>
-    <value>data.tx.pruning.plugin</value>
-    <description>
-      List of transaction pruning plugins; for CDAP HBase tables that use transaction
-      functionality to skip or clean invalid data
-    </description>
-  </property>
-
-  <property>
-    <name>data.tx.prune.state.table</name>
-    <value>${dataset.table.prefix}_system:tephra.state</value>
-    <description>
-      Table used to store intermediate state when invalid transaction list pruning is
-      enabled
-    </description>
-  </property>
-
-  <property>
-    <name>data.tx.pruning.plugin.class</name>
-    <value>co.cask.data2.txprune.DefaultHBaseTransactionPruningPlugin</value>
-    <description>
-      Class name for the default transaction pruning plugin
-    </description>
-  </property>
-
-  <property>
     <name>dataset.data.dir</name>
     <value>data</value>
     <description>
       Base directory for user data on the filesystem
+    </description>
+  </property>
+
+  <property>
+    <name>dataset.executor.bind.port</name>
+    <value>0</value>
+    <description>
+      Dataset executor bind port; if 0, binds to a random port
     </description>
   </property>
 
@@ -733,14 +749,6 @@
     <value>${master.service.max.instances}</value>
     <description>
       Maximum number of dataset executor instances
-    </description>
-  </property>
-
-  <property>
-    <name>dataset.executor.bind.port</name>
-    <value>0</value>
-    <description>
-      Dataset executor bind port; if 0, binds to a random port
     </description>
   </property>
 
@@ -800,7 +808,8 @@
     <name>explore.container.yarn.app.classpath.first</name>
     <value>false</value>
     <description>
-      Determines if the YARN application classpath precedes the query engine classpath
+      Determines if the YARN application classpath precedes the query engine
+      classpath
     </description>
   </property>
 
@@ -816,9 +825,9 @@
     <name>explore.executor.container.memory.mb</name>
     <value>1024</value>
     <description>
-      Memory in megabytes for each CDAP Explore executor instance.
-      This is explicitly set differently than ${master.service.memory.mb} as
-      Explore requires more memory to run than the CDAP Master service.
+      Memory in megabytes for each CDAP Explore executor instance. This is
+      explicitly set differently than ${master.service.memory.mb} as Explore
+      requires more memory to run than the CDAP Master service.
     </description>
   </property>
 
@@ -834,9 +843,10 @@
     <name>explore.http.timeout</name>
     <value>20</value>
     <description>
-      The timeout in seconds for HTTP requests to the CDAP Explore service. Because requests
-      may happen within a transaction, it is recommended to keep this timeout noticeably
-      shorter than the default transaction timeout, ${data.tx.timeout}.
+      The timeout in seconds for HTTP requests to the CDAP Explore service.
+      Because requests may happen within a transaction, it is recommended to
+      keep this timeout noticeably shorter than the default transaction
+      timeout, ${data.tx.timeout}.
     </description>
   </property>
 
@@ -871,8 +881,8 @@
     <description>
       Determines the start-up of the CDAP Explore service (ad-hoc SQL
       queries); if false, the Explore service starts up when CDAP is
-      started; if true, the Explore service will start upon the first
-      query it receives
+      started; if true, the Explore service will start upon the first query
+      it receives
     </description>
   </property>
 
@@ -965,8 +975,8 @@
     <name>kafka.server.log.flush.interval.messages</name>
     <value>10000</value>
     <description>
-      The interval length (in number of messages in the CDAP Kafka service) at which to
-      force an fsync of data written to the log
+      The interval length (in number of messages in the CDAP Kafka service)
+      at which to force an fsync of data written to the log
     </description>
   </property>
 
@@ -974,9 +984,9 @@
     <name>kafka.server.log.retention.hours</name>
     <value>24</value>
     <description>
-      The number of hours to keep a log file before deleting it; this is the time-to-live
-      in the CDAP Kafka service, while a log is in-flight between the container and the
-      CDAP log saver
+      The number of hours to keep a log file before deleting it; this is the
+      time-to-live in the CDAP Kafka service, while a log is in-flight
+      between the container and the CDAP log saver
     </description>
   </property>
 
@@ -1017,13 +1027,14 @@
     <name>kafka.zookeeper.quorum</name>
     <value></value>
     <description>
-      CDAP Kafka service ZooKeeper quorum and namespace. If set, this will override
-      the ZooKeeper quorum (set by ${zookeeper.quorum}) and the ZooKeeper namespace
-      (set by ${kafka.zookeeper.namespace}) when setting up a connection to
-      the Kafka service used by CDAP. If the same Kafka service ZooKeeper quorum
-      and namespace are shared by multiple CDAP instances, each CDAP instance
-      needs to distinguish its Kafka topics from those of other CDAP instances
-      with unique values for ${log.kafka.topic} and ${metrics.topic.prefix}.
+      CDAP Kafka service ZooKeeper quorum and namespace. If set, this will
+      override the ZooKeeper quorum (set by ${zookeeper.quorum}) and the
+      ZooKeeper namespace (set by ${kafka.zookeeper.namespace}) when setting
+      up a connection to the Kafka service used by CDAP. If the same Kafka
+      service ZooKeeper quorum and namespace are shared by multiple CDAP
+      instances, each CDAP instance needs to distinguish its Kafka topics
+      from those of other CDAP instances with unique values for
+      ${log.kafka.topic} and ${metrics.topic.prefix}.
     </description>
   </property>
 
@@ -1055,14 +1066,6 @@
   </property>
 
   <property>
-    <name>log.publish.num.partitions</name>
-    <value>10</value>
-    <description>
-      Number of CDAP Kafka service partitions to publish the logs to
-    </description>
-  </property>
-
-  <property>
     <name>log.pipeline.cdap.dir.permissions</name>
     <value>700</value>
     <description>
@@ -1071,10 +1074,28 @@
   </property>
 
   <property>
+    <name>log.pipeline.cdap.file.cleanup.interval.mins</name>
+    <value>1440</value>
+    <description>
+      Time in minutes for each interval of the log cleanup thread to run
+    </description>
+  </property>
+
+  <property>
+    <name>log.pipeline.cdap.file.cleanup.transaction.timeout</name>
+    <value>60</value>
+    <description>
+      Transaction timeout in seconds for running file cleanup tasks. This
+      should not be larger than ${data.tx.max.timeout}.
+    </description>
+  </property>
+
+  <property>
     <name>log.pipeline.cdap.file.max.lifetime.ms</name>
     <value>21600000</value>
     <description>
-      Maximum time in milliseconds a file is kept open by the system log appender
+      Maximum time in milliseconds a file is kept open by the system log
+      appender
     </description>
   </property>
 
@@ -1095,46 +1116,31 @@
   </property>
 
   <property>
-    <name>log.pipeline.cdap.file.sync.interval.bytes</name>
-    <value>10485760</value>
-    <description>
-      Number of bytes for the sync interval setting of the Avro file written by the system log appender
-    </description>
-  </property>
-
-  <property>
     <name>log.pipeline.cdap.file.retention.duration.days</name>
     <value>7</value>
     <description>
-      Maximum time in days a file is kept before it can be deleted by log cleanup.
+      Maximum time in days a file is kept before it can be deleted by log
+      cleanup.
     </description>
   </property>
 
   <property>
-    <name>log.pipeline.cdap.file.cleanup.transaction.timeout</name>
-    <value>60</value>
+    <name>log.pipeline.cdap.file.sync.interval.bytes</name>
+    <value>10485760</value>
     <description>
-      Transaction timeout in seconds for running file cleanup tasks.
-      This should not be larger than ${data.tx.max.timeout}.
+      Number of bytes for the sync interval setting of the Avro file written
+      by the system log appender
     </description>
   </property>
-
-  <property>
-    <name>log.pipeline.cdap.file.cleanup.interval.mins</name>
-    <value>1440</value>
-    <description>
-      Time in minutes for each interval of the log cleanup thread to run
-    </description>
-  </property>
-
 
   <property>
     <name>log.process.pipeline.auto.buffer.ratio</name>
     <value>0.7</value>
     <description>
-      The ratio of total memory used for determining processing pipeline buffer size.
-      This property is only used if ${log.process.pipeline.buffer.size}
-      is set to zero and the value should be greater than zero and less than one.
+      The ratio of total memory used for determining processing pipeline
+      buffer size. This property is only used if
+      ${log.process.pipeline.buffer.size} is set to zero and the value
+      should be greater than zero and less than one.
     </description>
   </property>
 
@@ -1143,8 +1149,9 @@
     <value>0</value>
     <description>
       The internal buffer size in bytes for each log processing pipeline.
-      Setting it to zero means the system will determine it dynamically based
-      on the container size as given by ${log.saver.container.memory.mb}.
+      Setting it to zero means the system will determine it dynamically
+      based on the container size as given by
+      ${log.saver.container.memory.mb}.
     </description>
   </property>
 
@@ -1160,9 +1167,9 @@
     <name>log.process.pipeline.config.dir</name>
     <value>/opt/cdap/master/ext/logging/config</value>
     <description>
-      A local directory on the CDAP Master that is scanned for log processing pipeline
-      configurations. Each pipeline is defined by a file in the logback XML format, with
-      ".xml" as the file name extension.
+      A local directory on the CDAP Master that is scanned for log
+      processing pipeline configurations. Each pipeline is defined by a file
+      in the logback XML format, with ".xml" as the file name extension.
     </description>
   </property>
 
@@ -1170,10 +1177,10 @@
     <name>log.process.pipeline.event.delay.ms</name>
     <value>2000</value>
     <description>
-      The time a log event stays in the log processing pipeline buffer before
-      writing out to log appenders in milliseconds. A longer delay will result
-      in better time ordering of log events before presenting to log appenders
-      but will consume more memory.
+      The time a log event stays in the log processing pipeline buffer
+      before writing out to log appenders in milliseconds. A longer delay
+      will result in better time ordering of log events before presenting to
+      log appenders but will consume more memory.
     </description>
   </property>
 
@@ -1181,7 +1188,8 @@
     <name>log.process.pipeline.kafka.fetch.size</name>
     <value>1048576</value>
     <description>
-      The buffer size in bytes, per topic partition, for fetching log events from Kafka
+      The buffer size in bytes, per topic partition, for fetching log events
+      from Kafka
     </description>
   </property>
 
@@ -1189,16 +1197,9 @@
     <name>log.process.pipeline.lib.dir</name>
     <value>/opt/cdap/master/ext/logging/lib</value>
     <description>
-      Semicolon-separated list of local directories on the CDAP Master scanned
-      for additional library JAR files to be included for log processing
-    </description>
-  </property>
-
-  <property>
-    <name>log.process.pipeline.logger.cache.size</name>
-    <value>1000</value>
-    <description>
-      The number of loggers that each log processing pipeline will cache
+      Semicolon-separated list of local directories on the CDAP Master
+      scanned for additional library JAR files to be included for log
+      processing
     </description>
   </property>
 
@@ -1211,14 +1212,49 @@
   </property>
 
   <property>
+    <name>log.process.pipeline.logger.cache.size</name>
+    <value>1000</value>
+    <description>
+      The number of loggers that each log processing pipeline will cache
+    </description>
+  </property>
+
+  <property>
+    <name>log.publish.num.partitions</name>
+    <value>10</value>
+    <description>
+      Number of CDAP Kafka service partitions to publish the logs to
+    </description>
+  </property>
+
+  <property>
     <name>log.publish.partition.key</name>
     <value>program</value>
     <description>
-      Publish logs from an application or a program to the same partition. Valid values
-      are "application" or "program". If set to "application", logs from all the programs
-      of an application go to the same partition. If set to "program", logs from the same
-      program go to the same partition. Changes to this property requires restarting of
-      all CDAP applications.
+      Publish logs from an application or a program to the same partition.
+      Valid values are "application" or "program". If set to "application",
+      logs from all the programs of an application go to the same partition.
+      If set to "program", logs from the same program go to the same
+      partition. Changes to this property requires restarting of all CDAP
+      applications.
+    </description>
+  </property>
+
+  <property>
+    <name>log.saver.container.memory.mb</name>
+    <value>1024</value>
+    <description>
+      Memory in megabytes for each log saver instance to run in YARN. This
+      is explicitly set differently than ${master.service.memory.mb} as Log
+      saver requires more memory to run than the CDAP Master service.
+    </description>
+  </property>
+
+  <property>
+    <name>log.saver.container.num.cores</name>
+    <value>2</value>
+    <description>
+      Number of virtual cores for each log saver instance in YARN
     </description>
   </property>
 
@@ -1239,24 +1275,6 @@
   </property>
 
   <property>
-    <name>log.saver.container.memory.mb</name>
-    <value>1024</value>
-    <description>
-      Memory in megabytes for each log saver instance to run in YARN.
-      This is explicitly set differently than ${master.service.memory.mb} as
-      Log saver requires more memory to run than the CDAP Master service.
-    </description>
-  </property>
-
-  <property>
-    <name>log.saver.container.num.cores</name>
-    <value>2</value>
-    <description>
-      Number of virtual cores for each log saver instance in YARN
-    </description>
-  </property>
-
-  <property>
     <name>log.saver.status.bind.address</name>
     <value>0.0.0.0</value>
     <description>
@@ -1271,13 +1289,31 @@
     <name>market.base.url</name>
     <value>http://market.cask.co/v2</value>
     <description>
-      The base URL of the Cask Market used by the CDAP UI for the Cask Market RESTful API.
-      The default value shown is that of the public Cask Market.
+      The base URL of the Cask Market used by the CDAP UI for the Cask
+      Market RESTful API. The default value shown is that of the public Cask
+      Market.
     </description>
   </property>
 
 
   <!-- Master Configuration -->
+
+  <property>
+    <name>hbase.client.retries.number</name>
+    <value>2</value>
+    <description>
+      Maximum number of retries while performing HBase operations from
+      master services
+    </description>
+  </property>
+
+  <property>
+    <name>hbase.rpc.timeout</name>
+    <value>15000</value>
+    <description>
+      RPC timeout from HBase operations performed from master services
+    </description>
+  </property>
 
   <property>
     <name>http.service.boss.threads</name>
@@ -1331,22 +1367,6 @@
   </property>
 
   <property>
-    <name>hbase.client.retries.number</name>
-    <value>2</value>
-    <description>
-      Maximum number of retries while performing HBase operations from master services
-    </description>
-  </property>
-
-  <property>
-    <name>hbase.rpc.timeout</name>
-    <value>15000</value>
-    <description>
-      RPC timeout from HBase operations performed from master services
-    </description>
-  </property>
-
-  <property>
     <name>master.service.max.instances</name>
     <value>5</value>
     <description>
@@ -1371,6 +1391,14 @@
   </property>
 
   <property>
+    <name>master.services.scheduler.queue</name>
+    <value></value>
+    <description>
+      Scheduler queue for CDAP Master services
+    </description>
+  </property>
+
+  <property>
     <name>master.startup.service.timeout.seconds</name>
     <value>600</value>
     <description>
@@ -1385,14 +1413,6 @@
     </description>
   </property>
 
-  <property>
-    <name>master.services.scheduler.queue</name>
-    <value></value>
-    <description>
-      Scheduler queue for CDAP Master services
-    </description>
-  </property>
-
 
   <!-- Messaging System Configuration -->
 
@@ -1401,15 +1421,6 @@
     <value>1</value>
     <description>
       Number of instances for the messaging service
-    </description>
-    <final>true</final>
-  </property>
-
-  <property>
-    <name>messaging.max.instances</name>
-    <value>1</value>
-    <description>
-      Maximum number of instances for the messaging service
     </description>
     <final>true</final>
   </property>
@@ -1431,11 +1442,20 @@
   </property>
 
   <property>
-    <name>messaging.local.data.cleanup.frequency.secs</name>
-    <value>3600</value>
+    <name>messaging.coprocessor.dir</name>
+    <value>tms</value>
     <description>
-      Scheduling frequency of time-to-live cleanup thread in seconds (only used in
-      Standalone CDAP)
+      Directory to store Messaging Service Table coprocessors. This path is
+      relative to ${hdfs.namespace}.
+    </description>
+  </property>
+
+  <property>
+    <name>messaging.coprocessor.metadata.cache.expiration.seconds</name>
+    <value>120</value>
+    <description>
+      Number of seconds after which the metadata cache in HBase data table
+      coprocessors will expire
     </description>
   </property>
 
@@ -1452,16 +1472,8 @@
     <value>1000</value>
     <description>
       Number of rows for caching that will be passed to HBase scanners.
-      Higher caching values will enable faster scanning but will use more memory.
-    </description>
-  </property>
-
-  <property>
-    <name>messaging.http.server.executor.threads</name>
-    <value>0</value>
-    <description>
-      Number of executor threads for the HTTP server in the messaging system.
-      If set to 0, no executor threads will be used and requests will be handled directly in the IO thread.
+      Higher caching values will enable faster scanning but will use more
+      memory.
     </description>
   </property>
 
@@ -1474,10 +1486,21 @@
   </property>
 
   <property>
+    <name>messaging.http.server.executor.threads</name>
+    <value>0</value>
+    <description>
+      Number of executor threads for the HTTP server in the messaging
+      system. If set to 0, no executor threads will be used and requests
+      will be handled directly in the IO thread.
+    </description>
+  </property>
+
+  <property>
     <name>messaging.http.server.max.request.size.mb</name>
     <value>10</value>
     <description>
-      Maximum request content size in megabytes for each request to the HTTP server in the messaging system
+      Maximum request content size in megabytes for each request to the HTTP
+      server in the messaging system
     </description>
   </property>
 
@@ -1490,18 +1513,38 @@
   </property>
 
   <property>
+    <name>messaging.local.data.cleanup.frequency.secs</name>
+    <value>3600</value>
+    <description>
+      Scheduling frequency of time-to-live cleanup thread in seconds (only
+      used in Standalone CDAP)
+    </description>
+  </property>
+
+  <property>
     <name>messaging.local.data.dir</name>
     <value>${local.data.dir}/messaging</value>
     <description>
-      Local storage directory for the messaging system (used only in Standalone CDAP)
+      Local storage directory for the messaging system (used only in
+      Standalone CDAP)
     </description>
+  </property>
+
+  <property>
+    <name>messaging.max.instances</name>
+    <value>1</value>
+    <description>
+      Maximum number of instances for the messaging service
+    </description>
+    <final>true</final>
   </property>
 
   <property>
     <name>messaging.message.table.hbase.splits</name>
     <value>16</value>
     <description>
-      Number of splits to use for the message table in HBase upon table creation
+      Number of splits to use for the message table in HBase upon table
+      creation
     </description>
   </property>
 
@@ -1525,7 +1568,8 @@
     <name>messaging.payload.table.hbase.splits</name>
     <value>16</value>
     <description>
-      Number of splits to use for the payload table in HBase upon table creation
+      Number of splits to use for the payload table in HBase upon table
+      creation
     </description>
   </property>
 
@@ -1541,11 +1585,13 @@
     <name>messaging.system.topics</name>
     <value>${audit.topic},${metrics.topic.prefix}:${metrics.messaging.topic.num},${notification.topic}</value>
     <description>
-      A comma-separated list of topics that are always available in the system namespace.
-      Multiple topics sharing the same prefix and distinguished by different numerical suffixes
-      can be specified with the syntax &lt;common.prefix&gt;:&lt;total.topic.number&gt;,
-      where the &lt;total.topic.number&gt; is the total number of topics sharing the &lt;common.prefix&gt;,
-      and the numerical suffixes will range from 0 to (&lt;total.topic.number&gt; - 1).
+      A comma-separated list of topics that are always available in the
+      system namespace. Multiple topics sharing the same prefix and
+      distinguished by different numerical suffixes can be specified with
+      the syntax &lt;common.prefix&gt;:&lt;total.topic.number&gt;, where the
+      &lt;total.topic.number&gt; is the total number of topics sharing the
+      &lt;common.prefix&gt;, and the numerical suffixes will range from 0 to
+      (&lt;total.topic.number&gt; - 1).
     </description>
   </property>
 
@@ -1562,22 +1608,6 @@
     <value>604800</value>
     <description>
       The default time-to-live in seconds for messages in a topic
-    </description>
-  </property>
-
-  <property>
-    <name>messaging.coprocessor.metadata.cache.expiration.seconds</name>
-    <value>120</value>
-    <description>
-      Number of seconds after which the metadata cache in HBase data table coprocessors will expire
-    </description>
-  </property>
-
-  <property>
-    <name>messaging.coprocessor.dir</name>
-    <value>tms</value>
-    <description>
-      Directory to store Messaging Service Table coprocessors. This path is relative to ${hdfs.namespace}.
     </description>
   </property>
 
@@ -1656,8 +1686,8 @@
     <name>metrics.data.table.retention.resolution.3600.seconds</name>
     <value>2592000</value>
     <description>
-      Retention resolution in seconds of the 1-hour resolution table; default
-      retention period is 30 days
+      Retention resolution in seconds of the 1-hour resolution table;
+      default retention period is 30 days
     </description>
   </property>
 
@@ -1754,9 +1784,10 @@
     <name>metrics.messaging.fetcher.limit</name>
     <value>200</value>
     <description>
-      Maximum number of metrics messages to be fetched from the messaging fetcher at a
-      time. It is also the maximum number of metric values to be persisted in the metrics
-      store after the number of fetched messages reaches the limit.
+      Maximum number of metrics messages to be fetched from the messaging
+      fetcher at a time. It is also the maximum number of metric values to
+      be persisted in the metrics store after the number of fetched messages
+      reaches the limit.
     </description>
   </property>
 
@@ -1772,11 +1803,11 @@
     <name>metrics.messaging.topic.num</name>
     <value>10</value>
     <description>
-      Number of topics for metrics messages. This property also sets the number of threads
-      used to fetch and process metrics in parallel from the messaging service. For a
-      value of N, topics will be created for metrics with names beginning at
-      ${metrics.topic.prefix}0, ${metrics.topic.prefix}1, up to
-      ${metrics.topic.prefix}(N-1).
+      Number of topics for metrics messages. This property also sets the
+      number of threads used to fetch and process metrics in parallel from
+      the messaging service. For a value of N, topics will be created for
+      metrics with names beginning at ${metrics.topic.prefix}0,
+      ${metrics.topic.prefix}1, up to ${metrics.topic.prefix}(N-1).
     </description>
   </property>
 
@@ -1818,7 +1849,8 @@
     <name>metrics.processor.num.cores</name>
     <value>1</value>
     <description>
-      Number of virtual cores for metrics processor service Apache Twill runnable
+      Number of virtual cores for metrics processor service Apache Twill
+      runnable
     </description>
   </property>
 
@@ -1901,8 +1933,8 @@
     <name>operational.stats.extensions.dir</name>
     <value>/opt/cdap/master/ext/operations</value>
     <description>
-      Semicolon-separated list of local directories on the CDAP Master
-      that are scanned for operational statistics extensions
+      Semicolon-separated list of local directories on the CDAP Master that
+      are scanned for operational statistics extensions
     </description>
   </property>
 
@@ -1910,7 +1942,8 @@
     <name>operational.stats.refresh.interval.secs</name>
     <value>60</value>
     <description>
-      Number of seconds after which operational statistics should be refreshed
+      Number of seconds after which operational statistics should be
+      refreshed
     </description>
   </property>
 
@@ -1950,7 +1983,8 @@
     <name>remote.system.op.exec.threads</name>
     <value>${http.service.exec.threads}</value>
     <description>
-      Number of Netty service executor threads for the remote system operation HTTP service
+      Number of Netty service executor threads for the remote system
+      operation HTTP service
     </description>
   </property>
 
@@ -1966,7 +2000,8 @@
     <name>remote.system.op.worker.threads</name>
     <value>${http.service.worker.threads}</value>
     <description>
-      Number of Netty service IO worker threads for the remote system operation HTTP service
+      Number of Netty service IO worker threads for the remote system
+      operation HTTP service
     </description>
   </property>
 
@@ -2091,8 +2126,8 @@
     <name>mapreduce.retry.policy.type</name>
     <value>exponential.backoff</value>
     <description>
-      The type of retry policy for MapReduce programs. Allowed options: "none",
-      "fixed.delay", or "exponential.backoff".
+      The type of retry policy for MapReduce programs. Allowed options:
+      "none", "fixed.delay", or "exponential.backoff".
     </description>
   </property>
 
@@ -2239,8 +2274,8 @@
     <name>system.metrics.retry.policy.type</name>
     <value>fixed.delay</value>
     <description>
-      The type of retry policy for metrics publishing. Allowed options: "none",
-      "fixed.delay", or "exponential.backoff".
+      The type of retry policy for metrics publishing. Allowed options:
+      "none", "fixed.delay", or "exponential.backoff".
     </description>
   </property>
 
@@ -2438,11 +2473,12 @@
     <name>router.userservice.fallback.strategy</name>
     <value>random</value>
     <description>
-      If a RouteConfig is not found for a particular user service, this property is used
-      to set the fallback routing strategy. Allowed options: "random", "smallest",
-      "largest", or "drop". A string comparison of the versions of the user service is
-      used for "smallest" or "largest". The "drop" option will not route the request to
-      any service and will return "service not found".
+      If a RouteConfig is not found for a particular user service, this
+      property is used to set the fallback routing strategy. Allowed
+      options: "random", "smallest", "largest", or "drop". A string
+      comparison of the versions of the user service is used for "smallest"
+      or "largest". The "drop" option will not route the request to any
+      service and will return "service not found".
     </description>
   </property>
 
@@ -2474,8 +2510,8 @@
     <name>cdap.ugi.cache.expiration.ms</name>
     <value>3600000</value>
     <description>
-      UserGroupInformation cache entry expiration time in milliseconds. It is only used when impersonation is
-      enabled.
+      UserGroupInformation cache entry expiration time in milliseconds. It
+      is only used when impersonation is enabled.
     </description>
   </property>
 
@@ -2499,9 +2535,10 @@
     <name>security.auth.server.announce.address</name>
     <value></value>
     <description>
-      CDAP Authentication service announce address, in the format of host:port. This is
-      the address that clients should use to communicate with the Authentication Server.
-      Leave empty to use the default value generated by the Authentication Server.
+      CDAP Authentication service announce address, in the format of
+      host:port. This is the address that clients should use to communicate
+      with the Authentication Server. Leave empty to use the default value
+      generated by the Authentication Server.
     </description>
   </property>
 
@@ -2561,14 +2598,16 @@
     <name>security.authorization.admin.users</name>
     <value></value>
     <description>
-      A comma-separated list of users for whom admin privileges are to be granted on the
-      CDAP instance during CDAP startup, so that these users can create namespaces. These
-      users are also granted admin privileges on the 'default' namespace, so that they can
-      manage privileges on the 'default' namespace. This provides a method to bootstrap CDAP on
-      an authorization-enabled cluster. The default value is empty, in which case no users have
-      access to creating namespaces or to managing privileges on the 'default' namespace.
-      In that scenario, authorization in CDAP has to be bootstrapped externally using interfaces
-      provided by the configured authorization extension.
+      A comma-separated list of users for whom admin privileges are to be
+      granted on the CDAP instance during CDAP startup, so that these users
+      can create namespaces. These users are also granted admin privileges
+      on the 'default' namespace, so that they can manage privileges on the
+      'default' namespace. This provides a method to bootstrap CDAP on an
+      authorization-enabled cluster. The default value is empty, in which
+      case no users have access to creating namespaces or to managing
+      privileges on the 'default' namespace. In that scenario, authorization
+      in CDAP has to be bootstrapped externally using interfaces provided by
+      the configured authorization extension.
     </description>
   </property>
 
@@ -2585,11 +2624,12 @@
     <name>security.authorization.cache.refresh.interval.secs</name>
     <value>50</value>
     <description>
-      The interval in seconds after which a background thread will refresh cached
-      authorization policies. It is recommended to keep this value slightly lower than
-      ${security.authorization.cache.ttl.secs}, so that the cached authorization policies
-      do not expire unless they have been explicitly revoked. This setting only takes
-      effect if ${security.authorization.cache.enabled} is set to true.
+      The interval in seconds after which a background thread will refresh
+      cached authorization policies. It is recommended to keep this value
+      slightly lower than ${security.authorization.cache.ttl.secs}, so that
+      the cached authorization policies do not expire unless they have been
+      explicitly revoked. This setting only takes effect if
+      ${security.authorization.cache.enabled} is set to true.
     </description>
   </property>
 
@@ -2597,9 +2637,9 @@
     <name>security.authorization.cache.ttl.secs</name>
     <value>60</value>
     <description>
-      The time-to-live in seconds for entries in the authorization cache used by programs.
-      This setting only takes effect if ${security.authorization.cache.enabled} is set to
-      true.
+      The time-to-live in seconds for entries in the authorization cache
+      used by programs. This setting only takes effect if
+      ${security.authorization.cache.enabled} is set to true.
     </description>
   </property>
 
@@ -2646,9 +2686,9 @@
     <name>security.keytab.path</name>
     <value></value>
     <description>
-      The location of Kerberos keytabs used for impersonation. The location can contain
-      ${name}, which will be replaced by the short user name of the principal being
-      impersonated.
+      The location of Kerberos keytabs used for impersonation. The location
+      can contain ${name}, which will be replaced by the short user name of
+      the principal being impersonated.
     </description>
   </property>
 
@@ -2723,8 +2763,8 @@
     <name>security.token.digest.key.expiration.ms</name>
     <value>3600000</value>
     <description>
-      Duration in milliseconds after which an active secret key used for signing tokens should
-      be retired
+      Duration in milliseconds after which an active secret key used for
+      signing tokens should be retired
     </description>
   </property>
 
@@ -2844,8 +2884,8 @@
     <name>stream.container.memory.mb</name>
     <value>${master.service.memory.mb}</value>
     <description>
-      Memory in megabytes for each YARN container that runs the
-      stream handler
+      Memory in megabytes for each YARN container that runs the stream
+      handler
     </description>
   </property>
 
@@ -2887,8 +2927,7 @@
     <name>stream.index.interval</name>
     <value>10000</value>
     <description>
-      Interval in milliseconds for emitting new index entry in
-      stream file
+      Interval in milliseconds for emitting new index entry in stream file
     </description>
   </property>
 
@@ -2958,8 +2997,9 @@
     <name>dashboard.router.check.timeout.secs</name>
     <value>0</value>
     <description>
-      Interval in seconds that the CDAP UI waits before exiting when unable to connect to
-      the CDAP Router service on startup; use a timeout of 0 to wait indefinitely
+      Interval in seconds that the CDAP UI waits before exiting when unable
+      to connect to the CDAP Router service on startup; use a timeout of 0
+      to wait indefinitely
     </description>
   </property>
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1120,7 +1120,7 @@
     <value>7</value>
     <description>
       Maximum time in days a file is kept before it can be deleted by log
-      cleanup.
+      cleanup
     </description>
   </property>
 
@@ -1245,8 +1245,8 @@
     <value>1024</value>
     <description>
       Memory in megabytes for each log saver instance to run in YARN. This
-      is explicitly set differently than ${master.service.memory.mb} as Log
-      saver requires more memory to run than the CDAP Master service.
+      is explicitly set differently than ${master.service.memory.mb} as the
+      log saver requires more memory to run than the CDAP Master service.
     </description>
   </property>
 
@@ -1278,7 +1278,7 @@
     <name>log.saver.status.bind.address</name>
     <value>0.0.0.0</value>
     <description>
-      Log Saver HTTP service bind address
+      Log saver HTTP service bind address
     </description>
   </property>
 
@@ -1867,7 +1867,7 @@
     <name>metrics.processor.status.bind.address</name>
     <value>0.0.0.0</value>
     <description>
-      Metrics Processor HTTP service bind address
+      Metrics processor HTTP service bind address
     </description>
   </property>
 
@@ -1875,7 +1875,7 @@
     <name>metrics.query.bind.address</name>
     <value>0.0.0.0</value>
     <description>
-      Metrics Query service bind address
+      Metrics query service bind address
     </description>
   </property>
 
@@ -1883,7 +1883,7 @@
     <name>metrics.query.bind.port</name>
     <value>45005</value>
     <description>
-      Metrics Query service bind port
+      Metrics query service bind port
     </description>
   </property>
 

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="d3c2f7590eeadd82727739912ac4f3c8"
+DEFAULT_XML_MD5_HASH="b2f7202e4db5f64f1586ad9f20bae737"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="97ddb1f9b71fa064d57b094d8b306865"
+DEFAULT_XML_MD5_HASH="d3c2f7590eeadd82727739912ac4f3c8"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
Re-built cdap-default.xml: properties in each section re-ordered alphabetically.

Update MD5 hash.

Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB302-2 (passes)

Page of interest: http://builds.cask.co/artifact/CDAP-DQB302/shared/build-2/Docs-HTML/4.1.0/en/admin-manual/appendices/cdap-site.html#appendix-cdap-site-xml