### PR TITLE
Use namespace id string instead of NamespaceId

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -514,7 +514,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
 
     String tempLocationName = String.format("%s/%s.%s.%s.%s.%s", cConf.get(Constants.AppFabric.TEMP_DIR),
                                             programId.getType().name().toLowerCase(),
-                                            programId.getNamespaceId(), programId.getApplication(),
+                                            programId.getNamespaceId().getEntityName(), programId.getApplication(),
                                             programId.getProgram(), context.getRunId().getId());
     Location location = locationFactory.get(programId.getNamespaceId()).append(tempLocationName);
     location.mkdirs();


### PR DESCRIPTION
The issue was in `MapReduceRuntimeService` instead of using namespace name as a string, we were using `NamespaceId.toString()`.

Build: http://builds.cask.co/browse/CDAP-DUT5567
ITM: http://builds.cask.co/browse/CDAP-ITM-113

Tested ValueMapperTest on cdh 5.8 which was failing without these changes.