### PR TITLE
CDAP-8979 Limit speed of echoing periods to the terminal

### DIFF
--- a/cdap-standalone/bin/cdap.bat
+++ b/cdap-standalone/bin/cdap.bat
@@ -332,6 +332,8 @@ attrib +h %~dsp0MyProg.pid >NUL
 
 :SearchLogs
 <nul (SET /p _tmp=.)
+REM Sleep for 1 seconds to prevent spinning on fast machines
+PING 127.0.0.1 -n 2 > NUL 2>&1
 findstr /R /C:".*Failed to start server.*" "%CDAP_HOME%\logs\cdap-process.log" >NUL 2>&1
 if %errorlevel% == 0 GOTO ServerError
 


### PR DESCRIPTION
Add sleep to prevent spinning on fast machines. Maximum of one period (".") echoed per second.

Part of fixing https://issues.cask.co/browse/CDAP-8979

Tested under Windows 8.1.