### PR TITLE
[HYDRATOR-1316] Show logs for pipeline preview

### DIFF
--- a/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.html
+++ b/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.html
@@ -1,0 +1,215 @@
+<!--
+  Copyright © 2017 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+<div class="log-viewer-container" ng-class="{'full-screen': LogViewerPreview.fullScreen}">
+  <!-- LOGS HEADERBAR -->
+  <div class="logs-headerbar">
+    <div class="log-stats-container">
+      <div class="logs-status-container" ng-if="LogViewerPreview.fullScreen">
+        <span class="application-name" ng-bind="LogViewerPreview.entityName"></span>
+        <span class="application-status" ng-class="{'program-primary' : LogViewerPreview.statusType === 0, 'program-secondary' : LogViewerPreview.statusType === 1, 'program-completed' : LogViewerPreview.statusType === 2, 'program-default' : LogViewerPreview.statusType === 3}">
+          <div class="status-circle" ng-class="{'program-primary-circle' : LogViewerPreview.statusType === 0, 'program-secondary-circle' : LogViewerPreview.statusType === 1, 'program-completed-circle' : LogViewerPreview.statusType === 2, 'program-default-circle' : LogViewerPreview.statusType === 3}">
+          </div>
+          {{LogViewerPreview.programStatus}}
+        </span>
+      </div>
+      <div class="log-stats-total log-stats text-center">
+          <span class="stat-name">Total Messages</span>
+          <div class="stat-count total-num">
+            <span class="stat-count-number">{{LogViewerPreview.totalCount}}</span></div>
+      </div>
+      <div class="log-stats-errors log-stats text-center">
+        <span class="stat-name log-stats-errors-text">Error</span>
+          <div class="stat-count errors-num"><span class="stat-count-number">{{LogViewerPreview.errorCount}}</span></div>
+      </div>
+      <div class="log-stats-warnings log-stats text-center">
+        <span class="stat-name log-stats-warnings-text">Warning</span>
+        <div class="stat-count warnings-num">
+          <span class="stat-count-number">{{LogViewerPreview.warningCount}}</span>
+        </div>
+      </div>
+    </div>
+    <div class="log-actions">
+      <div class="log-action-container">
+        <a href="{{LogViewerPreview.getDownloadUrl('raw')}}"
+          target="_blank"
+          class="log-action-btn view-raw btn btn-default"
+          ng-disabled="!LogViewerPreview.displayData.length || LogViewerPreview.loading"
+          ng-click="LogViewerPreview.preventClick($event)">
+          <span>View Raw Logs</span>
+        </a>
+
+        <a href="{{LogViewerPreview.getDownloadUrl('download')}}"
+          target="_blank"
+          class="log-action-btn download-all btn btn-default"
+          ng-disabled="!LogViewerPreview.displayData.length || LogViewerPreview.loading"
+          ng-click="LogViewerPreview.preventClick($event)">
+          <span>Download All</span>
+        </a>
+        <div class="search">
+          <input type="text" class="log-searchbar" placeholder="Search" ng-model="LogViewerPreview.searchText" ng-model-options="{ debounce: 500 }" ng-change="LogViewerPreview.filterSearch()">
+          <span class="fa fa-search"></span>
+        </div>
+        <i class="fa fa-expand" aria-hidden="true" ng-click="LogViewerPreview.updateScreenChangeInStore(!LogViewerPreview.fullScreen)"></i>
+      </div>
+    </div>
+  </div>
+
+  <a class="sr-only" id="logs-export-link" href="{{LogViewerPreview.url}}" download="{{LogViewerPreview.exportFileName}}.log">Export</a>
+
+  <!-- LOGS TIMELINE
+  <my-timeline
+    namespace-id="{{LogViewerPreview.namespaceId}}"
+    app-id="{{LogViewerPreview.appId}}"
+    program-type="{{LogViewerPreview.programType}}"
+    program-id="{{LogViewerPreview.programId}}"
+    run-id="{{LogViewerPreview.runId}}">
+  </my-timeline>
+  -->
+
+  <!-- LOGS TABLE -->
+  <div class="logs-table">
+    <table class="table table-bordered scroll scroll-table">
+      <thead>
+        <tr ng-style="LogViewerPreview.headerRowStyle">
+          <th class="time time-header log-header"
+              ng-if="LogViewerPreview.configOptions.time && !LogViewerPreview.hiddenColumns.time">
+            Time
+          </th>
+
+          <th class='level level-header'
+              ng-if="LogViewerPreview.configOptions.level && !LogViewerPreview.hiddenColumns.level">
+            <span uib-dropdown class="dropdown">
+              <span uib-dropdown-toggle>
+                Level <span class="fa fa-caret-down"></span>
+              </span>
+              <ul uib-dropdown-menu ng-click="$event.stopPropagation();">
+                <li ng-repeat="option in LogViewerPreview.logEvents"
+                    ng-click="LogViewerPreview.includeEvent($event, option)">
+                  <input
+                    type="checkbox"
+                    ng-model="LogViewerPreview.activeLogLevels[option]"/>
+                    <span>{{option}}</span>
+                </li>
+              </ul>
+            </span>
+          </th>
+
+          <th class="source source-header log-header"
+              ng-if="LogViewerPreview.configOptions.source && !LogViewerPreview.hiddenColumns.source">
+            Source
+          </th>
+
+          <th class="message-header"
+              ng-if="LogViewerPreview.configOptions.message && !LogViewerPreview.hiddenColumns.message"
+              ng-class="{'expanded': LogViewerPreview.isMessageExpanded }">
+            <span class="fa"
+                  ng-class="{ 'fa-arrow-left': !LogViewerPreview.isMessageExpanded,
+                    'fa-arrow-right': LogViewerPreview.isMessageExpanded}"
+                  ng-click="LogViewerPreview.collapseColumns()"></span>
+            <span>Message</span>
+            <button class="btn btn-default pull-right"
+                    ng-click="LogViewerPreview.toggleLogExpansion()"
+                    ng-disabled="LogViewerPreview.displayData.length === 0">
+              <span ng-if="!LogViewerPreview.toggleExpandAll">Expand All</span>
+              <span ng-if="LogViewerPreview.toggleExpandAll">Collapse All</span>
+            </button>
+          </th>
+        </tr>
+      </thead>
+      <tbody class="logs-table-body"
+             infinite-scroll="LogViewerPreview.scrollFn()"
+             infinite-scroll-immediate-check="false"
+             infinite-scroll-container="'.logs-table-body'"
+             infinite-scroll-disabled="(LogViewerPreview.statusType === 0 || LogViewerPreview.statusType === 1) && LogViewerPreview.displayData.length === LogViewerPreview.totalCount"
+             in-view-container
+             >
+
+        <tr ng-class="{'has-stack-trace' : entry.log.stackTrace.length > 0, 'row-selected' : $index+1  < LogViewerPreview.displayData.length && LogViewerPreview.displayData[$index + 1].stackTrace, 'row-expanded' : !entry.stackTrace && entry.selected }"
+            ng-repeat="entry in LogViewerPreview.displayData track by $index"
+            ng-click="LogViewerPreview.toggleStackTrace($index)"
+            in-view="LogViewerPreview.inViewScrollUpdate($index, $inview, $event)"
+            in-view-options="{ debounce : 500}">
+
+          <td class="time time-stack-trace"
+              ng-if="!entry.stackTrace && entry.log.stackTrace.length > 0 && LogViewerPreview.configOptions.time && !LogViewerPreview.hiddenColumns.time">
+            <span class="indicator-arrow" ng-if="entry.log.stackTrace.length > 0">
+              <i ng-if="($index+1 < LogViewerPreview.displayData.length) && (LogViewerPreview.displayData[$index +1].stackTrace )" class="fa fa-chevron-down"></i>
+              <i ng-if="($index+1 >= LogViewerPreview.displayData.length) || !LogViewerPreview.displayData[$index +1].stackTrace" class="fa fa-chevron-right"></i>
+            </span>
+            <span class="display-time" ng-bind="entry.log.displayTime"></span>
+          </td>
+
+          <td class="time"
+              ng-if="!entry.stackTrace && entry.log.stackTrace.length === 0 && LogViewerPreview.configOptions.time && !LogViewerPreview.hiddenColumns.time">
+            <span class="display-time" ng-bind="entry.log.displayTime"></span>
+          </td>
+
+          <td class="level"
+              ng-if="!entry.stackTrace && LogViewerPreview.configOptions.level && !LogViewerPreview.hiddenColumns.level"
+              ng-bind="entry.log.logLevel"></td>
+
+          <td class="source"
+              ng-if="!entry.stackTrace && LogViewerPreview.configOptions.source && !LogViewerPreview.hiddenColumns.source"
+              uib-tooltip="{{entry.log.threadName}}:{{entry.log.className}}#{{entry.log.lineNumber}}"
+              tooltip-append-to-body="true"
+              tooltip-placement="top"
+              tooltip-popup-delay="500"
+              tooltip-class="source-tooltip">
+              <span
+                ng-bind="(entry.log.threadName)+':'+(entry.log.className)+'#'+(entry.log.lineNumber)"></span>
+          </td>
+          <td class="log-message"
+              ng-if="!entry.stackTrace && LogViewerPreview.configOptions.message && !LogViewerPreview.hiddenColumns.message"
+              uib-tooltip="{{entry.log.message}}"
+              tooltip-append-to-body="true"
+              tooltip-placement="top"
+              tooltip-popup-delay="500"
+              tooltip-class="message-tooltip">
+            <span ng-bind-html="LogViewerPreview.highlight(entry.log.message)"></span>
+          </td>
+          <td class="stack-trace" ng-if="entry.stackTrace" colspan="4">
+            <pre ng-bind="entry.log.stackTrace"></pre>
+          </td>
+        </tr>
+
+        <tr class="message-holder">
+          <td colspan="4">
+            <div class="well well-sm text-center"
+                 ng-if="!LogViewerPreview.errorRetrievingLogs && !LogViewerPreview.loading && !LogViewerPreview.displayData.length && LogViewerPreview.statusType !== 0">
+              <h4>
+                No logs to display.
+              </h4>
+            </div>
+            <div class="well well-sm text-center"
+                 ng-if="LogViewerPreview.errorRetrievingLogs && !LogViewerPreview.loading">
+              <h4>
+                Error Retrieving Logs.
+              </h4>
+            </div>
+            <div class="well well-sm text-center"
+                 ng-if="!LogViewerPreview.errorRetrievingLogs && LogViewerPreview.statusType === 0 || LogViewerPreview.loading">
+              <h4 ng-if="!LogViewerPreview.displayData.length">Loading ...</h4>
+              <h6 ng-if="LogViewerPreview.displayData.length">
+                <span class="fa fa-spin fa-refresh"></span>
+              </h6>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="empty-buffer"></div>
+  </div>
+</div>

--- a/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.html
+++ b/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.html
@@ -190,13 +190,13 @@
             <div class="well well-sm text-center"
                  ng-if="!LogViewerPreview.errorRetrievingLogs && !LogViewerPreview.loading && !LogViewerPreview.displayData.length && LogViewerPreview.statusType !== 0">
               <h4>
-                No logs to display.
+                There are no logs yet to display.
               </h4>
             </div>
             <div class="well well-sm text-center"
                  ng-if="LogViewerPreview.errorRetrievingLogs && !LogViewerPreview.loading">
               <h4>
-                Error Retrieving Logs.
+                Unable to retrieve logs.
               </h4>
             </div>
             <div class="well well-sm text-center"

--- a/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.html
+++ b/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.html
@@ -69,16 +69,6 @@
 
   <a class="sr-only" id="logs-export-link" href="{{LogViewerPreview.url}}" download="{{LogViewerPreview.exportFileName}}.log">Export</a>
 
-  <!-- LOGS TIMELINE
-  <my-timeline
-    namespace-id="{{LogViewerPreview.namespaceId}}"
-    app-id="{{LogViewerPreview.appId}}"
-    program-type="{{LogViewerPreview.programType}}"
-    program-id="{{LogViewerPreview.programId}}"
-    run-id="{{LogViewerPreview.runId}}">
-  </my-timeline>
-  -->
-
   <!-- LOGS TABLE -->
   <div class="logs-table">
     <table class="table table-bordered scroll scroll-table">

--- a/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.js
+++ b/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.js
@@ -1,0 +1,756 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+function LogViewerPreviewController ($scope, $window, LogViewerStore, myPreviewLogsApi, LOGVIEWERSTORE_ACTIONS, MyCDAPDataSource, $sce, myCdapUrl, $timeout, $q, moment, myAlertOnValium) {
+  'ngInject';
+
+  /**
+   *  For reference:
+   *  The entry point for this log is startTimeRequest()
+   **/
+
+  var dataSrc = new MyCDAPDataSource($scope);
+  var pollPromise;
+  //Collapsing LogViewer Table Columns
+  var columnsList = [];
+  var collapseCount = 0;
+  var vm = this;
+
+  vm.viewLimit = 100;
+  vm.errorRetrievingLogs = false;
+
+  vm.setProgramMetadata = (status) => {
+    vm.programStatus = status;
+
+    if(!vm.entityName) {
+      vm.entityName = vm.runId;
+    }
+
+    switch(status){
+      case 'fNING':
+      case 'STARTED':
+        vm.statusType = 0;
+        break;
+      case 'STOPPED':
+      case 'KILLED':
+      case 'FAILED':
+      case 'SUSPENDED':
+        vm.statusType = 1;
+        break;
+      case 'COMPLETED':
+        vm.statusType = 2;
+        break;
+      default:
+        vm.statusType = 3;
+        break;
+    }
+  };
+  let page = angular.element(window);
+
+  vm.setDefault = () => {
+    vm.textFile = null;
+    vm.statusType = 3;
+    vm.displayData = [];
+    vm.data = [];
+    vm.loading = false;
+    vm.fullScreen = false;
+    vm.programStatus = 'Not Started';
+    vm.configOptions = {
+      time: true,
+      level: true,
+      source: true,
+      message: true
+    };
+
+    vm.hiddenColumns = {
+      time: false,
+      level: false,
+      source: false,
+      message: false
+    };
+    var cols = vm.configOptions;
+
+    if(cols['source']){
+      columnsList.push('source');
+    }
+    if(cols['level']){
+      columnsList.push('level');
+    }
+    if(cols['time']){
+      columnsList.push('time');
+    }
+    // FIXME: vm should have been defaulted from LogViewerStore but since we didn't plan for having a store for logviewer
+    // we are having vm adhoc assignment.
+    vm.totalCount = 0;
+    vm.warningCount = 0;
+    vm.errorCount = 0;
+  };
+
+  vm.setDefault();
+  angular.forEach($scope.displayOptions, (value, key) => {
+    vm.configOptions[key] = value;
+  });
+
+  vm.logEvents = ['ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE'];
+
+  vm.activeLogLevels = {
+    'ERROR' : true,
+    'WARN' : true,
+    'INFO' : true,
+    'DEBUG' : false,
+    'TRACE' : false
+  };
+
+  // dynamically sets the default log level filter
+  vm.logEvents.forEach(logLevel => {
+    if (vm.activeLogLevels[logLevel] === true) {
+      vm.selectedLogLevel = logLevel;
+    }
+  });
+
+  vm.toggleExpandAll = false;
+
+  let unsub = LogViewerStore.subscribe(() => {
+    let logViewerState = LogViewerStore.getState();
+
+    vm.totalCount = logViewerState.totalLogs;
+    vm.warningCount = logViewerState.totalWarnings;
+    vm.errorCount = logViewerState.totalErrors;
+
+    vm.fullScreen = logViewerState.fullScreen;
+
+    if (vm.data.length > 0) {
+      return;
+    }
+    // if (vm.logStartTime === logViewerState.startTime){
+    //   return;
+    // }
+
+    // vm.logStartTime = logViewerState.startTime;
+
+    // if (!vm.logStartTime || vm.startTimeMs === vm.logStartTime){
+    //   return;
+    // }
+
+    // vm.startTimeMs = (vm.logStartTime instanceof Date) ? vm.logStartTime.getTime() : vm.logStartTime;
+
+    // vm.fromOffset = -10000 + '.' + vm.startTimeMs;
+
+    vm.endRequest = false;
+    startTimeRequest();
+  });
+
+  let proximityVal = Number.MAX_VALUE;
+  let newTime;
+  let timeout;
+
+  vm.inViewScrollUpdate = (index, isInview, event) => {
+
+    if(isInview && vm.displayData && vm.displayData.length > 0) {
+
+      // tbody extends beyond the viewport when scrolling down the table
+      let topOfTable = event.inViewTarget.parentElement.getBoundingClientRect().top;
+
+      // measures the scroll position of the window within the viewport
+      let pageScrollPosition = page[0].scrollY;
+
+      // gives the offsetTop property for a row that is within the viewport
+      let rowTopVal = event.inViewTarget.offsetTop;
+
+      // Adjusted val combines the tbody absolute offset that may extend beyond the viewport, with it's relatively positioned table row, giving us an absolute positioning for the row
+      let adjustedVal = topOfTable + pageScrollPosition + rowTopVal;
+
+      // Difference accounts for the difference between the top of the logviewer table container and the table rows
+      let difference = adjustedVal - $scope.tableEl[0].offsetTop;
+
+      // Offset the height of the bottom timeline and scrollpin row (55 + 15) if in full-screen
+      if (vm.fullScreen){
+        difference-=70;
+      }
+
+      // By taking the smallest non-negative value, we have found the top-most row
+      if (difference > 0 && (proximityVal > difference || proximityVal < 0)){
+        index++;
+        newTime = vm.displayData[index].log.timestamp;
+        vm.updateScrollPositionInStore(newTime);
+      }
+
+      proximityVal = difference;
+    }
+  };
+
+  if (vm.previewId) {
+    // Get Initial Status
+    myPreviewLogsApi.getLogsStatus({
+      namespace : vm.namespaceId,
+      previewId : vm.previewId
+    }).$promise.then(
+      (statusRes) => {
+        LogViewerStore.dispatch({
+          type: LOGVIEWERSTORE_ACTIONS.SET_STATUS,
+          payload: {
+            status: statusRes.status,
+          }
+        });
+        vm.setProgramMetadata(statusRes.status);
+      },
+      (statusErr) => {
+        console.log('ERROR: ', statusErr);
+
+        if (statusErr.statusCode === 404) {
+          myAlertOnValium.show({
+            type: 'danger',
+            content: statusErr.data
+          });
+        }
+      });
+  }
+
+  vm.filterSearch = () => {
+    // Rerender data
+    vm.renderData();
+    // If the search query is blank, otherwise filter
+    if (vm.searchText.length === 0){
+      vm.updateSearchResultsInStore([]);
+      return;
+    }
+
+    let searchResults = [];
+
+    vm.displayData = vm.displayData.filter( data => {
+      if (data.log.message.toLowerCase().indexOf(vm.searchText.toLowerCase()) !== -1){
+        searchResults.push(data.log.timestamp);
+        return true;
+      }
+      return false;
+    });
+
+    vm.updateSearchResultsInStore(searchResults);
+  };
+
+  vm.toggleStackTrace = (index) => {
+    //If the currently clicked row is a stack trace itself, do nothing
+    if(vm.displayData[index].stackTrace){
+      return;
+    }
+
+    if( (index+1 < vm.displayData.length) && vm.displayData[index+1].stackTrace){
+      vm.displayData.splice(index+1, 1);
+      vm.displayData[index].selected = false;
+      return;
+    }
+    if(vm.displayData[index].log.stackTrace){
+      vm.displayData[index].selected = true;
+      let stackTraceObj = {
+        log: {
+          timestamp: vm.displayData[index].log.timestamp,
+          stackTrace: vm.displayData[index].log.stackTrace,
+        },
+        stackTrace: true
+      };
+      vm.displayData.splice(index+1, 0, stackTraceObj);
+    } else {
+      //otherwise, it does not have stack trace but has been selected
+      vm.displayData[index].selected = !vm.displayData[index].selected;
+    }
+  };
+
+  vm.collapseColumns = () => {
+    if(vm.isMessageExpanded){
+      vm.isMessageExpanded = !vm.isMessageExpanded;
+    }
+    if(collapseCount < columnsList.length){
+      vm.hiddenColumns[columnsList[collapseCount++]] = true;
+      if(collapseCount === columnsList.length){
+        vm.isMessageExpanded = true;
+      }
+    } else {
+      collapseCount = 0;
+      for(var key in vm.hiddenColumns){
+        if(vm.hiddenColumns.hasOwnProperty(key)){
+          vm.hiddenColumns[key] = false;
+        }
+      }
+    }
+  };
+
+  vm.updateScrollPositionInStore = (val) => {
+    LogViewerStore.dispatch({
+      type: LOGVIEWERSTORE_ACTIONS.SCROLL_POSITION,
+      payload: {
+        scrollPosition: val
+      }
+    });
+  };
+
+  vm.updateScreenChangeInStore = (state) => {
+
+    LogViewerStore.dispatch({
+      type: LOGVIEWERSTORE_ACTIONS.FULL_SCREEN,
+      payload: {
+        fullScreen: state
+      }
+    });
+  };
+
+  vm.updateSearchResultsInStore = (results) => {
+    LogViewerStore.dispatch({
+      type: LOGVIEWERSTORE_ACTIONS.SEARCH_RESULTS,
+      payload: {
+        searchResults: results
+      }
+    });
+  };
+
+  function validUrl() {
+    return vm.namespaceId && vm.previewId;
+  }
+
+  function requestWithOffset() {
+    if (vm.loading) { return; }
+
+    if (!validUrl()){
+       vm.loading = false;
+       return;
+    }
+
+    vm.loading = true;
+
+    if (pollPromise){
+      dataSrc.stopPoll(pollPromise.__pollId__);
+      pollPromise = null;
+    }
+
+    myPreviewLogsApi.nextLogsJsonOffset({
+      'namespace' : vm.namespaceId,
+      'previewId' : vm.previewId,
+      'fromOffset' : vm.fromOffset,
+      filter: `loglevel=${vm.selectedLogLevel}`
+    }).$promise.then(
+      (res) => {
+        vm.errorRetrievingLogs = false;
+        vm.loading = false;
+
+        if (res.length === 0) {
+          offsetScroll();
+          getStatus();
+
+          if (vm.statusType !== 0) {
+            vm.endRequest = true;
+          }
+
+          return;
+        }
+
+        vm.fromOffset = res[res.length-1].offset;
+        angular.forEach(res, (element, index) => {
+          //Format dates properly for rendering and computing
+          let formattedDate = new Date(res[index].log.timestamp);
+          res[index].log.timestamp = formattedDate;
+          res[index].log.displayTime = moment(formattedDate).format('L H:mm:ss');
+          res[index].log.stackTrace = res[index].log.stackTrace.trim();
+        });
+
+        vm.data = vm.data.concat(res);
+        vm.renderData();
+        if(vm.displayData.length < vm.viewLimit){
+          getStatus();
+        }
+      },
+      (err) => {
+        console.log('ERROR: ', err);
+        vm.errorRetrievingLogs = true;
+        vm.loading = false;
+        offsetScroll();
+      });
+  }
+
+  function getStatus () {
+    myPreviewLogsApi.getLogsStatus({
+      namespace : vm.namespaceId,
+      previewId : vm.previewId
+    }).$promise.then(
+      (statusRes) => {
+        LogViewerStore.dispatch({
+          type: LOGVIEWERSTORE_ACTIONS.SET_STATUS,
+          payload: {
+            status: statusRes.status,
+          }
+        });
+        vm.setProgramMetadata(statusRes.status);
+        if(vm.statusType === 0){
+          if (!pollPromise) {
+            pollForNewLogs();
+          }
+        } else {
+          if (pollPromise) {
+            dataSrc.stopPoll(pollPromise.__pollId__);
+          }
+        }
+      },
+      (statusErr) => {
+        console.log('ERROR: ', statusErr);
+      }
+    );
+  }
+
+  function pollForNewLogs () {
+    pollPromise = dataSrc.poll({
+      _cdapPath: '/namespaces/' + vm.namespaceId + '/previews/' + vm.previewId + '/logs/next?format=json&max=100&fromOffset=' + vm.fromOffset + '&filter=loglevel=' + vm.selectedLogLevel,
+      method: 'GET'
+    },
+    (res) => {
+      //We have recieved more logs, append to current dataset
+      vm.errorRetrievingLogs = false;
+
+      if(res.length > 0){
+        vm.fromOffset = res[res.length-1].offset;
+
+        angular.forEach(res, (element, index) => {
+          //Format dates properly for rendering and computing
+          let formattedDate = new Date(res[index].log.timestamp);
+          res[index].log.timestamp = formattedDate;
+          res[index].log.displayTime = moment(formattedDate).format('L H:mm:ss');
+          res[index].log.stackTrace = res[index].log.stackTrace.trim();
+        });
+
+        vm.data = vm.data.concat(res);
+        vm.renderData();
+      }
+
+      if(vm.displayData.length >= vm.viewLimit){
+        dataSrc.stopPoll(pollPromise.__pollId__);
+        pollPromise = null;
+      } else {
+        getStatus();
+      }
+
+    }, (err) => {
+      console.log('ERROR: ', err);
+      vm.errorRetrievingLogs = true;
+    });
+  }
+
+  vm.getDownloadUrl = (type = 'download') => {
+
+    // Generate backend path
+    let startTime = Math.floor(vm.startTimeMs/1000);
+    let path = `/namespaces/${vm.namespaceId}/previews/${vm.previewId}/logs?start=${startTime}&escape=false`;
+    path = encodeURIComponent(myCdapUrl.constructUrl({_cdapPath: path}));
+
+    let url = `/downloadLogs?backendUrl=${path}&type=${type}`;
+
+    if (type === 'download') {
+      // Generate filename
+      let filename = '';
+      if ('undefined' !== typeof this.getDownloadFilename()) {
+        filename = this.getDownloadFilename() + '-' + formatDate(new Date(this.startTimeMs), true);
+      } else {
+         filename = this.namespaceId + '-' + this.previewId + formatDate(new Date(this.startTimeMs), true);
+      }
+
+      url = `${url}&filename=${filename}.log`;
+    }
+
+    return url;
+  };
+
+  function startTimeRequest () {
+    if(!validUrl()){
+       vm.loading = false;
+       return;
+    }
+    vm.loading = true;
+    vm.data = [];
+    vm.renderData();
+    if(pollPromise){
+      dataSrc.stopPoll(pollPromise.__pollId__);
+      pollPromise = null;
+    }
+
+    //Scroll table to the top
+    angular.element(document.getElementsByClassName('logs-table-body'))[0].scrollTop = 0;
+    // binds window element to check whether scrollbar has appeared on resize event
+    angular.element($window).bind('resize', checkForScrollbar);
+
+    // myPreviewLogsApi.nextLogsJsonOffset({
+    myPreviewLogsApi.nextLogsJson({
+      namespace : vm.namespaceId,
+      previewId : vm.previewId,
+      // fromOffset: vm.fromOffset,
+      filter: `loglevel=${vm.selectedLogLevel}`
+    }).$promise.then(
+      (res) => {
+        vm.errorRetrievingLogs = false;
+        vm.loading = false;
+        vm.data = res;
+
+        if(res.length === 0){
+          //Update with start-time
+          getStatus();
+          if(vm.statusType !== 0){
+            // vm.loading = false;
+            vm.displayData = [];
+          }
+          vm.renderData();
+          return;
+        }
+
+        // vm.fromOffset = res[res.length-1].offset;
+        vm.displayData = [];
+
+        angular.forEach(res, (element, index) => {
+          let formattedDate = new Date(res[index].log.timestamp);
+          res[index].log.timestamp = formattedDate;
+          res[index].log.displayTime = moment(formattedDate).format('L H:mm:ss');
+          res[index].log.stackTrace = res[index].log.stackTrace.trim();
+        });
+
+        vm.renderData();
+        //Update the scroll needle to be positioned at the first element in the rendered data
+        if(vm.displayData.length > 0){
+          vm.updateScrollPositionInStore(vm.displayData[0].log.timestamp);
+        }
+
+        if(res.length < vm.viewLimit){
+          getStatus();
+        }
+      },
+      (err) => {
+        vm.setDefault();
+        vm.errorRetrievingLogs = true;
+        console.log('ERROR: ', err);
+      });
+  }
+
+  function formatDate(date, isDownload) {
+    let dateObj = {
+      month: date.getMonth() + 1,
+      day: date.getDate(),
+      year: date.getFullYear(),
+      hours: date.getHours(),
+      minutes: date.getMinutes(),
+      seconds: date.getSeconds()
+    };
+
+    angular.forEach(dateObj, (value, key) => {
+      if(value < 10){
+        dateObj[key] = '0' + value;
+      } else {
+        dateObj[key] = value.toString();
+      }
+    });
+
+    if(isDownload){
+      return dateObj.year + dateObj.day + dateObj.month + dateObj.hours + dateObj.minutes + dateObj.seconds;
+    }
+
+    return dateObj.month + '/' + dateObj.day + '/' + dateObj.year + ' ' + dateObj.hours + ':' + dateObj.minutes + ':' + dateObj.seconds;
+  }
+
+  vm.toggleLogExpansion = function() {
+    let len = vm.displayData.length;
+    vm.toggleExpandAll = !vm.toggleExpandAll;
+    for(var i = 0 ; i < len ; i++) {
+      let entry = vm.displayData[i];
+      if(!entry.stackTrace && entry.log.stackTrace.length > 0){
+        entry.isStackTraceExpanded = vm.toggleExpandAll;
+
+        if(i < vm.displayData.length && vm.toggleExpandAll && (i+1 === vm.displayData.length || !vm.displayData[i+1].stackTrace)){
+          vm.displayData[i].selected = true;
+          let stackTraceObj = {
+            log: {
+              timestamp: vm.displayData[i].log.timestamp,
+              stackTrace: vm.displayData[i].log.stackTrace,
+            },
+            stackTrace: true
+          };
+          vm.displayData.splice(i+1, 0, stackTraceObj);
+          len++;
+        } else if(!vm.toggleExpandAll && !entry.stackTrace && i+1 < vm.displayData.length && vm.displayData[i+1].stackTrace){
+          vm.displayData[i].selected = false;
+          vm.displayData.splice(i+1, 1);
+          len--;
+        }
+      } else {
+        vm.displayData[i].selected = vm.toggleExpandAll;
+      }
+    }
+    checkForScrollbar();
+  };
+
+  vm.includeEvent = function(event, eventType){
+    if (eventType === vm.selectedLogLevel) {
+      event.preventDefault();
+      return;
+    }
+
+    vm.endRequest = false;
+
+    // reset log levels
+    vm.activeLogLevels = {
+      'ERROR' : false,
+      'WARN' : false,
+      'INFO' : false,
+      'DEBUG' : false,
+      'TRACE' : false
+    };
+
+    switch (eventType) {
+      case 'TRACE':
+        vm.activeLogLevels['TRACE'] = true;
+        /* falls through */
+      case 'DEBUG':
+        vm.activeLogLevels['DEBUG'] = true;
+        /* falls through */
+      case 'INFO':
+        vm.activeLogLevels['INFO'] = true;
+        /* falls through */
+      case 'WARN':
+        vm.activeLogLevels['WARN'] = true;
+        /* falls through */
+      case 'ERROR':
+        vm.activeLogLevels['ERROR'] = true;
+    }
+
+    // Whenever we change the log level filter, the data needs
+    // to start from scratch
+    vm.data = [];
+    vm.fromOffset = -10000 + '.' + vm.startTimeMs;
+
+    vm.selectedLogLevel = eventType;
+    startTimeRequest();
+  };
+
+  vm.renderData = () => {
+    /*
+      This function used to do the UI only filtering for log level.
+      Not sure all the different scenarios. Since the log level filter
+      now comes from backend, all the function needs to do now is set the
+      displayData to the data list we get from backend
+    */
+    //Clean slate
+    vm.displayData = vm.data;
+    checkForScrollbar();
+  };
+
+  vm.highlight = (text) => {
+    if(!vm.searchText || (vm.searchText && !vm.searchText.length)){
+     return $sce.trustAsHtml(text);
+    }
+
+    return $sce.trustAsHtml(
+      text.replace(new RegExp(vm.searchText, 'gi'),
+      '<span class="highlighted-text">$&</span>'
+    ));
+  };
+
+  function offsetScroll() {
+    let logsTableContainer = document.getElementsByClassName('logs-table-body');
+
+    if (logsTableContainer && Array.isArray(logsTableContainer)) {
+      // Offset the scroll by a tiny margin to stop the infinite scroll to
+      // fire repeatedly
+      logsTableContainer[0].scrollTop = logsTableContainer[0].scrollTop - 15;
+    }
+  }
+
+  vm.scrollFn = _.throttle(function() {
+    if (vm.loading || vm.endRequest) { return; }
+    offsetScroll();
+    requestWithOffset();
+  }, 500);
+
+  vm.preventClick = function (event) {
+    // disabled is not a valid attribute for <a>
+    if (!vm.displayData.length || vm.loading) {
+      event.preventDefault();
+    }
+  };
+
+  function checkForScrollbar() {
+    // has to do timeout here for Firefox
+    timeout = $timeout(function(){
+      let tbodyEl = angular.element(document.querySelector('.logs-table-body'))[0];
+      if (tbodyEl.clientHeight < tbodyEl.scrollHeight) {
+        let bodyRowEl = angular.element(document.querySelector('.logs-table-body tr'))[0];
+        vm.headerRowStyle = {
+          width: bodyRowEl.offsetWidth + 'px'
+        };
+      } else {
+        vm.headerRowStyle = {};
+      }
+    }, 100);
+  }
+
+  // This is only for users who have their scrollbar preferences set to always show.
+  // When the user resizes the browser, a scrollbar over the entire browser will appear
+  // for about a second after the user stops resizing, then disappear, which will cause
+  // the width of the inner elements to change. This $watch is to handle showing the
+  // correct header width when that happens.
+  $scope.$watch(function() {
+    return angular.element(document.querySelector('.logs-table-body tr'))[0].offsetWidth;
+  }, function(newValue, oldValue) {
+    // different browsers have different width for the scrollbar
+    if (newValue >= oldValue + 15 && newValue <= oldValue + 20) {
+      vm.headerRowStyle = {
+        width: newValue + 'px'
+      };
+    } else {
+      vm.headerRowStyle = {};
+    }
+  });
+
+  $scope.$on('$destroy', function() {
+    if (unsub) {
+      unsub();
+    }
+    if (timeout) {
+      $timeout.cancel(timeout);
+    }
+    angular.element($window).unbind('resize', checkForScrollbar);
+    LogViewerStore.dispatch({
+      type: 'RESET'
+    });
+    if(pollPromise){
+      dataSrc.stopPoll(pollPromise.__pollId__);
+      pollPromise = null;
+    }
+  });
+}
+
+const link = (scope) => {
+  scope.tableEl = document.getElementsByClassName('logs-table-body');
+};
+
+angular.module(PKG.name + '.commons')
+  .value('THROTTLE_MILLISECONDS', 250) // throttle infinite scroll
+  .directive('myLogViewerPreview', function () {
+    return {
+      templateUrl: 'log-viewer-preview/log-viewer-preview.html',
+      controller: LogViewerPreviewController,
+      controllerAs: 'LogViewerPreview',
+      scope: {
+        displayOptions: '=?',
+        namespaceId: '@',
+        previewId: '@',
+        getDownloadFilename: '&',
+        entityName: '@'
+      },
+      link: link,
+      bindToController: true
+    };
+  });

--- a/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.js
+++ b/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.js
@@ -40,7 +40,7 @@ function LogViewerPreviewController ($scope, $window, LogViewerStore, myPreviewL
     }
 
     switch(status){
-      case 'fNING':
+      case 'RUNNING':
       case 'STARTED':
         vm.statusType = 0;
         break;
@@ -378,7 +378,7 @@ function LogViewerPreviewController ($scope, $window, LogViewerStore, myPreviewL
           }
         });
         vm.setProgramMetadata(statusRes.status);
-        if(vm.statusType === 0 || vm.statusType === 3){
+        if(vm.statusType === 0){
           if (!pollPromise) {
             pollForNewLogs();
           }

--- a/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.js
+++ b/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.js
@@ -378,7 +378,7 @@ function LogViewerPreviewController ($scope, $window, LogViewerStore, myPreviewL
           }
         });
         vm.setProgramMetadata(statusRes.status);
-        if(vm.statusType === 0){
+        if(vm.statusType === 0 || vm.statusType === 3){
           if (!pollPromise) {
             pollForNewLogs();
           }

--- a/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.js
+++ b/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.js
@@ -135,19 +135,6 @@ function LogViewerPreviewController ($scope, $window, LogViewerStore, myPreviewL
     if (vm.data.length > 0) {
       return;
     }
-    // if (vm.logStartTime === logViewerState.startTime){
-    //   return;
-    // }
-
-    // vm.logStartTime = logViewerState.startTime;
-
-    // if (!vm.logStartTime || vm.startTimeMs === vm.logStartTime){
-    //   return;
-    // }
-
-    // vm.startTimeMs = (vm.logStartTime instanceof Date) ? vm.logStartTime.getTime() : vm.logStartTime;
-
-    // vm.fromOffset = -10000 + '.' + vm.startTimeMs;
 
     vm.endRequest = false;
     startTimeRequest();
@@ -447,8 +434,7 @@ function LogViewerPreviewController ($scope, $window, LogViewerStore, myPreviewL
   vm.getDownloadUrl = (type = 'download') => {
 
     // Generate backend path
-    let startTime = Math.floor(vm.startTimeMs/1000);
-    let path = `/namespaces/${vm.namespaceId}/previews/${vm.previewId}/logs?start=${startTime}&escape=false`;
+    let path = `/namespaces/${vm.namespaceId}/previews/${vm.previewId}/logs?&escape=false`;
     path = encodeURIComponent(myCdapUrl.constructUrl({_cdapPath: path}));
 
     let url = `/downloadLogs?backendUrl=${path}&type=${type}`;
@@ -457,9 +443,9 @@ function LogViewerPreviewController ($scope, $window, LogViewerStore, myPreviewL
       // Generate filename
       let filename = '';
       if ('undefined' !== typeof this.getDownloadFilename()) {
-        filename = this.getDownloadFilename() + '-' + formatDate(new Date(this.startTimeMs), true);
+        filename = this.getDownloadFilename();
       } else {
-         filename = this.namespaceId + '-' + this.previewId + formatDate(new Date(this.startTimeMs), true);
+         filename = this.namespaceId + '-' + this.previewId;
       }
 
       url = `${url}&filename=${filename}.log`;
@@ -509,7 +495,7 @@ function LogViewerPreviewController ($scope, $window, LogViewerStore, myPreviewL
           return;
         }
 
-        // vm.fromOffset = res[res.length-1].offset;
+        vm.fromOffset = res[res.length-1].offset;
         vm.displayData = [];
 
         angular.forEach(res, (element, index) => {
@@ -534,31 +520,6 @@ function LogViewerPreviewController ($scope, $window, LogViewerStore, myPreviewL
         vm.errorRetrievingLogs = true;
         console.log('ERROR: ', err);
       });
-  }
-
-  function formatDate(date, isDownload) {
-    let dateObj = {
-      month: date.getMonth() + 1,
-      day: date.getDate(),
-      year: date.getFullYear(),
-      hours: date.getHours(),
-      minutes: date.getMinutes(),
-      seconds: date.getSeconds()
-    };
-
-    angular.forEach(dateObj, (value, key) => {
-      if(value < 10){
-        dateObj[key] = '0' + value;
-      } else {
-        dateObj[key] = value.toString();
-      }
-    });
-
-    if(isDownload){
-      return dateObj.year + dateObj.day + dateObj.month + dateObj.hours + dateObj.minutes + dateObj.seconds;
-    }
-
-    return dateObj.month + '/' + dateObj.day + '/' + dateObj.year + ' ' + dateObj.hours + ':' + dateObj.minutes + ':' + dateObj.seconds;
   }
 
   vm.toggleLogExpansion = function() {
@@ -629,7 +590,7 @@ function LogViewerPreviewController ($scope, $window, LogViewerStore, myPreviewL
     // Whenever we change the log level filter, the data needs
     // to start from scratch
     vm.data = [];
-    vm.fromOffset = -10000 + '.' + vm.startTimeMs;
+    // vm.fromOffset = -10000 + '.' + vm.startTimeMs;
 
     vm.selectedLogLevel = eventType;
     startTimeRequest();

--- a/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.js
+++ b/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.js
@@ -644,7 +644,7 @@ function LogViewerPreviewController ($scope, $window, LogViewerStore, myPreviewL
     // has to do timeout here for Firefox
     timeout = $timeout(function(){
       let tbodyEl = angular.element(document.querySelector('.logs-table-body'))[0];
-      if (tbodyEl.clientHeight < tbodyEl.scrollHeight) {
+      if (tbodyEl && tbodyEl.clientHeight < tbodyEl.scrollHeight) {
         let bodyRowEl = angular.element(document.querySelector('.logs-table-body tr'))[0];
         vm.headerRowStyle = {
           width: bodyRowEl.offsetWidth + 'px'

--- a/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.js
+++ b/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.js
@@ -132,7 +132,7 @@ function LogViewerPreviewController ($scope, $window, LogViewerStore, myPreviewL
 
     vm.fullScreen = logViewerState.fullScreen;
 
-    if (vm.data.length > 0) {
+    if (vm.startedTimeRequest) {
       return;
     }
 
@@ -472,23 +472,21 @@ function LogViewerPreviewController ($scope, $window, LogViewerStore, myPreviewL
     // binds window element to check whether scrollbar has appeared on resize event
     angular.element($window).bind('resize', checkForScrollbar);
 
-    // myPreviewLogsApi.nextLogsJsonOffset({
     myPreviewLogsApi.nextLogsJson({
       namespace : vm.namespaceId,
       previewId : vm.previewId,
-      // fromOffset: vm.fromOffset,
       filter: `loglevel=${vm.selectedLogLevel}`
     }).$promise.then(
       (res) => {
         vm.errorRetrievingLogs = false;
         vm.loading = false;
         vm.data = res;
+        vm.startedTimeRequest = true;
 
         if(res.length === 0){
           //Update with start-time
           getStatus();
           if(vm.statusType !== 0){
-            // vm.loading = false;
             vm.displayData = [];
           }
           vm.renderData();

--- a/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.less
+++ b/cdap-ui/app/directives/log-viewer-preview/log-viewer-preview.less
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#app-container {
+  .canvas-wrapper {
+    .top-panel {
+      .pipeline-settings {
+        &.pipeline-logs-section {
+          left: 0;
+          max-width: initial;
+          max-height: initial;
+
+          my-log-viewer-preview {
+            .logs-headerbar {
+              .fa-expand {
+                display: none;
+              }
+            }
+            .logs-table {
+              height: ~"calc(100vh - 192px)";
+              height: ~"-moz-calc(100vh - 192px)";
+              height: ~"-webkit-calc(100vh - 192px)";
+
+              tbody {
+                /* 46px: height of logs table headers */
+                height: ~"calc(100vh - 192px - 46px)";
+                height: ~"-moz-calc(100vh - 192px - 46px)";
+                height: ~"-webkit-calc(100vh - 192px - 46px)";
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/cdap-ui/app/directives/log-viewer/log-viewer.html
+++ b/cdap-ui/app/directives/log-viewer/log-viewer.html
@@ -189,13 +189,13 @@
             <div class="well well-sm text-center"
                  ng-if="!LogViewer.errorRetrievingLogs && !LogViewer.loading && !LogViewer.displayData.length && LogViewer.statusType !== 0">
               <h4>
-                No logs to display.
+                There are no logs yet to display.
               </h4>
             </div>
             <div class="well well-sm text-center"
                  ng-if="LogViewer.errorRetrievingLogs && !LogViewer.loading">
               <h4>
-                Error Retrieving Logs.
+                Unable to retrieve logs.
               </h4>
             </div>
             <div class="well well-sm text-center"

--- a/cdap-ui/app/directives/log-viewer/log-viewer.js
+++ b/cdap-ui/app/directives/log-viewer/log-viewer.js
@@ -698,7 +698,7 @@ function LogViewerController ($scope, $window, LogViewerStore, myLogsApi, LOGVIE
     // has to do timeout here for Firefox
     timeout = $timeout(function(){
       let tbodyEl = angular.element(document.querySelector('.logs-table-body'))[0];
-      if (tbodyEl.clientHeight < tbodyEl.scrollHeight) {
+      if (tbodyEl && tbodyEl.clientHeight < tbodyEl.scrollHeight) {
         let bodyRowEl = angular.element(document.querySelector('.logs-table-body tr'))[0];
         vm.headerRowStyle = {
           width: bodyRowEl.offsetWidth + 'px'

--- a/cdap-ui/app/directives/log-viewer/log-viewer.less
+++ b/cdap-ui/app/directives/log-viewer/log-viewer.less
@@ -129,7 +129,8 @@ body {
   }
 }
 
-my-log-viewer {
+my-log-viewer,
+my-log-viewer-preview {
   .empty-buffer {
     display: none;
   }

--- a/cdap-ui/app/directives/log-viewer/log-viewer.less
+++ b/cdap-ui/app/directives/log-viewer/log-viewer.less
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -37,6 +37,7 @@ class HydratorPlusPlusTopPanelCtrl {
     this.myAlertOnValium = myAlertOnValium;
     this.currentPreviewId = null;
     this.showRunTimeArguments = false;
+    this.viewLogs = false;
     // This is for now run time arguments. It will be a map of macroMap
     // in the future once we get list of macros for a pipeline config.
     this.macrosMap = {};
@@ -261,6 +262,7 @@ class HydratorPlusPlusTopPanelCtrl {
 
     this.myPipelineApi.runPreview(params, pipelineConfig).$promise
       .then((res) => {
+        console.log(res);
         this.previewStore.dispatch(
           this.previewActions.setPreviewId(res.application)
         );

--- a/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -289,9 +289,8 @@ class HydratorPlusPlusTopPanelCtrl {
           this.previewActions.setPreviewStartTime(startTime)
         );
         this.currentPreviewId = res.application;
-        if (this.$window.localStorage.getItem('LastDraftId') === this.HydratorPlusPlusConfigStore.getDraftId()) {
-          this.$window.localStorage.setItem('LastPreviewId', this.currentPreviewId);
-        }
+        this.$window.localStorage.setItem('LastDraftId', this.HydratorPlusPlusConfigStore.getDraftId());
+        this.$window.localStorage.setItem('LastPreviewId', this.currentPreviewId);
         this.startPollPreviewStatus(res.application);
       }, (err) => {
         this.previewLoading = false;

--- a/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -52,12 +52,9 @@ class HydratorPlusPlusTopPanelCtrl {
       this.openMetadata();
     }
 
-    if (this.HydratorPlusPlusConfigStore.getDraftId()) {
-      if (this.HydratorPlusPlusConfigStore.getDraftId() === this.$window.localStorage.getItem('LastDraftId')) {
-        this.currentPreviewId = this.$window.localStorage.getItem('LastPreviewId');
-      } else {
-        this.$window.localStorage.setItem('LastDraftId', this.HydratorPlusPlusConfigStore.getDraftId());
-      }
+    this.currentDraftId = this.HydratorPlusPlusConfigStore.getDraftId();
+    if (this.currentDraftId && this.currentDraftId === this.$window.localStorage.getItem('LastDraftId')) {
+      this.currentPreviewId = this.$window.localStorage.getItem('LastPreviewId');
     }
 
     this.isPreviewEnabled = angular.isObject(MY_CONFIG.hydrator) &&

--- a/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -46,6 +46,7 @@ class HydratorPlusPlusTopPanelCtrl {
     this.setState();
     this.HydratorPlusPlusConfigStore.registerOnChangeListener(this.setState.bind(this));
     this.focusTimeout = null;
+    this.timeoutInMinutes = 15;
 
     if ($stateParams.isClone) {
       this.openMetadata();
@@ -254,7 +255,7 @@ class HydratorPlusPlusTopPanelCtrl {
         'realDatasets' :[],
         'programName' : 'DataStreamsSparkStreaming',
         'programType': 'Spark',
-        'timeout': '15'
+        'timeout': this.timeoutInMinutes
       });
     }
     // Get start stages and end stages

--- a/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -51,8 +51,12 @@ class HydratorPlusPlusTopPanelCtrl {
       this.openMetadata();
     }
 
-    if (this.$window.localStorage.getItem('LastDraftId') === this.HydratorPlusPlusConfigStore.getDraftId()) {
-      this.currentPreviewId = this.$window.localStorage.getItem('LastPreviewId');
+    if (this.HydratorPlusPlusConfigStore.getDraftId()) {
+      if (this.HydratorPlusPlusConfigStore.getDraftId() === this.$window.localStorage.getItem('LastDraftId')) {
+        this.currentPreviewId = this.$window.localStorage.getItem('LastPreviewId');
+      } else {
+        this.$window.localStorage.setItem('LastDraftId', this.HydratorPlusPlusConfigStore.getDraftId());
+      }
     }
 
     this.isPreviewEnabled = angular.isObject(MY_CONFIG.hydrator) &&

--- a/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -253,7 +253,8 @@ class HydratorPlusPlusTopPanelCtrl {
       pipelineConfig.preview = Object.assign({}, previewConfig, {
         'realDatasets' :[],
         'programName' : 'DataStreamsSparkStreaming',
-        'programType': 'Spark'
+        'programType': 'Spark',
+        'timeout': '15'
       });
     }
     // Get start stages and end stages

--- a/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -216,6 +216,7 @@ class HydratorPlusPlusTopPanelCtrl {
   }
   runPreview() {
     this.previewLoading = true;
+    this.loadingLabel = 'Starting';
     this.showRunTimeArguments = false;
 
     this.displayDuration = {
@@ -312,6 +313,7 @@ class HydratorPlusPlusTopPanelCtrl {
       previewId: this.currentPreviewId
     };
     this.previewLoading = true;
+    this.loadingLabel = 'Stopping';
     this.stopTimer();
     this.myPipelineApi
         .stopPreview(params, {})

--- a/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -51,6 +51,10 @@ class HydratorPlusPlusTopPanelCtrl {
       this.openMetadata();
     }
 
+    if (this.$window.localStorage.getItem('LastDraftId') === this.HydratorPlusPlusConfigStore.getDraftId()) {
+      this.currentPreviewId = this.$window.localStorage.getItem('LastPreviewId');
+    }
+
     this.isPreviewEnabled = angular.isObject(MY_CONFIG.hydrator) &&
                             MY_CONFIG.hydrator.previewEnabled === true;
 
@@ -147,6 +151,8 @@ class HydratorPlusPlusTopPanelCtrl {
   onSaveDraft() {
     this.HydratorPlusPlusConfigActions.saveAsDraft();
     this.checkNameError();
+    this.$window.localStorage.setItem('LastDraftId', this.HydratorPlusPlusConfigStore.getDraftId());
+    this.$window.localStorage.setItem('LastPreviewId', this.currentPreviewId);
   }
   checkNameError() {
     let messages = this.consoleStore.getMessages() || [];
@@ -279,6 +285,9 @@ class HydratorPlusPlusTopPanelCtrl {
           this.previewActions.setPreviewStartTime(startTime)
         );
         this.currentPreviewId = res.application;
+        if (this.$window.localStorage.getItem('LastDraftId') === this.HydratorPlusPlusConfigStore.getDraftId()) {
+          this.$window.localStorage.setItem('LastPreviewId', this.currentPreviewId);
+        }
         this.startPollPreviewStatus(res.application);
       }, (err) => {
         this.previewLoading = false;

--- a/cdap-ui/app/hydrator/templates/create/toppanel.html
+++ b/cdap-ui/app/hydrator/templates/create/toppanel.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright © 2015 Cask Data, Inc.
+  Copyright © 2015-2017 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -143,6 +143,12 @@
         {{ HydratorPlusPlusTopPanelCtrl.displayDuration.minutes }}:{{ HydratorPlusPlusTopPanelCtrl.displayDuration.seconds }}
       </span>
     </div>
+    <div class="btn log-viewer"
+         ng-class="{'btn-select': HydratorPlusPlusTopPanelCtrl.viewLogs}"
+         ng-click="HydratorPlusPlusTopPanelCtrl.viewLogs = !HydratorPlusPlusTopPanelCtrl.viewLogs">
+      <span class="fa fa-file-text-o"></span>
+      <div class="button-label">Logs</div>
+    </div>
     <div class="pipeline-run-section text-left" ng-if="HydratorPlusPlusTopPanelCtrl.showRunTimeArguments">
       <h5>
         <strong>Runtime Arguments</strong>
@@ -155,8 +161,6 @@
       </div>
       <div class="clearfix">
         <div class="pull-right">
-
-
           <button class="btn btn-blue"
             ng-click="HydratorPlusPlusTopPanelCtrl.runPreview()">
             Start Now
@@ -181,3 +185,11 @@
     my-pipeline-settings>
   </div>
 </div>
+<div class="pipeline-settings pipeline-logs-section" ng-if="HydratorPlusPlusTopPanelCtrl.viewLogs">
+  <my-log-viewer-preview
+    namespace-id="{{HydratorPlusPlusTopPanelCtrl.$state.params.namespace}}"
+    preview-id="{{HydratorPlusPlusTopPanelCtrl.currentPreviewId}}"
+    entity-name="{{HydratorPlusPlusTopPanelCtrl.state.metadata['name']}}">
+  </my-log-viewer-preview>
+</div>
+

--- a/cdap-ui/app/hydrator/templates/create/toppanel.html
+++ b/cdap-ui/app/hydrator/templates/create/toppanel.html
@@ -124,24 +124,29 @@
             ng-if="!HydratorPlusPlusTopPanelCtrl.previewLoading && !HydratorPlusPlusTopPanelCtrl.previewRunning">
       </span>
       <div class="button-label"
-           ng-if="!HydratorPlusPlusTopPanelCtrl.previewLoading && !HydratorPlusPlusTopPanelCtrl.previewRunning">Start</div>
-
+           ng-if="!HydratorPlusPlusTopPanelCtrl.previewLoading && !HydratorPlusPlusTopPanelCtrl.previewRunning">
+           Start
+      </div>
       <span class="fa fa-stop text-danger"
             ng-if="!HydratorPlusPlusTopPanelCtrl.previewLoading && HydratorPlusPlusTopPanelCtrl.previewRunning">
       </span>
       <div class="button-label"
-           ng-if="!HydratorPlusPlusTopPanelCtrl.previewLoading && HydratorPlusPlusTopPanelCtrl.previewRunning">Stop</div>
-
+           ng-if="!HydratorPlusPlusTopPanelCtrl.previewLoading && HydratorPlusPlusTopPanelCtrl.previewRunning">
+           Stop
+      </div>
       <span ng-if="HydratorPlusPlusTopPanelCtrl.previewLoading">
         <span class="fa fa-refresh fa-spin"></span>
       </span>
       <div class="button-label"
-           ng-if="HydratorPlusPlusTopPanelCtrl.previewLoading">Starting</div>
+           ng-if="HydratorPlusPlusTopPanelCtrl.previewLoading">
+           Starting
+      </div>
     </div>
     <div class="btn run-time">
       <span>
         {{ HydratorPlusPlusTopPanelCtrl.displayDuration.minutes }}:{{ HydratorPlusPlusTopPanelCtrl.displayDuration.seconds }}
       </span>
+      <div class="button-label">Duration</div>
     </div>
     <div class="btn log-viewer"
          ng-class="{'btn-select': HydratorPlusPlusTopPanelCtrl.viewLogs}"
@@ -173,8 +178,11 @@
   <cask-resource-center-button></cask-resource-center-button>
 </div>
 <div class="pipeline-settings-backdrop"
-     ng-if="HydratorPlusPlusTopPanelCtrl.state.viewSettings || HydratorPlusPlusTopPanelCtrl.showRunTimeArguments"
-     ng-click="HydratorPlusPlusTopPanelCtrl.state.viewSettings = HydratorPlusPlusTopPanelCtrl.showRunTimeArguments = false"></div>
+     ng-if="HydratorPlusPlusTopPanelCtrl.state.viewSettings ||
+     HydratorPlusPlusTopPanelCtrl.viewLogs"
+     ng-click="HydratorPlusPlusTopPanelCtrl.state.viewSettings =
+     HydratorPlusPlusTopPanelCtrl.viewLogs = false">
+</div>
 <div class="pipeline-settings">
   <div
     store="HydratorPlusPlusTopPanelCtrl.HydratorPlusPlusConfigStore"

--- a/cdap-ui/app/hydrator/templates/create/toppanel.html
+++ b/cdap-ui/app/hydrator/templates/create/toppanel.html
@@ -154,34 +154,17 @@
       <span class="fa fa-file-text-o"></span>
       <div class="button-label">Logs</div>
     </div>
-    <div class="pipeline-run-section text-left" ng-if="HydratorPlusPlusTopPanelCtrl.showRunTimeArguments">
-      <h5>
-        <strong>Runtime Arguments</strong>
-      </h5>
-      <div class="arguments-container">
-        <key-value-widget
-          ng-model="HydratorPlusPlusTopPanelCtrl.macrosMap"
-          data-config="HydratorPlusPlusTopPanelCtrl.runTimeWidgetConfig"
-        ></key-value-widget>
-      </div>
-      <div class="clearfix">
-        <div class="pull-right">
-          <button class="btn btn-blue"
-            ng-click="HydratorPlusPlusTopPanelCtrl.runPreview()">
-            Start Now
-          </button>
-        </div>
-      </div>
-    </div>
   </div>
 
   <cask-resource-center-button></cask-resource-center-button>
 </div>
 <div class="pipeline-settings-backdrop"
      ng-if="HydratorPlusPlusTopPanelCtrl.state.viewSettings ||
-     HydratorPlusPlusTopPanelCtrl.viewLogs"
+     HydratorPlusPlusTopPanelCtrl.viewLogs ||
+     HydratorPlusPlusTopPanelCtrl.showRunTimeArguments"
      ng-click="HydratorPlusPlusTopPanelCtrl.state.viewSettings =
-     HydratorPlusPlusTopPanelCtrl.viewLogs = false">
+     HydratorPlusPlusTopPanelCtrl.viewLogs =
+     HydratorPlusPlusTopPanelCtrl.showRunTimeArguments = false">
 </div>
 <div class="pipeline-settings">
   <div
@@ -191,6 +174,25 @@
     is-disabled="false"
     template-type="{{HydratorPlusPlusTopPanelCtrl.state.artifact.name}}"
     my-pipeline-settings>
+  </div>
+</div>
+<div class="pipeline-run-section text-left" ng-if="HydratorPlusPlusTopPanelCtrl.showRunTimeArguments">
+  <h5>
+    <strong>Runtime Arguments</strong>
+  </h5>
+  <div class="arguments-container">
+    <key-value-widget
+      ng-model="HydratorPlusPlusTopPanelCtrl.macrosMap"
+      data-config="HydratorPlusPlusTopPanelCtrl.runTimeWidgetConfig"
+    ></key-value-widget>
+  </div>
+  <div class="clearfix">
+    <div class="pull-right">
+      <button class="btn btn-blue"
+        ng-click="HydratorPlusPlusTopPanelCtrl.runPreview()">
+        Start Now
+      </button>
+    </div>
   </div>
 </div>
 <div class="pipeline-settings pipeline-logs-section" ng-if="HydratorPlusPlusTopPanelCtrl.viewLogs">

--- a/cdap-ui/app/hydrator/templates/create/toppanel.html
+++ b/cdap-ui/app/hydrator/templates/create/toppanel.html
@@ -120,7 +120,7 @@
     <div class="btn"
          ng-click="!HydratorPlusPlusTopPanelCtrl.previewLoading && HydratorPlusPlusTopPanelCtrl.toggleRuntimeArguments()"
          ng-disabled="HydratorPlusPlusTopPanelCtrl.previewLoading">
-      <span class="fa fa-play"
+      <span class="fa fa-play text-success"
             ng-if="!HydratorPlusPlusTopPanelCtrl.previewLoading && !HydratorPlusPlusTopPanelCtrl.previewRunning">
       </span>
       <div class="button-label"
@@ -139,7 +139,7 @@
       </span>
       <div class="button-label"
            ng-if="HydratorPlusPlusTopPanelCtrl.previewLoading">
-           Starting
+           {{HydratorPlusPlusTopPanelCtrl.loadingLabel}}
       </div>
     </div>
     <div class="btn run-time">

--- a/cdap-ui/app/hydrator/toppanel.less
+++ b/cdap-ui/app/hydrator/toppanel.less
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-ui/app/hydrator/toppanel.less
+++ b/cdap-ui/app/hydrator/toppanel.less
@@ -99,10 +99,11 @@ body.theme-cdap {
 
         &.run-time {
           cursor: default;
-          color: @hydrator-blue;
-          font-size: 20px;
-          font-weight: 500;
-          height: 43px;
+          > span {
+            font-size: 18px;
+            font-weight: 500;
+            color: @hydrator-blue;
+          }
           &:hover { background-color: white; }
           &:active,
           &:focus {
@@ -260,9 +261,6 @@ body.theme-cdap {
       left: 130px;
       transition: all 0.2s ease;
       display: flex;
-    }
-    .pipeline-settings-backdrop {
-      z-index: 998;
     }
     .side-panel.top {
       .pipeline-run-section {

--- a/cdap-ui/app/hydrator/toppanel.less
+++ b/cdap-ui/app/hydrator/toppanel.less
@@ -263,62 +263,6 @@ body.theme-cdap {
       display: flex;
     }
     .side-panel.top {
-      .pipeline-run-section {
-        position: absolute;
-        left: -609px;
-        top: 43px;
-        background: #ebebeb;
-        width: 700px;
-        z-index: 1000;
-        box-shadow: 0 7px 7px rgba(0,0,0,.1),0 19px 59px rgba(0,0,0,.2);
-        .macro-error-container { width: 70%; }
-
-        h5 {
-          margin: 10px 10px 0;
-        }
-        .arguments-container {
-          padding: 10px;
-          width: 100%;
-          // This is 100vh - (header (90px) + footer (43px) + Run time arguments title (36px) + Startnow/Schedule buttons (42px))
-          max-height: ~"calc(100vh - 216px)";
-          max-height: ~"-moz-calc(100vh - 216px)";
-          max-height: ~"-webkit-calc(100vh - 216px)";
-          overflow-y: auto;
-          overflow-x: hidden;
-          // FIXME: Everything below. What follows is a custom styling for hydrator
-          // key-value widget was specifically meant for hydrator plugin configuration
-          // Tweaking it for run configuration is messy. Either fix keyvalue to occupy
-          // max space available or build a new widget for hydrator run configuration.
-          key-value-widget {
-            .key-val-directive-container {
-              padding: 0;
-              border: 0;
-              .row {
-                margin: 5px 0;
-                input.form-control {
-                  height: 28px;
-                  padding-top: 5px;
-                  &:first-child { width: 30%; }
-                  &:nth-child(2) { width: 69%; }
-                }
-                .col-xs-10.col-lg-8 {
-                  padding: 0;
-                  width: ~"calc(100% - 60px)";
-                  width: ~"-webkit-calc(100% - 60px)";
-                  width: ~"-moz-calc(100% - 60px)";
-                }
-                .col-xs-2.col-lg-4 {
-                  padding: 0;
-                  width: 60px;
-                }
-              }
-              .btn.btn-danger,
-              .btn.btn-info { padding: 5px; }
-            }
-          }
-        }
-        .clearfix { padding: 10px; }
-      }
       div.hydrator-metadata {
         flex-wrap: wrap;
         display: flex;
@@ -749,5 +693,61 @@ body.theme-cdap {
         }
       }
     }
+  }
+  .pipeline-run-section {
+    position: absolute;
+    left: 349px;
+    top: 92px;
+    background: #ebebeb;
+    width: 700px;
+    z-index: 1000;
+    box-shadow: 0 7px 7px rgba(0,0,0,.1),0 19px 59px rgba(0,0,0,.2);
+    .macro-error-container { width: 70%; }
+
+    h5 {
+      margin: 10px 10px 0;
+    }
+    .arguments-container {
+      padding: 10px;
+      width: 100%;
+      // This is 100vh - (header (90px) + footer (43px) + Run time arguments title (36px) + Startnow/Schedule buttons (42px))
+      max-height: ~"calc(100vh - 216px)";
+      max-height: ~"-moz-calc(100vh - 216px)";
+      max-height: ~"-webkit-calc(100vh - 216px)";
+      overflow-y: auto;
+      overflow-x: hidden;
+      // FIXME: Everything below. What follows is a custom styling for hydrator
+      // key-value widget was specifically meant for hydrator plugin configuration
+      // Tweaking it for run configuration is messy. Either fix keyvalue to occupy
+      // max space available or build a new widget for hydrator run configuration.
+      key-value-widget {
+        .key-val-directive-container {
+          padding: 0;
+          border: 0;
+          .row {
+            margin: 5px 0;
+            input.form-control {
+              height: 28px;
+              padding-top: 5px;
+              &:first-child { width: 30%; }
+              &:nth-child(2) { width: 69%; }
+            }
+            .col-xs-10.col-lg-8 {
+              padding: 0;
+              width: ~"calc(100% - 60px)";
+              width: ~"-webkit-calc(100% - 60px)";
+              width: ~"-moz-calc(100% - 60px)";
+            }
+            .col-xs-2.col-lg-4 {
+              padding: 0;
+              width: 60px;
+            }
+          }
+          .btn.btn-danger,
+          .btn.btn-info { padding: 5px; }
+        }
+      }
+    }
+    .clearfix { padding: 10px; }
   }
 }

--- a/cdap-ui/app/services/logsApi/my-preview-logs-api.js
+++ b/cdap-ui/app/services/logsApi/my-preview-logs-api.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+angular.module(PKG.name + '.services')
+  .factory('myPreviewLogsApi', function(myCdapUrl, $resource, myAuth, myHelpers) {
+
+    var url = myCdapUrl.constructUrl,
+        basepath = '/namespaces/:namespace/previews/:previewId',
+        logsPath = basepath + '/logs?';
+
+    return $resource(
+      url({ _cdapPath: basepath }),
+    {
+      namespace: '@namespace',
+      previewId: '@previewId',
+      start: '@start',
+      stop: '@stop',
+      fromOffset: '@fromOffset'
+    },
+    {
+      getLogs: myHelpers.getConfig('GET', 'REQUEST', basepath + '/logs', true),
+      getLogsStartAsJson: myHelpers.getConfig('GET', 'REQUEST', logsPath + 'format=json&max=100&start=:start', true),
+
+      getLogsStartAsRaw: myHelpers.getConfig('GET', 'REQUEST', logsPath + 'start=:start', false, {
+        interceptor: {
+          // This is very lame. ngResource by default considers EVERYTHING as json and converts plain string to JSON
+          // Thank you angular, $resource
+          response: function(data) {
+            return data.data;
+          }
+        }
+      }),
+
+      getLogsStatus: myHelpers.getConfig('GET', 'REQUEST', basepath + '/status', false),
+      nextLogs: myHelpers.getConfig('GET', 'REQUEST', basepath + '/logs/next', true),
+      nextLogsJson: myHelpers.getConfig('GET', 'REQUEST', basepath + '/logs/next?format=json', true),
+      nextLogsJsonOffset: myHelpers.getConfig('GET', 'REQUEST', basepath + '/logs/next?format=json&max=100&fromOffset=:fromOffset', true),
+      prevLogs: myHelpers.getConfig('GET', 'REQUEST', basepath + '/logs/prev', true),
+      prevLogsJson: myHelpers.getConfig('GET', 'REQUEST', basepath + '/logs/prev?format=json', true),
+    });
+  });


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/HYDRATOR-1316

Current approach clones the existing `log-viewer.html`, `log-viewer.js`, and `my-logs-api.js` and modifies the copies to be appropriate for preview logs. Didn't want to refactor these components just yet because we didn't want to cause regressions in the behavior of the current logviewer, and also because preview logs are implemented slightly differently in the backend than other logs.

Also this logviewer doesn't have the timeline component yet, since we don't have metrics for each preview run. This is currently being worked on in the backend.