### PR TITLE
[CDAP-9056] Fixes DataPrep to surface schema errors while exporting to pipelines

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/AddToPipelineModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/AddToPipelineModal.js
@@ -22,7 +22,8 @@ import MyDataPrepApi from 'api/dataprep';
 import DataPrepStore from 'components/DataPrep/store';
 import NamespaceStore from 'services/NamespaceStore';
 import {findHighestVersion} from 'services/VersionRange/VersionUtilities';
-
+import {objectQuery} from 'services/helpers';
+import T from 'i18n-react';
 export default class AddToHydratorModal extends Component {
   constructor(props) {
     super(props);
@@ -180,9 +181,8 @@ export default class AddToHydratorModal extends Component {
         });
 
       }, (err) => {
-        console.log('Failed to fetch schema', err);
         this.setState({
-          error: err.message,
+          error: objectQuery(err, 'response', 'message')  || T.translate('features.DataPrep.TopPanel.PipelineModal.defaultErrorMessage'),
           loading: false
         });
       });
@@ -202,9 +202,10 @@ export default class AddToHydratorModal extends Component {
     } else if (this.state.error) {
       content = (
         <div>
-          <h4 className="text-danger loading-container">
-            {this.state.error}
-          </h4>
+          <div className="text-danger error-message-container loading-container">
+            <span className="fa fa-exclamation-triangle"></span>
+            <span>{this.state.error}</span>
+          </div>
         </div>
       );
     } else {
@@ -237,7 +238,7 @@ export default class AddToHydratorModal extends Component {
       <Modal
         isOpen={true}
         toggle={this.props.toggle}
-        zIndex="1070"
+        size="lg"
         className="add-to-pipeline-dataprep-modal"
       >
         <ModalHeader>
@@ -263,4 +264,3 @@ export default class AddToHydratorModal extends Component {
 AddToHydratorModal.propTypes = {
   toggle: PropTypes.func
 };
-

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/SchemaModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/SchemaModal.js
@@ -23,6 +23,8 @@ import MyDataPrepApi from 'api/dataprep';
 import DataPrepStore from 'components/DataPrep/store';
 import fileDownload from 'react-file-download';
 import NamespaceStore from 'services/NamespaceStore';
+import {objectQuery} from 'services/helpers';
+import T from 'i18n-react';
 
 export default class SchemaModal extends Component {
   constructor(props) {
@@ -81,11 +83,9 @@ export default class SchemaModal extends Component {
           schema: res
         });
       }, (err) => {
-        console.log('Error fetching Schema', err);
-
         this.setState({
           loading: false,
-          error: err.message
+          error: objectQuery(err, 'response', 'message') || T.translate('features.DataPrep.TopPanel.SchemaModal.defaultErrorMessage')
         });
       });
   }
@@ -112,8 +112,9 @@ export default class SchemaModal extends Component {
       );
     } else if (this.state.error) {
       content = (
-        <div className="text-xs-center text-danger">
-          {this.state.error}
+        <div className="text-danger">
+          <span className="fa fa-exclamation-triangle"></span>
+          <span>{this.state.error}</span>
         </div>
       );
     } else {
@@ -128,7 +129,7 @@ export default class SchemaModal extends Component {
       <Modal
         isOpen={true}
         toggle={this.props.toggle}
-        zIndex="1070"
+        size="lg"
         className="dataprep-schema-modal"
       >
         <ModalHeader>
@@ -140,6 +141,7 @@ export default class SchemaModal extends Component {
             className="close-section float-xs-right"
           >
             <button
+              disabled={this.state.error ? 'disabled' : null}
               className="btn btn-link"
               onClick={this.download}
             >
@@ -162,4 +164,3 @@ export default class SchemaModal extends Component {
 SchemaModal.propTypes = {
   toggle: PropTypes.func
 };
-

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
@@ -99,6 +99,13 @@
 
     .loading-container {
       padding: 25px;
+      &.error-message-container {
+        padding: 15px;
+        .fa.fa-exclamation-triangle {
+          font-size: 15px;
+          margin-right: 5px;
+        }
+      }
     }
 
     .action-buttons {
@@ -122,6 +129,7 @@
 }
 
 .dataprep-schema-modal.modal-dialog {
+  margin-top: 100px;
   .modal-header {
     .fa {
       cursor: pointer;
@@ -133,6 +141,12 @@
       color: inherit;
       font-size: inherit;
 
+      &[disabled] {
+        .fa.fa-download {
+          cursor: inherit;
+        }
+      }
+
       &:focus,
       &:active {
         outline: none;
@@ -142,5 +156,9 @@
   .modal-body {
     overflow-y: auto;
     max-height: 75vh;
+    .fa.fa-exclamation-triangle {
+      margin-right: 5px;
+      font-size: 15px;
+    }
   }
 }

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/UpgradeModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/UpgradeModal.js
@@ -107,7 +107,6 @@ export default class UpgradeModal extends Component {
       <Modal
         isOpen={true}
         toggle={this.attemptClose}
-        zIndex="1070"
         className="dataprep-upgrade-modal"
       >
         <ModalHeader>
@@ -139,4 +138,3 @@ export default class UpgradeModal extends Component {
 UpgradeModal.propTypes = {
   toggle: PropTypes.func
 };
-

--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/WorkspaceModal.js
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/WorkspaceModal.js
@@ -309,7 +309,6 @@ export default class WorkspaceModal extends Component {
       <Modal
         isOpen={true}
         toggle={this.attemptModalClose}
-        zIndex="1070"
         className="workspace-management-modal"
       >
         <ModalHeader>

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -201,6 +201,11 @@ features:
       subtitle: Just added
   DataPrep:
     pageTitle: CDAP | Data Preparation
+    TopPanel:
+      SchemaModal:
+        defaultErrorMessage: Error generating schema.
+      PipelineModal:
+        defaultErrorMessage: Error adding to pipeline
   Dashboard:
     Title: Dashboard
 


### PR DESCRIPTION
Corresponding backend JIRA: https://github.com/hydrator/wrangler/pull/65

- Fixes 'Add Schema' button to show error if one of the columns is of type JSON OBJECT
- Fixes minor modal styling to be consistent (both Add schema & Add pipeline modals have same margin top and are bigger)
