### PR TITLE
(CDAP-9160) Fix FileSystem object leakage

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/security/TokenSecureStoreUpdater.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/security/TokenSecureStoreUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2016 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -55,6 +55,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 
 /**
  * A {@link SecureStoreUpdater} that updates all secure tokens used by the platform.
@@ -124,39 +125,54 @@ public final class TokenSecureStoreUpdater implements SecureStoreUpdater {
       return ImmutableList.of();
     }
 
-    FileSystem fileSystem = getFileSystem(locationFactory, config);
+    try (FileSystem fileSystem = getFileSystem(locationFactory, config)) {
+      if (fileSystem == null) {
+        LOG.warn("Unexpected: LocationFactory is not HDFS. Not getting delegation tokens.");
+        return ImmutableList.of();
+      }
 
-    if (fileSystem == null) {
-      LOG.warn("Unexpected: LocationFactory is not HDFS. Not getting delegation tokens.");
-      return ImmutableList.of();
+      String renewer = YarnUtils.getYarnTokenRenewer(config);
+
+      Token<?>[] tokens = fileSystem.addDelegationTokens(renewer, credentials);
+      LOG.debug("Added HDFS DelegationTokens: {}", Arrays.toString(tokens));
+
+      return tokens == null ? ImmutableList.<Token<?>>of() : ImmutableList.copyOf(tokens);
     }
-
-    String renewer = YarnUtils.getYarnTokenRenewer(config);
-
-    Token<?>[] tokens = fileSystem.addDelegationTokens(renewer, credentials);
-    LOG.debug("Added HDFS DelegationTokens: {}", Arrays.toString(tokens));
-
-    return tokens == null ? ImmutableList.<Token<?>>of() : ImmutableList.copyOf(tokens);
   }
 
   /**
-   * Gets the Hadoop FileSystem from LocationFactory.
+   * Returns a new the Hadoop FileSystem from LocationFactory.
    * TODO: copied from Twill 0.6 YarnUtils for CDAP-5350. Remove after this fix is moved to Twill.
    */
+  @Nullable
   private static FileSystem getFileSystem(LocationFactory locationFactory, Configuration config) throws IOException {
     LOG.debug("getFileSystem(): locationFactory is a {}", locationFactory.getClass());
-    if (locationFactory instanceof HDFSLocationFactory) {
-      return ((HDFSLocationFactory) locationFactory).getFileSystem();
-    }
+
     if (locationFactory instanceof ForwardingLocationFactory) {
       return getFileSystem(((ForwardingLocationFactory) locationFactory).getDelegate(), config);
     }
+
+    // This method will be ported back to Twill, hence copying the logic from Locations instead of refactoring
+    // to use a common method
+    Configuration hConf = null;
+    if (locationFactory instanceof HDFSLocationFactory) {
+      hConf = ((HDFSLocationFactory) locationFactory).getFileSystem().getConf();
+    } else if (locationFactory instanceof FileContextLocationFactory) {
+      hConf = ((FileContextLocationFactory) locationFactory).getConfiguration();
+    }
+
+    if (hConf == null) {
+      return null;
+    }
+
+    // Disable the FileSystem cache. The FileSystem will be closed when the InputStream is closed
+    String scheme = locationFactory.getHomeLocation().toURI().getScheme();
+    hConf = new Configuration(hConf);
+    hConf.set(String.format("fs.%s.impl.disable.cache", scheme), "true");
+
     // CDAP-5350: For encrypted file systems, FileContext does not acquire the KMS delegation token
     // Since we know we are in Yarn, it is safe to get the FileSystem directly, bypassing LocationFactory.
-    if (locationFactory instanceof FileContextLocationFactory) {
-      return FileSystem.get(config);
-    }
-    return null;
+    return FileSystem.get(hConf);
   }
 
   /**

--- a/cdap-common/src/main/java/co/cask/cdap/common/io/DFSSeekableInputStream.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/io/DFSSeekableInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2017 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,20 +16,18 @@
 
 package co.cask.cdap.common.io;
 
+import com.google.common.io.Closeables;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Seekable;
 import org.apache.twill.filesystem.Location;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.io.IOException;
 
 /**
  * Implementation of {@link SeekableInputStream} for {@link Location}.
  */
 final class DFSSeekableInputStream extends SeekableInputStream {
-
-  private static final Logger LOG = LoggerFactory.getLogger(DFSSeekableInputStream.class);
 
   private final Seekable seekable;
   private final StreamSizeProvider sizeProvider;
@@ -64,5 +62,16 @@ final class DFSSeekableInputStream extends SeekableInputStream {
   @Override
   public boolean seekToNewSource(long targetPos) throws IOException {
     return seekable.seekToNewSource(targetPos);
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      super.close();
+    } finally {
+      if (sizeProvider instanceof Closeable) {
+        Closeables.closeQuietly((Closeable) sizeProvider);
+      }
+    }
   }
 }

--- a/cdap-common/src/main/java/co/cask/cdap/common/kerberos/ImpersonationRequest.java
+++ b/cdap-common/src/main/java/co/cask/cdap/common/kerberos/ImpersonationRequest.java
@@ -18,6 +18,8 @@ package co.cask.cdap.common.kerberos;
 
 import co.cask.cdap.proto.id.NamespacedEntityId;
 
+import java.util.Objects;
+
 /**
  * A wrapper which wraps around the {@link co.cask.cdap.proto.id.NamespacedEntityId} on which impersonation needs to
  * be performed and the type of operation {@link ImpersonatedOpType} which will be performed.
@@ -45,5 +47,23 @@ public class ImpersonationRequest {
       "entityId=" + entityId +
       ", impersonatedOpType=" + impersonatedOpType +
       '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ImpersonationRequest that = (ImpersonationRequest) o;
+    return Objects.equals(entityId, that.entityId) &&
+      impersonatedOpType == that.impersonatedOpType;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(entityId, impersonatedOpType);
   }
 }


### PR DESCRIPTION
- The FileSystem has an internal cache from UGI to FileSystem object,
  which only gets cleanup on process shutdown. However, with impersonation,
  a lot of different UGI are created, hence causing the cache keep growing.
  The fix is to get the FileSystem object without caching and close
  it along with the input stream that associated with it.