### PR TITLE
Fix/windows test stream delete

### DIFF
--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -27,8 +27,6 @@ import co.cask.cdap.common.conf.CConfiguration;
 import co.cask.cdap.common.conf.Constants;
 import co.cask.cdap.common.kerberos.DefaultOwnerAdmin;
 import co.cask.cdap.common.kerberos.OwnerAdmin;
-import co.cask.cdap.common.namespace.NamespaceAdmin;
-import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
 import co.cask.cdap.common.runtime.RuntimeModule;
 import co.cask.cdap.common.twill.MasterServiceManager;
 import co.cask.cdap.common.utils.Networks;
@@ -67,11 +65,8 @@ import co.cask.cdap.gateway.handlers.preview.PreviewHttpHandler;
 import co.cask.cdap.internal.app.deploy.LocalApplicationManager;
 import co.cask.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
 import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
-import co.cask.cdap.internal.app.namespace.DefaultNamespaceAdmin;
-import co.cask.cdap.internal.app.namespace.DefaultNamespaceResourceDeleter;
 import co.cask.cdap.internal.app.namespace.DistributedStorageProviderNamespaceAdmin;
 import co.cask.cdap.internal.app.namespace.LocalStorageProviderNamespaceAdmin;
-import co.cask.cdap.internal.app.namespace.NamespaceResourceDeleter;
 import co.cask.cdap.internal.app.namespace.StorageProviderNamespaceAdmin;
 import co.cask.cdap.internal.app.runtime.artifact.ArtifactStore;
 import co.cask.cdap.internal.app.runtime.batch.InMemoryTransactionServiceManager;
@@ -117,7 +112,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Binder;
 import com.google.inject.Module;
-import com.google.inject.PrivateModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
@@ -151,8 +145,9 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
   @Override
   public Module getInMemoryModules() {
     return Modules.combine(new AppFabricServiceModule(
-                             StreamHandler.class, StreamFetchHandler.class,
-                             StreamViewHttpHandler.class),
+                               StreamHandler.class, StreamFetchHandler.class,
+                               StreamViewHttpHandler.class),
+                           new NamespaceAdminModule().getInMemoryModules(),
                            new ConfigStoreModule().getInMemoryModule(),
                            new EntityVerifierModule(),
                            new AuthenticationContextModules().getMasterModule(),
@@ -194,6 +189,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
     return Modules.combine(new AppFabricServiceModule(
                              StreamHandler.class, StreamFetchHandler.class,
                              StreamViewHttpHandler.class, PreviewHttpHandler.class),
+                           new NamespaceAdminModule().getStandaloneModules(),
                            new ConfigStoreModule().getStandaloneModule(),
                            new EntityVerifierModule(),
                            new AuthenticationContextModules().getMasterModule(),
@@ -261,6 +257,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
   public Module getDistributedModules() {
 
     return Modules.combine(new AppFabricServiceModule(ImpersonationHandler.class),
+                           new NamespaceAdminModule().getDistributedModules(),
                            new ConfigStoreModule().getDistributedModule(),
                            new EntityVerifierModule(),
                            new AuthenticationContextModules().getMasterModule(),
@@ -277,27 +274,27 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                MapBinder<String, MasterServiceManager> mapBinder = MapBinder.newMapBinder(
                                  binder(), String.class, MasterServiceManager.class);
                                mapBinder.addBinding(Constants.Service.LOGSAVER)
-                                        .to(LogSaverStatusServiceManager.class);
+                                 .to(LogSaverStatusServiceManager.class);
                                mapBinder.addBinding(Constants.Service.TRANSACTION)
-                                        .to(TransactionServiceManager.class);
+                                 .to(TransactionServiceManager.class);
                                mapBinder.addBinding(Constants.Service.METRICS_PROCESSOR)
-                                        .to(MetricsProcessorStatusServiceManager.class);
+                                 .to(MetricsProcessorStatusServiceManager.class);
                                mapBinder.addBinding(Constants.Service.METRICS)
-                                        .to(MetricsServiceManager.class);
+                                 .to(MetricsServiceManager.class);
                                mapBinder.addBinding(Constants.Service.APP_FABRIC_HTTP)
-                                        .to(AppFabricServiceManager.class);
+                                 .to(AppFabricServiceManager.class);
                                mapBinder.addBinding(Constants.Service.STREAMS)
-                                        .to(StreamServiceManager.class);
+                                 .to(StreamServiceManager.class);
                                mapBinder.addBinding(Constants.Service.DATASET_EXECUTOR)
-                                        .to(DatasetExecutorServiceManager.class);
+                                 .to(DatasetExecutorServiceManager.class);
                                mapBinder.addBinding(Constants.Service.METADATA_SERVICE)
-                                        .to(MetadataServiceManager.class);
+                                 .to(MetadataServiceManager.class);
                                mapBinder.addBinding(Constants.Service.REMOTE_SYSTEM_OPERATION)
-                                        .to(RemoteSystemOperationServiceManager.class);
+                                 .to(RemoteSystemOperationServiceManager.class);
                                mapBinder.addBinding(Constants.Service.EXPLORE_HTTP_USER_SERVICE)
-                                        .to(ExploreServiceManager.class);
+                                 .to(ExploreServiceManager.class);
                                mapBinder.addBinding(Constants.Service.MESSAGING_SERVICE)
-                                        .to(MessagingServiceManager.class);
+                                 .to(MessagingServiceManager.class);
 
                                Multibinder<String> servicesNamesBinder =
                                  Multibinder.newSetBinder(binder(), String.class,
@@ -319,7 +316,6 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
 
     private final List<Class<? extends HttpHandler>> handlerClasses;
 
-    @SafeVarargs
     private AppFabricServiceModule(Class<? extends HttpHandler>... handlerClasses) {
       this.handlerClasses = ImmutableList.copyOf(handlerClasses);
     }
@@ -344,19 +340,6 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       bind(ArtifactStore.class).in(Scopes.SINGLETON);
       bind(ProgramLifecycleService.class).in(Scopes.SINGLETON);
       bind(OwnerAdmin.class).to(DefaultOwnerAdmin.class);
-
-      install(new PrivateModule() {
-        @Override
-        protected void configure() {
-          bind(NamespaceResourceDeleter.class).to(DefaultNamespaceResourceDeleter.class).in(Scopes.SINGLETON);
-          bind(DefaultNamespaceAdmin.class).in(Scopes.SINGLETON);
-          bind(NamespaceAdmin.class).to(DefaultNamespaceAdmin.class);
-          bind(NamespaceQueryAdmin.class).to(DefaultNamespaceAdmin.class);
-
-          expose(NamespaceAdmin.class);
-          expose(NamespaceQueryAdmin.class);
-        }
-      });
 
       Multibinder<HttpHandler> handlerBinder = Multibinder.newSetBinder(
         binder(), HttpHandler.class, Names.named(Constants.AppFabric.HANDLERS_BINDING));

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/NamespaceAdminModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/guice/NamespaceAdminModule.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.app.guice;
+
+import co.cask.cdap.common.namespace.NamespaceAdmin;
+import co.cask.cdap.common.namespace.NamespaceQueryAdmin;
+import co.cask.cdap.common.runtime.RuntimeModule;
+import co.cask.cdap.internal.app.namespace.DefaultNamespaceAdmin;
+import co.cask.cdap.internal.app.namespace.DistributedNamespaceResourceDeleter;
+import co.cask.cdap.internal.app.namespace.LocalNamespaceResourceDeleter;
+import co.cask.cdap.internal.app.namespace.NamespaceResourceDeleter;
+import com.google.inject.Module;
+import com.google.inject.PrivateModule;
+import com.google.inject.Scopes;
+
+/**
+ * Namespace admin modules
+ */
+public class NamespaceAdminModule extends RuntimeModule {
+
+  @Override
+  public Module getInMemoryModules() {
+    return new PrivateModule() {
+      @Override
+      protected void configure() {
+        bind(NamespaceResourceDeleter.class).to(LocalNamespaceResourceDeleter.class).in(Scopes.SINGLETON);
+        bind(DefaultNamespaceAdmin.class).in(Scopes.SINGLETON);
+        bind(NamespaceAdmin.class).to(DefaultNamespaceAdmin.class);
+        bind(NamespaceQueryAdmin.class).to(DefaultNamespaceAdmin.class);
+
+        expose(NamespaceAdmin.class);
+        expose(NamespaceQueryAdmin.class);
+      }
+    };
+  }
+
+  @Override
+  public Module getStandaloneModules() {
+    return new PrivateModule() {
+      @Override
+      protected void configure() {
+        bind(NamespaceResourceDeleter.class).to(LocalNamespaceResourceDeleter.class).in(Scopes.SINGLETON);
+        bind(DefaultNamespaceAdmin.class).in(Scopes.SINGLETON);
+        bind(NamespaceAdmin.class).to(DefaultNamespaceAdmin.class);
+        bind(NamespaceQueryAdmin.class).to(DefaultNamespaceAdmin.class);
+
+        expose(NamespaceAdmin.class);
+        expose(NamespaceQueryAdmin.class);
+      }
+    };
+  }
+
+  @Override
+  public Module getDistributedModules() {
+    return new PrivateModule() {
+      @Override
+      protected void configure() {
+        bind(NamespaceResourceDeleter.class).to(DistributedNamespaceResourceDeleter.class).in(Scopes.SINGLETON);
+        bind(DefaultNamespaceAdmin.class).in(Scopes.SINGLETON);
+        bind(NamespaceAdmin.class).to(DefaultNamespaceAdmin.class);
+        bind(NamespaceQueryAdmin.class).to(DefaultNamespaceAdmin.class);
+
+        expose(NamespaceAdmin.class);
+        expose(NamespaceQueryAdmin.class);
+      }
+    };
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/app/preview/PreviewRunnerModule.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/app/preview/PreviewRunnerModule.java
@@ -36,9 +36,9 @@ import co.cask.cdap.explore.client.MockExploreClient;
 import co.cask.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
 import co.cask.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
 import co.cask.cdap.internal.app.namespace.DefaultNamespaceAdmin;
-import co.cask.cdap.internal.app.namespace.DefaultNamespaceResourceDeleter;
 import co.cask.cdap.internal.app.namespace.LocalStorageProviderNamespaceAdmin;
 import co.cask.cdap.internal.app.namespace.NamespaceResourceDeleter;
+import co.cask.cdap.internal.app.namespace.NoopNamespaceResourceDeleter;
 import co.cask.cdap.internal.app.namespace.StorageProviderNamespaceAdmin;
 import co.cask.cdap.internal.app.preview.DefaultDataTracerFactory;
 import co.cask.cdap.internal.app.preview.DefaultPreviewRunner;
@@ -133,7 +133,8 @@ public class PreviewRunnerModule extends PrivateModule {
     bind(RuntimeStore.class).to(DefaultStore.class);
     expose(RuntimeStore.class);
 
-    bind(NamespaceResourceDeleter.class).to(DefaultNamespaceResourceDeleter.class).in(Scopes.SINGLETON);
+    // we don't delete namespaces in preview as we just delete preview directory when its done
+    bind(NamespaceResourceDeleter.class).to(NoopNamespaceResourceDeleter.class).in(Scopes.SINGLETON);
     bind(NamespaceAdmin.class).to(DefaultNamespaceAdmin.class).in(Scopes.SINGLETON);
     bind(NamespaceQueryAdmin.class).to(DefaultNamespaceAdmin.class).in(Scopes.SINGLETON);
     expose(NamespaceAdmin.class);

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DistributedNamespaceResourceDeleter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/DistributedNamespaceResourceDeleter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.namespace;
+
+import co.cask.cdap.api.metrics.MetricStore;
+import co.cask.cdap.app.store.Store;
+import co.cask.cdap.config.DashboardStore;
+import co.cask.cdap.config.PreferencesStore;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.transaction.queue.QueueAdmin;
+import co.cask.cdap.data2.transaction.stream.StreamAdmin;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
+import co.cask.cdap.internal.app.services.ApplicationLifecycleService;
+import co.cask.cdap.messaging.MessagingService;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.security.impersonation.Impersonator;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of {@link NamespaceResourceDeleter} used in distributed mode.
+ */
+public class DistributedNamespaceResourceDeleter extends AbstractNamespaceResourceDeleter {
+  private static final Logger LOG = LoggerFactory.getLogger(DistributedNamespaceResourceDeleter.class);
+
+  private final StreamAdmin streamAdmin;
+
+  @Inject
+  DistributedNamespaceResourceDeleter(Impersonator impersonator, Store store, PreferencesStore preferencesStore,
+                                      DashboardStore dashboardStore, DatasetFramework dsFramework,
+                                      QueueAdmin queueAdmin, MetricStore metricStore, Scheduler scheduler,
+                                      ApplicationLifecycleService applicationLifecycleService,
+                                      ArtifactRepository artifactRepository,
+                                      StorageProviderNamespaceAdmin storageProviderNamespaceAdmin,
+                                      MessagingService messagingService, StreamAdmin streamAdmin) {
+    super(impersonator, store, preferencesStore, dashboardStore, dsFramework, queueAdmin, metricStore,
+          scheduler, applicationLifecycleService, artifactRepository, storageProviderNamespaceAdmin, messagingService);
+    this.streamAdmin = streamAdmin;
+  }
+
+  @Override
+  protected void deleteStreams(NamespaceId namespaceId) throws Exception {
+    // delete all streams
+    streamAdmin.dropAllInNamespace(namespaceId);
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/LocalNamespaceResourceDeleter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/LocalNamespaceResourceDeleter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.namespace;
+
+import co.cask.cdap.api.data.stream.StreamSpecification;
+import co.cask.cdap.api.metrics.MetricStore;
+import co.cask.cdap.app.store.Store;
+import co.cask.cdap.config.DashboardStore;
+import co.cask.cdap.config.PreferencesStore;
+import co.cask.cdap.data.stream.service.StreamHandler;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.transaction.queue.QueueAdmin;
+import co.cask.cdap.data2.transaction.stream.StreamAdmin;
+import co.cask.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import co.cask.cdap.internal.app.runtime.schedule.Scheduler;
+import co.cask.cdap.internal.app.services.ApplicationLifecycleService;
+import co.cask.cdap.messaging.MessagingService;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.security.impersonation.Impersonator;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Implementation of {@link NamespaceResourceDeleter} used in local mode.
+ */
+public class LocalNamespaceResourceDeleter extends AbstractNamespaceResourceDeleter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LocalNamespaceResourceDeleter.class);
+
+  private final StreamAdmin streamAdmin;
+  private final StreamHandler streamHandler;
+
+  @Inject
+  LocalNamespaceResourceDeleter(Impersonator impersonator, Store store, PreferencesStore preferencesStore,
+                                DashboardStore dashboardStore, DatasetFramework dsFramework, QueueAdmin queueAdmin,
+                                MetricStore metricStore, Scheduler scheduler,
+                                ApplicationLifecycleService applicationLifecycleService,
+                                ArtifactRepository artifactRepository,
+                                StorageProviderNamespaceAdmin storageProviderNamespaceAdmin,
+                                MessagingService messagingService, StreamAdmin streamAdmin,
+                                StreamHandler streamHandler) {
+    super(impersonator, store, preferencesStore, dashboardStore, dsFramework, queueAdmin, metricStore,
+          scheduler, applicationLifecycleService, artifactRepository, storageProviderNamespaceAdmin, messagingService);
+    this.streamAdmin = streamAdmin;
+    this.streamHandler = streamHandler;
+
+  }
+
+  @Override
+  protected void deleteStreams(NamespaceId namespaceId) throws Exception {
+    // delete all streams
+    List<StreamSpecification> streams = streamAdmin.listStreams(namespaceId);
+    for (StreamSpecification specification : streams) {
+      streamHandler.deleteStream(namespaceId.getNamespace(), specification.getName());
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/NoopNamespaceResourceDeleter.java
+++ b/cdap-app-fabric/src/main/java/co/cask/cdap/internal/app/namespace/NoopNamespaceResourceDeleter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.internal.app.namespace;
+
+import co.cask.cdap.proto.NamespaceMeta;
+
+/**
+ * No op implementation of naemspace resource deleter
+ */
+public class NoopNamespaceResourceDeleter implements NamespaceResourceDeleter {
+  @Override
+  public void deleteResources(NamespaceMeta namespaceMeta) throws Exception {
+    // no - op
+  }
+}

--- a/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
+++ b/cdap-data-fabric/src/main/java/co/cask/cdap/data/stream/service/StreamHandler.java
@@ -306,13 +306,17 @@ public final class StreamHandler extends AbstractHttpHandler {
   public void delete(HttpRequest request, HttpResponder responder,
                      @PathParam("namespace-id") String namespaceId,
                      @PathParam("stream") String stream) throws Exception {
+    deleteStream(namespaceId, stream);
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  public void deleteStream(String namespaceId, String stream) throws Exception {
     StreamId streamId = validateAndGetStreamId(namespaceId, stream);
     checkStreamExists(streamId);
     // On Windows, we can not move the file if it is open, and the stream writer may have an open file in this dir.
     // Since Windows is only supported in SDK/standalone, we don't need to worry about multiple stream writers here.
     streamWriter.close(streamId);
     streamAdmin.drop(streamId);
-    responder.sendStatus(HttpResponseStatus.OK);
   }
 
   @PUT


### PR DESCRIPTION
In windows the file reference have to be closed before it can be deleted, this was fixed in StreamHandler by CDAP-4695. 

However the namespace delete doesn't use stream handler to delete streams, so in this fix for standalone we would use streamHandler to delete streams while for distributed we would continue to use streamAdmin to delete streams.
JIRA : https://issues.cask.co/browse/CDAP-6348