### PR TITLE
prevent cdap cookbook 2.28.5 from overwriting client config

### DIFF
--- a/cdap-distributions/src/hdinsight/pkg/install.sh
+++ b/cdap-distributions/src/hdinsight/pkg/install.sh
@@ -73,7 +73,7 @@ ${__packerdir}/cookbook-setup.sh || die "Failed to install cookbooks"
 
 # CDAP cli install, ensures package dependencies are present
 # We must specify the cdap version
-echo "{\"cdap\": {\"version\": \"${CDAP_VERSION}\"}}" > ${__tmpdir}/cli-conf.json
+echo "{\"cdap\": {\"version\": \"${CDAP_VERSION}\", \"skip_prerequisites\": \"true\"}}" > ${__tmpdir}/cli-conf.json
 chef-solo -o 'recipe[cdap::cli]' -j ${__tmpdir}/cli-conf.json || die 'Failed during Chef CDAP CLI install'
 
 # Read zookeeper quorum from hbase-site.xml, using sourced init script function


### PR DESCRIPTION
cherry-picking the fix from #8047 forward to release/4.1.  Fix to prevent HDInsight provisioning failure.