### PR TITLE
CDAP-9005 Fix HBaseQueueDebugger in case of authorization.

### DIFF
--- a/cdap-master/src/test/java/co/cask/cdap/data/tools/HBaseQueueDebuggerTest.java
+++ b/cdap-master/src/test/java/co/cask/cdap/data/tools/HBaseQueueDebuggerTest.java
@@ -14,9 +14,8 @@
  * the License.
  */
 
-package co.cask.cdap.data.tools.flow;
+package co.cask.cdap.data.tools;
 
-import co.cask.cdap.data.tools.HBaseQueueDebugger;
 import org.junit.Test;
 
 /**


### PR DESCRIPTION
Fixes https://issues.cask.co/browse/CDAP-9005, by setting authorization enabled when running the hbase queue debugger. We only disable it for listing namespaces.
This makes it so that the QueueDebuggerTool sets the appropriate user in the header of the request made to CDAP's dataset service.

Integration Tests: http://builds.cask.co/browse/CDAP-ITM11-10