### PR TITLE
CDAP-8982 Use Ubuntu 16.04 for images

### DIFF
--- a/cdap-distributions/src/Dockerfile
+++ b/cdap-distributions/src/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright © 2012-2016 Cask Data, Inc.
+# Copyright © 2012-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,20 +13,18 @@
 # limitations under the License.
 #
 # Cask is a trademark of Cask Data, Inc. All rights reserved.
-###############################################################################################
-# Please visit Docker.com and follow instructions to download Docker SW in your environment.
-# This Dockerfile will build a CDAP image from scratch utilizing ubuntu 12.04 as a base image.
-# The assumption is that you are running this from the root of the cdap directory structure.
-#
-FROM ubuntu:12.04
+
+FROM ubuntu:16.04
 MAINTAINER Cask Data <ops@cask.co>
+
+# update system
+RUN apt-get update && \
+  apt-get dist-upgrade -y && \
+  apt-get install -y curl
 
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.7
-RUN apt-get update && \
-  apt-get install -y --no-install-recommends \
-    curl \
-    git && \
+RUN apt-get install -y --no-install-recommends git && \
   curl -vL \
     "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" > \
     /usr/local/bin/gosu && \

--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -6,27 +6,42 @@
     {
       "type": "virtualbox-iso",
       "guest_os_type": "Ubuntu_64",
-      "iso_url": "http://releases.ubuntu.com/12.04/ubuntu-12.04.5-server-amd64.iso",
-      "iso_checksum": "769474248a3897f4865817446f9a4a53",
+      "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.2-server-amd64.iso",
+      "iso_checksum": "2bce60d18248df9980612619ff0b34e6",
       "iso_checksum_type": "md5",
-      "ssh_username": "root",
+      "ssh_username": "cdap",
       "ssh_password": "cdap",
       "ssh_wait_timeout": "30m",
-      "shutdown_command": "shutdown -P now",
+      "shutdown_command": "sudo shutdown -P now",
       "format": "ova",
       "headless": true,
       "guest_additions_mode": "upload",
       "http_directory": "files",
       "boot_command": [
-        "<esc><esc><enter><wait>",
-        "/install/vmlinuz noapic ",
-        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg ",
-        "debian-installer=en_US auto locale=en_US kbd-chooser/method=us ",
-        "hostname={{ .Name }}.cask.co ",
-        "fb=false debconf/frontend=noninteractive ",
-        "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA ",
-        "keyboard-configuration/variant=USA console-setup/ask_detect=false ",
-        "initrd=/install/initrd.gz -- <enter>"
+        "<enter><wait><f6><esc><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "/install/vmlinuz<wait>",
+        " auto<wait>",
+        " console-setup/ask_detect=false<wait>",
+        " console-setup/layoutcode=us<wait>",
+        " console-setup/modelcode=pc105<wait>",
+        " debconf/frontend=noninteractive<wait>",
+        " debian-installer=en_US<wait>",
+        " fb=false<wait>",
+        " initrd=/install/initrd.gz<wait>",
+        " kbd-chooser/method=us<wait>",
+        " keyboard-configuration/layout=USA<wait>",
+        " keyboard-configuration/variant=USA<wait>",
+        " locale=en_US<wait>",
+        " netcfg/get_domain=cask.co<wait>",
+        " netcfg/get_hostname={{ .Name }}<wait>",
+        " grub-installer/bootdev=/dev/sda<wait>",
+        " noapic<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg",
+        " -- <wait>",
+        "<enter><wait>"
       ],
       "vboxmanage": [
         ["modifyvm", "{{ .Name }}", "--memory", "4096"],
@@ -46,7 +61,7 @@
       "ami_name": "CDAP SDK {{user `sdk_version`}} ({{timestamp}})",
       "instance_type": "m4.large",
       "region": "us-east-1",
-      "source_ami": "ami-42d6fb55",
+      "source_ami": "ami-1ac0120c",
       "ssh_username": "ubuntu",
       "name": "cdap-sdk-ami"
     }
@@ -62,17 +77,9 @@
       "pause_before": "10s"
     },
     {
-      "type": "shell",
-      "inline": [
-        "reboot"
-      ],
-      "only": ["cdap-sdk-vm"]
-    },
-    {
       "type": "chef-solo",
       "install_command": "curl -L https://www.chef.io/chef/install.sh | {{if .Sudo}}sudo{{end}} bash -s -- -v 12.19.36",
-      "remote_cookbook_paths": "/var/chef/cookbooks",
-      "pause_before": "10s"
+      "remote_cookbook_paths": "/var/chef/cookbooks"
     },
     {
       "type": "shell",
@@ -81,6 +88,7 @@
     },
     {
       "type": "shell",
+      "execute_command": "sudo bash -c '{{ .Vars }} {{ .Path }}'",
       "scripts": "scripts/eclipse-cookbook.sh",
       "only": ["cdap-sdk-vm"]
     },
@@ -100,7 +108,6 @@
       "type": "chef-solo",
       "remote_cookbook_paths": "/var/chef/cookbooks",
       "run_list": "recipe[maven],recipe[hadoop::flume_agent],recipe[idea],recipe[eclipse]",
-      "prevent_sudo": true,
       "skip_install": true,
       "json": {
         "eclipse": {
@@ -168,6 +175,7 @@
     },
     {
       "type": "shell",
+      "execute_command": "sudo bash -c '{{ .Vars }} {{ .Path }}'",
       "scripts": [
         "scripts/motd.sh",
         "scripts/xorg.sh",
@@ -196,6 +204,7 @@
     },
     {
       "type": "shell",
+      "execute_command": "sudo bash -c '{{ .Vars }} {{ .Path }}'",
       "scripts": [
         "scripts/random-root-password.sh",
         "scripts/zero-disk.sh"

--- a/cdap-distributions/src/packer/files/preseed.cfg
+++ b/cdap-distributions/src/packer/files/preseed.cfg
@@ -1,5 +1,5 @@
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -18,32 +18,36 @@
 #
 d-i debian-installer/locale string en_US
 d-i console-setup/ask_detect boolean false
-d-i keyboard-configuration/layoutcode string us
+d-i keyboard-configuration/xkb-keymap select us
 d-i netcfg/choose_interface select auto
 d-i netcfg/get_hostname string cdap-standalone-vm
 d-i netcfg/get_domain string cask.co
 d-i netcfg/wireless_wep string
-d-i mirror/country string us
+d-i mirror/country string manual
 d-i mirror/http/hostname string archive.ubuntu.com
 d-i mirror/http/directory string /ubuntu
 d-i mirror/http/proxy string
 d-i mirror/http/mirror select us.archive.ubuntu.com
-d-i mirror/suite string precise
+d-i mirror/suite string xenial
 d-i clock-setup/utc boolean true
 d-i time/zone string UTC
 d-i clock-setup/ntp boolean true
-d-i partman-auto/method string regular
+d-i partman-auto/method string lvm
 d-i partman-lvm/device_remove_lvm boolean true
 d-i partman-md/device_remove_md boolean true
 d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+d-i partman-auto-lvm/guided_size string max
 d-i partman-auto/choose_recipe select atomic
 d-i partman/default_filesystem string ext4
 d-i partman-partitioning/confirm_write_new_label boolean true
 d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true
+#d-i partman/mount_style select uuid
 d-i partman/mount_style select traditional
-d-i passwd/root-login boolean true
+d-i passwd/root-login boolean false
+# This is scrambled and disabled later
 d-i passwd/root-password password cdap
 d-i passwd/root-password-again password cdap
 d-i passwd/user-fullname string CDAP User
@@ -52,10 +56,9 @@ d-i passwd/user-password password cdap
 d-i passwd/user-password-again password cdap
 d-i user-setup/allow-password-weak boolean true
 d-i user-setup/encrypt-home boolean false
+#d-i base-installer/install-recommends boolean false
 d-i apt-setup/universe boolean true
-# Install smallest set of packages
 tasksel tasksel/first multiselect minimal
-# Add some packages of our own
 d-i pkgsel/include string openssh-server build-essential git subversion curl
 d-i pkgsel/upgrade select full-upgrade
 d-i pkgsel/update-policy select none
@@ -64,10 +67,10 @@ d-i pkgsel/install-language-support boolean false
 popularity-contest popularity-contest/participate boolean false
 d-i pkgsel/updatedb boolean true
 d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean false
+d-i finish-install/keep-consoles boolean true
 d-i finish-install/reboot_in_progress note
-xserver-xorg xserver-xorg/autodetect_monitor boolean true
-xserver-xorg xserver-xorg/config/monitor/selection-method select medium
-xserver-xorg xserver-xorg/config/monitor/mode-list select 1024x768 @ 60 Hz
+
 # Hack-fu to get passwordless sudo
 d-i preseed/late_command string \
-  sed -i 's/%sudo\tALL=(ALL:ALL) ALL/%sudo\tALL=(ALL:ALL) NOPASSWD:ALL/' /target/etc/sudoers
+  sed -i 's/ALL=(ALL:ALL) ALL/ALL=(ALL:ALL) NOPASSWD:ALL/' /target/etc/sudoers

--- a/cdap-distributions/src/packer/scripts/apt-cleanup.sh
+++ b/cdap-distributions/src/packer/scripts/apt-cleanup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -19,8 +19,8 @@
 #
 
 # Remove old kernels/headers
-apt-get remove --purge -y $(dpkg -l 'linux-image-*' | sed '/^ii/!d;/'"$(uname -r | sed "s/\(.*\)-\([^0-9]\+\)/\1/")"'/d;s/^[^ ]* [^ ]* \([^ ]*\).*/\1/;/[0-9]/!d')
-apt-get remove --purge -y $(dpkg -l 'linux-headers-*' | sed '/^ii/!d;/'"$(uname -r | sed "s/\(.*\)-\([^0-9]\+\)/\1/")"'/d;s/^[^ ]* [^ ]* \([^ ]*\).*/\1/;/[0-9]/!d')
+apt-get remove --purge -y $(dpkg -l 'linux-image-*' | sed '/^ii/!d;s/^[^ ]* [^ ]* \([^ ]*\).*/\1/;/[0-9]/!d' | sort | tail -n +2)
+apt-get remove --purge -y $(dpkg -l 'linux-headers-*' | sed '/^ii/!d;s/^[^ ]* [^ ]* \([^ ]*\).*/\1/;/[0-9]/!d' | sort | tail -n +2)
 
 # Remove build packages
 apt-get purge -y build-essential autoconf autogen automake autotools-dev

--- a/cdap-distributions/src/packer/scripts/cookbook-dir.sh
+++ b/cdap-distributions/src/packer/scripts/cookbook-dir.sh
@@ -31,8 +31,10 @@ if [[ $(which apt-get 2>/dev/null) ]]; then
 else
   yum install -y git || exit 1
 fi
+git config --global user.email "ops@cask.co"
+git config --global user.name "Cask Ops"
 git init || exit 1
-git add .gitignore
-git commit -m 'Initial commit'
+git add .gitignore || exit 1
+git commit -m 'Initial commit' || exit 1
 
 exit 0

--- a/cdap-distributions/src/packer/scripts/network-cleanup.sh
+++ b/cdap-distributions/src/packer/scripts/network-cleanup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2015-2016 Cask Data, Inc.
+# Copyright © 2015-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -17,7 +17,6 @@
 # Disable automatic udev rules for network interfaces in Ubuntu,
 # source: http://6.ptmc.org/164/
 rm -f /etc/udev/rules.d/70-persistent-net.rules
-mkdir -p /etc/udev/rules.d/70-persistent-net.rules
 rm -f /lib/udev/rules.d/75-persistent-net-generator.rules
 rm -rf /dev/.udev/ /var/lib/dhcp/*
 
@@ -27,8 +26,10 @@ for ndev in $(ls -1 /etc/sysconfig/network-scripts/ifcfg-* 2>/dev/null); do
 done
 
 # Adding a 2 sec delay to the interface up, to make the dhclient happy
-if [[ -e /etc/network/interfaces.d/eth0.cfg ]]; then
-  echo "pre-up sleep 2" >> /etc/network/interfaces.d/eth0.cfg
+if [[ -d /etc/network/interfaces.d ]]; then
+  if [[ -e /etc/network/interfaces.d/eth0.cfg ]]; then
+    echo "pre-up sleep 2" >> /etc/network/interfaces.d/eth0.cfg
+  fi
 else
   echo "pre-up sleep 2" >> /etc/network/interfaces
 fi


### PR DESCRIPTION
Common:
- Remove all kernels except latest, instead of current
- Configure root's Git user/email to ops@cask.co
- Error check git commands to fail fast
- Update network cleanup for newer cloud-init

AMI:
- Use Ubuntu 16.04 HVM SSD source AMI

Docker:
- Update `Dockerfile` to use `FROM ubuntu:16.04`
- Update system and install `curl` before `gosu`

VM:
- Use Ubuntu 16.04.2 Server source ISO
- Update `boot_command` for Ubuntu 16 installer
- Update `preseed.cfg` for Xenial and use LVM for root disk
- Use `cdap` user and sudo, instead of `root`
- Remove reboot after system update