### PR TITLE
[CDAP-8950] Stream details view broken when navigating from overview

### DIFF
--- a/cdap-ui/app/cdap/components/DatasetDetailedView/index.js
+++ b/cdap-ui/app/cdap/components/DatasetDetailedView/index.js
@@ -69,13 +69,13 @@ export default class DatasetDetailedView extends Component {
     this.fetchEntityDetails(namespace, datasetId);
     this.fetchEntitiesMetadata(namespace);
     if (
-      isNil(this.state.entityMetadata) ||
-      isEmpty(this.state.entityMetadata) ||
-      isNil(this.state.entity) ||
-      isEmpty(this.state.entity)
+      !isNil(this.state.entityMetadata) &&
+      !isEmpty(this.state.entityMetadata) &&
+      !isNil(this.state.entityDetail) &&
+      !isEmpty(this.state.entityDetail)
     ) {
       this.setState({
-        loading: true
+        loading: false
       });
     }
 

--- a/cdap-ui/app/cdap/components/StreamDetailedView/index.js
+++ b/cdap-ui/app/cdap/components/StreamDetailedView/index.js
@@ -70,13 +70,13 @@ export default class StreamDetailedView extends Component {
     this.fetchEntityDetails(namespace, streamId);
     this.fetchEntityMetadata(namespace, streamId);
     if (
-      isNil(this.state.entityMetadata) ||
-      isEmpty(this.state.entityMetadata) ||
-      isNil(this.state.entity) ||
-      isEmpty(this.state.entity)
+      !isNil(this.state.entityMetadata) &&
+      !isEmpty(this.state.entityMetadata) &&
+      !isNil(this.state.entityDetail) &&
+      !isEmpty(this.state.entityDetail)
     ) {
       this.setState({
-        loading: true
+        loading: false
       });
     }
 


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-8950

The problem was that in the stream & dataset detailed views, we didn't have code to disable the loading icon when we already had all the metadata of a stream/dataset, without having to call `fetchEntitiesMetadata()` or `fetchEntityDetails()`. `loading` state was only set to `false` when we had to call either of those two functions.

Also, we were referring to the wrong state variable (`this.state.entity`, which didn't exist, instead of `this.state.entityDetail`).