### PR TITLE
(CDAP-8980) Use the same defining class loader for all classes in Spark

### DIFF
--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/ClassRewriter.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/ClassRewriter.java
@@ -18,11 +18,21 @@ package co.cask.cdap.common.lang;
 
 import java.io.IOException;
 import java.io.InputStream;
+import javax.annotation.Nullable;
 
 /**
  * Represents classes that can rewrite class bytecode.
  */
 public interface ClassRewriter {
 
+  /**
+   * Rewrites a class with the original byte code provided from the given {@link InputStream}.
+   *
+   * @param className name of the class
+   * @param input an {@link InputStream} to provide the original bytecode of the class
+   * @return the bytecode of the rewritten class or {@code null} to indicate no rewriting is needed
+   * @throws IOException if failed in rewriting the class
+   */
+  @Nullable
   byte[] rewriteClass(String className, InputStream input) throws IOException;
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/lang/InterceptableClassLoader.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/lang/InterceptableClassLoader.java
@@ -55,6 +55,11 @@ public abstract class InterceptableClassLoader extends URLClassLoader implements
     try (InputStream is = resource.openStream()) {
       byte[] bytecode = rewriteClass(name, is);
 
+      // If no rewriting is needed, just load the name normally.
+      if (bytecode == null) {
+        return super.findClass(name);
+      }
+
       // Define the package based on the class package name
       String packageName = getPackageName(name);
       if (packageName != null && getPackage(packageName) == null) {

--- a/cdap-common/src/main/java/co/cask/cdap/internal/asm/Classes.java
+++ b/cdap-common/src/main/java/co/cask/cdap/internal/asm/Classes.java
@@ -106,7 +106,7 @@ public final class Classes {
   /**
    * Rewrites methods in the given class bytecode to noop methods.
    */
-  public static byte[] rewriteMethodToNoop(final String classFile,
+  public static byte[] rewriteMethodToNoop(final String className,
                                            InputStream byteCodeStream, final Set<String> methods) throws IOException {
     ClassReader cr = new ClassReader(byteCodeStream);
     ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
@@ -122,7 +122,7 @@ public final class Classes {
 
         // We can only rewrite method that returns void
         if (!Type.getReturnType(desc).equals(Type.VOID_TYPE)) {
-          LOG.warn("Cannot patch method {} in {} due to non-void return type: {}", name, classFile, desc);
+          LOG.warn("Cannot patch method {} in {} due to non-void return type: {}", name, className, desc);
           return methodVisitor;
         }
 

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRuntimeProvider.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkProgramRuntimeProvider.java
@@ -18,11 +18,12 @@ package co.cask.cdap.app.runtime.spark;
 
 import co.cask.cdap.app.runtime.ProgramRunner;
 import co.cask.cdap.app.runtime.ProgramRuntimeProvider;
+import co.cask.cdap.app.runtime.spark.classloader.SparkRunnerClassLoader;
 import co.cask.cdap.app.runtime.spark.distributed.DistributedSparkProgramRunner;
 import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.lang.ClassLoaders;
-import co.cask.cdap.internal.lang.Fields;
+import co.cask.cdap.internal.app.runtime.spark.SparkUtils;
 import co.cask.cdap.proto.ProgramType;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -39,6 +40,8 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A {@link ProgramRuntimeProvider} that provides runtime system support for {@link ProgramType#SPARK} program.
@@ -97,7 +100,7 @@ public class SparkProgramRuntimeProvider implements ProgramRuntimeProvider {
   private synchronized ClassLoader getDistributedRunnerClassLoader() {
     try {
       if (distributedRunnerClassLoader == null) {
-        // Never needs to rewrite yarn client in Spark
+        // Never needs to rewrite yarn client in CDAP master, which is the only place using distributed program runner
         distributedRunnerClassLoader = createClassLoader(false);
       }
       return distributedRunnerClassLoader;
@@ -190,11 +193,9 @@ public class SparkProgramRuntimeProvider implements ProgramRuntimeProvider {
   private synchronized SparkRunnerClassLoader createClassLoader(boolean rewriteYarnClient) throws IOException {
     SparkRunnerClassLoader classLoader;
     if (classLoaderUrls == null) {
-      classLoader = new SparkRunnerClassLoader(getClass().getClassLoader(), rewriteYarnClient);
-      classLoaderUrls = classLoader.getURLs();
-    } else {
-      classLoader = new SparkRunnerClassLoader(classLoaderUrls, getClass().getClassLoader(), rewriteYarnClient);
+      classLoaderUrls = getSparkClassloaderURLs(getClass().getClassLoader());
     }
+    classLoader = new SparkRunnerClassLoader(classLoaderUrls, getClass().getClassLoader(), rewriteYarnClient);
 
     // CDAP-8087: Due to Scala 2.10 bug in not able to support runtime reflection from multiple threads,
     // we create the runtime mirror from this synchronized method
@@ -224,5 +225,21 @@ public class SparkProgramRuntimeProvider implements ProgramRuntimeProvider {
     }
 
     return classLoader;
+  }
+
+  /**
+   * Returns an array of URLs to be used for creation of classloader for Spark, based on the urls used by the
+   * given {@link ClassLoader}.
+   */
+  private URL[] getSparkClassloaderURLs(ClassLoader classLoader) throws IOException {
+    List<URL> urls = ClassLoaders.getClassLoaderURLs(classLoader, new ArrayList<URL>());
+
+    // If Spark classes are not available in the given ClassLoader, try to locate the Spark assembly jar
+    // This class cannot have dependency on Spark directly, hence using the class resource to discover if SparkContext
+    // is there
+    if (classLoader.getResource("org/apache/spark/SparkContext.class") == null) {
+      urls.add(SparkUtils.locateSparkAssemblyJar().toURI().toURL());
+    }
+    return urls.toArray(new URL[urls.size()]);
   }
 }

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeUtils.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/SparkRuntimeUtils.java
@@ -16,6 +16,7 @@
 
 package co.cask.cdap.app.runtime.spark;
 
+import co.cask.cdap.app.runtime.spark.classloader.SparkRunnerClassLoader;
 import co.cask.cdap.common.internal.guava.ClassPath;
 import co.cask.cdap.common.lang.ClassLoaders;
 import co.cask.cdap.common.lang.ClassPathResources;

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkContainerClassLoader.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkContainerClassLoader.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark.classloader;
+
+import co.cask.cdap.common.app.MainClassLoader;
+import com.google.common.base.Function;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import javax.annotation.Nullable;
+
+/**
+ * The {@link ClassLoader} for Spark containers in distributed mode.
+ */
+public class SparkContainerClassLoader extends MainClassLoader {
+
+  private final SparkClassRewriter sparkClassRewriter;
+
+  /**
+   * Creates a new instance for the following set of {@link URL}.
+   *
+   * @param urls the URLs from which to load classes and resources
+   * @param parent the parent classloader for delegation
+   */
+  public SparkContainerClassLoader(URL[] urls, ClassLoader parent) {
+    super(urls, parent);
+    this.sparkClassRewriter = new SparkClassRewriter(new Function<String, URL>() {
+      @Nullable
+      @Override
+      public URL apply(String resourceName) {
+        return findResource(resourceName);
+      }
+    }, false);
+  }
+
+  @Override
+  protected boolean needIntercept(String className) {
+    if (super.needIntercept(className)) {
+      return true;
+    }
+    // There are certain Spark classes that need to be rewritten in distributed mode.
+    // Just intercept all Spark classes and determine what actually needs to be rewritten
+    // in the rewrite method.
+    return className.startsWith("org.apache.spark.");
+  }
+
+  @Nullable
+  @Override
+  public byte[] rewriteClass(String className, InputStream input) throws IOException {
+    byte[] rewrittenCode = super.rewriteClass(className, input);
+
+    // If it is not a Spark class, just return
+    if (!className.startsWith("org.apache.spark.")) {
+      return rewrittenCode;
+    }
+
+    // Otherwise rewrite it using the SparkClassRewriter
+    return sparkClassRewriter.rewriteClass(className,
+                                           rewrittenCode == null ? input : new ByteArrayInputStream(rewrittenCode));
+  }
+}

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkRunnerClassLoader.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/classloader/SparkRunnerClassLoader.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.runtime.spark.classloader;
+
+import co.cask.cdap.api.spark.Spark;
+import co.cask.cdap.common.internal.guava.ClassPath;
+import co.cask.cdap.common.lang.ClassPathResources;
+import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * A special {@link ClassLoader} for defining and loading all cdap-spark-core classes and Spark classes.
+ * This {@link ClassLoader} is used for Spark execution in SDK as well as the client container in
+ * distributed mode. For Spark containers (driver and executors), the {@link SparkContainerClassLoader} is used
+ * instead.
+ *
+ * IMPORTANT: Due to discovery in CDAP-5822, don't use getResourceAsStream in this class.
+ */
+public final class SparkRunnerClassLoader extends URLClassLoader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SparkRunnerClassLoader.class);
+
+  // Set of resources that are in cdap-api. They should be loaded by the parent ClassLoader
+  private static final Set<String> API_CLASSES;
+
+  private final SparkClassRewriter rewriter;
+
+  static {
+    Set<String> apiClasses = new HashSet<>();
+    try {
+      Iterables.addAll(
+        apiClasses, Iterables.transform(
+          Iterables.filter(ClassPathResources.getClassPathResources(Spark.class.getClassLoader(), Spark.class),
+                           ClassPath.ClassInfo.class),
+          ClassPathResources.CLASS_INFO_TO_CLASS_NAME
+        )
+      );
+    } catch (IOException e) {
+      // Shouldn't happen, because Spark.class is in cdap-api and it should always be there.
+      LOG.error("Unable to find cdap-api classes.", e);
+    }
+
+    API_CLASSES = Collections.unmodifiableSet(apiClasses);
+  }
+
+  public SparkRunnerClassLoader(URL[] urls, @Nullable ClassLoader parent, boolean rewriteYarnClient) {
+    super(urls, parent);
+    this.rewriter = new SparkClassRewriter(new Function<String, URL>() {
+      @Nullable
+      @Override
+      public URL apply(String resourceName) {
+        return findResource(resourceName);
+      }
+    }, rewriteYarnClient);
+  }
+
+  @Override
+  protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+    // We won't define the class with this ClassLoader for the following classes since they should
+    // come from the parent ClassLoader
+    // cdap-api-classes
+    // Any class that is not from cdap-api-spark or cdap-spark-core
+    // Any class that is not from Spark
+    // We also need to define the org.spark-project., fastxml and akka classes in this ClassLoader
+    // to avoid reference/thread leakage due to Spark assumption on process terminating after execution
+    if (API_CLASSES.contains(name) || (!name.startsWith("co.cask.cdap.api.spark.")
+        && !name.startsWith("co.cask.cdap.app.runtime.spark.")
+        && !name.startsWith("org.apache.spark.") && !name.startsWith("org.spark-project.")
+        && !name.startsWith("com.fasterxml.jackson.module.scala.")
+        && !name.startsWith("akka.") && !name.startsWith("com.typesafe."))) {
+      return super.loadClass(name, resolve);
+    }
+
+    // If the class is already loaded, return it
+    Class<?> cls = findLoadedClass(name);
+    if (cls != null) {
+      return cls;
+    }
+
+    // Define the class with this ClassLoader
+    try (InputStream is = openResource(name.replace('.', '/') + ".class")) {
+      if (is == null) {
+        throw new ClassNotFoundException("Failed to find resource for class " + name);
+      }
+
+      byte[] byteCode = rewriter.rewriteClass(name, is);
+
+      // If no rewrite was performed, just define the class with this classloader by calling findClass.
+      if (byteCode == null) {
+        cls = findClass(name);
+      } else {
+        cls = defineClass(name, byteCode, 0, byteCode.length);
+      }
+
+      if (resolve) {
+        resolveClass(cls);
+      }
+      return cls;
+    } catch (IOException e) {
+      throw new ClassNotFoundException("Failed to read class definition for class " + name, e);
+    }
+  }
+
+  /**
+   * Returns an {@link InputStream} to the given resource or {@code null} if cannot find the given resource
+   * with this {@link ClassLoader}.
+   */
+  @Nullable
+  private InputStream openResource(String resourceName) throws IOException {
+    URL resource = findResource(resourceName);
+    return resource == null ? null : resource.openStream();
+  }
+}

--- a/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/SparkContainerLauncher.java
+++ b/cdap-spark-core/src/main/java/co/cask/cdap/app/runtime/spark/distributed/SparkContainerLauncher.java
@@ -16,9 +16,8 @@
 
 package co.cask.cdap.app.runtime.spark.distributed;
 
-import co.cask.cdap.app.runtime.spark.SparkRunnerClassLoader;
 import co.cask.cdap.app.runtime.spark.SparkRuntimeContextProvider;
-import co.cask.cdap.common.app.MainClassLoader;
+import co.cask.cdap.app.runtime.spark.classloader.SparkContainerClassLoader;
 import co.cask.cdap.common.lang.ClassLoaders;
 import co.cask.cdap.common.logging.StandardOutErrorRedirector;
 import co.cask.cdap.common.logging.common.UncaughtExceptionHandler;
@@ -31,14 +30,14 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * This class launches Spark YARN containers with classes loaded through the {@link SparkRunnerClassLoader}.
+ * This class launches Spark YARN containers with classes loaded through the {@link SparkContainerClassLoader}.
  */
 public final class SparkContainerLauncher {
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkContainerLauncher.class);
 
   /**
-   * Launches the given main class. The main class will be loaded through the {@link SparkRunnerClassLoader}.
+   * Launches the given main class. The main class will be loaded through the {@link SparkContainerClassLoader}.
    *
    * @param mainClassName the main class to launch
    * @param args arguments for the main class
@@ -65,8 +64,7 @@ public final class SparkContainerLauncher {
     // Use the extension classloader as the parent instead of the system classloader because
     // Spark classes are in the system classloader which we want to rewrite.
     URL[] classLoaderUrls = urls.toArray(new URL[urls.size()]);
-    ClassLoader classLoader = new SparkRunnerClassLoader(
-      classLoaderUrls, new MainClassLoader(classLoaderUrls, systemClassLoader.getParent()), false);
+    ClassLoader classLoader = new SparkContainerClassLoader(classLoaderUrls, systemClassLoader.getParent());
 
     // Sets the context classloader and launch the actual Spark main class.
     Thread.currentThread().setContextClassLoader(classLoader);

--- a/cdap-spark-core/src/test/java/co/cask/cdap/app/runtime/spark/classloader/SparkRunnerClassLoaderTest.java
+++ b/cdap-spark-core/src/test/java/co/cask/cdap/app/runtime/spark/classloader/SparkRunnerClassLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,8 +14,9 @@
  * the License.
  */
 
-package co.cask.cdap.app.runtime.spark;
+package co.cask.cdap.app.runtime.spark.classloader;
 
+import co.cask.cdap.app.runtime.spark.classloader.SparkRunnerClassLoader;
 import co.cask.cdap.common.lang.ClassLoaders;
 import com.google.common.io.Closeables;
 import org.junit.Test;


### PR DESCRIPTION
container for system classes.

- Separate out the Spark class rewrite logic from the SparkRunnerClassLoader
- Allow ClassRewriter.rewrite to return null
  - This allow determining if a class is actually needed to be rewritten
    after inspecting the byte code
  - The InterceptableClassLoader.needIntercept method is still needed
    as a quick check before opening the byte code to inspect
- Move SparkRunnerClassLoader into classloader package