### PR TITLE
DataPrep Side Panel

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/ColumnsTab/ColumnsTabRow.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/ColumnsTab/ColumnsTabRow.js
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { Component, PropTypes } from 'react';
+import classnames from 'classnames';
+
+export default class ColumnsTabRow extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      expanded: false
+    };
+
+    this.toggleRowExpand = this.toggleRowExpand.bind(this);
+  }
+
+  toggleRowExpand() {
+    if (!this.state.expanded) {
+      let elem = document.getElementById(`column-${this.props.columnName}`);
+      elem.scrollIntoView();
+
+      elem.classList.add('selected');
+
+      setTimeout(() => {
+        elem.classList.remove('selected');
+      }, 3000);
+    }
+
+    this.setState({expanded: !this.state.expanded});
+  }
+
+  renderTypesTable() {
+    let types = this.props.rowInfo.types;
+    if (!types) { return; }
+
+    let headers = Object.keys(types);
+
+    return (
+      <div className="types-table-container">
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Inferred Type</th>
+              <th>% Chance</th>
+            </tr>
+          </thead>
+
+          <tbody>
+            {
+              headers.map((head) => {
+                return (
+                  <tr key={head}>
+                    <td>{head}</td>
+                    <td>{types[head]}</td>
+                  </tr>
+                );
+              })
+            }
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
+  renderExpanded() {
+    if (!this.state.expanded) { return null; }
+
+    let generalInfo = this.props.rowInfo.general;
+
+    let nonNull = generalInfo['non-null'] || 0,
+        nullCell = generalInfo['null'] || 0,
+        empty = generalInfo['empty'] || 0;
+
+    let filled = nonNull - empty;
+
+    return (
+      <div className="expanded-row">
+        <div className="quality-bar">
+          <span
+            className="filled"
+            style={{width: `${filled}%`}}
+          />
+
+          <span
+            className="empty"
+            style={{width: `${empty}%`}}
+          />
+
+          <span
+            className="null-cell"
+            style={{width: `${nullCell}%`}}
+          />
+        </div>
+
+        {this.renderTypesTable()}
+
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <div className="columns-tab-row">
+        <div
+          className={classnames('row-header', {
+            'expanded': this.state.expanded,
+            'invalid': !this.props.rowInfo.isValid
+          })}
+          onClick={this.toggleRowExpand}
+        >
+          {this.props.index + 1}. {this.props.columnName}
+        </div>
+
+        {this.renderExpanded()}
+      </div>
+    );
+  }
+}
+
+ColumnsTabRow.propTypes = {
+  rowInfo: PropTypes.object,
+  index: PropTypes.number,
+  columnName: PropTypes.string
+};

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/ColumnsTab/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/ColumnsTab/index.js
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { Component } from 'react';
+import DataPrepStore from 'components/DataPrep/store';
+import MyDataPrepApi from 'api/dataprep';
+import shortid from 'shortid';
+import ColumnsTabRow from 'components/DataPrep/DataPrepSidePanel/ColumnsTab/ColumnsTabRow';
+import {objectQuery} from 'services/helpers';
+import NamespaceStore from 'services/NamespaceStore';
+
+export default class ColumnsTab extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      columns: {},
+      headers: [],
+      loading: true,
+      error: null,
+      searchText: ''
+    };
+
+    this.handleChangeSearch = this.handleChangeSearch.bind(this);
+    this.clearSearch = this.clearSearch.bind(this);
+
+    this.sub = DataPrepStore.subscribe(this.getSummary.bind(this));
+
+    this.getSummary();
+  }
+
+  componentWillUnmount() {
+    this.sub();
+  }
+
+  getSummary() {
+    let state = DataPrepStore.getState().dataprep;
+    if (!state.workspaceId) { return; }
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    let params = {
+      namespace,
+      workspaceId: state.workspaceId,
+      limit: 100,
+      directive: state.directives
+    };
+
+    MyDataPrepApi.summary(params)
+      .subscribe((res) => {
+        let columns = {};
+
+        state.headers.forEach((head) => {
+          columns[head] = {
+            general: objectQuery(res, 'value', 'statistics', head, 'general'),
+            types: objectQuery(res, 'value', 'statistics', head, 'types'),
+            isValid: objectQuery(res, 'value', 'validation', head, 'valid')
+          };
+        });
+
+        this.setState({
+          columns,
+          loading: false,
+          headers: state.headers.map((res) => {
+            let obj = {
+              name: res,
+              uniqueId: shortid.generate()
+            };
+            return obj;
+          })
+        });
+      }, (err) => {
+        console.log('error fetching summary', err);
+        this.setState({
+          loading: false,
+          error: err.message
+        });
+      });
+  }
+
+  handleChangeSearch(e) {
+    this.setState({searchText: e.target.value});
+  }
+
+  clearSearch() {
+    this.setState({searchText: ''});
+  }
+
+  render() {
+    if (this.state.loading) {
+      return (
+        <div className="columns-tab text-xs-center">
+          <span className="fa fa-spin fa-spinner" />
+        </div>
+      );
+    }
+
+    let displayHeaders = this.state.headers;
+
+    if (this.state.searchText.length > 0) {
+      displayHeaders = displayHeaders.filter((head) => {
+        let headerLower = head.name.toLowerCase();
+        let search = this.state.searchText.toLowerCase();
+
+        return headerLower.indexOf(search) !== -1;
+      });
+    }
+
+    return (
+      <div className="columns-tab">
+        <div className="search-box">
+          <input
+            type="text"
+            className="form-control"
+            placeholder="search"
+            value={this.state.searchText}
+            onChange={this.handleChangeSearch}
+          />
+
+          {
+            this.state.searchText.length === 0 ?
+              (<span className="fa fa-search" />)
+            :
+              (
+                <span
+                  className="fa fa-times-circle"
+                  onClick={this.clearSearch}
+                />
+              )
+          }
+        </div>
+        <div className="columns-list">
+          {
+            displayHeaders.map((head, index) => {
+              return (
+                <ColumnsTabRow
+                  rowInfo={this.state.columns[head.name]}
+                  columnName={head.name}
+                  index={index}
+                  key={head.uniqueId}
+                />
+              );
+            })
+          }
+        </div>
+      </div>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/DataPrepSidePanel.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/DataPrepSidePanel.scss
@@ -1,0 +1,188 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+$tab-header-height: 37px;
+
+.dataprep-container {
+  .dataprep-side-panel {
+    border-left: 1px solid #cccccc;
+    height: 100%;
+    padding: 0;
+
+    .tabs-headers {
+      height: $tab-header-height;
+      display: inline-flex;
+      width: 100%;
+
+      .tab {
+        flex-grow: 1;
+        padding: 0 10px;
+        line-height: $tab-header-height;
+        cursor: pointer;
+        background-color: #aaaaaa;
+        color: white;
+
+        &.active {
+          background-color: white;
+          color: #333333;
+        }
+
+        &:not(:last-child) {
+          border-right: 1px solid #cccccc;
+        }
+      }
+    }
+
+    .tabs {
+      height: 100%;
+
+      .empty-message { margin-top: 25px; }
+    }
+
+    .tab-content {
+      height: calc(100% - 37px);
+      overflow: auto;
+    }
+
+    .directives-tab {
+      .directives-tab-header,
+      .directives-row {
+        border-bottom: 1px solid #cccccc;
+        padding: 10px;
+
+        > span {
+          display: inline-block;
+
+          &:first-child {
+            width: 25px;
+          }
+
+          &:nth-child(2) {
+            width: calc(100% - 50px);
+            vertical-align: middle;
+            word-break: break-word;
+
+            &.expandable { cursor: pointer; }
+
+            &.truncate {
+              overflow: hidden;
+              white-space: nowrap;
+              text-overflow: ellipsis;
+            }
+          }
+        }
+      }
+
+      .directives-tab-header {
+        font-weight: 500;
+
+        .fa.fa-download { cursor: pointer; }
+      }
+
+      .directives-row {
+        &.inactive {
+          background-color: #cccccc;
+          color: white;
+        }
+      }
+
+      .fa.fa-times { cursor: pointer; }
+    }
+
+    .columns-tab {
+      height: 100%;
+
+      .search-box {
+        height: 40px;
+        padding: 5px;
+        border-bottom: 1px solid #cccccc;
+        position: relative;
+
+        .form-control {
+          border-radius: 13px;
+          padding-right: 28px;
+          height: 26px;
+        }
+
+        .fa {
+          position: absolute;
+          right: 13px;
+          top: 11px;
+          color: #999999;
+          font-size: 14px;
+          &.fa-search { top: 10px; }
+          &.fa-times-circle { cursor: pointer; }
+        }
+      }
+
+      .columns-list {
+        height: calc(100% - 40px);
+        overflow-y: auto;
+      }
+
+      .columns-tab-row {
+        border-bottom: 1px solid #cccccc;
+
+        .row-header {
+          padding: 5px 10px;
+          cursor: pointer;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+
+          &.expanded {
+            background-color: #dedede;
+            white-space: pre-wrap;
+            word-break: break-all;
+          }
+
+          &.invalid {
+            background-color: #c0392b;
+            color: white;
+          }
+        }
+
+        .expanded-row {
+          background-color: #dedede;
+          padding: 10px;
+          border-bottom: 1px solid #999999;
+
+          .quality-bar {
+            border: 1px solid #999999;
+            border-radius: 4px;
+            height: 15px;
+            overflow: hidden;
+            margin-top: -10px;
+            margin-bottom: 10px;
+
+            > span {
+              height: 15px;
+              display: inline-block;
+
+              &.filled {
+                background-color: #2ecc71;
+                font-size: 8px;
+              }
+              &.empty { background-color: #e74c3c; }
+              &.null-cell { background-color: #95a5a6; }
+            }
+
+          }
+        }
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/DirectivesTab/DirectivesTabRow.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/DirectivesTab/DirectivesTabRow.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { Component, PropTypes } from 'react';
+import classnames from 'classnames';
+
+export default class DirectivesTabRow extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      expandable: false,
+      isExpanded: false
+    };
+
+    this.toggleExpand = this.toggleExpand.bind(this);
+  }
+
+  componentDidMount() {
+    let container = document.getElementById(`name-container-${this.props.rowInfo.uniqueId}`);
+    let content = document.getElementById(`name-content-${this.props.rowInfo.uniqueId}`);
+
+    if (content.offsetWidth > container.offsetWidth) {
+      this.setState({
+        expandable: true
+      });
+    }
+  }
+
+  toggleExpand() {
+    this.setState({isExpanded: !this.state.isExpanded});
+  }
+
+  render() {
+    return (
+      <div
+        className={classnames('directives-row', {
+          'inactive': this.props.isInactive
+        })}
+      >
+        <span>{this.props.rowIndex + 1}</span>
+        <span
+          id={`name-container-${this.props.rowInfo.uniqueId}`}
+          className={classnames({
+            'truncate': !this.state.isExpanded,
+            'expandable': this.state.expandable
+          })}
+          onClick={this.toggleExpand}
+        >
+          <span id={`name-content-${this.props.rowInfo.uniqueId}`}>{this.props.rowInfo.name}</span>
+        </span>
+        <span className="float-xs-right">
+          <span
+            className="fa fa-times"
+            onClick={this.props.handleDelete}
+            onMouseEnter={this.props.handleMouseEnter}
+            onMouseLeave={this.props.handleMouseLeave}
+          />
+        </span>
+      </div>
+    );
+  }
+}
+
+DirectivesTabRow.propTypes = {
+  rowInfo: PropTypes.object,
+  rowIndex: PropTypes.number,
+  isInactive: PropTypes.bool,
+  handleDelete: PropTypes.func,
+  handleMouseEnter: PropTypes.func,
+  handleMouseLeave: PropTypes.func
+};

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/DirectivesTab/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/DirectivesTab/index.js
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { Component } from 'react';
+import DataPrepStore from 'components/DataPrep/store';
+import DataPrepActions from 'components/DataPrep/store/DataPrepActions';
+import shortid from 'shortid';
+import MyDataPrepApi from 'api/dataprep';
+import DirectivesTabRow from 'components/DataPrep/DataPrepSidePanel/DirectivesTab/DirectivesTabRow';
+import fileDownload from 'react-file-download';
+import NamespaceStore from 'services/NamespaceStore';
+
+export default class DirectivesTab extends Component {
+  constructor(props) {
+    super(props);
+
+    let store = DataPrepStore.getState().dataprep;
+
+    this.state = {
+      deleteHover: null,
+      directives: store.directives.map((directive) => {
+        let obj = {
+          name: directive,
+          uniqueId: shortid.generate()
+        };
+        return obj;
+      })
+    };
+
+    this.download = this.download.bind(this);
+
+    this.sub = DataPrepStore.subscribe(() => {
+      let state = DataPrepStore.getState().dataprep;
+
+      this.setState({
+        directives: state.directives.map((directive) => {
+          let obj = {
+            name: directive,
+            uniqueId: shortid.generate()
+          };
+          return obj;
+        })
+      });
+    });
+
+  }
+
+  componentWillUnmount() {
+    this.sub();
+  }
+
+  onMouseEnter(index) {
+    this.setState({deleteHover: index});
+  }
+  onMouseLeave() {
+    this.setState({deleteHover: null});
+  }
+
+  deleteDirective(index) {
+    let state = DataPrepStore.getState().dataprep;
+    let directives = state.directives;
+
+    let newDirectives = directives.slice(0, index);
+
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    let params = {
+      namespace,
+      workspaceId: state.workspaceId,
+      limit: 100,
+      directive: newDirectives
+    };
+
+    MyDataPrepApi.execute(params)
+      .subscribe((res) => {
+        this.setState({
+          deleteHover: null
+        });
+
+        DataPrepStore.dispatch({
+          type: DataPrepActions.setDirectives,
+          payload: {
+            data: res.value,
+            headers: res.header,
+            directives: newDirectives
+          }
+        });
+      }, (err) => {
+        // Should not ever come to this.. this is only if backend
+        // fails somehow
+        console.log('Error deleting directives', err);
+      });
+  }
+
+  download() {
+    let state = DataPrepStore.getState().dataprep;
+    let workspaceId = state.workspaceId,
+        directives = state.directives;
+
+    let data = directives.join('\n'),
+        filename = `${workspaceId}-directives.txt`;
+
+    fileDownload(data, filename);
+  }
+
+  render() {
+    return (
+      <div className="directives-tab">
+
+        <div className="directives-tab-header">
+          <span>#</span>
+          <span>Directives</span>
+          <span className="float-xs-right">
+            <span
+              className="fa fa-download"
+              onClick={this.download}
+            />
+          </span>
+        </div>
+
+        <div className="directives-tab-body">
+          {
+            this.state.directives.map((directive, index) => {
+              return (
+                <DirectivesTabRow
+                  key={directive.uniqueId}
+                  rowInfo={directive}
+                  rowIndex={index}
+                  isInactive={this.state.deleteHover !== null && index >= this.state.deleteHover}
+                  handleDelete={this.deleteDirective.bind(this, index)}
+                  handleMouseEnter={this.onMouseEnter.bind(this, index)}
+                  handleMouseLeave={this.onMouseLeave.bind(this)}
+                />
+              );
+            })
+          }
+        </div>
+      </div>
+    );
+  }
+}

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/index.js
@@ -15,17 +15,109 @@
  */
 
 import React, { Component } from 'react';
+import DataPrepStore from 'components/DataPrep/store';
+import classnames from 'classnames';
+import ColumnsTab from 'components/DataPrep/DataPrepSidePanel/ColumnsTab';
+import DirectivesTab from 'components/DataPrep/DataPrepSidePanel/DirectivesTab';
+
+require('./DataPrepSidePanel.scss');
 
 export default class DataPrepSidePanel extends Component {
   constructor(props) {
     super(props);
 
+    let storeState = DataPrepStore.getState().dataprep;
+
+    this.state = {
+      activeTab: 1,
+      deleteHover: null,
+      headers: storeState.headers,
+      directives: storeState.directives,
+      summary: {}
+    };
+
+    this.sub = DataPrepStore.subscribe(() => {
+      let state = DataPrepStore.getState().dataprep;
+
+      this.setState({
+        headers: state.headers,
+        directives: state.directives
+      });
+    });
+  }
+
+  componentWillUnmount() {
+    this.sub();
+  }
+
+  setActiveTab(tab) {
+    this.setState({activeTab: tab});
+  }
+
+  renderColumns() {
+    if (this.state.headers.length === 0) {
+      return (
+        <h5 className="empty-message text-xs-center">
+          No Columns
+        </h5>
+      );
+    }
+
+    return (
+      <div className="tab-content">
+        <ColumnsTab />
+      </div>
+    );
+  }
+
+  renderDirectives() {
+    if (this.state.directives.length === 0) {
+      return (
+        <h5 className="empty-message text-xs-center">
+          No Directives
+        </h5>
+      );
+    }
+
+    return (
+      <div className="tab-content">
+        <DirectivesTab />
+      </div>
+    );
+  }
+
+  renderTabContent() {
+    switch (this.state.activeTab) {
+      case 1:
+        return this.renderDirectives();
+      case 2:
+        return this.renderColumns();
+      default:
+        return null;
+    }
   }
 
   render() {
     return (
-      <div className="col-xs-3">
-        <h4>Side Panel</h4>
+      <div className="col-xs-3 dataprep-side-panel">
+        <div className="tabs">
+          <div className="tabs-headers">
+            <div
+              className={classnames('tab', { 'active': this.state.activeTab === 1 })}
+              onClick={this.setActiveTab.bind(this, 1)}
+            >
+              Directives ({this.state.directives.length})
+            </div>
+            <div
+              className={classnames('tab', { 'active': this.state.activeTab === 2 })}
+              onClick={this.setActiveTab.bind(this, 2)}
+            >
+              Columns ({this.state.headers.length})
+            </div>
+          </div>
+
+          {this.renderTabContent()}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Features

### Directives Tab
- User should be able to see the list of directives applied
- User should be able to delete a directive
- Hovering on the delete icon will highlights the directives being deleted (current directives and all subsequent directives)
- User should be able to download the list of the directives
- User should be able to copy paste the downloaded list of directives and paste on the CLI, and user should come back to the same state if User applied the list of directives on same base data


### Columns Tab
- User should be able to see the list of columns
- User should be able to search a column
- User should be able to clear search query
- Activating the row by clicking should expand the row, scroll to view the column in the table view, and highlight the table header to blue for 3 seconds.
- Expanded view should show a bar with distribution indicator over filled and empty row for that column.
- Expanded view should display a table of inferred types with % chance if information is available


#### Note
- Currently branched from `feature/ui-dataprep-cli` for ease of review. Will change base branch to `develop` once other branches are merged.