### PR TITLE
[CDAP-8461] Show overview when navigating from detailed view to overview

### DIFF
--- a/cdap-ui/app/cdap/components/AppDetailedView/index.js
+++ b/cdap-ui/app/cdap/components/AppDetailedView/index.js
@@ -53,18 +53,24 @@ export default class AppDetailedView extends Component {
       },
       loading: true,
       entityMetadata: objectQuery(this.props, 'location', 'state', 'entityMetadata') || {},
-      isInvalid: false
+      isInvalid: false,
+      previousPathName: null
     };
   }
   componentWillMount() {
+    let selectedNamespace = NamespaceStore.getState().selectedNamespace;
     let {namespace, appId} = this.props.params;
+    let previousPathName = objectQuery(this.props, 'location', 'state', 'previousPathname') ||
+      `/ns/${selectedNamespace}?overviewid=${appId}&overviewtype=application`;
     if (!namespace) {
       namespace = NamespaceStore.getState().selectedNamespace;
     }
     ExploreTablesStore.dispatch(
       fetchTables(namespace)
     );
-
+    this.setState({
+      previousPathName
+    });
     if (this.state.entityDetail.programs.length === 0) {
       MyAppApi
         .get({
@@ -198,10 +204,8 @@ export default class AppDetailedView extends Component {
         </div>
       );
     }
-    let selectedNamespace = NamespaceStore.getState().selectedNamespace;
-    let previousPathname = objectQuery(this.props, 'location', 'state', 'previousPathname')  || `/ns/${selectedNamespace}`;
     let previousPaths = [{
-      pathname: previousPathname,
+      pathname: this.state.previousPathName,
       label: T.translate('commons.back')
     }];
     return (

--- a/cdap-ui/app/cdap/components/DatasetDetailedView/index.js
+++ b/cdap-ui/app/cdap/components/DatasetDetailedView/index.js
@@ -41,7 +41,6 @@ require('./DatasetDetailedView.scss');
 export default class DatasetDetailedView extends Component {
   constructor(props) {
     super(props);
-
     this.state = {
       entityDetail: objectQuery(this.props, 'location', 'state', 'entityDetail') | {
         schema: null,
@@ -53,15 +52,21 @@ export default class DatasetDetailedView extends Component {
       routeToHome: false,
       successMessage: null,
       notFound: false,
-      modalToOpen: objectQuery(this.props, 'location', 'query', 'modalToOpen') || ''
+      modalToOpen: objectQuery(this.props, 'location', 'query', 'modalToOpen') || '',
+      previousPathName: null
     };
   }
 
   componentWillMount() {
+    let selectedNamespace = NamespaceStore.getState().selectedNamespace;
     let {namespace, datasetId} = this.props.params;
+    let previousPathName = objectQuery(this.props, 'location', 'state', 'previousPathname')  || `/ns/${selectedNamespace}?overviewid=${datasetId}&overviewtype=dataset`;
     if (!namespace) {
       namespace = NamespaceStore.getState().selectedNamespace;
     }
+    this.setState({
+      previousPathName
+    });
     ExploreTablesStore.dispatch(
       fetchTables(namespace)
     );
@@ -240,10 +245,8 @@ export default class DatasetDetailedView extends Component {
         />
       );
     }
-    let selectedNamespace = NamespaceStore.getState().selectedNamespace;
-    let previousPathname = objectQuery(this.props, 'location', 'state', 'previousPathname')  || `/ns/${selectedNamespace}`;
     let previousPaths = [{
-      pathname: previousPathname,
+      pathname: this.state.previousPathName,
       label: T.translate('commons.back')
     }];
     return (

--- a/cdap-ui/app/cdap/components/DatasetStreamCards/index.js
+++ b/cdap-ui/app/cdap/components/DatasetStreamCards/index.js
@@ -20,6 +20,7 @@ import {parseMetadata} from 'services/metadata-parser';
 import {convertEntityTypeToApi} from 'services/entity-type-api-converter';
 import {Link} from 'react-router';
 import shortid from 'shortid';
+import {createRouterPath} from 'react-router/LocationUtils';
 require('./DataStreamCards.scss');
 
 export default function DatasetStreamCards({dataEntities}) {
@@ -39,7 +40,14 @@ export default function DatasetStreamCards({dataEntities}) {
     <div className="dataentity-cards">
       {
         data.map(dataEntity => (
-          <Link to={`/ns/${currentNamespace}/${convertEntityTypeToApi(dataEntity.type)}/${dataEntity.id}`}>
+          <Link
+            to={{
+              pathname: `/ns/${currentNamespace}/${convertEntityTypeToApi(dataEntity.type)}/${dataEntity.id}`,
+              state: {
+                previousPathname: createRouterPath(location).replace(/\/cdap\//g, '/')
+              }
+            }}
+          >
             <EntityCard
               className="entity-card-container"
               entity={dataEntity}

--- a/cdap-ui/app/cdap/components/EntityListView/EntityListView.scss
+++ b/cdap-ui/app/cdap/components/EntityListView/EntityListView.scss
@@ -19,23 +19,7 @@
 .entity-list-view {
   height: calc(100vh - 155px);
   align-items: flex-start;
-
-  .subtitle {
-    color: #999999;
-    border-bottom: 1px solid #dddddd;
-    height: 11px;
-    clear: both;
-    margin-right: 20px;
-    margin-left: 5px;
-    width: 100%;
-
-    span {
-      background-color: #ffffff;
-      padding-right: 15px;
-    }
-
-    margin-bottom: 15px;
-  }
+  overflow-x: hidden;
 
   .namespace-not-found {
     .open-namespace-wizard-link {
@@ -50,6 +34,11 @@
     flex-wrap: wrap;
     width: 100%;
 
+    &.error-holder {
+      height: 100%;
+      align-items: center;
+      justify-content: center;
+    }
     .entities-all-list-container {
       display: inline-flex;
       flex-wrap: wrap;

--- a/cdap-ui/app/cdap/components/EntityListView/JustAddedSection/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/JustAddedSection/index.js
@@ -25,17 +25,18 @@ import EntityCard from 'components/EntityCard';
 import T from 'i18n-react';
 import ee from 'event-emitter';
 import globalEvents from 'services/global-events';
-
+import SearchStore from 'components/EntityListView/SearchStore';
+import {JUSTADDED_THRESHOLD_TIME} from 'components/EntityListView/SearchStore/SearchConstants';
+import isNil from 'lodash/isNil';
 require('./JustAddedSection.scss');
-
-const TIME_THRESHOLD = 300000; // 5 minutes in millisecond
 
 export default class JustAddedSection extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      entities: []
+      entities: [],
+      selectedEntity: {}
     };
 
     this.fetchEntities = this.fetchEntities.bind(this);
@@ -50,6 +51,27 @@ export default class JustAddedSection extends Component {
 
   componentWillMount() {
     this.fetchEntities();
+    this.searchStoreSubscription = SearchStore.subscribe(() => {
+      let overviewEntity = SearchStore.getState().search.overviewEntity;
+      if (isNil(overviewEntity)) {
+        this.setState({
+          selectedEntity: {}
+        });
+        return;
+      }
+      let matchingEntity = this.state.entities
+        // The unique id check to make sure not to highlight entities in both Just added section and the normal grid view.
+        .find(entity => entity.id === overviewEntity.id && entity.type === overviewEntity.type && entity.uniqueId === overviewEntity.uniqueId);
+      if (matchingEntity) {
+        this.setState({
+          selectedEntity: matchingEntity
+        });
+      } else {
+        this.setState({
+          selectedEntity: {}
+        });
+      }
+    });
   }
 
   componentWillUnmount() {
@@ -58,16 +80,20 @@ export default class JustAddedSection extends Component {
     this.eventEmitter.off(globalEvents.PUBLISHPIPELINE, this.fetchEntities);
     this.eventEmitter.off(globalEvents.DELETEENTITY, this.fetchEntities);
     this.eventEmitter.off(globalEvents.ARTIFACTUPLOAD, this.fetchEntities);
+    if (this.searchStoreSubscription) {
+      this.searchStoreSubscription();
+    }
     this.namespaceSub();
   }
 
   fetchEntities() {
     this.setState({loading: true});
     let namespace = NamespaceStore.getState().selectedNamespace;
+    let numColumns = SearchStore.getState().search.numColumns;
     const params = {
       namespace,
       target: ['app', 'artifact', 'dataset', 'stream'],
-      limit: this.props.limit,
+      limit: numColumns,
       query: '*',
       sort: 'creation-time desc'
     };
@@ -80,7 +106,7 @@ export default class JustAddedSection extends Component {
             let creationTime = objectQuery(entity, 'metadata', 'metadata', 'SYSTEM', 'properties', 'creation-time');
 
             creationTime = parseInt(creationTime, 10);
-            let thresholdTime = Date.now() - TIME_THRESHOLD;
+            let thresholdTime = Date.now() - JUSTADDED_THRESHOLD_TIME;
             return creationTime >= thresholdTime;
           })
           .map((entity) => {
@@ -99,6 +125,12 @@ export default class JustAddedSection extends Component {
       });
   }
 
+  onClick(entity) {
+    this.setState({
+      selectedEntity: entity
+    });
+    this.props.clickHandler(entity);
+  }
   render() {
     if (this.props.currentPage !== 1 || this.state.entities.length === 0 || this.state.loading) {
       return null;
@@ -109,12 +141,12 @@ export default class JustAddedSection extends Component {
         <EntityCard
           className={
             classnames('entity-card-container',
-              { active: entity.uniqueId === objectQuery(this.props, 'activeEntity', 'uniqueId') }
+              { active: entity.uniqueId === objectQuery(this.state.selectedEntity, 'uniqueId') }
             )
           }
           key={entity.uniqueId}
           id={entity.uniqueId}
-          onClick={this.props.clickHandler.bind(this, entity)}
+          onClick={this.onClick.bind(this, entity)}
           entity={entity}
           onFastActionSuccess={this.props.onFastActionSuccess}
           onUpdate={this.props.onUpdate}

--- a/cdap-ui/app/cdap/components/EntityListView/ListView/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/ListView/index.js
@@ -17,100 +17,60 @@
 import React, {PropTypes, Component} from 'react';
 import EntityCard from 'components/EntityCard';
 import classnames from 'classnames';
-import {objectQuery} from 'services/helpers';
-import T from 'i18n-react';
 import JustAddedSection from 'components/EntityListView/JustAddedSection';
 import NoEntitiesMessage from 'components/EntityListView/NoEntitiesMessage';
+import SearchStore from 'components/EntityListView/SearchStore';
+import SearchStoreActions from 'components/EntityListView/SearchStore/SearchStoreActions';
+import ListViewHeader from 'components/EntityListView/ListViewHeader';
+import {search, updateQueryString} from 'components/EntityListView/SearchStore/ActionCreator';
+import {DEFAULT_SEARCH_SORT_OPTIONS, DEFAULT_SEARCH_QUERY, DEFAULT_SEARCH_FILTERS} from 'components/EntityListView/SearchStore/SearchConstants';
+import isNil from 'lodash/isNil';
 
 export default class HomeListView extends Component {
   constructor(props) {
     super(props);
     this.state = {
       loading: this.props.loading || false,
-      list: this.props.list || [],
-      selectedEntity: {}
+      list: this.props.list || []
     };
   }
 
   componentWillReceiveProps(nextProps) {
     this.setState({
       list: nextProps.list,
-      loading: nextProps.loading,
-      animationDirection: nextProps.animationDirection,
-      activeEntity: nextProps.activeEntity,
-      errorMessage: nextProps.errorMessage,
-      errorStatusCode: nextProps.errorStatusCode,
-      retryCounter: nextProps.retryCounter
+      loading: nextProps.loading
     });
   }
-
   onClick(entity) {
-    let activeEntity = this.state.list.filter(e => e.id === entity.id);
-    if (activeEntity.length) {
-      this.setState({
-        activeEntity: activeEntity[0]
-      });
-    }
-    if (this.props.onEntityClick) {
-      this.props.onEntityClick(entity);
-    }
-  }
-
-  filtersAreApplied() {
-    return this.props.activeFilter.length > 0 && this.props.activeFilter.length < this.props.filterOptions.length;
-  }
-
-  clearSearchAndFilters() {
-    this.props.onSearch('');
-    this.props.onFiltersCleared();
-  }
-
-  getActiveFilterStrings() {
-    return this.props.activeFilter.map(filter => {
-      if (filter === 'app') {
-        filter = 'application';
+    SearchStore.dispatch({
+      type: SearchStoreActions.SETOVERVIEWENTITY,
+      payload: {
+        overviewEntity: {
+          id: entity.id,
+          type: entity.type,
+          uniqueId: entity.uniqueId
+        }
       }
-      return T.translate(`commons.entity.${filter}.plural`);
     });
+    updateQueryString();
   }
-
-  getSubtitle() {
-    let text = {
-      search: T.translate('features.EntityListView.Info.subtitle.search'),
-      filteredBy: T.translate('features.EntityListView.Info.subtitle.filteredBy'),
-      sortedBy: T.translate('features.EntityListView.Info.subtitle.sortedBy'),
-      displayAll: T.translate('features.EntityListView.Info.subtitle.displayAll'),
-      displaySome: T.translate('features.EntityListView.Info.subtitle.displaySome'),
-    };
-
-    let filtersAreApplied = this.filtersAreApplied();
-    let activeFilters = this.getActiveFilterStrings();
-    let activeFilterString = activeFilters.join(', ');
-    let activeSort = this.props.activeSort;
-    let searchText = this.props.searchText;
-    let subtitle;
-
-    if (searchText) {
-      subtitle = `${text.search} "${searchText}"`;
-      if (filtersAreApplied) {
-        subtitle += `, ${text.filteredBy} ${activeFilterString}`;
-      }
-    } else {
-      if (!filtersAreApplied) {
-        subtitle = `${text.displayAll}`;
-      } else {
-        subtitle = `${text.displaySome} ${activeFilterString}`;
-      }
-      if (activeSort) {
-        subtitle += `, ${text.sortedBy} ${activeSort.displayName}`;
-      }
-    }
-
-    return subtitle;
-  }
-
   render() {
     let content;
+    let searchState = SearchStore.getState().search;
+    let query = searchState.query;
+    let activeFilters = searchState.activeFilters;
+    let filterOptions = searchState.filters;
+    let overviewEntity = searchState.overviewEntity;
+    let isEntityActive = (entity) => {
+      if (isNil(overviewEntity)) {
+        return false;
+      }
+      return (
+        entity.id === overviewEntity.id &&
+        entity.type === overviewEntity.type &&
+        (overviewEntity.uniqueId === entity.uniqueId || isNil(overviewEntity.uniqueId)) // This will happen when the entity id and type comes from url and not through click
+      );
+    };
     if (this.state.loading) {
       content = (
         <h3 className="text-xs-center">
@@ -121,9 +81,24 @@ export default class HomeListView extends Component {
 
     if (!this.state.loading && !this.state.list.length) {
       content = <NoEntitiesMessage
-                  searchText={this.props.searchText}
-                  filtersAreApplied={this.filtersAreApplied.bind(this)}
-                  clearSearchAndFilters={this.clearSearchAndFilters.bind(this)}
+                  searchText={query}
+                  filtersAreApplied={() => activeFilters.length > 0 && activeFilters.length < filterOptions.length}
+                  clearSearchAndFilters={() => {
+                    let searchState = SearchStore.getState().search;
+                    SearchStore.dispatch({
+                      type: SearchStoreActions.SETSORTFILTERSEARCHCURRENTPAGE,
+                      payload: {
+                        query: DEFAULT_SEARCH_QUERY,
+                        activeSort: DEFAULT_SEARCH_SORT_OPTIONS[4],
+                        activeFilters: DEFAULT_SEARCH_FILTERS,
+                        currentPage: 1,
+                        offset: searchState.offset,
+                        overviewEntity: null
+                      }
+                    });
+                    search();
+                    updateQueryString();
+                  }}
                 />;
 
     }
@@ -133,7 +108,7 @@ export default class HomeListView extends Component {
           <EntityCard
             className={
               classnames('entity-card-container',
-                { active: entity.uniqueId === objectQuery(this.state, 'activeEntity', 'uniqueId') }
+                { active: isEntityActive(entity)}
               )
             }
             id={entity.uniqueId}
@@ -141,34 +116,29 @@ export default class HomeListView extends Component {
             onClick={this.onClick.bind(this, entity)}
             entity={entity}
             onFastActionSuccess={this.props.onFastActionSuccess}
-            onUpdate={this.props.onUpdate}
           />
         );
       });
     }
 
+    let currentPage = SearchStore.getState().search.currentPage;
     return (
-      <div className={this.props.className}>
+      <div
+        id={this.props.id}
+        className={this.props.className}
+      >
         {
-          this.props.searchText || !this.props.numColumns ?
+          !this.props.showJustAddedSection ?
             null
           :
             (<JustAddedSection
               clickHandler={this.onClick.bind(this)}
               onFastActionSuccess={this.props.onFastActionSuccess}
-              onUpdate={this.props.onUpdate}
-              activeEntity={this.props.activeEntity}
-              currentPage={this.props.currentPage}
-              limit={this.props.numColumns}
+              currentPage={currentPage}
+              limit={this.props.pageSize}
             />)
         }
-
-        <div className="subtitle">
-          <span>
-            {this.getSubtitle()}
-          </span>
-        </div>
-
+        <ListViewHeader/>
         <div className="entities-all-list-container">
           {content}
         </div>
@@ -180,17 +150,9 @@ export default class HomeListView extends Component {
 HomeListView.propTypes = {
   list: PropTypes.array,
   loading: PropTypes.bool,
-  onEntityClick: PropTypes.func,
-  onUpdate: PropTypes.func,
-  onFastActionSuccess: PropTypes.func,
-  onSearch: PropTypes.func,
-  onFiltersCleared: PropTypes.func,
+  onFastActionSuccess: PropTypes.func, // FIXME: This is not right. I don't think onFastActionSuccess is being used correct here. Not able to reason.
   className: PropTypes.string,
-  activeEntity: PropTypes.object,
-  currentPage: PropTypes.number,
-  activeFilter: PropTypes.array,
-  filterOptions: PropTypes.array,
-  activeSort: PropTypes.obj,
-  searchText: PropTypes.string,
-  numColumns: PropTypes.number
+  pageSize: PropTypes.number,
+  showJustAddedSection: PropTypes.bool,
+  id: PropTypes.string
 };

--- a/cdap-ui/app/cdap/components/EntityListView/ListViewHeader/ListViewHeader.scss
+++ b/cdap-ui/app/cdap/components/EntityListView/ListViewHeader/ListViewHeader.scss
@@ -14,24 +14,21 @@
  * the License.
  */
 
-.just-added-container {
-  width: 100%;
-  margin-bottom: 15px;
-
-  .entity-cards { outline: 3px solid #2ecc71; }
-  .subtitle.just-added {
+.list-view-header {
+  &.subtitle {
     color: #999999;
     border-bottom: 1px solid #dddddd;
     height: 11px;
     clear: both;
     margin-right: 20px;
     margin-left: 5px;
-    margin-bottom: 15px;
+    width: 100%;
 
     span {
+      background-color: #ffffff;
       padding-right: 15px;
-      background: white;
     }
+
+    margin-bottom: 15px;
   }
-  .just-added-entities-list { width: 100%; }
 }

--- a/cdap-ui/app/cdap/components/EntityListView/ListViewHeader/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/ListViewHeader/index.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import T from 'i18n-react';
+require('./ListViewHeader.scss');
+import {DEFAULT_SEARCH_QUERY, DEFAULT_SEARCH_FILTER_OPTIONS} from 'components/EntityListView/SearchStore/SearchConstants';
+import SearchStore from 'components/EntityListView/SearchStore';
+
+export default function ListViewHeader() {
+  let searchState = SearchStore.getState().search;
+  let activeFilters = searchState.activeFilters;
+  let activeSort = searchState.activeSort;
+  let searchText = searchState.query;
+  let filterOptions = DEFAULT_SEARCH_FILTER_OPTIONS;
+
+  const getActiveFilterStrings = () => {
+    return activeFilters.map(filter => {
+      if (filter === 'app') {
+        filter = 'application';
+      }
+      return T.translate(`commons.entity.${filter}.plural`);
+    });
+  };
+  let text = {
+    search: T.translate('features.EntityListView.Info.subtitle.search'),
+    filteredBy: T.translate('features.EntityListView.Info.subtitle.filteredBy'),
+    sortedBy: T.translate('features.EntityListView.Info.subtitle.sortedBy'),
+    displayAll: T.translate('features.EntityListView.Info.subtitle.displayAll'),
+    displaySome: T.translate('features.EntityListView.Info.subtitle.displaySome'),
+  };
+
+  let i18nResolved_activeFilters = getActiveFilterStrings();
+  let allFiltersSelected = (i18nResolved_activeFilters.length === 0 || i18nResolved_activeFilters.length === filterOptions.length);
+  let activeFilterString = i18nResolved_activeFilters.join(', ');
+  let subtitle;
+
+  if (searchText !== DEFAULT_SEARCH_QUERY) {
+    subtitle = `${text.search} "${searchText}"`;
+    if (!allFiltersSelected) {
+      subtitle += `, ${text.filteredBy} ${activeFilterString}`;
+    }
+  } else {
+    if (allFiltersSelected) {
+      subtitle = `${text.displayAll}`;
+    } else {
+      subtitle = `${text.displaySome} ${activeFilterString}`;
+    }
+    if (activeSort) {
+      subtitle += `, ${text.sortedBy} ${activeSort.displayName}`;
+    }
+  }
+
+  return (
+    <div className="list-view-header subtitle">
+      <span>
+        {subtitle}
+      </span>
+    </div>
+  );
+}

--- a/cdap-ui/app/cdap/components/EntityListView/NoEntitiesMessage/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/NoEntitiesMessage/index.js
@@ -21,6 +21,7 @@ import PlusButtonStore from 'services/PlusButtonStore';
 import ee from 'event-emitter';
 import globalEvents from 'services/global-events';
 require('./NoEntitiesMessage.scss');
+import {DEFAULT_SEARCH_QUERY} from 'components/EntityListView/SearchStore/SearchConstants';
 
 export default function NoEntitiesMessage({searchText, filtersAreApplied, clearSearchAndFilters}) {
   let eventEmitter = ee(ee);
@@ -42,7 +43,7 @@ export default function NoEntitiesMessage({searchText, filtersAreApplied, clearS
   let emptyMessage = T.translate('features.EntityListView.emptyMessage.default', {namespace});
   let clearText;
 
-  if (searchText) {
+  if (searchText !== DEFAULT_SEARCH_QUERY) {
     emptyMessage = T.translate('features.EntityListView.emptyMessage.search', {searchText});
     clearText = T.translate('features.EntityListView.emptyMessage.clearText.search');
   } else if (filtersAreApplied && filtersAreApplied()) {

--- a/cdap-ui/app/cdap/components/EntityListView/SearchStore/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/EntityListView/SearchStore/ActionCreator.js
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import {MySearchApi} from 'api/search';
+import NamespaceStore from 'services/NamespaceStore';
+import {parseMetadata} from 'services/metadata-parser';
+import shortid from 'shortid';
+import SearchStore from 'components/EntityListView/SearchStore';
+import SearchStoreAction from 'components/EntityListView/SearchStore/SearchStoreActions';
+import ExploreTablesStore from 'services/ExploreTables/ExploreTablesStore';
+import {fetchTables} from 'services/ExploreTables/ActionCreator';
+import {DEFAULT_SEARCH_QUERY} from 'components/EntityListView/SearchStore/SearchConstants';
+import SearchStoreActions from 'components/EntityListView/SearchStore/SearchStoreActions';
+import isNil from 'lodash/isNil';
+
+const search = () => {
+  let namespace = NamespaceStore.getState().selectedNamespace;
+  let {
+    offset,
+    numCursors,
+    limit,
+    activeFilters,
+    activeSort,
+    query
+  } = SearchStore.getState().search;
+
+  let params = {
+    namespace: namespace,
+    target: activeFilters,
+    limit,
+    offset,
+    numCursors,
+    sort: activeSort.fullSort,
+    query
+  };
+  if (query !== DEFAULT_SEARCH_QUERY) {
+    delete params.sort;
+    delete params.numCursors;
+    params.query = params.query + '*';
+  }
+
+  ExploreTablesStore.dispatch(
+    fetchTables(namespace)
+  );
+
+  SearchStore.dispatch({
+    type: SearchStoreAction.LOADING,
+    payload: {
+      loading: true
+    }
+  });
+
+  MySearchApi.search(params)
+    .map((res) => {
+      return Object.assign({}, {
+        total: res.total,
+        limit: res.limit,
+        results: res.results
+          .map(parseMetadata)
+          .map((entity) => {
+            entity.uniqueId = shortid.generate();
+            return entity;
+          })
+      });
+    })
+    .subscribe(
+      (response) => {
+        let currentPage = SearchStore.getState().search.currentPage;
+        if (response.total > 0 && Math.ceil(response.total/limit) < currentPage) {
+          SearchStore.dispatch({
+            type: SearchStoreActions.SETERROR,
+            payload: {
+              errorStatusCode: 'PAGE_NOT_FOUND',
+              errorMessage: null
+            }
+          });
+          return;
+        }
+        SearchStore.dispatch({
+          type: SearchStoreAction.SETRESULTS,
+          payload: {response}
+        });
+      },
+      (error) => {
+        SearchStore.dispatch({
+          type: SearchStoreActions.SETERROR,
+          payload: {
+            errorStatusCode: error.statusCode,
+            errorMessage: typeof err === 'object' ? error.response : error,
+          }
+        });
+      }
+    );
+};
+
+const updateQueryString = () => {
+  let queryString = '';
+  let sort = '';
+  let filter = '';
+  let query = '';
+  let page = '';
+  let queryParams = [];
+
+  let searchState = SearchStore.getState().search;
+  let {activeSort, activeFilters, query:searchQuery, currentPage, overviewEntity} = searchState;
+
+  // Generate sort params
+  if (activeSort.sort !== 'none') {
+    sort = 'sort=' + activeSort.sort + '&order=' + activeSort.order;
+  }
+
+  // Generate filter params
+  if (activeFilters.length === 1) {
+    filter = 'filter=' + activeFilters[0];
+  } else if (activeFilters.length > 1) {
+    filter = 'filter=' + activeFilters.join('&filter=');
+  }
+
+  // Generate search param
+  if (searchQuery.length > 0) {
+    query = 'q=' + searchQuery;
+  }
+
+  // Generate page param
+  page = 'page=' + currentPage;
+
+  // Combine query parameters into query string
+  queryParams = [query, sort, filter, page].filter((element) => {
+    return element.length > 0;
+  });
+  queryString = queryParams.join('&');
+
+  if (queryString.length > 0) {
+    queryString = '?' + queryString;
+  }
+
+  if (!isNil(overviewEntity)) {
+    queryString += `&overviewid=${overviewEntity.id}&overviewtype=${overviewEntity.type}`;
+  }
+
+  let obj = {
+    title: 'CDAP',
+    url: location.pathname + queryString
+  };
+
+  // Modify URL to match application state
+  history.pushState(obj, obj.title, obj.url);
+};
+export {
+  search,
+  updateQueryString
+};

--- a/cdap-ui/app/cdap/components/EntityListView/SearchStore/SearchConstants.js
+++ b/cdap-ui/app/cdap/components/EntityListView/SearchStore/SearchConstants.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+import T from 'i18n-react';
+
+const DEFAULT_SEARCH_FILTER_OPTIONS = [
+  {
+    displayName: T.translate('commons.entity.application.plural'),
+    id: 'app'
+  },
+  {
+    displayName: T.translate('commons.entity.artifact.plural'),
+    id: 'artifact'
+  },
+  {
+    displayName: T.translate('commons.entity.dataset.plural'),
+    id: 'dataset'
+  },
+  {
+    displayName: T.translate('commons.entity.stream.plural'),
+    id: 'stream'
+  }
+];
+
+const DEFAULT_SEARCH_FILTERS = DEFAULT_SEARCH_FILTER_OPTIONS.map(filter => filter.id);
+
+const DEFAULT_SEARCH_SORT_OPTIONS = [
+  {
+    displayName: T.translate('features.EntityListView.Header.sortOptions.none'),
+    sort: 'none',
+    fullSort: 'none'
+  },
+  {
+    displayName: T.translate('features.EntityListView.Header.sortOptions.entityNameAsc.displayName'),
+    sort: 'name',
+    order: 'asc',
+    fullSort: 'entity-name asc'
+  },
+  {
+    displayName: T.translate('features.EntityListView.Header.sortOptions.entityNameDesc.displayName'),
+    sort: 'name',
+    order: 'desc',
+    fullSort: 'entity-name desc'
+  },
+  {
+    displayName: T.translate('features.EntityListView.Header.sortOptions.creationTimeAsc.displayName'),
+    sort: 'creation-time',
+    order: 'asc',
+    fullSort: 'creation-time asc'
+  },
+  {
+    displayName: T.translate('features.EntityListView.Header.sortOptions.creationTimeDesc.displayName'),
+    sort: 'creation-time',
+    order: 'desc',
+    fullSort: 'creation-time desc'
+  }
+];
+
+const DEFAULT_SEARCH_SORT = DEFAULT_SEARCH_SORT_OPTIONS[4];
+
+const DEFAULT_SEARCH_QUERY = '*';
+
+const DEFAULT_SEARCH_PAGE_SIZE = 30;
+
+const JUSTADDED_THRESHOLD_TIME = 300000; // 5 minutes in millisecond
+export {
+  DEFAULT_SEARCH_FILTER_OPTIONS,
+  DEFAULT_SEARCH_PAGE_SIZE,
+  DEFAULT_SEARCH_FILTERS,
+  DEFAULT_SEARCH_SORT,
+  DEFAULT_SEARCH_SORT_OPTIONS,
+  DEFAULT_SEARCH_QUERY,
+  JUSTADDED_THRESHOLD_TIME
+};

--- a/cdap-ui/app/cdap/components/EntityListView/SearchStore/SearchStoreActions.js
+++ b/cdap-ui/app/cdap/components/EntityListView/SearchStore/SearchStoreActions.js
@@ -14,24 +14,18 @@
  * the License.
  */
 
-.just-added-container {
-  width: 100%;
-  margin-bottom: 15px;
-
-  .entity-cards { outline: 3px solid #2ecc71; }
-  .subtitle.just-added {
-    color: #999999;
-    border-bottom: 1px solid #dddddd;
-    height: 11px;
-    clear: both;
-    margin-right: 20px;
-    margin-left: 5px;
-    margin-bottom: 15px;
-
-    span {
-      padding-right: 15px;
-      background: white;
-    }
-  }
-  .just-added-entities-list { width: 100%; }
-}
+export default {
+  SETACTIVEFILTERS: 'SET_ACTIVE_FILTER',
+  SETACTIVESORT: 'SET_SORT',
+  SETQUERY: 'SET_QUERY',
+  SETRESULTS: 'SET_REULTS',
+  LOADING: 'LOADING',
+  SETPAGESIZE: 'SET_PAGE_SIZE',
+  SETCURRENTPAGE: 'SET_CURRENT_PAGE',
+  SETERROR: 'SET_ERROR',
+  RESETERROR: 'RESET_ERROR',
+  SETOVERVIEWENTITY: 'SET_OVERVIEW_ENTITY',
+  RESETOVERVIEWENTITY: 'RESET_OVERVIEW_ENTITY',
+  SETSORTFILTERSEARCHCURRENTPAGE: 'SET_SORT_FITLER_SEARCH_CURRENTPAGE',
+  RESETSTORE: 'RESET_STORE'
+};

--- a/cdap-ui/app/cdap/components/EntityListView/SearchStore/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/SearchStore/index.js
@@ -1,0 +1,212 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+import {combineReducers, createStore} from 'redux';
+import SearchStoreActions from 'components/EntityListView/SearchStore/SearchStoreActions';
+import {
+  DEFAULT_SEARCH_QUERY,
+  DEFAULT_SEARCH_FILTER_OPTIONS,
+  DEFAULT_SEARCH_FILTERS,
+  DEFAULT_SEARCH_SORT,
+  DEFAULT_SEARCH_SORT_OPTIONS,
+  DEFAULT_SEARCH_PAGE_SIZE
+} from 'components/EntityListView/SearchStore/SearchConstants';
+import isNil from 'lodash/isNil';
+
+const defaultAction = {
+  type: {},
+  payload: {}
+};
+
+const defaultErrorState = {
+  statusCode: null,
+  message: ''
+};
+
+const defaultSearchState = {
+  filters: DEFAULT_SEARCH_FILTER_OPTIONS,
+  activeFilters: DEFAULT_SEARCH_FILTERS,
+  sort: DEFAULT_SEARCH_SORT_OPTIONS,
+  activeSort: DEFAULT_SEARCH_SORT,
+  query: DEFAULT_SEARCH_QUERY,
+
+  offset: 0,
+  limit: DEFAULT_SEARCH_PAGE_SIZE,
+  numColumns: null,
+  numCursors: 10,
+  total: 0,
+  currentPage: 1,
+
+  loading: false,
+  results: [],
+
+  error: defaultErrorState,
+
+  overviewEntity: null
+};
+
+const defaultInitialState = {
+  search: defaultSearchState
+};
+
+const getPageSize = (element) => {
+    // different screen sizes
+    // consistent with media queries in style sheet
+    const sevenColumnWidth = 1701;
+    const sixColumnWidth = 1601;
+    const fiveColumnWidth = 1201;
+    const fourColumnWidth = 993;
+    const threeColumnWidth = 768;
+
+    // 140 = cardHeight (128) + (5 x 2 top bottom margins) + (1 x 2 border widths)
+    const cardHeightWithMarginAndBorder = 140;
+
+    let entityListViewEle = element;
+
+    if (!entityListViewEle.length) {
+      return;
+    }
+
+    // Subtract 65px to account for entity-list-info's height (45px) and paddings (20px)
+    // minus 10px of padding from top and bottom (10px each)
+    let containerHeight = entityListViewEle[0].offsetHeight - 65 - 10;
+    let containerWidth = entityListViewEle[0].offsetWidth;
+    let numColumns = 1;
+
+    // different screen sizes
+    // consistent with media queries in style sheet
+    if (containerWidth >= sevenColumnWidth) {
+      numColumns = 7;
+    } else if (containerWidth >= sixColumnWidth && containerWidth < sevenColumnWidth) {
+      numColumns = 6;
+    } else if (containerWidth >= fiveColumnWidth && containerWidth < sixColumnWidth) {
+      numColumns = 5;
+    } else if (containerWidth >= fourColumnWidth && containerWidth < fiveColumnWidth) {
+      numColumns = 4;
+    } else if (containerWidth >= threeColumnWidth && containerWidth < fourColumnWidth) {
+      numColumns = 3;
+    }
+
+    let numRows = Math.floor(containerHeight / cardHeightWithMarginAndBorder);
+
+    // We must have one column and one row at the very least
+    if (numRows === 0) {
+      numRows = 1;
+    }
+    return {
+      numColumns,
+      limit: numColumns * numRows
+    };
+};
+
+const search = (state = defaultSearchState, action = defaultAction) => {
+  switch (action.type) {
+    case SearchStoreActions.SETRESULTS: {
+      let {results, total, limit} = action.payload.response;
+      return Object.assign({}, state, {
+        results: results,
+        total,
+        limit,
+        loading: false,
+        error: {}
+      });
+    }
+    case SearchStoreActions.SETACTIVEFILTERS:
+      return Object.assign({}, state, {
+        activeFilters: action.payload.activeFilters,
+        overviewEntity: null
+      });
+    case SearchStoreActions.SETACTIVESORT:
+      if (isNil(action.payload.activeSort)) {
+        return state;
+      }
+      return Object.assign({}, state, {
+        activeSort: action.payload.activeSort,
+        overviewEntity: null,
+        query: action.payload.query || state.query
+      });
+    case SearchStoreActions.SETQUERY:
+      return Object.assign({}, state, {
+        query: action.payload.query === '' ? '*' : action.payload.query,
+        currentPage: 1,
+        offset: 0,
+        activeSort: action.payload.query !== '*' ? DEFAULT_SEARCH_SORT_OPTIONS[0] : state.activeSort,
+        overviewEntity: ['', '*'].indexOf(action.payload.query) !== -1 ? state.overviewEntity : null
+      });
+    case SearchStoreActions.LOADING:
+      return Object.assign({}, state, {
+        loading: action.payload.loading || false
+      });
+    case SearchStoreActions.SETPAGESIZE: {
+      let {limit, numColumns} = getPageSize(action.payload.element);
+      return Object.assign({}, state, {
+        limit,
+        numColumns
+      });
+    }
+    case SearchStoreActions.SETCURRENTPAGE:
+      return Object.assign({}, state, {
+        currentPage: action.payload.currentPage,
+        offset: action.payload.offset,
+        overviewEntity: null
+      });
+    case SearchStoreActions.RESETERROR:
+      return Object.assign({}, state, {
+        error: defaultErrorState
+      });
+    case SearchStoreActions.SETERROR:
+      return Object.assign({}, state, {
+        error: {
+          statusCode: action.payload.errorStatusCode,
+          message: action.payload.errorMessage
+        }
+      });
+    case SearchStoreActions.RESETOVERVIEWENTITY:
+      return Object.assign({}, state, {
+        overviewEntity: null
+      });
+    case SearchStoreActions.SETOVERVIEWENTITY:
+      return Object.assign({}, state, {
+        overviewEntity: action.payload.overviewEntity
+      });
+    case SearchStoreActions.SETSORTFILTERSEARCHCURRENTPAGE:
+      return Object.assign({}, state, {
+        query: action.payload.query === '' ? '*' : action.payload.query,
+        activeSort: action.payload.query !== '*' ? DEFAULT_SEARCH_SORT_OPTIONS[0] : action.payload.activeSort,
+        activeFilters: action.payload.activeFilters,
+        currentPage: action.payload.currentPage,
+        offset: action.payload.offset,
+        overviewEntity: action.payload.overviewEntity,
+        error: {}
+      });
+    case SearchStoreActions.RESETSTORE:
+      return defaultSearchState;
+    default:
+      return state;
+  }
+};
+
+const searchStoreWrapper = () => {
+  return createStore(
+    combineReducers({
+      search
+    }),
+    defaultInitialState
+  );
+};
+
+const SearchStore = searchStoreWrapper();
+export default SearchStore;

--- a/cdap-ui/app/cdap/components/EntityListView/WelcomeScreen/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/WelcomeScreen/index.js
@@ -14,52 +14,82 @@
  * the License.
  */
 
-import React, {PropTypes} from 'react';
+import React, {PropTypes, Component} from 'react';
 import T from 'i18n-react';
 import ResourceCenterButton from 'components/ResourceCenterButton';
+import PlusButtonStore from 'services/PlusButtonStore';
+import MyUserStoreApi from 'api/userstore';
+import isNil from 'lodash/isNil';
+import isObject from 'lodash/isObject';
 require('./WelcomeScreen.scss');
 
-export default function WelcomeScreen({onClose, onAddEntity}) {
-  return (
-    <div className="splash-screen-container">
-      <div className="splash-screen-first-time">
-        <h2 className="welcome-message">
-          {T.translate('features.EntityListView.SplashScreen.welcomeMessage1')}
-        </h2>
-        <div className="welcome-message">
-          {T.translate('features.EntityListView.SplashScreen.welcomeMessage2')}
+export default class WelcomeScreen extends Component {
+  onAddEntity() {
+    PlusButtonStore.dispatch({
+      type: 'TOGGLE_PLUSBUTTON_MODAL',
+      payload: {
+        modalState: true
+      }
+    });
+  }
+  onClose() {
+    MyUserStoreApi
+      .get()
+      .subscribe(res => {
+        if (isNil(res)) {
+          res = {};
+        }
+        if (!isObject(res.property)) {
+          res.property = {};
+        }
+        res.property['user-has-visited'] = true;
+        MyUserStoreApi.set({}, res.property);
+      });
+    if (this.props.onClose) {
+      this.props.onClose();
+    }
+  }
+  render() {
+    return (
+      <div className="splash-screen-container">
+        <div className="splash-screen-first-time">
+          <h2 className="welcome-message">
+            {T.translate('features.EntityListView.SplashScreen.welcomeMessage1')}
+          </h2>
+          <div className="welcome-message">
+            {T.translate('features.EntityListView.SplashScreen.welcomeMessage2')}
+          </div>
+
+          <div className="cdap-fist-icon">
+            <span className="icon-fist" />
+          </div>
+
+          <div
+            className="splash-screen-first-time-btn"
+            onClick={this.onAddEntity.bind(this)}
+          >
+            {T.translate('features.EntityListView.SplashScreen.addentity')}
+          </div>
+          <div
+            className="go-to-cdap"
+            onClick={this.onClose.bind(this)}
+          >
+            {T.translate('features.EntityListView.SplashScreen.gotoLabel')}
+          </div>
+          <div className="splash-screen-disclaimer">
+            <p>
+              {T.translate('features.EntityListView.SplashScreen.disclaimerMessage')}
+            </p>
+          </div>
         </div>
 
-        <div className="cdap-fist-icon">
-          <span className="icon-fist" />
-        </div>
-
-        <div
-          className="splash-screen-first-time-btn"
-          onClick={onAddEntity}
-        >
-          {T.translate('features.EntityListView.SplashScreen.addentity')}
-        </div>
-        <div
-          className="go-to-cdap"
-          onClick={onClose}
-        >
-          {T.translate('features.EntityListView.SplashScreen.gotoLabel')}
-        </div>
-        <div className="splash-screen-disclaimer">
-          <p>
-            {T.translate('features.EntityListView.SplashScreen.disclaimerMessage')}
-          </p>
+        <div className="resource-center-hidden">
+          <ResourceCenterButton />
         </div>
       </div>
-
-      <div className="resource-center-hidden">
-        <ResourceCenterButton />
-      </div>
-    </div>
-  );
+    );
+  }
 }
 WelcomeScreen.propTypes = {
-  onClose: PropTypes.func,
-  onAddEntity: PropTypes.func
+  onClose: PropTypes.func
 };

--- a/cdap-ui/app/cdap/components/EntityListView/index.js
+++ b/cdap-ui/app/cdap/components/EntityListView/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -12,153 +12,117 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */
+*/
 
 import React, {Component, PropTypes} from 'react';
-import {MySearchApi} from 'api/search';
-import {parseMetadata} from 'services/metadata-parser';
-import EntityListHeader from './EntityListHeader';
-import Pagination from 'components/Pagination';
-import T from 'i18n-react';
-const shortid = require('shortid');
-const classNames = require('classnames');
+import SearchStore from 'components/EntityListView/SearchStore';
+import {search, updateQueryString} from 'components/EntityListView/SearchStore/ActionCreator';
+import HomeListView from 'components/EntityListView/ListView';
+import MyUserStoreApi from 'api/userstore';
+import isNil from 'lodash/isNil';
+import EntityListHeader from 'components/EntityListView/EntityListHeader';
+import EntityListInfo from 'components/EntityListView/EntityListInfo';
+import NamespaceStore from 'services/NamespaceStore';
+import NamespaceActions from 'services/NamespaceStore/NamespaceActions';
+import SearchStoreActions from 'components/EntityListView/SearchStore/SearchStoreActions';
+import globalEvents from 'services/global-events';
+import ee from 'event-emitter';
 import ExploreTablesStore from 'services/ExploreTables/ExploreTablesStore';
 import {fetchTables} from 'services/ExploreTables/ActionCreator';
-import MyUserStoreApi from 'api/userstore';
-import PlusButtonStore from 'services/PlusButtonStore';
-import globalEvents from 'services/global-events';
-import isNil from 'lodash/isNil';
-import Overview from 'components/Overview';
-import EntityListInfo from './EntityListInfo';
-import WelcomeScreen from 'components/EntityListView/WelcomeScreen';
-import HomeListView from 'components/EntityListView/ListView';
-import NamespaceStore from 'services/NamespaceStore';
-import Page404 from 'components/404';
 import PageErrorMessage from 'components/EntityListView/ErrorMessage/PageErrorMessage';
 import HomeErrorMessage from 'components/EntityListView/ErrorMessage';
+import Overview from 'components/Overview';
 import isEqual from 'lodash/isEqual';
-import isObject from 'lodash/isObject';
+import isEmpty from 'lodash/isEmpty';
+import intersection from 'lodash/intersection';
+import {objectQuery} from 'services/helpers';
+import WelcomeScreen from 'components/EntityListView/WelcomeScreen';
+import classnames from 'classnames';
+import {
+  DEFAULT_SEARCH_FILTERS, DEFAULT_SEARCH_SORT,
+  DEFAULT_SEARCH_QUERY, DEFAULT_SEARCH_SORT_OPTIONS,
+  DEFAULT_SEARCH_PAGE_SIZE
+} from 'components/EntityListView/SearchStore/SearchConstants';
+
 require('./EntityListView.scss');
-import ee from 'event-emitter';
 
-const defaultFilter = ['app', 'artifact', 'dataset', 'stream'];
-
-class EntityListView extends Component {
+export default class EntityListView extends Component {
   constructor(props) {
     super(props);
-    this.filterOptions = [
-      {
-        displayName: T.translate('commons.entity.application.plural'),
-        id: 'app'
-      },
-      {
-        displayName: T.translate('commons.entity.artifact.plural'),
-        id: 'artifact'
-      },
-      {
-        displayName: T.translate('commons.entity.dataset.plural'),
-        id: 'dataset'
-      },
-      {
-        displayName: T.translate('commons.entity.stream.plural'),
-        id: 'stream'
-      }
-    ];
-
-    // Accepted filter ids to be compared against incoming query parameters
-    this.acceptedFilterIds = this.filterOptions.map( (item) => {
-      return item.id;
-    });
-
-    this.sortOptions = [
-      {
-        displayName: T.translate('features.EntityListView.Header.sortOptions.none'),
-        sort: 'none',
-        fullSort: 'none'
-      },
-      {
-        displayName: T.translate('features.EntityListView.Header.sortOptions.entityNameAsc.displayName'),
-        sort: 'name',
-        order: 'asc',
-        fullSort: 'entity-name asc'
-      },
-      {
-        displayName: T.translate('features.EntityListView.Header.sortOptions.entityNameDesc.displayName'),
-        sort: 'name',
-        order: 'desc',
-        fullSort: 'entity-name desc'
-      },
-      {
-        displayName: T.translate('features.EntityListView.Header.sortOptions.creationTimeAsc.displayName'),
-        sort: 'creation-time',
-        order: 'asc',
-        fullSort: 'creation-time asc'
-      },
-      {
-        displayName: T.translate('features.EntityListView.Header.sortOptions.creationTimeDesc.displayName'),
-        sort: 'creation-time',
-        order: 'desc',
-        fullSort: 'creation-time desc'
-      }
-    ];
-
     this.state = {
-      filter: defaultFilter,
-      sortObj: this.sortOptions[4],
-      query: '',
       entities: [],
-      selectedEntity: null,
-      numPages: 1,
-      loading: true,
-      currentPage: 1,
-      animationDirection: 'next',
-      showSplash: true,
-      userStoreObj : '',
-      notFound: false,
-      numColumns: null,
+      loading: false,
+      limit: DEFAULT_SEARCH_PAGE_SIZE,
       total: 0,
-      allEntitiesFetched: false
+      overview: true, // Start showing spinner until we get a response from backend.
+      userStoreObj: null,
+      showSplash: true
     };
-
-    // FIXME: @ajainarayanan: I'm not sure why this is outside of state :|
-    this.retryCounter = 0; // being used for search API retry
-
-    // By default, expect a single page -- update when search is performed and we can parse it
-    this.pageSize = 1;
-    this.dismissSplash = this.dismissSplash.bind(this);
-    this.calculatePageSize = this.calculatePageSize.bind(this);
-    this.updateQueryString = this.updateQueryString.bind(this);
-    this.getQueryObject = this.getQueryObject.bind(this);
-    this.handlePageChange = this.handlePageChange.bind(this);
-    this.setAnimationDirection = this.setAnimationDirection.bind(this);
     this.eventEmitter = ee(ee);
+    // Maintaining a retryCounter outside the state as it doesn't affect the state/view directly.
+    // We just need to retry for 5 times exponentially and then stop with a message.
+    this.retryCounter = 0;
     this.refreshSearchByCreationTime = this.refreshSearchByCreationTime.bind(this);
     this.eventEmitter.on(globalEvents.APPUPLOAD, this.refreshSearchByCreationTime);
     this.eventEmitter.on(globalEvents.STREAMCREATE, this.refreshSearchByCreationTime);
     this.eventEmitter.on(globalEvents.PUBLISHPIPELINE, this.refreshSearchByCreationTime);
     this.eventEmitter.on(globalEvents.ARTIFACTUPLOAD, this.refreshSearchByCreationTime);
   }
-
-  refreshSearchByCreationTime() {
-    let namespace = NamespaceStore.getState().selectedNamespace;
-    ExploreTablesStore.dispatch(
-     fetchTables(namespace)
-   );
-    this.setState({
-      sortObj: this.sortOptions[4],
-      selectedEntity: null
-    }, this.search.bind(this));
+  componentWillMount() {
+    MyUserStoreApi.get().subscribe((res) => {
+      let userProperty = typeof res.property === 'object' ? res.property : {};
+      let showSplash = userProperty['user-has-visited'] || false;
+      this.setState({
+        userStoreObj : res,
+        showSplash : showSplash
+      });
+    });
   }
-
-  componentWillUnmount() {
-    this.eventEmitter.off(globalEvents.APPUPLOAD, this.refreshSearchByCreationTime);
-    this.eventEmitter.off(globalEvents.STREAMCREATE, this.refreshSearchByCreationTime);
-    this.eventEmitter.off(globalEvents.PUBLISHPIPELINE, this.refreshSearchByCreationTime);
-    this.eventEmitter.off(globalEvents.ARTIFACTUPLOAD, this.refreshSearchByCreationTime);
+  componentDidMount() {
+    this.searchStoreSubscription = SearchStore.subscribe(() => {
+      let {
+        results:entities,
+        loading,
+        limit,
+        total,
+        overviewEntity,
+      } = SearchStore.getState().search;
+      this.setState({
+        entities,
+        loading,
+        limit,
+        total,
+        overview: !isNil(overviewEntity)
+      });
+    });
+    SearchStore.dispatch({
+      type: SearchStoreActions.SETPAGESIZE,
+      payload: {
+        element: document.getElementsByClassName('entity-list-view')
+      }
+    });
+    this.parseUrlAndUpdateStore();
   }
-
+  parseUrlAndUpdateStore(nextProps) {
+    let props = nextProps || this.props;
+    let queryObject = this.getQueryObject(props.location.query);
+    let pageSize = SearchStore.getState().search.limit;
+    SearchStore.dispatch({
+      type: SearchStoreActions.SETSORTFILTERSEARCHCURRENTPAGE,
+      payload: {
+        activeSort: queryObject.sort,
+        activeFilters: queryObject.filters,
+        query: queryObject.query,
+        currentPage: queryObject.page,
+        offset: (queryObject.page - 1) * pageSize,
+        overviewEntity: queryObject.overview
+      }
+    });
+    search();
+  }
   componentWillReceiveProps(nextProps) {
-    if (nextProps.currentPage !== this.state.currentPage) {
+    let searchState = SearchStore.getState().search;
+    if (nextProps.currentPage !== searchState.currentPage) {
       // To enable explore fastaction on each card in entity list page.
       ExploreTablesStore.dispatch(
        fetchTables(nextProps.params.namespace)
@@ -169,541 +133,165 @@ class EntityListView extends Component {
     if (
       (nextProps.params.namespace !== this.props.params.namespace) ||
       (
-        !isEqual(queryObject.filter, this.state.filter) ||
-        queryObject.sort.fullSort !== this.state.sortObj.fullSort ||
-        queryObject.query !== this.state.query ||
-        queryObject.page !== this.state.currentPage
+        !isEqual(queryObject.filters, searchState.activeFilters) ||
+        queryObject.sort.fullSort !== searchState.activeSort.fullSort ||
+        queryObject.query !== searchState.query ||
+        queryObject.page !== searchState.currentPage ||
+        objectQuery(queryObject, 'overview', 'id') !== objectQuery(searchState, 'overviewEntity', 'id') ||
+        objectQuery(queryObject, 'overview', 'type') !== objectQuery(searchState, 'overviewEntity', 'type')
       )
     ) {
-      this.updateData(queryObject.query, queryObject.filter, queryObject.sort, nextProps.params.namespace, queryObject.page);
-      this.setState({
-        filter: queryObject.filter,
-        sortObj: queryObject.sort,
-        query: queryObject.query,
-        currentPage: queryObject.page,
-        loading: true,
-        entityErr: false,
-        errStatusCode: null
-      });
-    }
-  }
-
-  // Update Store and State to correspond to query parameters before component renders
-  componentWillMount() {
-    MyUserStoreApi.get().subscribe((res) => {
-      let userProperty = typeof res.property === 'object' ? res.property : {};
-      let showSplash = userProperty['user-has-visited'] || false;
-      this.setState({
-        userStoreObj : res,
-        showSplash : showSplash
-      });
-    });
-
-    // To enable explore fastaction on each card in Entity list view
-     ExploreTablesStore.dispatch(
-      fetchTables(this.props.params.namespace)
-    );
-
-    // Process and return valid query parameters
-    let queryObject = this.getQueryObject(this.props.location.query);
-    this.setState({
-      filter: queryObject.filter,
-      sortObj: queryObject.sort,
-      query: queryObject.query,
-      currentPage: queryObject.page
-    });
-  }
-
-  // Performs calculations to determine number of entities to render per page
-  calculatePageSize() {
-    // different screen sizes
-    // consistent with media queries in style sheet
-    const sevenColumnWidth = 1701;
-    const sixColumnWidth = 1601;
-    const fiveColumnWidth = 1201;
-    const fourColumnWidth = 993;
-    const threeColumnWidth = 768;
-
-    // 140 = cardHeight (128) + (5 x 2 top bottom margins) + (1 x 2 border widths)
-    const cardHeightWithMarginAndBorder = 140;
-
-    let entityListViewEle = document.getElementsByClassName('entity-list-view');
-
-    if (!entityListViewEle.length) {
-      return;
-    }
-
-    // Subtract 65px to account for entity-list-info's height (45px) and paddings (20px)
-    // minus 10px of padding from top and bottom (10px each)
-    let containerHeight = entityListViewEle[0].offsetHeight - 65 - 10;
-    let containerWidth = entityListViewEle[0].offsetWidth;
-    let numColumns = 1;
-
-    // different screen sizes
-    // consistent with media queries in style sheet
-    if (containerWidth >= sevenColumnWidth) {
-      numColumns = 7;
-    } else if (containerWidth >= sixColumnWidth && containerWidth < sevenColumnWidth) {
-      numColumns = 6;
-    } else if (containerWidth >= fiveColumnWidth && containerWidth < sixColumnWidth) {
-      numColumns = 5;
-    } else if (containerWidth >= fourColumnWidth && containerWidth < fiveColumnWidth) {
-      numColumns = 4;
-    } else if (containerWidth >= threeColumnWidth && containerWidth < fourColumnWidth) {
-      numColumns = 3;
-    }
-
-    this.setState({numColumns});
-
-    let numRows = Math.floor(containerHeight / cardHeightWithMarginAndBorder);
-
-    // We must have one column and one row at the very least
-    if (numRows === 0) {
-      numRows = 1;
-    }
-
-    this.pageSize = numColumns * numRows;
-  }
-
-  // Retrieve entities for rendering
-  componentDidMount() {
-    let namespaces = NamespaceStore.getState().namespaces.map(ns => ns.name);
-    if (namespaces.length) {
-      let selectedNamespace = NamespaceStore.getState().selectedNamespace;
-      if (namespaces.indexOf(selectedNamespace) === -1) {
-        this.setState({
-          notFound: true,
-          loading: false
+      if ((nextProps.params.namespace !== this.props.params.namespace)) {
+        NamespaceStore.dispatch({
+          type: NamespaceActions.selectNamespace,
+          payload: {
+            selectedNamespace: nextProps.params.namespace
+          }
         });
-      } else {
-        this.calculatePageSize();
-        this.updateData();
       }
-    } else {
-      const namespaceSubcriber = () => {
-        let selectedNamespace = NamespaceStore.getState().selectedNamespace;
-        let namespaces = NamespaceStore.getState().namespaces.map(ns => ns.name);
-        if (namespaces.length && namespaces.indexOf(selectedNamespace) === -1) {
-          this.setState({
-            notFound: true
-          });
-        } else {
-          this.setState({
-            notFound: false,
-            currentPage: this.state.currentPage
-          }, () => {
-            this.calculatePageSize();
-            this.search();
-            this.namespaceStoreSubscription();
-          });
-        }
-      };
-      this.namespaceStoreSubscription = NamespaceStore.subscribe(namespaceSubcriber.bind(this));
+      this.parseUrlAndUpdateStore(nextProps);
     }
   }
-
-  // Construct and return query object from query parameters
+  componentWillUnmount() {
+    SearchStore.dispatch({
+      type: SearchStoreActions.RESETSTORE
+    });
+    if (this.searchStoreSubscription) {
+      this.searchStoreSubscription();
+    }
+    this.eventEmitter.off(globalEvents.APPUPLOAD, this.refreshSearchByCreationTime);
+    this.eventEmitter.off(globalEvents.STREAMCREATE, this.refreshSearchByCreationTime);
+    this.eventEmitter.off(globalEvents.PUBLISHPIPELINE, this.refreshSearchByCreationTime);
+    this.eventEmitter.off(globalEvents.ARTIFACTUPLOAD, this.refreshSearchByCreationTime);
+  }
+  refreshSearchByCreationTime() {
+    let namespace = NamespaceStore.getState().selectedNamespace;
+    ExploreTablesStore.dispatch(
+     fetchTables(namespace)
+   );
+   SearchStore.dispatch({
+     type: SearchStoreActions.SETACTIVESORT,
+     payload: {
+       activeSort: SearchStore.getState().search.sort[4]
+     }
+   });
+   search();
+   updateQueryString();
+  }
   getQueryObject(query) {
-    let sortBy = '';
-    let orderBy = '';
-    let searchTerm = '';
-    let sortOption = '';
-    let filters = '';
-    let page = this.state.currentPage;
-    let verifiedFilters = null;
-    let invalidFilter = false;
-
-    // Get filters, order, sort, search from query
-    if (query) {
-      if (typeof query.q === 'undefined') {
-        sortBy = typeof query.sort === 'string' ? query.sort : '';
-        orderBy = typeof query.order === 'string' ? query.order : '';
+    if (isNil(query)) {
+      query = {};
+    }
+    let {
+      q = '*',
+      sort=DEFAULT_SEARCH_SORT.sort,
+      order=DEFAULT_SEARCH_SORT.order,
+      filter=DEFAULT_SEARCH_FILTERS,
+      page=1,
+      overviewid = null,
+      overviewtype = null
+    } = query;
+    const getSort = (sortOption, order, q) => {
+      let isValidSortOption = DEFAULT_SEARCH_SORT_OPTIONS.find(sortOpt => sortOpt.sort === sortOption && sortOpt.order === order);
+      if (!isValidSortOption) {
+        return DEFAULT_SEARCH_SORT;
       }
-      searchTerm = typeof query.q === 'string' ? query.q : '';
-      page = isNaN(query.page) ? this.state.currentPage : Number(query.page);
-
-      if (page <= 0) {
-        page = 1;
+      if (q !== DEFAULT_SEARCH_QUERY) {
+        return DEFAULT_SEARCH_SORT_OPTIONS[0];
       }
-
-      if (typeof query.filter === 'string') {
-        filters = [query.filter];
-      } else if (Array.isArray(query.filter)) {
-        filters = query.filter;
-      }
-    }
-
-    // Ensure sort parameters are valid
-    sortOption = this.sortOptions.filter((option) => {
-      return ( sortBy === option.sort && orderBy === option.order);
-    });
-
-    // Ensure filter parameters are valid
-    if (filters.length > 0) {
-      verifiedFilters = filters.filter( (filterOption) => {
-        if (this.acceptedFilterIds.indexOf(filterOption) !== -1) {
-          return true;
-        } else {
-          invalidFilter = true;
-          return false;
-        }
-      });
-    }
-
-    // Ensure all defaults are applied if an invalid parameter is passed
-    if (invalidFilter) {
-      defaultFilter.forEach(( option ) => {
-        if (verifiedFilters.indexOf(option) === -1) {
-          verifiedFilters.push(option);
-        }
-      });
-    }
-    let sort;
-    if (!searchTerm) {
-      sort = sortOption.length === 0 ? this.state.sortObj : sortOption[0];
-    } else {
-      sort = this.sortOptions[0];
-    }
-    // Return valid query parameters or return current state values if query params are invalid
-    return ({
-      'query' : searchTerm ? searchTerm : this.state.query,
-      'sort': sort,
-      'filter' : verifiedFilters ? verifiedFilters : this.state.filter,
-      'page' : page
-    });
-  }
-
-  updateData(
-    query = this.state.query,
-    filter = this.state.filter,
-    sortObj = this.state.sortObj,
-    namespace = this.props.params.namespace,
-    currentPage = this.state.currentPage
-  ) {
-    let offset = (currentPage - 1) * this.pageSize;
-    const numCursors = 10;
-
-    // TODO/FIXME: hack to not display programs when filter is empty (which means all
-    // entities should be displayed). Maybe this should be a backend change?
-    if (filter.length === 0) {
-      filter = ['app', 'artifact', 'dataset', 'stream'];
-    }
-
-    this.setState({
-      loading : true,
-      selectedEntity: null
-    });
-
-    let params = {
-      namespace: namespace,
-      target: filter,
-      limit: this.pageSize,
-      offset: offset
+      return isValidSortOption;
     };
-
-    if (typeof query === 'string' && query.length) {
-      params.query = query.charAt(query.length - 1) === '*' ? query : `${query}*`;
-    } else {
-      params.sort = sortObj.fullSort === 'none' ? this.sortOptions[3].fullSort : sortObj.fullSort;
-      params.query = '*';
-      params.numCursors = numCursors;
-    }
-
-    let total, limit;
-    MySearchApi.search(params)
-      .map((res) => {
-        total = res.total;
-        limit = res.limit;
-        return res.results
-          .map(parseMetadata)
-          .map((entity) => {
-            entity.uniqueId = shortid.generate();
-            return entity;
-          });
-      })
-      .subscribe((res) => {
-        if (total > 0 && Math.ceil(total/limit) < this.state.currentPage) {
-          this.setState({
-            entityErr: true,
-            errStatusCode: 'PAGE_NOT_FOUND',
-            loading: false
-          });
-        } else {
-          // numCursors is the number of chunks after the first limit, so the
-          // total would be limit * (numCursors + 1)
-          let allEntitiesFetched = total < (limit * (numCursors + 1) + offset);
-          this.setState({
-            entities: res,
-            total: total,
-            loading: false,
-            entityErr: false,
-            errStatusCode: null,
-            numPages: Math.ceil(total / this.pageSize),
-            allEntitiesFetched
-          });
-
-          this.retryCounter = 0;
-        }
-      }, (err) => {
-        this.retryCounter++;
-
-        // On Error: render page as if there are no results found
-        this.setState({
-          loading: false,
-          entities: [],
-          total: 0,
-          entityErr: typeof err === 'object' ? err.response : err,
-          errStatusCode: err.statusCode
-        });
-      });
-  }
-  search(
-    query = this.state.query,
-    filter = this.state.filter,
-    sortObj = this.state.sortObj,
-    namespace = this.props.params.namespace,
-    currentPage = this.state.currentPage
-  ) {
-    this.updateData(query, filter, sortObj, namespace, currentPage);
-    this.updateQueryString();
-  }
-
-  resetFilters() {
-    let filters = defaultFilter;
-    this.setState({
-      filter : filters,
-      selectedEntity: null,
-      currentPage: 1
-    }, () => {
-      this.search(this.state.query, filters, this.state.sortObj);
-    });
-  }
-
-  handleFilterClick(option) {
-    let filters = [...this.state.filter];
-    if (this.state.filter.indexOf(option.id) !== -1) {
-      let index = filters.indexOf(option.id);
-      filters.splice(index, 1);
-    } else {
-      filters.push(option.id);
-    }
-
-    this.setState({
-      filter : filters,
-      selectedEntity: null,
-      currentPage: 1
-    }, () => {
-      this.search(this.state.query, filters, this.state.sortObj);
-    });
-  }
-
-  handlePageChange(pageNumber) {
-    if (pageNumber < 1 || pageNumber > this.state.numPages) {
-      return;
-    }
-
-    let direction = pageNumber >= this.state.currentPage ? 'next' : 'prev';
-
-    this.setState({
-      currentPage : pageNumber,
-      animationDirection : direction,
-      selectedEntity: null
-    }, () => this.search());
-  }
-
-  handleSortClick(option) {
-    this.setState({
-      sortObj : option,
-      query: '',
-      selectedEntity: null,
-      currentPage: 1
-    }, () => {
-      this.search(this.state.query, this.state.filter, option);
-    });
-  }
-
-  handleSearch(query) {
-    let sortObj = this.sortOptions[0];
-    if (query.length === 0) {
-      sortObj = this.sortOptions[4]; // search text is empty, revert to default ('Newest')
-    }
-    this.setState({
-      query,
-      sortObj,
-      selectedEntity: null,
-      currentPage: this.state.currentPage
-    }, () => {
-      this.search(query, this.state.filter, this.state.sortObj);
-    });
-  }
-
-  handleEntityClick(entity) {
-    this.setState({selectedEntity: entity});
-  }
-
-  // Set query string using current application state
-  updateQueryString() {
-    let queryString = '';
-    let sort = '';
-    let filter = '';
-    let query = '';
-    let page = '';
-    let queryParams = [];
-
-    // Generate sort params
-    if (this.state.sortObj.sort !== 'none') {
-      sort = 'sort=' + this.state.sortObj.sort + '&order=' + this.state.sortObj.order;
-    }
-
-    // Generate filter params
-    if (this.state.filter.length === 1) {
-      filter = 'filter=' + this.state.filter[0];
-    } else if (this.state.filter.length > 1) {
-      filter = 'filter=' + this.state.filter.join('&filter=');
-    }
-
-    // Generate search param
-    if (this.state.query.length > 0) {
-      query = 'q=' + this.state.query;
-    }
-
-    // Generate page param
-    page = 'page=' + this.state.currentPage;
-
-    // Combine query parameters into query string
-    queryParams = [query, sort, filter, page].filter((element) => {
-      return element.length > 0;
-    });
-    queryString = queryParams.join('&');
-
-    if (queryString.length > 0) {
-      queryString = '?' + queryString;
-    }
-
-    let obj = {
-      title: 'CDAP',
-      url: location.pathname + queryString
+    const getFilters = (filters) => {
+      if (!Array.isArray(filters)) {
+        filters = [filters];
+      }
+      let validFilters = intersection(filters, DEFAULT_SEARCH_FILTERS);
+      if (!validFilters.length) {
+        return DEFAULT_SEARCH_FILTERS;
+      }
+      return validFilters;
     };
-
-    // Modify URL to match application state
-    history.pushState(obj, obj.title, obj.url);
+    const getPageNum = (page) => {
+      if (isNaN(page)) {
+        return 1;
+      }
+      return parseInt(page, 10);
+    };
+    const getSearchQuery = (q) => {
+      if (isNil(q) || isEmpty(q)) {
+        return DEFAULT_SEARCH_QUERY;
+      }
+      return q;
+    };
+    const getOverviewEntity = (overviewid, overviewtype) => {
+      if (!isNil(overviewid) && !isNil(overviewtype)) {
+        return {
+          id: overviewid,
+          type: overviewtype
+        };
+      }
+      return null;
+    };
+    let queryObject = {
+      sort: getSort(sort, order, q),
+      filters: getFilters(filter),
+      page: getPageNum(page),
+      query: getSearchQuery(q),
+      overview: getOverviewEntity(overviewid, overviewtype)
+    };
+    return queryObject;
   }
-
-  setAnimationDirection(direction) {
+  retrySearch() {
+    this.retryCounter += 1;
+    search();
+  }
+  onOverviewCloseAndRefresh() {
     this.setState({
-      animationDirection : direction,
-      selectedEntity: null
+      overview: false
     });
+    SearchStore.dispatch({
+      type: SearchStoreActions.RESETOVERVIEWENTITY
+    });
+    search();
   }
-
   dismissSplash() {
-    MyUserStoreApi
-      .get()
-      .subscribe(res => {
-        if (isNil(res)) {
-          res = {};
-        }
-        if (!isObject(res.property)) {
-          res.property = {};
-        }
-        res.property['user-has-visited'] = true;
-        MyUserStoreApi.set({}, res.property);
-      });
     this.setState({
       showSplash: true
     });
+    this.parseUrlAndUpdateStore();
   }
-
-  openAddEntityModal() {
-    PlusButtonStore.dispatch({
-      type: 'TOGGLE_PLUSBUTTON_MODAL',
-      payload: {
-        modalState: true
-      }
-    });
-
-    MyUserStoreApi
-      .get()
-      .subscribe(res => {
-        if (isNil(res)) {
-          res = {};
-        }
-        if (!isObject(res.property)) {
-          res.property = {};
-        }
-        res.property['user-has-visited'] = true;
-        MyUserStoreApi.set({}, res.property);
-      });
-  }
-
-  onOverviewCloseAndRefresh() {
-    this.setState({selectedEntity: null}, this.search.bind(this));
-  }
-
-  onFastActionSuccess() {
-    if (this.state.selectedEntity) {
-      this.onOverviewCloseAndRefresh();
-      return;
-    }
-    this.search();
-  }
-
   render() {
-    if (this.state.notFound) {
-      return (
-        <div className="entity-list-view">
-          <Page404
-            entityType="Namespace"
-            entityName={this.props.params.namespace}
-          >
-            <div className="namespace-not-found text-xs-center">
-              <h4>
-                <strong>
-                  {T.translate('features.EntityListView.NamespaceNotFound.createMessage')}
-                  <span
-                    className="open-namespace-wizard-link"
-                    onClick={() => {
-                      this.eventEmitter.emit(globalEvents.CREATENAMESPACE);
-                    }}
-                  >
-                    {T.translate('features.EntityListView.NamespaceNotFound.createLinkLabel')}
-                  </span>
-                </strong>
-              </h4>
-              <h4>
-                <strong>
-                  {T.translate('features.EntityListView.NamespaceNotFound.switchMessage')}
-                </strong>
-              </h4>
-            </div>
-          </Page404>
-        </div>
-      );
-    }
+    let namespace = NamespaceStore.getState().selectedNamespace;
+    let searchState = SearchStore.getState();
+    let currentPage = searchState.search.currentPage;
+    let query = searchState.search.query;
+    let searchText = searchState.search.query;
+    let numCursors = searchState.search.numCursors;
+    let offset = searchState.search.offset;
+    let {statusCode:errorStatusCode, message:errorMessage } = searchState.search.error;
+    let errorContent;
+
     if (!this.state.showSplash) {
       return (
         <WelcomeScreen
           onClose={this.dismissSplash.bind(this)}
-          onAddEntity={this.openAddEntityModal.bind(this)}
         />
       );
     }
-
-    let errorContent = null;
-    if (this.state.entityErr) {
-      if (this.state.errStatusCode === 'PAGE_NOT_FOUND') {
+    if (!isNil(errorStatusCode)) {
+      if (errorStatusCode === 'PAGE_NOT_FOUND') {
         errorContent = (
           <PageErrorMessage
-            pageNum={this.state.currentPage}
-            query={this.state.query}
+            pageNum={currentPage}
+            query={query}
           />
         );
       } else {
         errorContent = (
           <HomeErrorMessage
-            errorMessage={this.state.entityErr}
-            errorStatusCode={this.state.errStatusCode}
-            onRetry={this.search.bind(this)}
+            errorMessage={errorMessage}
+            errorStatusCode={errorStatusCode}
+            onRetry={this.retrySearch.bind(this)}
             retryCounter={this.retryCounter}
           />
         );
@@ -712,63 +300,41 @@ class EntityListView extends Component {
 
     return (
       <div>
-        <EntityListHeader
-          filterOptions={this.filterOptions}
-          onFilterClick={this.handleFilterClick.bind(this)}
-          activeFilter={this.state.filter}
-          sortOptions={this.sortOptions}
-          activeSort={this.state.sortObj}
-          onSortClick={this.handleSortClick.bind(this)}
-          onSearch={this.handleSearch.bind(this)}
-          searchText={this.state.query}
-          onPageChange={this.handlePageChange}
-        />
-        <Pagination
-          className="entity-list-view"
-          setCurrentPage={this.handlePageChange}
-          totalPages={this.state.numPages}
-          currentPage={this.state.currentPage}
-          setDirection={this.setAnimationDirection}
-        >
-          <EntityListInfo
-            className="entity-list-info"
-            namespace={this.props.params.namespace}
-            numberOfEntities={this.state.total}
-            numberOfPages={this.state.numPages}
-            currentPage={this.state.currentPage}
-            onPageChange={this.handlePageChange}
-            allEntitiesFetched={this.state.allEntitiesFetched}
-          />
-          <div className={classNames("entities-container")}>
+        <EntityListHeader />
+        <div className="entity-list-view">
+          {
+            !isNil(errorContent) ?
+              null
+            :
+              <EntityListInfo
+                className="entity-list-info"
+                namespace={namespace}
+                numberOfEntities={this.state.total}
+                numberOfPages={this.state.total / this.state.limit}
+                currentPage={currentPage}
+                allEntitiesFetched = {this.state.total < (this.state.limit * (numCursors + 1) + offset)}
+              />
+          }
+          <div className={classnames("entities-container", {'error-holder': errorContent})}>
             {
-              this.state.entityErr ?
+              !isNil(errorContent) ?
                 errorContent
               :
                 <HomeListView
-                  className={classNames("home-list-view-container", {"show-overview-main-container": !isNil(this.state.selectedEntity)})}
-                  list={this.state.entities}
+                  id="home-list-view-container"
                   loading={this.state.loading}
-                  onEntityClick={this.handleEntityClick.bind(this)}
-                  onFastActionSuccess={this.onFastActionSuccess.bind(this)}
-                  onSearch={this.handleSearch.bind(this)}
-                  onFiltersCleared={this.resetFilters.bind(this)}
-                  activeEntity={this.state.selectedEntity}
-                  currentPage={this.state.currentPage}
-                  activeFilter={this.state.filter}
-                  filterOptions={this.filterOptions}
-                  activeSort={this.state.sortObj}
-                  searchText={this.state.query}
-                  numColumns={this.state.numColumns}
+                  className={classnames("home-list-view-container", {"show-overview-main-container": this.state.overview})}
+                  list={this.state.entities}
+                  pageSize={this.state.limit}
+                  showJustAddedSection={searchText === DEFAULT_SEARCH_QUERY}
+                  onFastActionSuccess={search}
                 />
             }
             <Overview
-              toggleOverview={!isNil(this.state.selectedEntity)}
-              entity={this.state.selectedEntity}
-              onClose={this.handleEntityClick.bind(this)}
               onCloseAndRefresh={this.onOverviewCloseAndRefresh.bind(this)}
             />
           </div>
-        </Pagination>
+        </div>
       </div>
     );
   }
@@ -782,5 +348,3 @@ EntityListView.propTypes = {
   history: PropTypes.object,
   pathname: PropTypes.string
 };
-
-export default EntityListView;

--- a/cdap-ui/app/cdap/components/StreamDetailedView/index.js
+++ b/cdap-ui/app/cdap/components/StreamDetailedView/index.js
@@ -42,7 +42,6 @@ require('./StreamDetailedView.scss');
 export default class StreamDetailedView extends Component {
   constructor(props) {
     super(props);
-
     this.state = {
       entityDetail: objectQuery(this.props, 'location', 'state', 'entityDetail') || {
         schema: null,
@@ -54,12 +53,15 @@ export default class StreamDetailedView extends Component {
       routeToHome: false,
       successMessage: null,
       notFound: false,
-      modalToOpen: objectQuery(this.props, 'location', 'query', 'modalToOpen') || ''
+      modalToOpen: objectQuery(this.props, 'location', 'query', 'modalToOpen') || '',
+      previousPathName: null
     };
   }
 
   componentWillMount() {
     let {namespace, streamId} = this.props.params;
+    let selectedNamespace = NamespaceStore.getState().selectedNamespace;
+    let previousPathName = objectQuery(this.props, 'location', 'state', 'previousPathname')  || `/ns/${selectedNamespace}?overviewid=${streamId}&overviewtype=stream`;
     if (!namespace) {
       namespace = NamespaceStore.getState().selectedNamespace;
     }
@@ -67,6 +69,9 @@ export default class StreamDetailedView extends Component {
       fetchTables(namespace)
     );
 
+    this.setState({
+      previousPathName
+    });
     this.fetchEntityDetails(namespace, streamId);
     this.fetchEntityMetadata(namespace, streamId);
     if (
@@ -241,11 +246,8 @@ export default class StreamDetailedView extends Component {
         />
       );
     }
-
-    let selectedNamespace = NamespaceStore.getState().selectedNamespace;
-    let previousPathname = objectQuery(this.props, 'location', 'state', 'previousPathname')  || `/ns/${selectedNamespace}`;
     let previousPaths = [{
-      pathname: previousPathname,
+      pathname: this.state.previousPathName,
       label: T.translate('commons.back')
     }];
     return (


### PR DESCRIPTION
- Adds SearchStore, Actions, ActionCreator & Constants to be used in EntityListView
- Adds pure stateless ListViewHeader based on SearchStore's state
- Fixes EntityListHeader to use SearchStore to update its own state
- Removes subtitle section from ListView as it is being rendered as stateless pure component
- Fixes JustAddedSection to ListView to show approriate newly created entities
- Adds Error handling in EntityListView
- Adds overview state to URL to go let the user come back to overview state from anywhere
- Fixes NamespaceDropdown when using browser back button to go to previous namespace
- Fixes <NoEntitiesMessage /> component based on SearchStore changes
- Fixes JustAddedSection to show only one row + fix highlighting issues between entities in just added section and normal list view
- Fixes scroll to view for overview entities
- Fixes search + pagination in entity listview home page



Cherry pick for `release/4.1` https://github.com/caskdata/cdap/pull/8307