### PR TITLE
disable the parcel repo merging by default

### DIFF
--- a/cdap-distributions/bin/build_parcel_repo.sh
+++ b/cdap-distributions/bin/build_parcel_repo.sh
@@ -19,7 +19,7 @@
 # copy new parcel into repo dir
 # symlink parcels
 # create manifest
-# s3cmd ls to see if repo exists
+# optionally (set MERGE_REPO=true) s3cmd ls to see if repo exists
 # - yes, sync repo manifest locally, merge
 # - no, do nothing
 
@@ -112,7 +112,9 @@ function merge_manifest() {
 setup_repo_staging || die "Something went wrong setting up the staging directory"
 add_parcels_to_repo_staging || die "Failed copying parcels to staging directory"
 make_manifest_in_repo_staging || die "Failed to create repository from staging directory"
-merge_manifest || die "Failed to merge in existing repository manifest"
+if [[ -n ${MERGE_REPO} ]]; then
+  merge_manifest || die "Failed to merge in existing repository manifest"
+fi
 
 cp -f ${STAGE_DIR}/${__maj_min}/manifest.json ${TARGET_DIR}
 


### PR DESCRIPTION
Disables the merging of any existing parcel repo by default.  [This BUT build](http://builds.cask.co/browse/CDAP-BUT872-81) failed because the version hasn't been updated, and it attempted to merge a new 4.1.0 and prod 4.1.0 together.

Instead, the plan is to do the merging only on the deploy build.  (We might remove this option entirely at that time)