### PR TITLE
[docs] add note that CSD will prompt for CM mgmt service restart

### DIFF
--- a/cdap-docs/admin-manual/source/installation/cloudera.rst
+++ b/cdap-docs/admin-manual/source/installation/cloudera.rst
@@ -235,6 +235,9 @@ available services which CM can install.
    using the instructions given for the case of installing software in the form of a parcel.
    In this case, you install the CSD first and then install the parcel second.
 
+#. The first time the CDAP CSD is installed, the Cloudera Management Service may prompt
+   to be restarted. This is necessary for the CDAP services to be properly monitored.
+
 .. _cloudera-installation-download-distribute-parcel:
 
 Downloading and Installing Parcels


### PR DESCRIPTION
Adds a quick note that installing the CSD causes the Cloudera Management Service to prompt for restarting.  This is needed to add a monitoring entry so that the green/red lights show up.