### PR TITLE
UI + Docs: Add support for Widget Spec 1.4

### DIFF
--- a/cdap-docs/vars
+++ b/cdap-docs/vars
@@ -60,7 +60,7 @@ GIT_VERSION_CDAP_APPS="0.8.0"
 # From https://github.com/caskdata/hydrator-plugins
 GIT_BRANCH_CDAP_PIPELINES="release/1.6"
 GIT_BRANCH_HYDRATOR_PLUGINS="release/1.2"
-GIT_PLUGINS_SPEC_VERSION="1.3"
+GIT_PLUGINS_SPEC_VERSION="1.4"
 
 # Used by examples manual
 GIT_BRANCH_CDAP_GUIDES="release/cdap-4.1-compatible"

--- a/cdap-ui/app/hydrator/bottompanel.less
+++ b/cdap-ui/app/hydrator/bottompanel.less
@@ -442,6 +442,9 @@ body.theme-cdap.state-hydrator {
           }
         }
       }
+      .empty-hidden-properties-message {
+        margin: 0 0 5px 0;
+      }
     }
     .post-actions-detail,
     .post-actions-tab {

--- a/cdap-ui/app/hydrator/services/plugin-config-factory.js
+++ b/cdap-ui/app/hydrator/services/plugin-config-factory.js
@@ -46,7 +46,7 @@ class HydratorPlusPlusPluginConfigFactory {
             } else {
               throw 'NO_JSON_FOUND';
             }
-          } catch(e) {
+          } catch (e) {
             throw (e && e.name === 'SyntaxError')? 'CONFIG_SYNTAX_JSON_ERROR': e;
           }
         },
@@ -67,7 +67,7 @@ class HydratorPlusPlusPluginConfigFactory {
 
   generateNodeConfig(backendProperties, nodeConfig) {
     var specVersion = this.myHelpers.objectQuery(nodeConfig, 'metadata', 'spec-version') || '0.0';
-    switch(specVersion) {
+    switch (specVersion) {
       case '0.0':
         return this.generateConfigForOlderSpec(backendProperties, nodeConfig);
       case '1.0':
@@ -76,6 +76,7 @@ class HydratorPlusPlusPluginConfigFactory {
       case '1.2':
         return this.generateConfigFor12Spec(backendProperties, nodeConfig);
       case '1.3':
+      case '1.4':
         return this.generateConfigFor13Spec(backendProperties, nodeConfig);
       default: // No spec version which means
         throw 'NO_JSON_FOUND';

--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-properties-template.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-properties-template.html
@@ -26,11 +26,17 @@
            ng-model="HydratorPlusPlusNodeConfigCtrl.state.node.plugin.label">
   </div>
 
+  <div class="text-danger empty-hidden-properties-message" ng-if="HydratorPlusPlusNodeConfigCtrl.emptyHiddenFields.length">
+    Plugin contains hidden propertie(s) {{HydratorPlusPlusNodeConfigCtrl.emptyHiddenFields.join(', ')}} that do not have default values.
+    Please provide a default value in the 'widget-attributes' section of the widget JSON.
+  </div>
   <div ng-repeat="group in HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.groups">
     <div class="widget-group-container">
       <h4>{{::group.display}}</h4>
       <div ng-repeat="field in group.fields">
-        <div ng-if="field.name !== HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.outputSchema.schemaProperty">
+        <div
+          ng-if="field.name !== HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.outputSchema.schemaProperty && field['widget-type'] !== 'hidden'"
+        >
 
           <div class="form-group">
             <label class="control-label">


### PR DESCRIPTION
**UI Changes**: 
  Fixes plugin config factory to factor in spec 1.4 changes to handle `hide-property` in widget json

**Docs Changes**: 
  Updates the specification of the CDAP UI Widgets to v 1.4 and documents changes to date.

Running as a Quick Build: http://builds.cask.co/browse/CDAP-DQB318-5

Page of interest: http://builds.cask.co/artifact/CDAP-DQB318/shared/build-5/Docs-HTML/4.1.0/en/developers-manual/pipelines/developing-plugins/presentation-plugins.html