### PR TITLE
[CDAP-4798] Fixes Explore Fastaction to give actively running querie counts.

### DIFF
--- a/cdap-ui/app/cdap/components/DatasetDetailedView/DatasetDetailedView.scss
+++ b/cdap-ui/app/cdap/components/DatasetDetailedView/DatasetDetailedView.scss
@@ -33,6 +33,18 @@
     .overview-meta-section {
       .fast-actions-container {
         align-items: flex-start;
+        h4 {
+          vertical-align: top;
+          > span {
+            padding: 0;
+            vertical-align: top;
+            display: inline-block;
+            background: transparent;
+            &:hover {
+              background: transparent;
+            }
+          }
+        }
       }
     }
     .overview-tab {

--- a/cdap-ui/app/cdap/components/DatasetStreamTable/DatasetStreamTable.scss
+++ b/cdap-ui/app/cdap/components/DatasetStreamTable/DatasetStreamTable.scss
@@ -102,6 +102,20 @@ $border-color: #bbbbbb;
             .fast-actions-container {
               min-width: 215px;
               max-width: 400px;
+
+              h4 {
+                vertical-align: top;
+                > span {
+                  border: 0;
+                  padding: 0;
+                  vertical-align: top;
+                  display: inline-block;
+                  background: transparent;
+                  &:hover {
+                    background: transparent;
+                  }
+                }
+              }
             }
           }
 

--- a/cdap-ui/app/cdap/components/DatasetStreamTable/index.js
+++ b/cdap-ui/app/cdap/components/DatasetStreamTable/index.js
@@ -113,9 +113,9 @@ export default class DatasetStreamTable extends Component {
                 </td>
                 <td>
                   <Link to={link}>
-                    <div className="fast-actions-container">
+                    <div className="fast-actions-container text-xs-center">
                       <FastActions
-                        className="text-xs-left"
+                        className="text-xs-left btn-group"
                         entity={dataEntity}
                       />
                     </div>

--- a/cdap-ui/app/cdap/components/EntityCard/EntityCard.scss
+++ b/cdap-ui/app/cdap/components/EntityCard/EntityCard.scss
@@ -35,6 +35,19 @@ $jump-button-container-size: 80px;
     }
     .fast-actions-container {
       background: $color;
+      h4 {
+        vertical-align: top;
+        > span {
+          border: 0;
+          padding: 0;
+          vertical-align: top;
+          display: inline-block;
+          background: transparent;
+          &:hover {
+            background: transparent;
+          }
+        }
+      }
       .btn-link {
         color: white;
       }
@@ -197,6 +210,13 @@ $jump-button-container-size: 80px;
 
     h4 {
       margin: 0;
+      vertical-align: top;
+      > span {
+        border: 0;
+        padding: 0;
+        vertical-align: top;
+        display: inline-block;
+      }
     }
   }
 }

--- a/cdap-ui/app/cdap/components/EntityCard/FastActions/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/FastActions/index.js
@@ -16,6 +16,8 @@
 
 import React, {Component, PropTypes} from 'react';
 import FastAction from 'components/FastAction';
+import {objectQuery} from 'services/helpers';
+import isNil from 'lodash/isNil';
 
 export default class FastActions extends Component {
   constructor(props) {
@@ -79,6 +81,7 @@ export default class FastActions extends Component {
                   entity={this.props.entity}
                   opened={true}
                   onSuccess={this.onSuccess.bind(this, action)}
+                  argsToAction={isNil(objectQuery(this.props.argsToActions, action)) ? {} : this.props.argsToActions[action]}
                 />
               );
             }
@@ -89,6 +92,7 @@ export default class FastActions extends Component {
                   type={action}
                   entity={this.props.entity}
                   onSuccess={this.onSuccess.bind(this, action)}
+                  argsToAction={isNil(objectQuery(this.props.argsToActions, action)) ? {} : this.props.argsToActions[action]}
                 />
               );
             }
@@ -104,5 +108,15 @@ FastActions.propTypes = {
   onUpdate: PropTypes.func,
   className: PropTypes.string,
   onSuccess: PropTypes.func,
-  actionToOpen: PropTypes.string
+  actionToOpen: PropTypes.string,
+  argsToActions: PropTypes.shape({
+    delete: PropTypes.object,
+    setPreferences: PropTypes.object,
+    truncate: PropTypes.object,
+    explore: PropTypes.object,
+    sendEvents: PropTypes.object,
+    viewEvents: PropTypes.object,
+    startStop: PropTypes.object,
+    log: PropTypes.object
+  })
 };

--- a/cdap-ui/app/cdap/components/EntityCard/index.js
+++ b/cdap-ui/app/cdap/components/EntityCard/index.js
@@ -150,11 +150,12 @@ export default class EntityCard extends Component {
 
           {this.renderEntityStatus()}
 
-          <div className="fast-actions-container">
+          <div className="fast-actions-container text-xs-center">
             <FastActions
               entity={this.props.entity}
               onUpdate={this.onFastActionUpdate.bind(this)}
               onSuccess={this.props.onFastActionSuccess}
+              className="btn-group"
             />
           </div>
         </Card>

--- a/cdap-ui/app/cdap/components/FastAction/DeleteAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/DeleteAction/index.js
@@ -112,7 +112,7 @@ export default class DeleteAction extends Component {
     const tooltipID = `${this.props.entity.uniqueId}-delete`;
 
     return (
-      <span>
+      <span className="btn btn-secondary btn-sm">
         <FastActionButton
           icon="fa fa-trash"
           action={this.toggleModal}

--- a/cdap-ui/app/cdap/components/FastAction/ExploreAction/ExploreAction.scss
+++ b/cdap-ui/app/cdap/components/FastAction/ExploreAction/ExploreAction.scss
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+@import "../../../styles/variables.scss";
+
+.fast-action-with-popover {
+  &.btn.btn-secondary.btn-sm {
+    position: relative;
+    border: 1px solid $success-message-bg;
+
+    .fast-action-popover-container {
+      position: absolute;
+      background: $success-message-bg;
+      padding: 5px;
+      top: -15px;
+      right: -3px;
+      border-radius: 7px;
+      font-size: 11px;
+      color: white;
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/FastAction/ExploreAction/ExploreModal.js
+++ b/cdap-ui/app/cdap/components/FastAction/ExploreAction/ExploreModal.js
@@ -225,24 +225,47 @@ export default class ExploreModal extends Component {
       });
     }
   }
+  onModalToggle() {
+    let runningQueries = this.state.queries.filter(query => query.status === 'RUNNING');
+    this.props.onClose(runningQueries.length);
+  }
 
   render() {
     const renderQueryRow = (query) => {
       return (
         <tr key={shortid.generate()}>
           <td> {humanReadableDate(query.timestamp, true)} </td>
-          <td> {query.status} </td>
           <td> {query.statement} </td>
           <td>
+            {
+              query.status === 'RUNNING' ?
+                <span>
+                  <span className="query-status-value">{query.status}</span>
+                  <i className="fa fa-spinner fa-spin"></i>
+                </span>
+              :
+                <span>{query.status}</span>
+            }
+          </td>
+          <td>
             <div className="btn-group">
-              <a
-                href={this.getDownloadUrl(query)}
-                onClick={this.updateQueryState.bind(this, query)}
-                className="btn btn-secondary"
-                disabled={!query.is_active || query.status !== 'FINISHED' ? 'disabled' : null}
-              >
-                <i className="fa fa-download"></i>
-              </a>
+              {
+                !query.is_active || query.status !== 'FINISHED' ?
+                  <button
+                    className="btn btn-secondary"
+                    disabled="disabled"
+                    >
+                    <i className="fa fa-download"></i>
+                  </button>
+                :
+                  <a
+                    href={this.getDownloadUrl(query)}
+                    onClick={this.updateQueryState.bind(this, query)}
+                    className="btn btn-secondary"
+                  >
+                    <i className="fa fa-download"></i>
+                  </a>
+              }
               <button
                 className="btn btn-secondary"
                 onClick={this.showPreview.bind(this, query)}
@@ -317,14 +340,14 @@ export default class ExploreModal extends Component {
     return (
       <Modal
         className="explore-modal confirmation-modal"
-        toggle={this.props.onClose}
+        toggle={this.onModalToggle.bind(this)}
         isOpen={this.props.isOpen}
         backdrop='static'
       >
         <ModalHeader>
           Explore Dataset
           <div
-           onClick={this.props.onClose}
+           onClick={this.onModalToggle.bind(this)}
            className="float-xs-right"
           >
             <span className="fa fa-times" />
@@ -365,8 +388,8 @@ export default class ExploreModal extends Component {
                 <thead>
                   <tr>
                     <th className="query-timestamp">Start time</th>
-                    <th className="query-status">Status</th>
                     <th>SQL Query</th>
+                    <th className="query-status">Status</th>
                     <th className="query-actions">Actions</th>
                   </tr>
                 </thead>

--- a/cdap-ui/app/cdap/components/FastAction/ExploreAction/ExploreModal.scss
+++ b/cdap-ui/app/cdap/components/FastAction/ExploreAction/ExploreModal.scss
@@ -35,6 +35,12 @@ $exploremodalwidth: 80vw;
     .fa.fa-spinner {
       margin-right: 10px;
     }
+    .clearfix {
+      .text-danger {
+        word-wrap: break-word;
+        word-break: break-all;
+      }
+    }
     .queries-table-wrapper {
       margin-top: 10px;
       // FIXME: MAGIC NUMBER Alert. This is BS and we need to figure out how to nest tables.
@@ -43,22 +49,41 @@ $exploremodalwidth: 80vw;
     }
     .queries-table {
       background-color: #f6f6f6;
+      border: 1px solid #bbbbbb;
 
       th,
       td {
-        border-color: #dddddd;
+        border: 0;
+        vertical-align: middle;
+      }
+      tbody,
+      thead {
+        tr {
+          border-bottom: 1px solid #bbbbbb;
+        }
       }
 
       .btn-group {
         .btn.btn-secondary {
+          &:first-child {
+            padding-left: 0;
+          }
           padding: 7px;
+          border: 0;
+          background: transparent;
         }
       }
       .query-timestamp {
-        width: 165px;
+        width: 185px;
       }
       .query-status {
-        width: 80px;
+        width: 115px;
+      }
+      .query-status-value {
+        margin-right: 10px;
+        ~ .fa-spinner {
+          margin: 0;
+        }
       }
       .query-actions {
         width: 105px;

--- a/cdap-ui/app/cdap/components/FastAction/LogAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/LogAction/index.js
@@ -99,7 +99,7 @@ export default class LogAction extends Component {
     );
 
     return (
-      <span>
+      <span className="btn btn-secondary btn-sm">
         <span id={tooltipID}>
           {this.state.runId ? renderLog : renderDisabled}
         </span>

--- a/cdap-ui/app/cdap/components/FastAction/SendEventAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/SendEventAction/index.js
@@ -57,7 +57,7 @@ export default class SendEventAction extends Component {
   render() {
     let tooltipID = `${this.props.entity.uniqueId}-sendevents`;
     return (
-      <span>
+      <span className="btn btn-secondary btn-sm">
         <FastActionButton
           icon="fa fa-upload"
           action={this.toggleModal}

--- a/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceAction.scss
+++ b/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceAction.scss
@@ -43,6 +43,18 @@ $focused-input-color: #66afe9;
 }
 
 .fast-actions-container {
+  h4 {
+    vertical-align: middle;
+    > span {
+      padding: 0;
+      vertical-align: top;
+      display: inline-block;
+      background: transparent;
+      &:hover {
+        background: transparent;
+      }
+    }
+  }
   .fa-wrench {
     &.saved-success {
       color: $success-message-bg;

--- a/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/index.js
@@ -80,7 +80,7 @@ export default class SetPreferenceAction extends Component {
       tooltipID = `${this.props.entity.uniqueId}-setpreferences`;
     }
     return (
-      <span>
+      <span className="btn btn-secondary btn-sm">
         <FastActionButton
           icon={wrenchClasses}
           action={this.toggleModal}

--- a/cdap-ui/app/cdap/components/FastAction/StartStopAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/StartStopAction/index.js
@@ -143,7 +143,7 @@ export default class StartStopAction extends Component {
     let tooltipID = `${this.props.entity.uniqueId}-${this.startStop}`;
 
     return (
-      <span>
+      <span className="btn btn-secondary btn-sm">
         {
           this.state.modal ? (
             <ConfirmationModal

--- a/cdap-ui/app/cdap/components/FastAction/TruncateAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/TruncateAction/index.js
@@ -105,7 +105,7 @@ export default class TruncateAction extends Component {
     const tooltipID = `${this.props.entity.uniqueId}-truncate`;
     let truncateActionClassNames = 'fa fa-scissors';
     return (
-      <span>
+      <span className="btn btn-secondary btn-sm">
         <FastActionButton
           icon={classnames(truncateActionClassNames, {'text-success': this.state.success})}
           action={this.toggleModal}

--- a/cdap-ui/app/cdap/components/FastAction/ViewEventsAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/ViewEventsAction/index.js
@@ -56,7 +56,7 @@ export default class ViewEventsAccess extends Component {
     const tooltipId = `${this.props.entity.uniqueId}-viewevents`;
 
     return (
-      <span>
+      <span className="btn btn-secondary btn-sm">
         <FastActionButton
           icon="fa fa-filter"
           action={this.toggleModal}

--- a/cdap-ui/app/cdap/components/FastAction/index.js
+++ b/cdap-ui/app/cdap/components/FastAction/index.js
@@ -23,6 +23,7 @@ import SendEventAction from 'components/FastAction/SendEventAction';
 import SetPreferenceAction from 'components/FastAction/SetPreferenceAction';
 import LogAction from 'components/FastAction/LogAction';
 import ViewEventsAction from 'components/FastAction/ViewEventsAction';
+import {objectQuery} from 'services/helpers';
 
 export default class FastAction extends Component {
   constructor(props) {
@@ -39,6 +40,7 @@ export default class FastAction extends Component {
           <DeleteAction
             entity={this.props.entity}
             onSuccess={this.props.onSuccess}
+            argsToAction={objectQuery(this.props.argsToAction)}
           />
         );
       case 'truncate':
@@ -46,6 +48,7 @@ export default class FastAction extends Component {
           <TruncateAction
             entity={this.props.entity}
             onSuccess={this.props.onSuccess}
+            argsToAction={objectQuery(this.props.argsToAction)}
           />
         );
       case 'startStop':
@@ -53,6 +56,7 @@ export default class FastAction extends Component {
           <StartStopAction
             entity={this.props.entity}
             onSuccess={this.props.onSuccess}
+            argsToAction={objectQuery(this.props.argsToAction)}
           />
         );
       case 'explore':
@@ -60,6 +64,7 @@ export default class FastAction extends Component {
           <ExploreAction
             entity={this.props.entity}
             opened={this.props.opened}
+            argsToAction={objectQuery(this.props.argsToAction)}
           />
         );
       case 'sendEvents':
@@ -68,6 +73,7 @@ export default class FastAction extends Component {
             entity={this.props.entity}
             onSuccess={this.props.onSuccess}
             opened={this.props.opened}
+            argsToAction={objectQuery(this.props.argsToAction)}
           />
         );
       case 'setPreferences':
@@ -75,18 +81,21 @@ export default class FastAction extends Component {
           <SetPreferenceAction
             entity={this.props.entity}
             onSuccess={this.props.onSuccess}
+            argsToAction={objectQuery(this.props.argsToAction)}
           />
         );
       case 'log':
         return (
           <LogAction
             entity={this.props.entity}
+            argsToAction={objectQuery(this.props.argsToAction)}
           />
         );
       case 'viewEvents':
         return (
           <ViewEventsAction
             entity={this.props.entity}
+            argsToAction={objectQuery(this.props.argsToAction)}
           />
         );
     }
@@ -101,5 +110,6 @@ FastAction.propTypes = {
   type: PropTypes.oneOf(['delete', 'truncate', 'startStop', 'sendEvents', 'explore', 'setPreferences', 'log']),
   entity: PropTypes.object,
   onSuccess: PropTypes.func,
-  opened: PropTypes.bool
+  opened: PropTypes.bool,
+  argsToAction: PropTypes.object
 };

--- a/cdap-ui/app/cdap/components/Overview/OverviewMetaSection/OverviewMetaSection.scss
+++ b/cdap-ui/app/cdap/components/Overview/OverviewMetaSection/OverviewMetaSection.scss
@@ -44,6 +44,21 @@
     justify-content: space-between;
     align-items: center;
 
+    h4 {
+      vertical-align: top;
+      > span {
+        padding: 0;
+        vertical-align: top;
+        display: inline-block;
+        background: transparent;
+        &:hover,
+        &:focus {
+          background: transparent;
+          outline: none;
+        }
+      }
+    }
+
     .btn-group {
       .dropdown-toggle {
         font-weight: bold;
@@ -63,11 +78,11 @@
       color: rgba(102, 102, 102, 1);
     }
     .overview-fast-actions {
-      border: 1px solid rgba(219, 219, 219, 1);
       margin: 0;
       border-radius: 4px;
 
       > span {
+        display: inline-block;
         &:last-child {
           .btn.btn-link {
             border-right: 0;
@@ -80,7 +95,6 @@
         color: #4f5050;
         padding: 0;
         vertical-align: top;
-        border-right: 1px solid rgba(219, 219, 219, 1);
 
         &:hover {
           background-color: $cdap-gray;

--- a/cdap-ui/app/cdap/components/Overview/OverviewMetaSection/index.js
+++ b/cdap-ui/app/cdap/components/Overview/OverviewMetaSection/index.js
@@ -119,7 +119,7 @@ export default class OverviewMetaSection extends Component {
         <h2 title={this.props.entity.id}>
           {this.props.entity.id}
         </h2>
-        <div className="fast-actions-container">
+        <div className="fast-actions-container text-xs-center">
           <div>
             {
               this.props.entity.type === 'application' ?
@@ -143,11 +143,16 @@ export default class OverviewMetaSection extends Component {
             </small>
           </div>
           <FastActions
-            className="overview-fast-actions"
+            className="overview-fast-actions btn-group"
             entity={entity}
             onSuccess={this.onFastActionSuccess.bind(this)}
             onUpdate={this.onFastActionUpdate.bind(this)}
             actionToOpen={this.props.fastActionToOpen}
+            argsToActions={{
+              explore: {
+                showQueriesCount: true
+              }
+            }}
           />
         </div>
 

--- a/cdap-ui/app/cdap/components/ProgramTable/ProgramTable.scss
+++ b/cdap-ui/app/cdap/components/ProgramTable/ProgramTable.scss
@@ -71,10 +71,18 @@ $border-color: #bbbbbb;
           padding-right: 0;
         }
 
-        .fast-actions-container .btn-link {
-          color: #4f5050;
-          padding-left: 5%;
-          padding-right: 5%;
+        .fast-actions-container {
+          h4 {
+            > span {
+              border: 0;
+            }
+          }
+          .btn-link {
+            color: #4f5050;
+            margin-left: 5px;
+            padding: 5px;
+            border: 0;
+          }
         }
       }
     }

--- a/cdap-ui/app/cdap/components/ProgramTable/index.js
+++ b/cdap-ui/app/cdap/components/ProgramTable/index.js
@@ -115,9 +115,9 @@ export default class ProgramTable extends Component {
                   }
                 </td>
                 <td>
-                  <div className="fast-actions-container">
+                  <div className="fast-actions-container text-xs-center">
                     <FastActions
-                      className="text-xs-left"
+                      className="text-xs-left btn-group"
                       entity={program}
                     />
                   </div>

--- a/cdap-ui/app/cdap/components/StreamDetailedView/StreamDetailedView.scss
+++ b/cdap-ui/app/cdap/components/StreamDetailedView/StreamDetailedView.scss
@@ -32,6 +32,19 @@
     .overview-meta-section {
       .fast-actions-container {
         align-items: flex-start;
+
+        h4 {
+          vertical-align: top;
+          > span {
+            padding: 0;
+            vertical-align: top;
+            display: inline-block;
+            background: transparent;
+            &:hover {
+              background: transparent;
+            }
+          }
+        }
       }
     }
     .overview-tab {

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -261,6 +261,7 @@ features:
       numEventsTitle: Set Number of Events
       timeRangeTitle: Select Time Range
       to: To
+    doneLabel: Done
 
   JumpButton:
     buttonLabel: Jump


### PR DESCRIPTION
- Adds an ability to send properties down from `FastActions` to individual Fastactions
- Fixes `ExploreAction` to show actively running queries and display Done once all queries have completed
- Fixes styling for FastAction buttons

### Todo:
- We don't surface number failed in the notification
- Properties like `opened` and others should now come via `argsToActions` property. Will do that in a separate PR post current sprint.

Bamboo build: http://builds.cask.co/browse/CDAP-DRC6049-1