### PR TITLE
CDAP-9189 fix metrics count for records.in for sink in data streams p…

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/DataStreamsTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/co/cask/cdap/datastreams/DataStreamsTest.java
@@ -772,7 +772,10 @@ public class DataStreamsTest extends HydratorTestBase {
     Map<String, String> tags = ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, appId.getNamespace(),
                                                Constants.Metrics.Tag.APP, appId.getEntityName(),
                                                Constants.Metrics.Tag.SPARK, DataStreamsSparkLauncher.NAME);
-    metricsManager.waitForTotalMetricCount(tags, "user." + metric, expected, 10, TimeUnit.SECONDS);
-    metricsManager.waitForTotalMetricCount(tags, "user." + metric, expected, 10, TimeUnit.SECONDS);
+    String metricName = "user." + metric;
+    metricsManager.waitForTotalMetricCount(tags, metricName, expected, 10, TimeUnit.SECONDS);
+    metricsManager.waitForTotalMetricCount(tags, metricName, expected, 10, TimeUnit.SECONDS);
+    // wait for won't throw an exception if the metric count is greater than expected
+    Assert.assertEquals(expected, metricsManager.getTotalMetric(tags, metricName));
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/StreamingBatchSinkFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/co/cask/cdap/etl/spark/streaming/function/StreamingBatchSinkFunction.java
@@ -78,7 +78,6 @@ public class StreamingBatchSinkFunction<T> implements Function2<JavaRDD<T>, Time
       });
       isPrepared = true;
 
-      data = data.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in", null));
       sinkFactory.writeFromRDD(data.flatMapToPair(sinkFunction), sec, stageName, Object.class, Object.class);
       isDone = true;
       sec.execute(new TxRunnable() {


### PR DESCRIPTION
…ipeline
JIRA: https://issues.cask.co/browse/CDAP-9189
Build: http://builds.cask.co/browse/CDAP-DUT5615-1

We are counting the same record twice in TrackedTransform and CountingFunction. The unit test did not catch it since waitForTotalMetricCount does not throw exception when the actual number is larger than the expected.