### PR TITLE
Fixes page title and active navbar link in data prep view

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrepHome/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepHome/index.js
@@ -17,6 +17,8 @@
 import React, { Component } from 'react';
 import DataPrep from 'components/DataPrep';
 import NavigationPrompt from 'react-router/NavigationPrompt';
+import Helmet from 'react-helmet';
+import T from 'i18n-react';
 
 /**
  *  Routing container for DataPrep for React
@@ -37,6 +39,9 @@ export default class DataPrepHome extends Component {
   render() {
     return (
       <div>
+        <Helmet
+          title={T.translate('features.DataPrep.pageTitle')}
+        />
         <DataPrep />
 
         <NavigationPrompt

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -199,6 +199,8 @@ features:
       switchMessage: Select a different namespace from the namespace dropdown
     JustAddedSection:
       subtitle: Just added
+  DataPrep:
+    pageTitle: CDAP | Data Preparation
   Dashboard:
     Title: Dashboard
 


### PR DESCRIPTION
- Fixes page title to be `CDAP | Data Preparation` while in Data Prep view.
- Fixes headerbar to not highlight `Overview` when in Data Prep view.