### PR TITLE
CDAP-9019 Add loggerName to json Logs

### DIFF
--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogData.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogData.java
@@ -37,9 +37,11 @@ public final class LogData {
   private final String message;
   @SuppressWarnings({"FieldCanBeLocal", "UnusedDeclaration"})
   private final String stackTrace;
+  @SuppressWarnings({"FieldCanBeLocal", "UnusedDeclaration"})
+  private final String loggerName;
 
   LogData(Long timestamp, String logLevel, String threadName, String className, String simpleClassName,
-          Integer lineNumber, String message, String stackTrace) {
+          Integer lineNumber, String message, String stackTrace, String loggerName) {
     this.timestamp = timestamp;
     this.logLevel = logLevel;
     this.threadName = threadName;
@@ -48,6 +50,7 @@ public final class LogData {
     this.lineNumber = lineNumber;
     this.message = message;
     this.stackTrace = stackTrace;
+    this.loggerName = loggerName;
   }
 
   public Long getTimestamp() {
@@ -80,5 +83,9 @@ public final class LogData {
 
   public String getStackTrace() {
     return stackTrace;
+  }
+
+  public String getLoggerName() {
+    return loggerName;
   }
 }

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogDataOffsetCallback.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogDataOffsetCallback.java
@@ -52,7 +52,7 @@ public class LogDataOffsetCallback extends AbstractJSONCallback {
     }
     LogData logData = new LogData(event.getTimeStamp(), event.getLevel().toString(), event.getThreadName(),
                                   className, simpleClassName, lineNumber, event.getFormattedMessage(),
-                                  ThrowableProxyUtil.asString(event.getThrowableProxy()));
+                                  ThrowableProxyUtil.asString(event.getThrowableProxy()), event.getLoggerName());
     return modifyLogJsonElememnt(GSON.toJsonTree(new FormattedLogDataEvent(logData, logEvent.getOffset())));
   }
 

--- a/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogDataOffsetProducer.java
+++ b/cdap-watchdog/src/main/java/co/cask/cdap/logging/gateway/handlers/LogDataOffsetProducer.java
@@ -52,7 +52,7 @@ public class LogDataOffsetProducer extends AbstractJSONLogProducer {
     }
     LogData logData = new LogData(event.getTimeStamp(), event.getLevel().toString(), event.getThreadName(),
                                   className, simpleClassName, lineNumber, event.getFormattedMessage(),
-                                  ThrowableProxyUtil.asString(event.getThrowableProxy()));
+                                  ThrowableProxyUtil.asString(event.getThrowableProxy()), event.getLoggerName());
     return modifyLogJsonElememnt(GSON.toJsonTree(new FormattedLogDataEvent(logData, logEvent.getOffset())));
   }
 


### PR DESCRIPTION
CDAP-9019 Add loggerName to json Logs as Raw logs use logger name as source. 