### PR TITLE
[CDAP-8995] - Bug fix Complex schema editor in react UI

### DIFF
--- a/cdap-ui/app/cdap/components/Overview/Overview.scss
+++ b/cdap-ui/app/cdap/components/Overview/Overview.scss
@@ -40,7 +40,7 @@
     .overview-wrapper {
       position: fixed;
       width: $overview-width;
-      height: calc(100vh - 217px);
+      height: calc(100vh - 225px);
       border-top: 1px solid rgba(219, 219, 219, 1);
       background: rgba(238, 238, 238, 1);
       box-shadow: 0px 1px 10px 0 rgba(0, 0, 0, 0.3);

--- a/cdap-ui/app/cdap/components/Overview/Tabs/SchemaTab/index.js
+++ b/cdap-ui/app/cdap/components/Overview/Tabs/SchemaTab/index.js
@@ -15,13 +15,10 @@
  */
 
 import React, { Component, PropTypes } from 'react';
-import {objectQuery} from 'services/helpers';
 import SchemaStore from 'components/SchemaEditor/SchemaStore';
 import SchemaEditor from 'components/SchemaEditor';
-import {getParsedSchema} from 'components/SchemaEditor/SchemaHelpers';
 import {Tooltip} from 'reactstrap';
 import T from 'i18n-react';
-
 require('./SchemaTab.scss');
 
 export default class SchemaTab extends Component {
@@ -37,21 +34,14 @@ export default class SchemaTab extends Component {
 
   componentWillMount() {
     if (!this.props.entity.schema) { return; }
-
-    let fields = getParsedSchema(this.props.entity.schema);
-    this.setSchema({fields});
-  }
-
-  componentWillReceiveProps(nextProps) {
-    let entitiesMatch = objectQuery(nextProps, 'entity', 'name') === objectQuery(this.props, 'entity', 'name');
-    if (!entitiesMatch) {
-      this.setState({
-        entity: nextProps.entity
-      });
-
-      let fields = getParsedSchema(nextProps.entity.schema);
-      this.setSchema({fields});
+    let schema;
+    try {
+      schema = JSON.parse(this.props.entity.schema);
+    } catch (e) {
+      console.error('Error parsing schema: ', e);
+      schema = { fields: []};
     }
+    this.setSchema({fields: schema.fields});
   }
 
   componentWillUnmount() {

--- a/cdap-ui/app/cdap/components/SchemaEditor/ArraySchemaRow/index.js
+++ b/cdap-ui/app/cdap/components/SchemaEditor/ArraySchemaRow/index.js
@@ -39,7 +39,7 @@ export default class ArraySchemaRow extends Component {
         showAbstractSchemaRow: true,
         error: ''
       };
-      this.parsedType = itemsType;
+      this.parsedType = parsedItemsType.type;
     } else {
       this.state = {
         displayType: {
@@ -96,8 +96,6 @@ export default class ArraySchemaRow extends Component {
     if (error) {
       this.setState({error});
       return;
-    } else {
-      this.setState({error: ''});
     }
     this.parsedType = this.state.displayType.nullable ? [cloneDeep(itemsState): 'null'] : cloneDeep(itemsState);
     this.updateParent();

--- a/cdap-ui/app/cdap/components/SchemaEditor/MapSchemaRow/index.js
+++ b/cdap-ui/app/cdap/components/SchemaEditor/MapSchemaRow/index.js
@@ -208,6 +208,7 @@ export default class MapSchemaRow extends Component {
               <div className="btn btn-link">
                 <Input
                   type="checkbox"
+                  addon={true}
                   checked={this.state.keysTypeNullable}
                   onChange={this.onKeysTypeNullableChange.bind(this)}
                 />
@@ -250,6 +251,7 @@ export default class MapSchemaRow extends Component {
               <div className="btn btn-link">
                 <Input
                   type="checkbox"
+                  addon={true}
                   checked={this.state.valuesTypeNullable}
                   onChange={this.onValuesTypeNullableChange.bind(this)}
                 />

--- a/cdap-ui/app/cdap/components/SchemaEditor/UnionSchemaRow/index.js
+++ b/cdap-ui/app/cdap/components/SchemaEditor/UnionSchemaRow/index.js
@@ -173,6 +173,7 @@ export default class UnionSchemaRow extends Component {
                     <div className="btn btn-link">
                       <Input
                         type="checkbox"
+                        addon={true}
                         checked={displayType.nullable}
                         onChange={this.onNullableChange.bind(this, index)}
                       />

--- a/cdap-ui/app/cdap/components/SchemaEditor/index.js
+++ b/cdap-ui/app/cdap/components/SchemaEditor/index.js
@@ -17,7 +17,6 @@
 import React, {Component} from 'react';
 import {Provider} from 'react-redux';
 require('./SchemaEditor.scss');
-import {getParsedSchema} from 'components/SchemaEditor/SchemaHelpers';
 import RecordSchemaRow from 'components/SchemaEditor/RecordSchemaRow';
 import SchemaStore from 'components/SchemaEditor/SchemaStore';
 import cdapavsc from 'cdap-avsc';
@@ -41,7 +40,7 @@ export default class SchemaEditor extends Component {
       let state = SchemaStore.getState();
       let rows;
       try {
-        rows = getParsedSchema(state.schema);
+        rows = cdapavsc.parse(state.schema, { wrapUnions: true });
       } catch (e) {
         return;
       }

--- a/cdap-ui/app/cdap/components/SelectWithOptions/index.js
+++ b/cdap-ui/app/cdap/components/SelectWithOptions/index.js
@@ -15,7 +15,6 @@
  */
 import React, {PropTypes} from 'react';
 import {Input} from 'reactstrap';
-import shortid from 'shortid';
 
 export default function SelectWithOptions({className, value, onChange, options}) {
   return (
@@ -29,14 +28,14 @@ export default function SelectWithOptions({className, value, onChange, options})
         if (typeof o === 'object') {
           return (
             <option
-              key={shortid.generate()}
+              key={o.id}
               value={o.id}
             >
               {o.value}
             </option>
           );
         }
-        return (<option key={shortid.generate()}>{o}</option>);
+        return (<option key={o}>{o}</option>);
       })}
     </Input>
   );


### PR DESCRIPTION
- Fix parsing schema in `ArraySchemaRow, SchemaEditor & SchemaTab` components to use `cdapavsc.parse` instead of custom helper function
- Fixes styling for individual schema row components (checkbox wasn't aligning for map & union schema fields).

JIRA: https://issues.cask.co/browse/CDAP-8995
Bamboo build: http://builds.cask.co/browse/CDAP-DRC6087/latest