### PR TITLE
DataPrep Top Panel

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+.dataprep-container {
+  .top-panel {
+    height: 50px;
+    border-bottom: 1px solid #cccccc;
+
+    .left-title {
+      .data-prep-name {
+        font-size: 18px;
+        padding: 0 10px;
+      }
+
+      .workspace-mgmt {
+        padding-left: 11px;
+        cursor: pointer;
+        font-size: 14px;
+
+        .fa-pencil { margin-left: 10px; }
+      }
+    }
+
+    .tag {
+      font-size: 10px;
+      vertical-align: top;
+      margin-left: 3px;
+      margin-top: 2px;
+      padding-bottom: 3px;
+    }
+
+    .action-buttons {
+      padding-right: 15px;
+      margin-top: 10px;
+
+      .btn { margin-left: 10px; }
+    }
+  }
+}
+
+.workspace-management-modal.modal-dialog {
+  .modal-body {
+    .button-container {
+      margin-top: 10px;
+
+      .btn:not(:first-child) {
+        margin-left: 5px;
+      }
+    }
+
+    .record-delimiter {
+      margin-top: 10px;
+      .label-control { margin-right: 10px; }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/WorkspaceModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/WorkspaceModal.js
@@ -81,7 +81,7 @@ export default class WorkspaceModal extends Component {
 
     MyDataPrepApi.execute(params)
       .subscribe((res) => {
-        cookie.save('DATAPREP_WORKSPACE', workspaceId);
+        cookie.save('DATAPREP_WORKSPACE', workspaceId, { path: '/' });
 
         DataPrepStore.dispatch({
           type: DataPrepActions.setWorkspace,
@@ -114,7 +114,7 @@ export default class WorkspaceModal extends Component {
         message: res.message
       });
 
-      cookie.save('DATAPREP_WORKSPACE', workspaceId);
+      cookie.save('DATAPREP_WORKSPACE', workspaceId, { path: '/' });
 
       DataPrepStore.dispatch({
         type: DataPrepActions.setWorkspace,
@@ -154,7 +154,7 @@ export default class WorkspaceModal extends Component {
           }
         });
 
-        cookie.remove('DATAPREP_WORKSPACE');
+        cookie.remove('DATAPREP_WORKSPACE', { path: '/' });
       }
     }, (err) => {
       console.log(err);

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/WorkspaceModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/WorkspaceModal.js
@@ -75,7 +75,7 @@ export default class WorkspaceModal extends Component {
 
     let params = {
       namespace,
-      workspaceId: workspaceId,
+      workspaceId,
       limit: 100
     };
 
@@ -248,7 +248,7 @@ export default class WorkspaceModal extends Component {
 
     return (
       <div>
-        <hr/>
+        <hr />
 
         <div>
           <h5>Upload Data</h5>
@@ -331,7 +331,7 @@ export default class WorkspaceModal extends Component {
                 <h5>
                   Current Active Workspace: <em>{this.state.activeWorkspace}</em>
                 </h5>
-                <hr/>
+                <hr />
               </div>
             ) : null
           }

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/WorkspaceModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/WorkspaceModal.js
@@ -1,0 +1,384 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { Component, PropTypes } from 'react';
+import {Modal, ModalHeader, ModalBody} from 'reactstrap';
+import MyDataPrepApi from 'api/dataprep';
+import UploadFile from 'services/upload-file';
+import DataPrepStore from 'components/DataPrep/store';
+import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
+import CardActionFeedback from 'components/CardActionFeedback';
+import cookie from 'react-cookie';
+import isNil from 'lodash/isNil';
+import NamespaceStore from 'services/NamespaceStore';
+
+export default class WorkspaceModal extends Component {
+  constructor(props) {
+    super(props);
+
+    let initialWorkspace = DataPrepStore.getState().dataprep.workspaceId;
+
+    this.state = {
+      activeWorkspace: initialWorkspace,
+      workspaceId: null,
+      file: null,
+      message: null,
+      messageType: null,
+      recordDelimiter: '\\n'
+    };
+
+    this.handleWorkspaceInput = this.handleWorkspaceInput.bind(this);
+    this.setWorkspace = this.setWorkspace.bind(this);
+    this.createWorkspace = this.createWorkspace.bind(this);
+    this.deleteWorkspace = this.deleteWorkspace.bind(this);
+    this.fileChange = this.fileChange.bind(this);
+    this.upload = this.upload.bind(this);
+    this.attemptModalClose = this.attemptModalClose.bind(this);
+    this.handleRecordDelimiterChange = this.handleRecordDelimiterChange.bind(this);
+
+    this.sub = DataPrepStore.subscribe(() => {
+      this.setState({
+        activeWorkspace: DataPrepStore.getState().dataprep.workspaceId
+      });
+    });
+  }
+
+  componentDidMount() {
+    this.workspaceInputRef.focus();
+  }
+
+  componentWillUnmount() {
+    this.sub();
+  }
+
+  handleWorkspaceInput(e) {
+    this.setState({workspaceId: e.target.value});
+  }
+
+  setWorkspace() {
+    if (!this.state.workspaceId) { return; }
+    let workspaceId = this.state.workspaceId;
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    let params = {
+      namespace,
+      workspaceId: workspaceId,
+      limit: 100
+    };
+
+    MyDataPrepApi.execute(params)
+      .subscribe((res) => {
+        cookie.save('DATAPREP_WORKSPACE', workspaceId);
+
+        DataPrepStore.dispatch({
+          type: DataPrepActions.setWorkspace,
+          payload: {
+            workspaceId,
+            data: res.value,
+            headers: res.header
+          }
+        });
+      }, (err) => {
+        console.log('err', err);
+        this.setState({
+          messageType: 'DANGER',
+          message: err.message || `${workspaceId} workspace does not exist`
+        });
+      });
+  }
+
+  createWorkspace() {
+    if (!this.state.workspaceId) { return; }
+    let workspaceId = this.state.workspaceId;
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    MyDataPrepApi.create({
+      namespace,
+      workspaceId
+    }).subscribe((res) => {
+      this.setState({
+        messageType: 'SUCCESS',
+        message: res.message
+      });
+
+      cookie.save('DATAPREP_WORKSPACE', workspaceId);
+
+      DataPrepStore.dispatch({
+        type: DataPrepActions.setWorkspace,
+        payload: {
+          workspaceId
+        }
+      });
+
+    }, (err) => {
+      this.setState({
+        messageType: 'DANGER',
+        message: err.message
+      });
+    });
+  }
+
+  deleteWorkspace() {
+    if (!this.state.workspaceId) { return; }
+    let workspaceId = this.state.workspaceId;
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    MyDataPrepApi.delete({
+      namespace,
+      workspaceId
+    }).subscribe((res) => {
+      console.log(res);
+      this.setState({
+        messageType: 'SUCCESS',
+        message: res.message
+      });
+
+      if (this.state.workspaceId === this.state.activeWorkspace) {
+        DataPrepStore.dispatch({
+          type: DataPrepActions.setWorkspace,
+          payload: {
+            workspaceId: ''
+          }
+        });
+
+        cookie.remove('DATAPREP_WORKSPACE');
+      }
+    }, (err) => {
+      console.log(err);
+
+      this.setState({
+        messageType: 'DANGER',
+        message: err.message
+      });
+    });
+
+  }
+
+  fileChange(e) {
+    this.setState({file: e.target.files[0]});
+  }
+
+  handleRecordDelimiterChange(e) {
+    this.setState({recordDelimiter: e.target.value});
+  }
+
+  upload() {
+    if (!this.state.file) { return; }
+
+    let delimiter = this.state.recordDelimiter;
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    let url = `/namespaces/${namespace}/apps/wrangler/services/service/methods/workspaces/${this.state.activeWorkspace}/upload`;
+
+    let headers = {
+      'Content-Type': 'application/octet-stream',
+      'X-Archive-Name': name
+    };
+
+    if (window.CDAP_CONFIG.securityEnabled) {
+      let token = cookie.load('CDAP_Auth_Token');
+      if (!isNil(token)) {
+        headers.Authorization = `Bearer ${token}`;
+      }
+    }
+
+    if (delimiter) {
+      headers['recorddelimiter'] = delimiter;
+    }
+
+    UploadFile({url, fileContents: this.state.file, headers})
+      .subscribe((res) => {
+        console.log(res);
+
+        let params = {
+          namespace,
+          workspaceId: this.state.activeWorkspace,
+          limit: 100
+        };
+
+        MyDataPrepApi.execute(params)
+          .subscribe((response) => {
+            console.log('res', response);
+
+            DataPrepStore.dispatch({
+              type: DataPrepActions.setWorkspace,
+              payload: {
+                workspaceId: this.state.activeWorkspace,
+                data: response.value,
+                headers: response.header
+              }
+            });
+
+            this.setState({
+              messageType: 'SUCCESS',
+              message: `Success uploading file to workspace ${this.state.activeWorkspace}`
+            });
+          }, (err) => {
+            console.log('err', err);
+            this.setState({
+              messageType: 'DANGER',
+              message: err.message || `${this.state.activeWorkspace} workspace does not exist`
+            });
+          });
+
+      }, (err) => {
+        console.log(err);
+        this.setState({
+          messageType: 'DANGER',
+          message: err.message
+        });
+      });
+  }
+
+  renderUploadSection() {
+    if (!this.state.activeWorkspace) { return null; }
+
+    return (
+      <div>
+        <hr/>
+
+        <div>
+          <h5>Upload Data</h5>
+          <h6>Select the file to be uploaded to active workspace</h6>
+          <div className="file-input">
+            <input
+              type="file"
+              className="form-control"
+              onChange={this.fileChange}
+            />
+          </div>
+
+          <div className="clearfix">
+            <div className="button-container float-xs-left">
+              <button
+                className="btn btn-secondary"
+                onClick={this.upload}
+                disabled={!this.state.file}
+              >
+                Upload
+              </button>
+            </div>
+
+            <div className="record-delimiter form-inline float-xs-right">
+              <label className="label-control">Record Delimiter:</label>
+              <input
+                type="text"
+                className="form-control"
+                value={this.state.recordDelimiter}
+                onChange={this.handleRecordDelimiterChange}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  renderFooter() {
+    if (!this.state.message) { return null; }
+
+    return (
+      <CardActionFeedback
+        type={this.state.messageType}
+        message={this.state.message}
+      />
+    );
+  }
+
+  attemptModalClose() {
+    if (!this.state.activeWorkspace) { return; }
+
+    this.props.toggle();
+  }
+
+  render() {
+    return (
+      <Modal
+        isOpen={true}
+        toggle={this.attemptModalClose}
+        zIndex="1070"
+        className="workspace-management-modal"
+      >
+        <ModalHeader>
+          <span>
+            Workspace
+          </span>
+
+          <div
+            className="close-section float-xs-right"
+            onClick={this.props.toggle}
+          >
+            <span className="fa fa-times" />
+          </div>
+        </ModalHeader>
+        <ModalBody>
+          {
+            this.state.activeWorkspace ? (
+              <div>
+                <h5>
+                  Current Active Workspace: <em>{this.state.activeWorkspace}</em>
+                </h5>
+                <hr/>
+              </div>
+            ) : null
+          }
+
+          <div>
+            <h5>Set or Create New Workspace</h5>
+            <small>Create workspace before starting to wrangle</small>
+            <input
+              type="text"
+              className="form-control"
+              value={this.state.workspaceId}
+              onChange={this.handleWorkspaceInput}
+              ref={ref => this.workspaceInputRef = ref}
+            />
+          </div>
+          <div className="button-container">
+            <button
+              className="btn btn-secondary"
+              onClick={this.setWorkspace}
+            >
+              Set
+            </button>
+            <button
+              className="btn btn-primary"
+              onClick={this.createWorkspace}
+            >
+              Create
+            </button>
+
+            <button
+              className="btn btn-danger float-xs-right"
+              onClick={this.deleteWorkspace}
+            >
+              Delete
+            </button>
+          </div>
+
+          {this.renderUploadSection()}
+
+        </ModalBody>
+
+        {this.renderFooter()}
+      </Modal>
+    );
+  }
+}
+
+WorkspaceModal.propTypes = {
+  toggle: PropTypes.func.isRequired
+};

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/index.js
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { Component } from 'react';
+import WorkspaceModal from 'components/DataPrep/TopPanel/WorkspaceModal';
+import DataPrepStore from 'components/DataPrep/store';
+import ee from 'event-emitter';
+
+require('./TopPanel.scss');
+
+export default class DataPrepTopPanel extends Component {
+  constructor(props) {
+    super(props);
+
+    let initialWorkspace = DataPrepStore.getState().dataprep.workspaceId;
+    this.state = {
+      workspaceId: initialWorkspace,
+      workspaceModal: false,
+    };
+
+    this.toggleWorkspaceModal = this.toggleWorkspaceModal.bind(this);
+    this.eventEmitter = ee(ee);
+
+    this.eventEmitter.on('DATAPREP_NO_WORKSPACE_ID', this.toggleWorkspaceModal);
+
+    this.sub = DataPrepStore.subscribe(() => {
+      let storeWorkspace = DataPrepStore.getState().dataprep.workspaceId;
+      this.setState({
+        workspaceId: storeWorkspace
+      });
+    });
+  }
+
+  componentWillUnmount() {
+    this.sub();
+    this.eventEmitter.off('DATAPREP_NO_WORKSPACE_ID', this.toggleWorkspaceModal);
+  }
+
+  toggleWorkspaceModal() {
+    this.setState({workspaceModal: !this.state.workspaceModal});
+  }
+
+  renderWorkspaceModal() {
+    if (!this.state.workspaceModal) { return null; }
+
+    return (
+      <WorkspaceModal toggle={this.toggleWorkspaceModal} />
+    );
+  }
+
+  render() {
+    return (
+      <div className="top-panel clearfix">
+        <div className="left-title float-xs-left">
+          <div className="data-prep-name">
+            <strong>Data Preparation</strong>
+            <span className="tag tag-success">BETA</span>
+          </div>
+
+          <div
+            className="workspace-mgmt"
+            onClick={this.toggleWorkspaceModal}
+          >
+            <span>
+              {this.state.workspaceId}
+              {this.renderWorkspaceModal()}
+            </span>
+            <span className="fa fa-pencil" />
+          </div>
+        </div>
+
+        <div className="action-buttons float-xs-right">
+          <button
+            className="btn btn-primary"
+            disabled
+          >
+            Add to Pipeline
+          </button>
+
+          <button
+            className="btn btn-secondary"
+            disabled
+          >
+            View Schema
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/index.js
@@ -15,7 +15,7 @@
  */
 
 import React, { Component } from 'react';
-// import DataPrepTopPanel from 'components/DataPrep/TopPanel';
+import DataPrepTopPanel from 'components/DataPrep/TopPanel';
 // import DataPrepTable from 'components/DataPrep/DataPrepTable';
 // import DataPrepSidePanel from 'components/DataPrep/DataPrepSidePanel';
 // import DataPrepCLI from 'components/DataPrep/DataPrepCLI';
@@ -106,7 +106,7 @@ export default class DataPrep extends Component {
 
     return (
       <div className="dataprep-container">
-        <h4>DataPrep</h4>
+        <DataPrepTopPanel />
       </div>
     );
   }

--- a/cdap-ui/app/cdap/components/DataPrep/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/index.js
@@ -36,7 +36,8 @@ export default class DataPrep extends Component {
     super(props);
 
     this.state = {
-      backendDown: false
+      backendDown: false,
+      loading: true
     };
 
     this.toggleBackendDown = this.toggleBackendDown.bind(this);
@@ -66,7 +67,10 @@ export default class DataPrep extends Component {
             workspaceId
           }
         });
+
+        this.setState({loading: false});
       }, (err) => {
+        this.setState({loading: false});
         if (err.statusCode === 503) {
           console.log('backend not started');
           this.eventEmitter.emit('DATAPREP_BACKEND_DOWN');
@@ -80,6 +84,7 @@ export default class DataPrep extends Component {
         });
         this.eventEmitter.emit('DATAPREP_NO_WORKSPACE_ID');
       });
+
   }
 
   componentWillUnmount() {
@@ -103,6 +108,16 @@ export default class DataPrep extends Component {
 
   render() {
     if (this.state.backendDown) { return this.renderBackendDown(); }
+
+    if (this.state.loading) {
+      return (
+        <div className="dataprep-container">
+          <h3 className="text-xs-center">
+            <span className="fa fa-spin fa-spinner" />
+          </h3>
+        </div>
+      );
+    }
 
     return (
       <div className="dataprep-container">

--- a/cdap-ui/app/cdap/components/DataPrep/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/index.js
@@ -77,7 +77,7 @@ export default class DataPrep extends Component {
           return;
         }
 
-        cookie.remove('DATAPREP_WORKSPACE');
+        cookie.remove('DATAPREP_WORKSPACE', { path: '/' });
 
         DataPrepStore.dispatch({
           type: DataPrepActions.setInitialized


### PR DESCRIPTION
### Functionality:
- If no cookie present, the workspace modal should open
- User should be able to create, set, or delete a workspace
- If there is an active workspace, user can upload file and specify record delimiter (default to `\n`)




Currently pointing to `feature/ui-dataprep-improvement` branch for ease of review. Will change the merge branch to develop once that branch is merged