### PR TITLE
CDAP-8924: Fix LogHandlerTestRun Unit Test

### DIFF
--- a/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/log/MockLogReader.java
+++ b/cdap-gateway/src/test/java/co/cask/cdap/gateway/handlers/log/MockLogReader.java
@@ -217,7 +217,7 @@ public class MockLogReader implements LogReader {
             break;
           }
 
-          if (filter != Filter.EMPTY_FILTER && logLine.getOffset().getKafkaOffset() % 2 != 0) {
+          if (!filter.match(logLine.getLoggingEvent())) {
             continue;
           }
 


### PR DESCRIPTION
cherry-pick https://github.com/caskdata/cdap/pull/8394
Fixes the LogHandlerTestRun filter tests to test on basis of filter and not directly using the kafkaoffset. 