### PR TITLE
CDAP-9139 Handle exception in getting privileges

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/PrivilegeFetchException.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/PrivilegeFetchException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.common;
+
+import co.cask.cdap.api.common.HttpErrorStatusProvider;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Exception thrown when failed to fetch privileges from underlying authorization extension.
+ */
+public class PrivilegeFetchException extends Exception implements HttpErrorStatusProvider {
+
+
+  public PrivilegeFetchException(Throwable cause) {
+    super(cause);
+  }
+
+  @Override
+  public int getStatusCode() {
+    return HttpResponseStatus.UNAUTHORIZED.getCode();
+  }
+}

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/AbstractAuthorizationService.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/AbstractAuthorizationService.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.security.authorization;
 
+import co.cask.cdap.common.PrivilegeFetchException;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.proto.id.EntityId;
@@ -27,6 +28,7 @@ import co.cask.cdap.security.spi.authorization.PrivilegesFetcher;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
+import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -36,10 +38,12 @@ import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -178,7 +182,12 @@ public class AbstractAuthorizationService extends AbstractScheduledService {
   }
 
   protected Map<EntityId, Set<Action>> getPrivileges(Principal principal) throws Exception {
-    return cacheEnabled ? authPolicyCache.get(principal) : fetchPrivileges(principal);
+    try {
+      return cacheEnabled ? authPolicyCache.get(principal) : fetchPrivileges(principal);
+    } catch (ExecutionException e) {
+      Throwables.propagateIfPossible(e.getCause(), IOException.class, PrivilegeFetchException.class);
+      throw new IllegalStateException(e);
+    }
   }
 
   protected void doInvalidate(final Predicate<Principal> predicate) {

--- a/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizationEnforcementModule.java
+++ b/cdap-security/src/main/java/co/cask/cdap/security/authorization/AuthorizationEnforcementModule.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.security.authorization;
 
+import co.cask.cdap.common.PrivilegeFetchException;
 import co.cask.cdap.common.runtime.RuntimeModule;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
@@ -163,7 +164,13 @@ public class AuthorizationEnforcementModule extends RuntimeModule {
 
     @Override
     public Set<Privilege> listPrivileges(Principal principal) throws Exception {
-      return authorizerInstantiator.get().listPrivileges(principal);
+      try {
+        return authorizerInstantiator.get().listPrivileges(principal);
+      } catch (Exception e) {
+        // if we failed to fetch privileges from the authorization extension for any
+        // reason catch it and rethrow it as PrivilegeFetchException
+        throw new PrivilegeFetchException(e);
+      }
     }
   }
 }


### PR DESCRIPTION
Fetching privileges from security extensions can fail for various reason depending on the the security extension and the authorization provider so we are catching the exception and sending [502](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502)  (The HTTP 502 Bad Gateway server error response code indicates that the server, while acting as a gateway or proxy, received an invalid response from the upstream server.) rather than 500 internal server error.

For example in case of CDAP-Sentry extension if a user which does not exists in HadoopGroupMappingService for sentry logins to cdap then cdap fails to fetch its privileges. This is especially problematic in UI since UI thinks cdap services are down as it gets 500 error continuously. 

Issue: https://issues.cask.co/browse/CDAP-9139

Build: http://builds.cask.co/browse/CDAP-RUT865-1