### PR TITLE
CDAP-8902 Add CLI endpoints for scheduling

### DIFF
--- a/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/co/cask/cdap/cli/CLIMainTest.java
@@ -814,8 +814,7 @@ public class CLIMainTest extends CLITestBase {
                               Joiner.on(",").join(FakeWorkflow.FakeAction.TOKEN_KEY, GSON.toJson(tokenValues)));
     testCommandOutputNotContains(cli, String.format("get workflow token %s %s scope system", workflow, runId),
                                  Joiner.on(",").join(FakeWorkflow.FakeAction.TOKEN_KEY, GSON.toJson(tokenValues)));
-    testCommandOutputContains(
-      cli, String.format("get workflow token %s %s scope user key %s", workflow, runId,
+    testCommandOutputContains(cli, String.format("get workflow token %s %s scope user key %s", workflow, runId,
                          FakeWorkflow.FakeAction.TOKEN_KEY),
       Joiner.on(",").join(FakeWorkflow.FakeAction.TOKEN_KEY, GSON.toJson(tokenValues)));
 
@@ -832,6 +831,27 @@ public class CLIMainTest extends CLITestBase {
                          FakeWorkflow.FakeAction.ANOTHER_FAKE_NAME, FakeWorkflow.FakeAction.TOKEN_KEY), fakeNodeValue);
 
     testCommandOutputContains(cli, "get workflow logs " + workflow, FakeWorkflow.FAKE_LOG);
+
+    // Test schedule
+    testCommandOutputContains(
+      cli, String.format("add time schedule %s for workflow %s at \"0 4 * * *\"", FakeWorkflow.SCHEDULE, workflow),
+      String.format("Successfully added schedule '%s' in app '%s'", FakeWorkflow.SCHEDULE, FakeApp.NAME));
+    testCommandOutputContains(cli, String.format("get workflow schedules %s", workflow), "0 4 * * *");
+
+    testCommandOutputContains(
+      cli, String.format("update time schedule %s for workflow %s description \"testdesc\" at \"* * * * *\" " +
+                           "concurrency 4 properties \"key=value\"", FakeWorkflow.SCHEDULE, workflow),
+      String.format("Successfully updated schedule '%s' in app '%s'", FakeWorkflow.SCHEDULE, FakeApp.NAME));
+    testCommandOutputContains(cli, String.format("get workflow schedules %s", workflow), "* * * * *");
+    testCommandOutputContains(cli, String.format("get workflow schedules %s", workflow), "testdesc");
+    testCommandOutputContains(cli, String.format("get workflow schedules %s", workflow), "{\"key\":\"value\"}");
+
+    testCommandOutputContains(
+      cli, String.format("delete schedule %s.%s", FakeApp.NAME, FakeWorkflow.SCHEDULE),
+      String.format("Successfully deleted schedule '%s' in app '%s'", FakeWorkflow.SCHEDULE, FakeApp.NAME));
+    testCommandOutputNotContains(cli, String.format("get workflow schedules %s", workflow), "* * * * *");
+    testCommandOutputNotContains(cli, String.format("get workflow schedules %s", workflow), "testdesc");
+    testCommandOutputNotContains(cli, String.format("get workflow schedules %s", workflow), "{\"key\":\"value\"}");
 
     // stop workflow
     testCommandOutputContains(cli, "stop workflow " + workflow,

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/ArgumentName.java
@@ -35,6 +35,7 @@ public enum ArgumentName {
   SERVICE("app-id.service-id"),
   MAPREDUCE("app-id.mapreduce-id"),
   SPARK("app-id.spark-id"),
+  SCHEDULE("app-id.schedule-id"),
 
   APP_CONFIG("app-config"),
   APP_CONFIG_FILE("app-config-file"),
@@ -76,6 +77,10 @@ public enum ArgumentName {
   ENDPOINT("endpoint"),
   HEADERS("headers"),
   HTTP_BODY("body"),
+  CRON_EXPRESSION("cron-expression"),
+  SCHEDULE_NAME("schedule-name"),
+  SCHEDULE_PROPERTIES("schedule-properties"),
+  CONCURRENCY("concurrency"),
   /**
    * stream format
    */

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/ElementType.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/ElementType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2015 Cask Data, Inc.
+ * Copyright © 2014-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -56,6 +56,8 @@ public enum ElementType {
   STREAM("stream", new Noun("stream"), new Noun("Stream"), null, null, ArgumentName.STREAM, Capability.LIST),
 
   PROGRAM("program", new Noun("program"), new Noun("Program"), null, null, ArgumentName.PROGRAM),
+
+  SCHEDULE("schedule", new Noun("schedule"), new Noun("Schedule"), null, null, ArgumentName.SCHEDULE),
 
   FLOW("flow", new Noun("flow"), new Noun("Flow"), ProgramType.FLOW, null, ArgumentName.FLOW,
        Capability.RUNS, Capability.LOGS, Capability.LIVE_INFO, Capability.STATUS, Capability.START, Capability.STOP,

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/schedule/AddTimeScheduleCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/schedule/AddTimeScheduleCommand.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.cli.command.schedule;
+
+import co.cask.cdap.api.schedule.Schedule;
+import co.cask.cdap.api.schedule.Schedules;
+import co.cask.cdap.cli.ArgumentName;
+import co.cask.cdap.cli.CLIConfig;
+import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.english.Article;
+import co.cask.cdap.cli.english.Fragment;
+import co.cask.cdap.cli.exception.CommandInputError;
+import co.cask.cdap.cli.util.AbstractCommand;
+import co.cask.cdap.cli.util.ArgumentParser;
+import co.cask.cdap.client.ScheduleClient;
+import co.cask.cdap.proto.ScheduleInstanceConfiguration;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ScheduleId;
+import co.cask.common.cli.Arguments;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+
+import java.io.PrintStream;
+import java.util.Map;
+
+/**
+ * Adds a schedule.
+ */
+public final class AddTimeScheduleCommand extends AbstractCommand {
+
+  private final ScheduleClient scheduleClient;
+
+  @Inject
+  public AddTimeScheduleCommand(CLIConfig cliConfig, ScheduleClient scheduleClient) {
+    super(cliConfig);
+    this.scheduleClient = scheduleClient;
+  }
+
+  @Override
+  public void perform(Arguments arguments, PrintStream printStream) throws Exception {
+    String scheduleName = arguments.get(ArgumentName.SCHEDULE_NAME.toString());
+    String[] programIdParts = arguments.get(ArgumentName.PROGRAM.toString()).split("\\.");
+    String version = arguments.getOptional(ArgumentName.APP_VERSION.toString());
+    String scheduleDescription = arguments.getOptional(ArgumentName.DESCRIPTION.toString(), "");
+    String cronExpression = arguments.get(ArgumentName.CRON_EXPRESSION.toString());
+    String schedulePropertiesString = arguments.getOptional(ArgumentName.SCHEDULE_PROPERTIES.toString(), "");
+    String scheduleRunConcurrencyString = arguments.getOptional(ArgumentName.CONCURRENCY.toString(), null);
+
+    if (programIdParts.length < 2) {
+      throw new CommandInputError(this);
+    }
+
+    String appId = programIdParts[0];
+    NamespaceId namespaceId = cliConfig.getCurrentNamespace();
+    ApplicationId applicationId = (version == null) ? namespaceId.app(appId) : namespaceId.app(appId, version);
+    ScheduleId scheduleId = applicationId.schedule(scheduleName);
+
+    Schedules.Builder builder = Schedules.builder(scheduleName);
+    if (scheduleRunConcurrencyString != null) {
+      builder.setMaxConcurrentRuns(Integer.valueOf(scheduleRunConcurrencyString));
+    }
+    if (scheduleDescription != null) {
+      builder.setDescription(scheduleDescription);
+    }
+    Schedule schedule = builder.createTimeSchedule(cronExpression);
+
+    Map<String, String> programMap = ImmutableMap.of("programName", programIdParts[1],
+                                                     "programType", ElementType.WORKFLOW.name().toUpperCase());
+    Map<String, String> propertiesMap = ArgumentParser.parseMap(schedulePropertiesString,
+                                                                ArgumentName.SCHEDULE_PROPERTIES.toString());
+
+    ScheduleInstanceConfiguration configuration =
+      new ScheduleInstanceConfiguration("TIME", schedule, programMap, propertiesMap);
+
+    scheduleClient.add(scheduleId, configuration);
+    printStream.printf("Successfully added schedule '%s' in app '%s'\n", scheduleName, appId);
+  }
+
+  @Override
+  public String getPattern() {
+    return String.format("add time schedule <%s> for workflow <%s> [version <%s>] " +
+                           "[description <%s>] at <%s> [concurrency <%s>] [properties <%s>]",
+                         ArgumentName.SCHEDULE_NAME, ArgumentName.PROGRAM, ArgumentName.APP_VERSION,
+                         ArgumentName.DESCRIPTION, ArgumentName.CRON_EXPRESSION, ArgumentName.CONCURRENCY,
+                         ArgumentName.SCHEDULE_PROPERTIES);
+  }
+
+  @Override
+  public String getDescription() {
+    return String.format("Adds %s which is associated with %s given",
+                         Fragment.of(Article.A, ElementType.SCHEDULE.getName()),
+                         Fragment.of(Article.THE, ElementType.PROGRAM.getName()));
+  }
+}

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/schedule/DeleteScheduleCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/schedule/DeleteScheduleCommand.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.cli.command.schedule;
+
+import co.cask.cdap.cli.CLIConfig;
+import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.english.Article;
+import co.cask.cdap.cli.english.Fragment;
+import co.cask.cdap.cli.exception.CommandInputError;
+import co.cask.cdap.cli.util.AbstractCommand;
+import co.cask.cdap.client.ScheduleClient;
+import co.cask.cdap.proto.id.ScheduleId;
+import co.cask.common.cli.Arguments;
+import com.google.inject.Inject;
+
+import java.io.PrintStream;
+import javax.lang.model.element.Element;
+
+/**
+ * Deletes a schedule.
+ */
+public final class DeleteScheduleCommand extends AbstractCommand {
+
+  private final ScheduleClient scheduleClient;
+
+  @Inject
+  public DeleteScheduleCommand(CLIConfig cliConfig, ScheduleClient scheduleClient) {
+    super(cliConfig);
+    this.scheduleClient = scheduleClient;
+  }
+
+  @Override
+  public void perform(Arguments arguments, PrintStream printStream) throws Exception {
+    String[] programIdParts = arguments.get(ElementType.SCHEDULE.getArgumentName().toString()).split("\\.");
+    if (programIdParts.length < 2) {
+      throw new CommandInputError(this);
+    }
+
+    String appId = programIdParts[0];
+    String scheduleName = programIdParts[1];
+    ScheduleId schedule = cliConfig.getCurrentNamespace().app(appId).schedule(scheduleName);
+
+    scheduleClient.delete(schedule);
+    printStream.printf("Successfully deleted schedule '%s' in app '%s'\n", scheduleName, appId);
+  }
+
+  @Override
+  public String getPattern() {
+    return String.format("delete schedule <%s>", ElementType.SCHEDULE.getArgumentName());
+  }
+
+  @Override
+  public String getDescription() {
+    return String.format("Deletes %s", Fragment.of(Article.A, ElementType.SCHEDULE.getName()));
+  }
+}

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/schedule/GetScheduleStatusCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/schedule/GetScheduleStatusCommand.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015-2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.cli.command.schedule;
+
+import co.cask.cdap.cli.CLIConfig;
+import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.english.Article;
+import co.cask.cdap.cli.english.Fragment;
+import co.cask.cdap.cli.exception.CommandInputError;
+import co.cask.cdap.cli.util.AbstractCommand;
+import co.cask.cdap.client.ScheduleClient;
+import co.cask.cdap.proto.id.ScheduleId;
+import co.cask.common.cli.Arguments;
+import com.google.inject.Inject;
+
+import java.io.PrintStream;
+
+/**
+ * Gets the status of a schedule.
+ */
+public final class GetScheduleStatusCommand extends AbstractCommand {
+
+  private final ScheduleClient scheduleClient;
+
+  @Inject
+  public GetScheduleStatusCommand(CLIConfig cliConfig, ScheduleClient scheduleClient) {
+    super(cliConfig);
+    this.scheduleClient = scheduleClient;
+  }
+
+  @Override
+  public void perform(Arguments arguments, PrintStream printStream) throws Exception {
+    String[] programIdParts = arguments.get(ElementType.SCHEDULE.getArgumentName().toString()).split("\\.");
+    if (programIdParts.length < 2) {
+      throw new CommandInputError(this);
+    }
+
+    String appId = programIdParts[0];
+    String scheduleName = programIdParts[1];
+    ScheduleId scheduleId = cliConfig.getCurrentNamespace().app(appId).schedule(scheduleName);
+
+    printStream.println(scheduleClient.getStatus(scheduleId));
+  }
+
+  @Override
+  public String getPattern() {
+    return String.format("get schedule status <%s>", ElementType.SCHEDULE.getArgumentName());
+  }
+
+  @Override
+  public String getDescription() {
+    return String.format("Gets the status of %s", Fragment.of(Article.A, ElementType.SCHEDULE.getName()));
+  }
+}

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/schedule/ListWorkflowSchedulesCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/schedule/ListWorkflowSchedulesCommand.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2015-2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.cli.command.schedule;
+
+import co.cask.cdap.api.schedule.Schedule;
+import co.cask.cdap.api.schedule.ScheduleSpecification;
+import co.cask.cdap.cli.CLIConfig;
+import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.english.Article;
+import co.cask.cdap.cli.english.Fragment;
+import co.cask.cdap.cli.exception.CommandInputError;
+import co.cask.cdap.cli.util.AbstractCommand;
+import co.cask.cdap.cli.util.RowMaker;
+import co.cask.cdap.cli.util.table.Table;
+import co.cask.cdap.client.ScheduleClient;
+import co.cask.cdap.internal.schedule.StreamSizeSchedule;
+import co.cask.cdap.internal.schedule.TimeSchedule;
+import co.cask.cdap.proto.id.WorkflowId;
+import co.cask.common.cli.Arguments;
+import com.google.common.collect.Lists;
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+
+import java.io.PrintStream;
+import java.util.List;
+
+/**
+ * Lists the schedules for a given workflow.
+ */
+public final class ListWorkflowSchedulesCommand extends AbstractCommand {
+
+  private static final Gson GSON = new Gson();
+
+  private final ScheduleClient scheduleClient;
+
+  @Inject
+  ListWorkflowSchedulesCommand(CLIConfig cliConfig, ScheduleClient scheduleClient) {
+    super(cliConfig);
+    this.scheduleClient = scheduleClient;
+  }
+
+  @Override
+  public void perform(Arguments arguments, PrintStream output) throws Exception {
+    String[] programIdParts = arguments.get(ElementType.WORKFLOW.getArgumentName().toString()).split("\\.");
+    if (programIdParts.length < 2) {
+      throw new CommandInputError(this);
+    }
+
+    final String appId = programIdParts[0];
+    String workflowName = programIdParts[1];
+    WorkflowId workflowId = cliConfig.getCurrentNamespace().app(appId).workflow(workflowName);
+
+    List<ScheduleSpecification> list = scheduleClient.list(workflowId);
+    Table table = Table.builder()
+      .setHeader("application", "program", "program type", "name", "type", "description", "properties",
+                 "runtime args")
+      .setRows(list, new RowMaker<ScheduleSpecification>() {
+        @Override
+        public List<?> makeRow(ScheduleSpecification object) {
+          return Lists.newArrayList(appId,
+                                    object.getProgram().getProgramName(),
+                                    object.getProgram().getProgramType().name(),
+                                    object.getSchedule().getName(),
+                                    getScheduleType(object.getSchedule()),
+                                    object.getSchedule().getDescription(),
+                                    getScheduleProperties(object.getSchedule()),
+                                    GSON.toJson(object.getProperties()));
+        }
+      }).build();
+    cliConfig.getTableRenderer().render(cliConfig, output, table);
+  }
+
+  private String getScheduleType(Schedule schedule) {
+    return schedule.getClass().getName();
+  }
+
+  private String getScheduleProperties(Schedule schedule) {
+    if (schedule instanceof TimeSchedule) {
+      TimeSchedule timeSchedule = (TimeSchedule) schedule;
+      return String.format("cron entry: %s", timeSchedule.getCronEntry());
+    } else if (schedule instanceof StreamSizeSchedule) {
+      StreamSizeSchedule streamSizeSchedule = (StreamSizeSchedule) schedule;
+      return String.format("stream: %s, trigger MB: %d",
+                           streamSizeSchedule.getStreamName(), streamSizeSchedule.getDataTriggerMB());
+    } else {
+      return "";
+    }
+  }
+
+  @Override
+  public String getPattern() {
+    return String.format("get %s schedules <%s>",
+                         ElementType.WORKFLOW.getName(), ElementType.WORKFLOW.getArgumentName());
+  }
+
+  @Override
+  public String getDescription() {
+    return String.format("Gets schedules of %s", Fragment.of(Article.A, ElementType.WORKFLOW.getName()));
+
+  }
+}

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/schedule/ResumeScheduleCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/schedule/ResumeScheduleCommand.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015-2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.cli.command.schedule;
+
+import co.cask.cdap.cli.CLIConfig;
+import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.english.Article;
+import co.cask.cdap.cli.english.Fragment;
+import co.cask.cdap.cli.exception.CommandInputError;
+import co.cask.cdap.cli.util.AbstractCommand;
+import co.cask.cdap.client.ScheduleClient;
+import co.cask.cdap.proto.id.ScheduleId;
+import co.cask.common.cli.Arguments;
+import com.google.inject.Inject;
+
+import java.io.PrintStream;
+
+/**
+ * Resumes a schedule.
+ */
+public final class ResumeScheduleCommand extends AbstractCommand {
+
+  private final ScheduleClient scheduleClient;
+
+  @Inject
+  public ResumeScheduleCommand(CLIConfig cliConfig, ScheduleClient scheduleClient) {
+    super(cliConfig);
+    this.scheduleClient = scheduleClient;
+  }
+
+  @Override
+  public void perform(Arguments arguments, PrintStream printStream) throws Exception {
+    String[] programIdParts = arguments.get(ElementType.SCHEDULE.getArgumentName().toString()).split("\\.");
+    if (programIdParts.length < 2) {
+      throw new CommandInputError(this);
+    }
+
+    String appId = programIdParts[0];
+    String scheduleName = programIdParts[1];
+    ScheduleId schedule = cliConfig.getCurrentNamespace().app(appId).schedule(scheduleName);
+
+    scheduleClient.resume(schedule);
+    printStream.printf("Successfully resumed schedule '%s' in app '%s'\n", scheduleName, appId);
+  }
+
+  @Override
+  public String getPattern() {
+    return String.format("resume schedule <%s>", ElementType.SCHEDULE.getArgumentName());
+  }
+
+  @Override
+  public String getDescription() {
+    return String.format("Resumes %s", Fragment.of(Article.A, ElementType.SCHEDULE.getName()));
+  }
+}

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/schedule/SuspendScheduleCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/schedule/SuspendScheduleCommand.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015-2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.cli.command.schedule;
+
+import co.cask.cdap.cli.CLIConfig;
+import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.english.Article;
+import co.cask.cdap.cli.english.Fragment;
+import co.cask.cdap.cli.exception.CommandInputError;
+import co.cask.cdap.cli.util.AbstractCommand;
+import co.cask.cdap.client.ScheduleClient;
+import co.cask.cdap.proto.id.ScheduleId;
+import co.cask.common.cli.Arguments;
+import com.google.inject.Inject;
+
+import java.io.PrintStream;
+
+/**
+ * Suspends a schedule.
+ */
+public final class SuspendScheduleCommand extends AbstractCommand {
+
+  private final ScheduleClient scheduleClient;
+
+  @Inject
+  public SuspendScheduleCommand(CLIConfig cliConfig, ScheduleClient scheduleClient) {
+    super(cliConfig);
+    this.scheduleClient = scheduleClient;
+  }
+
+  @Override
+  public void perform(Arguments arguments, PrintStream printStream) throws Exception {
+    String[] programIdParts = arguments.get(ElementType.SCHEDULE.getArgumentName().toString()).split("\\.");
+    if (programIdParts.length < 2) {
+      throw new CommandInputError(this);
+    }
+
+    String appId = programIdParts[0];
+    String scheduleName = programIdParts[1];
+    ScheduleId scheduleId = cliConfig.getCurrentNamespace().app(appId).schedule(scheduleName);
+
+    scheduleClient.suspend(scheduleId);
+    printStream.printf("Successfully suspended schedule '%s' in app '%s'\n", scheduleName, appId);
+  }
+
+  @Override
+  public String getPattern() {
+    return String.format("suspend schedule <%s>", ElementType.SCHEDULE.getArgumentName());
+  }
+
+  @Override
+  public String getDescription() {
+    return String.format("Suspends %s", Fragment.of(Article.A, ElementType.SCHEDULE.getName()));
+  }
+}

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/command/schedule/UpdateTimeScheduleCommand.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/command/schedule/UpdateTimeScheduleCommand.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.cli.command.schedule;
+
+import co.cask.cdap.api.schedule.Schedule;
+import co.cask.cdap.api.schedule.Schedules;
+import co.cask.cdap.cli.ArgumentName;
+import co.cask.cdap.cli.CLIConfig;
+import co.cask.cdap.cli.ElementType;
+import co.cask.cdap.cli.english.Article;
+import co.cask.cdap.cli.english.Fragment;
+import co.cask.cdap.cli.exception.CommandInputError;
+import co.cask.cdap.cli.util.AbstractCommand;
+import co.cask.cdap.cli.util.ArgumentParser;
+import co.cask.cdap.client.ScheduleClient;
+import co.cask.cdap.proto.ScheduleInstanceConfiguration;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.id.ScheduleId;
+import co.cask.common.cli.Arguments;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+
+import java.io.PrintStream;
+import java.util.Map;
+
+/**
+ * Updates a schedule.
+ */
+public final class UpdateTimeScheduleCommand extends AbstractCommand {
+
+  private final ScheduleClient scheduleClient;
+
+  @Inject
+  public UpdateTimeScheduleCommand(CLIConfig cliConfig, ScheduleClient scheduleClient) {
+    super(cliConfig);
+    this.scheduleClient = scheduleClient;
+  }
+
+  @Override
+  public void perform(Arguments arguments, PrintStream printStream) throws Exception {
+    String scheduleName = arguments.get(ArgumentName.SCHEDULE_NAME.toString());
+    String[] programIdParts = arguments.get(ArgumentName.PROGRAM.toString()).split("\\.");
+    String version = arguments.getOptional(ArgumentName.APP_VERSION.toString());
+    String scheduleDescription = arguments.getOptional(ArgumentName.DESCRIPTION.toString(), "");
+    String cronExpression = arguments.get(ArgumentName.CRON_EXPRESSION.toString());
+    String schedulePropertiesString = arguments.getOptional(ArgumentName.SCHEDULE_PROPERTIES.toString(), "");
+    String scheduleRunConcurrencyString = arguments.getOptional(ArgumentName.CONCURRENCY.toString(), null);
+
+    if (programIdParts.length < 2) {
+      throw new CommandInputError(this);
+    }
+
+    String appId = programIdParts[0];
+    NamespaceId namespaceId = cliConfig.getCurrentNamespace();
+    ApplicationId applicationId = (version == null) ? namespaceId.app(appId) : namespaceId.app(appId, version);
+    ScheduleId scheduleId = applicationId.schedule(scheduleName);
+
+    Schedules.Builder builder = Schedules.builder(scheduleName);
+    if (scheduleRunConcurrencyString != null) {
+      builder.setMaxConcurrentRuns(Integer.valueOf(scheduleRunConcurrencyString));
+    }
+    if (scheduleDescription != null) {
+      builder.setDescription(scheduleDescription);
+    }
+    Schedule schedule = builder.createTimeSchedule(cronExpression);
+
+    Map<String, String> programMap = ImmutableMap.of("programName", programIdParts[1],
+                                                     "programType", ElementType.WORKFLOW.name().toUpperCase());
+    Map<String, String> propertiesMap = ArgumentParser.parseMap(schedulePropertiesString,
+                                                                ArgumentName.SCHEDULE_PROPERTIES.toString());
+
+    ScheduleInstanceConfiguration configuration =
+      new ScheduleInstanceConfiguration("TIME", schedule, programMap, propertiesMap);
+
+    scheduleClient.update(scheduleId, configuration);
+    printStream.printf("Successfully updated schedule '%s' in app '%s'\n", scheduleName, appId);
+  }
+
+  @Override
+  public String getPattern() {
+    return String.format("update time schedule <%s> for workflow <%s> [version <%s>] " +
+                           "[description <%s>] at <%s> [concurrency <%s>] [properties <%s>]",
+                         ArgumentName.SCHEDULE_NAME, ArgumentName.PROGRAM, ArgumentName.APP_VERSION,
+                         ArgumentName.DESCRIPTION, ArgumentName.CRON_EXPRESSION, ArgumentName.CONCURRENCY,
+                         ArgumentName.SCHEDULE_PROPERTIES);
+  }
+
+  @Override
+  public String getDescription() {
+    return String.format("Updates %s which is associated with %s given",
+                         Fragment.of(Article.A, ElementType.SCHEDULE.getName()),
+                         Fragment.of(Article.THE, ElementType.PROGRAM.getName()));
+  }
+}

--- a/cdap-cli/src/main/java/co/cask/cdap/cli/english/Article.java
+++ b/cdap-cli/src/main/java/co/cask/cdap/cli/english/Article.java
@@ -22,6 +22,7 @@ package co.cask.cdap.cli.english;
 public abstract class Article {
 
   public static final Article A = new A();
+  public static final Article THE = new The();
 
   public abstract String toString(Word word);
 
@@ -39,4 +40,13 @@ public abstract class Article {
     }
   }
 
+  /**
+   * "the"
+   */
+  private static class The extends Article {
+    @Override
+    public String toString(Word word) {
+      return "the";
+    }
+  }
 }

--- a/cdap-client-tests/src/main/java/co/cask/cdap/client/app/FakeWorkflow.java
+++ b/cdap-client-tests/src/main/java/co/cask/cdap/client/app/FakeWorkflow.java
@@ -36,6 +36,7 @@ public class FakeWorkflow implements Workflow {
 
   public static final String NAME = "FakeWorkflow";
   public static final String FAKE_LOG = "Running " + NAME;
+  public static final String SCHEDULE = "FakeSchedule";
 
   @Override
   public void configure(WorkflowConfigurer configurer) {

--- a/cdap-proto/src/main/java/co/cask/cdap/proto/ScheduleInstanceConfiguration.java
+++ b/cdap-proto/src/main/java/co/cask/cdap/proto/ScheduleInstanceConfiguration.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2014-2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.proto;
+
+import co.cask.cdap.api.schedule.Schedule;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * POJO that carries schedule type and properties information for create schedule request
+ */
+public final class ScheduleInstanceConfiguration {
+  private final String scheduleType;
+  private final Schedule schedule;
+  private final Map<String, String> program;
+  private final Map<String, String> properties;
+
+  public ScheduleInstanceConfiguration(String scheduleType, Schedule schedule,
+                                       Map<String, String> program, Map<String, String> properties) {
+    this.scheduleType = scheduleType;
+    this.schedule = schedule;
+    this.program = program;
+    this.properties = properties;
+  }
+
+  public String getScheduleType() {
+    return scheduleType;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties == null ? Collections.<String, String>emptyMap() : properties;
+  }
+
+  public Schedule getSchedule() {
+    return schedule;
+  }
+
+  public Map<String, String> getProgram() {
+    return program;
+  }
+}


### PR DESCRIPTION
This commit introduces introduces 'add time schedule', 'update time
schedule' and 'delete schedule' CLI endpoints. In addition to this, a
lot of refactoring was done in order to pull out unnecessarily nested
classes.

JIRA: https://issues.cask.co/browse/CDAP-8902
Bamboo: https://builds.cask.co/browse/CDAP-RUT876