### PR TITLE
CDAP-8095 Script: cdap version

### DIFF
--- a/cdap-common/bin/cdap
+++ b/cdap-common/bin/cdap
@@ -81,6 +81,7 @@ case ${1} in
   cli) shift; cdap_cli "${@}"; __ret=${?} ;;
   config-tool) shift; cdap_config_tool ${@}; __ret=${?} ;;
   upgrade) shift; cdap_upgrade_tool ${@}; __ret=${?} ;;
+  version) shift; cdap_version_command ${@}; __ret=${?} ;;
   run) shift; cdap_run_class ${@}; __ret=${?} ;;
   sdk) shift; cdap_sdk ${@}; __ret=${?} ;;
   setup) shift; cdap_setup ${@}; __ret=${?} ;;
@@ -112,6 +113,7 @@ case ${1} in
     echo "    apply-pack   - Installs a CDAP Pack specified as an argument"
     echo "    cli          - Starts an interactive CDAP CLI session"
     echo "    debug        - Runs CDAP debug functions"
+    echo "    version      - Displays versions of local CDAP components"
     echo
     echo " Get more help for each command by executing:"
     echo " ${0} <command> --help"

--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -803,6 +803,30 @@ cdap_version() {
   echo ${__version}
 }
 
+#
+# cdap_version_command
+# returns the version of CDAP SDK or all locally installed CDAP Distributed components
+#
+cdap_version_command() {
+  local readonly __context=$(cdap_context)
+  local __component __name
+  if [[ ${__context} == sdk ]]; then
+    echo "CDAP SDK version $(cdap_version)"
+    echo
+  else # Distributed, possibly CLI-only
+    if [[ -r ${CDAP_HOME}/VERSION ]]; then
+      echo "CDAP configuration version $(cdap_version)"
+    fi
+    for __component in cli gateway kafka master security ui; do
+      if [[ -r ${CDAP_HOME}/${__component}/VERSION ]]; then
+        echo "CDAP ${__component} version $(cdap_version ${__component})"
+      fi
+    done
+    echo
+  fi
+  return 0
+}
+
 ###
 #
 # CDAP SDK functions

--- a/cdap-distributions/pom.xml
+++ b/cdap-distributions/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright © 2014-2016 Cask Data, Inc.
+  Copyright © 2014-2017 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -41,6 +41,14 @@
             <directory>${project.basedir}/src/etc</directory>
             <targetPath>${stage.dir}/etc</targetPath>
           </resource>
+          <resource>
+            <directory>${project.basedir}</directory>
+            <targetPath>${stage.dir}/opt/cdap</targetPath>
+            <includes>
+              <include>VERSION</include>
+            </includes>
+            <filtering>true</filtering>
+          </resource>
         </resources>
       </build>
     </profile>
@@ -52,6 +60,14 @@
           <resource>
             <directory>${project.basedir}/src/etc</directory>
             <targetPath>${stage.dir}-deb/etc</targetPath>
+          </resource>
+          <resource>
+            <directory>${project.basedir}</directory>
+            <targetPath>${stage.dir}-deb/opt/cdap</targetPath>
+            <includes>
+              <include>VERSION</include>
+            </includes>
+            <filtering>true</filtering>
           </resource>
         </resources>
       </build>
@@ -99,7 +115,7 @@
                     --depends glibc-common
                     --depends shadow-utils
                     ${package.config.dirs}
-                    etc
+                    ${package.dirs}
                   </commandlineArgs>
                 </configuration>
               </execution>
@@ -179,7 +195,7 @@
                     --depends libc-bin
                     --depends passwd
                     ${package.config.dirs}
-                    etc
+                    ${package.dirs}
                   </commandlineArgs>
                 </configuration>
               </execution>

--- a/cdap-standalone/bin/cdap.bat
+++ b/cdap-standalone/bin/cdap.bat
@@ -270,7 +270,7 @@ echo     cli         - Starts a CDAP CLI session
 echo     sdk         - Sends the arguments to the SDK service
 echo     tx-debugger - Sends the arguments to the CDAP transaction debugger
 echo     apply-pack  - Installs a CDAP Pack specified as an argument
-echo     version     - Displays version of CDAP SDK
+echo     version     - Displays version of the CDAP SDK
 echo:
 echo   Get help for a command by executing:
 echo:

--- a/cdap-standalone/bin/cdap.bat
+++ b/cdap-standalone/bin/cdap.bat
@@ -266,10 +266,10 @@ echo Usage: %APP% ^<command^> [arguments]
 echo:
 echo   Commands:
 echo:
+echo     apply-pack  - Installs a CDAP Pack specified as an argument
 echo     cli         - Starts a CDAP CLI session
 echo     sdk         - Sends the arguments to the SDK service
 echo     tx-debugger - Sends the arguments to the CDAP transaction debugger
-echo     apply-pack  - Installs a CDAP Pack specified as an argument
 echo     version     - Displays version of the CDAP SDK
 echo:
 echo   Get help for a command by executing:

--- a/cdap-standalone/bin/cdap.bat
+++ b/cdap-standalone/bin/cdap.bat
@@ -57,6 +57,7 @@ IF "%1" == "cli" GOTO CLI
 IF "%1" == "sdk" GOTO SDK
 IF "%1" == "tx-debugger" GOTO TX_DEBUGGER
 IF "%1" == "apply-pack" GOTO APPLY_PACK
+IF "%1" == "version" GOTO VERSION
 REM Process deprecated SDK arguments
 IF "%1" == "start" GOTO SDK_DEPRECATED
 IF "%1" == "stop" GOTO SDK_DEPRECATED
@@ -254,6 +255,11 @@ IF "%1" == "cli" for /f "usebackq tokens=1*" %%i in (`echo %*`) DO @ set params=
 "%JAVACMD%" -classpath "%CLASSPATH%" %class% %params%
 GOTO FINALLY
 
+:VERSION
+echo CDAP SDK version %CDAP_VERSION%
+echo:
+GOTO FINALLY
+
 :USAGE
 echo:
 echo Usage: %APP% ^<command^> [arguments]
@@ -264,6 +270,7 @@ echo     cli         - Starts a CDAP CLI session
 echo     sdk         - Sends the arguments to the SDK service
 echo     tx-debugger - Sends the arguments to the CDAP transaction debugger
 echo     apply-pack  - Installs a CDAP Pack specified as an argument
+echo     version     - Displays version of CDAP SDK
 echo:
 echo   Get help for a command by executing:
 echo:


### PR DESCRIPTION
Adds a context-sensitive `version` command to `cdap` script.

```
$ cdap version
CDAP configuration version 4.2.0-SNAPSHOT
CDAP cli version 4.2.0-SNAPSHOT
CDAP gateway version 4.2.0-SNAPSHOT
CDAP kafka version 4.2.0-SNAPSHOT
CDAP master version 4.2.0-SNAPSHOT
CDAP security version 4.2.0-SNAPSHOT
CDAP ui version 4.2.0-SNAPSHOT

```