### PR TITLE
DataPrep CLI and AutoComplete

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/AutoComplete/AutoComplete.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/AutoComplete/AutoComplete.scss
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+.dataprep-auto-complete-container {
+  position: absolute;
+  bottom: 29px;
+  left: 0;
+  right: 0;
+  background-color: black;
+  color: #cccccc;
+
+  &.has-error { bottom: 48px; }
+
+  .result-row {
+    border-bottom: 1px solid #cccccc;
+    padding: 5px 10px;
+    cursor: pointer;
+
+    &.active,
+    &:hover {
+      background-color: #333333;
+    }
+
+    .directive-description {
+      padding-left: 20px;
+      font-size: 12px;
+      color: #888888;
+    }
+
+    .directive-usage {
+      margin-top: 5px;
+      padding-left: 20px;
+
+      pre {
+        color: #27ae60;
+        margin-top: 5px;
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/AutoComplete/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/AutoComplete/index.js
@@ -1,0 +1,237 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { Component, PropTypes } from 'react';
+import MyDataPrepApi from 'api/dataprep';
+import Fuse from 'fuse.js';
+import shortid from 'shortid';
+import reverse from 'lodash/reverse';
+import Mousetrap from 'mousetrap';
+import classnames from 'classnames';
+import NamespaceStore from 'services/NamespaceStore';
+
+require('./AutoComplete.scss');
+
+export default class DataPrepAutoComplete extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      activeResults: [],
+      input: '',
+      matched: false,
+      activeSelectionIndex: null
+    };
+  }
+
+  componentWillMount() {
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    MyDataPrepApi.getUsage({ namespace })
+      .subscribe((res) => {
+        const fuseOptions = {
+          include: ['matches', 'score'],
+          caseSensitive: false,
+          threshold: 0,
+          shouldSort: true,
+          location: 0,
+          distance: 100,
+          minMatchCharLength: 1,
+          maxPatternLength: 32,
+          keys: [
+            "directive"
+          ]
+        };
+
+        this.fuse = new Fuse(res.values, fuseOptions);
+      });
+  }
+
+  componentDidMount() {
+    let directiveInput = document.getElementById('directive-input');
+    this.mousetrap = new Mousetrap(directiveInput);
+
+    this.mousetrap.bind('esc', this.props.toggle);
+    this.mousetrap.bind('up', this.handleUpArrow.bind(this));
+    this.mousetrap.bind('down', this.handleDownArrow.bind(this));
+    this.mousetrap.bind('enter', this.handleEnterKey.bind(this));
+    this.mousetrap.bind('tab', this.handleTabKey.bind(this));
+  }
+
+  componentWillUnmount() {
+    this.mousetrap.unbind('esc');
+    this.mousetrap.unbind('up');
+    this.mousetrap.unbind('down');
+    this.mousetrap.unbind('enter');
+    this.mousetrap.unbind('tab');
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.input !== this.state.input) {
+      this.searchMatch(nextProps.input);
+    }
+  }
+
+  handleRowClick(row) {
+    if (typeof this.props.onRowClick !== 'function') { return; }
+
+    let eventObject = {
+      target: { value: `${row.item.directive} `}
+    };
+
+    this.props.onRowClick(eventObject);
+    this.props.inputRef.focus();
+  }
+
+  handleUpArrow(e) {
+    if (e.preventDefault) {
+      e.preventDefault();
+    } else {
+      e.returnValue = false;
+    }
+    if (this.state.activeSelectionIndex === 0) { return; }
+
+    this.setState({activeSelectionIndex: this.state.activeSelectionIndex - 1});
+  }
+
+  handleDownArrow(e) {
+    if (e.preventDefault) {
+      e.preventDefault();
+    } else {
+      e.returnValue = false;
+    }
+    if (this.state.activeSelectionIndex === this.state.activeResults.length - 1) { return; }
+
+    this.setState({activeSelectionIndex: this.state.activeSelectionIndex + 1});
+  }
+
+  handleEnterKey() {
+    if (this.state.input.length === 0) { return; }
+
+    let selectedDirective = this.state.activeResults[this.state.activeSelectionIndex];
+
+    let inputSplit = this.state.input.split(' '),
+        directiveSplit = selectedDirective ? selectedDirective.item.directive.split(' ') : [];
+
+    let splitLengthCheck = inputSplit.length < directiveSplit.length,
+        stringLengthCheck = selectedDirective && this.state.input.length <= selectedDirective.item.directive.length;
+
+    if (selectedDirective && (splitLengthCheck || stringLengthCheck)) {
+      this.handleRowClick(this.state.activeResults[this.state.activeSelectionIndex]);
+    } else {
+      this.props.execute([this.state.input]);
+    }
+  }
+
+  handleTabKey(e) {
+    if (this.state.input.length === 0 || this.state.input.split(' ').length !== 1) { return; }
+
+    if (e.preventDefault) {
+      e.preventDefault();
+    } else {
+      e.returnValue = false;
+    }
+
+    this.handleEnterKey();
+  }
+
+  searchMatch(query) {
+    let results = [];
+    let input = query;
+    let spaceIndex = input.indexOf(' ');
+    if (spaceIndex !== -1) {
+      input = input.slice(0, spaceIndex);
+    }
+
+    // Currently only showing 3 matches. Future improvement will be to allow
+    // user to scroll through all the matches
+    if (this.fuse && input.length > 0) {
+      results = this.fuse.search(input)
+        .slice(0, 3)
+        .filter((row, index) => {
+          if (spaceIndex === -1) {
+            return true;
+          }
+
+          return row.score === 0 && index === 0;
+        })
+        .map((row) => {
+          row.uniqueId = shortid.generate();
+          return row;
+        });
+
+        reverse(results);
+    }
+
+    this.setState({
+      activeResults: results,
+      input: query,
+      matched: spaceIndex !== -1,
+      activeSelectionIndex: results.length - 1
+    });
+  }
+
+  render() {
+    if (!this.props.isOpen || this.state.activeResults.length === 0) { return null; }
+
+    return (
+      <div className={classnames('dataprep-auto-complete-container', {
+        'has-error': this.props.hasError
+      })}>
+        {
+          this.state.activeResults.map((row, index) => {
+            return (
+              <div
+                className={classnames('result-row', { active: index === this.state.activeSelectionIndex})}
+                key={row.uniqueId}
+                onClick={this.handleRowClick.bind(this, row)}
+              >
+                <div className="directive-title">
+                  <strong>{row.item.directive}</strong>
+                </div>
+                <div className="directive-description">
+                  {row.item.description}
+                </div>
+
+                { this.state.matchedmatched || this.state.activeResults.length === 1  ?
+                    (
+                      <div className="directive-usage">
+                        <span>Usage: </span>
+                        <pre>{row.item.usage}</pre>
+                      </div>
+                    )
+                  :
+                    null
+                }
+              </div>
+            );
+          })
+        }
+      </div>
+    );
+  }
+}
+
+DataPrepAutoComplete.propTypes = {
+  isOpen: PropTypes.bool,
+  toggle: PropTypes.func,
+  input: PropTypes.string,
+  onRowClick: PropTypes.func,
+  inputRef: PropTypes.any,
+  hasError: PropTypes.any,
+  execute: PropTypes.func
+};
+

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepCLI/DataPrepCLI.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepCLI/DataPrepCLI.scss
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+$cli-color: #27ae60;
+$cli-font: "Courier New", Courier, monospace;
+
+.dataprep-container {
+  .dataprep-cli {
+    position: fixed;
+    bottom: 54px;
+    height: 30px;
+    width: 75%;
+    border-top: 1px solid #cccccc;
+
+    .error-bar {
+      background-color: #c0392b;
+      color: white;
+      padding: 0 10px;
+      position: absolute;
+      width: 100%;
+      bottom: 29px;
+      z-index: 1000;
+
+      .content {
+        width: calc(100% - 30px);
+        display: inline-block;
+        word-break: break-word;
+      }
+
+      .fa.fa-times {
+        cursor: pointer;
+        position: absolute;
+        top: 3px;
+        right: 5px;
+      }
+    }
+
+    .input-container {
+      background-color: black;
+      color: $cli-color;
+      font-family: $cli-font;
+      strong {
+        margin-left: 10px;
+        user-select: none;
+      }
+
+      .directive-input {
+        width: calc(100% - 25px);
+        display: inline-block;
+
+        .form-control {
+          border: 0;
+          background-color: black;
+          color: $cli-color;
+          font-family: $cli-font;
+          font-size: 14px;
+        }
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepCLI/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepCLI/index.js
@@ -1,0 +1,166 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { Component } from 'react';
+import DataPrepStore from 'components/DataPrep/store';
+import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
+import MyDataPrepApi from 'api/dataprep';
+import DataPrepAutoComplete from 'components/DataPrep/AutoComplete';
+import NamespaceStore from 'services/NamespaceStore';
+require('./DataPrepCLI.scss');
+
+export default class DataPrepCLI extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      directiveInput: '',
+      error: null,
+      autoCompleteOpen: false
+    };
+
+    this.handleDirectiveChange = this.handleDirectiveChange.bind(this);
+    this.toggleAutoComplete = this.toggleAutoComplete.bind(this);
+    this.dismissError = this.dismissError.bind(this);
+    this.handlePaste = this.handlePaste.bind(this);
+    this.execute = this.execute.bind(this);
+  }
+
+  componentDidMount() {
+    if (this.directiveRef) {
+      this.directiveRef.focus();
+    }
+  }
+
+  handleDirectiveChange(e) {
+    this.setState({
+      directiveInput: e.target.value,
+      autoCompleteOpen: true
+    });
+  }
+
+  toggleAutoComplete() {
+    this.setState({autoCompleteOpen: !this.state.autoCompleteOpen});
+  }
+
+  execute(addDirective) {
+    if (addDirective.length === 0) { return; }
+
+    let store = DataPrepStore.getState().dataprep;
+    let updatedDirectives = store.directives.concat(addDirective);
+
+    let workspaceId = store.workspaceId;
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    let params = {
+      namespace,
+      workspaceId,
+      limit: 100,
+      directive: updatedDirectives
+    };
+
+    MyDataPrepApi.execute(params)
+      .subscribe((res) => {
+        this.setState({
+          error: null,
+          directiveInput: ''
+        });
+
+        DataPrepStore.dispatch({
+          type: DataPrepActions.setDirectives,
+          payload: {
+            data: res.value,
+            headers: res.header,
+            directives: updatedDirectives
+          }
+        });
+      }, (err) => {
+        this.setState({
+          error: err.message || err.response.message
+        });
+      });
+
+  }
+
+  dismissError() {
+    this.setState({error: null});
+  }
+
+  renderError() {
+    if (!this.state.error) { return null; }
+
+    return (
+      <div className="error-bar">
+        <span className="content">
+          {this.state.error}
+        </span>
+
+        <span
+          className="fa fa-times float-xs-right"
+          onClick={this.dismissError}
+        />
+      </div>
+    );
+  }
+
+  handlePaste(e) {
+    let data = e.clipboardData.getData('Text');
+    data = data.split('\n')
+      .filter((row) => {
+        // filter out empty rows
+        return row.trim().length > 0;
+      });
+
+    if (data.length > 1) {
+      e.preventDefault();
+      this.execute(data);
+    }
+  }
+
+  render() {
+    return (
+      <div className="dataprep-cli">
+
+        {this.renderError()}
+
+        <DataPrepAutoComplete
+          input={this.state.directiveInput}
+          onRowClick={this.handleDirectiveChange}
+          inputRef={this.directiveRef}
+          toggle={this.toggleAutoComplete}
+          isOpen={this.state.autoCompleteOpen}
+          hasError={this.state.error}
+          execute={this.execute}
+        />
+
+        <div className="input-container">
+          <strong>$</strong>
+          <div className="directive-input">
+            <input
+              type="text"
+              className="form-control mousetrap"
+              id="directive-input"
+              value={this.state.directiveInput}
+              onChange={this.handleDirectiveChange}
+              ref={(ref) => this.directiveRef = ref}
+              onPaste={this.handlePaste}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/index.js
@@ -18,7 +18,7 @@ import React, { Component } from 'react';
 import DataPrepTopPanel from 'components/DataPrep/TopPanel';
 import DataPrepTable from 'components/DataPrep/DataPrepTable';
 import DataPrepSidePanel from 'components/DataPrep/DataPrepSidePanel';
-// import DataPrepCLI from 'components/DataPrep/DataPrepCLI';
+import DataPrepCLI from 'components/DataPrep/DataPrepCLI';
 import MyDataPrepApi from 'api/dataprep';
 import cookie from 'react-cookie';
 import DataPrepStore from 'components/DataPrep/store';
@@ -128,6 +128,7 @@ export default class DataPrep extends Component {
         <div className="row dataprep-body">
           <div className="dataprep-main col-xs-9">
             <DataPrepTable />
+            <DataPrepCLI />
           </div>
 
           <DataPrepSidePanel />


### PR DESCRIPTION
## Features:

### CLI: 
- User should be able to execute directive command
- When an error occurred, error bar should show up above the CLI
- User should be able to close the error
- When user submitted a directive successfully, the CLI should clear, autocomplete closed, and DataPrepTable updated with the new data.

### Autocomplete:
- When user types in the CLI, the top 3 matched directives should show up in the autocomplete displayed in reverse order of matched score. 
- When there are more than 1 match, the autocomplete only show the directive name and description. Default selection is the bottom most directive.
- When there is only 1 match, the autocomplete section will display the usage information for that particular directive.
- When user click on the autocomplete, the full directive name will be applied to CLI + a space.
- User should be able to navigate the autocomplete matches using keyboard arrow up and down. This interaction should not move the cursor on the CLI.
- User can apply selection by hitting `TAB` or `ENTER`.

### Pasting Directives:
- When user paste 1 line of directive, the full line should show up in the CLI without it being applied
- When user paste multiple line of directive, it should apply all the directives, and CLI remains empty
- If an error occurred during pasting of multiline, none of the directives should be applied, and error message surfaced
- Pasting multiline should ignore empty line



#### Note:
- Currently, the autocomplete only works with single word directive.
- Branched from `feature/ui-dataprep-table` for ease of review. Will change base branch to `develop` once other branch is merged.