### PR TITLE
[CDAP-8433][CDAP-8861] Minor UI bugfixes

### DIFF
--- a/cdap-ui/app/cdap/components/AdminDetailPanel/index.js
+++ b/cdap-ui/app/cdap/components/AdminDetailPanel/index.js
@@ -35,6 +35,14 @@ class AdminDetailPanel extends Component {
 
   constructor(props) {
     super(props);
+    this.statsWithUnits = [
+      'RemainingBytes',
+      'TotalBytes',
+      'UsedBytes',
+      'FreeMemory',
+      'TotalMemory',
+      'UsedMemory'
+    ];
   }
 
   render() {
@@ -52,7 +60,7 @@ class AdminDetailPanel extends Component {
         Object.keys(this.props.serviceData[key]).map((item) => {
           let humanReadableNum;
 
-          if (key === 'storage' || key === 'memory') {
+          if (this.statsWithUnits.indexOf(item) > -1) {
             humanReadableNum = humanReadableNumber(this.props.serviceData[key][item], 'STORAGE');
           } else {
             humanReadableNum = humanReadableNumber(this.props.serviceData[key][item]);

--- a/cdap-ui/app/cdap/components/Header/ProductDropdown/AccessTokenModal/index.js
+++ b/cdap-ui/app/cdap/components/Header/ProductDropdown/AccessTokenModal/index.js
@@ -192,7 +192,6 @@ export default class AccessTokenModal extends Component {
 }
 
 AccessTokenModal.propTypes = {
-  cdapVersion: PropTypes.string,
   isOpen: PropTypes.bool,
   toggle: PropTypes.func
 };

--- a/cdap-ui/app/cdap/components/MarketActionsContainer/index.js
+++ b/cdap-ui/app/cdap/components/MarketActionsContainer/index.js
@@ -152,8 +152,7 @@ MarketActionsContainer.contextTypes = {
     author: PropTypes.string,
     description: PropTypes.string,
     org: PropTypes.string,
-    created: PropTypes.number,
-    cdapVersion: PropTypes.string
+    created: PropTypes.number
   })
 };
 

--- a/cdap-ui/app/cdap/components/MarketPlaceEntity/index.js
+++ b/cdap-ui/app/cdap/components/MarketPlaceEntity/index.js
@@ -263,12 +263,6 @@ export default class MarketPlaceEntity extends Component {
                     </span>
                     <span> {this.props.entity.author} </span>
                   </div>
-                  <div>
-                    <span>
-                      <strong> {T.translate('features.MarketPlaceEntity.Metadata.cdapversion')} </strong>
-                    </span>
-                    <span> {this.props.entity.cdapVersion} </span>
-                  </div>
                 </div>
               </div>
             </div>

--- a/cdap-ui/app/cdap/components/MarketPlaceUsecaseEntity/index.js
+++ b/cdap-ui/app/cdap/components/MarketPlaceUsecaseEntity/index.js
@@ -57,18 +57,6 @@ export default class MarketPlaceUsecaseEntity extends Component {
     });
   }
 
-  getVersion() {
-    const versionElem = (
-      <span>
-        <strong>
-          {this.props.entity.cdapVersion}
-        </strong>
-      </span>
-    );
-
-    return this.props.entity.cdapVersion ? versionElem : null;
-  }
-
   fetchEntityDetail() {
     if (this.state.showActions) {
       this.setState({ showActions: false });
@@ -149,8 +137,6 @@ export default class MarketPlaceUsecaseEntity extends Component {
                   {(moment(this.props.entity.created * 1000)).format('MM-DD-YYYY HH:mm A')}
                 </strong>
               </span>
-              {this.props.entity.cdapVersion ? <div>CDAP Version</div> : null}
-              {this.getVersion()}
             </div>
           </div>
         </div>
@@ -204,7 +190,6 @@ MarketPlaceUsecaseEntity.propTypes = {
     description: PropTypes.string,
     org: PropTypes.string,
     created: PropTypes.number,
-    cdapVersion: PropTypes.string,
     beta: PropTypes.bool
   })
 };

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -446,7 +446,6 @@ features:
       author: Author
       company: Company
       created: Created
-      cdapversion: CDAP Version
     doneLabel: Done
     closeLabel: Close
   MarketEntityModal:


### PR DESCRIPTION
[CDAP-8433] https://issues.cask.co/browse/CDAP-8433
- Show units for memory for YARN in the Administration page.

[CDAP-8861] https://issues.cask.co/browse/CDAP-8861
- Removed CDAP Version Range from the card of Market entities.
- Also removed unnecessary cdapVersion prop in the AccessTokenModal.