### PR TITLE
HYDRATOR-1453 allow pipelines that contain a single action

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/co/cask/cdap/datapipeline/DataPipelineTest.java
@@ -125,13 +125,9 @@ public class DataPipelineTest extends HydratorTestBase {
   public void testMacroEvaluationActionPipeline(Engine engine) throws Exception {
     ETLStage action1 = new ETLStage("action1", MockAction.getPlugin("actionTable", "action1.row", "action1.column",
                                                                     "${value}"));
-    ETLStage action2 = new ETLStage("action2", MockAction.getPlugin("actionTable", "action2.row", "action2.column",
-                                                                    "action2.value"));
 
     ETLBatchConfig etlConfig = co.cask.cdap.etl.proto.v2.ETLBatchConfig.builder("* * * * *")
       .addStage(action1)
-      .addStage(action2)
-      .addConnection(new Connection(action1.getName(), action2.getName()))
       .setEngine(engine)
       .build();
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/co/cask/cdap/etl/spec/PipelineSpecGenerator.java
@@ -41,6 +41,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -279,7 +280,7 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig, P extends Pipel
                         stage.getName()));
       }
       // if stage is Action stage, add it to the Action stage set
-      if (Action.PLUGIN_TYPE.equals(stage.getPlugin().getType())) {
+      if (isAction(stage.getPlugin().getType())) {
         actionStages.add(stage.getName());
       }
       stageTypes.put(stage.getName(), stage.getPlugin().getType());
@@ -294,6 +295,22 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig, P extends Pipel
       if (!stageNames.contains(connection.getTo())) {
         throw new IllegalArgumentException(
           String.format("Invalid connection %s. %s is not a stage.", connection, connection.getTo()));
+      }
+    }
+
+    List<StageConnections> traversalOrder = new ArrayList<>(stageNames.size());
+
+    // can only have empty connections if the pipeline consists of a single action.
+    if (config.getConnections().isEmpty()) {
+      if (actionStages.size() == 1 && stageNames.size() == 1) {
+        traversalOrder.add(new StageConnections(config.getStages().iterator().next(),
+                                                Collections.<String>emptyList(),
+                                                Collections.<String>emptyList()));
+        return traversalOrder;
+      } else {
+        throw new IllegalArgumentException(
+          "Invalid pipeline. There are no connections between stages. " +
+            "This is only allowed if the pipeline consists of a single action plugin.");
       }
     }
 
@@ -321,8 +338,7 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig, P extends Pipel
         }
       } else {
         // check that other non-action plugins are not sources or sinks in the dag
-        boolean isAction = Action.PLUGIN_TYPE.equals(stageType);
-        if (!isAction) {
+        if (!isAction(stageType)) {
           if (stageInputs.isEmpty()) {
             throw new IllegalArgumentException(
               String.format("Stage %s is unreachable, it has no incoming connections.", stageName));
@@ -350,12 +366,16 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig, P extends Pipel
       stages.put(stageName, new StageConnections(stage, stageInputs, stageOutputs));
     }
 
-    List<StageConnections> traversalOrder = new ArrayList<>(stages.size());
     for (String stageName : dag.getTopologicalOrder()) {
       traversalOrder.add(stages.get(stageName));
     }
 
     return traversalOrder;
+  }
+
+  // will soon have another action type
+  private boolean isAction(String pluginType) {
+    return Action.PLUGIN_TYPE.equals(pluginType);
   }
 
   private boolean isSource(String pluginType) {


### PR DESCRIPTION
Fixed a bug that prevented deployment of pipelines that contain
a single action.