### PR TITLE
Docs: Add security note

### DIFF
--- a/cdap-docs/admin-manual/source/security/impersonation.rst
+++ b/cdap-docs/admin-manual/source/security/impersonation.rst
@@ -62,8 +62,8 @@ described in the installation section for each distribution (:ref:`Cloudera Mana
 :ref:`MapR <mapr-hdfs-permissions>`, and :ref:`packages <packages-hdfs-permissions>`).
 
 Note that you can use the HDFS command ``hdfs groups [username ...]`` to confirm that the
-groups are set correctly, and that HBase permissions and external security services such
-as LDAP are configured correctly.
+groups are set correctly, and that external security services such as LDAP are configured
+correctly.
 
 Application-level Impersonation
 -------------------------------

--- a/cdap-docs/admin-manual/source/security/impersonation.rst
+++ b/cdap-docs/admin-manual/source/security/impersonation.rst
@@ -61,6 +61,10 @@ described in the installation section for each distribution (:ref:`Cloudera Mana
 <cloudera-hdfs-permissions>`, :ref:`Ambari <ambari-hdfs-permissions>`, 
 :ref:`MapR <mapr-hdfs-permissions>`, and :ref:`packages <packages-hdfs-permissions>`).
 
+Note that you can use the HDFS command ``hdfs groups [username ...]`` to confirm that the
+groups are set correctly, and that HBase permissions and external security services such
+as LDAP are configured correctly.
+
 Application-level Impersonation
 -------------------------------
 To use application-level impersonation in CDAP |---| where applications, datasets, and streams have


### PR DESCRIPTION
Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB317-1 (passed)

Page of interest: http://builds.cask.co/artifact/CDAP-DQB317/shared/build-1/Docs-HTML/4.1.0/en/admin-manual/security/impersonation.html#hdfs-permissions