### PR TITLE
[CDAP-8900] DataPrep upgrade ability if newer artifact exist

### DIFF
--- a/cdap-ui/app/cdap/api/dataprep.js
+++ b/cdap-ui/app/cdap/api/dataprep.js
@@ -31,12 +31,15 @@ const MyDataPrepApi = {
   summary: apiCreator(dataSrc, 'GET', 'REQUEST', `${basepath}/summary`),
   getSchema: apiCreator(dataSrc, 'GET', 'REQUEST', `${basepath}/schema`),
   getUsage: apiCreator(dataSrc, 'GET', 'REQUEST', `${baseServicePath}/methods/usage`),
+  getInfo: apiCreator(dataSrc, 'GET', 'REQUEST', `${baseServicePath}/methods/info`),
 
   // WRANGLER SERVICE MANAGEMENT
   getApp: apiCreator(dataSrc, 'GET', 'REQUEST', `${appPath}`),
   startService: apiCreator(dataSrc, 'POST', 'REQUEST', `${baseServicePath}/start`),
+  stopService: apiCreator(dataSrc, 'POST', 'REQUEST', `${baseServicePath}/stop`),
   pollServiceStatus: apiCreator(dataSrc, 'GET', 'POLL', `${baseServicePath}/status`),
-  createApp: apiCreator(dataSrc, 'PUT', 'REQUEST', `${appPath}`)
+  createApp: apiCreator(dataSrc, 'PUT', 'REQUEST', `${appPath}`),
+  ping: apiCreator(dataSrc, 'GET', 'REQUEST', `${baseServicePath}/methods/usage`, { interval: 2000 })
 };
 
 export default MyDataPrepApi;

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepServiceControl/ServiceEnablerUtilities.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepServiceControl/ServiceEnablerUtilities.js
@@ -1,0 +1,197 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import NamespaceStore from 'services/NamespaceStore';
+import {findHighestVersion} from 'services/VersionRange/VersionUtilities';
+import {MyArtifactApi} from 'api/artifact';
+import MyDataPrepApi from 'api/dataprep';
+
+import Rx from 'rx';
+
+export default function enableDataPreparationService(shouldStopService) {
+  function enableService(observer) {
+
+    /**
+     *  1. Get Wrangler Service App
+     *  2. If not found, create app
+     *  3. Start Wrangler Service
+     *  4. Poll until service starts, then reload page
+     **/
+
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    MyArtifactApi.list({ namespace })
+      .subscribe((res) => {
+        let wranglerArtifacts = res.filter((artifact) => {
+          return artifact.name === 'wrangler-service';
+        });
+
+        if (wranglerArtifacts.length === 0) {
+          observer.onError({
+            error: 'Cannot find wrangler-service artifact'
+          });
+          return;
+        }
+
+        let versionsArray = wranglerArtifacts.map((artifact) => {
+          return artifact.version;
+        });
+
+        let highestVersion = findHighestVersion(versionsArray, true);
+
+        let highestVersionArtifact = wranglerArtifacts.filter((artifact) => {
+          return artifact.version === highestVersion;
+        });
+
+        if (highestVersionArtifact.length > 1) {
+          // The only times when the length is greater than 1 is
+          // when there are two artifacts with the same version;
+          // USER and SYSTEM scope. In that case, take the USER scope
+          highestVersionArtifact = highestVersionArtifact[0];
+          highestVersionArtifact.scope = 'USER';
+        } else {
+          highestVersionArtifact = highestVersionArtifact[0];
+        }
+
+        MyDataPrepApi.getApp({ namespace })
+          .subscribe((res) => {
+            if (res.artifact.version !== highestVersion) {
+              // there's higher version available, so create
+              // new app with the higher version
+              createApp(highestVersionArtifact, observer);
+              return;
+            }
+
+            // Wrangler app already exist
+            // Just start service
+            startService(observer);
+          }, () => {
+            // App does not exist
+            // Go to create app
+            createApp(highestVersionArtifact, observer);
+          });
+      });
+
+  }
+
+  function createApp(artifact, observer) {
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    MyDataPrepApi.createApp({ namespace }, { artifact })
+      .subscribe(() => {
+        startService(observer);
+      }, (err) => {
+        observer.onError({
+          error: 'Failed to enable data preparation',
+          extendedMessage: err.data || err
+        });
+      });
+  }
+
+  function startService(observer) {
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    MyDataPrepApi.startService({ namespace })
+      .subscribe(() => {
+        pollServiceStatus(observer);
+      }, (err) => {
+        observer.onError({
+          error: 'Failed to enable data preparation',
+          extendedMessage: err.data || err
+        });
+      });
+  }
+
+  function pollServiceStatus(observer) {
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    let servicePoll = MyDataPrepApi.pollServiceStatus({ namespace })
+      .subscribe((res) => {
+        if (res.status === 'RUNNING') {
+          servicePoll.dispose();
+          pingService(observer);
+        }
+      }, (err) => {
+        observer.onError({
+          error: 'Failed to enable data preparation',
+          extendedMessage: err.data || err
+        });
+      });
+  }
+
+  function pingService(observer) {
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+
+    function ping() {
+      MyDataPrepApi.ping({ namespace })
+        .subscribe(() => {
+          observer.onCompleted();
+          window.location.reload();
+        }, () => {
+          setTimeout(() => {
+            ping();
+          }, 2000);
+        });
+    }
+
+    ping();
+  }
+
+  function stopService(observer) {
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    MyDataPrepApi.stopService({ namespace })
+      .subscribe(() => {
+        pollStopServiceStatus(observer);
+      }, (err) => {
+        observer.onError({
+          error: 'Failed to stop Data Preparation service',
+          extendedMessage: err.data || err
+        });
+      });
+
+  }
+
+  function pollStopServiceStatus(observer) {
+    let namespace = NamespaceStore.getState().selectedNamespace;
+
+    let servicePoll = MyDataPrepApi.pollServiceStatus({ namespace })
+      .subscribe((res) => {
+        if (res.status === 'STOPPED') {
+          enableService(observer);
+
+          servicePoll.dispose();
+        }
+      }, (err) => {
+        observer.onError({
+          error: 'Failed to stop Data Preparation service',
+          extendedMessage: err.data || err
+        });
+      });
+  }
+
+
+  let subject = new Rx.Subject();
+
+  if (shouldStopService) {
+    stopService(subject);
+  } else {
+    enableService(subject);
+  }
+
+  return subject;
+}

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepServiceControl/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepServiceControl/index.js
@@ -15,10 +15,7 @@
  */
 
 import React, { Component } from 'react';
-import MyDataPrepApi from 'api/dataprep';
-import {MyArtifactApi} from 'api/artifact';
-import find from 'lodash/find';
-import NamespaceStore from 'services/NamespaceStore';
+import enableDataPreparationService from 'components/DataPrep/DataPrepServiceControl/ServiceEnablerUtilities';
 
 export default class DataPrepServiceControl extends Component {
   constructor(props) {
@@ -42,74 +39,13 @@ export default class DataPrepServiceControl extends Component {
   enableService() {
     this.setState({loading: true});
 
-    /**
-     *  1. Get Wrangler Service App
-     *  2. If not found, create app
-     *  3. Start Wrangler Service
-     *  4. Poll until service starts, then reload page
-     **/
-
-    let namespace = NamespaceStore.getState().selectedNamespace;
-
-    MyDataPrepApi.getApp({ namespace })
+    enableDataPreparationService(false)
       .subscribe(() => {
-        // Wrangler app already exist
-        // Just start service
-        this.startService();
-      }, () => {
-        // App does not exist
-        // Go to create app
-        this.createApp();
-      });
-  }
-
-  createApp() {
-    let namespace = NamespaceStore.getState().selectedNamespace;
-
-    MyArtifactApi.list({ namespace })
-      .subscribe((res) => {
-        let artifact = find(res, { 'name': 'wrangler-service' });
-
-        MyDataPrepApi.createApp({ namespace }, { artifact })
-          .subscribe(() => {
-            this.startService();
-          }, (err) => {
-            this.setState({
-              error: 'Failed to enable data preparation',
-              extendedMessage: err.data || err,
-              loading: false
-            });
-          });
-      });
-  }
-
-  startService() {
-    let namespace = NamespaceStore.getState().selectedNamespace;
-
-    MyDataPrepApi.startService({ namespace })
-      .subscribe(() => {
-        this.pollServiceStatus();
+        console.log('success');
       }, (err) => {
         this.setState({
-          error: 'Failed to enable data preparation',
-          extendedMessage: err.data || err,
-          loading: false
-        });
-      });
-  }
-
-  pollServiceStatus() {
-    let namespace = NamespaceStore.getState().selectedNamespace;
-
-    this.servicePoll = MyDataPrepApi.pollServiceStatus({ namespace })
-      .subscribe((res) => {
-        if (res.status === 'RUNNING') {
-          window.location.reload();
-        }
-      }, (err) => {
-        this.setState({
-          error: 'Failed to enable data preparation',
-          extendedMessage: err.data || err,
+          error: err.error,
+          extendedMessage: err.extendedMessage,
           loading: false
         });
       });

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/AddToPipelineModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/AddToPipelineModal.js
@@ -21,6 +21,7 @@ import find from 'lodash/find';
 import MyDataPrepApi from 'api/dataprep';
 import DataPrepStore from 'components/DataPrep/store';
 import NamespaceStore from 'services/NamespaceStore';
+import {findHighestVersion} from 'services/VersionRange/VersionUtilities';
 
 export default class AddToHydratorModal extends Component {
   constructor(props) {
@@ -41,6 +42,61 @@ export default class AddToHydratorModal extends Component {
   generateLinks() {
     let namespace = NamespaceStore.getState().selectedNamespace;
 
+    MyDataPrepApi.getInfo({ namespace })
+      .subscribe((res) => {
+        let pluginVersion = res.value[0]['plugin.version'];
+
+        this.constructProperties(pluginVersion);
+      }, (err) => {
+        if (err.statusCode === 404) {
+          console.log('cannot find method');
+          // can't find method; use latest wrangler-transform
+          this.constructProperties();
+        }
+      });
+  }
+
+  findWranglerArtifacts(artifacts, pluginVersion) {
+    let wranglerArtifacts = artifacts.filter((artifact) => {
+      if (pluginVersion) {
+        return artifact.name === 'wrangler-transform' && artifact.version === pluginVersion;
+      }
+
+      return artifact.name === 'wrangler-transform';
+    });
+
+    if (wranglerArtifacts.length === 0) {
+      // cannot find plugin. Error out
+      this.setState({
+        error: 'Cannot find wrangler-transform plugin. Please load wrangler transform from Cask Market'
+      });
+
+      return null;
+    }
+
+    let filteredArtifacts = wranglerArtifacts;
+
+    if (!pluginVersion) {
+      let highestVersion = findHighestVersion(wranglerArtifacts.map((artifact) => {
+        return artifact.version;
+      }), true);
+
+      filteredArtifacts = wranglerArtifacts.filter((artifact) => {
+        return artifact.version === highestVersion;
+      });
+    }
+
+    let returnArtifact = filteredArtifacts[0];
+
+    if (filteredArtifacts.length > 1) {
+      returnArtifact.scope = 'USER';
+    }
+
+    return returnArtifact;
+  }
+
+  constructProperties(pluginVersion) {
+    let namespace = NamespaceStore.getState().selectedNamespace;
     let state = DataPrepStore.getState().dataprep;
     let workspaceId = state.workspaceId;
 
@@ -59,7 +115,7 @@ export default class AddToHydratorModal extends Component {
       .subscribe((res) => {
         let batchArtifact = find(res[0], { 'name': 'cdap-data-pipeline' });
         let realtimeArtifact = find(res[0], { 'name': 'cdap-data-streams' });
-        let wranglerArtifact = find(res[0], { 'name': 'wrangler-transform' });
+        let wranglerArtifact = this.findWranglerArtifacts(res[0], pluginVersion);
 
         let tempSchema = {
           name: 'avroSchema',
@@ -130,7 +186,7 @@ export default class AddToHydratorModal extends Component {
 
     if (this.state.loading) {
       content = (
-        <div>
+        <div className="loading-container">
           <h4 className="text-xs-center">
             <span className="fa fa-spin fa-spinner" />
           </h4>
@@ -139,7 +195,7 @@ export default class AddToHydratorModal extends Component {
     } else if (this.state.error) {
       content = (
         <div>
-          <h4 className="text-danger text-xs-center">
+          <h4 className="text-danger loading-container">
             {this.state.error}
           </h4>
         </div>

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
@@ -34,6 +34,15 @@
       }
     }
 
+    .upgrade-button {
+      margin-top: 3px;
+      margin-left: 15px;
+
+      .fa.fa-wrench {
+        margin-right: 3px;
+      }
+    }
+
     .tag {
       font-size: 10px;
       vertical-align: top;
@@ -52,7 +61,8 @@
 }
 
 .workspace-management-modal,
-.add-to-pipeline-dataprep-modal {
+.add-to-pipeline-dataprep-modal,
+.dataprep-upgrade-modal {
   .close-section {
     cursor: pointer;
   }
@@ -78,11 +88,18 @@
   }
 }
 
-.add-to-pipeline-dataprep-modal.modal-dialog {
+.add-to-pipeline-dataprep-modal.modal-dialog,
+.dataprep-upgrade-modal.modal-dialog {
+  margin-top: 100px;
+
   .modal-body {
     padding: 0;
 
     .message { padding: 15px; }
+
+    .loading-container {
+      padding: 25px;
+    }
 
     .action-buttons {
       margin-top: 10px;

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/UpgradeModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/UpgradeModal.js
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { Component, PropTypes } from 'react';
+import { Modal, ModalHeader, ModalBody } from 'reactstrap';
+import enableDataPreparationService from 'components/DataPrep/DataPrepServiceControl/ServiceEnablerUtilities';
+import CardActionFeedback from 'components/CardActionFeedback';
+
+export default class UpgradeModal extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      loading: false,
+      error: null,
+      extendedMessage: null
+    };
+
+    this.attemptClose = this.attemptClose.bind(this);
+    this.upgradeClick = this.upgradeClick.bind(this);
+  }
+
+  attemptClose() {
+    if (this.state.loading) { return; }
+
+    this.props.toggle();
+  }
+
+  upgradeClick() {
+    this.setState({loading: true});
+
+    enableDataPreparationService(true)
+      .subscribe(() => {
+      }, (err) => {
+        this.setState({
+          loading: false,
+          error: err.error,
+          extendedMessage: err.extendedMessage
+        });
+      });
+  }
+
+  renderError() {
+    if (!this.state.error) { return null; }
+
+    return (
+      <CardActionFeedback
+        type="DANGER"
+        message={this.state.error}
+        extendedMessage={this.state.extendedMessage}
+      />
+    );
+  }
+
+  render() {
+    let content;
+
+    if (this.state.loading) {
+      content = (
+        <div className="loading-container">
+          <h3 className="text-xs-center">
+            <span className="fa fa-spin fa-spinner" />
+          </h3>
+        </div>
+      );
+    } else {
+      content = (
+        <div>
+          <div className="message">
+            Are you sure you want to upgrade Data Preparation?
+          </div>
+
+          <div className="action-buttons">
+            <div className="action-buttons">
+              <button
+                className="btn btn-secondary"
+                onClick={this.upgradeClick}
+              >
+                Yes
+              </button>
+              <button
+                className="btn btn-secondary"
+                onClick={this.attemptClose}
+              >
+                No
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <Modal
+        isOpen={true}
+        toggle={this.attemptClose}
+        zIndex="1070"
+        className="dataprep-upgrade-modal"
+      >
+        <ModalHeader>
+          <span>
+            Upgrade Data Preparation
+          </span>
+          {
+            this.state.loading ? null : (
+              <div
+                className="close-section float-xs-right"
+              >
+                <span
+                  className="fa fa-times"
+                  onClick={this.attemptClose}
+                />
+              </div>
+            )
+          }
+        </ModalHeader>
+        <ModalBody>
+          {content}
+          {this.renderError()}
+        </ModalBody>
+      </Modal>
+    );
+  }
+}
+
+UpgradeModal.propTypes = {
+  toggle: PropTypes.func
+};
+

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/index.js
@@ -19,6 +19,7 @@ import WorkspaceModal from 'components/DataPrep/TopPanel/WorkspaceModal';
 import DataPrepStore from 'components/DataPrep/store';
 import SchemaModal from 'components/DataPrep/TopPanel/SchemaModal';
 import AddToPipelineModal from 'components/DataPrep/TopPanel/AddToPipelineModal';
+import UpgradeModal from 'components/DataPrep/TopPanel/UpgradeModal';
 import ee from 'event-emitter';
 
 require('./TopPanel.scss');
@@ -27,25 +28,29 @@ export default class DataPrepTopPanel extends Component {
   constructor(props) {
     super(props);
 
-    let initialWorkspace = DataPrepStore.getState().dataprep.workspaceId;
+    let initialState = DataPrepStore.getState().dataprep;
     this.state = {
-      workspaceId: initialWorkspace,
+      workspaceId: initialState.workspaceId,
       workspaceModal: false,
       schemaModal: false,
-      addToPipelineModal: false
+      addToPipelineModal: false,
+      upgradeModal: false,
+      higherVersion: initialState.higherVersion
     };
 
     this.toggleWorkspaceModal = this.toggleWorkspaceModal.bind(this);
     this.toggleSchemaModal = this.toggleSchemaModal.bind(this);
     this.toggleAddToPipelineModal = this.toggleAddToPipelineModal.bind(this);
+    this.toggleUpgradeModal = this.toggleUpgradeModal.bind(this);
     this.eventEmitter = ee(ee);
 
     this.eventEmitter.on('DATAPREP_NO_WORKSPACE_ID', this.toggleWorkspaceModal);
 
     this.sub = DataPrepStore.subscribe(() => {
-      let storeWorkspace = DataPrepStore.getState().dataprep.workspaceId;
+      let state = DataPrepStore.getState().dataprep;
       this.setState({
-        workspaceId: storeWorkspace
+        workspaceId: state.workspaceId,
+        higherVersion: state.higherVersion
       });
     });
   }
@@ -65,6 +70,10 @@ export default class DataPrepTopPanel extends Component {
 
   toggleAddToPipelineModal() {
     this.setState({addToPipelineModal: !this.state.addToPipelineModal});
+  }
+
+  toggleUpgradeModal() {
+    this.setState({upgradeModal: !this.state.upgradeModal});
   }
 
   renderSchemaModal() {
@@ -91,6 +100,14 @@ export default class DataPrepTopPanel extends Component {
     );
   }
 
+  renderUpgradeModal() {
+    if (!this.state.upgradeModal) { return null; }
+
+    return (
+      <UpgradeModal toggle={this.toggleUpgradeModal} />
+    );
+  }
+
   render() {
     return (
       <div className="top-panel clearfix">
@@ -110,6 +127,21 @@ export default class DataPrepTopPanel extends Component {
             </span>
             <span className="fa fa-pencil" />
           </div>
+        </div>
+
+        <div className="upgrade-button float-xs-left">
+          {
+            this.state.higherVersion ? (
+              <button
+                className="btn btn-info btn-sm"
+                onClick={this.toggleUpgradeModal}
+              >
+                <span className="fa fa-wrench fa-fw" />
+                Upgrade
+              </button>
+            ) : null
+          }
+          {this.renderUpgradeModal()}
         </div>
 
         <div className="action-buttons float-xs-right">

--- a/cdap-ui/app/cdap/components/DataPrep/store/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/store/index.js
@@ -27,7 +27,8 @@ const defaultInitialState = {
   workspaceId: '',
   data: [],
   headers: [],
-  directives: []
+  directives: [],
+  higherVersion: null
 };
 
 const dataprep = (state = defaultInitialState, action = defaultAction) => {
@@ -58,6 +59,11 @@ const dataprep = (state = defaultInitialState, action = defaultAction) => {
       break;
     case DataPrepActions.setInitialized:
       stateCopy = Object.assign({}, state, { initialized: true });
+      break;
+    case DataPrepActions.setHigherVersion:
+      stateCopy = Object.assign({}, state, {
+        higherVersion: action.payload.higherVersion
+      });
       break;
     case DataPrepActions.reset:
       return defaultInitialState;

--- a/cdap-ui/app/cdap/components/Header/ProductDropdown/index.js
+++ b/cdap-ui/app/cdap/components/Header/ProductDropdown/index.js
@@ -91,7 +91,7 @@ export default class ProductDropdown extends Component {
     let cdapVersion = VersionStore.getState().version;
     let docsUrl = `http://docs.cask.co/cdap/${cdapVersion}/en/index.html`;
     let administrationURL = `${baseCDAPURL}/administration`;
-    let dataprepUrl = `${baseCDAPURL}/dataprep`;
+    let dataprepUrl = `${baseCDAPURL}/ns/${this.state.currentNamespace}/dataprep`;
     let oldUIUrl = `/oldcdap/ns/${this.state.currentNamespace}`;
     let userSection;
     if (this.state.username && window.CDAP_CONFIG.securityEnabled) {
@@ -167,7 +167,7 @@ export default class ProductDropdown extends Component {
             <DropdownItem tag="li">
               {
                 !this.props.nativeLink ?
-                  <Link to={`/dataprep`}>
+                  <Link to={`/ns/${this.state.currentNamespace}/dataprep`}>
                     {T.translate('features.Navbar.ProductDropdown.dataPrep')}
                     <span className="beta-badge">BETA</span>
                   </Link>

--- a/cdap-ui/app/cdap/main.js
+++ b/cdap-ui/app/cdap/main.js
@@ -30,7 +30,6 @@ import Header from 'components/Header';
 import Footer from 'components/Footer';
 import SplashScreen from 'components/SplashScreen';
 import ConnectionExample from 'components/ConnectionExample';
-import Experimental from 'components/Experimental';
 import cookie from 'react-cookie';
 import Router from 'react-router/BrowserRouter';
 import T from 'i18n-react';
@@ -117,7 +116,6 @@ class CDAP extends Component {
                 <Match exactly pattern="/ns" component={RouteToNamespace} />
                 <Match pattern="/ns/:namespace" history={history} component={Home} />
                 <Match exactly pattern="/ns/:namespace/dashboard" component={Dashboard} />
-                <Match pattern="/dataprep" component={Experimental} />
                 <Match pattern="/socket-example" component={ConnectionExample} />
                 <Match pattern="/schemaeditor" component={SchemaEditor} />
                 <Miss component={Page404} />

--- a/cdap-ui/app/cdap/services/VersionRange/Version.js
+++ b/cdap-ui/app/cdap/services/VersionRange/Version.js
@@ -90,4 +90,8 @@ export default class Version {
     // for invalid comparison
     return null;
   }
+
+  toString() {
+    return this.version;
+  }
 }

--- a/cdap-ui/app/cdap/services/VersionRange/VersionUtilities.js
+++ b/cdap-ui/app/cdap/services/VersionRange/VersionUtilities.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import Version from 'services/VersionRange/Version';
+
+export function findHighestVersion(versions, returnString) {
+  let highestVersion;
+
+  versions.forEach((version) => {
+    let currentVersion = version;
+    if (typeof currentVersion === 'string') {
+      currentVersion = new Version(currentVersion);
+    }
+
+    if (!highestVersion || currentVersion.compareTo(highestVersion) === 1) {
+      highestVersion = currentVersion;
+    }
+  });
+
+  return returnString ? highestVersion.toString() : highestVersion;
+}
+
+export function findLowestVersion(versions, returnString) {
+  let lowestVersion;
+
+  versions.forEach((version) => {
+    let currentVersion = version;
+    if (typeof currentVersion === 'string') {
+      currentVersion = new Version(currentVersion);
+    }
+
+    if (!lowestVersion || currentVersion.compareTo(lowestVersion) === -1) {
+      lowestVersion = currentVersion;
+    }
+  });
+
+  return returnString ? lowestVersion.toString() : lowestVersion;
+}

--- a/cdap-ui/app/cdap/services/VersionRange/__tests__/versionUtilities.test.js
+++ b/cdap-ui/app/cdap/services/VersionRange/__tests__/versionUtilities.test.js
@@ -14,13 +14,25 @@
  * the License.
  */
 
-const DataPrepActions = {
-  setData: 'DATAPREP_SET_DATA',
-  setDirectives: 'DATAPREP_SET_DIRECTIVES',
-  setWorkspace: 'DATAPREP_SET_WORKSPACE',
-  setInitialized: 'DATAPREP_SET_INITIALIZED',
-  setHigherVersion: 'DATAPREP_SET_HIGHER_VERSION',
-  reset: 'DATAPREP_RESET'
-};
+import {
+  findHighestVersion,
+  findLowestVersion
+} from 'services/VersionRange/VersionUtilities';
 
-export default DataPrepActions;
+describe('Version Utilities', () => {
+  const versionsArray = [
+    '1.0.0',
+    '1.2.0-SNAPSHOT',
+    '1.1.0',
+    '1.2.1',
+    '1.1.5'
+  ];
+
+  it('should find highest version', () => {
+    expect(findHighestVersion(versionsArray, true)).toBe('1.2.1');
+  });
+
+  it('should find lowest version', () => {
+    expect(findLowestVersion(versionsArray, true)).toBe('1.0.0');
+  });
+});


### PR DESCRIPTION
- If newer artifact exist, Upgrade button should show up
- During service enable, check for newer artifact version. If exist, create new app with newer version
- Use the `plugin.version` specified by wrangler-service when add to pipeline.

JIRA: https://issues.cask.co/browse/CDAP-8900
