### PR TITLE
set ui pack version in maven

### DIFF
--- a/cdap-ui/pom.xml
+++ b/cdap-ui/pom.xml
@@ -31,6 +31,7 @@
 
   <properties>
     <app.main.class>co.cask.cdap.ui.ConfigurationJsonTool</app.main.class>
+    <ui.pack.version>1</ui.pack.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Setting the ``ui.pack.version`` property version in maven.  The build will produce a ui-pack version as:

``cdap-ui-pack-<cdap.version>_p<ui.pack.version>``

where

``<cdap.version>``: cdap version from top-level maven pom.xml
``<ui.pack.version>``: ui.pack.version from cdap-ui/pom.xml

for example:  ``cdap-ui-pack-4.1.0_p1.zip``