### PR TITLE
update Join Types widget behavior

### DIFF
--- a/cdap-ui/app/directives/widget-container/widget-join-types/widget-join-types.html
+++ b/cdap-ui/app/directives/widget-container/widget-join-types/widget-join-types.html
@@ -26,14 +26,23 @@
          ng-if="JoinTypes.joinType === 'Outer'">
       <div class="subtitle">Required Inputs</div>
 
+      <div class="text-warning"
+           ng-if="JoinTypes.selectedCount === JoinTypes.inputs.length">
+        <span>Setting all stages as required inputs will be treated as Inner Join.</span>
+      </div>
+
       <div class="row checkboxes">
         <div class="col-xs-6 clearfix" ng-repeat="input in JoinTypes.inputs">
-          <span class="input-name">{{ input.name }}</span>
+          <div class="checkbox">
+            <label>
+              <input type="checkbox"
+                     class="checkbox"
+                     ng-model="input.selected"
+                     ng-change="JoinTypes.formatOutput()">
 
-          <input type="checkbox"
-                 class="checkbox"
-                 ng-model="input.selected"
-                 ng-change="JoinTypes.formatOutput()">
+              {{ input.name }}
+            </label>
+          </div>
         </div>
       </div>
     </div>

--- a/cdap-ui/app/directives/widget-container/widget-join-types/widget-join-types.js
+++ b/cdap-ui/app/directives/widget-container/widget-join-types/widget-join-types.js
@@ -20,23 +20,24 @@ function JoinTypesController() {
   let vm = this;
 
   vm.optionsDropdown = ['Inner', 'Outer'];
+  vm.selectedCount = 0;
 
   vm.changeJoinType = () => {
-    if (vm.joinType === 'Inner') {
-      angular.forEach(vm.inputs, (input) => {
-        input.selected = true;
-      });
+    angular.forEach(vm.inputs, (input) => {
+      input.selected = vm.joinType === 'Inner';
+    });
 
-      vm.formatOutput();
-    }
+    vm.formatOutput();
   };
 
   vm.formatOutput = () => {
     let outputArr = [];
+    vm.selectedCount = 0;
 
     angular.forEach(vm.inputs, (input) => {
       if (input.selected) {
         outputArr.push(input.name);
+        vm.selectedCount++;
       }
     });
 

--- a/cdap-ui/app/directives/widget-container/widget-join-types/widget-join-types.less
+++ b/cdap-ui/app/directives/widget-container/widget-join-types/widget-join-types.less
@@ -25,6 +25,8 @@ my-join-types {
         margin-bottom: 5px;
       }
 
+      .text-warning { margin-bottom: 5px; }
+
       .checkboxes {
         margin-right: 0;
         margin-left: 0;
@@ -32,10 +34,11 @@ my-join-types {
         & > .col-xs-6 {
           padding-right: 75px;
         }
-      }
 
-      .input-name { float: left; }
-      .checkbox { float: right; }
+        input.checkbox {
+          margin-top: 3px;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
switching join types to outer will by default select no stage. If user select Outer join and select all stages, a warning will show up that it is Inner join.