### PR TITLE
CDAP-8764 Fix HBaseConsumerTest

### DIFF
--- a/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/StreamConsumerTestBase.java
+++ b/cdap-data-fabric-tests/src/test/java/co/cask/cdap/data2/transaction/stream/StreamConsumerTestBase.java
@@ -430,6 +430,7 @@ public abstract class StreamConsumerTestBase {
   @Category(SlowTests.class)
   @Test
   public void testTTLStartingFile() throws Exception {
+    final int groupConfigurationDelayTime = 1000;
     String stream = "testTTLStartingFile";
     StreamId streamId = TEST_NAMESPACE.stream(stream);
     StreamAdmin streamAdmin = getStreamAdmin();
@@ -473,6 +474,8 @@ public abstract class StreamConsumerTestBase {
       // Need to create consumer before write event because in HBase, creation of consumer took couple seconds.
       streamAdmin.configureGroups(streamId, ImmutableMap.of(0L, 1));
       streamAdmin.configureGroups(streamId, ImmutableMap.of(0L, 1, 1L, 1));
+      // Sleep to ensure that groups are configured (CDAP-8764)
+      Thread.sleep(groupConfigurationDelayTime);
       newConsumer = consumerFactory.create(streamId, stream,
                                            new ConsumerConfig(1L, 0, 1, DequeueStrategy.FIFO, null));
 
@@ -491,6 +494,8 @@ public abstract class StreamConsumerTestBase {
       // Need to create consumer before write event because in HBase, creation of consumer took couple seconds.
       streamAdmin.configureGroups(streamId, ImmutableMap.of(0L, 1));
       streamAdmin.configureGroups(streamId, ImmutableMap.of(0L, 1, 1L, 1));
+      // Sleep to ensure that groups are configured (CDAP-8764)
+      Thread.sleep(groupConfigurationDelayTime);
       newConsumer = consumerFactory.create(streamId, stream,
                                            new ConsumerConfig(1L, 0, 1, DequeueStrategy.FIFO, null));
 
@@ -514,6 +519,8 @@ public abstract class StreamConsumerTestBase {
       // Need to create consumer before write event because in HBase, creation of consumer took couple seconds.
       streamAdmin.configureGroups(streamId, ImmutableMap.of(0L, 1));
       streamAdmin.configureGroups(streamId, ImmutableMap.of(0L, 1, 1L, 1));
+      // Sleep to ensure that groups are configured (CDAP-8764)
+      Thread.sleep(groupConfigurationDelayTime);
       newConsumer = consumerFactory.create(streamId, stream,
                                            new ConsumerConfig(1L, 0, 1, DequeueStrategy.FIFO, null));
 


### PR DESCRIPTION
This test case failure was caused due to a race condition from writing a
configuration to a group and reading that group's configuration. This
commit solves this by sleeping before reading the group's configuration.

JIRA: https://issues.cask.co/browse/CDAP-8764
Bamboo: http://builds.cask.co/browse/CDAP-DUT5599