### PR TITLE
CDAP-5715 fix endpoint context plugin loading

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepository.java
@@ -318,7 +318,7 @@ public class ArtifactRepository {
    * Returns a {@link Map.Entry} representing the plugin information for the plugin being requested.
    *
    * @param namespace the namespace to get plugins from
-   * @param artifactId the id of the artifact to get plugins for
+   * @param artifactRange the artifact range to get plugins for
    * @param pluginType plugin type name
    * @param pluginName plugin name
    * @param selector for selecting which plugin to use
@@ -327,19 +327,25 @@ public class ArtifactRepository {
    * @throws ArtifactNotFoundException if the given artifact does not exist
    * @throws PluginNotExistsException if no plugins of the given type and name are available to the given artifact
    */
-  public Map.Entry<ArtifactDescriptor, PluginClass> findPlugin(NamespaceId namespace, Id.Artifact artifactId,
+  public Map.Entry<ArtifactDescriptor, PluginClass> findPlugin(NamespaceId namespace, ArtifactRange artifactRange,
                                                                String pluginType, String pluginName,
                                                                PluginSelector selector)
     throws IOException, PluginNotExistsException, ArtifactNotFoundException {
     SortedMap<ArtifactDescriptor, PluginClass> pluginClasses = artifactStore.getPluginClasses(
-      namespace, artifactId, pluginType, pluginName);
+      namespace, artifactRange, pluginType, pluginName);
+    return getPluginEntries(pluginClasses, selector, artifactRange.getNamespace().toId(), pluginType, pluginName);
+  }
+
+  private Map.Entry<ArtifactDescriptor, PluginClass> getPluginEntries(
+    SortedMap<ArtifactDescriptor, PluginClass> pluginClasses, PluginSelector selector, Id.Namespace namespace,
+    String pluginType, String pluginName) throws PluginNotExistsException {
     SortedMap<ArtifactId, PluginClass> artifactIds = Maps.newTreeMap();
     for (Map.Entry<ArtifactDescriptor, PluginClass> pluginClassEntry : pluginClasses.entrySet()) {
       artifactIds.put(pluginClassEntry.getKey().getArtifactId(), pluginClassEntry.getValue());
     }
     Map.Entry<ArtifactId, PluginClass> chosenArtifact = selector.select(artifactIds);
     if (chosenArtifact == null) {
-      throw new PluginNotExistsException(artifactId, pluginType, pluginName);
+      throw new PluginNotExistsException(namespace, pluginType, pluginName);
     }
 
     for (Map.Entry<ArtifactDescriptor, PluginClass> pluginClassEntry : pluginClasses.entrySet()) {
@@ -347,7 +353,7 @@ public class ArtifactRepository {
         return pluginClassEntry;
       }
     }
-    throw new PluginNotExistsException(artifactId, pluginType, pluginName);
+    throw new PluginNotExistsException(namespace, pluginType, pluginName);
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
@@ -398,8 +398,11 @@ public class ArtifactRepositoryTest {
   @Test
   public void testPluginSelector() throws Exception {
     // No plugin yet
+    ArtifactRange appArtifactRange = new ArtifactRange(APP_ARTIFACT_ID.getNamespace(), APP_ARTIFACT_ID.getName(),
+                                                       APP_ARTIFACT_ID.getVersion(), true,
+                                                       APP_ARTIFACT_ID.getVersion(), true);
     try {
-      artifactRepository.findPlugin(NamespaceId.DEFAULT, APP_ARTIFACT_ID,
+      artifactRepository.findPlugin(NamespaceId.DEFAULT, appArtifactRange,
                                     "plugin", "TestPlugin2", new PluginSelector());
       Assert.fail();
     } catch (PluginNotExistsException e) {
@@ -421,7 +424,7 @@ public class ArtifactRepositoryTest {
 
     // Should get the only version.
     Map.Entry<ArtifactDescriptor, PluginClass> plugin =
-      artifactRepository.findPlugin(NamespaceId.DEFAULT, APP_ARTIFACT_ID,
+      artifactRepository.findPlugin(NamespaceId.DEFAULT, appArtifactRange,
                                     "plugin", "TestPlugin2", new PluginSelector());
     Assert.assertNotNull(plugin);
     Assert.assertEquals(new ArtifactVersion("1.0"), plugin.getKey().getArtifactId().getVersion());
@@ -435,7 +438,7 @@ public class ArtifactRepositoryTest {
     artifactRepository.addArtifact(artifact2Id, jarFile, parents);
 
     // Should select the latest version
-    plugin = artifactRepository.findPlugin(NamespaceId.DEFAULT, APP_ARTIFACT_ID,
+    plugin = artifactRepository.findPlugin(NamespaceId.DEFAULT, appArtifactRange,
                                            "plugin", "TestPlugin2", new PluginSelector());
     Assert.assertNotNull(plugin);
     Assert.assertEquals(new ArtifactVersion("2.0"), plugin.getKey().getArtifactId().getVersion());
@@ -449,7 +452,7 @@ public class ArtifactRepositoryTest {
       Class<?> pluginClass = pluginClassLoader.loadClass(TestPlugin2.class.getName());
 
       // Use a custom plugin selector to select with smallest version
-      plugin = artifactRepository.findPlugin(NamespaceId.DEFAULT, APP_ARTIFACT_ID,
+      plugin = artifactRepository.findPlugin(NamespaceId.DEFAULT, appArtifactRange,
                                              "plugin", "TestPlugin2", new PluginSelector() {
           @Override
           public Map.Entry<ArtifactId, PluginClass> select(SortedMap<ArtifactId, PluginClass> plugins) {

--- a/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ArtifactHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/co/cask/cdap/internal/app/services/http/handlers/ArtifactHttpHandlerTest.java
@@ -488,6 +488,9 @@ public class ArtifactHttpHandlerTest extends AppFabricTestBase {
     Assert.assertEquals(HttpResponseStatus.OK.getCode(),
                         addAppArtifact(wordCount1Id, WordCountApp.class).getStatusLine().getStatusCode());
 
+    Id.Artifact wordCount2Id = Id.Artifact.from(Id.Namespace.DEFAULT, "testartifact", "1.0.0");
+    Assert.assertEquals(HttpResponseStatus.OK.getCode(),
+                        addAppArtifact(wordCount2Id, WordCountApp.class).getStatusLine().getStatusCode());
     // add some plugins.
     // plugins-3.0.0 extends wordcount[1.0.0,2.0.0)
     Manifest manifest = new Manifest();
@@ -514,8 +517,14 @@ public class ArtifactHttpHandlerTest extends AppFabricTestBase {
     manifest = new Manifest();
     manifest.getMainAttributes().put(ManifestFields.EXPORT_PACKAGE, CallingPlugin.class.getPackage().getName());
     Id.Artifact plugins4Id = Id.Artifact.from(Id.Namespace.DEFAULT, "plugins4", "1.0.0");
+    // we also add test artifact as parent for calling plugin,
+    // when callable plugin is loaded by calling plugin's method,
+    // it will try with "testArtifact" parent - wouldn't be able to load
+    // then it will load using "wordcount" parent  and succeed
     Set<ArtifactRange> plugins4Parents = Sets.newHashSet(new ArtifactRange(
-      NamespaceId.DEFAULT, "wordcount", new ArtifactVersion("1.0.0"), new ArtifactVersion("2.0.0")));
+      NamespaceId.DEFAULT, "wordcount", new ArtifactVersion("1.0.0"), new ArtifactVersion("2.0.0")),
+                                                         new ArtifactRange(
+      NamespaceId.DEFAULT, "testartifact", new ArtifactVersion("1.0.0"), new ArtifactVersion("2.0.0")));
     Assert.assertEquals(HttpResponseStatus.OK.getCode(),
                         addPluginArtifact(plugins4Id, CallingPlugin.class, manifest,
                                           plugins4Parents).getStatusLine().getStatusCode());


### PR DESCRIPTION
earlier we looked at only one of the parent artifact to load the plugin in EndpointPluginContext implementation.
Now we use all parent artifacts and use them to load the plugin. we return the plugin once we are able to load.
JIRA: https://issues.cask.co/browse/CDAP-5715