### PR TITLE
(CDAP-8980) Use one ClassLoader as the defining ClassLoader for all Spark class in Spark containers

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/app/MainClassLoader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/app/MainClassLoader.java
@@ -28,7 +28,6 @@ import co.cask.cdap.internal.asm.Classes;
 import com.google.common.base.Function;
 import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
-import com.google.common.io.ByteStreams;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -49,7 +48,7 @@ import javax.annotation.Nullable;
  * The main {@link ClassLoader} used by CDAP. This class performs necessary class rewriting for the whole CDAP
  * system.
  */
-public final class MainClassLoader extends InterceptableClassLoader {
+public class MainClassLoader extends InterceptableClassLoader {
 
   private static final String DATASET_CLASS_NAME = Dataset.class.getName();
   private final DatasetClassRewriter datasetRewriter;
@@ -140,13 +139,17 @@ public final class MainClassLoader extends InterceptableClassLoader {
 
   @Override
   public byte[] rewriteClass(String className, InputStream input) throws IOException {
+    byte[] rewrittenCode = null;
+
     if (isDatasetRewriteNeeded(className)) {
-      input = new ByteArrayInputStream(datasetRewriter.rewriteClass(className, input));
+      rewrittenCode = datasetRewriter.rewriteClass(className, input);
     }
+
     if (isAuthRewriteNeeded(className)) {
-      input = new ByteArrayInputStream(authEnforceRewriter.rewriteClass(className, input));
+      rewrittenCode = authEnforceRewriter.rewriteClass(
+        className, rewrittenCode == null ? input : new ByteArrayInputStream(rewrittenCode));
     }
-    return ByteStreams.toByteArray(input);
+    return rewrittenCode;
   }
 
   /**

--- a/cdap-common/src/main/java/co/cask/cdap/common/app/MainClassLoader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/app/MainClassLoader.java
@@ -137,6 +137,7 @@ public class MainClassLoader extends InterceptableClassLoader {
     }
   }
 
+  @Nullable
   @Override
   public byte[] rewriteClass(String className, InputStream input) throws IOException {
     byte[] rewrittenCode = null;

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/ClassRewriter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/ClassRewriter.java
@@ -24,5 +24,13 @@ import java.io.InputStream;
  */
 public interface ClassRewriter {
 
+  /**
+   * Rewrites a class with the original byte code provided from the given {@link InputStream}.
+   *
+   * @param className name of the class
+   * @param input an {@link InputStream} to provide the original bytecode of the class
+   * @return the bytecode of the rewritten class
+   * @throws IOException if failed in rewriting the class
+   */
   byte[] rewriteClass(String className, InputStream input) throws IOException;
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/ClassRewriter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/ClassRewriter.java
@@ -18,6 +18,7 @@ package co.cask.cdap.common.lang;
 
 import java.io.IOException;
 import java.io.InputStream;
+import javax.annotation.Nullable;
 
 /**
  * Represents classes that can rewrite class bytecode.
@@ -29,8 +30,9 @@ public interface ClassRewriter {
    *
    * @param className name of the class
    * @param input an {@link InputStream} to provide the original bytecode of the class
-   * @return the bytecode of the rewritten class
+   * @return the bytecode of the rewritten class or {@code null} to indicate no rewriting is needed
    * @throws IOException if failed in rewriting the class
    */
+  @Nullable
   byte[] rewriteClass(String className, InputStream input) throws IOException;
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/InterceptableClassLoader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/InterceptableClassLoader.java
@@ -55,6 +55,11 @@ public abstract class InterceptableClassLoader extends URLClassLoader implements
     try (InputStream is = resource.openStream()) {
       byte[] bytecode = rewriteClass(name, is);
 
+      // If no rewriting is needed, just load the name normally.
+      if (bytecode == null) {
+        return super.findClass(name);
+      }
+
       // Define the package based on the class package name
       String packageName = getPackageName(name);
       if (packageName != null && getPackage(packageName) == null) {

--- a/cdap-common/src/main/java/co/cask/cdap/internal/asm/Classes.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/asm/Classes.java
@@ -106,7 +106,7 @@ public final class Classes {
   /**
    * Rewrites methods in the given class bytecode to noop methods.
    */
-  public static byte[] rewriteMethodToNoop(final String classFile,
+  public static byte[] rewriteMethodToNoop(final String className,
                                            InputStream byteCodeStream, final Set<String> methods) throws IOException {
     ClassReader cr = new ClassReader(byteCodeStream);
     ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
@@ -122,7 +122,7 @@ public final class Classes {
 
         // We can only rewrite method that returns void
         if (!Type.getReturnType(desc).equals(Type.VOID_TYPE)) {
-          LOG.warn("Cannot patch method {} in {} due to non-void return type: {}", name, classFile, desc);
+          LOG.warn("Cannot patch method {} in {} due to non-void return type: {}", name, className, desc);
           return methodVisitor;
         }
 

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRuntimeProvider.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRuntimeProvider.java
@@ -18,11 +18,11 @@ package co.cask.cdap.app.runtime.spark;
 
 import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.app.runtime.ProgramRuntimeProvider;
+import co.cask.cdap.app.runtime.spark.classloader.SparkRunnerClassLoader;
 import co.cask.cdap.app.runtime.spark.distributed.DistributedSparkProgramRunner;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.lang.ClassLoaders;
-import co.cask.cdap.internal.lang.Fields;
 import co.cask.cdap.proto.ProgramType;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRuntimeProvider.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRuntimeProvider.java
@@ -23,6 +23,7 @@ import co.cask.cdap.app.runtime.spark.distributed.DistributedSparkProgramRunner;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.lang.ClassLoaders;
+import co.cask.cdap.internal.app.runtime.spark.SparkUtils;
 import co.cask.cdap.proto.ProgramType;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -39,6 +40,8 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A {@link ProgramRuntimeProvider} that provides runtime system support for {@link ProgramType#SPARK} program.
@@ -97,7 +100,7 @@ public class SparkProgramRuntimeProvider implements ProgramRuntimeProvider {
   private synchronized ClassLoader getDistributedRunnerClassLoader() {
     try {
       if (distributedRunnerClassLoader == null) {
-        // Never needs to rewrite yarn client in Spark
+        // Never needs to rewrite yarn client in CDAP master, which is the only place using distributed program runner
         distributedRunnerClassLoader = createClassLoader(false);
       }
       return distributedRunnerClassLoader;
@@ -190,11 +193,9 @@ public class SparkProgramRuntimeProvider implements ProgramRuntimeProvider {
   private synchronized SparkRunnerClassLoader createClassLoader(boolean rewriteYarnClient) throws IOException {
     SparkRunnerClassLoader classLoader;
     if (classLoaderUrls == null) {
-      classLoader = new SparkRunnerClassLoader(getClass().getClassLoader(), rewriteYarnClient);
-      classLoaderUrls = classLoader.getURLs();
-    } else {
-      classLoader = new SparkRunnerClassLoader(classLoaderUrls, getClass().getClassLoader(), rewriteYarnClient);
+      classLoaderUrls = getSparkClassloaderURLs(getClass().getClassLoader());
     }
+    classLoader = new SparkRunnerClassLoader(classLoaderUrls, getClass().getClassLoader(), rewriteYarnClient);
 
     // CDAP-8087: Due to Scala 2.10 bug in not able to support runtime reflection from multiple threads,
     // we create the runtime mirror from this synchronized method
@@ -224,5 +225,21 @@ public class SparkProgramRuntimeProvider implements ProgramRuntimeProvider {
     }
 
     return classLoader;
+  }
+
+  /**
+   * Returns an array of URLs to be used for creation of classloader for Spark, based on the urls used by the
+   * given {@link ClassLoader}.
+   */
+  private URL[] getSparkClassloaderURLs(ClassLoader classLoader) throws IOException {
+    List<URL> urls = ClassLoaders.getClassLoaderURLs(classLoader, new ArrayList<URL>());
+
+    // If Spark classes are not available in the given ClassLoader, try to locate the Spark assembly jar
+    // This class cannot have dependency on Spark directly, hence using the class resource to discover if SparkContext
+    // is there
+    if (classLoader.getResource("org/apache/spark/SparkContext.class") == null) {
+      urls.add(SparkUtils.locateSparkAssemblyJar().toURI().toURL());
+    }
+    return urls.toArray(new URL[urls.size()]);
   }
 }

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRunnerClassLoader.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRunnerClassLoader.java
@@ -17,27 +17,16 @@
 package co.cask.cdap.app.runtime.spark;
 
 import co.cask.cdap.api.spark.Spark;
+import co.cask.cdap.app.runtime.spark.classloader.SparkClassRewriter;
 import co.cask.cdap.common.internal.guava.ClassPath;
 import co.cask.cdap.common.lang.ClassLoaders;
 import co.cask.cdap.common.lang.ClassPathResources;
 import co.cask.cdap.internal.app.runtime.spark.SparkUtils;
-import co.cask.cdap.internal.asm.Classes;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
-import org.objectweb.asm.commons.AdviceAdapter;
-import org.objectweb.asm.commons.GeneratorAdapter;
-import org.objectweb.asm.commons.Method;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -47,7 +36,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 
 /**
@@ -59,41 +47,10 @@ public final class SparkRunnerClassLoader extends URLClassLoader {
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkRunnerClassLoader.class);
 
-  // Define some of the class types used for bytecode rewriting purpose. Cannot be referred with .class since
-  // those classes may not be available to the ClassLoader of this class (they are loadable from this ClassLoader).
-  private static final Type SPARK_RUNTIME_ENV_TYPE =
-    Type.getObjectType("co/cask/cdap/app/runtime/spark/SparkRuntimeEnv");
-  private static final Type SPARK_RUNTIME_UTILS_TYPE =
-    Type.getObjectType("co/cask/cdap/app/runtime/spark/SparkRuntimeUtils");
-  private static final Type SPARK_CONTEXT_TYPE = Type.getObjectType("org/apache/spark/SparkContext");
-  private static final Type SPARK_STREAMING_CONTEXT_TYPE =
-    Type.getObjectType("org/apache/spark/streaming/StreamingContext");
-  private static final Type SPARK_CONF_TYPE = Type.getObjectType("org/apache/spark/SparkConf");
-  // SparkSubmit is a companion object, hence the "$" at the end
-  private static final Type SPARK_SUBMIT_TYPE = Type.getObjectType("org/apache/spark/deploy/SparkSubmit$");
-  private static final Type SPARK_YARN_CLIENT_TYPE = Type.getObjectType("org/apache/spark/deploy/yarn/Client");
-  private static final Type SPARK_DSTREAM_GRAPH_TYPE = Type.getObjectType("org/apache/spark/streaming/DStreamGraph");
-  private static final Type YARNSPARKHADOOPUTIL_TYPE =
-    Type.getObjectType("org/apache/spark/deploy/yarn/YarnSparkHadoopUtil");
-
-  // Don't refer akka Remoting with the ".class" because in future Spark version, akka dependency is removed and
-  // we don't want to force a dependency on akka.
-  private static final Type AKKA_REMOTING_TYPE = Type.getObjectType("akka/remote/Remoting");
-  private static final Type EXECUTION_CONTEXT_TYPE = Type.getObjectType("scala/concurrent/ExecutionContext");
-  private static final Type EXECUTION_CONTEXT_EXECUTOR_TYPE =
-    Type.getObjectType("scala/concurrent/ExecutionContextExecutor");
-
-  // File name of the Spark conf directory as defined by the Spark framework
-  // This is for the Hack to workaround CDAP-5019 (SPARK-13441)
-  private static final String LOCALIZED_CONF_DIR = SparkUtils.LOCALIZED_CONF_DIR;
-  private static final String LOCALIZED_CONF_DIR_ZIP = LOCALIZED_CONF_DIR + ".zip";
-  // File entry name of the SparkConf properties file inside the Spark conf zip
-  private static final String SPARK_CONF_FILE = "__spark_conf__.properties";
-
   // Set of resources that are in cdap-api. They should be loaded by the parent ClassLoader
   private static final Set<String> API_CLASSES;
 
-  private final boolean rewriteYarnClient;
+  private final SparkClassRewriter rewriter;
 
   static {
     Set<String> apiClasses = new HashSet<>();
@@ -131,7 +88,13 @@ public final class SparkRunnerClassLoader extends URLClassLoader {
 
   public SparkRunnerClassLoader(URL[] urls, @Nullable ClassLoader parent, boolean rewriteYarnClient) {
     super(urls, parent);
-    this.rewriteYarnClient = rewriteYarnClient;
+    this.rewriter = new SparkClassRewriter(new Function<String, URL>() {
+      @Nullable
+      @Override
+      public URL apply(String resourceName) {
+        return findResource(resourceName);
+      }
+    }, rewriteYarnClient);
   }
 
   @Override
@@ -163,35 +126,13 @@ public final class SparkRunnerClassLoader extends URLClassLoader {
         throw new ClassNotFoundException("Failed to find resource for class " + name);
       }
 
-      if (name.equals(SPARK_CONTEXT_TYPE.getClassName())) {
-        // Define the SparkContext class by rewriting the constructor to save the context to SparkRuntimeEnv
-        cls = defineContext(SPARK_CONTEXT_TYPE, is);
-      } else if (name.equals(SPARK_STREAMING_CONTEXT_TYPE.getClassName())) {
-        // Define the StreamingContext class by rewriting the constructor to save the context to SparkRuntimeEnv
-        cls = defineContext(SPARK_STREAMING_CONTEXT_TYPE, is);
-      } else if (name.equals(SPARK_CONF_TYPE.getClassName())) {
-        // Define the SparkConf class by rewriting the class to put all properties from
-        // SparkRuntimeEnv to the SparkConf in the constructors
-        cls = defineSparkConf(SPARK_CONF_TYPE, is);
-      } else if (name.startsWith(SPARK_SUBMIT_TYPE.getClassName())) {
-        // Rewrite System.setProperty call to SparkRuntimeEnv.setProperty for SparkSubmit and all inner classes
-        cls = rewriteSetPropertiesAndDefineClass(name, is);
-      } else if (name.equals(SPARK_YARN_CLIENT_TYPE.getClassName()) && rewriteYarnClient) {
-        // Rewrite YarnClient for workaround SPARK-13441.
-        cls = defineClient(name, is);
-      } else if (name.equals(SPARK_DSTREAM_GRAPH_TYPE.getClassName())) {
-        // Rewrite DStreamGraph to set TaskSupport on parallel array usage to avoid Thread leak
-        cls = defineDStreamGraph(name, is);
-      } else if (name.equals(AKKA_REMOTING_TYPE.getClassName())) {
-        // Define the akka.remote.Remoting class to avoid thread leakage
-        cls = defineAkkaRemoting(name, is);
-      } else if (name.equals(YARNSPARKHADOOPUTIL_TYPE.getClassName())) {
-        // CDAP-8636 Rewrite methods of YarnSparkHadoopUtil to avoid acquiring delegation token, because when we execute
-        // spark submit, we don't have keytab login
-        cls = defineHadoopSparkHadoopUtil(name, is);
-      } else {
-        // Otherwise, just define it with this ClassLoader
+      byte[] byteCode = rewriter.rewriteClass(name, is);
+
+      // If no rewrite was performed, just define the class with this classloader by calling findClass.
+      if (byteCode == null) {
         cls = findClass(name);
+      } else {
+        cls = defineClass(name, byteCode, 0, byteCode.length);
       }
 
       if (resolve) {
@@ -204,388 +145,12 @@ public final class SparkRunnerClassLoader extends URLClassLoader {
   }
 
   /**
-   * Defines the class by rewriting the constructor to call
-   * SparkRuntimeEnv#setContext(SparkContext) or SparkRuntimeEnv#setContext(StreamingContext),
-   * depending on the class type.
+   * Returns an {@link InputStream} to the given resource or {@code null} if cannot find the given resource
+   * with this {@link ClassLoader}.
    */
-  private Class<?> defineContext(final Type contextType, InputStream byteCodeStream) throws IOException {
-    return rewriteConstructorAndDefineClass(contextType, byteCodeStream, new ConstructorRewriter() {
-      @Override
-      public void onMethodExit(GeneratorAdapter generatorAdapter) {
-        generatorAdapter.loadThis();
-        generatorAdapter.invokeStatic(SPARK_RUNTIME_ENV_TYPE,
-                                      new Method("setContext", Type.VOID_TYPE, new Type[] { contextType }));
-      }
-    });
-  }
-
-  /**
-   * Defines the SparkConf class by rewriting the constructor to call SparkRuntimeEnv#setupSparkConf(SparkConf).
-   */
-  private Class<?> defineSparkConf(final Type sparkConfType, InputStream byteCodeStream) throws IOException {
-    return rewriteConstructorAndDefineClass(sparkConfType, byteCodeStream, new ConstructorRewriter() {
-      @Override
-      public void onMethodExit(GeneratorAdapter generatorAdapter) {
-        generatorAdapter.loadThis();
-        generatorAdapter.invokeStatic(SPARK_RUNTIME_ENV_TYPE,
-                                      new Method("setupSparkConf", Type.VOID_TYPE, new Type[] { sparkConfType }));
-      }
-    });
-  }
-
-  /**
-   * Defines the DStreamGraph class by rewriting calls to parallel array with a call to
-   * SparkRuntimeUtils#setTaskSupport(ParArray).
-   */
-  private Class<?> defineDStreamGraph(String name, InputStream byteCodeStream) throws IOException {
-    ClassReader cr = new ClassReader(byteCodeStream);
-    ClassWriter cw = new ClassWriter(0);
-
-    cr.accept(new ClassVisitor(Opcodes.ASM5, cw) {
-      @Override
-      public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
-        MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
-        return new MethodVisitor(Opcodes.ASM5, mv) {
-          @Override
-          public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
-            super.visitMethodInsn(opcode, owner, name, desc, itf);
-            // If detected call to ArrayBuffer.par(), set the TaskSupport to avoid thread leak.
-            //INVOKEVIRTUAL scala/collection/mutable/ ArrayBuffer.par ()Lscala/collection/parallel/mutable/ParArray;
-            Type returnType = Type.getReturnType(desc);
-            if (opcode == Opcodes.INVOKEVIRTUAL && name.equals("par")
-                && owner.equals("scala/collection/mutable/ArrayBuffer")
-                && returnType.getClassName().equals("scala.collection.parallel.mutable.ParArray")) {
-              super.visitMethodInsn(Opcodes.INVOKESTATIC, SPARK_RUNTIME_UTILS_TYPE.getInternalName(),
-                                    "setTaskSupport", Type.getMethodDescriptor(returnType, returnType), false);
-            }
-          }
-        };
-      }
-    }, ClassReader.EXPAND_FRAMES);
-
-    byte[] byteCode = cw.toByteArray();
-    return defineClass(name, byteCode, 0, byteCode.length);
-  }
-
-  /**
-   * Rewrites the constructors who don't delegate to other constructor with the given {@link ConstructorRewriter}
-   * and define the class.
-   *
-   * @param classType type of the class to be defined
-   * @param byteCodeStream {@link InputStream} for reading the original bytecode of the class
-   * @param rewriter a {@link ConstructorRewriter} for rewriting the constructor
-   * @return a defined Class
-   */
-  private Class<?> rewriteConstructorAndDefineClass(final Type classType, InputStream byteCodeStream,
-                                                    final ConstructorRewriter rewriter) throws IOException {
-    ClassReader cr = new ClassReader(byteCodeStream);
-    ClassWriter cw = new ClassWriter(0);
-
-    cr.accept(new ClassVisitor(Opcodes.ASM5, cw) {
-
-      @Override
-      public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
-        // Call super so that the method signature is registered with the ClassWriter (parent)
-        MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
-
-        // We only attempt to rewrite constructor
-        if (!"<init>".equals(name)) {
-          return mv;
-        }
-
-        return new AdviceAdapter(Opcodes.ASM5, mv, access, name, desc) {
-
-          boolean calledThis;
-
-          @Override
-          public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
-            // See if in this constructor it is calling other constructor (this(..)).
-            calledThis = calledThis || (opcode == Opcodes.INVOKESPECIAL
-              && Type.getObjectType(owner).equals(classType)
-              && name.equals("<init>")
-              && Type.getReturnType(desc).equals(Type.VOID_TYPE));
-            super.visitMethodInsn(opcode, owner, name, desc, itf);
-          }
-
-          @Override
-          protected void onMethodExit(int opcode) {
-            if (calledThis) {
-              // For constructors that call this(), we don't need to generate a call to SparkContextCache
-              return;
-            }
-            // Add a call to SparkContextCache.setContext() for the normal method return path
-            if (opcode == RETURN) {
-              rewriter.onMethodExit(this);
-            }
-          }
-        };
-      }
-    }, ClassReader.EXPAND_FRAMES);
-
-    byte[] byteCode = cw.toByteArray();
-    return defineClass(classType.getClassName(), byteCode, 0, byteCode.length);
-  }
-
-  /**
-   * Defines a class by rewriting all calls to {@link System#setProperty(String, String)} to
-   * {@link SparkRuntimeEnv#setProperty(String, String)}.
-   *
-   * @param name name of the class to define
-   * @param byteCodeStream {@link InputStream} for reading in the original bytecode.
-   * @return a defined class
-   */
-  private Class<?> rewriteSetPropertiesAndDefineClass(String name, InputStream byteCodeStream) throws IOException {
-    final Type systemType = Type.getType(System.class);
-    ClassReader cr = new ClassReader(byteCodeStream);
-    ClassWriter cw = new ClassWriter(0);
-
-    cr.accept(new ClassVisitor(Opcodes.ASM5, cw) {
-      @Override
-      public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
-        MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
-        return new MethodVisitor(Opcodes.ASM5, mv) {
-          @Override
-          public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
-            // If we see a call to System.setProperty, change it to SparkRuntimeEnv.setProperty
-            if (opcode == Opcodes.INVOKESTATIC && name.equals("setProperty")
-                && owner.equals(systemType.getInternalName())) {
-              super.visitMethodInsn(opcode, SPARK_RUNTIME_ENV_TYPE.getInternalName(), name, desc, false);
-            } else {
-              super.visitMethodInsn(opcode, owner, name, desc, itf);
-            }
-          }
-        };
-      }
-    }, ClassReader.EXPAND_FRAMES);
-
-    byte[] byteCode = cw.toByteArray();
-    return defineClass(name, byteCode, 0, byteCode.length);
-  }
-
-  /**
-   * Define the akka.remote.Remoting by rewriting usages of scala.concurrent.ExecutionContext.Implicits.global
-   * to Remoting.system().dispatcher() in the shutdown() method for fixing the Akka thread/permgen leak bug in
-   * https://github.com/akka/akka/issues/17729
-   */
-  private Class<?> defineAkkaRemoting(String name,
-                                      InputStream byteCodeStream) throws IOException, ClassNotFoundException {
-    final Type dispatcherReturnType = determineAkkaDispatcherReturnType();
-    if (dispatcherReturnType == null) {
-      LOG.warn("Failed to determine ActorSystem.dispatcher() return type. " +
-                 "No rewriting of akka.remote.Remoting class. ClassLoader leakage might happen in SDK.");
-      return findClass(name);
-    }
-
-    ClassReader cr = new ClassReader(byteCodeStream);
-    ClassWriter cw = new ClassWriter(0);
-
-    cr.accept(new ClassVisitor(Opcodes.ASM5, cw) {
-      @Override
-      public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
-        // Call super so that the method signature is registered with the ClassWriter (parent)
-        MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
-
-        // Only rewrite the shutdown() method
-        if (!"shutdown".equals(name)) {
-          return mv;
-        }
-
-        return new MethodVisitor(Opcodes.ASM5, mv) {
-          @Override
-          public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
-            // Detect if it is making call "import scala.concurrent.ExecutionContext.Implicits.global",
-            // which translate to Java code as
-            // scala.concurrent.ExecutionContext$Implicits$.MODULE$.global()
-            // hence as bytecode
-            // GETSTATIC scala/concurrent/ExecutionContext$Implicits$.MODULE$ :
-            //           Lscala/concurrent/ExecutionContext$Implicits$;
-            // INVOKEVIRTUAL scala/concurrent/ExecutionContext$Implicits$.global
-            //           ()Lscala/concurrent/ExecutionContextExecutor;
-            if (opcode == Opcodes.INVOKEVIRTUAL
-                && "global".equals(name)
-                && "scala/concurrent/ExecutionContext$Implicits$".equals(owner)
-                && Type.getMethodDescriptor(EXECUTION_CONTEXT_EXECUTOR_TYPE).equals(desc)) {
-              // Discard the GETSTATIC result from the stack by popping it
-              super.visitInsn(Opcodes.POP);
-              // Make the call "import system.dispatch", which translate to Java code as
-              // this.system().dispatcher()
-              // hence as bytecode
-              // ALOAD 0 (load this)
-              // INVOKEVIRTUAL akka/remote/Remoting.system ()Lakka/actor/ExtendedActorSystem;
-              // INVOKEVIRTUAL akka/actor/ExtendedActorSystem.dispatcher ()Lscala/concurrent/ExecutionContextExecutor;
-              Type extendedActorSystemType = Type.getObjectType("akka/actor/ExtendedActorSystem");
-              super.visitVarInsn(Opcodes.ALOAD, 0);
-              super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "akka/remote/Remoting", "system",
-                                    Type.getMethodDescriptor(extendedActorSystemType), false);
-              super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, extendedActorSystemType.getInternalName(), "dispatcher",
-                                    Type.getMethodDescriptor(dispatcherReturnType), false);
-            } else {
-              // For other instructions, just call parent to deal with it
-              super.visitMethodInsn(opcode, owner, name, desc, itf);
-            }
-          }
-        };
-      }
-    }, ClassReader.EXPAND_FRAMES);
-
-    byte[] byteCode = cw.toByteArray();
-    return defineClass(name, byteCode, 0, byteCode.length);
-  }
-
-  /**
-   * Find the return type of the ActorSystem.dispatcher() method. It is ExecutionContextExecutor in
-   * Akka 2.3 (Spark 1.2+) and ExecutionContext in Akka 2.2 (Spark < 1.2, which CDAP doesn't support,
-   * however the Spark 1.5 in CDH 5.6. still has Akka 2.2, instead of 2.3).
-   *
-   * @return the return type of the ActorSystem.dispatcher() method or {@code null} if no such method
-   */
-  @Nullable
-  private Type determineAkkaDispatcherReturnType() {
-    try (InputStream is = openResource("akka/actor/ActorSystem.class")) {
-      if (is == null) {
-        return null;
-      }
-      final AtomicReference<Type> result = new AtomicReference<>();
-      ClassReader cr = new ClassReader(is);
-      cr.accept(new ClassVisitor(Opcodes.ASM5) {
-        @Override
-        public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
-          if (name.equals("dispatcher") && Type.getArgumentTypes(desc).length == 0) {
-            // Expected to be either ExecutionContext (akka 2.2, only in CDH spark)
-            // or ExecutionContextExecutor (akka 2.3, for open source, HDP spark).
-            Type returnType = Type.getReturnType(desc);
-            if (returnType.equals(EXECUTION_CONTEXT_TYPE)
-              || returnType.equals(EXECUTION_CONTEXT_EXECUTOR_TYPE)) {
-              result.set(returnType);
-            } else {
-              LOG.warn("Unsupported return type of ActorSystem.dispatcher(): {}", returnType.getClassName());
-            }
-          }
-          return super.visitMethod(access, name, desc, signature, exceptions);
-        }
-      }, ClassReader.SKIP_DEBUG | ClassReader.SKIP_CODE | ClassReader.SKIP_FRAMES);
-      return result.get();
-    } catch (IOException e) {
-      LOG.warn("Failed to determine ActorSystem dispatcher() return type.", e);
-      return null;
-    }
-  }
-
-  /**
-   * Defines the org.apache.spark.deploy.yarn.Client class with rewriting of the createConfArchive method to
-   * workaround the SPARK-13441 bug.
-   */
-  private Class<?> defineClient(String name, InputStream createConfArchive) throws IOException, ClassNotFoundException {
-    // We only need to rewrite if listing either HADOOP_CONF_DIR or YARN_CONF_DIR return null.
-    boolean needRewrite = false;
-    for (String env : ImmutableList.of("HADOOP_CONF_DIR", "YARN_CONF_DIR")) {
-      String value = System.getenv(env);
-      if (value != null) {
-        File path = new File(value);
-        if (path.isDirectory() && path.listFiles() == null) {
-          needRewrite = true;
-          break;
-        }
-      }
-    }
-
-    // If rewrite is not needed
-    if (!needRewrite) {
-      return findClass(name);
-    }
-
-    ClassReader cr = new ClassReader(createConfArchive);
-    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
-    cr.accept(new ClassVisitor(Opcodes.ASM5, cw) {
-      @Override
-      public MethodVisitor visitMethod(final int access, final String name,
-                                       final String desc, String signature, String[] exceptions) {
-        MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
-
-        // Only rewrite the createConfArchive method
-        if (!"createConfArchive".equals(name)) {
-          return mv;
-        }
-
-        // Check if it's a recognizable return type.
-        // Spark 1.5+ return type is File
-        boolean isReturnFile = Type.getReturnType(desc).equals(Type.getType(File.class));
-        Type optionType = Type.getObjectType("scala/Option");
-        if (!isReturnFile) {
-          // Spark 1.4 return type is Option<File>
-          if (!Type.getReturnType(desc).equals(optionType)) {
-            // Unknown type. Not going to modify the code.
-            return mv;
-          }
-        }
-
-        // Generate this for Spark 1.5+
-        // return SparkRuntimeUtils.createConfArchive(this.sparkConf, SPARK_CONF_FILE,
-        //                                            LOCALIZED_CONF_DIR, LOCALIZED_CONF_DIR_ZIP);
-        // Generate this for Spark 1.4
-        // return Option.apply(SparkRuntimeUtils.createConfArchive(this.sparkConf, SPARK_CONF_FILE,
-        //                                                         LOCALIZED_CONF_DIR, LOCALIZED_CONF_DIR_ZIP));
-        GeneratorAdapter mg = new GeneratorAdapter(mv, access, name, desc);
-
-        // load this.sparkConf to the stack
-        mg.loadThis();
-        mg.getField(Type.getObjectType("org/apache/spark/deploy/yarn/Client"), "sparkConf", SPARK_CONF_TYPE);
-
-        // push three constants to the stack
-        mg.visitLdcInsn(SPARK_CONF_FILE);
-        mg.visitLdcInsn(LOCALIZED_CONF_DIR);
-        mg.visitLdcInsn(LOCALIZED_CONF_DIR_ZIP);
-
-        // call SparkRuntimeUtils.createConfArchive, return a File and leave it in stack
-        Type stringType = Type.getType(String.class);
-        mg.invokeStatic(SPARK_RUNTIME_UTILS_TYPE,
-                        new Method("createConfArchive", Type.getType(File.class),
-                                   new Type[] { SPARK_CONF_TYPE, stringType, stringType, stringType}));
-        if (isReturnFile) {
-          // Spark 1.5+ return type is File, hence just return the File from the stack
-          mg.returnValue();
-          mg.endMethod();
-        } else {
-          // Spark 1.4 return type is Option<File>
-          // return Option.apply(<file from stack>);
-          // where the file is actually just popped from the stack
-          mg.invokeStatic(optionType, new Method("apply", optionType, new Type[] { Type.getType(Object.class) }));
-          mg.checkCast(optionType);
-          mg.returnValue();
-          mg.endMethod();
-        }
-
-        return null;
-      }
-    }, ClassReader.EXPAND_FRAMES);
-
-    byte[] byteCode = cw.toByteArray();
-    return defineClass(name, byteCode, 0, byteCode.length);
-  }
-
-  /**
-   * CDAP-8636 Rewrite methods of YarnSparkHadoopUtil to avoid acquiring delegation token, because when we execute
-   * spark submit, we don't have keytab login. Because of that and the change in SPARK-12241, the attempt to acquire
-   * delegation tokens causes a spark program submission failure.
-   */
-  private Class<?> defineHadoopSparkHadoopUtil(String name,
-                                               InputStream byteCodeStream) throws IOException, ClassNotFoundException {
-    Set<String> methods =
-      ImmutableSet.of("obtainTokensForNamenodes", "obtainTokenForHiveMetastore", "obtainTokenForHBase");
-    byte[] byteCode = Classes.rewriteMethodToNoop(name, byteCodeStream, methods);
-    return defineClass(name, byteCode, 0, byteCode.length);
-  }
-
   @Nullable
   private InputStream openResource(String resourceName) throws IOException {
     URL resource = findResource(resourceName);
     return resource == null ? null : resource.openStream();
-  }
-
-  /**
-   * Private interface for rewriting constructor.
-   */
-  private interface ConstructorRewriter {
-    void onMethodExit(GeneratorAdapter generatorAdapter);
   }
 }

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRunnerClassLoader.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRunnerClassLoader.java
@@ -18,6 +18,7 @@ package co.cask.cdap.app.runtime.spark;
 
 import co.cask.cdap.api.spark.Spark;
 import co.cask.cdap.app.runtime.spark.classloader.SparkClassRewriter;
+import co.cask.cdap.app.runtime.spark.classloader.SparkContainerClassLoader;
 import co.cask.cdap.common.internal.guava.ClassPath;
 import co.cask.cdap.common.lang.ClassLoaders;
 import co.cask.cdap.common.lang.ClassPathResources;
@@ -40,6 +41,9 @@ import javax.annotation.Nullable;
 
 /**
  * A special {@link ClassLoader} for defining and loading all cdap-spark-core classes and Spark classes.
+ * This {@link ClassLoader} is used for Spark execution in SDK as well as the client container in
+ * distributed mode. For Spark containers (driver and executors), the {@link SparkContainerClassLoader} is used
+ * instead.
  *
  * IMPORTANT: Due to discovery in CDAP-5822, don't use getResourceAsStream in this class.
  */

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeUtils.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeUtils.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.app.runtime.spark;
 
+import co.cask.cdap.app.runtime.spark.classloader.SparkRunnerClassLoader;
 import co.cask.cdap.common.internal.guava.ClassPath;
 import co.cask.cdap.common.lang.ClassLoaders;
 import co.cask.cdap.common.lang.ClassPathResources;

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkClassRewriter.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkClassRewriter.java
@@ -1,0 +1,510 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark.classloader;
+
+import co.cask.cdap.app.runtime.spark.SparkRuntimeEnv;
+import co.cask.cdap.common.lang.ClassRewriter;
+import co.cask.cdap.internal.app.runtime.spark.SparkUtils;
+import co.cask.cdap.internal.asm.Classes;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.AdviceAdapter;
+import org.objectweb.asm.commons.GeneratorAdapter;
+import org.objectweb.asm.commons.Method;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+
+/**
+ * A {@link ClassRewriter} for rewriting Spark related classes.
+ */
+public class SparkClassRewriter implements ClassRewriter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SparkClassRewriter.class);
+
+  // Define some of the class types used for bytecode rewriting purpose. Cannot be referred with .class since
+  // those classes may not be available to the ClassLoader of this class (they are loadable from this ClassLoader).
+  private static final Type SPARK_RUNTIME_ENV_TYPE =
+    Type.getObjectType("co/cask/cdap/app/runtime/spark/SparkRuntimeEnv");
+  private static final Type SPARK_RUNTIME_UTILS_TYPE =
+    Type.getObjectType("co/cask/cdap/app/runtime/spark/SparkRuntimeUtils");
+  private static final Type SPARK_CONTEXT_TYPE = Type.getObjectType("org/apache/spark/SparkContext");
+  private static final Type SPARK_STREAMING_CONTEXT_TYPE =
+    Type.getObjectType("org/apache/spark/streaming/StreamingContext");
+  private static final Type SPARK_CONF_TYPE = Type.getObjectType("org/apache/spark/SparkConf");
+  // SparkSubmit is a companion object, hence the "$" at the end
+  private static final Type SPARK_SUBMIT_TYPE = Type.getObjectType("org/apache/spark/deploy/SparkSubmit$");
+  private static final Type SPARK_YARN_CLIENT_TYPE = Type.getObjectType("org/apache/spark/deploy/yarn/Client");
+  private static final Type SPARK_DSTREAM_GRAPH_TYPE = Type.getObjectType("org/apache/spark/streaming/DStreamGraph");
+  private static final Type YARN_SPARK_HADOOP_UTIL_TYPE =
+    Type.getObjectType("org/apache/spark/deploy/yarn/YarnSparkHadoopUtil");
+
+  // Don't refer akka Remoting with the ".class" because in future Spark version, akka dependency is removed and
+  // we don't want to force a dependency on akka.
+  private static final Type AKKA_REMOTING_TYPE = Type.getObjectType("akka/remote/Remoting");
+  private static final Type EXECUTION_CONTEXT_TYPE = Type.getObjectType("scala/concurrent/ExecutionContext");
+  private static final Type EXECUTION_CONTEXT_EXECUTOR_TYPE =
+    Type.getObjectType("scala/concurrent/ExecutionContextExecutor");
+
+  // File name of the Spark conf directory as defined by the Spark framework
+  // This is for the Hack to workaround CDAP-5019 (SPARK-13441)
+  private static final String LOCALIZED_CONF_DIR = SparkUtils.LOCALIZED_CONF_DIR;
+  private static final String LOCALIZED_CONF_DIR_ZIP = LOCALIZED_CONF_DIR + ".zip";
+  // File entry name of the SparkConf properties file inside the Spark conf zip
+  private static final String SPARK_CONF_FILE = "__spark_conf__.properties";
+
+  private final Function<String, URL> resourceLookup;
+  private final boolean rewriteYarnClient;
+
+  public SparkClassRewriter(Function<String, URL> resourceLookup, boolean rewriteYarnClient) {
+    this.resourceLookup = resourceLookup;
+    this.rewriteYarnClient = rewriteYarnClient;
+  }
+
+  @Nullable
+  @Override
+  public byte[] rewriteClass(String className, InputStream input) throws IOException {
+    if (className.equals(SPARK_CONTEXT_TYPE.getClassName())) {
+      // Rewrite the SparkContext class by rewriting the constructor to save the context to SparkRuntimeEnv
+      return rewriteContext(SPARK_CONTEXT_TYPE, input);
+    }
+    if (className.equals(SPARK_STREAMING_CONTEXT_TYPE.getClassName())) {
+      // Rewrite the StreamingContext class by rewriting the constructor to save the context to SparkRuntimeEnv
+      return rewriteContext(SPARK_STREAMING_CONTEXT_TYPE, input);
+    }
+    if (className.equals(SPARK_CONF_TYPE.getClassName())) {
+      // Define the SparkConf class by rewriting the class to put all properties from
+      // SparkRuntimeEnv to the SparkConf in the constructors
+      return rewriteSparkConf(SPARK_CONF_TYPE, input);
+    }
+    if (className.startsWith(SPARK_SUBMIT_TYPE.getClassName())) {
+      // Rewrite System.setProperty call to SparkRuntimeEnv.setProperty for SparkSubmit and all inner classes
+      return rewriteSetProperties(input);
+    }
+    if (className.equals(SPARK_YARN_CLIENT_TYPE.getClassName()) && rewriteYarnClient) {
+      // Rewrite YarnClient for workaround SPARK-13441.
+      return rewriteClient(input);
+    }
+    if (className.equals(SPARK_DSTREAM_GRAPH_TYPE.getClassName())) {
+      // Rewrite DStreamGraph to set TaskSupport on parallel array usage to avoid Thread leak
+      return rewriteDStreamGraph(input);
+    }
+    if (className.equals(AKKA_REMOTING_TYPE.getClassName())) {
+      // Define the akka.remote.Remoting class to avoid thread leakage
+      return rewriteAkkaRemoting(input);
+    }
+    if (className.equals(YARN_SPARK_HADOOP_UTIL_TYPE.getClassName())) {
+      // CDAP-8636 Rewrite methods of YarnSparkHadoopUtil to avoid acquiring delegation token, because when we execute
+      // spark submit, we don't have keytab login
+      return rewriteSparkHadoopUtil(className, input);
+    }
+
+    return null;
+  }
+
+  /**
+   * Rewrites the constructor to call SparkRuntimeEnv#setContext(SparkContext)
+   * or SparkRuntimeEnv#setContext(StreamingContext), depending on the class type.
+   */
+  private byte[] rewriteContext(final Type contextType, InputStream byteCodeStream) throws IOException {
+    return rewriteConstructor(contextType, byteCodeStream, new ConstructorRewriter() {
+      @Override
+      public void onMethodExit(GeneratorAdapter generatorAdapter) {
+        generatorAdapter.loadThis();
+        generatorAdapter.invokeStatic(SPARK_RUNTIME_ENV_TYPE,
+                                      new Method("setContext", Type.VOID_TYPE, new Type[] { contextType }));
+      }
+    });
+  }
+
+  /**
+   * Rewrites the SparkConf class constructor to call SparkRuntimeEnv#setupSparkConf(SparkConf).
+   */
+  private byte[] rewriteSparkConf(final Type sparkConfType, InputStream byteCodeStream) throws IOException {
+    return rewriteConstructor(sparkConfType, byteCodeStream, new ConstructorRewriter() {
+      @Override
+      public void onMethodExit(GeneratorAdapter generatorAdapter) {
+        generatorAdapter.loadThis();
+        generatorAdapter.invokeStatic(SPARK_RUNTIME_ENV_TYPE,
+                                      new Method("setupSparkConf", Type.VOID_TYPE, new Type[] { sparkConfType }));
+      }
+    });
+  }
+
+  /**
+   * Rewrites the DStreamGraph class for calls to parallel array with a call to
+   * SparkRuntimeUtils#setTaskSupport(ParArray).
+   */
+  private byte[] rewriteDStreamGraph(InputStream byteCodeStream) throws IOException {
+    ClassReader cr = new ClassReader(byteCodeStream);
+    ClassWriter cw = new ClassWriter(0);
+
+    cr.accept(new ClassVisitor(Opcodes.ASM5, cw) {
+      @Override
+      public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+        MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
+        return new MethodVisitor(Opcodes.ASM5, mv) {
+          @Override
+          public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
+            super.visitMethodInsn(opcode, owner, name, desc, itf);
+            // If detected call to ArrayBuffer.par(), set the TaskSupport to avoid thread leak.
+            //INVOKEVIRTUAL scala/collection/mutable/ ArrayBuffer.par ()Lscala/collection/parallel/mutable/ParArray;
+            Type returnType = Type.getReturnType(desc);
+            if (opcode == Opcodes.INVOKEVIRTUAL && name.equals("par")
+              && owner.equals("scala/collection/mutable/ArrayBuffer")
+              && returnType.getClassName().equals("scala.collection.parallel.mutable.ParArray")) {
+              super.visitMethodInsn(Opcodes.INVOKESTATIC, SPARK_RUNTIME_UTILS_TYPE.getInternalName(),
+                                    "setTaskSupport", Type.getMethodDescriptor(returnType, returnType), false);
+            }
+          }
+        };
+      }
+    }, ClassReader.EXPAND_FRAMES);
+
+    return cw.toByteArray();
+  }
+
+  /**
+   * Rewrites the constructors who don't delegate to other constructor with the given {@link ConstructorRewriter}
+   * and define the class.
+   *
+   * @param classType type of the class to be defined
+   * @param byteCodeStream {@link InputStream} for reading the original bytecode of the class
+   * @param rewriter a {@link ConstructorRewriter} for rewriting the constructor
+   * @return a defined Class
+   */
+  private byte[] rewriteConstructor(final Type classType, InputStream byteCodeStream,
+                                    final ConstructorRewriter rewriter) throws IOException {
+    ClassReader cr = new ClassReader(byteCodeStream);
+    ClassWriter cw = new ClassWriter(0);
+
+    cr.accept(new ClassVisitor(Opcodes.ASM5, cw) {
+
+      @Override
+      public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+        // Call super so that the method signature is registered with the ClassWriter (parent)
+        MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
+
+        // We only attempt to rewrite constructor
+        if (!"<init>".equals(name)) {
+          return mv;
+        }
+
+        return new AdviceAdapter(Opcodes.ASM5, mv, access, name, desc) {
+
+          boolean calledThis;
+
+          @Override
+          public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
+            // See if in this constructor it is calling other constructor (this(..)).
+            calledThis = calledThis || (opcode == Opcodes.INVOKESPECIAL
+              && Type.getObjectType(owner).equals(classType)
+              && name.equals("<init>")
+              && Type.getReturnType(desc).equals(Type.VOID_TYPE));
+            super.visitMethodInsn(opcode, owner, name, desc, itf);
+          }
+
+          @Override
+          protected void onMethodExit(int opcode) {
+            if (calledThis) {
+              // For constructors that call this(), we don't need to generate a call to SparkContextCache
+              return;
+            }
+            // Add a call to SparkContextCache.setContext() for the normal method return path
+            if (opcode == RETURN) {
+              rewriter.onMethodExit(this);
+            }
+          }
+        };
+      }
+    }, ClassReader.EXPAND_FRAMES);
+
+    return cw.toByteArray();
+  }
+
+
+
+  /**
+   * Rewrites a class by rewriting all calls to {@link System#setProperty(String, String)} to
+   * {@link SparkRuntimeEnv#setProperty(String, String)}.
+   *
+   * @param byteCodeStream {@link InputStream} for reading in the original bytecode.
+   * @return a defined class
+   */
+  private byte[] rewriteSetProperties(InputStream byteCodeStream) throws IOException {
+    final Type systemType = Type.getType(System.class);
+    ClassReader cr = new ClassReader(byteCodeStream);
+    ClassWriter cw = new ClassWriter(0);
+
+    cr.accept(new ClassVisitor(Opcodes.ASM5, cw) {
+      @Override
+      public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+        MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
+        return new MethodVisitor(Opcodes.ASM5, mv) {
+          @Override
+          public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
+            // If we see a call to System.setProperty, change it to SparkRuntimeEnv.setProperty
+            if (opcode == Opcodes.INVOKESTATIC && name.equals("setProperty")
+              && owner.equals(systemType.getInternalName())) {
+              super.visitMethodInsn(opcode, SPARK_RUNTIME_ENV_TYPE.getInternalName(), name, desc, false);
+            } else {
+              super.visitMethodInsn(opcode, owner, name, desc, itf);
+            }
+          }
+        };
+      }
+    }, ClassReader.EXPAND_FRAMES);
+
+    return cw.toByteArray();
+  }
+
+  /**
+   * Rewrites the akka.remote.Remoting by rewriting usages of scala.concurrent.ExecutionContext.Implicits.global
+   * to Remoting.system().dispatcher() in the shutdown() method for fixing the Akka thread/permgen leak bug in
+   * https://github.com/akka/akka/issues/17729.
+   *
+   * @return the rewritten bytes or {@code null} if no rewriting is needed
+   */
+  @Nullable
+  private byte[] rewriteAkkaRemoting(InputStream byteCodeStream) throws IOException {
+    final Type dispatcherReturnType = determineAkkaDispatcherReturnType();
+    if (dispatcherReturnType == null) {
+      LOG.warn("Failed to determine ActorSystem.dispatcher() return type. " +
+                 "No rewriting of akka.remote.Remoting class. ClassLoader leakage might happen in SDK.");
+      return null;
+    }
+
+    ClassReader cr = new ClassReader(byteCodeStream);
+    ClassWriter cw = new ClassWriter(0);
+
+    cr.accept(new ClassVisitor(Opcodes.ASM5, cw) {
+      @Override
+      public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+        // Call super so that the method signature is registered with the ClassWriter (parent)
+        MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
+
+        // Only rewrite the shutdown() method
+        if (!"shutdown".equals(name)) {
+          return mv;
+        }
+
+        return new MethodVisitor(Opcodes.ASM5, mv) {
+          @Override
+          public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
+            // Detect if it is making call "import scala.concurrent.ExecutionContext.Implicits.global",
+            // which translate to Java code as
+            // scala.concurrent.ExecutionContext$Implicits$.MODULE$.global()
+            // hence as bytecode
+            // GETSTATIC scala/concurrent/ExecutionContext$Implicits$.MODULE$ :
+            //           Lscala/concurrent/ExecutionContext$Implicits$;
+            // INVOKEVIRTUAL scala/concurrent/ExecutionContext$Implicits$.global
+            //           ()Lscala/concurrent/ExecutionContextExecutor;
+            if (opcode == Opcodes.INVOKEVIRTUAL
+              && "global".equals(name)
+              && "scala/concurrent/ExecutionContext$Implicits$".equals(owner)
+              && Type.getMethodDescriptor(EXECUTION_CONTEXT_EXECUTOR_TYPE).equals(desc)) {
+              // Discard the GETSTATIC result from the stack by popping it
+              super.visitInsn(Opcodes.POP);
+              // Make the call "import system.dispatch", which translate to Java code as
+              // this.system().dispatcher()
+              // hence as bytecode
+              // ALOAD 0 (load this)
+              // INVOKEVIRTUAL akka/remote/Remoting.system ()Lakka/actor/ExtendedActorSystem;
+              // INVOKEVIRTUAL akka/actor/ExtendedActorSystem.dispatcher ()Lscala/concurrent/ExecutionContextExecutor;
+              Type extendedActorSystemType = Type.getObjectType("akka/actor/ExtendedActorSystem");
+              super.visitVarInsn(Opcodes.ALOAD, 0);
+              super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "akka/remote/Remoting", "system",
+                                    Type.getMethodDescriptor(extendedActorSystemType), false);
+              super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, extendedActorSystemType.getInternalName(), "dispatcher",
+                                    Type.getMethodDescriptor(dispatcherReturnType), false);
+            } else {
+              // For other instructions, just call parent to deal with it
+              super.visitMethodInsn(opcode, owner, name, desc, itf);
+            }
+          }
+        };
+      }
+    }, ClassReader.EXPAND_FRAMES);
+
+    return cw.toByteArray();
+  }
+
+  /**
+   * Find the return type of the ActorSystem.dispatcher() method. It is ExecutionContextExecutor in
+   * Akka 2.3 (Spark 1.2+) and ExecutionContext in Akka 2.2 (Spark < 1.2, which CDAP doesn't support,
+   * however the Spark 1.5 in CDH 5.6. still has Akka 2.2, instead of 2.3).
+   *
+   * @return the return type of the ActorSystem.dispatcher() method or {@code null} if no such method
+   */
+  @Nullable
+  private Type determineAkkaDispatcherReturnType() {
+    URL resource = resourceLookup.apply("akka/actor/ActorSystem.class");
+    if (resource == null) {
+      return null;
+    }
+
+    try (InputStream is = resource.openStream()) {
+      final AtomicReference<Type> result = new AtomicReference<>();
+      ClassReader cr = new ClassReader(is);
+      cr.accept(new ClassVisitor(Opcodes.ASM5) {
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+          if (name.equals("dispatcher") && Type.getArgumentTypes(desc).length == 0) {
+            // Expected to be either ExecutionContext (akka 2.2, only in CDH spark)
+            // or ExecutionContextExecutor (akka 2.3, for open source, HDP spark).
+            Type returnType = Type.getReturnType(desc);
+            if (returnType.equals(EXECUTION_CONTEXT_TYPE)
+              || returnType.equals(EXECUTION_CONTEXT_EXECUTOR_TYPE)) {
+              result.set(returnType);
+            } else {
+              LOG.warn("Unsupported return type of ActorSystem.dispatcher(): {}", returnType.getClassName());
+            }
+          }
+          return super.visitMethod(access, name, desc, signature, exceptions);
+        }
+      }, ClassReader.SKIP_DEBUG | ClassReader.SKIP_CODE | ClassReader.SKIP_FRAMES);
+      return result.get();
+    } catch (IOException e) {
+      LOG.warn("Failed to determine ActorSystem dispatcher() return type.", e);
+      return null;
+    }
+  }
+
+  /**
+   * Defines the org.apache.spark.deploy.yarn.Client class with rewriting of the createConfArchive method to
+   * workaround the SPARK-13441 bug.
+   */
+  @Nullable
+  private byte[] rewriteClient(InputStream byteCodeStream) throws IOException {
+    // We only need to rewrite if listing either HADOOP_CONF_DIR or YARN_CONF_DIR return null.
+    boolean needRewrite = false;
+    for (String env : ImmutableList.of("HADOOP_CONF_DIR", "YARN_CONF_DIR")) {
+      String value = System.getenv(env);
+      if (value != null) {
+        File path = new File(value);
+        if (path.isDirectory() && path.listFiles() == null) {
+          needRewrite = true;
+          break;
+        }
+      }
+    }
+
+    // If rewrite is not needed
+    if (!needRewrite) {
+      return null;
+    }
+
+    ClassReader cr = new ClassReader(byteCodeStream);
+    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+    cr.accept(new ClassVisitor(Opcodes.ASM5, cw) {
+      @Override
+      public MethodVisitor visitMethod(final int access, final String name,
+                                       final String desc, String signature, String[] exceptions) {
+        MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
+
+        // Only rewrite the createConfArchive method
+        if (!"createConfArchive".equals(name)) {
+          return mv;
+        }
+
+        // Check if it's a recognizable return type.
+        // Spark 1.5+ return type is File
+        boolean isReturnFile = Type.getReturnType(desc).equals(Type.getType(File.class));
+        Type optionType = Type.getObjectType("scala/Option");
+        if (!isReturnFile) {
+          // Spark 1.4 return type is Option<File>
+          if (!Type.getReturnType(desc).equals(optionType)) {
+            // Unknown type. Not going to modify the code.
+            return mv;
+          }
+        }
+
+        // Generate this for Spark 1.5+
+        // return SparkRuntimeUtils.createConfArchive(this.sparkConf, SPARK_CONF_FILE,
+        //                                            LOCALIZED_CONF_DIR, LOCALIZED_CONF_DIR_ZIP);
+        // Generate this for Spark 1.4
+        // return Option.apply(SparkRuntimeUtils.createConfArchive(this.sparkConf, SPARK_CONF_FILE,
+        //                                                         LOCALIZED_CONF_DIR, LOCALIZED_CONF_DIR_ZIP));
+        GeneratorAdapter mg = new GeneratorAdapter(mv, access, name, desc);
+
+        // load this.sparkConf to the stack
+        mg.loadThis();
+        mg.getField(Type.getObjectType("org/apache/spark/deploy/yarn/Client"), "sparkConf", SPARK_CONF_TYPE);
+
+        // push three constants to the stack
+        mg.visitLdcInsn(SPARK_CONF_FILE);
+        mg.visitLdcInsn(LOCALIZED_CONF_DIR);
+        mg.visitLdcInsn(LOCALIZED_CONF_DIR_ZIP);
+
+        // call SparkRuntimeUtils.createConfArchive, return a File and leave it in stack
+        Type stringType = Type.getType(String.class);
+        mg.invokeStatic(SPARK_RUNTIME_UTILS_TYPE,
+                        new Method("createConfArchive", Type.getType(File.class),
+                                   new Type[] { SPARK_CONF_TYPE, stringType, stringType, stringType}));
+        if (isReturnFile) {
+          // Spark 1.5+ return type is File, hence just return the File from the stack
+          mg.returnValue();
+          mg.endMethod();
+        } else {
+          // Spark 1.4 return type is Option<File>
+          // return Option.apply(<file from stack>);
+          // where the file is actually just popped from the stack
+          mg.invokeStatic(optionType, new Method("apply", optionType, new Type[] { Type.getType(Object.class) }));
+          mg.checkCast(optionType);
+          mg.returnValue();
+          mg.endMethod();
+        }
+
+        return null;
+      }
+    }, ClassReader.EXPAND_FRAMES);
+
+    return cw.toByteArray();
+  }
+
+  /**
+   * CDAP-8636 Rewrite methods of YarnSparkHadoopUtil to avoid acquiring delegation token, because when we execute
+   * spark submit, we don't have keytab login. Because of that and the change in SPARK-12241, the attempt to acquire
+   * delegation tokens causes a spark program submission failure.
+   */
+  private byte[] rewriteSparkHadoopUtil(String name, InputStream byteCodeStream) throws IOException {
+    Set<String> methods =
+      ImmutableSet.of("obtainTokensForNamenodes", "obtainTokenForHiveMetastore", "obtainTokenForHBase");
+    return Classes.rewriteMethodToNoop(name, byteCodeStream, methods);
+  }
+
+  /**
+   * Private interface for rewriting constructor.
+   */
+  private interface ConstructorRewriter {
+    void onMethodExit(GeneratorAdapter generatorAdapter);
+  }
+}

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkContainerClassLoader.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkContainerClassLoader.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark.classloader;
+
+import co.cask.cdap.common.app.MainClassLoader;
+import com.google.common.base.Function;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import javax.annotation.Nullable;
+
+/**
+ * The {@link ClassLoader} for Spark containers in distributed mode.
+ */
+public class SparkContainerClassLoader extends MainClassLoader {
+
+  private final SparkClassRewriter sparkClassRewriter;
+
+  /**
+   * Creates a new instance for the following set of {@link URL}.
+   *
+   * @param urls the URLs from which to load classes and resources
+   * @param parent the parent classloader for delegation
+   */
+  public SparkContainerClassLoader(URL[] urls, ClassLoader parent) {
+    super(urls, parent);
+    this.sparkClassRewriter = new SparkClassRewriter(new Function<String, URL>() {
+      @Nullable
+      @Override
+      public URL apply(String resourceName) {
+        return findResource(resourceName);
+      }
+    }, false);
+  }
+
+  @Override
+  protected boolean needIntercept(String className) {
+    if (super.needIntercept(className)) {
+      return true;
+    }
+    // There are certain Spark classes that need to be rewritten in distributed mode.
+    // Just intercept all Spark classes and determine what actually needs to be rewritten
+    // in the rewrite method.
+    return className.startsWith("org.apache.spark.");
+  }
+
+  @Nullable
+  @Override
+  public byte[] rewriteClass(String className, InputStream input) throws IOException {
+    byte[] rewrittenCode = super.rewriteClass(className, input);
+
+    // If it is not a Spark class, just return
+    if (!className.startsWith("org.apache.spark.")) {
+      return rewrittenCode;
+    }
+
+    // Otherwise rewrite it using the SparkClassRewriter
+    return sparkClassRewriter.rewriteClass(className,
+                                           rewrittenCode == null ? input : new ByteArrayInputStream(rewrittenCode));
+  }
+}

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkRunnerClassLoader.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkRunnerClassLoader.java
@@ -18,9 +18,7 @@ package co.cask.cdap.app.runtime.spark.classloader;
 
 import co.cask.cdap.api.spark.Spark;
 import co.cask.cdap.common.internal.guava.ClassPath;
-import co.cask.cdap.common.lang.ClassLoaders;
 import co.cask.cdap.common.lang.ClassPathResources;
-import co.cask.cdap.internal.app.runtime.spark.SparkUtils;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
@@ -30,10 +28,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -70,22 +66,6 @@ public final class SparkRunnerClassLoader extends URLClassLoader {
     }
 
     API_CLASSES = Collections.unmodifiableSet(apiClasses);
-  }
-
-  private static URL[] getClassloaderURLs(ClassLoader classLoader) throws IOException {
-    List<URL> urls = ClassLoaders.getClassLoaderURLs(classLoader, new ArrayList<URL>());
-
-    // If Spark classes are not available in the given ClassLoader, try to locate the Spark assembly jar
-    // This class cannot have dependency on Spark directly, hence using the class resource to discover if SparkContext
-    // is there
-    if (classLoader.getResource("org/apache/spark/SparkContext.class") == null) {
-      urls.add(SparkUtils.locateSparkAssemblyJar().toURI().toURL());
-    }
-    return urls.toArray(new URL[urls.size()]);
-  }
-
-  public SparkRunnerClassLoader(ClassLoader parent, boolean rewriteYarnClient) throws IOException {
-    this(getClassloaderURLs(parent), parent, rewriteYarnClient);
   }
 
   public SparkRunnerClassLoader(URL[] urls, @Nullable ClassLoader parent, boolean rewriteYarnClient) {

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkRunnerClassLoader.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkRunnerClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,11 +14,9 @@
  * the License.
  */
 
-package co.cask.cdap.app.runtime.spark;
+package co.cask.cdap.app.runtime.spark.classloader;
 
 import co.cask.cdap.api.spark.Spark;
-import co.cask.cdap.app.runtime.spark.classloader.SparkClassRewriter;
-import co.cask.cdap.app.runtime.spark.classloader.SparkContainerClassLoader;
 import co.cask.cdap.common.internal.guava.ClassPath;
 import co.cask.cdap.common.lang.ClassLoaders;
 import co.cask.cdap.common.lang.ClassPathResources;

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/SparkContainerLauncher.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/SparkContainerLauncher.java
@@ -16,9 +16,8 @@
 
 package co.cask.cdap.app.runtime.spark.distributed;
 
-import co.cask.cdap.app.runtime.spark.SparkRunnerClassLoader;
 import co.cask.cdap.app.runtime.spark.SparkRuntimeContextProvider;
-import co.cask.cdap.common.app.MainClassLoader;
+import co.cask.cdap.app.runtime.spark.classloader.SparkContainerClassLoader;
 import co.cask.cdap.common.lang.ClassLoaders;
 import co.cask.cdap.common.logging.StandardOutErrorRedirector;
 import co.cask.cdap.common.logging.common.UncaughtExceptionHandler;
@@ -31,14 +30,14 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * This class launches Spark YARN containers with classes loaded through the {@link SparkRunnerClassLoader}.
+ * This class launches Spark YARN containers with classes loaded through the {@link SparkContainerClassLoader}.
  */
 public final class SparkContainerLauncher {
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkContainerLauncher.class);
 
   /**
-   * Launches the given main class. The main class will be loaded through the {@link SparkRunnerClassLoader}.
+   * Launches the given main class. The main class will be loaded through the {@link SparkContainerClassLoader}.
    *
    * @param mainClassName the main class to launch
    * @param args arguments for the main class
@@ -65,8 +64,7 @@ public final class SparkContainerLauncher {
     // Use the extension classloader as the parent instead of the system classloader because
     // Spark classes are in the system classloader which we want to rewrite.
     URL[] classLoaderUrls = urls.toArray(new URL[urls.size()]);
-    ClassLoader classLoader = new SparkRunnerClassLoader(
-      classLoaderUrls, new MainClassLoader(classLoaderUrls, systemClassLoader.getParent()), false);
+    ClassLoader classLoader = new SparkContainerClassLoader(classLoaderUrls, systemClassLoader.getParent());
 
     // Sets the context classloader and launch the actual Spark main class.
     Thread.currentThread().setContextClassLoader(classLoader);

--- a/cdap-spark-core/src/test/java/co/cask/cdap/app/runtime/spark/classloader/SparkRunnerClassLoaderTest.java
+++ b/cdap-spark-core/src/test/java/co/cask/cdap/app/runtime/spark/classloader/SparkRunnerClassLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,8 +14,9 @@
  * the License.
  */
 
-package co.cask.cdap.app.runtime.spark;
+package co.cask.cdap.app.runtime.spark.classloader;
 
+import co.cask.cdap.app.runtime.spark.classloader.SparkRunnerClassLoader;
 import co.cask.cdap.common.lang.ClassLoaders;
 import com.google.common.io.Closeables;
 import org.junit.Test;


### PR DESCRIPTION
The changes has been grouped into multiple commits for easy review. 

The main commits that fixes the issue is the third one "Use the same defining class loader for all classes in Spark container".