### PR TITLE
Parse schema passed from backend for any errors before importing to pipeline studio

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
+++ b/cdap-ui/app/cdap/components/DataPrep/TopPanel/TopPanel.scss
@@ -101,6 +101,9 @@
       padding: 25px;
       &.error-message-container {
         padding: 15px;
+        pre {
+          margin: 0;
+        }
         .fa.fa-exclamation-triangle {
           font-size: 15px;
           margin-right: 5px;
@@ -156,6 +159,9 @@
   .modal-body {
     overflow-y: auto;
     max-height: 75vh;
+    pre {
+      margin: 0;
+    }
     .fa.fa-exclamation-triangle {
       margin-right: 5px;
       font-size: 15px;

--- a/cdap-ui/app/cdap/components/SchemaEditor/SchemaHelpers.js
+++ b/cdap-ui/app/cdap/components/SchemaEditor/SchemaHelpers.js
@@ -118,6 +118,47 @@ function getParsedSchema(schema) {
   return parsedSchema;
 }
 
+// FIXME: This is solely added for showing schema in data prep
+// We shouldn't have two copies of the same function
+function getParsedSchemaForDataPrep(schema) {
+  let defaultSchema = {
+    name: '',
+    type: 'string',
+    displayType: 'string',
+    nullable: false,
+    id: 'a' + uuid.v4().split('-').join(''),
+    nested: false
+  };
+  const isEmptySchema = (schema) => {
+    if (!schema && !(schema.fields || (schema.getFields && schema.getFields().length))) {
+      return true;
+    }
+    return false;
+  };
+
+  if (isEmptySchema(schema) || (!schema || schema === 'record')) {
+    return defaultSchema;
+  }
+  let parsed;
+
+  // Manually catch it outside.
+  parsed = cdapavsc.parse(schema, { wrapUnions: true });
+
+  let parsedSchema = parsed.getFields().map((field) => {
+    let type = field.getType();
+
+    let partialObj = parseType(type);
+
+    return Object.assign({}, partialObj, {
+      id: 'a' + uuid.v4().split('-').join(''),
+      name: field.getName()
+    });
+
+  });
+
+  return parsedSchema;
+}
+
 function checkComplexType(displayType) {
   let complexTypes = ['array', 'enum', 'map', 'record', 'union'];
   return complexTypes.indexOf(displayType) !== -1 ? true : false;
@@ -138,5 +179,6 @@ export {
   parseType,
   checkComplexType,
   getParsedSchema,
+  getParsedSchemaForDataPrep,
   checkParsedTypeForError
 };

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -202,6 +202,9 @@ features:
   DataPrep:
     pageTitle: CDAP | Data Preparation
     TopPanel:
+      invalidFieldNameMessage: Invalid field name "{fieldName}"
+      invalidFieldNameRemedies1: "Your field name contains an invalid character: no space or special character other than - or _ are allowed"
+      invalidFieldNameRemedies2: Try to apply directive “cleanse-column-names”
       SchemaModal:
         defaultErrorMessage: Error generating schema.
       PipelineModal:


### PR DESCRIPTION
This is to catch columns with invalid characters that are not part of the avro spec before importing the data prep schema to pipeline.