### PR TITLE
CDAP-9003 Increase Explore memory

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -823,7 +823,7 @@
 
   <property>
     <name>explore.executor.container.memory.mb</name>
-    <value>1024</value>
+    <value>2048</value>
     <description>
       Memory in megabytes for each CDAP Explore executor instance. This is
       explicitly set differently than ${master.service.memory.mb} as Explore

--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="b2f7202e4db5f64f1586ad9f20bae737"
+DEFAULT_XML_MD5_HASH="ac2fdbd6e33e17770efc73762bfdc570"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
Doubling Explore memory to the same setting that we use to run integration tests. IMO, we shouldn't need to increase memory for our testing, only tune down for smaller deployments.